### PR TITLE
fix: upload-artifacts deprecation

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -88,14 +88,14 @@ jobs:
     
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: test-results
         path: mobile/test-results/
     
     - name: Upload coverage report
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: mobile/coverage/


### PR DESCRIPTION
Fixes #259 by upgrading `upload-artifacts` to v4 in a GH Actions workflow.
