### PR TITLE
fix: delete account was hanging in release builds

### DIFF
--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -140,24 +140,22 @@ Future<void> showDeleteAllContentWarningDialog({
               style: TextStyle(color: Colors.grey, fontSize: 16),
             ),
           ),
-          Flexible(
-            child: ElevatedButton(
-              onPressed: confirmationController.text == requiredText
-                  ? () {
-                      context.pop();
-                      onConfirm();
-                    }
-                  : null,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.red,
-                foregroundColor: Colors.white,
-                disabledBackgroundColor: Colors.grey.shade800,
-                disabledForegroundColor: Colors.grey,
-              ),
-              child: const Text(
-                'Delete All Content',
-                style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
-              ),
+          ElevatedButton(
+            onPressed: confirmationController.text == requiredText
+                ? () {
+                    context.pop();
+                    onConfirm();
+                  }
+                : null,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+              disabledBackgroundColor: Colors.grey.shade800,
+              disabledForegroundColor: Colors.grey,
+            ),
+            child: const Text(
+              'Delete All Content',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
             ),
           ),
         ],


### PR DESCRIPTION
## Description
When selecting "Delete Account and Data" from the Settings menu of the release build, the app would hang and not display the dialog where you are to confirm that you really want to delete your account.

The dialog displayed fine when running a debug build from VS Code. But if you built a release APK and installed that, then the app would hang.

By incrementally starting with a simple dialog and adding back in the original elements, I figured out that the Flexible wrapper around the ElevatedButton was causing the problem.

**Related Issue:** Closes #1033

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore