### PR TITLE
fix: parallelize profile stats API calls to reduce load time

### DIFF
--- a/mobile/lib/providers/profile_stats_provider.g.dart
+++ b/mobile/lib/providers/profile_stats_provider.g.dart
@@ -68,7 +68,7 @@ final class FetchProfileStatsProvider
   }
 }
 
-String _$fetchProfileStatsHash() => r'275487acf0609c172893da2a72fc503803cf5a92';
+String _$fetchProfileStatsHash() => r'000dee5740c0a16be5df4512b400b7853f85a831';
 
 /// Async provider for loading profile statistics
 


### PR DESCRIPTION
## Summary
- Run video subscription and follower stats fetch concurrently using `Future.wait()` instead of sequentially
- Reduces profile load time from ~5-6 seconds to ~2-3 seconds when viewing another user's profile

## Root Cause
In `profile_stats_provider.dart`, two independent async operations were awaited sequentially:
1. `subscribeToUserVideos()` (~2-3s)
2. `getFollowerStats()` (~2-3s)

Total: 5-6 seconds (sum of both)

## Solution
Changed to parallel execution with `Future.wait()`, so total time is now ~2-3 seconds (the slower of the two).

## Test plan
- [ ] Navigate to another user's profile
- [ ] Verify stats (followers, following, loops, likes) load in <3 seconds
- [ ] Verify all stats display correctly (no "-" placeholder stuck)
- [ ] Verify video grid loads properly

Related to #861