### PR TITLE
fix: get likes by batch to avoid overload

### DIFF
--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -4492,10 +4492,9 @@ class VideoEventService extends ChangeNotifier {
         }
       }
     } else if (subscriptionType == SubscriptionType.profile) {
-      final authorHex =
-          videoEvent.isRepost && videoEvent.reposterPubkey != null
-              ? videoEvent.reposterPubkey!
-              : videoEvent.pubkey;
+      final authorHex = videoEvent.isRepost && videoEvent.reposterPubkey != null
+          ? videoEvent.reposterPubkey!
+          : videoEvent.pubkey;
       final bucket = _authorBuckets[authorHex];
       if (bucket != null) {
         final bucketIndex = bucket.indexWhere((v) => v.id == videoId);

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -285,10 +285,7 @@ class LikesRepository {
     for (final event in events) {
       // Find the 'e' tag that references the target event
       for (final tag in event.tags) {
-        if (tag is List &&
-            tag.isNotEmpty &&
-            tag[0] == 'e' &&
-            tag.length > 1) {
+        if (tag is List && tag.isNotEmpty && tag[0] == 'e' && tag.length > 1) {
           final targetId = tag[1] as String;
           if (counts.containsKey(targetId)) {
             counts[targetId] = counts[targetId]! + 1;

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -536,48 +536,50 @@ void main() {
         verifyNever(() => mockNostrClient.queryEvents(any()));
       });
 
-      test('queries relay for multiple event counts in single request',
-          () async {
-        const eventId1 = 'event_id_1_1234567890abcdef01234567890abcdef';
-        const eventId2 = 'event_id_2_1234567890abcdef01234567890abcdef';
-        const eventId3 = 'event_id_3_1234567890abcdef01234567890abcdef';
+      test(
+        'queries relay for multiple event counts in single request',
+        () async {
+          const eventId1 = 'event_id_1_1234567890abcdef01234567890abcdef';
+          const eventId2 = 'event_id_2_1234567890abcdef01234567890abcdef';
+          const eventId3 = 'event_id_3_1234567890abcdef01234567890abcdef';
 
-        // Create mock reaction events with 'e' tags pointing to target events
-        final mockReaction1 = MockEvent();
-        when(() => mockReaction1.tags).thenReturn([
-          ['e', eventId1],
-        ]);
+          // Create mock reaction events with 'e' tags pointing to target events
+          final mockReaction1 = MockEvent();
+          when(() => mockReaction1.tags).thenReturn([
+            ['e', eventId1],
+          ]);
 
-        final mockReaction2 = MockEvent();
-        when(() => mockReaction2.tags).thenReturn([
-          ['e', eventId1],
-        ]);
+          final mockReaction2 = MockEvent();
+          when(() => mockReaction2.tags).thenReturn([
+            ['e', eventId1],
+          ]);
 
-        final mockReaction3 = MockEvent();
-        when(() => mockReaction3.tags).thenReturn([
-          ['e', eventId2],
-        ]);
+          final mockReaction3 = MockEvent();
+          when(() => mockReaction3.tags).thenReturn([
+            ['e', eventId2],
+          ]);
 
-        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
-          (_) async => [mockReaction1, mockReaction2, mockReaction3],
-        );
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+            (_) async => [mockReaction1, mockReaction2, mockReaction3],
+          );
 
-        repository = LikesRepository(
-          nostrClient: mockNostrClient,
-          localStorage: mockLocalStorage,
-        );
+          repository = LikesRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+          );
 
-        final result = await repository.getLikeCounts([
-          eventId1,
-          eventId2,
-          eventId3,
-        ]);
+          final result = await repository.getLikeCounts([
+            eventId1,
+            eventId2,
+            eventId3,
+          ]);
 
-        expect(result[eventId1], equals(2));
-        expect(result[eventId2], equals(1));
-        expect(result[eventId3], equals(0));
-        verify(() => mockNostrClient.queryEvents(any())).called(1);
-      });
+          expect(result[eventId1], equals(2));
+          expect(result[eventId2], equals(1));
+          expect(result[eventId3], equals(0));
+          verify(() => mockNostrClient.queryEvents(any())).called(1);
+        },
+      );
 
       test('initializes all event IDs to zero', () async {
         const eventId1 = 'event_id_1_1234567890abcdef01234567890abcdef';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
  - Batch like count fetching to prevent ANR issues from too many concurrent relay requests
  - Add getLikeCounts method to LikesRepository for fetching multiple like counts in a single query
  - Debounce and batch video like count requests (150ms debounce, max 50 per batch)


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore