### PR TITLE
fix: Comments error when opening a second time

### DIFF
--- a/mobile/lib/services/social_service.dart
+++ b/mobile/lib/services/social_service.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/immediate_completion_helper.dart';
@@ -1641,6 +1642,7 @@ class SocialService {
   }
 
   // === COMMENT SYSTEM ===
+  final Map<String, ReplaySubject<Event>> _commentSubjects = {};
 
   /// Posts a comment in reply to a root event (video)
   Future<void> postComment({
@@ -1745,7 +1747,10 @@ class SocialService {
     );
 
     // Create a StreamController to emit events
-    final controller = StreamController<Event>();
+    final controller = _commentSubjects.putIfAbsent(
+      rootEventId,
+      () => ReplaySubject<Event>(),
+    );
 
     // Create managed subscription for comments
     // NOTE: No onComplete callback - keep subscription open for real-time comments

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1624,7 +1624,7 @@ packages:
     source: hosted
     version: "3.0.3"
   rxdart:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       name: rxdart
       sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   riverpod_annotation: ^3.0.0
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
+  rxdart: ^0.28.0
 
   # Networking
   http: ^1.5.0


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

**Related Issue:** Part of #448 

Fix a bug that if you opened the comments from a video a second time, no comments would be loaded.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore