### PR TITLE
feat: move liked videos fetch logic to repository

### DIFF
--- a/mobile/lib/widgets/profile/profile_grid_view.dart
+++ b/mobile/lib/widgets/profile/profile_grid_view.dart
@@ -94,12 +94,14 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
     final likesRepository = ref.watch(likesRepositoryProvider);
 
     // Build the base widget with ProfileLikedVideosBloc
+    // Pass userIdHex as targetUserPubkey so the BLoC knows whose likes to fetch
     final tabContent = BlocProvider<ProfileLikedVideosBloc>(
       create: (_) =>
           ProfileLikedVideosBloc(
               likesRepository: likesRepository,
               videoEventService: videoEventService,
               nostrClient: nostrClient,
+              targetUserPubkey: widget.userIdHex,
             )
             ..add(const ProfileLikedVideosSubscriptionRequested())
             ..add(const ProfileLikedVideosSyncRequested()),

--- a/mobile/packages/likes_repository/lib/src/exceptions.dart
+++ b/mobile/packages/likes_repository/lib/src/exceptions.dart
@@ -85,3 +85,12 @@ class SyncFailedException extends LikesRepositoryException {
   @override
   String toString() => 'SyncFailedException: $message';
 }
+
+/// Exception thrown when fetching another user's likes from relays fails.
+class FetchLikesFailedException extends LikesRepositoryException {
+  /// Creates a new fetch likes failed exception.
+  const FetchLikesFailedException(super.message);
+
+  @override
+  String toString() => 'FetchLikesFailedException: $message';
+}

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -331,6 +331,54 @@ class LikesRepository {
     }
   }
 
+  /// Fetch liked event IDs for any user from relays.
+  ///
+  /// Unlike [syncUserReactions], this method:
+  /// - Does NOT cache results locally (since it's not the current user's data)
+  /// - Does NOT require authentication
+  /// - Is intended for viewing other users' liked content
+  ///
+  /// Returns a list of event IDs that the specified user has liked,
+  /// ordered by recency (most recent first).
+  ///
+  /// Parameters:
+  /// - [pubkey]: The public key (hex) of the user whose likes to fetch
+  ///
+  /// Throws [FetchLikesFailedException] if the fetch fails.
+  Future<List<String>> fetchUserLikes(String pubkey) async {
+    final filter = Filter(
+      kinds: const [_reactionKind],
+      authors: [pubkey],
+      limit: _defaultReactionFetchLimit,
+    );
+
+    try {
+      final events = await _nostrClient.queryEvents([filter]);
+      final likedEventIds = <String>[];
+      final seenIds = <String>{};
+
+      // Sort events by createdAt descending (most recent first)
+      events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+
+      for (final event in events) {
+        // Only process '+' reactions (likes)
+        if (event.content != _likeContent) continue;
+
+        final targetId = _extractTargetEventId(event);
+        if (targetId != null && !seenIds.contains(targetId)) {
+          seenIds.add(targetId);
+          likedEventIds.add(targetId);
+        }
+      }
+
+      return likedEventIds;
+    } catch (e) {
+      throw FetchLikesFailedException(
+        'Failed to fetch likes for user $pubkey: $e',
+      );
+    }
+  }
+
   /// Builds a [LikesSyncResult] from the current in-memory cache.
   LikesSyncResult _buildSyncResult() {
     // Sort records by createdAt descending (most recent first)


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

  1. LikesRepository (packages/likes_repository/lib/src/likes_repository.dart)

  Added new method fetchUserLikes(String pubkey):
  - Queries relays for Kind 7 reactions authored by any user
  - Filters for '+' reactions (likes only)
  - Returns ordered list of liked event IDs (most recent first)
  - Does NOT cache results (since it's not current user's data)
  - Throws FetchLikesFailedException on error

  2. ProfileLikedVideosBloc (lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart)

  Simplified significantly:
  - _fetchOtherUserLikedEventIds() now just calls _likesRepository.fetchUserLikes()

<!--- Describe your changes in detail -->

**Related Issue:** Closes #881

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore