### PR TITLE
Fix/blossom server list

### DIFF
--- a/mobile/lib/screens/blossom_settings_screen.dart
+++ b/mobile/lib/screens/blossom_settings_screen.dart
@@ -64,7 +64,7 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
       if (uri == null || !uri.hasScheme || !uri.hasAuthority) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
-            content: Text('Please enter a valid server URL (e.g., https://blossom.divine.video)'),
+            content: Text('Please enter a valid server URL (e.g., https://blossom.band)'),
             backgroundColor: Colors.red,
           ),
         );
@@ -91,7 +91,7 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
-            content: Text('Blossom settings saved'),
+            content: Text('Blossom settings saved', style: TextStyle(color: Colors.white)),
             backgroundColor: VineTheme.vineGreen,
           ),
         );
@@ -149,13 +149,13 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
                     width: 20,
                     height: 20,
                     child: CircularProgressIndicator(
-                      color: VineTheme.vineGreen,
+                      color: Colors.white,
                       strokeWidth: 2,
                     ),
                   )
                 : const Text(
                     'Save',
-                    style: TextStyle(color: VineTheme.vineGreen),
+                    style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
                   ),
           ),
         ],
@@ -198,7 +198,7 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
                   const SizedBox(height: 12),
                   Text(
                     'Blossom is a decentralized media storage protocol that allows you to upload videos to any compatible server. '
-                    'When enabled, your videos will be uploaded to your chosen Blossom server instead of Divine\'s default storage.',
+                    'By default, videos are uploaded to diVine\'s Blossom server. Enable the option below to use a custom server instead.',
                     style: TextStyle(
                       color: Colors.white.withValues(alpha:0.8),
                       fontSize: 14,
@@ -213,23 +213,19 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
           // Enable/Disable toggle
           SwitchListTile(
             title: const Text(
-              'Use Blossom Upload',
+              'Use Custom Blossom Server',
               style: TextStyle(color: Colors.white, fontSize: 16),
             ),
             subtitle: Text(
               _isBlossomEnabled
-                  ? 'Videos will be uploaded to your Blossom server'
-                  : 'Videos will be uploaded to Divine\'s servers',
+                  ? 'Videos will be uploaded to your custom Blossom server'
+                  : 'Your videos are currently being uploaded to diVine\'s Blossom server',
               style: TextStyle(color: Colors.white.withValues(alpha:0.6)),
             ),
             value: _isBlossomEnabled,
             onChanged: (value) {
               setState(() {
                 _isBlossomEnabled = value;
-                // Set default server to diVine Blossom when enabling for the first time
-                if (value && _serverController.text.isEmpty) {
-                  _serverController.text = 'https://blossom.divine.video';
-                }
               });
             },
             activeThumbColor: VineTheme.vineGreen,
@@ -238,15 +234,13 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
           ),
           const SizedBox(height: 20),
 
-          // Server URL input
-          AnimatedOpacity(
-            opacity: _isBlossomEnabled ? 1.0 : 0.5,
-            duration: const Duration(milliseconds: 300),
-            child: Column(
+          // Server URL input (only shown when custom server is enabled)
+          if (_isBlossomEnabled) ...[
+            Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 const Text(
-                  'Blossom Server URL',
+                  'Custom Blossom Server URL',
                   style: TextStyle(
                     color: Colors.white,
                     fontSize: 16,
@@ -256,10 +250,9 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
                 const SizedBox(height: 8),
                 TextField(
                   controller: _serverController,
-                  enabled: _isBlossomEnabled,
                   style: const TextStyle(color: Colors.white),
                   decoration: InputDecoration(
-                    hintText: 'https://blossom.divine.video',
+                    hintText: 'https://blossom.band',
                     hintStyle: TextStyle(color: Colors.white.withValues(alpha:0.4)),
                     filled: true,
                     fillColor: Colors.white.withValues(alpha:0.1),
@@ -281,12 +274,6 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
                         color: VineTheme.vineGreen,
                       ),
                     ),
-                    disabledBorder: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(8),
-                      borderSide: BorderSide(
-                        color: Colors.grey.withValues(alpha:0.3),
-                      ),
-                    ),
                     prefixIcon: const Icon(
                       Icons.cloud_upload,
                       color: VineTheme.vineGreen,
@@ -297,7 +284,7 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  'Enter the URL of your Blossom server',
+                  'Enter the URL of your custom Blossom server',
                   style: TextStyle(
                     color: Colors.white.withValues(alpha:0.6),
                     fontSize: 12,
@@ -305,11 +292,9 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
                 ),
               ],
             ),
-          ),
-          const SizedBox(height: 30),
+            const SizedBox(height: 30),
 
-          // Popular Blossom servers section
-          if (_isBlossomEnabled) ...[
+            // Popular Blossom servers section
             const Text(
               'Popular Blossom Servers',
               style: TextStyle(
@@ -319,7 +304,6 @@ class _BlossomSettingsScreenState extends ConsumerState<BlossomSettingsScreen> {
               ),
             ),
             const SizedBox(height: 12),
-            _buildServerOption('https://blossom.divine.video', 'diVine Blossom (Default)'),
             _buildServerOption('https://blossom.band', 'Blossom Band'),
             _buildServerOption('https://cdn.satellite.earth', 'Satellite Earth'),
             _buildServerOption('https://blossom.primal.net', 'Primal'),

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -574,18 +574,23 @@ class UploadManager {
       Log.info('🌸 Using Blossom upload service',
           name: 'UploadManager', category: LogCategory.video);
 
-      final isBlossomEnabled = await _blossomService.isBlossomEnabled();
-      if (!isBlossomEnabled) {
-        throw Exception('Blossom upload is disabled. Please configure Blossom server in settings.');
-      }
+      // Check if custom server is enabled, otherwise use default diVine server
+      final isCustomServerEnabled = await _blossomService.isBlossomEnabled();
+      String blossomServer;
 
-      final blossomServer = await _blossomService.getBlossomServer();
-      if (blossomServer == null || blossomServer.isEmpty) {
-        throw Exception('No Blossom server configured. Please configure Blossom server in settings.');
+      if (isCustomServerEnabled) {
+        final customServer = await _blossomService.getBlossomServer();
+        if (customServer == null || customServer.isEmpty) {
+          throw Exception('Custom Blossom server enabled but not configured. Please configure a server in settings.');
+        }
+        blossomServer = customServer;
+        Log.info('🌸 Uploading to custom Blossom server: $blossomServer',
+            name: 'UploadManager', category: LogCategory.video);
+      } else {
+        blossomServer = 'https://blossom.divine.video';
+        Log.info('🌸 Uploading to default diVine Blossom server: $blossomServer',
+            name: 'UploadManager', category: LogCategory.video);
       }
-
-      Log.info('🌸 Uploading to Blossom server: $blossomServer',
-          name: 'UploadManager', category: LogCategory.video);
 
       final result = await _blossomService.uploadVideo(
         videoFile: videoFile,


### PR DESCRIPTION
The wording for the Blossom settings page was confusing. I updated the default toggle to default to using diVine's Blossom and then allowing the user to switch to their own Custom Blossom. I updated the list of Custom Blossom servers, removing ones that were not Blossom (they were NIP-96) and added ones that were and moved from POST to PUT methods. Tested successfully.