### PR TITLE
feat: paginate liked video grid

### DIFF
--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_event.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_event.dart
@@ -25,3 +25,12 @@ final class ProfileLikedVideosSubscriptionRequested
     extends ProfileLikedVideosEvent {
   const ProfileLikedVideosSubscriptionRequested();
 }
+
+/// Request to load more liked videos (pagination).
+///
+/// Fetches the next batch of videos from the existing [likedEventIds] list.
+/// Only effective after initial sync has completed.
+final class ProfileLikedVideosLoadMoreRequested
+    extends ProfileLikedVideosEvent {
+  const ProfileLikedVideosLoadMoreRequested();
+}

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_state.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_state.dart
@@ -36,12 +36,16 @@ enum ProfileLikedVideosError {
 /// - [videos]: The list of liked video events (ordered by recency)
 /// - [status]: The current loading status
 /// - [error]: Any error that occurred
+/// - [isLoadingMore]: Whether more videos are being loaded (pagination)
+/// - [hasMoreContent]: Whether there are more videos to load
 final class ProfileLikedVideosState extends Equatable {
   const ProfileLikedVideosState({
     this.status = ProfileLikedVideosStatus.initial,
     this.videos = const [],
     this.likedEventIds = const [],
     this.error,
+    this.isLoadingMore = false,
+    this.hasMoreContent = true,
   });
 
   /// The current loading status
@@ -55,6 +59,12 @@ final class ProfileLikedVideosState extends Equatable {
 
   /// Error that occurred during loading, if any
   final ProfileLikedVideosError? error;
+
+  /// Whether more videos are being loaded (pagination)
+  final bool isLoadingMore;
+
+  /// Whether there are more videos to load
+  final bool hasMoreContent;
 
   /// Whether data has been successfully loaded
   bool get isLoaded => status == ProfileLikedVideosStatus.success;
@@ -71,15 +81,26 @@ final class ProfileLikedVideosState extends Equatable {
     List<String>? likedEventIds,
     ProfileLikedVideosError? error,
     bool clearError = false,
+    bool? isLoadingMore,
+    bool? hasMoreContent,
   }) {
     return ProfileLikedVideosState(
       status: status ?? this.status,
       videos: videos ?? this.videos,
       likedEventIds: likedEventIds ?? this.likedEventIds,
       error: clearError ? null : (error ?? this.error),
+      isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      hasMoreContent: hasMoreContent ?? this.hasMoreContent,
     );
   }
 
   @override
-  List<Object?> get props => [status, videos, likedEventIds, error];
+  List<Object?> get props => [
+    status,
+    videos,
+    likedEventIds,
+    error,
+    isLoadingMore,
+    hasMoreContent,
+  ];
 }

--- a/mobile/lib/widgets/profile/profile_liked_grid.dart
+++ b/mobile/lib/widgets/profile/profile_liked_grid.dart
@@ -48,28 +48,58 @@ class _ProfileLikedGridState extends State<ProfileLikedGrid> {
           return const _LikedEmptyState();
         }
 
-        return CustomScrollView(
-          slivers: [
-            SliverPadding(
-              padding: const EdgeInsets.all(2),
-              sliver: SliverGrid(
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 3,
-                  crossAxisSpacing: 2,
-                  mainAxisSpacing: 2,
-                  childAspectRatio: 1,
-                ),
-                delegate: SliverChildBuilderDelegate((context, index) {
-                  if (index >= likedVideos.length) {
-                    return const SizedBox.shrink();
-                  }
+        return NotificationListener<ScrollNotification>(
+          onNotification: (notification) {
+            // Trigger load more when near the bottom
+            if (notification is ScrollUpdateNotification) {
+              final pixels = notification.metrics.pixels;
+              final maxExtent = notification.metrics.maxScrollExtent;
+              // Load more when within 200 pixels of the bottom
+              if (pixels >= maxExtent - 200 &&
+                  state.hasMoreContent &&
+                  !state.isLoadingMore) {
+                context.read<ProfileLikedVideosBloc>().add(
+                  const ProfileLikedVideosLoadMoreRequested(),
+                );
+              }
+            }
+            return false;
+          },
+          child: CustomScrollView(
+            slivers: [
+              SliverPadding(
+                padding: const EdgeInsets.all(2),
+                sliver: SliverGrid(
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 3,
+                    crossAxisSpacing: 2,
+                    mainAxisSpacing: 2,
+                    childAspectRatio: 1,
+                  ),
+                  delegate: SliverChildBuilderDelegate((context, index) {
+                    if (index >= likedVideos.length) {
+                      return const SizedBox.shrink();
+                    }
 
-                  final videoEvent = likedVideos[index];
-                  return _LikedGridTile(videoEvent: videoEvent, index: index);
-                }, childCount: likedVideos.length),
+                    final videoEvent = likedVideos[index];
+                    return _LikedGridTile(videoEvent: videoEvent, index: index);
+                  }, childCount: likedVideos.length),
+                ),
               ),
-            ),
-          ],
+              // Loading indicator at the bottom
+              if (state.isLoadingMore)
+                const SliverToBoxAdapter(
+                  child: Padding(
+                    padding: EdgeInsets.all(16),
+                    child: Center(
+                      child: CircularProgressIndicator(
+                        color: VineTheme.vineGreen,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
         );
       },
     );

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -157,6 +157,7 @@ void main() {
             status: ProfileLikedVideosStatus.success,
             videos: [],
             likedEventIds: [],
+            hasMoreContent: false,
           ),
         ],
       );
@@ -417,6 +418,7 @@ void main() {
             status: ProfileLikedVideosStatus.success,
             videos: [],
             likedEventIds: [],
+            hasMoreContent: false,
           ),
         ],
         verify: (_) {
@@ -464,6 +466,7 @@ void main() {
             status: ProfileLikedVideosStatus.success,
             videos: [],
             likedEventIds: [],
+            hasMoreContent: false,
           ),
         ],
         verify: (_) {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
  1. Initial sync: Fetches all liked IDs (up to 500), but only loads videos for the first 18
  2. On scroll: When within 200px of bottom, triggers ProfileLikedVideosLoadMoreRequested
  3. Load more: Fetches next 18 videos from existing likedEventIds list
  4. Loading indicator: Shows spinner at bottom while loading more

**Related Issue:** Closes #884

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore