### PR TITLE
feat: re-apply username claim endpoint with NIP-98 auth

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -5,7 +5,6 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart';
 import 'package:openvine/models/user_profile.dart' as app_models;
-import 'package:openvine/repositories/username_repository.dart';
 import 'package:openvine/services/user_profile_service.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:profile_repository/profile_repository.dart';
@@ -17,17 +16,14 @@ part 'profile_editor_state.dart';
 class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
   ProfileEditorBloc({
     required ProfileRepository profileRepository,
-    required UsernameRepository usernameRepository,
     required UserProfileService userProfileService,
   }) : _profileRepository = profileRepository,
-       _usernameRepository = usernameRepository,
        _userProfileService = userProfileService,
        super(const ProfileEditorState()) {
     on<ProfileSaved>(_onProfileSaved);
   }
 
   final ProfileRepository _profileRepository;
-  final UsernameRepository _usernameRepository;
   final UserProfileService _userProfileService;
 
   Future<void> _onProfileSaved(
@@ -98,10 +94,9 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       name: 'ProfileEditorBloc',
     );
 
-    final result = await _usernameRepository.register(
-      username: username,
-      pubkey: event.pubkey,
-    );
+    final result = await _profileRepository.claimUsername(username: username);
+
+    Log.info('📝 Username claim result: $result', name: 'ProfileEditorBloc');
 
     final error = switch (result) {
       UsernameClaimSuccess() => null,

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -7,6 +7,7 @@ import 'dart:core';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:http/http.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:nostr_client/nostr_client.dart'
@@ -373,14 +374,13 @@ class BlocklistVersion extends _$BlocklistVersion {
   void increment() => state++;
 }
 
-/// NIP-05 service for username registration and verification
+/// NIP-05 service for username availability checking
 @riverpod
 Nip05Service nip05Service(Ref ref) {
-  final nostrClient = ref.read(nostrServiceProvider);
-  return Nip05Service(nostrClient: nostrClient);
+  return Nip05Service();
 }
 
-/// Username repository for availability checking and registration
+/// Username repository for availability checking
 @riverpod
 UsernameRepository usernameRepository(Ref ref) {
   final nip05Service = ref.watch(nip05ServiceProvider);
@@ -644,7 +644,7 @@ ProfileRepository profileRepository(Ref ref) {
     'ProfileRepository accessed without authentication',
   );
 
-  return ProfileRepository(nostrClient: nostrClient);
+  return ProfileRepository(nostrClient: nostrClient, httpClient: Client());
 }
 
 // ProfileStatsProvider is now handled by profile_stats_provider.dart with pure Riverpod

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -1350,17 +1350,17 @@ abstract class _$BlocklistVersion extends $Notifier<int> {
   }
 }
 
-/// NIP-05 service for username registration and verification
+/// NIP-05 service for username availability checking
 
 @ProviderFor(nip05Service)
 const nip05ServiceProvider = Nip05ServiceProvider._();
 
-/// NIP-05 service for username registration and verification
+/// NIP-05 service for username availability checking
 
 final class Nip05ServiceProvider
     extends $FunctionalProvider<Nip05Service, Nip05Service, Nip05Service>
     with $Provider<Nip05Service> {
-  /// NIP-05 service for username registration and verification
+  /// NIP-05 service for username availability checking
   const Nip05ServiceProvider._()
     : super(
         from: null,
@@ -1394,14 +1394,14 @@ final class Nip05ServiceProvider
   }
 }
 
-String _$nip05ServiceHash() => r'1d27e1b137a09246fedc50586a7a28bcf37542b0';
+String _$nip05ServiceHash() => r'b7f7e1471a3783305bf1070cb64f1b95c4bdb516';
 
-/// Username repository for availability checking and registration
+/// Username repository for availability checking
 
 @ProviderFor(usernameRepository)
 const usernameRepositoryProvider = UsernameRepositoryProvider._();
 
-/// Username repository for availability checking and registration
+/// Username repository for availability checking
 
 final class UsernameRepositoryProvider
     extends
@@ -1411,7 +1411,7 @@ final class UsernameRepositoryProvider
           UsernameRepository
         >
     with $Provider<UsernameRepository> {
-  /// Username repository for availability checking and registration
+  /// Username repository for availability checking
   const UsernameRepositoryProvider._()
     : super(
         from: null,
@@ -2133,7 +2133,7 @@ final class ProfileRepositoryProvider
   }
 }
 
-String _$profileRepositoryHash() => r'3f492aba74b38fc183ffc4efeb35d2185b5996dd';
+String _$profileRepositoryHash() => r'66f7386da11435f5e686d2c3bd390ec927eaf901';
 
 /// Enhanced notification service with Nostr integration (lazy loaded)
 

--- a/mobile/lib/providers/username_notifier.dart
+++ b/mobile/lib/providers/username_notifier.dart
@@ -124,6 +124,14 @@ class UsernameNotifier extends _$UsernameNotifier {
     state = const UsernameState();
   }
 
+  /// Mark username as reserved (called after claim returns 403)
+  void setReserved(String username) {
+    state = UsernameState(
+      username: username,
+      status: UsernameCheckStatus.reserved,
+    );
+  }
+
   /// Validate username format locally
   bool _isValidFormat(String username) {
     final regex = RegExp(r'^[a-z0-9\-_.]+$', caseSensitive: false);

--- a/mobile/lib/providers/username_notifier.g.dart
+++ b/mobile/lib/providers/username_notifier.g.dart
@@ -53,7 +53,7 @@ final class UsernameNotifierProvider
   }
 }
 
-String _$usernameNotifierHash() => r'76514b404ff53d88f1e6597414e2d8d7a4aafdd9';
+String _$usernameNotifierHash() => r'c0cdbb21233200ea3e6ba1e5863591954a59de35';
 
 /// Notifier for managing username availability checking
 ///

--- a/mobile/lib/repositories/username_repository.dart
+++ b/mobile/lib/repositories/username_repository.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Repository for username availability checking and registration
+// ABOUTME: Repository for username availability checking
 // ABOUTME: Wraps Nip05Service to provide a clean data layer interface
 
 import 'package:openvine/services/nip05_service.dart';
@@ -15,39 +15,12 @@ enum UsernameAvailability {
   error,
 }
 
-/// Sealed class representing the result of a username claim attempt.
-sealed class UsernameClaimResult {
-  const UsernameClaimResult();
-}
-
-/// Username was successfully claimed.
-class UsernameClaimSuccess extends UsernameClaimResult {
-  const UsernameClaimSuccess();
-}
-
-/// Username is already taken by another user.
-class UsernameClaimTaken extends UsernameClaimResult {
-  const UsernameClaimTaken();
-}
-
-/// Username is reserved and requires contacting support to claim.
-class UsernameClaimReserved extends UsernameClaimResult {
-  const UsernameClaimReserved();
-}
-
-/// An error occurred during username registration.
-class UsernameClaimError extends UsernameClaimResult {
-  /// Creates an error result with the given [message].
-  const UsernameClaimError(this.message);
-
-  /// Description of what went wrong.
-  final String message;
-}
-
-/// Repository that handles username-related data operations
+/// Repository that handles username availability checking.
 ///
 /// This sits between the controller and service layers, providing
 /// a clean interface for the presentation layer to use.
+///
+/// Note: Username claiming/registration is handled by ProfileRepository.
 class UsernameRepository {
   UsernameRepository(this._nip05Service);
 
@@ -68,25 +41,6 @@ class UsernameRepository {
           : UsernameAvailability.taken;
     } catch (e) {
       return UsernameAvailability.error;
-    }
-  }
-
-  /// Register a username for the given pubkey
-  ///
-  /// Delegates to [Nip05Service.registerUsername] and returns the result.
-  Future<UsernameClaimResult> register({
-    required String username,
-    required String pubkey,
-  }) async {
-    try {
-      await _nip05Service.registerUsername(username, pubkey);
-      return const UsernameClaimSuccess();
-    } on UsernameTakenException {
-      return const UsernameClaimTaken();
-    } on UsernameReservedException {
-      return const UsernameClaimReserved();
-    } on Nip05ServiceException catch (e) {
-      return UsernameClaimError(e.message ?? 'Unknown error');
     }
   }
 }

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -18,7 +19,6 @@ import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/username_notifier.dart';
 import 'package:openvine/state/username_state.dart';
-import 'package:divine_ui/divine_ui.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/profile/nostr_info_sheet_content.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -43,13 +43,11 @@ class ProfileSetupScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final profileRepository = ref.watch(profileRepositoryProvider);
-    final usernameRepository = ref.watch(usernameRepositoryProvider);
     final userProfileService = ref.watch(userProfileServiceProvider);
 
     return BlocProvider<ProfileEditorBloc>(
       create: (context) => ProfileEditorBloc(
         profileRepository: profileRepository,
-        usernameRepository: usernameRepository,
         userProfileService: userProfileService,
       ),
       child: ProfileSetupScreenView(isNewUser: isNewUser),
@@ -224,6 +222,8 @@ class _ProfileSetupScreenViewState
 
   @override
   Widget build(BuildContext context) {
+    // TODO(refactor): Migrate usernameProvider to ProfileEditorBloc with
+    // debounced username validation
     final usernameState = ref.watch(usernameProvider);
     final pubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
 
@@ -305,7 +305,9 @@ class _ProfileSetupScreenViewState
               showDialog<void>(
                 context: context,
                 builder: (context) => UsernameReservedDialog(username),
-              );
+              ).then((_) {
+                ref.read(usernameProvider.notifier).setReserved(username);
+              });
             case ProfileEditorError.publishFailed:
               ScaffoldMessenger.of(context).showSnackBar(
                 const SnackBar(

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -8,6 +8,7 @@ import 'package:nostr_client/src/models/models.dart';
 import 'package:nostr_client/src/relay_manager.dart';
 import 'package:nostr_gateway/nostr_gateway.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/utils/hash_util.dart';
 
 /// {@template nostr_client}
 /// Abstraction layer for Nostr communication
@@ -918,6 +919,32 @@ class NostrClient {
     );
 
     return subscribe([filter]);
+  }
+
+  /// Creates a NIP-98 HTTP authentication header.
+  ///
+  /// Generates a signed kind 27235 event containing the [url] and [method],
+  /// plus an optional SHA256 hash of the [payload]. Returns the header value
+  /// in the format `Nostr <base64-encoded-event>`.
+  Future<String?> createNip98AuthHeader({
+    required String url,
+    required String method,
+    String? payload,
+  }) async {
+    final tags = [
+      ['u', url],
+      ['method', method],
+      if (payload != null)
+        ['payload', HashUtil.sha256Bytes(utf8.encode(payload))],
+    ];
+    final nip98Event = Event(_nostr.publicKey, EventKind.httpAuth, tags, '');
+    await _nostr.signEvent(nip98Event);
+
+    if (nip98Event.id.isEmpty || nip98Event.sig.isEmpty) return null;
+
+    final eventJson = jsonEncode(nip98Event.toJson());
+    final base64Event = base64Encode(utf8.encode(eventJson));
+    return 'Nostr $base64Event';
   }
 
   /// Disposes the client and cleans up resources

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:db_client/db_client.dart' hide Filter;
 import 'package:flutter_test/flutter_test.dart';
@@ -6,6 +7,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_gateway/nostr_gateway.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:nostr_sdk/utils/hash_util.dart';
 
 class _MockNostr extends Mock implements Nostr {}
 
@@ -1789,6 +1791,85 @@ void main() {
 
         expect(result, isNull);
       });
+    });
+
+    group('createNip98AuthHeader', () {
+      test(
+        'returns "Nostr <base64>" with payload tag when payload is provided',
+        () async {
+          when(() => mockNostr.signEvent(any())).thenAnswer((invocation) {
+            invocation.positionalArguments[0] as Event
+              ..id = 'id'
+              ..sig = 'sig';
+            return Future.value();
+          });
+
+          const url = 'https://divine.video/api/username/claim';
+          final authHeader = await client.createNip98AuthHeader(
+            url: url,
+            method: 'POST',
+            payload: 'payload',
+          );
+          final decoded =
+              jsonDecode(utf8.decode(base64Decode(authHeader!.split(' ')[1])))
+                  as Map<String, dynamic>;
+          final tags = (decoded['tags'] as List).cast<List<dynamic>>();
+
+          expect(authHeader, startsWith('Nostr '));
+          expect(decoded['kind'], equals(EventKind.httpAuth));
+          expect(tags[0][1], equals(url));
+          expect(tags[1][1], equals('POST'));
+          expect(
+            tags[2][1],
+            equals(HashUtil.sha256Bytes(utf8.encode('payload'))),
+          );
+        },
+      );
+
+      test(
+        'returns "Nostr <base64>" without payload tag when payload is not '
+        'provided',
+        () async {
+          when(() => mockNostr.signEvent(any())).thenAnswer((invocation) {
+            invocation.positionalArguments[0] as Event
+              ..id = 'id'
+              ..sig = 'sig';
+            return Future.value();
+          });
+
+          const url = 'https://divine.video/api/username/claim';
+          final authHeader = await client.createNip98AuthHeader(
+            url: url,
+            method: 'POST',
+          );
+          final decoded =
+              jsonDecode(utf8.decode(base64Decode(authHeader!.split(' ')[1])))
+                  as Map<String, dynamic>;
+          final tags = (decoded['tags'] as List).cast<List<dynamic>>();
+
+          expect(authHeader, startsWith('Nostr '));
+          expect(decoded['kind'], equals(EventKind.httpAuth));
+          expect(tags[0][1], equals(url));
+          expect(tags[1][1], equals('POST'));
+          expect(tags.length, equals(2));
+        },
+      );
+
+      test(
+        'returns null when signing fails',
+        () async {
+          when(
+            () => mockNostr.signEvent(any()),
+          ).thenAnswer((_) => Future.value());
+
+          const url = 'https://divine.video/api/username/claim';
+          final authHeader = await client.createNip98AuthHeader(
+            url: url,
+            method: 'POST',
+          );
+          expect(authHeader, isNull);
+        },
+      );
     });
 
     group('dispose', () {

--- a/mobile/packages/profile_repository/lib/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/profile_repository.dart
@@ -3,3 +3,4 @@ library;
 
 export 'src/exceptions.dart';
 export 'src/profile_repository.dart';
+export 'src/username_claim_result.dart';

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -2,17 +2,27 @@
 // ABOUTME: Delegates to NostrClient for relay operations.
 // ABOUTME: Throws ProfilePublishFailedException on publish failure.
 
+import 'dart:convert';
+
+import 'package:http/http.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
-import 'package:profile_repository/src/exceptions.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+/// API endpoint for claiming usernames via NIP-98 auth.
+const _usernameClaimUrl = 'https://names.divine.video/api/username/claim';
 
 /// Repository for fetching and publishing user profiles (Kind 0 metadata).
 class ProfileRepository {
   /// Creates a new profile repository.
-  const ProfileRepository({required NostrClient nostrClient})
-    : _nostrClient = nostrClient;
+  const ProfileRepository({
+    required NostrClient nostrClient,
+    required Client httpClient,
+  }) : _nostrClient = nostrClient,
+       _httpClient = httpClient;
 
   final NostrClient _nostrClient;
+  final Client _httpClient;
 
   /// Fetches a user profile by pubkey.
   ///
@@ -52,5 +62,50 @@ class ProfileRepository {
     }
 
     return UserProfile.fromNostrEvent(profileEvent);
+  }
+
+  /// Claims a username via NIP-98 authenticated request.
+  ///
+  /// Makes a POST request to `names.divine.video/api/username/claim` with the
+  /// username. The pubkey is extracted from the NIP-98 auth header by the
+  /// server.
+  ///
+  /// Returns a [UsernameClaimResult] indicating success or the type of failure.
+  Future<UsernameClaimResult> claimUsername({
+    required String username,
+  }) async {
+    final payload = jsonEncode({
+      'name': username,
+    });
+    final authHeader = await _nostrClient.createNip98AuthHeader(
+      url: _usernameClaimUrl,
+      method: 'POST',
+      payload: payload,
+    );
+
+    if (authHeader == null) {
+      return const UsernameClaimError('Nip98 authorization failed');
+    }
+
+    final Response response;
+    try {
+      response = await _httpClient.post(
+        Uri.parse(_usernameClaimUrl),
+        headers: {
+          'Authorization': authHeader,
+          'Content-Type': 'application/json',
+        },
+        body: payload,
+      );
+
+      return switch (response.statusCode) {
+        200 || 201 => const UsernameClaimSuccess(),
+        403 => const UsernameClaimReserved(),
+        409 => const UsernameClaimTaken(),
+        _ => UsernameClaimError('Unexpected response: ${response.statusCode}'),
+      };
+    } on Exception catch (e) {
+      return UsernameClaimError('Network error: $e');
+    }
   }
 }

--- a/mobile/packages/profile_repository/lib/src/username_claim_result.dart
+++ b/mobile/packages/profile_repository/lib/src/username_claim_result.dart
@@ -1,0 +1,35 @@
+/// Sealed class representing the result of a username claim attempt.
+sealed class UsernameClaimResult {
+  /// Creates a username claim result.
+  const UsernameClaimResult();
+}
+
+/// Username was successfully claimed.
+class UsernameClaimSuccess extends UsernameClaimResult {
+  /// Creates a success result.
+  const UsernameClaimSuccess();
+}
+
+/// Username is already taken by another user.
+class UsernameClaimTaken extends UsernameClaimResult {
+  /// Creates a taken result.
+  const UsernameClaimTaken();
+}
+
+/// Username is reserved and requires contacting support to claim.
+class UsernameClaimReserved extends UsernameClaimResult {
+  /// Creates a reserved result.
+  const UsernameClaimReserved();
+}
+
+/// An error occurred during username claiming.
+class UsernameClaimError extends UsernameClaimResult {
+  /// Creates an error result with the given [message].
+  const UsernameClaimError(this.message);
+
+  /// Description of what went wrong.
+  final String message;
+
+  @override
+  String toString() => 'UsernameClaimError($message)';
+}

--- a/mobile/packages/profile_repository/pubspec.yaml
+++ b/mobile/packages/profile_repository/pubspec.yaml
@@ -17,6 +17,7 @@ dev_dependencies:
 
 dependencies:
   equatable: ^2.0.8
+  http: ^1.2.2
   models:
     path: '../models'
   nostr_client:

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:http/http.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
@@ -11,11 +12,14 @@ class MockNostrClient extends Mock implements NostrClient {}
 
 class MockEvent extends Mock implements Event {}
 
+class MockHttpClient extends Mock implements Client {}
+
 void main() {
   group('ProfileRepository', () {
     late MockNostrClient mockNostrClient;
     late ProfileRepository repository;
     late MockEvent mockProfileEvent;
+    late MockHttpClient mockHttpClient;
 
     const testPubkey =
         'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
@@ -24,12 +28,17 @@ void main() {
 
     setUpAll(() {
       registerFallbackValue(<String, dynamic>{});
+      registerFallbackValue(Uri.parse('https://example.com'));
     });
 
     setUp(() {
       mockNostrClient = MockNostrClient();
       mockProfileEvent = MockEvent();
-      repository = ProfileRepository(nostrClient: mockNostrClient);
+      mockHttpClient = MockHttpClient();
+      repository = ProfileRepository(
+        nostrClient: mockNostrClient,
+        httpClient: mockHttpClient,
+      );
 
       // Default mock event setup
       when(() => mockProfileEvent.kind).thenReturn(0);
@@ -248,6 +257,188 @@ void main() {
 
         expect(e.message, isNull);
         expect(e.toString(), contains('ProfileRepositoryException'));
+      });
+    });
+
+    group('claimUsername', () {
+      test('returns UsernameClaimSuccess when response is 200', () async {
+        when(
+          () => mockNostrClient.createNip98AuthHeader(
+            url: any(named: 'url'),
+            method: any(named: 'method'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenAnswer((_) => Future.value('authHeader'));
+        when(
+          () => mockHttpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) => Future.value(Response('body', 200)));
+
+        final usernameClaimResult = await repository.claimUsername(
+          username: 'username',
+        );
+        expect(usernameClaimResult, equals(const UsernameClaimSuccess()));
+      });
+
+      test('returns UsernameClaimSuccess when response is 201', () async {
+        when(
+          () => mockNostrClient.createNip98AuthHeader(
+            url: any(named: 'url'),
+            method: any(named: 'method'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenAnswer((_) => Future.value('authHeader'));
+        when(
+          () => mockHttpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) => Future.value(Response('body', 201)));
+
+        final usernameClaimResult = await repository.claimUsername(
+          username: 'username',
+        );
+        expect(usernameClaimResult, equals(const UsernameClaimSuccess()));
+      });
+
+      test('returns UsernameClaimReserved when response is 403', () async {
+        when(
+          () => mockNostrClient.createNip98AuthHeader(
+            url: any(named: 'url'),
+            method: any(named: 'method'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenAnswer((_) => Future.value('authHeader'));
+        when(
+          () => mockHttpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) => Future.value(Response('body', 403)));
+
+        final usernameClaimResult = await repository.claimUsername(
+          username: 'username',
+        );
+        expect(usernameClaimResult, equals(const UsernameClaimReserved()));
+      });
+
+      test('returns UsernameClaimTaken when response is 409', () async {
+        when(
+          () => mockNostrClient.createNip98AuthHeader(
+            url: any(named: 'url'),
+            method: any(named: 'method'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenAnswer((_) => Future.value('authHeader'));
+        when(
+          () => mockHttpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) => Future.value(Response('body', 409)));
+
+        final usernameClaimResult = await repository.claimUsername(
+          username: 'username',
+        );
+        expect(usernameClaimResult, equals(const UsernameClaimTaken()));
+      });
+
+      test('returns UsernameClaimError when response is unexpected', () async {
+        when(
+          () => mockNostrClient.createNip98AuthHeader(
+            url: any(named: 'url'),
+            method: any(named: 'method'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenAnswer((_) => Future.value('authHeader'));
+        when(
+          () => mockHttpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) => Future.value(Response('body', 500)));
+
+        final usernameClaimResult = await repository.claimUsername(
+          username: 'username',
+        );
+        expect(
+          usernameClaimResult,
+          isA<UsernameClaimError>().having(
+            (e) => e.message,
+            'message',
+            'Unexpected response: 500',
+          ),
+        );
+      });
+
+      test('returns UsernameClaimError on network exception ', () async {
+        when(
+          () => mockNostrClient.createNip98AuthHeader(
+            url: any(named: 'url'),
+            method: any(named: 'method'),
+            payload: any(named: 'payload'),
+          ),
+        ).thenAnswer((_) => Future.value('authHeader'));
+        when(
+          () => mockHttpClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenThrow(Exception('network exception'));
+
+        final usernameClaimResult = await repository.claimUsername(
+          username: 'username',
+        );
+        expect(
+          usernameClaimResult,
+          isA<UsernameClaimError>().having(
+            (e) => e.message,
+            'message',
+            'Network error: Exception: network exception',
+          ),
+        );
+      });
+
+      test(
+        'returns UsernameClaimError when nip98 auth header is null',
+        () async {
+          when(
+            () => mockNostrClient.createNip98AuthHeader(
+              url: any(named: 'url'),
+              method: any(named: 'method'),
+              payload: any(named: 'payload'),
+            ),
+          ).thenAnswer((_) => Future.value());
+
+          final usernameClaimResult = await repository.claimUsername(
+            username: 'username',
+          );
+          expect(
+            usernameClaimResult,
+            isA<UsernameClaimError>().having(
+              (e) => e.message,
+              'message',
+              'Nip98 authorization failed',
+            ),
+          );
+
+          verifyNever(() => mockHttpClient.post(any()));
+        },
+      );
+    });
+
+    group('UsernameClaimResult', () {
+      test('UsernameClaimError toString returns formatted message', () {
+        const error = UsernameClaimError('test error');
+        expect(error.toString(), equals('UsernameClaimError(test error)'));
       });
     });
   });

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -7,11 +7,8 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
 import 'package:openvine/models/user_profile.dart' as app_models;
-import 'package:openvine/repositories/username_repository.dart';
 import 'package:openvine/services/user_profile_service.dart';
 import 'package:profile_repository/profile_repository.dart';
-
-class _MockUsernameRepository extends Mock implements UsernameRepository {}
 
 class _MockProfileRepository extends Mock implements ProfileRepository {}
 
@@ -19,7 +16,6 @@ class _MockUserProfileService extends Mock implements UserProfileService {}
 
 void main() {
   group('ProfileEditorBloc', () {
-    late _MockUsernameRepository mockUsernameRepository;
     late _MockProfileRepository mockProfileRepository;
     late _MockUserProfileService mockUserProfileService;
 
@@ -62,7 +58,6 @@ void main() {
     });
 
     setUp(() {
-      mockUsernameRepository = _MockUsernameRepository();
       mockProfileRepository = _MockProfileRepository();
       mockUserProfileService = _MockUserProfileService();
 
@@ -73,7 +68,6 @@ void main() {
 
     ProfileEditorBloc createBloc() => ProfileEditorBloc(
       profileRepository: mockProfileRepository,
-      usernameRepository: mockUsernameRepository,
       userProfileService: mockUserProfileService,
     );
 
@@ -134,9 +128,8 @@ void main() {
               ),
             ).called(1);
             verifyNever(
-              () => mockUsernameRepository.register(
+              () => mockProfileRepository.claimUsername(
                 username: any(named: 'username'),
-                pubkey: any(named: 'pubkey'),
               ),
             );
           },
@@ -251,10 +244,7 @@ void main() {
               ),
             ).thenAnswer((_) async => createTestProfile());
             when(
-              () => mockUsernameRepository.register(
-                username: testUsername,
-                pubkey: testPubkey,
-              ),
+              () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimSuccess());
           },
           build: createBloc,
@@ -290,10 +280,7 @@ void main() {
               ),
             ).called(1);
             verify(
-              () => mockUsernameRepository.register(
-                username: testUsername,
-                pubkey: testPubkey,
-              ),
+              () => mockProfileRepository.claimUsername(username: testUsername),
             ).called(1);
           },
         );
@@ -369,9 +356,8 @@ void main() {
           ),
           verify: (_) {
             verifyNever(
-              () => mockUsernameRepository.register(
+              () => mockProfileRepository.claimUsername(
                 username: any(named: 'username'),
-                pubkey: any(named: 'pubkey'),
               ),
             );
           },
@@ -396,10 +382,7 @@ void main() {
               ),
             ).thenAnswer((_) async => createTestProfile());
             when(
-              () => mockUsernameRepository.register(
-                username: testUsername,
-                pubkey: testPubkey,
-              ),
+              () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimTaken());
             when(
               () => mockProfileRepository.saveProfileEvent(
@@ -454,10 +437,7 @@ void main() {
               ),
             ).thenAnswer((_) async => createTestProfile());
             when(
-              () => mockUsernameRepository.register(
-                username: testUsername,
-                pubkey: testPubkey,
-              ),
+              () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimTaken());
             when(
               () => mockProfileRepository.saveProfileEvent(
@@ -515,10 +495,7 @@ void main() {
               ),
             ).thenAnswer((_) async => createTestProfile());
             when(
-              () => mockUsernameRepository.register(
-                username: testUsername,
-                pubkey: testPubkey,
-              ),
+              () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimTaken());
             when(
               () => mockProfileRepository.saveProfileEvent(
@@ -579,10 +556,7 @@ void main() {
               ),
             ).thenAnswer((_) async => createTestProfile());
             when(
-              () => mockUsernameRepository.register(
-                username: testUsername,
-                pubkey: testPubkey,
-              ),
+              () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimReserved());
             when(
               () => mockProfileRepository.saveProfileEvent(
@@ -637,10 +611,7 @@ void main() {
               ),
             ).thenAnswer((_) async => createTestProfile());
             when(
-              () => mockUsernameRepository.register(
-                username: testUsername,
-                pubkey: testPubkey,
-              ),
+              () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimReserved());
             when(
               () => mockProfileRepository.saveProfileEvent(
@@ -701,10 +672,7 @@ void main() {
               ),
             ).thenAnswer((_) async => createTestProfile());
             when(
-              () => mockUsernameRepository.register(
-                username: testUsername,
-                pubkey: testPubkey,
-              ),
+              () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer(
               (_) async => const UsernameClaimError('Server unavailable'),
             );
@@ -763,10 +731,7 @@ void main() {
               ),
             ).thenAnswer((_) async => createTestProfile());
             when(
-              () => mockUsernameRepository.register(
-                username: testUsername,
-                pubkey: testPubkey,
-              ),
+              () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimTaken());
             when(
               () => mockProfileRepository.saveProfileEvent(

--- a/mobile/test/helpers/test_provider_overrides.mocks.dart
+++ b/mobile/test/helpers/test_provider_overrides.mocks.dart
@@ -1066,6 +1066,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i8.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/integration/account_deletion_flow_test.mocks.dart
+++ b/mobile/test/integration/account_deletion_flow_test.mocks.dart
@@ -513,6 +513,22 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as _i7.Stream<_i8.Event>);
 
   @override
+  _i7.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i7.Future<String?>.value(),
+          )
+          as _i7.Future<String?>);
+
+  @override
   _i7.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/integration/home_feed_seen_videos_test.mocks.dart
+++ b/mobile/test/integration/home_feed_seen_videos_test.mocks.dart
@@ -1295,6 +1295,22 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as _i11.Stream<_i10.Event>);
 
   @override
+  _i11.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i11.Future<String?>.value(),
+          )
+          as _i11.Future<String?>);
+
+  @override
   _i11.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/integration/reactive_pagination_test.mocks.dart
+++ b/mobile/test/integration/reactive_pagination_test.mocks.dart
@@ -500,6 +500,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/integration/search_navigation_integration_test.mocks.dart
+++ b/mobile/test/integration/search_navigation_integration_test.mocks.dart
@@ -1294,6 +1294,22 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as _i11.Stream<_i10.Event>);
 
   @override
+  _i11.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i11.Future<String?>.value(),
+          )
+          as _i11.Future<String?>);
+
+  @override
   _i11.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/integration/upload_publish_e2e_comprehensive_test.mocks.dart
+++ b/mobile/test/integration/upload_publish_e2e_comprehensive_test.mocks.dart
@@ -962,6 +962,22 @@ class MockNostrClient extends _i1.Mock implements _i11.NostrClient {
           as _i6.Stream<_i10.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/integration/video_event_service_simple_test.mocks.dart
+++ b/mobile/test/integration/video_event_service_simple_test.mocks.dart
@@ -500,6 +500,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/profile_fetching_test.mocks.dart
+++ b/mobile/test/profile_fetching_test.mocks.dart
@@ -502,6 +502,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/providers/curation_provider_lifecycle_test.mocks.dart
+++ b/mobile/test/providers/curation_provider_lifecycle_test.mocks.dart
@@ -522,6 +522,22 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as _i7.Stream<_i8.Event>);
 
   @override
+  _i7.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i7.Future<String?>.value(),
+          )
+          as _i7.Future<String?>);
+
+  @override
   _i7.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/providers/curation_provider_tab_refresh_test.mocks.dart
+++ b/mobile/test/providers/curation_provider_tab_refresh_test.mocks.dart
@@ -522,6 +522,22 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as _i7.Stream<_i8.Event>);
 
   @override
+  _i7.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i7.Future<String?>.value(),
+          )
+          as _i7.Future<String?>);
+
+  @override
   _i7.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/providers/home_feed_provider_test.mocks.dart
+++ b/mobile/test/providers/home_feed_provider_test.mocks.dart
@@ -1295,6 +1295,22 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as _i11.Stream<_i10.Event>);
 
   @override
+  _i11.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i11.Future<String?>.value(),
+          )
+          as _i11.Future<String?>);
+
+  @override
   _i11.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/providers/readiness_gate_providers_test.mocks.dart
+++ b/mobile/test/providers/readiness_gate_providers_test.mocks.dart
@@ -499,6 +499,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/providers/video_events_listener_simple_test.mocks.dart
+++ b/mobile/test/providers/video_events_listener_simple_test.mocks.dart
@@ -1294,6 +1294,22 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as _i11.Stream<_i10.Event>);
 
   @override
+  _i11.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i11.Future<String?>.value(),
+          )
+          as _i11.Future<String?>);
+
+  @override
   _i11.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/providers/video_events_provider_listener_test.mocks.dart
+++ b/mobile/test/providers/video_events_provider_listener_test.mocks.dart
@@ -1294,6 +1294,22 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as _i11.Stream<_i10.Event>);
 
   @override
+  _i11.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i11.Future<String?>.value(),
+          )
+          as _i11.Future<String?>);
+
+  @override
   _i11.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/repositories/username_repository_test.dart
+++ b/mobile/test/repositories/username_repository_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Unit tests for UsernameRepository
-// ABOUTME: Tests availability checking and registration delegation to Nip05Service
+// ABOUTME: Tests availability checking delegation to Nip05Service
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -66,88 +66,6 @@ void main() {
           () => mockNip05Service.checkUsernameAvailability('erroruser'),
         ).called(1);
       });
-    });
-
-    group('register', () {
-      const validPubkey =
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-
-      test('returns UsernameClaimSuccess on successful registration', () async {
-        // Arrange
-        when(
-          () => mockNip05Service.registerUsername('newuser', validPubkey),
-        ).thenAnswer((_) async {});
-
-        // Act
-        final result = await repository.register(
-          username: 'newuser',
-          pubkey: validPubkey,
-        );
-
-        // Assert
-        expect(result, isA<UsernameClaimSuccess>());
-        verify(
-          () => mockNip05Service.registerUsername('newuser', validPubkey),
-        ).called(1);
-      });
-
-      test(
-        'returns UsernameClaimTaken when service throws UsernameTakenException',
-        () async {
-          // Arrange
-          when(
-            () => mockNip05Service.registerUsername('takenuser', validPubkey),
-          ).thenThrow(const UsernameTakenException());
-
-          // Act
-          final result = await repository.register(
-            username: 'takenuser',
-            pubkey: validPubkey,
-          );
-
-          // Assert
-          expect(result, isA<UsernameClaimTaken>());
-        },
-      );
-
-      test(
-        'returns UsernameClaimReserved when service throws UsernameReservedException',
-        () async {
-          // Arrange
-          when(
-            () => mockNip05Service.registerUsername('reserved', validPubkey),
-          ).thenThrow(const UsernameReservedException());
-
-          // Act
-          final result = await repository.register(
-            username: 'reserved',
-            pubkey: validPubkey,
-          );
-
-          // Assert
-          expect(result, isA<UsernameClaimReserved>());
-        },
-      );
-
-      test(
-        'returns UsernameClaimError when service throws Nip05ServiceException',
-        () async {
-          // Arrange
-          when(
-            () => mockNip05Service.registerUsername('erroruser', validPubkey),
-          ).thenThrow(const Nip05ServiceException('Network error'));
-
-          // Act
-          final result = await repository.register(
-            username: 'erroruser',
-            pubkey: validPubkey,
-          );
-
-          // Assert
-          expect(result, isA<UsernameClaimError>());
-          expect((result as UsernameClaimError).message, 'Network error');
-        },
-      );
     });
   });
 }

--- a/mobile/test/router/nav_extensions_test.mocks.dart
+++ b/mobile/test/router/nav_extensions_test.mocks.dart
@@ -761,6 +761,22 @@ class MockNostrClient extends _i1.Mock implements _i8.NostrClient {
           as _i4.Stream<_i7.Event>);
 
   @override
+  _i4.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i4.Future<String?>.value(),
+          )
+          as _i4.Future<String?>);
+
+  @override
   _i4.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/router/search_navigation_test.mocks.dart
+++ b/mobile/test/router/search_navigation_test.mocks.dart
@@ -761,6 +761,22 @@ class MockNostrClient extends _i1.Mock implements _i8.NostrClient {
           as _i4.Stream<_i7.Event>);
 
   @override
+  _i4.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i4.Future<String?>.value(),
+          )
+          as _i4.Future<String?>);
+
+  @override
   _i4.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/screens/explore_screen_video_display_test.mocks.dart
+++ b/mobile/test/screens/explore_screen_video_display_test.mocks.dart
@@ -1294,6 +1294,22 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as _i11.Stream<_i10.Event>);
 
   @override
+  _i11.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i11.Future<String?>.value(),
+          )
+          as _i11.Future<String?>);
+
+  @override
   _i11.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/screens/profile_setup_relay_confirmation_test.mocks.dart
+++ b/mobile/test/screens/profile_setup_relay_confirmation_test.mocks.dart
@@ -510,6 +510,22 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/screens/search_screen_pure_url_test.mocks.dart
+++ b/mobile/test/screens/search_screen_pure_url_test.mocks.dart
@@ -1294,6 +1294,22 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as _i11.Stream<_i10.Event>);
 
   @override
+  _i11.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i11.Future<String?>.value(),
+          )
+          as _i11.Future<String?>);
+
+  @override
   _i11.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/screens/sound_detail_screen_test.mocks.dart
+++ b/mobile/test/screens/sound_detail_screen_test.mocks.dart
@@ -650,6 +650,22 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as _i4.Stream<_i7.Event>);
 
   @override
+  _i4.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i4.Future<String?>.value(),
+          )
+          as _i4.Future<String?>);
+
+  @override
   _i4.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/account_deletion_service_test.mocks.dart
+++ b/mobile/test/services/account_deletion_service_test.mocks.dart
@@ -507,6 +507,22 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/content_blocklist_service_test.mocks.dart
+++ b/mobile/test/services/content_blocklist_service_test.mocks.dart
@@ -499,6 +499,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/content_deletion_service_test.mocks.dart
+++ b/mobile/test/services/content_deletion_service_test.mocks.dart
@@ -507,6 +507,22 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/content_reporting_service_test.mocks.dart
+++ b/mobile/test/services/content_reporting_service_test.mocks.dart
@@ -507,6 +507,22 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curated_list_service_collaboration_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_collaboration_test.mocks.dart
@@ -507,6 +507,22 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curated_list_service_crud_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_crud_test.mocks.dart
@@ -566,6 +566,23 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+            returnValueForMissingStub: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curated_list_service_initialization_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_initialization_test.mocks.dart
@@ -507,6 +507,22 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curated_list_service_persistence_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_persistence_test.mocks.dart
@@ -507,6 +507,22 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curated_list_service_playlist_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_playlist_test.mocks.dart
@@ -507,6 +507,22 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curated_list_service_query_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_query_test.mocks.dart
@@ -507,6 +507,22 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curated_list_service_stream_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_stream_test.mocks.dart
@@ -507,6 +507,22 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curated_list_service_video_management_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_video_management_test.mocks.dart
@@ -507,6 +507,22 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curation_publish_test.mocks.dart
+++ b/mobile/test/services/curation_publish_test.mocks.dart
@@ -520,6 +520,22 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as _i7.Stream<_i8.Event>);
 
   @override
+  _i7.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i7.Future<String?>.value(),
+          )
+          as _i7.Future<String?>);
+
+  @override
   _i7.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curation_service_analytics_test.mocks.dart
+++ b/mobile/test/services/curation_service_analytics_test.mocks.dart
@@ -520,6 +520,22 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as _i7.Stream<_i8.Event>);
 
   @override
+  _i7.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i7.Future<String?>.value(),
+          )
+          as _i7.Future<String?>);
+
+  @override
   _i7.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curation_service_create_test.mocks.dart
+++ b/mobile/test/services/curation_service_create_test.mocks.dart
@@ -526,6 +526,22 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
           as _i8.Stream<_i9.Event>);
 
   @override
+  _i8.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i8.Future<String?>.value(),
+          )
+          as _i8.Future<String?>);
+
+  @override
   _i8.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curation_service_editors_picks_test.mocks.dart
+++ b/mobile/test/services/curation_service_editors_picks_test.mocks.dart
@@ -520,6 +520,22 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as _i7.Stream<_i8.Event>);
 
   @override
+  _i7.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i7.Future<String?>.value(),
+          )
+          as _i7.Future<String?>);
+
+  @override
   _i7.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curation_service_kind_30005_test.mocks.dart
+++ b/mobile/test/services/curation_service_kind_30005_test.mocks.dart
@@ -520,6 +520,22 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as _i7.Stream<_i8.Event>);
 
   @override
+  _i7.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i7.Future<String?>.value(),
+          )
+          as _i7.Future<String?>);
+
+  @override
   _i7.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curation_service_test.mocks.dart
+++ b/mobile/test/services/curation_service_test.mocks.dart
@@ -520,6 +520,22 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as _i7.Stream<_i8.Event>);
 
   @override
+  _i7.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i7.Future<String?>.value(),
+          )
+          as _i7.Future<String?>);
+
+  @override
   _i7.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/curation_service_trending_fetch_test.mocks.dart
+++ b/mobile/test/services/curation_service_trending_fetch_test.mocks.dart
@@ -520,6 +520,22 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as _i7.Stream<_i8.Event>);
 
   @override
+  _i7.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i7.Future<String?>.value(),
+          )
+          as _i7.Future<String?>);
+
+  @override
   _i7.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/nip05_service_test.dart
+++ b/mobile/test/services/nip05_service_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Unit tests for NIP-05 username registration service
-// ABOUTME: Tests username validation, availability checking, and registration flow
+// ABOUTME: Unit tests for NIP-05 username availability service
+// ABOUTME: Tests username validation and availability checking
 
 import 'dart:convert';
 
@@ -7,29 +7,19 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/services/nip05_service.dart';
 
-@GenerateMocks([http.Client, NostrClient])
+@GenerateMocks([http.Client])
 import 'nip05_service_test.mocks.dart';
 
 void main() {
   group('Nip05Service', () {
     late Nip05Service service;
     late MockClient mockClient;
-    late MockNostrClient mockNostrClient;
 
     setUp(() {
       mockClient = MockClient();
-      mockNostrClient = MockNostrClient();
-      // Stub connectedRelays getter
-      when(
-        mockNostrClient.connectedRelays,
-      ).thenReturn(['wss://relay1.com', 'wss://relay2.com']);
-      service = Nip05Service(
-        httpClient: mockClient,
-        nostrClient: mockNostrClient,
-      );
+      service = Nip05Service(httpClient: mockClient);
     });
 
     group('checkUsernameAvailability', () {
@@ -97,154 +87,6 @@ void main() {
 
         // Assert
         expect(result, false);
-      });
-    });
-
-    group('registerUsername', () {
-      const validPubkey =
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-
-      test('successfully registers a username', () async {
-        // Arrange
-        const username = 'newuser';
-
-        when(
-          mockClient.post(
-            any,
-            headers: anyNamed('headers'),
-            body: anyNamed('body'),
-          ),
-        ).thenAnswer(
-          (_) async => http.Response(jsonEncode({'success': true}), 201),
-        );
-
-        // Act & Assert - should complete without throwing
-        await expectLater(
-          service.registerUsername(username, validPubkey),
-          completes,
-        );
-
-        // Verify post was called
-        verify(
-          mockClient.post(
-            any,
-            headers: anyNamed('headers'),
-            body: anyNamed('body'),
-          ),
-        ).called(1);
-      });
-
-      test('throws UsernameTakenException on 409', () async {
-        // Arrange
-        const username = 'taken';
-
-        when(
-          mockClient.post(
-            any,
-            headers: anyNamed('headers'),
-            body: anyNamed('body'),
-          ),
-        ).thenAnswer(
-          (_) async => http.Response(
-            jsonEncode({'error': 'Username already taken'}),
-            409,
-          ),
-        );
-
-        // Act & Assert
-        await expectLater(
-          () => service.registerUsername(username, validPubkey),
-          throwsA(isA<UsernameTakenException>()),
-        );
-      });
-
-      test('throws UsernameReservedException on 403', () async {
-        // Arrange
-        const username = 'reserved';
-
-        when(
-          mockClient.post(
-            any,
-            headers: anyNamed('headers'),
-            body: anyNamed('body'),
-          ),
-        ).thenAnswer(
-          (_) async =>
-              http.Response(jsonEncode({'error': 'Username is reserved'}), 403),
-        );
-
-        // Act & Assert
-        await expectLater(
-          () => service.registerUsername(username, validPubkey),
-          throwsA(isA<UsernameReservedException>()),
-        );
-      });
-
-      test('throws ArgumentError for invalid username format', () async {
-        // Act & Assert
-        await expectLater(
-          () => service.registerUsername('ab', validPubkey), // too short
-          throwsA(isA<ArgumentError>()),
-        );
-
-        await expectLater(
-          () => service.registerUsername('user@invalid', validPubkey),
-          throwsA(isA<ArgumentError>()),
-        );
-      });
-
-      test('throws ArgumentError for invalid pubkey format', () async {
-        // Act & Assert - too short
-        await expectLater(
-          () => service.registerUsername(
-            'validuser',
-            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-          ),
-          throwsA(isA<ArgumentError>()),
-        );
-
-        // Non-hex characters
-        await expectLater(
-          () => service.registerUsername(
-            'validuser',
-            'gggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg',
-          ),
-          throwsA(isA<ArgumentError>()),
-        );
-      });
-
-      test('throws Nip05ServiceException on network error', () async {
-        // Arrange
-        when(
-          mockClient.post(
-            any,
-            headers: anyNamed('headers'),
-            body: anyNamed('body'),
-          ),
-        ).thenThrow(Exception('Network error'));
-
-        // Act & Assert
-        await expectLater(
-          () => service.registerUsername('validuser', validPubkey),
-          throwsA(isA<Nip05ServiceException>()),
-        );
-      });
-
-      test('throws Nip05ServiceException on unexpected status code', () async {
-        // Arrange
-        when(
-          mockClient.post(
-            any,
-            headers: anyNamed('headers'),
-            body: anyNamed('body'),
-          ),
-        ).thenAnswer((_) async => http.Response('Server error', 500));
-
-        // Act & Assert
-        await expectLater(
-          () => service.registerUsername('validuser', validPubkey),
-          throwsA(isA<Nip05ServiceException>()),
-        );
       });
     });
   });

--- a/mobile/test/services/nip05_service_test.mocks.dart
+++ b/mobile/test/services/nip05_service_test.mocks.dart
@@ -3,16 +3,13 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
-import 'dart:convert' as _i5;
-import 'dart:typed_data' as _i7;
+import 'dart:async' as _i3;
+import 'dart:convert' as _i4;
+import 'dart:typed_data' as _i6;
 
 import 'package:http/http.dart' as _i2;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i6;
-import 'package:nostr_client/src/models/models.dart' as _i3;
-import 'package:nostr_client/src/nostr_client.dart' as _i8;
-import 'package:nostr_sdk/nostr_sdk.dart' as _i9;
+import 'package:mockito/src/dummies.dart' as _i5;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -40,11 +37,6 @@ class _FakeStreamedResponse_1 extends _i1.SmartFake
     : super(parent, parentInvocation);
 }
 
-class _FakeCountResult_2 extends _i1.SmartFake implements _i3.CountResult {
-  _FakeCountResult_2(Object parent, Invocation parentInvocation)
-    : super(parent, parentInvocation);
-}
-
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -54,37 +46,37 @@ class MockClient extends _i1.Mock implements _i2.Client {
   }
 
   @override
-  _i4.Future<_i2.Response> head(Uri? url, {Map<String, String>? headers}) =>
+  _i3.Future<_i2.Response> head(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
             Invocation.method(#head, [url], {#headers: headers}),
-            returnValue: _i4.Future<_i2.Response>.value(
+            returnValue: _i3.Future<_i2.Response>.value(
               _FakeResponse_0(
                 this,
                 Invocation.method(#head, [url], {#headers: headers}),
               ),
             ),
           )
-          as _i4.Future<_i2.Response>);
+          as _i3.Future<_i2.Response>);
 
   @override
-  _i4.Future<_i2.Response> get(Uri? url, {Map<String, String>? headers}) =>
+  _i3.Future<_i2.Response> get(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
             Invocation.method(#get, [url], {#headers: headers}),
-            returnValue: _i4.Future<_i2.Response>.value(
+            returnValue: _i3.Future<_i2.Response>.value(
               _FakeResponse_0(
                 this,
                 Invocation.method(#get, [url], {#headers: headers}),
               ),
             ),
           )
-          as _i4.Future<_i2.Response>);
+          as _i3.Future<_i2.Response>);
 
   @override
-  _i4.Future<_i2.Response> post(
+  _i3.Future<_i2.Response> post(
     Uri? url, {
     Map<String, String>? headers,
     Object? body,
-    _i5.Encoding? encoding,
+    _i4.Encoding? encoding,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
@@ -92,7 +84,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
               [url],
               {#headers: headers, #body: body, #encoding: encoding},
             ),
-            returnValue: _i4.Future<_i2.Response>.value(
+            returnValue: _i3.Future<_i2.Response>.value(
               _FakeResponse_0(
                 this,
                 Invocation.method(
@@ -103,14 +95,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
               ),
             ),
           )
-          as _i4.Future<_i2.Response>);
+          as _i3.Future<_i2.Response>);
 
   @override
-  _i4.Future<_i2.Response> put(
+  _i3.Future<_i2.Response> put(
     Uri? url, {
     Map<String, String>? headers,
     Object? body,
-    _i5.Encoding? encoding,
+    _i4.Encoding? encoding,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
@@ -118,7 +110,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
               [url],
               {#headers: headers, #body: body, #encoding: encoding},
             ),
-            returnValue: _i4.Future<_i2.Response>.value(
+            returnValue: _i3.Future<_i2.Response>.value(
               _FakeResponse_0(
                 this,
                 Invocation.method(
@@ -129,14 +121,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
               ),
             ),
           )
-          as _i4.Future<_i2.Response>);
+          as _i3.Future<_i2.Response>);
 
   @override
-  _i4.Future<_i2.Response> patch(
+  _i3.Future<_i2.Response> patch(
     Uri? url, {
     Map<String, String>? headers,
     Object? body,
-    _i5.Encoding? encoding,
+    _i4.Encoding? encoding,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
@@ -144,7 +136,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
               [url],
               {#headers: headers, #body: body, #encoding: encoding},
             ),
-            returnValue: _i4.Future<_i2.Response>.value(
+            returnValue: _i3.Future<_i2.Response>.value(
               _FakeResponse_0(
                 this,
                 Invocation.method(
@@ -155,14 +147,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
               ),
             ),
           )
-          as _i4.Future<_i2.Response>);
+          as _i3.Future<_i2.Response>);
 
   @override
-  _i4.Future<_i2.Response> delete(
+  _i3.Future<_i2.Response> delete(
     Uri? url, {
     Map<String, String>? headers,
     Object? body,
-    _i5.Encoding? encoding,
+    _i4.Encoding? encoding,
   }) =>
       (super.noSuchMethod(
             Invocation.method(
@@ -170,7 +162,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
               [url],
               {#headers: headers, #body: body, #encoding: encoding},
             ),
-            returnValue: _i4.Future<_i2.Response>.value(
+            returnValue: _i3.Future<_i2.Response>.value(
               _FakeResponse_0(
                 this,
                 Invocation.method(
@@ -181,525 +173,48 @@ class MockClient extends _i1.Mock implements _i2.Client {
               ),
             ),
           )
-          as _i4.Future<_i2.Response>);
+          as _i3.Future<_i2.Response>);
 
   @override
-  _i4.Future<String> read(Uri? url, {Map<String, String>? headers}) =>
+  _i3.Future<String> read(Uri? url, {Map<String, String>? headers}) =>
       (super.noSuchMethod(
             Invocation.method(#read, [url], {#headers: headers}),
-            returnValue: _i4.Future<String>.value(
-              _i6.dummyValue<String>(
+            returnValue: _i3.Future<String>.value(
+              _i5.dummyValue<String>(
                 this,
                 Invocation.method(#read, [url], {#headers: headers}),
               ),
             ),
           )
-          as _i4.Future<String>);
+          as _i3.Future<String>);
 
   @override
-  _i4.Future<_i7.Uint8List> readBytes(
+  _i3.Future<_i6.Uint8List> readBytes(
     Uri? url, {
     Map<String, String>? headers,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#readBytes, [url], {#headers: headers}),
-            returnValue: _i4.Future<_i7.Uint8List>.value(_i7.Uint8List(0)),
+            returnValue: _i3.Future<_i6.Uint8List>.value(_i6.Uint8List(0)),
           )
-          as _i4.Future<_i7.Uint8List>);
+          as _i3.Future<_i6.Uint8List>);
 
   @override
-  _i4.Future<_i2.StreamedResponse> send(_i2.BaseRequest? request) =>
+  _i3.Future<_i2.StreamedResponse> send(_i2.BaseRequest? request) =>
       (super.noSuchMethod(
             Invocation.method(#send, [request]),
-            returnValue: _i4.Future<_i2.StreamedResponse>.value(
+            returnValue: _i3.Future<_i2.StreamedResponse>.value(
               _FakeStreamedResponse_1(
                 this,
                 Invocation.method(#send, [request]),
               ),
             ),
           )
-          as _i4.Future<_i2.StreamedResponse>);
+          as _i3.Future<_i2.StreamedResponse>);
 
   @override
   void close() => super.noSuchMethod(
     Invocation.method(#close, []),
     returnValueForMissingStub: null,
   );
-}
-
-/// A class which mocks [NostrClient].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockNostrClient extends _i1.Mock implements _i8.NostrClient {
-  MockNostrClient() {
-    _i1.throwOnMissingStub(this);
-  }
-
-  @override
-  String get publicKey =>
-      (super.noSuchMethod(
-            Invocation.getter(#publicKey),
-            returnValue: _i6.dummyValue<String>(
-              this,
-              Invocation.getter(#publicKey),
-            ),
-          )
-          as String);
-
-  @override
-  bool get isInitialized =>
-      (super.noSuchMethod(Invocation.getter(#isInitialized), returnValue: false)
-          as bool);
-
-  @override
-  bool get isDisposed =>
-      (super.noSuchMethod(Invocation.getter(#isDisposed), returnValue: false)
-          as bool);
-
-  @override
-  bool get hasKeys =>
-      (super.noSuchMethod(Invocation.getter(#hasKeys), returnValue: false)
-          as bool);
-
-  @override
-  List<String> get configuredRelays =>
-      (super.noSuchMethod(
-            Invocation.getter(#configuredRelays),
-            returnValue: <String>[],
-          )
-          as List<String>);
-
-  @override
-  List<String> get connectedRelays =>
-      (super.noSuchMethod(
-            Invocation.getter(#connectedRelays),
-            returnValue: <String>[],
-          )
-          as List<String>);
-
-  @override
-  int get connectedRelayCount =>
-      (super.noSuchMethod(
-            Invocation.getter(#connectedRelayCount),
-            returnValue: 0,
-          )
-          as int);
-
-  @override
-  int get configuredRelayCount =>
-      (super.noSuchMethod(
-            Invocation.getter(#configuredRelayCount),
-            returnValue: 0,
-          )
-          as int);
-
-  @override
-  Map<String, _i3.RelayConnectionStatus> get relayStatuses =>
-      (super.noSuchMethod(
-            Invocation.getter(#relayStatuses),
-            returnValue: <String, _i3.RelayConnectionStatus>{},
-          )
-          as Map<String, _i3.RelayConnectionStatus>);
-
-  @override
-  _i4.Stream<Map<String, _i3.RelayConnectionStatus>> get relayStatusStream =>
-      (super.noSuchMethod(
-            Invocation.getter(#relayStatusStream),
-            returnValue:
-                _i4.Stream<Map<String, _i3.RelayConnectionStatus>>.empty(),
-          )
-          as _i4.Stream<Map<String, _i3.RelayConnectionStatus>>);
-
-  @override
-  String get primaryRelay =>
-      (super.noSuchMethod(
-            Invocation.getter(#primaryRelay),
-            returnValue: _i6.dummyValue<String>(
-              this,
-              Invocation.getter(#primaryRelay),
-            ),
-          )
-          as String);
-
-  @override
-  _i4.Future<void> initialize() =>
-      (super.noSuchMethod(
-            Invocation.method(#initialize, []),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
-          )
-          as _i4.Future<void>);
-
-  @override
-  _i4.Future<_i9.Event?> publishEvent(
-    _i9.Event? event, {
-    List<String>? targetRelays,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #publishEvent,
-              [event],
-              {#targetRelays: targetRelays},
-            ),
-            returnValue: _i4.Future<_i9.Event?>.value(),
-          )
-          as _i4.Future<_i9.Event?>);
-
-  @override
-  _i4.Future<List<_i9.Event>> queryEvents(
-    List<_i9.Filter>? filters, {
-    String? subscriptionId,
-    List<String>? tempRelays,
-    List<int>? relayTypes = const [1, 2, 3, 4],
-    bool? sendAfterAuth = false,
-    bool? useGateway = true,
-    bool? useCache = true,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #queryEvents,
-              [filters],
-              {
-                #subscriptionId: subscriptionId,
-                #tempRelays: tempRelays,
-                #relayTypes: relayTypes,
-                #sendAfterAuth: sendAfterAuth,
-                #useGateway: useGateway,
-                #useCache: useCache,
-              },
-            ),
-            returnValue: _i4.Future<List<_i9.Event>>.value(<_i9.Event>[]),
-          )
-          as _i4.Future<List<_i9.Event>>);
-
-  @override
-  _i4.Future<_i3.CountResult> countEvents(
-    List<_i9.Filter>? filters, {
-    String? subscriptionId,
-    List<String>? tempRelays,
-    List<int>? relayTypes = const [1, 2, 3, 4],
-    Duration? timeout = const Duration(seconds: 10),
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #countEvents,
-              [filters],
-              {
-                #subscriptionId: subscriptionId,
-                #tempRelays: tempRelays,
-                #relayTypes: relayTypes,
-                #timeout: timeout,
-              },
-            ),
-            returnValue: _i4.Future<_i3.CountResult>.value(
-              _FakeCountResult_2(
-                this,
-                Invocation.method(
-                  #countEvents,
-                  [filters],
-                  {
-                    #subscriptionId: subscriptionId,
-                    #tempRelays: tempRelays,
-                    #relayTypes: relayTypes,
-                    #timeout: timeout,
-                  },
-                ),
-              ),
-            ),
-          )
-          as _i4.Future<_i3.CountResult>);
-
-  @override
-  _i4.Future<_i9.Event?> fetchEventById(
-    String? eventId, {
-    String? relayUrl,
-    bool? useGateway = true,
-    bool? useCache = true,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #fetchEventById,
-              [eventId],
-              {
-                #relayUrl: relayUrl,
-                #useGateway: useGateway,
-                #useCache: useCache,
-              },
-            ),
-            returnValue: _i4.Future<_i9.Event?>.value(),
-          )
-          as _i4.Future<_i9.Event?>);
-
-  @override
-  _i4.Future<_i9.Event?> fetchProfile(
-    String? pubkey, {
-    bool? useGateway = true,
-    bool? useCache = true,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #fetchProfile,
-              [pubkey],
-              {#useGateway: useGateway, #useCache: useCache},
-            ),
-            returnValue: _i4.Future<_i9.Event?>.value(),
-          )
-          as _i4.Future<_i9.Event?>);
-
-  @override
-  _i4.Stream<_i9.Event> subscribe(
-    List<_i9.Filter>? filters, {
-    String? subscriptionId,
-    List<String>? tempRelays,
-    List<String>? targetRelays,
-    List<int>? relayTypes = const [1, 2, 3, 4],
-    bool? sendAfterAuth = false,
-    void Function()? onEose,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #subscribe,
-              [filters],
-              {
-                #subscriptionId: subscriptionId,
-                #tempRelays: tempRelays,
-                #targetRelays: targetRelays,
-                #relayTypes: relayTypes,
-                #sendAfterAuth: sendAfterAuth,
-                #onEose: onEose,
-              },
-            ),
-            returnValue: _i4.Stream<_i9.Event>.empty(),
-          )
-          as _i4.Stream<_i9.Event>);
-
-  @override
-  _i4.Future<void> unsubscribe(String? subscriptionId) =>
-      (super.noSuchMethod(
-            Invocation.method(#unsubscribe, [subscriptionId]),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
-          )
-          as _i4.Future<void>);
-
-  @override
-  _i4.Future<void> closeAllSubscriptions() =>
-      (super.noSuchMethod(
-            Invocation.method(#closeAllSubscriptions, []),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
-          )
-          as _i4.Future<void>);
-
-  @override
-  _i4.Future<bool> addRelay(String? relayUrl) =>
-      (super.noSuchMethod(
-            Invocation.method(#addRelay, [relayUrl]),
-            returnValue: _i4.Future<bool>.value(false),
-          )
-          as _i4.Future<bool>);
-
-  @override
-  _i4.Future<bool> removeRelay(String? relayUrl) =>
-      (super.noSuchMethod(
-            Invocation.method(#removeRelay, [relayUrl]),
-            returnValue: _i4.Future<bool>.value(false),
-          )
-          as _i4.Future<bool>);
-
-  @override
-  _i4.Future<Map<String, dynamic>?> getRelayStats() =>
-      (super.noSuchMethod(
-            Invocation.method(#getRelayStats, []),
-            returnValue: _i4.Future<Map<String, dynamic>?>.value(),
-          )
-          as _i4.Future<Map<String, dynamic>?>);
-
-  @override
-  _i4.Future<void> retryDisconnectedRelays() =>
-      (super.noSuchMethod(
-            Invocation.method(#retryDisconnectedRelays, []),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
-          )
-          as _i4.Future<void>);
-
-  @override
-  _i4.Future<void> forceReconnectAll() =>
-      (super.noSuchMethod(
-            Invocation.method(#forceReconnectAll, []),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
-          )
-          as _i4.Future<void>);
-
-  @override
-  Map<String, bool> getRelayStatus() =>
-      (super.noSuchMethod(
-            Invocation.method(#getRelayStatus, []),
-            returnValue: <String, bool>{},
-          )
-          as Map<String, bool>);
-
-  @override
-  _i4.Future<_i9.Event?> sendLike(
-    String? eventId, {
-    String? content,
-    List<String>? tempRelays,
-    List<String>? targetRelays,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #sendLike,
-              [eventId],
-              {
-                #content: content,
-                #tempRelays: tempRelays,
-                #targetRelays: targetRelays,
-              },
-            ),
-            returnValue: _i4.Future<_i9.Event?>.value(),
-          )
-          as _i4.Future<_i9.Event?>);
-
-  @override
-  _i4.Future<_i9.Event?> sendProfile({
-    required Map<String, dynamic>? profileContent,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(#sendProfile, [], {
-              #profileContent: profileContent,
-            }),
-            returnValue: _i4.Future<_i9.Event?>.value(),
-          )
-          as _i4.Future<_i9.Event?>);
-
-  @override
-  _i4.Future<_i9.Event?> sendRepost(
-    String? eventId, {
-    String? relayAddr,
-    String? content = '',
-    List<String>? tempRelays,
-    List<String>? targetRelays,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #sendRepost,
-              [eventId],
-              {
-                #relayAddr: relayAddr,
-                #content: content,
-                #tempRelays: tempRelays,
-                #targetRelays: targetRelays,
-              },
-            ),
-            returnValue: _i4.Future<_i9.Event?>.value(),
-          )
-          as _i4.Future<_i9.Event?>);
-
-  @override
-  _i4.Future<_i9.Event?> sendGenericRepost({
-    required String? addressableId,
-    required int? targetKind,
-    required String? authorPubkey,
-    String? content = '',
-    List<String>? tempRelays,
-    List<String>? targetRelays,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(#sendGenericRepost, [], {
-              #addressableId: addressableId,
-              #targetKind: targetKind,
-              #authorPubkey: authorPubkey,
-              #content: content,
-              #tempRelays: tempRelays,
-              #targetRelays: targetRelays,
-            }),
-            returnValue: _i4.Future<_i9.Event?>.value(),
-          )
-          as _i4.Future<_i9.Event?>);
-
-  @override
-  _i4.Future<_i9.Event?> deleteEvent(
-    String? eventId, {
-    List<String>? tempRelays,
-    List<String>? targetRelays,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #deleteEvent,
-              [eventId],
-              {#tempRelays: tempRelays, #targetRelays: targetRelays},
-            ),
-            returnValue: _i4.Future<_i9.Event?>.value(),
-          )
-          as _i4.Future<_i9.Event?>);
-
-  @override
-  _i4.Future<_i9.Event?> deleteEvents(
-    List<String>? eventIds, {
-    List<String>? tempRelays,
-    List<String>? targetRelays,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #deleteEvents,
-              [eventIds],
-              {#tempRelays: tempRelays, #targetRelays: targetRelays},
-            ),
-            returnValue: _i4.Future<_i9.Event?>.value(),
-          )
-          as _i4.Future<_i9.Event?>);
-
-  @override
-  _i4.Future<_i9.Event?> sendContactList(
-    _i9.ContactList? contacts,
-    String? content, {
-    List<String>? tempRelays,
-    List<String>? targetRelays,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #sendContactList,
-              [contacts, content],
-              {#tempRelays: tempRelays, #targetRelays: targetRelays},
-            ),
-            returnValue: _i4.Future<_i9.Event?>.value(),
-          )
-          as _i4.Future<_i9.Event?>);
-
-  @override
-  _i4.Stream<_i9.Event> searchVideos(
-    String? query, {
-    List<String>? authors,
-    DateTime? since,
-    DateTime? until,
-    int? limit,
-  }) =>
-      (super.noSuchMethod(
-            Invocation.method(
-              #searchVideos,
-              [query],
-              {#authors: authors, #since: since, #until: until, #limit: limit},
-            ),
-            returnValue: _i4.Stream<_i9.Event>.empty(),
-          )
-          as _i4.Stream<_i9.Event>);
-
-  @override
-  _i4.Stream<_i9.Event> searchUsers(String? query, {int? limit}) =>
-      (super.noSuchMethod(
-            Invocation.method(#searchUsers, [query], {#limit: limit}),
-            returnValue: _i4.Stream<_i9.Event>.empty(),
-          )
-          as _i4.Stream<_i9.Event>);
-
-  @override
-  _i4.Future<void> dispose() =>
-      (super.noSuchMethod(
-            Invocation.method(#dispose, []),
-            returnValue: _i4.Future<void>.value(),
-            returnValueForMissingStub: _i4.Future<void>.value(),
-          )
-          as _i4.Future<void>);
 }

--- a/mobile/test/services/nostr_key_manager_profile_fetch_test.mocks.dart
+++ b/mobile/test/services/nostr_key_manager_profile_fetch_test.mocks.dart
@@ -503,6 +503,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/notification_service_enhanced_test.mocks.dart
+++ b/mobile/test/services/notification_service_enhanced_test.mocks.dart
@@ -509,6 +509,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/profile_editing_test.mocks.dart
+++ b/mobile/test/services/profile_editing_test.mocks.dart
@@ -511,6 +511,22 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/profile_update_test.mocks.dart
+++ b/mobile/test/services/profile_update_test.mocks.dart
@@ -500,6 +500,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/social_service_toggle_repost_test.mocks.dart
+++ b/mobile/test/services/social_service_toggle_repost_test.mocks.dart
@@ -508,6 +508,22 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/subscribed_list_video_cache_test.mocks.dart
+++ b/mobile/test/services/subscribed_list_video_cache_test.mocks.dart
@@ -508,6 +508,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/subscription_manager_cache_test.mocks.dart
+++ b/mobile/test/services/subscription_manager_cache_test.mocks.dart
@@ -558,6 +558,23 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+            returnValueForMissingStub: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/video_event_service_consolidation_test.mocks.dart
+++ b/mobile/test/services/video_event_service_consolidation_test.mocks.dart
@@ -500,6 +500,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/video_event_service_deduplication_test.mocks.dart
+++ b/mobile/test/services/video_event_service_deduplication_test.mocks.dart
@@ -500,6 +500,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/video_event_service_pagination_test.mocks.dart
+++ b/mobile/test/services/video_event_service_pagination_test.mocks.dart
@@ -500,6 +500,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/video_event_service_replaceable_test.mocks.dart
+++ b/mobile/test/services/video_event_service_replaceable_test.mocks.dart
@@ -500,6 +500,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/video_event_service_repost_test.mocks.dart
+++ b/mobile/test/services/video_event_service_repost_test.mocks.dart
@@ -500,6 +500,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/video_event_service_reposters_test.mocks.dart
+++ b/mobile/test/services/video_event_service_reposters_test.mocks.dart
@@ -500,6 +500,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/video_event_service_sorted_queries_integration_test.mocks.dart
+++ b/mobile/test/services/video_event_service_sorted_queries_integration_test.mocks.dart
@@ -518,6 +518,22 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as _i7.Stream<_i8.Event>);
 
   @override
+  _i7.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i7.Future<String?>.value(),
+          )
+          as _i7.Future<String?>);
+
+  @override
   _i7.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/services/video_sharing_service_test.mocks.dart
+++ b/mobile/test/services/video_sharing_service_test.mocks.dart
@@ -512,6 +512,22 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/unit/curated_list_relay_sync_test.mocks.dart
+++ b/mobile/test/unit/curated_list_relay_sync_test.mocks.dart
@@ -566,6 +566,23 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as _i6.Stream<_i7.Event>);
 
   @override
+  _i6.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i6.Future<String?>.value(),
+            returnValueForMissingStub: _i6.Future<String?>.value(),
+          )
+          as _i6.Future<String?>);
+
+  @override
   _i6.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/unit/services/nip17_message_service_test.mocks.dart
+++ b/mobile/test/unit/services/nip17_message_service_test.mocks.dart
@@ -667,6 +667,22 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
           as _i4.Stream<_i7.Event>);
 
   @override
+  _i4.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i4.Future<String?>.value(),
+          )
+          as _i4.Future<String?>);
+
+  @override
   _i4.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/unit/services/subscription_manager_filter_test.mocks.dart
+++ b/mobile/test/unit/services/subscription_manager_filter_test.mocks.dart
@@ -499,6 +499,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/unit/services/video_event_service_infinite_scroll_test.mocks.dart
+++ b/mobile/test/unit/services/video_event_service_infinite_scroll_test.mocks.dart
@@ -500,6 +500,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/unit/services/video_event_service_pagination_test.mocks.dart
+++ b/mobile/test/unit/services/video_event_service_pagination_test.mocks.dart
@@ -500,6 +500,22 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/unit/services/video_event_service_search_test.mocks.dart
+++ b/mobile/test/unit/services/video_event_service_search_test.mocks.dart
@@ -559,6 +559,23 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+            returnValueForMissingStub: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/unit/subscription_manager_tdd_test.mocks.dart
+++ b/mobile/test/unit/subscription_manager_tdd_test.mocks.dart
@@ -558,6 +558,23 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as _i5.Stream<_i6.Event>);
 
   @override
+  _i5.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i5.Future<String?>.value(),
+            returnValueForMissingStub: _i5.Future<String?>.value(),
+          )
+          as _i5.Future<String?>);
+
+  @override
   _i5.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/widgets/popular_videos_tab_test.mocks.dart
+++ b/mobile/test/widgets/popular_videos_tab_test.mocks.dart
@@ -1294,6 +1294,22 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as _i11.Stream<_i10.Event>);
 
   @override
+  _i11.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i11.Future<String?>.value(),
+          )
+          as _i11.Future<String?>);
+
+  @override
   _i11.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),

--- a/mobile/test/widgets/tabbed_settings_screen_test.mocks.dart
+++ b/mobile/test/widgets/tabbed_settings_screen_test.mocks.dart
@@ -796,6 +796,22 @@ class MockNostrClient extends _i1.Mock implements _i12.NostrClient {
           as _i8.Stream<_i11.Event>);
 
   @override
+  _i8.Future<String?> createNip98AuthHeader({
+    required String? url,
+    required String? method,
+    String? payload,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#createNip98AuthHeader, [], {
+              #url: url,
+              #method: method,
+              #payload: payload,
+            }),
+            returnValue: _i8.Future<String?>.value(),
+          )
+          as _i8.Future<String?>);
+
+  @override
   _i8.Future<void> dispose() =>
       (super.noSuchMethod(
             Invocation.method(#dispose, []),


### PR DESCRIPTION
## Summary

Re-applies #1020 after it was temporarily reverted in #1045 for the release.

**Original PR:** #1020
**Revert PR:** #1045

## Changes

- `ProfileRepository.claimUsername()` - NIP-98 authenticated username claiming
- `UsernameClaimResult` sealed class for type-safe error handling
- `createNip98AuthHeader()` with signing validation
- Reserved username indicator fix after dialog closes
- Cleanup of unused registration code from `Nip05Service`