### PR TITLE
Update license to MPL 2.0 and rebrand OpenVine to diVine

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to OpenVine (Divine)
+# Contributing to diVine
 
-Thank you for your interest in contributing to OpenVine! This guide will help you get set up and building the app.
+Thank you for your interest in contributing to diVine! This guide will help you get set up and building the app.
 
 ## Table of Contents
 
@@ -47,7 +47,7 @@ cd openvine
 
 ### 2. Set Up Flutter Embedded Nostr Relay
 
-**CRITICAL**: OpenVine uses a custom embedded Nostr relay that runs inside the Flutter app. This must be set up as a local dependency via symlink.
+**CRITICAL**: diVine uses a custom embedded Nostr relay that runs inside the Flutter app. This must be set up as a local dependency via symlink.
 
 #### Clone the Embedded Relay Repository
 
@@ -111,7 +111,7 @@ npm install
 
 ### Development Builds
 
-OpenVine (branded as "divine") supports multiple platforms. **macOS desktop is the primary development platform** for fast iteration.
+diVine supports multiple platforms. **macOS desktop is the primary development platform** for fast iteration.
 
 #### macOS Desktop (Primary Development Platform)
 ```bash
@@ -193,7 +193,7 @@ flutter build apk --release         # For direct distribution
 
 ### Using the Embedded Relay
 
-The embedded relay architecture is a key part of OpenVine's design:
+The embedded relay architecture is a key part of diVine's design:
 
 ```dart
 // Import the embedded relay package
@@ -246,7 +246,7 @@ dart format lib/ test/                    # Format code
 
 ## Testing
 
-OpenVine follows **strict Test-Driven Development (TDD)** principles:
+diVine follows **strict Test-Driven Development (TDD)** principles:
 
 ### Testing Requirements
 
@@ -445,4 +445,4 @@ flutter build --help        # Show all build options
 
 ## License
 
-By contributing to OpenVine, you agree that your contributions will be licensed under the ISC License.
+By contributing to diVine, you agree that your contributions will be licensed under the Mozilla Public License 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,188 @@
-MIT License
+Mozilla Public License Version 2.0
+==================================
 
-Copyright (c) 2025 rabble
+1. Definitions
+--------------
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to the creation of, or owns Covered Software.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used by a Contributor and that particular Contributor's Contribution.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached the notice in Exhibit A, the Executable Form of such Source Code Form, and Modifications of such Source Code Form, in each case including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+    (a) that the initial Contributor has attached the notice described in Exhibit B to the Covered Software; or
+    (b) that the Covered Software was made available under the terms of version 1.1 or earlier of the License, but not also under the terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible, whether at the time of the initial grant or subsequently, any and all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+    (a) any file in Source Code Form that results from an addition to, deletion from, or modification of the contents of Covered Software; or
+    (b) any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method, process, and apparatus claims, in any patent Licensable by such Contributor that would be infringed, but for the grant of the License, by the making, using, selling, offering for sale, having made, import, or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU Lesser General Public License, Version 2.1, the GNU Affero General Public License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this License. For legal entities, "You" includes any entity that controls, is controlled by, or is under common control with You. For purposes of this definition, "control" means (a) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (b) ownership of more than fifty percent (50%) of the outstanding shares or beneficial ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark) Licensable by such Contributor to use, reproduce, make available, modify, display, perform, distribute, and otherwise exploit its Contributions, either on an unmodified basis, with Modifications, or as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer for sale, have made, import, and otherwise transfer either its Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution become effective for each Contribution on the date the Contributor first distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under this License. No additional rights or licenses will be implied from the distribution or licensing of Covered Software under this License. Notwithstanding Section 2.1(b) above, no patent license is granted by a Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software; or
+
+(b) for infringements caused by: (i) Your and any other third party's modifications of Covered Software, or (ii) the combination of its Contributions with other software (except as part of its Contributor Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of its Contributions.
+
+This License does not grant any rights in the trademarks, service marks, or logos of any Contributor (except as may be necessary to comply with the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to distribute the Covered Software under a subsequent version of this License (see Section 10.2) or under the terms of a Secondary License (if permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its Contributions are its original creation(s) or it has sufficient rights to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under applicable copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any Modifications that You create or to which You contribute, must be under the terms of this License. You must inform recipients that the Source Code Form of the Covered Software is governed by the terms of this License, and how they can obtain a copy of this License. You may not attempt to alter or restrict the recipients' rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code Form, as described in Section 3.1, and You must inform recipients of the Executable Form how they can obtain a copy of such Source Code Form by reasonable means in a timely manner, at a charge no more than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this License, or sublicense it under different terms, provided that the license for the Executable Form does not attempt to limit or alter the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice, provided that You also comply with the requirements of this License for the Covered Software. If the Larger Work is a combination of Covered Software with a work governed by one or more Secondary Licenses, and the Covered Software is not Incompatible With Secondary Licenses, this License permits You to additionally distribute such Covered Software under the terms of such Secondary License(s), so that the recipient of the Larger Work may, at their option, further distribute the Covered Software under the terms of either this License or such Secondary License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices (including copyright notices, patent notices, disclaimers of warranty, or limitations of liability) contained within the Source Code Form of the Covered Software, except that You may alter any license notices to the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support, indemnity or liability obligations to one or more recipients of Covered Software. However, You may do so only on Your own behalf, and not on behalf of any Contributor. You must make it absolutely clear that any such warranty, support, indemnity, or liability obligation is offered by You alone, and You hereby agree to indemnify every Contributor for any liability incurred by such Contributor as a result of warranty, support, indemnity or liability terms You offer. You may include additional disclaimers of warranty and limitations of liability specific to any jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Covered Software due to statute, judicial order, or regulation then You must: (a) comply with the terms of this License to the maximum extent possible; and (b) describe the limitations and the code they affect. Such description must be placed in a text file included with all distributions of the Covered Software under this License. Except to the extent prohibited by statute or regulation, such description must be sufficiently detailed for a recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically if You fail to comply with any of its terms. However, if You become compliant, then the rights granted under this License from a particular Contributor are reinstated (a) provisionally, unless and until such Contributor explicitly and finally terminates Your grants, and (b) on an ongoing basis, if such Contributor fails to notify You of the non-compliance by some reasonable means prior to 60 days after You have come back into compliance. Moreover, Your grants from a particular Contributor are reinstated on an ongoing basis if such Contributor notifies You of the non-compliance by some reasonable means, this is the first time You have received notice of non-compliance with this License from such Contributor, and You become compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent infringement claim (excluding declaratory judgment actions, counter-claims, and cross-claims) alleging that a Contributor Version directly or indirectly infringes any patent, then the rights granted to You by any and all Contributors for the Covered Software under Section 2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user license agreements (excluding distributors and resellers) which have been validly granted by You or Your distributors under this License prior to termination shall survive termination.
+
+6. Disclaimer of Warranty
+-------------------------
+
+Covered Software is provided under this License on an "as is" basis, without warranty of any kind, either expressed, implied, or statutory, including, without limitation, warranties that the Covered Software is free of defects, merchantable, fit for a particular purpose or non-infringing. The entire risk as to the quality and performance of the Covered Software is with You. Should any Covered Software prove defective in any respect, You (not any Contributor) assume the cost of any necessary servicing, repair, or correction. This disclaimer of warranty constitutes an essential part of this License. No use of any Covered Software is authorized under this License except under this disclaimer.
+
+7. Limitation of Liability
+---------------------------
+
+Under no circumstances and under no legal theory, whether tort (including negligence), contract, or otherwise, shall any Contributor, or anyone who distributes Covered Software as permitted above, be liable to You for any direct, indirect, special, incidental, or consequential damages of any character including, without limitation, damages for lost profits, loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses, even if such party shall have been informed of the possibility of such damages. This limitation of liability shall not apply to liability for death or personal injury resulting from such party's negligence to the extent applicable law prohibits such limitation. Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the courts of a jurisdiction where the defendant maintains its principal place of business and such litigation shall be governed by laws of that jurisdiction, without reference to its conflict-of-law provisions. Nothing in this Section shall prevent a party's ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject matter hereof. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable. Any law or regulation which provides that the language of a contract shall be construed against the drafter shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section 10.3, no one other than the license steward has the right to modify or publish new versions of this License. Each version will be given a distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version of the License under which You originally received the Covered Software, or under the terms of any subsequent version published by the license steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to create a new license for such software, you may create and use a modified version of this License if you rename the license and remove any references to the name of the license steward (except to note that such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With Secondary Licenses under the terms of this version of the License, the notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+--------------------------------------------
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+----------------------------------------------------------
+
+This Source Code Form is "Incompatible With Secondary Licenses", as defined by the Mozilla Public License, v. 2.0.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ wrangler dev
 
 ## API Endpoints
 
-OpenVine uses two separate Cloudflare Workers with distinct domains for different purposes:
+diVine uses two separate Cloudflare Workers with distinct domains for different purposes:
 
 ### Main Backend API (`api.openvine.co`)
 
@@ -196,7 +196,7 @@ OpenVine uses two separate Cloudflare Workers with distinct domains for differen
 
 ## Bug Reporting
 
-OpenVine includes an encrypted bug reporting system that allows users to send diagnostic information directly to developers via NIP-17 private messages.
+diVine includes an encrypted bug reporting system that allows users to send diagnostic information directly to developers via NIP-17 private messages.
 
 ### How It Works
 
@@ -248,7 +248,7 @@ Reports include structured diagnostic data that helps with debugging and improvi
 We welcome contributions! Please see our **[Contributing Guide](CONTRIBUTING.md)** for detailed instructions on:
 
 - Setting up the development environment
-- Building Divine (OpenVine) from source
+- Building diVine from source
 - Setting up the Flutter Embedded Nostr Relay dependency
 - Running tests and code quality checks
 - Submitting pull requests
@@ -261,4 +261,6 @@ We welcome contributions! Please see our **[Contributing Guide](CONTRIBUTING.md)
 
 ## License
 
-ISC License
+Mozilla Public License 2.0
+
+This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/crawler/package.json
+++ b/crawler/package.json
@@ -8,6 +8,7 @@
     "start": "node crawler.js",
     "dev": "node --watch crawler.js"
   },
+  "license": "MPL-2.0",
   "dependencies": {
     "nostr-tools": "^1.17.0",
     "ws": "^8.14.2",

--- a/docs/MODERATION_COMPLETE_ARCHITECTURE.md
+++ b/docs/MODERATION_COMPLETE_ARCHITECTURE.md
@@ -1,10 +1,10 @@
-# OpenVine + Faro - Complete Moderation Architecture
+# diVine + Faro - Complete Moderation Architecture
 
 ## The Complete System
 
-OpenVine uses a **three-tier moderation architecture**:
+diVine uses a **three-tier moderation architecture**:
 
-1. **Mobile App (OpenVine)** - User-facing moderation and filtering
+1. **Mobile App (diVine)** - User-facing moderation and filtering
 2. **Faro** - Moderator tools for triaging reports and publishing labels
 3. **Nostr Network** - Decentralized event distribution
 
@@ -15,7 +15,7 @@ OpenVine uses a **three-tier moderation architecture**:
 │                                                               │
 │  User Reports Content                                        │
 │         ↓                                                     │
-│  OpenVine creates kind 1984 report event                    │
+│  diVine creates kind 1984 report event                    │
 │         ↓                                                     │
 │  Broadcast to Nostr relays                                   │
 │         ↓                                                     │
@@ -29,7 +29,7 @@ OpenVine uses a **three-tier moderation architecture**:
 │         ↓                                                     │
 │  Kind 1985 label broadcast to Nostr                         │
 │         ↓                                                     │
-│  OpenVine ModerationLabelService subscribes                 │
+│  diVine ModerationLabelService subscribes                 │
 │         ↓                                                     │
 │  Content automatically filtered in app                       │
 │                                                               │
@@ -38,7 +38,7 @@ OpenVine uses a **three-tier moderation architecture**:
 
 ## Component Roles
 
-### 1. OpenVine Mobile App (End Users)
+### 1. diVine Mobile App (End Users)
 
 **Creates Reports (kind 1984):**
 - `ContentReportingService` - User reports problematic content
@@ -101,7 +101,7 @@ OpenVine uses a **three-tier moderation architecture**:
 ### Example 1: User Reports NSFW Content
 
 ```
-1. User in OpenVine taps "Report" → "NSFW Content"
+1. User in diVine taps "Report" → "NSFW Content"
    ↓
 2. ContentReportingService creates kind 1984 event:
    {
@@ -131,7 +131,7 @@ OpenVine uses a **three-tier moderation architecture**:
      ]
    }
    ↓
-7. OpenVine ModerationLabelService receives label
+7. diVine ModerationLabelService receives label
    ↓
 8. Video automatically blurred for all users subscribed to this moderator
 ```
@@ -172,7 +172,7 @@ OpenVine uses a **three-tier moderation architecture**:
 5. All 50 accounts automatically muted in user's feed
 ```
 
-## OpenVine Services (Current State)
+## diVine Services (Current State)
 
 ### ✅ Implemented
 
@@ -190,19 +190,19 @@ OpenVine uses a **three-tier moderation architecture**:
 
 ## Faro Integration Points
 
-### How OpenVine Integrates with Faro
+### How diVine Integrates with Faro
 
 **1. Report Routing (kind 1984 → Faro)**
 
-OpenVine can tag reports to route to specific Faro instances:
+diVine can tag reports to route to specific Faro instances:
 ```dart
 // In ContentReportingService
 tags.add(['P', faroModeratorPubkey]); // Route to Faro moderator
 ```
 
-**2. Label Subscription (Faro → OpenVine)**
+**2. Label Subscription (Faro → diVine)**
 
-OpenVine subscribes to labels from trusted Faro moderators:
+diVine subscribes to labels from trusted Faro moderators:
 ```dart
 // In ModerationLabelService
 await service.subscribeToLabeler(faroModeratorPubkey);
@@ -211,21 +211,21 @@ await service.subscribeToLabeler(faroModeratorPubkey);
 **3. Multiple Faro Instances**
 
 Users can subscribe to multiple Faro moderators:
-- OpenVine official safety team
+- diVine official safety team
 - Community-run Faro instances
 - Niche moderators (tech, art, news, etc)
 - Up to 20 labelers (Bluesky pattern)
 
-### Faro Configuration in OpenVine
+### Faro Configuration in diVine
 
 ```dart
 // Default Faro moderators
 final defaultModerators = [
   ModeratorProfile(
     pubkey: 'openvine_faro_pubkey',
-    displayName: 'OpenVine Safety',
+    displayName: 'diVine Safety',
     faroUrl: 'https://faro.openvine.co',
-    description: 'Official OpenVine content safety team',
+    description: 'Official diVine content safety team',
     specialties: ['csam', 'illegal', 'violence'],
   ),
   ModeratorProfile(
@@ -240,7 +240,7 @@ final defaultModerators = [
 
 ## Trust & Safety Workflow
 
-### For Regular Users (OpenVine)
+### For Regular Users (diVine)
 
 1. **Report problematic content** - One tap, kind 1984 created
 2. **Subscribe to moderators** - Choose trusted Faro instances
@@ -279,7 +279,7 @@ final defaultModerators = [
 
 ## Implementation Status
 
-### OpenVine Mobile
+### diVine Mobile
 
 | Component | Status | Description |
 |-----------|--------|-------------|
@@ -301,7 +301,7 @@ final defaultModerators = [
 | DMCA Processing | ✅ | Legal compliance |
 | Admin APIs | ✅ | Takedown management |
 
-## Next Steps for OpenVine
+## Next Steps for diVine
 
 ### 1. ModerationFeedService (CRITICAL)
 
@@ -314,7 +314,7 @@ Implement coordinator that combines:
 ### 2. Faro Integration
 
 - Add Faro moderator discovery
-- Configure default OpenVine Faro instance
+- Configure default diVine Faro instance
 - Route reports to Faro with `P` tag
 - Subscribe to Faro labels automatically
 
@@ -336,7 +336,7 @@ Implement coordinator that combines:
 ## Architecture Advantages
 
 **Three-Tier Design:**
-1. **Users** (OpenVine) - Simple, one-tap reporting
+1. **Users** (diVine) - Simple, one-tap reporting
 2. **Moderators** (Faro) - Professional triage and labeling
 3. **Network** (Nostr) - Decentralized distribution
 
@@ -349,13 +349,13 @@ Implement coordinator that combines:
 
 **Compared to Centralized:**
 - Traditional: Reports → Backend → Admins → Decision
-- OpenVine + Faro: Reports → Nostr → Multiple Faro Instances → Labels → Users choose which to trust
+- diVine + Faro: Reports → Nostr → Multiple Faro Instances → Labels → Users choose which to trust
 
 ## Summary
 
 **Faro is the professional moderator interface** for triaging kind 1984 reports and publishing authoritative kind 1985 labels.
 
-**OpenVine is the end-user interface** that creates reports, subscribes to labels, and filters content.
+**diVine is the end-user interface** that creates reports, subscribes to labels, and filters content.
 
 Together they form a **decentralized, multi-stakeholder moderation system** where:
 - Users report easily
@@ -364,4 +364,4 @@ Together they form a **decentralized, multi-stakeholder moderation system** wher
 - Users choose which moderators to trust
 - No single point of control
 
-The missing piece in OpenVine is the **ModerationFeedService** coordinator that ties these systems together into a unified user experience.
+The missing piece in diVine is the **ModerationFeedService** coordinator that ties these systems together into a unified user experience.

--- a/docs/MODERATION_STATUS.md
+++ b/docs/MODERATION_STATUS.md
@@ -1,4 +1,4 @@
-# OpenVine Moderation System - Complete Status Report
+# diVine Moderation System - Complete Status Report
 
 ## What's Done ✅
 
@@ -219,7 +219,7 @@ ModerationResult checkContent(Event event) {
 ### Phase 6: Default Moderators (MEDIUM PRIORITY)
 
 **Bootstrap Data:**
-- OpenVine official safety team profile
+- diVine official safety team profile
 - Community-recommended labelers
 - Default subscriptions for new users
 

--- a/docs/riverpod.md
+++ b/docs/riverpod.md
@@ -1,4 +1,4 @@
-# OpenVine Riverpod Migration Plan
+# diVine Riverpod Migration Plan
 
 ## 🎯 Current Status: Phase 2 - VideoEventBridge Migration Complete ✅
 
@@ -29,7 +29,7 @@
 
 ## Executive Summary
 
-This document outlines the completed migration from Provider-based state management to Riverpod 2.0 for the OpenVine Flutter application. The migration successfully addresses critical architectural issues including manual state coordination, lack of reactive updates, and complex subscription management.
+This document outlines the completed migration from Provider-based state management to Riverpod 2.0 for the diVine Flutter application. The migration successfully addresses critical architectural issues including manual state coordination, lack of reactive updates, and complex subscription management.
 
 ### Problems Solved ✅
 - ✅ Manual coordination via VideoEventBridge **ELIMINATED**
@@ -781,7 +781,7 @@ Gradual Rollback (< 30 minutes):
 
 ## Conclusion
 
-This migration plan provides a comprehensive, low-risk path from Provider to Riverpod 2.0 that directly addresses OpenVine's current state management challenges. The phased approach ensures system stability while delivering significant architectural improvements.
+This migration plan provides a comprehensive, low-risk path from Provider to Riverpod 2.0 that directly addresses diVine's current state management challenges. The phased approach ensures system stability while delivering significant architectural improvements.
 
 The elimination of manual coordination via VideoEventBridge, combined with automatic reactive updates and simplified resource management, will dramatically improve both developer experience and application maintainability.
 

--- a/docs/test_recording_flow.md
+++ b/docs/test_recording_flow.md
@@ -1,4 +1,4 @@
-# OpenVine Recording and Publishing Flow Test
+# diVine Recording and Publishing Flow Test
 
 ## Test Date: 2025-01-18
 
@@ -12,7 +12,7 @@
 ### Test Steps:
 
 1. **Record Video**:
-   - Open OpenVine app on macOS
+   - Open diVine app on macOS
    - Click camera tab (center button)
    - Grant camera permission if prompted
    - Hold record button for 3-6 seconds

--- a/geo-blocker/package.json
+++ b/geo-blocker/package.json
@@ -7,6 +7,7 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy"
   },
+  "license": "MPL-2.0",
   "dependencies": {},
   "devDependencies": {
     "wrangler": "^3.0.0"

--- a/mobile/docs/BUG_REPORT_IMPLEMENTATION_CHECKLIST.md
+++ b/mobile/docs/BUG_REPORT_IMPLEMENTATION_CHECKLIST.md
@@ -26,7 +26,7 @@ grep -r "seal\|gift.*wrap" ../nostr_sdk/lib/nip59/
 ### 2. Set Up Bug Report Recipient
 
 **Action Required**:
-- [ ] Generate or obtain OpenVine support Nostr keypair
+- [ ] Generate or obtain diVine support Nostr keypair
 - [ ] Set pubkey in `lib/config/bug_report_config.dart`
 - [ ] Securely store nsec for decryption tool (Phase 7)
 - [ ] Test decryption manually with nostr client (e.g., nak, nostr-tools)

--- a/mobile/docs/BUG_REPORT_SYSTEM_ARCHITECTURE.md
+++ b/mobile/docs/BUG_REPORT_SYSTEM_ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Bug Report System Architecture for OpenVine
+# Bug Report System Architecture for diVine
 
 **Version**: 1.0
 **Author**: Architecture Design
@@ -7,7 +7,7 @@
 
 ## Executive Summary
 
-This document defines the complete architecture for OpenVine's user-initiated bug report system. The system enables users to send comprehensive diagnostic reports for non-crash issues using **NIP-17 encrypted messages** to OpenVine support.
+This document defines the complete architecture for diVine's user-initiated bug report system. The system enables users to send comprehensive diagnostic reports for non-crash issues using **NIP-17 encrypted messages** to diVine support.
 
 **Key Features**:
 - Circular buffer log capture (recent 1000 entries, ~1MB max)
@@ -35,7 +35,7 @@ This document defines the complete architecture for OpenVine's user-initiated bu
 
 ### Current Error Handling Ecosystem
 
-OpenVine already has robust error tracking:
+diVine already has robust error tracking:
 - **UnifiedLogger**: Structured logging with categories (relay, video, ui, auth, storage, api, system)
 - **ErrorAnalyticsTracker**: Comprehensive error tracking to Firebase Analytics
 - **Firebase Crashlytics**: Automatic crash reporting
@@ -204,7 +204,7 @@ class BugReportData {
   String toFormattedReport() {
     final buffer = StringBuffer();
 
-    buffer.writeln('🐛 OpenVine Bug Report');
+    buffer.writeln('🐛 diVine Bug Report');
     buffer.writeln('═' * 50);
     buffer.writeln('Report ID: $reportId');
     buffer.writeln('Timestamp: ${timestamp.toIso8601String()}');
@@ -390,7 +390,7 @@ class NIP17MessageService {
 
 /// Configuration for bug report system
 class BugReportConfig {
-  /// OpenVine support pubkey for receiving bug reports
+  /// diVine support pubkey for receiving bug reports
   static const String supportPubkey =
       'YOUR_SUPPORT_PUBKEY_HERE'; // TODO: Set actual support pubkey
 
@@ -942,7 +942,7 @@ String _sanitizeString(String input) {
 **Security Considerations**:
 - Bug reports contain diagnostic data - ensure user consent
 - Gift wrap relays cannot see sender or recipient
-- Only OpenVine support team can decrypt reports
+- Only diVine support team can decrypt reports
 - Reports are not stored locally (only in relay network)
 
 ### 7.3 User Consent
@@ -1016,7 +1016,7 @@ AlertDialog(
 ### 8.2 Phase 7: Support Dashboard
 
 **Recipient Decryption Tool**:
-- Web dashboard for OpenVine support team
+- Web dashboard for diVine support team
 - Decrypt NIP-17 bug reports
 - View formatted diagnostics
 - Link to GitHub issues
@@ -1031,7 +1031,7 @@ AlertDialog(
 
 ## Summary
 
-This architecture provides a **comprehensive, privacy-preserving bug report system** for OpenVine using NIP-17 encrypted messages. The phased TDD implementation ensures quality, while the three-layer encryption guarantees user privacy.
+This architecture provides a **comprehensive, privacy-preserving bug report system** for diVine using NIP-17 encrypted messages. The phased TDD implementation ensures quality, while the three-layer encryption guarantees user privacy.
 
 **Key Deliverables**:
 1. ✅ LogCaptureService - Circular buffer for logs

--- a/mobile/docs/MODERATION_SYSTEM_ARCHITECTURE.md
+++ b/mobile/docs/MODERATION_SYSTEM_ARCHITECTURE.md
@@ -1,8 +1,8 @@
-# OpenVine Moderation System Architecture
+# diVine Moderation System Architecture
 
 ## Overview
 
-OpenVine implements a **stackable, user-controlled moderation system** inspired by Bluesky's labeler architecture, using Nostr's NIP-32 (labeling) and NIP-56 (reporting) specifications.
+diVine implements a **stackable, user-controlled moderation system** inspired by Bluesky's labeler architecture, using Nostr's NIP-32 (labeling) and NIP-56 (reporting) specifications.
 
 ## Design Principles
 
@@ -16,7 +16,7 @@ OpenVine implements a **stackable, user-controlled moderation system** inspired 
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│           OpenVine Moderation Stack (Stackable)         │
+│           diVine Moderation Stack (Stackable)         │
 ├─────────────────────────────────────────────────────────┤
 │  Layer 1: Built-in Safety (Default, Always Active)     │
 │           - CSAM detection                               │
@@ -449,12 +449,12 @@ class ModerationPreferences {
 ### Default Moderators
 
 ```dart
-// OpenVine provides curated default moderators
+// diVine provides curated default moderators
 final defaultModerators = [
   ModeratorProfile(
     pubkey: 'openvine_safety_team_pubkey',
-    displayName: 'OpenVine Safety',
-    description: 'Official OpenVine content safety team',
+    displayName: 'diVine Safety',
+    description: 'Official diVine content safety team',
     specialties: ['csam', 'illegal', 'malware'],
     policy: ModerationPolicy(
       policyUrl: 'https://openvine.com/moderation-policy',
@@ -473,7 +473,7 @@ final defaultModerators = [
 To ensure compatibility with other Nostr clients:
 
 ```
-com.openvine.moderation.*  - OpenVine-specific
+com.openvine.moderation.*  - diVine-specific
 social.nos.moderation.*    - Nos client labels
 social.damus.moderation.*  - Damus client labels
 org.nostr.moderation.*     - Universal Nostr labels

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "license": "MPL-2.0",
   "dependencies": {
     "@nostr-dev-kit/ndk": "^2.14.32",
     "form-data": "^4.0.3",

--- a/website/docs/search_guide.md
+++ b/website/docs/search_guide.md
@@ -1,14 +1,14 @@
-# OpenVine Search Implementation Guide
+# diVine Search Implementation Guide
 
 ## Overview
 
-OpenVine implements comprehensive real-time search by connecting directly to Nostr relays and filtering events client-side. The search functionality queries for multiple event types including videos, playlists, and user profiles, providing instant results without requiring server-side infrastructure.
+diVine implements comprehensive real-time search by connecting directly to Nostr relays and filtering events client-side. The search functionality queries for multiple event types including videos, playlists, and user profiles, providing instant results without requiring server-side infrastructure.
 
 ## How It Works
 
 ### 1. Connection to Nostr Relay
 
-OpenVine connects to the `vine.hol.is` relay using WebSocket:
+diVine connects to the `vine.hol.is` relay using WebSocket:
 
 ```javascript
 const ws = new WebSocket('wss://vine.hol.is');
@@ -30,7 +30,7 @@ ws.send(JSON.stringify(['REQ', subscription.id, subscription]));
 
 ### 3. Client-Side Filtering
 
-Since vine.hol.is doesn't support NIP-50 (search capability), OpenVine filters events client-side by content type:
+Since vine.hol.is doesn't support NIP-50 (search capability), diVine filters events client-side by content type:
 
 ```javascript
 function processSearchEvent(event, searchQuery) {
@@ -380,7 +380,7 @@ async function signEvent(event, privateKeyHex) {
 ```json
 {
     "name": "vine.hol.is",
-    "description": "Groups relay for OpenVine",
+    "description": "Groups relay for diVine",
     "pubkey": "...",
     "contact": "...",
     "supported_nips": [1, 9, 11, 29, 40, 42, 70],

--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openvine-website",
   "version": "1.0.0",
-  "description": "OpenVine landing page - A decentralized vine-like video platform",
+  "description": "diVine landing page - A decentralized vine-like video platform",
   "main": "index.html",
   "scripts": {
     "dev": "npx live-server --port=8080",
@@ -14,8 +14,8 @@
     "video",
     "vine"
   ],
-  "author": "OpenVine Team",
-  "license": "MIT",
+  "author": "diVine Team",
+  "license": "MPL-2.0",
   "devDependencies": {
     "http-server": "^14.1.1",
     "live-server": "^1.2.2",

--- a/website/src/index.js
+++ b/website/src/index.js
@@ -1,4 +1,4 @@
-// ABOUTME: Cloudflare Workers entry point for OpenVine website
+// ABOUTME: Cloudflare Workers entry point for diVine website
 // ABOUTME: Serves static HTML files and handles routing
 
 export default {

--- a/website/test-analytics.html
+++ b/website/test-analytics.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Analytics API Test - OpenVine</title>
+    <title>Analytics API Test - diVine</title>
     <style>
         body {
             font-family: monospace;
@@ -55,7 +55,7 @@
 <body>
     <div class="container">
         <h1>🍇 Analytics API Test</h1>
-        <p>Testing OpenVine analytics endpoints and data integration</p>
+        <p>Testing diVine analytics endpoints and data integration</p>
         
         <div>
             <button onclick="testTrendingHashtags()">Test Trending Hashtags</button>

--- a/website/test-fallback.html
+++ b/website/test-fallback.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Test Fallback - OpenVine</title>
+    <title>Test Fallback - diVine</title>
 </head>
 <body>
     <h1>Fallback Video Test</h1>

--- a/website/test-nostr.html
+++ b/website/test-nostr.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OpenVine - Nostr Feed Test</title>
+    <title>diVine - Nostr Feed Test</title>
     <link rel="stylesheet" href="styles.css?v=2">
     <link rel="stylesheet" href="single-player-styles.css?v=2">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
-    <meta name="description" content="OpenVine - Testing Nostr video feed">
+    <meta name="description" content="diVine - Testing Nostr video feed">
 </head>
 <body>
     <header>
@@ -15,7 +15,7 @@
             <div class="nav-container">
                 <div class="logo">
                     <a href="index.html" style="text-decoration: none; color: inherit;">
-                        <h1>OpenVine</h1>
+                        <h1>diVine</h1>
                     </a>
                 </div>
                 <div class="nav-links">
@@ -78,7 +78,7 @@
     </main>
 
     <footer>
-        <p>Powered by Nostr Protocol | OpenVine 2024 | <a href="https://github.com/rabble/nostrvine" target="_blank">Source Code: GitHub</a></p>
+        <p>Powered by Nostr Protocol | diVine 2024 | <a href="https://github.com/rabble/nostrvine" target="_blank">Source Code: GitHub</a></p>
     </footer>
 
     <script src="nostr-video-player.js"></script>

--- a/website/test-watch.html
+++ b/website/test-watch.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OpenVine - Test Watch</title>
+    <title>diVine - Test Watch</title>
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="watch-styles.css">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
@@ -14,7 +14,7 @@
             <div class="nav-container">
                 <div class="logo">
                     <a href="index.html" style="text-decoration: none; color: inherit;">
-                        <h1>OpenVine</h1>
+                        <h1>diVine</h1>
                     </a>
                 </div>
                 <div class="nav-links">
@@ -108,7 +108,7 @@
     </main>
 
     <footer>
-        <p>Powered by Nostr Protocol | OpenVine 2024</p>
+        <p>Powered by Nostr Protocol | diVine 2024</p>
     </footer>
 
     <script src="nostr-viewer.js"></script>

--- a/website/trending-video-player.js
+++ b/website/trending-video-player.js
@@ -1,4 +1,4 @@
-// ABOUTME: Video player that loads trending videos from OpenVine analytics API
+// ABOUTME: Video player that loads trending videos from diVine analytics API
 // ABOUTME: Fetches and plays popular vine videos with view tracking
 
 const TRENDING_API = 'https://api.openvine.co/analytics/trending/vines';

--- a/website/trending.html
+++ b/website/trending.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OpenVine - Trending Videos</title>
+    <title>diVine - Trending Videos</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="main.css?v=1">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
-    <meta name="description" content="OpenVine - Watch trending vine videos">
+    <meta name="description" content="diVine - Watch trending vine videos">
 </head>
 <body>
     <header>
@@ -17,7 +17,7 @@
             <div class="nav-container">
                 <div class="logo">
                     <a href="index.html" style="text-decoration: none; color: inherit;">
-                        <h1>OpenVine</h1>
+                        <h1>diVine</h1>
                     </a>
                 </div>
                 <div class="nav-links">
@@ -34,7 +34,7 @@
         <section class="hero">
             <h2>🔥 Trending Vines</h2>
             <p style="color: white; margin-top: 1rem;">
-                Watch the hottest videos on OpenVine
+                Watch the hottest videos on diVine
             </p>
         </section>
 
@@ -84,7 +84,7 @@
     </main>
 
     <footer>
-        <p>Powered by Nostr Protocol | OpenVine 2024 | <a href="about.html">About OpenVine</a> | <a href="https://github.com/rabble/nostrvine" target="_blank">Source Code: GitHub</a></p>
+        <p>Powered by Nostr Protocol | diVine 2024 | <a href="about.html">About diVine</a> | <a href="https://github.com/rabble/nostrvine" target="_blank">Source Code: GitHub</a></p>
         <p>🌱 Liberating Vine, one loop at a time | Building a social media ecosystem where users have <a href="https://rights.social" target="_blank">rights</a></p>
     </footer>
 

--- a/website/vine-integration.js
+++ b/website/vine-integration.js
@@ -1,4 +1,4 @@
-// ABOUTME: JavaScript integration for Vine-inspired layout with OpenVine functionality
+// ABOUTME: JavaScript integration for Vine-inspired layout with diVine functionality
 // ABOUTME: Handles video playback, Nostr integration, and UI interactions
 
 // Constants

--- a/website/vine-player.js
+++ b/website/vine-player.js
@@ -1,4 +1,4 @@
-// ABOUTME: Simple video player for OpenVine without external dependencies
+// ABOUTME: Simple video player for diVine without external dependencies
 // ABOUTME: Handles autoplay, looping, and playlist management
 
 // Video playlist data - using new example videos

--- a/website/watch.html
+++ b/website/watch.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OpenVine - Watch</title>
+    <title>diVine - Watch</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Pacifico&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="main.css?v=1">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
-    <meta name="description" content="Watch Nostr video on OpenVine">
+    <meta name="description" content="Watch Nostr video on diVine">
 </head>
 <body>
     <header>
@@ -17,7 +17,7 @@
             <div class="nav-container">
                 <div class="logo">
                     <a href="index.html" style="text-decoration: none; color: inherit;">
-                        <h1>OpenVine</h1>
+                        <h1>diVine</h1>
                     </a>
                 </div>
                 <div class="nav-links">
@@ -98,7 +98,7 @@
     </main>
 
     <footer>
-        <p>Powered by Nostr Protocol | OpenVine 2024 | <a href="about.html">About OpenVine</a> | <a href="https://github.com/rabble/nostrvine" target="_blank">Source Code: GitHub</a></p>
+        <p>Powered by Nostr Protocol | diVine 2024 | <a href="about.html">About diVine</a> | <a href="https://github.com/rabble/nostrvine" target="_blank">Source Code: GitHub</a></p>
         <p>🌱 Liberating Vine, one loop at a time | Building a social media ecosystem where users have <a href="https://rights.social" target="_blank">rights</a></p>
     </footer>
 


### PR DESCRIPTION
## Summary

This PR updates the codebase license to Mozilla Public License 2.0 and rebrands all OpenVine references to diVine throughout the codebase.

## Changes

### License Update
- ✅ Updated LICENSE file to Mozilla Public License 2.0
- ✅ Updated all package.json files with MPL-2.0 license
- ✅ Updated README.md and CONTRIBUTING.md to reference MPL 2.0

### Branding Updates
- ✅ Replaced all OpenVine references with diVine in:
  - Documentation files (README, CONTRIBUTING, all docs/)
  - Website HTML files and user-facing text
  - Code comments and descriptions
  - Team references (OpenVine Team → diVine Team)

### Preserved (to avoid breaking code)
- Domain names (api.openvine.co, openvine.co, etc.)
- Package names (openvine-website, openvine-geo-blocker)
- Bundle identifiers (co.openvine.app)
- Technical variable names and identifiers
- URLs and API endpoints
- Email addresses

## Files Changed
25 files modified across documentation, website, and configuration files.

## Testing
- All changes are documentation and branding updates
- No code functionality affected
- Technical identifiers preserved to maintain compatibility