### PR TITLE
feat: added a semantic "identifier" for the UserProfileTile for testing.

### DIFF
--- a/mobile/lib/widgets/user_profile_tile.dart
+++ b/mobile/lib/widgets/user_profile_tile.dart
@@ -53,7 +53,7 @@ class UserProfileTile extends ConsumerWidget {
         // wrapping with Semantics for testability and accessibility
         return Semantics(
           identifier: 'user_profile_tile_$pubkey',
-          label: profile?.betterDisplayName('Unknown'),
+          label: profile?.bestDisplayName ?? 'Loading...',
           container: true,
           explicitChildNodes: false,
           child: Container(


### PR DESCRIPTION
Added an identifier to the Semantics label for the UserProfileTile to assist with testing.

## Description

The Semantic widget was added recently to the UserProfileTile, however, it only had a label.  For testing, they need it to also have an identifier.

**Related Issue:** Closes #716

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore