### PR TITLE
fix(tags): make tag text flexible to improve layout responsiveness

### DIFF
--- a/mobile/lib/widgets/video_metadata/video_metadata_tags_input.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_tags_input.dart
@@ -232,15 +232,17 @@ class _TagChip extends ConsumerWidget {
           ),
           const SizedBox(width: 4),
           // Tag text
-          Text(
-            tag,
-            overflow: .ellipsis,
-            style: GoogleFonts.bricolageGrotesque(
-              color: VineTheme.onSurface,
-              fontSize: 14,
-              fontWeight: .w800,
-              height: 1.43,
-              letterSpacing: 0.10,
+          Flexible(
+            child: Text(
+              tag,
+              overflow: .ellipsis,
+              style: GoogleFonts.bricolageGrotesque(
+                color: VineTheme.onSurface,
+                fontSize: 14,
+                fontWeight: .w800,
+                height: 1.43,
+                letterSpacing: 0.10,
+              ),
             ),
           ),
           const SizedBox(width: 8),


### PR DESCRIPTION
## Description

Fixes an issue where tags could no longer be deleted when their text exceeded the screen width.

**Related Issue:** Closes #1101

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore