### PR TITLE
feat(bottom-sheet): enhance VineBottomSheet layout and structure

### DIFF
--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
@@ -31,6 +31,7 @@ class VineBottomSheet extends StatelessWidget {
     this.trailing,
     this.bottomInput,
     this.expanded = true,
+    this.showHeaderDivider = true,
     super.key,
   }) : assert(
          children != null || body != null || buildScrollBody != null,
@@ -80,6 +81,11 @@ class VineBottomSheet extends StatelessWidget {
   /// Set to false for simple content that should wrap.
   final bool expanded;
 
+  /// Whether to show the divider below the header.
+  ///
+  /// Defaults to true.
+  final bool showHeaderDivider;
+
   /// Shows the bottom sheet as a modal.
   ///
   /// Set [scrollable] to false for fixed-height sheets (e.g., action menus).
@@ -95,6 +101,7 @@ class VineBottomSheet extends StatelessWidget {
     Widget? trailing,
     Widget? bottomInput,
     bool expanded = true,
+    bool showHeaderDivider = true,
     bool? isScrollControlled,
     double initialChildSize = 0.6,
     double minChildSize = 0.3,
@@ -129,6 +136,7 @@ class VineBottomSheet extends StatelessWidget {
             trailing: trailing,
             bottomInput: bottomInput,
             expanded: expanded,
+            showHeaderDivider: showHeaderDivider,
             body: body,
             children: children,
           ),
@@ -148,6 +156,7 @@ class VineBottomSheet extends StatelessWidget {
           trailing: trailing,
           bottomInput: bottomInput,
           expanded: expanded,
+          showHeaderDivider: showHeaderDivider,
           body: body,
           children: children,
         ),
@@ -172,6 +181,7 @@ class VineBottomSheet extends StatelessWidget {
                 scrollController: scrollController,
                 contentTitle: contentTitle,
                 bottomInput: bottomInput,
+                showHeaderDivider: showHeaderDivider,
                 children: children,
               )
             : _FixedContent(
@@ -180,6 +190,7 @@ class VineBottomSheet extends StatelessWidget {
                 body: body,
                 contentTitle: contentTitle,
                 bottomInput: bottomInput,
+                showHeaderDivider: showHeaderDivider,
                 children: children,
               ),
       ),
@@ -197,6 +208,7 @@ class _ScrollableContent extends StatelessWidget {
     required this.contentTitle,
     required this.children,
     required this.bottomInput,
+    required this.showHeaderDivider,
   });
 
   final Widget? title;
@@ -207,13 +219,18 @@ class _ScrollableContent extends StatelessWidget {
   final String? contentTitle;
   final List<Widget>? children;
   final Widget? bottomInput;
+  final bool showHeaderDivider;
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
         // Header with drag handle, title, trailing actions, and divider
-        VineBottomSheetHeader(title: title, trailing: trailing),
+        VineBottomSheetHeader(
+          title: title,
+          trailing: trailing,
+          showDivider: showHeaderDivider,
+        ),
 
         // Scrollable content area (contentTitle is first element inside)
         Expanded(
@@ -263,6 +280,7 @@ class _FixedContent extends StatelessWidget {
     required this.contentTitle,
     required this.children,
     required this.bottomInput,
+    required this.showHeaderDivider,
   });
 
   final Widget? title;
@@ -271,6 +289,7 @@ class _FixedContent extends StatelessWidget {
   final String? contentTitle;
   final List<Widget>? children;
   final Widget? bottomInput;
+  final bool showHeaderDivider;
 
   @override
   Widget build(BuildContext context) {
@@ -280,7 +299,11 @@ class _FixedContent extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           // Header with drag handle and divider
-          VineBottomSheetHeader(title: title, trailing: trailing),
+          VineBottomSheetHeader(
+            title: title,
+            trailing: trailing,
+            showDivider: showHeaderDivider,
+          ),
 
           // Fixed content area with minimum height for menu entries (2 × 56px)
           Flexible(

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_action_menu.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_action_menu.dart
@@ -75,8 +75,10 @@ class VineBottomSheetActionMenu {
       context: context,
       title: title,
       expanded: false,
+      scrollable: false,
       isScrollControlled: true,
       body: SingleChildScrollView(
+        padding: const .only(top: 8),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_header.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_header.dart
@@ -11,13 +11,23 @@ import 'package:flutter/material.dart';
 class VineBottomSheetHeader extends StatelessWidget {
   /// Creates a [VineBottomSheetHeader] with the given title and optional
   /// trailing widget.
-  const VineBottomSheetHeader({this.title, this.trailing, super.key});
+  const VineBottomSheetHeader({
+    this.title,
+    this.trailing,
+    this.showDivider = true,
+    super.key,
+  });
 
   /// Optional title widget displayed in the center
   final Widget? title;
 
   /// Optional trailing widget on the right (e.g., badge, button)
   final Widget? trailing;
+
+  /// Whether to show the divider below the header.
+  ///
+  /// Defaults to true.
+  final bool showDivider;
 
   @override
   Widget build(BuildContext context) {
@@ -71,11 +81,12 @@ class VineBottomSheetHeader extends StatelessWidget {
         ),
 
         // Divider separating header from content
-        const Divider(
-          height: 2,
-          thickness: 2,
-          color: VineTheme.outlinedDisabled,
-        ),
+        if (showDivider)
+          const Divider(
+            height: 2,
+            thickness: 2,
+            color: VineTheme.outlinedDisabled,
+          ),
       ],
     );
   }

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_selection_menu.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_selection_menu.dart
@@ -53,6 +53,7 @@ class VineBottomSheetSelectionMenu {
       context: context,
       title: title,
       expanded: false,
+      scrollable: false,
       isScrollControlled: true,
       body: SingleChildScrollView(
         child: Column(


### PR DESCRIPTION
## Description

That PR improve the following stuff:

1. Add `DefaultTextStyle` to the title widget to ensure that if no style is applied, it will fall back to the desired bottom sheet title style.  
2. Enable `useSafeArea` to avoid content appearing behind the status bar when the content fills the entire screen. This wasn’t an issue with the scrollable bottom sheet as long as `maxChildSize` wasn’t set to 1.0.  
3. Add a `buildScrollBody` method that returns the scroll controller, allowing to build a custom scrollable body using the controller from the `DraggableScrollableSheet`.  
4. Wrap the body from `_buildFixedContent` in a `Flexible` widget to prevent layout issues.  
5. Replace `_build` methods with private widgets.
6. Add `showHeaderDivider` to allow hiding the header divider in special designs.  
7. Fix an issue in `VineBottomSheetSelectionMenu` and `VineBottomSheetActionMenu` where taps outside the bottom sheet no longer close it.




## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore