### PR TITLE
fix: show truncated npub instead of Loading for users without profiles

### DIFF
--- a/mobile/lib/utils/nostr_key_utils.dart
+++ b/mobile/lib/utils/nostr_key_utils.dart
@@ -50,4 +50,21 @@ class NostrKeyUtils {
       return false;
     }
   }
+
+  /// Create a truncated npub for display (e.g., "npub1abc...xyz")
+  ///
+  /// Converts a hex pubkey to npub format and truncates for UI display.
+  /// Shows first 10 characters + "..." + last 6 characters.
+  /// Use this when displaying usernames for users without a Kind 0 profile.
+  static String truncateNpub(String hexPubkey) {
+    try {
+      final fullNpub = encodePubKey(hexPubkey);
+      if (fullNpub.length <= 16) return fullNpub;
+      return '${fullNpub.substring(0, 10)}...${fullNpub.substring(fullNpub.length - 6)}';
+    } catch (e) {
+      // Fallback to shortened hex pubkey if encoding fails
+      if (hexPubkey.length <= 16) return hexPubkey;
+      return '${hexPubkey.substring(0, 8)}...${hexPubkey.substring(hexPubkey.length - 6)}';
+    }
+  }
 }

--- a/mobile/lib/widgets/user_profile_tile.dart
+++ b/mobile/lib/widgets/user_profile_tile.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:openvine/services/image_cache_manager.dart';
 
@@ -53,13 +54,14 @@ class UserProfileTile extends ConsumerWidget {
       builder: (context, snapshot) {
         final profile = userProfileService.getCachedProfile(pubkey);
         // wrapping with Semantics for testability and accessibility
-        // Get display name or truncated npub
-        final displayName = profile?.bestDisplayName ?? 'Loading...';
+        // Get display name or truncated npub (fallback for users without Kind 0)
+        final truncatedNpub = NostrKeyUtils.truncateNpub(pubkey);
+        final displayName = profile?.bestDisplayName ?? truncatedNpub;
 
-        // Get unique identifier: NIP-05 if available, otherwise npub
+        // Get unique identifier: NIP-05 if available, otherwise truncated npub
         final uniqueIdentifier = profile?.nip05?.isNotEmpty == true
             ? profile!.nip05!
-            : profile?.npub ?? 'Loading...';
+            : truncatedNpub;
 
         return Semantics(
           identifier: 'user_profile_tile_$pubkey',

--- a/mobile/lib/widgets/video_explore_tile.dart
+++ b/mobile/lib/widgets/video_explore_tile.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/nav_extensions.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/proofmode_badge.dart';
 import 'package:openvine/widgets/proofmode_badge_row.dart';
@@ -142,7 +143,7 @@ class _CreatorInfo extends ConsumerWidget {
 
     final displayName = switch (profileAsync) {
       AsyncData(:final value) when value != null => value.bestDisplayName,
-      AsyncData() || AsyncError() => 'Unknown',
+      AsyncData() || AsyncError() => NostrKeyUtils.truncateNpub(pubkey),
       AsyncLoading() => 'Loading...',
     };
 

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -2,28 +2,27 @@
 // ABOUTME: Each video gets its own controller with automatic lifecycle management via Riverpod autoDispose
 
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
+import 'package:models/models.dart' hide LogCategory, NIP71VideoKinds;
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
-import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
-import 'package:models/models.dart' hide LogCategory, NIP71VideoKinds;
 import 'package:openvine/providers/active_video_provider.dart'; // For isVideoActiveProvider (router-driven)
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/individual_video_providers.dart'; // For individualVideoControllerProvider only
-import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/nav_extensions.dart';
 import 'package:openvine/router/page_context_provider.dart';
 import 'package:openvine/router/route_utils.dart';
 import 'package:openvine/screens/curated_list_feed_screen.dart';
 import 'package:openvine/services/visibility_tracker.dart';
-import 'package:divine_ui/divine_ui.dart';
 import 'package:openvine/ui/overlay_policy.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/badge_explanation_modal.dart';
@@ -33,6 +32,7 @@ import 'package:openvine/widgets/proofmode_badge.dart';
 import 'package:openvine/widgets/proofmode_badge_row.dart';
 import 'package:openvine/widgets/share_video_menu.dart';
 import 'package:openvine/widgets/user_name.dart';
+import 'package:openvine/widgets/video_feed_item/actions/actions.dart';
 import 'package:openvine/widgets/video_feed_item/audio_attribution_row.dart';
 import 'package:openvine/widgets/video_feed_item/list_attribution_chip.dart';
 import 'package:openvine/widgets/video_feed_item/video_error_overlay.dart';
@@ -255,14 +255,20 @@ class _VideoFeedItemState extends ConsumerState<VideoFeedItem> {
   void _createInteractionsBloc() {
     final likesRepository = ref.read(likesRepositoryProvider);
     final commentsRepository = ref.read(commentsRepositoryProvider);
+    final repostsRepository = ref.read(repostsRepositoryProvider);
+
+    // Build addressable ID for reposts if video has a d-tag (vineId)
+    final addressableId = widget.video.addressableId;
 
     _interactionsBloc = VideoInteractionsBloc(
       eventId: widget.video.id,
       authorPubkey: widget.video.pubkey,
       likesRepository: likesRepository,
       commentsRepository: commentsRepository,
+      repostsRepository: repostsRepository,
+      addressableId: addressableId,
     );
-    // Start listening for liked IDs changes
+    // Start listening for liked/reposted IDs changes
     _interactionsBloc.add(const VideoInteractionsSubscriptionRequested());
     // Trigger initial fetch
     _interactionsBloc.add(const VideoInteractionsFetchRequested());
@@ -1031,7 +1037,8 @@ class VideoOverlayActions extends ConsumerWidget {
                     );
                     final avatarUrl = profile?.picture;
                     final displayName =
-                        profile?.bestDisplayName ?? 'Loading...';
+                        profile?.bestDisplayName ??
+                        NostrKeyUtils.truncateNpub(video.pubkey);
                     final loopCount = video.originalLoops ?? 0;
 
                     void navigateToProfile() {
@@ -1385,122 +1392,8 @@ class VideoOverlayActions extends ConsumerWidget {
 
                   const SizedBox(height: 4),
 
-                  // Repost/Revine button - wrapped in Consumer to isolate rebuilds
-                  Consumer(
-                    builder: (context, ref, _) {
-                      final socialState = ref.watch(socialProvider);
-                      // Construct addressable ID for repost state check
-                      final dTag = video.rawTags['d'];
-                      final addressableId = dTag != null
-                          ? '${NIP71VideoKinds.addressableShortVideo}:${video.pubkey}:$dTag'
-                          : video.id;
-                      final isReposted = socialState.hasReposted(addressableId);
-                      final isRepostInProgress = socialState.isRepostInProgress(
-                        video.id,
-                      );
-
-                      return Column(
-                        children: [
-                          Semantics(
-                            identifier: 'repost_button',
-                            container: true,
-                            explicitChildNodes: true,
-                            button: true,
-                            label: isReposted
-                                ? 'Remove repost'
-                                : 'Repost video',
-                            child: IconButton(
-                              padding: const EdgeInsets.all(8),
-                              constraints: const BoxConstraints.tightFor(
-                                width: 48,
-                                height: 48,
-                              ),
-                              style: IconButton.styleFrom(
-                                highlightColor: Colors.transparent,
-                                splashFactory: NoSplash.splashFactory,
-                              ),
-                              onPressed: isRepostInProgress
-                                  ? null
-                                  : () async {
-                                      Log.info(
-                                        '🔁 Repost button tapped for ${video.id}',
-                                        name: 'VideoFeedItem',
-                                        category: LogCategory.ui,
-                                      );
-                                      await ref
-                                          .read(socialProvider.notifier)
-                                          .toggleRepost(video);
-                                    },
-                              icon: isRepostInProgress
-                                  ? const SizedBox(
-                                      width: 32,
-                                      height: 32,
-                                      child: CircularProgressIndicator(
-                                        strokeWidth: 2,
-                                        color: Colors.white,
-                                      ),
-                                    )
-                                  : DecoratedBox(
-                                      decoration: BoxDecoration(
-                                        boxShadow: [
-                                          BoxShadow(
-                                            color: Colors.black.withValues(
-                                              alpha: 0.15,
-                                            ),
-                                            blurRadius: 15,
-                                            spreadRadius: 1,
-                                          ),
-                                        ],
-                                      ),
-                                      child: SvgPicture.asset(
-                                        'assets/icon/content-controls/repost.svg',
-                                        width: 32,
-                                        height: 32,
-                                        colorFilter: ColorFilter.mode(
-                                          isReposted
-                                              ? VineTheme.vineGreen
-                                              : Colors.white,
-                                          BlendMode.srcIn,
-                                        ),
-                                      ),
-                                    ),
-                            ),
-                          ),
-                          // Show repost count: Nostr reposts + original reposts (if any)
-                          Builder(
-                            builder: (context) {
-                              final nostrReposts =
-                                  video.reposterPubkeys?.length ?? 0;
-                              final originalReposts =
-                                  video.originalReposts ?? 0;
-                              final totalReposts =
-                                  nostrReposts + originalReposts;
-
-                              if (totalReposts > 0) {
-                                return Padding(
-                                  padding: const EdgeInsets.only(bottom: 8),
-                                  child: Text(
-                                    StringUtils.formatCompactNumber(
-                                      totalReposts,
-                                    ),
-                                    style: const TextStyle(
-                                      fontFamily: 'Bricolage Grotesque',
-                                      color: Colors.white,
-                                      fontSize: 14,
-                                      fontWeight: FontWeight.w600,
-                                      height: 1,
-                                      letterSpacing: 0.5,
-                                    ),
-                                  ),
-                                );
-                              }
-                              return const SizedBox.shrink();
-                            },
-                          ),
-                        ],
-                      );
-                    },
-                  ),
+                  // Repost button
+                  RepostActionButton(video: video),
 
                   const SizedBox(height: 4),
 
@@ -1510,7 +1403,7 @@ class VideoOverlayActions extends ConsumerWidget {
                   const SizedBox(height: 4),
 
                   // Like button
-                  _LikeActionButtonThemed(video: video),
+                  LikeActionButton(video: video),
                 ],
               ),
             ),
@@ -1809,7 +1702,8 @@ class VideoRepostHeader extends ConsumerWidget {
     }
 
     final displayName =
-        reposterProfile?.bestDisplayName ?? reposterPubkey.substring(0, 8);
+        reposterProfile?.bestDisplayName ??
+        NostrKeyUtils.truncateNpub(reposterPubkey);
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
@@ -1948,135 +1842,6 @@ class _CommentActionButton extends StatelessWidget {
             padding: const EdgeInsets.only(bottom: 8),
             child: Text(
               StringUtils.formatCompactNumber(totalComments),
-              style: const TextStyle(
-                fontFamily: 'Bricolage Grotesque',
-                color: Colors.white,
-                fontSize: 14,
-                fontWeight: FontWeight.w600,
-                height: 1,
-                letterSpacing: 0.5,
-              ),
-            ),
-          ),
-        ],
-      ],
-    );
-  }
-}
-
-/// Like button with theming-d0.1 SVG icon style.
-///
-/// Displays a heart icon that changes color when liked.
-/// Shows like count below if > 0.
-///
-/// Uses [VideoInteractionsBloc] for like state when available.
-class _LikeActionButtonThemed extends StatelessWidget {
-  const _LikeActionButtonThemed({required this.video});
-
-  final VideoEvent video;
-
-  @override
-  Widget build(BuildContext context) {
-    final interactionsBloc = context.read<VideoInteractionsBloc?>();
-
-    if (interactionsBloc == null) {
-      // No bloc available - show disabled state with original likes only
-      return _buildButton(
-        context: context,
-        isLiked: false,
-        isLikeInProgress: false,
-        totalLikes: video.originalLikes ?? 0,
-        onPressed: null,
-      );
-    }
-
-    return BlocBuilder<VideoInteractionsBloc, VideoInteractionsState>(
-      builder: (context, state) {
-        final isLiked = state.isLiked;
-        final isLikeInProgress = state.isLikeInProgress;
-        final likeCount = state.likeCount ?? 0;
-        final totalLikes = likeCount + (video.originalLikes ?? 0);
-
-        return _buildButton(
-          context: context,
-          isLiked: isLiked,
-          isLikeInProgress: isLikeInProgress,
-          totalLikes: totalLikes,
-          onPressed: () {
-            Log.info(
-              '❤️ Like button tapped for ${video.id}',
-              name: 'VideoFeedItem',
-              category: LogCategory.ui,
-            );
-            context.read<VideoInteractionsBloc>().add(
-              const VideoInteractionsLikeToggled(),
-            );
-          },
-        );
-      },
-    );
-  }
-
-  Widget _buildButton({
-    required BuildContext context,
-    required bool isLiked,
-    required bool isLikeInProgress,
-    required int totalLikes,
-    required VoidCallback? onPressed,
-  }) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Semantics(
-          identifier: 'like_button',
-          container: true,
-          explicitChildNodes: true,
-          button: true,
-          label: isLiked ? 'Unlike video' : 'Like video',
-          child: IconButton(
-            padding: const EdgeInsets.all(8),
-            constraints: const BoxConstraints.tightFor(width: 48, height: 48),
-            style: IconButton.styleFrom(
-              highlightColor: Colors.transparent,
-              splashFactory: NoSplash.splashFactory,
-            ),
-            onPressed: isLikeInProgress || onPressed == null ? null : onPressed,
-            icon: isLikeInProgress
-                ? const SizedBox(
-                    width: 32,
-                    height: 32,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: Colors.white,
-                    ),
-                  )
-                : DecoratedBox(
-                    decoration: BoxDecoration(
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withValues(alpha: 0.15),
-                          blurRadius: 15,
-                          spreadRadius: 1,
-                        ),
-                      ],
-                    ),
-                    child: SvgPicture.asset(
-                      'assets/icon/content-controls/like.svg',
-                      width: 32,
-                      height: 32,
-                      colorFilter: ColorFilter.mode(
-                        isLiked ? Colors.red : Colors.white,
-                        BlendMode.srcIn,
-                      ),
-                    ),
-                  ),
-          ),
-        ),
-        if (totalLikes > 0) ...[
-          Padding(
-            padding: const EdgeInsets.only(bottom: 8),
-            child: Text(
-              StringUtils.formatCompactNumber(totalLikes),
               style: const TextStyle(
                 fontFamily: 'Bricolage Grotesque',
                 color: Colors.white,


### PR DESCRIPTION
## Summary

- Users without a Kind 0 profile event were seeing "Loading..." indefinitely
- Now shows truncated npub (e.g., `npub1abc...xyz`) as fallback

## Changes

- **nostr_key_utils.dart**: Added `truncateNpub()` utility method
- **video_explore_tile.dart**: Use truncated npub for missing/error profile states
- **user_profile_tile.dart**: Use truncated npub instead of "Loading..." fallback
- **video_feed_item.dart**: Fixed author display and repost banner (was using raw `substring(0,8)`)

Closes #804