### PR TITLE
fix: show Classic Viners avatars using Nostr profile fallback

### DIFF
--- a/mobile/lib/providers/classic_vines_provider.g.dart
+++ b/mobile/lib/providers/classic_vines_provider.g.dart
@@ -219,14 +219,16 @@ String _$classicVinesAvailableHash() =>
 
 /// Provider for top classic Viners derived from classic videos
 ///
-/// Aggregates videos by pubkey and sorts by total loop count
+/// Aggregates videos by pubkey and sorts by total loop count.
+/// Also triggers profile prefetching for Viners without avatars.
 
 @ProviderFor(topClassicViners)
 const topClassicVinersProvider = TopClassicVinersProvider._();
 
 /// Provider for top classic Viners derived from classic videos
 ///
-/// Aggregates videos by pubkey and sorts by total loop count
+/// Aggregates videos by pubkey and sorts by total loop count.
+/// Also triggers profile prefetching for Viners without avatars.
 
 final class TopClassicVinersProvider
     extends
@@ -240,7 +242,8 @@ final class TopClassicVinersProvider
         $FutureProvider<List<ClassicViner>> {
   /// Provider for top classic Viners derived from classic videos
   ///
-  /// Aggregates videos by pubkey and sorts by total loop count
+  /// Aggregates videos by pubkey and sorts by total loop count.
+  /// Also triggers profile prefetching for Viners without avatars.
   const TopClassicVinersProvider._()
     : super(
         from: null,
@@ -267,4 +270,4 @@ final class TopClassicVinersProvider
   }
 }
 
-String _$topClassicVinersHash() => r'580ba7973d049a9db3ff40c2d3cd6dcc3d451adf';
+String _$topClassicVinersHash() => r'90b684e574cff9f8f46ac85a9c8b78fe5640cfb9';


### PR DESCRIPTION
## Summary
- Classic Viners slider now attempts to display actual profile pictures instead of green placeholders
- Falls back to Nostr profile service when REST API doesn't provide author_avatar
- Prefetches profiles for Viners without avatars to ensure they're cached before render

## Problem
The Classic Viners slider was showing green placeholder circles instead of actual profile pictures. The Funnelcake REST API doesn't return `author_avatar` data for classic Viners.

## Solution (Partial)
1. Convert `_VinerAvatar` widget to `ConsumerWidget` to access Riverpod providers
2. Use `UserProfileService.getCachedProfile()` as fallback when `viner.authorAvatar` is null
3. Add profile prefetching in `topClassicVinersProvider` for Viners without avatars from REST API

## Limitation
This fix only works for Viners who have Nostr profiles (Kind 0 events). Most classic Viners don't have Nostr accounts, so they'll still show placeholders.

## Root Cause (Backend Fix Required)
The archived-vines-publisher adds `["author", username]` tags to video events, but NOT `["author_avatar", avatar_url]` tags. The avatar URL exists in the archive metadata but isn't propagated to video events.

**Required backend fixes:**
1. `archived-vines-publisher`: Add `["author_avatar", avatar_url]` tag when building video events
2. `divine-funnelcake`: Update the `author_avatar` materialized column to extract from the tag (currently hardcoded to empty string)

## Test plan
- [ ] Navigate to Explore > Classics tab
- [ ] Verify Classic Viners with Nostr profiles show their avatars
- [ ] Tap on a Viner to verify navigation to profile works with correct avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)