### PR TITLE
fix: video resume after closing a modal

### DIFF
--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -963,7 +963,7 @@ class VideoOverlayActions extends ConsumerWidget {
           right: 16,
           child: GestureDetector(
             onTap: () {
-              _showBadgeExplanationModal(context, ref, video);
+              _showBadgeExplanationModal(context, ref, video, isActive);
             },
             child: ProofModeBadgeRow(video: video, size: BadgeSize.small),
           ),
@@ -1356,7 +1356,7 @@ class VideoOverlayActions extends ConsumerWidget {
                               name: 'VideoFeedItem',
                               category: LogCategory.ui,
                             );
-                            _showShareMenu(context, ref, video);
+                            _showShareMenu(context, ref, video, isActive);
                           },
                           icon: const Icon(
                             Icons.share_outlined,
@@ -1459,6 +1459,7 @@ class VideoOverlayActions extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     VideoEvent video,
+    bool isActive,
   ) async {
     // Pause video before showing share menu
     bool wasPaused = false;
@@ -1511,9 +1512,6 @@ class VideoOverlayActions extends ConsumerWidget {
         final controller = ref.read(
           individualVideoControllerProvider(controllerParams),
         );
-        final stableId = video.vineId ?? video.id;
-        final isActive = ref.read(isVideoActiveProvider(stableId));
-
         if (isActive &&
             controller.value.isInitialized &&
             !controller.value.isPlaying) {
@@ -1544,6 +1542,7 @@ class VideoOverlayActions extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
     VideoEvent video,
+    bool isActive,
   ) async {
     // Pause video before showing modal
     bool wasPaused = false;
@@ -1597,9 +1596,6 @@ class VideoOverlayActions extends ConsumerWidget {
         final controller = ref.read(
           individualVideoControllerProvider(controllerParams),
         );
-        final stableId = video.vineId ?? video.id;
-        final isActive = ref.read(isVideoActiveProvider(stableId));
-
         // Only resume if video is still active (not scrolled away)
         if (isActive &&
             controller.value.isInitialized &&


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Logic of resuming a video after closing a modal was implemented but it was not working as expected and video was not getting replayed after that.

<!--- Describe your changes in detail -->

**Related Issue:** Related to #571 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore