### PR TITLE
chore: added search_back_button semantic id for testing

### DIFF
--- a/mobile/lib/screens/pure/search_screen_pure.dart
+++ b/mobile/lib/screens/pure/search_screen_pure.dart
@@ -440,9 +440,13 @@ class _SearchScreenPureState extends ConsumerState<SearchScreenPure>
       backgroundColor: VineTheme.backgroundColor,
       appBar: AppBar(
         backgroundColor: VineTheme.cardBackground,
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back, color: VineTheme.whiteText),
-          onPressed: () => Navigator.of(context).pop(),
+        leading: Semantics(
+          identifier: 'search_back_button',
+          button: true,
+          child: IconButton(
+            icon: const Icon(Icons.arrow_back, color: VineTheme.whiteText),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
         ),
         title: searchBar,
         bottom: PreferredSize(


### PR DESCRIPTION
Ale Berardinelli requested a semantic identifier be added to the search bar's back button to assist with testing.

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore