### PR TITLE
fix: tapping "Contact Support" from app drawer

### DIFF
--- a/mobile/lib/widgets/vine_drawer.dart
+++ b/mobile/lib/widgets/vine_drawer.dart
@@ -189,13 +189,13 @@ class _VineDrawerState extends ConsumerState<VineDrawer> {
                       final userPubkey = authService.currentPublicKeyHex;
 
                       // Get root context before closing drawer
-                      final navigator = Navigator.of(context);
+                      final navigatorContext = Navigator.of(context).context;
 
                       context.pop(); // Close drawer
 
                       // Wait for drawer close animation
                       await Future.delayed(const Duration(milliseconds: 300));
-                      if (!navigator.context.mounted) {
+                      if (!navigatorContext.mounted) {
                         print('⚠️ Context not mounted after drawer close');
                         return;
                       }
@@ -203,7 +203,7 @@ class _VineDrawerState extends ConsumerState<VineDrawer> {
                       // Show support options dialog using root context
                       // Pass captured services instead of ref
                       _showSupportOptionsDialog(
-                        navigator.context,
+                        navigatorContext,
                         bugReportService,
                         userPubkey,
                         isZendeskAvailable,


### PR DESCRIPTION
When tapping "Contact Support" from the app drawer, sometimes a popup dialog was displayed and sometimes nothing happened. Once the dialog was displayed, a layout overflow could occur.

## Description
Using navigator.context instead of rootContext resolves the issue.

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore