### PR TITLE
fix: remove broken back button behavior on Clips screen

### DIFF
--- a/mobile/lib/screens/clip_library_screen.dart
+++ b/mobile/lib/screens/clip_library_screen.dart
@@ -129,25 +129,6 @@ class _ClipLibraryScreenState extends ConsumerState<ClipLibraryScreen> {
       backgroundColor: VineTheme.vineGreen,
       foregroundColor: VineTheme.whiteText,
       title: Text(_buildAppBarTitle()),
-      leading: IconButton(
-        icon: const Icon(Icons.arrow_back, color: VineTheme.whiteText),
-        onPressed: () {
-          if (_selectedClipIds.isNotEmpty && !widget.selectionMode) {
-            // Clear selection first
-            _clearSelection();
-          } else if (widget.selectionMode) {
-            Navigator.of(context).pop();
-          } else {
-            final authService = ref.read(authServiceProvider);
-            final npub = authService.currentNpub;
-            if (npub != null) {
-              context.go('/profile/$npub');
-            } else {
-              context.go('/home/0');
-            }
-          }
-        },
-      ),
       actions: [
         // Clear selection button when clips are selected
         if (_selectedClipIds.isNotEmpty && !widget.selectionMode)


### PR DESCRIPTION
## Description
Custom back button behavior on the Clips screen was not working resulting in the user unable to leave the Clips screen. This PR removes that functionality so that the back button works as expected.

**Related Issue:** Closes #733 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore