### PR TITLE
feat(camera): add screen flash feature for front camera using maximum brightness

### DIFF
--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
@@ -42,7 +42,8 @@ class DivineCameraPlugin :
             "initializeCamera" -> {
                 val lens = call.argument<String>("lens") ?: "back"
                 val videoQuality = call.argument<String>("videoQuality") ?: "fhd"
-                initializeCamera(lens, videoQuality, result)
+                val enableScreenFlash = call.argument<Boolean>("enableScreenFlash") ?: true
+                initializeCamera(lens, videoQuality, enableScreenFlash, result)
             }
 
             "disposeCamera" -> {
@@ -103,7 +104,7 @@ class DivineCameraPlugin :
         }
     }
 
-    private fun initializeCamera(lens: String, videoQuality: String, result: Result) {
+    private fun initializeCamera(lens: String, videoQuality: String, enableScreenFlash: Boolean, result: Result) {
         val currentActivity = activity
         if (currentActivity == null) {
             result.error("NO_ACTIVITY", "Activity not available", null)
@@ -123,7 +124,7 @@ class DivineCameraPlugin :
                 channel.invokeMethod("onRecordingAutoStopped", recordingResult)
             }
 
-            cameraController?.initialize(lens, videoQuality) { state, error ->
+            cameraController?.initialize(lens, videoQuality, enableScreenFlash) { state, error ->
                 if (error != null) {
                     result.error("INIT_ERROR", error, null)
                 } else {

--- a/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
@@ -45,7 +45,8 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
             let args = call.arguments as? [String: Any] ?? [:]
             let lens = args["lens"] as? String ?? "back"
             let videoQuality = args["videoQuality"] as? String ?? "fhd"
-            initializeCamera(lens: lens, videoQuality: videoQuality, result: result)
+            let enableScreenFlash = args["enableScreenFlash"] as? Bool ?? true
+            initializeCamera(lens: lens, videoQuality: videoQuality, enableScreenFlash: enableScreenFlash, result: result)
             
         case "disposeCamera":
             disposeCamera(result: result)
@@ -99,7 +100,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         }
     }
     
-    private func initializeCamera(lens: String, videoQuality: String, result: @escaping FlutterResult) {
+    private func initializeCamera(lens: String, videoQuality: String, enableScreenFlash: Bool, result: @escaping FlutterResult) {
         guard let registry = textureRegistry else {
             result(FlutterError(code: "NO_REGISTRY", message: "Texture registry not available", details: nil))
             return
@@ -108,7 +109,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         cameraController?.release()
         cameraController = CameraController(textureRegistry: registry)
         
-        cameraController?.initialize(lens: lens, videoQuality: videoQuality) { [weak self] state, error in
+        cameraController?.initialize(lens: lens, videoQuality: videoQuality, enableScreenFlash: enableScreenFlash) { [weak self] state, error in
             DispatchQueue.main.async {
                 if let error = error {
                     result(FlutterError(code: "INIT_ERROR", message: error, details: nil))

--- a/mobile/packages/divine_camera/lib/divine_camera.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera.dart
@@ -62,10 +62,13 @@ class DivineCamera {
   ///
   /// [lens] specifies which camera to use (front or back).
   /// [videoQuality] specifies the video recording quality (default: FHD/1080p).
+  /// [enableScreenFlash] enables using screen brightness as flash for
+  /// front camera (default: true).
   /// Returns the initialized camera state.
   Future<CameraState> initialize({
     DivineCameraLens lens = DivineCameraLens.back,
     DivineVideoQuality videoQuality = DivineVideoQuality.fhd,
+    bool enableScreenFlash = true,
   }) async {
     // Register auto-stop callback with platform
     _platform.onRecordingAutoStopped = _handleAutoStop;
@@ -73,6 +76,7 @@ class DivineCamera {
     _state = await _platform.initializeCamera(
       lens: lens,
       videoQuality: videoQuality,
+      enableScreenFlash: enableScreenFlash,
     );
     _notifyStateChanged();
     return _state;
@@ -202,11 +206,17 @@ class DivineCamera {
   /// Maximum zoom level supported by the camera.
   double get maxZoomLevel => _state.maxZoomLevel;
 
+  /// The current zoom level.
+  double get zoomLevel => _state.zoomLevel;
+
   /// Whether the camera is initialized and ready to use.
   bool get isInitialized => _state.isInitialized;
 
   /// Whether the camera supports manual focus point selection.
   bool get isFocusPointSupported => _state.isFocusPointSupported;
+
+  /// Whether the camera supports manual exposure point selection.
+  bool get isExposurePointSupported => _state.isExposurePointSupported;
 
   /// Whether the camera is ready to record (initialized and not recording).
   bool get canRecord => _state.canRecord;
@@ -220,8 +230,20 @@ class DivineCamera {
   /// Whether the camera is currently recording.
   bool get isRecording => _state.isRecording;
 
+  /// Whether the device has a front-facing camera.
+  bool get hasFrontCamera => _state.hasFrontCamera;
+
+  /// Whether the device has a back-facing camera.
+  bool get hasBackCamera => _state.hasBackCamera;
+
+  /// Whether the camera is currently switching between lenses.
+  bool get isSwitchingCamera => _state.isSwitchingCamera;
+
   /// The texture ID for the camera preview.
   int? get textureId => _state.textureId;
+
+  /// The currently active camera lens (front or back).
+  DivineCameraLens get lens => _state.lens;
 
   /// Notifies listeners of state changes.
   void _notifyStateChanged() {

--- a/mobile/packages/divine_camera/lib/divine_camera_method_channel.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera_method_channel.dart
@@ -62,12 +62,14 @@ class MethodChannelDivineCamera extends DivineCameraPlatform {
   Future<CameraState> initializeCamera({
     DivineCameraLens lens = DivineCameraLens.back,
     DivineVideoQuality videoQuality = DivineVideoQuality.fhd,
+    bool enableScreenFlash = true,
   }) async {
     final result = await methodChannel.invokeMapMethod<dynamic, dynamic>(
       'initializeCamera',
       {
         'lens': lens.toNativeString(),
         'videoQuality': videoQuality.value,
+        'enableScreenFlash': enableScreenFlash,
       },
     );
     if (result == null) {

--- a/mobile/packages/divine_camera/lib/divine_camera_platform_interface.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera_platform_interface.dart
@@ -39,6 +39,7 @@ abstract class DivineCameraPlatform extends PlatformInterface {
   Future<CameraState> initializeCamera({
     DivineCameraLens lens = DivineCameraLens.back,
     DivineVideoQuality videoQuality = DivineVideoQuality.fhd,
+    bool enableScreenFlash = true,
   }) {
     throw UnimplementedError('initializeCamera() has not been implemented.');
   }

--- a/mobile/packages/divine_camera/test/divine_camera_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_test.dart
@@ -30,6 +30,7 @@ class MockDivineCameraPlatform
   Future<CameraState> initializeCamera({
     DivineCameraLens lens = DivineCameraLens.back,
     DivineVideoQuality videoQuality = DivineVideoQuality.fhd,
+    bool enableScreenFlash = true,
   }) async {
     return _state = CameraState(
       isInitialized: true,
@@ -152,6 +153,20 @@ void main() {
       test('initializes with video quality', () async {
         final state = await DivineCamera.instance.initialize(
           videoQuality: DivineVideoQuality.uhd,
+        );
+
+        expect(state.isInitialized, isTrue);
+      });
+
+      test('initializes with enableScreenFlash true (default)', () async {
+        final state = await DivineCamera.instance.initialize();
+
+        expect(state.isInitialized, isTrue);
+      });
+
+      test('initializes with enableScreenFlash false', () async {
+        final state = await DivineCamera.instance.initialize(
+          enableScreenFlash: false,
         );
 
         expect(state.isInitialized, isTrue);

--- a/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
+++ b/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
@@ -28,6 +28,7 @@ class MockDivineCameraPlatform
   Future<CameraState> initializeCamera({
     DivineCameraLens lens = DivineCameraLens.back,
     DivineVideoQuality videoQuality = DivineVideoQuality.fhd,
+    bool enableScreenFlash = true,
   }) async {
     return _state = CameraState(
       isInitialized: true,


### PR DESCRIPTION
## Description

Adds a screen flash for the front camera using maximum display brightness, matching native camera behavior and ensuring proper illumination when users record selfies.


**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore