### PR TITLE
fix: share menu closes after os share

### DIFF
--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -857,10 +857,6 @@ class _ShareVideoMenuState extends ConsumerState<ShareVideoMenu> {
       final shareText = sharingService.generateShareText(widget.video);
 
       await SharePlus.instance.share(ShareParams(text: shareText));
-
-      if (mounted) {
-        Navigator.of(context).pop();
-      }
     } catch (e) {
       Log.error(
         'Failed to share externally: $e',


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Don't close the video's share menu after closing the "share externally" menu.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #227

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
