### PR TITLE
fix: public lists loading indifinitely

### DIFF
--- a/mobile/lib/providers/list_providers.dart
+++ b/mobile/lib/providers/list_providers.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Riverpod providers for user lists (kind 30000) and curated video lists (kind 30005)
 // ABOUTME: Manages list state and provides reactive updates for the Lists tab
 
+import 'dart:async';
+
 import 'package:openvine/models/video_event.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/video_events_providers.dart';
@@ -90,11 +92,15 @@ Stream<List<CuratedList>> publicListsContainingVideo(
   String videoId,
 ) async* {
   final service = await ref.watch(curatedListServiceProvider.future);
+  final curatedListStream = service.streamPublicListsContainingVideo(videoId);
   final accumulated = <CuratedList>[];
   final seenIds = <String>{};
 
+  // Yield an initial value to avoid hanging if the stream is empty
+  yield const <CuratedList>[];
+
   // Stream events from Nostr relays, accumulating as they arrive
-  await for (final list in service.streamPublicListsContainingVideo(videoId)) {
+  await for (final list in curatedListStream) {
     if (!seenIds.contains(list.id)) {
       seenIds.add(list.id);
       accumulated.add(list);

--- a/mobile/lib/providers/list_providers.g.dart
+++ b/mobile/lib/providers/list_providers.g.dart
@@ -392,7 +392,7 @@ final class PublicListsContainingVideoProvider
 }
 
 String _$publicListsContainingVideoHash() =>
-    r'56a96d33f61a940b6338feb6f6f22ef371cc07f2';
+    r'3b529d01bfb47dba5d78907674eb3cc28939c8ba';
 
 /// Provider that streams public lists containing a specific video
 /// Accumulates results as they arrive from Nostr relays, yielding updated list

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -3075,7 +3075,7 @@ class _PublicListsSectionState extends ConsumerState<_PublicListsSection> {
     );
 
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         const Text(
           'Public Lists',


### PR DESCRIPTION
Fix "Public Lists" section loading indefinitely in the video sharing page.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

If a video has not been added to any lists, the publicListsContainingVideo provider will never 
exit its `AsyncLoading` state because it will indefinitely wait for events.

This PR adds an "initial value" to the stream so that there is always at least one value.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #219

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
