### PR TITLE
fix: apply camera fixes from derekross/camera-fixes-rabble

### DIFF
--- a/mobile/lib/widgets/camera_controls_overlay.dart
+++ b/mobile/lib/widgets/camera_controls_overlay.dart
@@ -24,34 +24,9 @@ class CameraControlsOverlay extends StatefulWidget {
 class _CameraControlsOverlayState extends State<CameraControlsOverlay> {
   @override
   Widget build(BuildContext context) {
-    // Only show enhanced controls for enhanced mobile camera
-    if (widget.cameraInterface is! EnhancedMobileCameraInterface) {
-      return const SizedBox.shrink();
-    }
-
-    final enhancedCamera =
-        widget.cameraInterface as EnhancedMobileCameraInterface;
-    final isRecording = widget.recordingState == VineRecordingState.recording;
-
-    return Stack(
-      children: [
-        // Top controls (flash toggle)
-        if (!isRecording)
-          Positioned(
-            top: MediaQuery.of(context).padding.top + 16,
-            right: 16,
-            child: Column(
-              children: [
-                // Flash toggle button
-                _buildControlButton(
-                  icon: Icons.flash_auto,
-                  onTap: () => enhancedCamera.toggleFlash(),
-                ),
-              ],
-            ),
-          ),
-      ],
-    );
+    // CameraControlsOverlay now only handles gesture-based controls (zoom, focus)
+    // Flash, timer, and aspect ratio buttons are in UniversalCameraScreenPure._buildCameraControls
+    return const SizedBox.shrink();
   }
 
   Widget _buildControlButton({


### PR DESCRIPTION
This commit applies two critical camera fixes that were previously merged to derekross/camera-fixes-rabble but not fully applied to rabble/main:

1. Fix front camera black screen issue (from commit 8499b32):
   - Dispose old camera controller BEFORE initializing new one in switchCamera()
   - Android only allows one camera open at a time
   - Previous code initialized new camera first, causing black screen
   - Added isFrontCamera getter to EnhancedMobileCameraInterface
   - Added setFlashMode() method for direct flash control

2. Fix duplicate flash buttons (from commit 8499b32):
   - Removed flash button from CameraControlsOverlay
   - Flash button now only in UniversalCameraScreenPure._buildCameraControls
   - Properly hides flash button when using front camera

These fixes ensure:
- Front camera switches without black screen
- No overlapping flash buttons
- Flash button only shows for rear camera

🤖 Generated with [Claude Code](https://claude.com/claude-code)