### PR TITLE
fix: Correct Zendesk SDK API

### DIFF
--- a/mobile/lib/services/zendesk_support_service.dart
+++ b/mobile/lib/services/zendesk_support_service.dart
@@ -325,6 +325,20 @@ class ZendeskSupportService {
         );
         return false;
       }
+    } on MissingPluginException {
+      // Native SDK not available (macOS, Windows, Web)
+      // Fall back to REST API
+      Log.info(
+        'Native createTicket not available, falling back to REST API',
+        category: LogCategory.system,
+      );
+      return createTicketViaApi(
+        subject: subject,
+        description: description,
+        requesterName: _userName,
+        requesterEmail: _userEmail,
+        tags: tags,
+      );
     } on PlatformException catch (e) {
       Log.error(
         'Platform error creating Zendesk ticket: ${e.code} - ${e.message}',


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

- Fix Android build failure caused by incorrect Zendesk Support SDK API usage
- Correct import paths for RequestProvider, ZendeskCallback, and ErrorResponse
- Fix callback generic type from `CreateRequest` to `Request`
- Add null safety check for `Support.INSTANCE.provider()`
- Add Flutter-side fallback to REST API if native method unavailable

## Root Cause
The `createTicket` native implementation was using wrong package paths and API patterns 
for Zendesk Support SDK v5.x. The SDK uses `com.zendesk.service` for callbacks (not 
`zendesk.core`) and requires getting RequestProvider via factory method rather than 
direct construction.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore