### PR TITLE
fix: prevent navigation blocking when switching between tabs

### DIFF
--- a/mobile/lib/screens/explore_screen_router.dart
+++ b/mobile/lib/screens/explore_screen_router.dart
@@ -39,9 +39,10 @@ class _ExploreScreenRouterState extends ConsumerState<ExploreScreenRouter>
     return buildAsyncUI(
       pageContext,
       onData: (ctx) {
-        // Only handle explore routes
+        // Only handle explore routes - if we receive a non-explore route, the user
+        // is navigating away and this widget is being unmounted. Return empty.
         if (ctx.type != RouteType.explore) {
-          return const Center(child: Text('Not an explore route'));
+          return const SizedBox.shrink();
         }
 
         int urlIndex = 0;

--- a/mobile/lib/screens/hashtag_screen_router.dart
+++ b/mobile/lib/screens/hashtag_screen_router.dart
@@ -28,13 +28,10 @@ class _HashtagScreenRouterState extends ConsumerState<HashtagScreenRouter>
   Widget build(BuildContext context) {
     final routeCtx = ref.watch(pageContextProvider).asData?.value;
 
+    // If route context is null or not a hashtag route, the user is navigating
+    // away and this widget is being unmounted. Return empty container.
     if (routeCtx == null || routeCtx.type != RouteType.hashtag) {
-      Log.warning(
-        'HashtagScreenRouter: Invalid route context',
-        name: 'HashtagRouter',
-        category: LogCategory.ui,
-      );
-      return const Scaffold(body: Center(child: Text('Invalid hashtag route')));
+      return const SizedBox.shrink();
     }
 
     final hashtag = routeCtx.hashtag ?? 'trending';

--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -136,9 +136,10 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
     return buildAsyncUI(
       pageContext,
       onData: (ctx) {
-        // Only handle profile routes
+        // Only handle profile routes - if we receive a non-profile route, the user
+        // is navigating away and this widget is being unmounted. Return empty.
         if (ctx.type != RouteType.profile) {
-          return const Center(child: Text('Not a profile route'));
+          return const SizedBox.shrink();
         }
 
         // Convert npub to hex for profile feed provider


### PR DESCRIPTION
## Summary

- **Fixed critical navigation bug** where tapping the Explore tab would redirect back to Home
- Screen routers watch `pageContextProvider` which emits the current route type globally
- When navigating away, old screens received the new route type and either:
  - **HomeScreenRouter**: Redirected back to `/home/0` (blocking navigation entirely)
  - **Other routers**: Showed visible error text during transition

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `home_screen_router.dart` | Redirect loop blocked tab switching | Return `SizedBox.shrink()` |
| `explore_screen_router.dart` | Showed "Not an explore route" text | Return `SizedBox.shrink()` |
| `profile_screen_router.dart` | Showed "Not a profile route" text | Return `SizedBox.shrink()` |
| `hashtag_screen_router.dart` | Showed "Invalid hashtag route" in Scaffold | Return `SizedBox.shrink()` |

## Root Cause

When a screen receives a route type it doesn't handle, the user is navigating **away** - the widget is being unmounted. The correct behavior is to return an empty container and let navigation complete naturally.

## Test plan

- [ ] Tap Home tab → Tap Explore tab → Should navigate to Explore (not bounce back)
- [ ] Tap Explore tab → Tap Profile tab → Should navigate to Profile
- [ ] Tap Profile tab → Tap Home tab → Should navigate to Home
- [ ] Navigate to hashtag screen → Tap any tab → Should navigate correctly
- [ ] No flash of error text during any tab transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)