### PR TITLE
chore: rename macOS app from OpenVine to divine

### DIFF
--- a/mobile/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/mobile/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "OpenVine.app"
+               BuildableName = "divine.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "OpenVine.app"
+            BuildableName = "divine.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "OpenVine.app"
+            BuildableName = "divine.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "OpenVine.app"
+            BuildableName = "divine.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
## Summary
- Update Xcode scheme to use `divine.app` build name instead of `OpenVine.app`

## Test plan
- [ ] Build macOS app
- [ ] Verify app name shows as "divine" in Finder

🤖 Generated with [Claude Code](https://claude.ai/claude-code)