### PR TITLE
fix: controller cleanup in clip manager, editor, and camera

### DIFF
--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -7,47 +7,47 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:openvine/models/audio_event.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/router/app_shell.dart';
+import 'package:openvine/router/route_utils.dart';
+import 'package:openvine/screens/blossom_settings_screen.dart';
+import 'package:openvine/screens/clip_library_screen.dart';
+import 'package:openvine/screens/clip_manager_screen.dart';
+import 'package:openvine/screens/curated_list_feed_screen.dart';
+import 'package:openvine/screens/developer_options_screen.dart';
 import 'package:openvine/screens/explore_screen.dart';
-import 'package:openvine/screens/hashtag_screen_router.dart';
-import 'package:openvine/screens/home_screen_router.dart';
-import 'package:openvine/screens/liked_videos_screen_router.dart';
-import 'package:openvine/screens/notifications_screen.dart';
-import 'package:openvine/screens/profile_screen_router.dart';
-import 'package:openvine/screens/pure/search_screen_pure.dart';
-import 'package:openvine/screens/pure/universal_camera_screen_pure.dart';
 import 'package:openvine/screens/followers/my_followers_screen.dart';
 import 'package:openvine/screens/followers/others_followers_screen.dart';
 import 'package:openvine/screens/following/my_following_screen.dart';
 import 'package:openvine/screens/following/others_following_screen.dart';
-import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/screens/fullscreen_video_feed_screen.dart';
+import 'package:openvine/screens/hashtag_screen_router.dart';
+import 'package:openvine/screens/home_screen_router.dart';
 import 'package:openvine/screens/key_import_screen.dart';
-import 'package:openvine/screens/profile_setup_screen.dart';
-import 'package:openvine/screens/blossom_settings_screen.dart';
 import 'package:openvine/screens/key_management_screen.dart';
+import 'package:openvine/screens/liked_videos_screen_router.dart';
 import 'package:openvine/screens/notification_settings_screen.dart';
+import 'package:openvine/screens/notifications_screen.dart';
+import 'package:openvine/screens/other_profile_screen.dart';
+import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/screens/profile_setup_screen.dart';
+import 'package:openvine/screens/pure/search_screen_pure.dart';
+import 'package:openvine/screens/pure/universal_camera_screen_pure.dart';
 import 'package:openvine/screens/relay_diagnostic_screen.dart';
 import 'package:openvine/screens/relay_settings_screen.dart';
 import 'package:openvine/screens/safety_settings_screen.dart';
 import 'package:openvine/screens/settings_screen.dart';
+import 'package:openvine/screens/sound_detail_screen.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/screens/video_editor_screen.dart';
-import 'package:openvine/screens/fullscreen_video_feed_screen.dart';
-import 'package:openvine/screens/other_profile_screen.dart';
-import 'package:openvine/screens/clip_manager_screen.dart';
-import 'package:openvine/screens/clip_library_screen.dart';
-import 'package:openvine/screens/curated_list_feed_screen.dart';
-import 'package:openvine/screens/developer_options_screen.dart';
-import 'package:openvine/screens/sound_detail_screen.dart';
 import 'package:openvine/screens/welcome_screen.dart';
-import 'package:openvine/router/route_utils.dart';
-import 'package:openvine/models/audio_event.dart';
-import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/sounds_providers.dart';
-import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/video_stop_navigator_observer.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 // Navigator keys for per-tab state preservation
@@ -71,6 +71,8 @@ final _likedVideosGridKey = GlobalKey<NavigatorState>(
 final _likedVideosFeedKey = GlobalKey<NavigatorState>(
   debugLabel: 'liked-videos-feed',
 );
+final RouteObserver<ModalRoute<dynamic>> routeObserver =
+    RouteObserver<ModalRoute<dynamic>>();
 
 /// Maps URL location to bottom nav tab index
 /// Returns -1 for non-tab routes (like search, settings, edit-profile) to hide bottom nav
@@ -199,6 +201,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
     navigatorKey: _rootKey,
     initialLocation: '/home/0',
     observers: [
+      routeObserver,
       VideoStopNavigatorObserver(),
       FirebaseAnalyticsObserver(analytics: FirebaseAnalytics.instance),
     ],

--- a/mobile/lib/screens/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor_screen.dart
@@ -9,7 +9,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:just_audio/just_audio.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:openvine/models/vine_draft.dart';
 import 'package:openvine/providers/sound_library_service_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
@@ -20,6 +19,7 @@ import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/sound_picker/sound_picker_modal.dart';
 import 'package:openvine/widgets/text_overlay/draggable_text_overlay.dart';
 import 'package:openvine/widgets/text_overlay/text_overlay_editor.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:video_player/video_player.dart';
 
@@ -435,9 +435,22 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen> {
     }
   }
 
-  void _handleBack() {
-    // Stop audio preview when going back
-    _audioPlayer?.stop();
+  void _handleBack() async {
+    try {
+      await _audioPlayer?.stop();
+      await _videoController?.pause();
+    } catch (e) {
+      Log.error(
+        '📹 VideoEditorScreen: Failed to stop audio or pause video: $e',
+        category: LogCategory.video,
+      );
+    }
+
+    _videoController?.dispose();
+    _videoController = null;
+
+    _audioPlayer?.dispose();
+    _audioPlayer = null;
 
     if (widget.onBack != null) {
       widget.onBack!();


### PR DESCRIPTION
## Description

**Draft PR**: I started investigating an OOM reported on older devices (specifically iPhone 8). I can’t currently validate on iPhone 8, so I’m opening this as a **draft** for **Alex** (ticket owner) to take over and finish/verify.

This PR focuses on **reducing memory pressure** in the recording → clip manager → editor flow by tightening controller lifecycle and preventing duplicate/overlapping initialization.

- **Clip Manager**
  - Prevent overlapping preview initialization (`_isPreviewInitializing`) to avoid multiple `VideoPlayerController` init/dispose cycles.
  - Tear down/recreate external audio preview player more defensively to avoid retaining audio resources.
  - Dispose preview video/audio and release camera resources before navigating/exporting to reduce peak memory usage.
- **Video Editor**
  - On back navigation, stop/pause playback and explicitly dispose video/audio controllers to free resources earlier.
- **Camera / Router**
  - Ensure RouteObserver is wired and the camera screen unsubscribes on dispose.
  - Gate auto camera re-initialization behind `_isRouteActive` to avoid reinitializing while not visible.

**Notes**
- This may or may not fully resolve iPhone 8 OOM (untested). It should still be a safe improvement to reduce peak allocations and retained resources.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore