### PR TITLE
fix: rename client tag from openvine to diVine

### DIFF
--- a/mobile/docs/BUG_REPORT_SYSTEM_ARCHITECTURE.md
+++ b/mobile/docs/BUG_REPORT_SYSTEM_ARCHITECTURE.md
@@ -353,7 +353,7 @@ class NIP17MessageService {
       'created_at': (DateTime.now().millisecondsSinceEpoch ~/ 1000),
       'tags': [
         ['p', recipientPubkey],
-        ['client', 'openvine_bug_report'],
+        ['client', 'diVine_bug_report'],
         ...additionalTags,
       ],
     };

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -519,7 +519,7 @@ class BookmarkService with NostrListServiceMixin {
 
       // Create NIP-51 kind 10003 tags
       final tags = <List<String>>[
-        ['client', 'openvine'],
+        ['client', 'diVine'],
       ];
 
       // Add bookmark items as tags
@@ -559,7 +559,7 @@ class BookmarkService with NostrListServiceMixin {
       final tags = <List<String>>[
         ['d', set.id], // Identifier for replaceable event
         ['title', set.name],
-        ['client', 'openvine'],
+        ['client', 'diVine'],
       ];
 
       // Add description if present

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -266,7 +266,7 @@ class BugReportService {
         recipientPubkey: recipientPubkey,
         content: messageContent,
         additionalTags: [
-          ['client', 'openvine_bug_report'],
+          ['client', 'diVine_bug_report'],
           ['report_id', data.reportId],
           ['app_version', data.appVersion],
           if (bugReportUrl != null) ['bug_report_url', bugReportUrl],

--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -236,7 +236,7 @@ class ContentDeletionService {
       // Build NIP-09 compliant tags (kind 5)
       final tags = <List<String>>[
         ['e', originalEventId], // Event being deleted
-        ['client', 'openvine'], // Deleting client
+        ['client', 'diVine'], // Deleting client
       ];
 
       // Add additional context as tags if provided

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -317,7 +317,7 @@ class ContentReportingService {
         ['e', eventId], // Event being reported
         ['p', authorPubkey], // Author of reported content
         ['report', reason.name], // Report reason as per NIP-56
-        ['client', 'openvine'], // Reporting client
+        ['client', 'diVine'], // Reporting client
       ];
 
       // Add hashtags as 't' tags

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -806,7 +806,7 @@ class CuratedListService {
       final tags = <List<String>>[
         ['d', list.id], // Identifier for replaceable event
         ['title', list.name],
-        ['client', 'openvine'],
+        ['client', 'diVine'],
       ];
 
       // Add description if present

--- a/mobile/lib/services/curation_service.dart
+++ b/mobile/lib/services/curation_service.dart
@@ -780,7 +780,7 @@ class CurationService {
     final tags = <List<String>>[
       ['d', id], // Replaceable event identifier
       ['title', title],
-      ['client', 'openvine'], // Attribution
+      ['client', 'diVine'], // Attribution
     ];
 
     if (description != null) {

--- a/mobile/lib/services/mute_service.dart
+++ b/mobile/lib/services/mute_service.dart
@@ -445,7 +445,7 @@ class MuteService {
 
       // Create NIP-51 kind 10000 tags
       final tags = <List<String>>[
-        ['client', 'openvine'],
+        ['client', 'diVine'],
       ];
 
       // Add muted items as tags (only non-expired, permanent mutes for Nostr)

--- a/mobile/lib/services/social_service.dart
+++ b/mobile/lib/services/social_service.dart
@@ -1241,7 +1241,7 @@ class SocialService {
       final tags = <List<String>>[
         ['d', set.id], // Identifier for replaceable event
         ['title', set.name],
-        ['client', 'openvine'],
+        ['client', 'diVine'],
       ];
 
       // Add description if present

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -358,7 +358,7 @@ class VideoEventPublisher {
       }
 
       // Add client tag
-      tags.add(['client', 'openvine']);
+      tags.add(['client', 'diVine']);
 
       // Add published_at tag (current timestamp)
       tags.add([

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -92,7 +92,7 @@ class VideoSharingService {
       // Create NIP-04 encrypted DM (kind 4)
       final tags = <List<String>>[
         ['p', recipientPubkey], // Recipient
-        ['client', 'openvine'],
+        ['client', 'diVine'],
       ];
 
       // Add video reference as tag

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -2356,7 +2356,7 @@ class _EditVideoDialogState extends ConsumerState<_EditVideoDialog> {
       }
 
       // Add client tag
-      tags.add(['client', 'openvine']);
+      tags.add(['client', 'diVine']);
 
       // Create and sign the updated event
       final content = _descriptionController.text.trim();

--- a/mobile/test/integration/vine_tag_integration_test.dart
+++ b/mobile/test/integration/vine_tag_integration_test.dart
@@ -97,7 +97,7 @@ void main() {
         [
           ['h', 'vine'],
           ['url', 'https://example.com/video.mp4'],
-          ['client', 'openvine'],
+          ['client', 'diVine'],
           ['expiration', '${(DateTime.now().millisecondsSinceEpoch ~/ 1000) + 3600}'],
         ],
         'Test video content',
@@ -110,7 +110,7 @@ void main() {
         22,
         [
           ['url', 'https://example.com/video.mp4'],
-          ['client', 'openvine'],
+          ['client', 'diVine'],
           ['expiration', '${(DateTime.now().millisecondsSinceEpoch ~/ 1000) + 3600}'],
         ],
         'Test video content',

--- a/mobile/test/services/curation_publish_test.dart
+++ b/mobile/test/services/curation_publish_test.dart
@@ -147,7 +147,7 @@ void main() {
         expect(event, isNotNull);
 
         // Should include client tag
-        expect(event!.tags, contains(['client', 'openvine']));
+        expect(event!.tags, contains(['client', 'diVine']));
       });
     });
 

--- a/mobile/test/services/vine_tag_requirement_test.dart
+++ b/mobile/test/services/vine_tag_requirement_test.dart
@@ -63,7 +63,7 @@ void main() {
     test('vine tag should be automatically added to existing tags', () async {
       // Simulate adding vine tag to existing tags
       final existingTags = [
-        ['client', 'openvine'],
+        ['client', 'diVine'],
         ['t', 'hashtag'],
         ['p', 'somepubkey'],
       ];
@@ -72,7 +72,7 @@ void main() {
       finalTags.add(['h', 'vine']);
 
       expect(finalTags, containsOnce(['h', 'vine']));
-      expect(finalTags, containsOnce(['client', 'openvine']));
+      expect(finalTags, containsOnce(['client', 'diVine']));
       expect(finalTags, containsOnce(['t', 'hashtag']));
       expect(finalTags, containsOnce(['p', 'somepubkey']));
 

--- a/mobile/test/unit/curated_list_relay_sync_test.dart
+++ b/mobile/test/unit/curated_list_relay_sync_test.dart
@@ -116,7 +116,7 @@ void main() {
           ['t', 'demo'],
           ['e', 'video1'],
           ['e', 'video2'],
-          ['client', 'openvine'],
+          ['client', 'diVine'],
           ['expiration', '${(DateTime.now().millisecondsSinceEpoch ~/ 1000) + 3600}'],
         ],
         'Test curated list',

--- a/mobile/test/unit/services/nip17_message_service_test.dart
+++ b/mobile/test/unit/services/nip17_message_service_test.dart
@@ -263,7 +263,7 @@ void main() {
         recipientPubkey: recipientPubkey,
         content: 'Test message',
         additionalTags: [
-          ['client', 'openvine_bug_report'],
+          ['client', 'diVine_bug_report'],
           ['report_id', 'test-123'],
         ],
       );


### PR DESCRIPTION
Update all Nostr event client tags to use the current app name "diVine" instead of the legacy "openvine" name.