### PR TITLE
fix: use Navigator.pop() instead of context.pop() to close drawer

### DIFF
--- a/mobile/lib/widgets/vine_drawer.dart
+++ b/mobile/lib/widgets/vine_drawer.dart
@@ -146,7 +146,9 @@ class _VineDrawerState extends ConsumerState<VineDrawer> {
                       onTap: () {
                         // Capture router before closing drawer to avoid context issues
                         final router = GoRouter.of(context);
-                        Navigator.of(context).pop(); // Close drawer (not context.pop!)
+                        Navigator.of(
+                          context,
+                        ).pop(); // Close drawer (not context.pop!)
                         router.push(ProfileSetupScreen.editPath);
                       },
                     ),
@@ -161,7 +163,9 @@ class _VineDrawerState extends ConsumerState<VineDrawer> {
                     onTap: () {
                       // Capture router before closing drawer to avoid context issues
                       final router = GoRouter.of(context);
-                      Navigator.of(context).pop(); // Close drawer (not context.pop!)
+                      Navigator.of(
+                        context,
+                      ).pop(); // Close drawer (not context.pop!)
                       router.push(SettingsScreen.path);
                     },
                   ),


### PR DESCRIPTION
## Summary

When the user is on the Profile Screen and taps "Edit Profile" in the drawer, nothing happened because context.pop() (GoRouter) tries to pop a navigation route rather than close the drawer overlay.

Changed all drawer button handlers to use Navigator.of(context).pop() which correctly closes the drawer before navigating.