### PR TITLE
fix: profile videos showing 0 for users with videos in feed

### DIFF
--- a/mobile/lib/providers/profile_stats_provider.g.dart
+++ b/mobile/lib/providers/profile_stats_provider.g.dart
@@ -8,12 +8,16 @@ part of 'profile_stats_provider.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// Async provider for loading profile statistics
+/// Async provider for loading profile statistics.
+/// Derives video count from profileFeedProvider to ensure consistency
+/// and proper waiting for relay events.
 
 @ProviderFor(fetchProfileStats)
 const fetchProfileStatsProvider = FetchProfileStatsFamily._();
 
-/// Async provider for loading profile statistics
+/// Async provider for loading profile statistics.
+/// Derives video count from profileFeedProvider to ensure consistency
+/// and proper waiting for relay events.
 
 final class FetchProfileStatsProvider
     extends
@@ -23,7 +27,9 @@ final class FetchProfileStatsProvider
           FutureOr<ProfileStats>
         >
     with $FutureModifier<ProfileStats>, $FutureProvider<ProfileStats> {
-  /// Async provider for loading profile statistics
+  /// Async provider for loading profile statistics.
+  /// Derives video count from profileFeedProvider to ensure consistency
+  /// and proper waiting for relay events.
   const FetchProfileStatsProvider._({
     required FetchProfileStatsFamily super.from,
     required String super.argument,
@@ -68,9 +74,11 @@ final class FetchProfileStatsProvider
   }
 }
 
-String _$fetchProfileStatsHash() => r'14c6f29c55d8c8cd2e4f338722b0f32dc900c28c';
+String _$fetchProfileStatsHash() => r'c4d7f95b45334084b4a1dd8f1394c5bd52bd58e4';
 
-/// Async provider for loading profile statistics
+/// Async provider for loading profile statistics.
+/// Derives video count from profileFeedProvider to ensure consistency
+/// and proper waiting for relay events.
 
 final class FetchProfileStatsFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<ProfileStats>, String> {
@@ -83,7 +91,9 @@ final class FetchProfileStatsFamily extends $Family
         isAutoDispose: true,
       );
 
-  /// Async provider for loading profile statistics
+  /// Async provider for loading profile statistics.
+  /// Derives video count from profileFeedProvider to ensure consistency
+  /// and proper waiting for relay events.
 
   FetchProfileStatsProvider call(String pubkey) =>
       FetchProfileStatsProvider._(argument: pubkey, from: this);


### PR DESCRIPTION
## Summary

- Fixes profiles showing "0 Videos" and "No Videos Yet" when the same user's videos play correctly in discovery/home feeds
- Two root causes identified and fixed:
  1. **Cross-population gap in `_addVideoToSubscription`**: Videos arriving via discovery/home feed subscriptions were only routed to the current user's author bucket. Other users' videos were never cross-populated to their author buckets, causing previously-viewed profiles to stay permanently at 0.
  2. **Stats timing race in `fetchProfileStats`**: The provider independently called `subscribeToUserVideos` and immediately read `authorVideos()`, getting 0 before relay events arrived, then caching that stale 0 for 5 minutes.
- Now cross-populates author buckets for any author with an existing bucket entry (profile previously viewed)
- Stats now derive video count from `profileFeedProvider` which properly waits for relay events via its stability mechanism
- Skips caching 0-video results to avoid persisting timing-related zeros

## Test plan

- [x] Profile stats provider tests pass (4 passed, 2 skipped)
- [x] Video event service subscription tests pass (5 passed, 1 skipped)
- [x] Video event service deduplication tests pass
- [x] Profile feed provider tests pass (7 passed)
- [x] Static analysis passes with no errors
- [ ] Manual test: Open a user's profile from the feed and verify video count matches
- [ ] Manual test: Navigate to a profile before their videos load, confirm it updates when videos arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)