### PR TITLE
fix: Correctly handling camera switch to avoid camera controls inconsistency

### DIFF
--- a/mobile/lib/services/camera/camerawesome_mobile_camera_interface.dart
+++ b/mobile/lib/services/camera/camerawesome_mobile_camera_interface.dart
@@ -321,16 +321,19 @@ class CamerAwesomeMobileCameraInterface extends CameraPlatformInterface {
         category: LogCategory.system,
       );
 
+      // Toggle our tracking state
+      _isFrontCamera = !_isFrontCamera;
+
       // Use CamerAwesome's built-in switchCameraSensor which properly handles
       // front/back camera switching with correct surface management
       await _cameraState!.switchCameraSensor(
         aspectRatio: CameraAspectRatios.ratio_16_9,
         zoom: 0.0,
-        flash: FlashMode.none,
+        // Internally in the CamerAwesome code a FlasMode.none is treated as "auto",
+        // And no flash mode is allowed for front camera, so we set null when changing to
+        // the front camera to ensure no errors occur.
+        flash: _isFrontCamera ? null : FlashMode.none,
       );
-
-      // Toggle our tracking state
-      _isFrontCamera = !_isFrontCamera;
 
       if (!_isFrontCamera) {
         // Switched back to rear - restore the last rear camera index


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Before, when switching the camera back and forth the camera controls would be inconsistent with what the selected camera supported.

That happened only on iOS and the cause for that was that a wrong value would be passed in the switch camera method, causing an exception to occur on the native layer, leaving the controls configuration inconsistent

**Related Issue:** Closes #383 


https://github.com/user-attachments/assets/912a1a6f-b7a7-4c86-bae7-8b2ef823ef40



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore