### PR TITLE
fix: Correct navigation on record video button on empty drafts screen

### DIFF
--- a/mobile/lib/screens/vine_drafts_screen.dart
+++ b/mobile/lib/screens/vine_drafts_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/models/vine_draft.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/router/nav_extensions.dart';
 import 'package:openvine/screens/pure/video_metadata_screen_pure.dart';
 import 'package:openvine/theme/vine_theme.dart';
 
@@ -141,13 +142,7 @@ class _VineDraftsScreenState extends ConsumerState<VineDraftsScreen> {
         const SizedBox(height: 32),
         ElevatedButton.icon(
           onPressed: () {
-            // Wait for navigation animation to complete before allowing camera FAB to push
-            // This prevents navigation timing race condition that causes black screens
-            WidgetsBinding.instance.addPostFrameCallback((_) {
-              if (mounted) {
-                Navigator.of(context).pop();
-              }
-            });
+            context.pushCamera();
           },
           icon: const Icon(Icons.videocam),
           label: const Text('Record a Video'),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Before, when tapping the Record video button on the empty drafts state screen, the user would go be sent to an invalid route, leaving them in a black screen.

This PR fixes it.

**Related Issue:** Closes #396 


https://github.com/user-attachments/assets/088f0be0-a386-42c1-93ba-42fd892f9526



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore