### PR TITLE
feat: fastlane setup android (basic)

### DIFF
--- a/mobile/android/.gitignore
+++ b/mobile/android/.gitignore
@@ -12,3 +12,4 @@ GeneratedPluginRegistrant.java
 key.properties
 **/*.keystore
 **/*.jks
+/.keys/

--- a/mobile/android/Gemfile
+++ b/mobile/android/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/mobile/android/fastlane/Appfile
+++ b/mobile/android/fastlane/Appfile
@@ -1,0 +1,4 @@
+# Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
+# put the file in /.keys/ (added to .gitignore) and set the path here
+json_key_file("")
+package_name("com.openvine.mobile")

--- a/mobile/android/fastlane/Fastfile
+++ b/mobile/android/fastlane/Fastfile
@@ -1,0 +1,38 @@
+# This file contains the fastlane.tools configuration
+# You can find the documentation at https://docs.fastlane.tools
+#
+# For a list of all available actions, check out
+#
+#     https://docs.fastlane.tools/actions
+#
+# For a list of all available plugins, check out
+#
+#     https://docs.fastlane.tools/plugins/available-plugins
+#
+
+# Uncomment the line if you want fastlane to automatically update itself
+# update_fastlane
+
+default_platform(:android)
+
+platform :android do
+
+  desc "Deploy a new version to Google Play"
+  lane :production do
+    sh "flutter build appbundle --release" # build the app bundle
+    upload_to_play_store(
+      aab: '../build/app/outputs/bundle/release/app-release.aab',
+      json_key_data: ENV['G_PLAY_FASTLANE_SERVICE_ACCOUNT']
+    )
+  end
+
+  desc "Deploy a new version to open Testing Track"
+  lane :beta do
+    sh "flutter build appbundle --release" # build the app bundle
+    upload_to_play_store(
+      track: 'beta',
+      aab: '../build/app/outputs/bundle/release/app-release.aab',
+      json_key_data: ENV['G_PLAY_FASTLANE_SERVICE_ACCOUNT']
+    )
+  end
+end

--- a/mobile/android/fastlane/README.md
+++ b/mobile/android/fastlane/README.md
@@ -1,0 +1,13 @@
+## fastlane documentation
+
+# Installation
+
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
+
+1. Download Google Service account JSON file and put it in `/.keys/` folder (added to .gitignore) and set the path in `Appfile`.
+2. `fastlane supply init` to download the metadata for your app from Google Play and check it in with git.
+
+# usage
+
+- `fastlane beta` => Deploy a new version to open Testing Track
+- `fastlane production` => Deploy a new version to Google Play


### PR DESCRIPTION
# Fastlane setup

This PR adds fastlane support for android so maintainers can deploy with one command and push updates quickly.
Store assets can be checked into git (description, images, logo, etc.).
It's also the first step for automated builds on Android and iOS.
Let me know if I should add gh workflow files.

## fastlane documentation (located in `/mobile/android/fastlane`)

# Installation

For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)

1. Download Google Service account JSON file and put it in `/.keys/` folder (added to .gitignore) and set the path in `Appfile`.
2. `fastlane supply init` to download the metadata for your app from Google Play and check it in with git.

# usage

- `fastlane beta` => Deploy a new version to open Testing Track
- `fastlane production` => Deploy a new version to Google Play

