### PR TITLE
fix: Pull to refresh on the explore screen

### DIFF
--- a/mobile/lib/screens/explore_screen.dart
+++ b/mobile/lib/screens/explore_screen.dart
@@ -1156,8 +1156,7 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
           await ref.read(popularNowFeedProvider.notifier).refresh();
         } else {
           // For Trending tab, refresh video events
-          ref.invalidate(videoEventsProvider);
-          await ref.read(videoEventsProvider.future);
+          final _ = await ref.refresh(videoEventsProvider);
         }
       },
       emptyBuilder: () => Center(


### PR DESCRIPTION
Uses a `ref.refresh` to do the pull to refresh on the explore trending tab since it is a more reliable way of doing so.

Previous we were doing a `ref.invalidate` and reading the future to the provider to do that, and that future would never complete, causing the pull to refresh to remain on screen forever

Fixes #195 