### PR TITLE
ci: enforce warnings and infos as fatal in flutter analyze

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -35,4 +35,4 @@ jobs:
         run: dart format --output=none --set-exit-if-changed lib test
 
       - name: 🕵️ Analyze code
-        run: flutter analyze --no-fatal-warnings --no-fatal-infos lib test
+        run: flutter analyze lib test

--- a/.github/workflows/models_ci.yaml
+++ b/.github/workflows/models_ci.yaml
@@ -44,7 +44,7 @@ jobs:
               run: dart format --output=none --set-exit-if-changed lib test
 
             - name: 🕵️ Analyze code
-              run: flutter analyze --no-fatal-warnings --no-fatal-infos lib test
+              run: flutter analyze lib test
 
             - name: 🧪 Run tests
               run: flutter test

--- a/mobile/packages/models/test/src/divine_filter_test.dart
+++ b/mobile/packages/models/test/src/divine_filter_test.dart
@@ -3,6 +3,7 @@
 
 // No need for const constructors in tests
 // ignore_for_file: prefer_const_constructors
+// ignore_for_file: avoid_dynamic_calls
 
 import 'package:models/models.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';

--- a/mobile/packages/models/test/src/gateway_response_test.dart
+++ b/mobile/packages/models/test/src/gateway_response_test.dart
@@ -1,5 +1,6 @@
 // ABOUTME: Tests for GatewayResponse model parsing
 // ABOUTME: Validates JSON deserialization from REST gateway responses
+// ignore_for_file: inference_failure_on_collection_literal
 
 import 'package:models/models.dart';
 import 'package:test/test.dart';

--- a/mobile/packages/models/test/src/pending_upload_proofmode_test.dart
+++ b/mobile/packages/models/test/src/pending_upload_proofmode_test.dart
@@ -1,5 +1,6 @@
 // ABOUTME: Unit tests for ProofMode integration with PendingUpload model
-// ABOUTME: Tests serialization, deserialization, and helper methods for NativeProofData storage
+// ABOUTME: Tests serialization/deserialization and helper methods for NativeProofData
+// ignore_for_file: lines_longer_than_80_chars
 
 import 'dart:convert';
 

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -1,5 +1,6 @@
-// ABOUTME: Tests for VideoEvent parsing from Nostr events, including streaming formats
-// ABOUTME: Verifies support for divine.video schema and open protocol URL validation
+// ABOUTME: Tests for VideoEvent parsing from Nostr events
+// ABOUTME: Verifies divine.video schema and open protocol URL validation
+// ignore_for_file: lines_longer_than_80_chars
 
 import 'package:models/models.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';

--- a/mobile/packages/models/test/src/vine_draft_publish_status_test.dart
+++ b/mobile/packages/models/test/src/vine_draft_publish_status_test.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Tests for PublishStatus enum and publish tracking fields in VineDraft
+// ABOUTME: Tests for PublishStatus enum and publish tracking in VineDraft
 // ABOUTME: Validates serialization, migration, and status lifecycle
 
 import 'dart:io';

--- a/mobile/test/services/content_moderation_service_nip51_test.mocks.dart
+++ b/mobile/test/services/content_moderation_service_nip51_test.mocks.dart
@@ -3,6 +3,7 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+// ignore_for_file: unused_shown_name
 import 'dart:async' as _i5;
 
 import 'package:mockito/mockito.dart' as _i1;


### PR DESCRIPTION
Remove --no-fatal-warnings --no-fatal-infos flags from CI workflows so that flutter analyze treats all warnings and info messages as failures. This ensures code quality issues are caught early.

Also adds lint ignore directives to test files where appropriate:
- avoid_dynamic_calls in divine_filter_test.dart
- inference_failure_on_collection_literal in gateway_response_test.dart
- lines_longer_than_80_chars in test files with long ABOUTME comments
- unused_shown_name in generated mock files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore