### PR TITLE
fix: back button appears in explore and notifications tab

### DIFF
--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -226,10 +226,12 @@ class AppShell extends ConsumerWidget {
         final isExploreVideo =
             ctx.type == RouteType.explore && ctx.videoIndex != null;
         // Notifications base state is index 0, not null
-        final isNotificationVideo = ctx.type == RouteType.notifications &&
+        final isNotificationVideo =
+            ctx.type == RouteType.notifications &&
             ctx.videoIndex != null &&
             ctx.videoIndex != 0;
-        final isOtherUserProfile = ctx.type == RouteType.profile &&
+        final isOtherUserProfile =
+            ctx.type == RouteType.profile &&
             ctx.npub != ref.read(authServiceProvider).currentNpub;
         final isProfileVideo =
             ctx.type == RouteType.profile && ctx.videoIndex != null;


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

**Related Issue:** Closes #779

Back button should be displayed only when navigating to a sub route 

Note: this does not fix issue with Android back button

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore