### PR TITLE
fix: text overflow in delete all content warning

### DIFF
--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -77,6 +77,7 @@ Future<void> showDeleteAllContentWarningDialog({
           fontWeight: FontWeight.bold,
         ),
       ),
+      scrollable: true,
       content: const Text(
         'WARNING: This action is PERMANENT and CANNOT be undone!\n\n'
         'This will:\n'
@@ -88,7 +89,6 @@ Future<void> showDeleteAllContentWarningDialog({
         'This is IRREVERSIBLE. Are you ABSOLUTELY CERTAIN?',
         style: TextStyle(color: Colors.white, fontSize: 16, height: 1.5),
       ),
-      scrollable: true,
       actions: [
         TextButton(
           onPressed: () => context.pop(),


### PR DESCRIPTION
A text overflow error occurred when trying to Delete Account and Data

## Description

If you go to the app's Settings page and select Delete Account and Data, the popup that gets displayed was not able to display its content in the available space

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore