### PR TITLE
fix: android deep links

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -103,7 +103,7 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
-            <!-- Deep links for divine.video and login.divine.video. -->
+            <!-- Deep links for divine.video and login.divine.video -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>


### PR DESCRIPTION
## Description
Previously after installing our Android app from [play.google.com](https://play.google.com/store/apps/details?id=co.openvine.app&hl=en-US&ah=R1C5i7K1Q-mvTNx7u_79Is_CT0E) the deep link after doing a password reset was not opening our app.

Running: **`adb shell pm get-app-links co.openvine.app`** indicated a 1024 error for login.divine.video:

```
  co.openvine.app:
    ID: cfd3383e-9f81-4585-9c2a-ed7a485a49be
    Signatures: [10:B8:04:F9:48:FC:91:EC:28:27:B9:67:15:C3:21:2E:AB:1A:0B:46:AF:52:1B:3A:31:6C:9D:78:BF:A4:39:6E]
    Domain verification state:
      login.divine.video: 1024
      divine.video: verified
```
My research suggests that combining our two intent-filter blocks into one will eliminate this problem.

After build 1.0.4(#148) which included this branch was deployed to google play, the get-app-links command indicates that  both links are verified.

```
  co.openvine.app:
    ID: 17067a7b-b5de-4cd1-ac2d-9d7f6eadce9d
    Signatures: [10:B8:04:F9:48:FC:91:EC:28:27:B9:67:15:C3:21:2E:AB:1A:0B:46:AF:52:1B:3A:31:6C:9D:78:BF:A4:39:6E]
    Domain verification state:
      login.divine.video: verified
      divine.video: verified
```


**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore