### PR TITLE
feat: delete account progress indicator

### DIFF
--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -3,12 +3,14 @@
 
 import 'dart:async';
 
+import 'package:divine_ui/divine_ui.dart';
+import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/services/account_deletion_service.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/utils/unified_logger.dart';
-import 'package:divine_ui/divine_ui.dart';
 
 /// Show warning dialog for removing keys from device only
 Future<void> showRemoveKeysWarningDialog({
@@ -164,81 +166,72 @@ Future<void> showDeleteAllContentWarningDialog({
   );
 }
 
-/// Progress dialog that shows deletion progress
-class _DeletionProgressDialog extends StatefulWidget {
-  const _DeletionProgressDialog({required this.progressNotifier});
-
-  final ValueNotifier<(int, int)> progressNotifier;
-
-  @override
-  State<_DeletionProgressDialog> createState() =>
-      _DeletionProgressDialogState();
-}
-
-class _DeletionProgressDialogState extends State<_DeletionProgressDialog> {
-  @override
-  void initState() {
-    super.initState();
-    widget.progressNotifier.addListener(_onProgressChanged);
-  }
-
-  @override
-  void dispose() {
-    widget.progressNotifier.removeListener(_onProgressChanged);
-    super.dispose();
-  }
-
-  void _onProgressChanged() {
-    if (mounted) setState(() {});
-  }
+/// Progress dialog that shows deletion progress using BLoC pattern.
+class _DeletionProgressDialog extends StatelessWidget {
+  const _DeletionProgressDialog();
 
   @override
   Widget build(BuildContext context) {
-    final (current, total) = widget.progressNotifier.value;
-    final hasProgress = total > 0;
-
     return Center(
       child: Card(
         color: VineTheme.cardBackground,
         child: Padding(
           padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (hasProgress) ...[
-                CircularProgressIndicator(
-                  value: current / total,
-                  color: VineTheme.vineGreen,
-                  backgroundColor: Colors.grey.shade800,
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  'Deleting content...',
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  '$current / $total events',
-                  style: TextStyle(color: Colors.grey.shade400, fontSize: 14),
-                ),
-              ] else ...[
-                const CircularProgressIndicator(color: VineTheme.vineGreen),
-                const SizedBox(height: 16),
-                const Text(
-                  'Preparing deletion...',
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 16,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-              ],
-            ],
-          ),
+          child:
+              BlocBuilder<
+                AccountDeletionProgressCubit,
+                AccountDeletionProgressState
+              >(
+                builder: (context, state) {
+                  return Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: switch (state) {
+                      AccountDeletionProgressUpdating(
+                        :final current,
+                        :final total,
+                      ) =>
+                        [
+                          CircularProgressIndicator(
+                            value: current / total,
+                            color: VineTheme.vineGreen,
+                            backgroundColor: Colors.grey.shade800,
+                          ),
+                          const SizedBox(height: 16),
+                          const Text(
+                            'Deleting content...',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            '$current / $total events',
+                            style: TextStyle(
+                              color: Colors.grey.shade400,
+                              fontSize: 14,
+                            ),
+                          ),
+                        ],
+                      AccountDeletionProgressPreparing() => [
+                        const CircularProgressIndicator(
+                          color: VineTheme.vineGreen,
+                        ),
+                        const SizedBox(height: 16),
+                        const Text(
+                          'Preparing deletion...',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 16,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ],
+                    },
+                  );
+                },
+              ),
         ),
       ),
     );
@@ -262,73 +255,136 @@ Future<void> executeAccountDeletion({
   required AuthService authService,
   String screenName = 'AccountDeletion',
 }) async {
-  // Create progress notifier for the dialog
-  final progressNotifier = ValueNotifier<(int, int)>((0, 0));
+  // Create cubit for tracking progress
+  final cubit = AccountDeletionProgressCubit();
 
-  // Show progress dialog
+  // Show progress dialog with BlocProvider
   if (!context.mounted) return;
   unawaited(
     showDialog<void>(
       context: context,
       barrierDismissible: false,
-      builder: (context) =>
-          _DeletionProgressDialog(progressNotifier: progressNotifier),
+      builder: (dialogContext) => BlocProvider.value(
+        value: cubit,
+        child: const _DeletionProgressDialog(),
+      ),
     ),
   );
 
-  // Step 1: Execute NIP-62 deletion request (requires working signer)
-  final result = await deletionService.deleteAccount(
-    onProgress: (current, total) {
-      progressNotifier.value = (current, total);
-    },
-  );
+  // Track if dialog was dismissed to avoid double-popping
+  var dialogDismissed = false;
 
-  // Clean up the notifier
-  progressNotifier.dispose();
-
-  if (result.success) {
-    // Step 2: Delete Keycast account if one exists (invalidates signer)
-    // We log but don't block on failure since NIP-62 already succeeded
-    final (keycastSuccess, keycastError) = await authService
-        .deleteKeycastAccount();
-    if (!keycastSuccess) {
-      Log.warning(
-        'Keycast account deletion failed (continuing anyway): $keycastError',
-        name: screenName,
-        category: LogCategory.auth,
-      );
+  void dismissDialog() {
+    if (!dialogDismissed && context.mounted) {
+      dialogDismissed = true;
+      context.pop();
     }
-
-    // Step 3: Sign out and delete local keys
-    // Router will automatically redirect to /welcome when auth state
-    // becomes unauthenticated
-    await authService.signOut(deleteKeys: true);
-
-    // Close loading indicator and show success snackbar
-    // Router will automatically redirect to /welcome after sign out
-    if (!context.mounted) return;
-    context.pop();
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text(
-          'Your account has been deleted',
-          style: TextStyle(color: Colors.white),
-        ),
-        backgroundColor: VineTheme.vineGreen,
-      ),
-    );
-  } else {
-    // Close loading indicator and show error
-    if (!context.mounted) return;
-    context.pop();
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          result.error ?? 'Failed to delete content from relays',
-          style: const TextStyle(color: Colors.white),
-        ),
-        backgroundColor: Colors.red,
-      ),
-    );
   }
+
+  // Step 1: Execute NIP-62 deletion request (requires working signer)
+  try {
+    final result = await deletionService.deleteAccount(
+      onProgress: cubit.updateProgress,
+    );
+
+    if (result.success) {
+      // Step 2: Delete Keycast account if one exists (invalidates signer)
+      // We log but don't block on failure since NIP-62 already succeeded
+      final (keycastSuccess, keycastError) = await authService
+          .deleteKeycastAccount();
+      if (!keycastSuccess) {
+        Log.warning(
+          'Keycast account deletion failed (continuing anyway): $keycastError',
+          name: screenName,
+          category: LogCategory.auth,
+        );
+      }
+
+      // Step 3: Sign out and delete local keys
+      // Router will automatically redirect to /welcome when auth state
+      // becomes unauthenticated
+      await authService.signOut(deleteKeys: true);
+
+      // Close loading indicator and show success snackbar
+      // Router will automatically redirect to /welcome after sign out
+      dismissDialog();
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text(
+              'Your account has been deleted',
+              style: TextStyle(color: Colors.white),
+            ),
+            backgroundColor: VineTheme.vineGreen,
+          ),
+        );
+      }
+    } else {
+      // Close loading indicator and show error
+      dismissDialog();
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              result.error ?? 'Failed to delete content from relays',
+              style: const TextStyle(color: Colors.white),
+            ),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  } finally {
+    await cubit.close();
+
+    // Ensure dialog is dismissed even if an exception occurred
+    dismissDialog();
+  }
+}
+
+/// Cubit for managing account deletion progress state.
+///
+/// Used by the deletion progress dialog to display real-time
+/// progress updates during the NIP-62 account deletion flow.
+class AccountDeletionProgressCubit extends Cubit<AccountDeletionProgressState> {
+  AccountDeletionProgressCubit()
+    : super(const AccountDeletionProgressPreparing());
+
+  /// Update the deletion progress.
+  ///
+  /// [current] - Number of events processed so far
+  /// [total] - Total number of events to process
+  void updateProgress(int current, int total) {
+    emit(AccountDeletionProgressUpdating(current: current, total: total));
+  }
+}
+
+/// State for the account deletion progress cubit.
+sealed class AccountDeletionProgressState extends Equatable {
+  const AccountDeletionProgressState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Initial state while preparing for deletion (fetching events).
+class AccountDeletionProgressPreparing extends AccountDeletionProgressState {
+  const AccountDeletionProgressPreparing();
+}
+
+/// State with active deletion progress.
+class AccountDeletionProgressUpdating extends AccountDeletionProgressState {
+  const AccountDeletionProgressUpdating({
+    required this.current,
+    required this.total,
+  });
+
+  /// Number of events processed so far.
+  final int current;
+
+  /// Total number of events to process.
+  final int total;
+
+  @override
+  List<Object?> get props => [current, total];
 }


### PR DESCRIPTION


## Description
When deleting an account, we now have a loop that deletes all your content. (In addition to sending the nip 62 forget me event).  

This PR adds a progress dialog while that loop is running.

<img width="250" src="https://github.com/user-attachments/assets/2f8fee2a-5bad-48b5-a03f-a36f89370d0f" />


**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore