### PR TITLE
fix(macos): resolve silent camera failure on macOS desktop

### DIFF
--- a/mobile/lib/models/video_recorder/video_recorder_provider_state.dart
+++ b/mobile/lib/models/video_recorder/video_recorder_provider_state.dart
@@ -25,6 +25,7 @@ class VideoRecorderProviderState {
     this.aspectRatio = .vertical,
     this.flashMode = .auto,
     this.timerDuration = .off,
+    this.initializationErrorMessage,
   });
 
   /// Camera focus point in normalized coordinates (0.0-1.0).
@@ -70,6 +71,9 @@ class VideoRecorderProviderState {
   /// Current recording state.
   final VideoRecorderState recordingState;
 
+  /// Custom error message when camera initialization fails.
+  final String? initializationErrorMessage;
+
   // Convenience getters used by UI
   /// Whether currently recording.
   bool get isRecording => recordingState == .recording;
@@ -80,8 +84,10 @@ class VideoRecorderProviderState {
   /// Whether in error state.
   bool get isError => recordingState == .error;
 
-  /// Error message if in error state.
-  String? get errorMessage => isError ? 'Recording error occurred' : null;
+  /// Error message if in error state or initialization failed.
+  String? get errorMessage =>
+      initializationErrorMessage ??
+      (isError ? 'Recording error occurred' : null);
 
   /// Creates a copy of this state with updated values.
   VideoRecorderProviderState copyWith({
@@ -99,6 +105,7 @@ class VideoRecorderProviderState {
     model.AspectRatio? aspectRatio,
     DivineFlashMode? flashMode,
     TimerDuration? timerDuration,
+    String? initializationErrorMessage,
   }) {
     return VideoRecorderProviderState(
       recordingState: recordingState ?? this.recordingState,
@@ -115,6 +122,8 @@ class VideoRecorderProviderState {
       aspectRatio: aspectRatio ?? this.aspectRatio,
       flashMode: flashMode ?? this.flashMode,
       timerDuration: timerDuration ?? this.timerDuration,
+      initializationErrorMessage:
+          initializationErrorMessage ?? this.initializationErrorMessage,
     );
   }
 }

--- a/mobile/lib/providers/video_recorder_provider.dart
+++ b/mobile/lib/providers/video_recorder_provider.dart
@@ -91,7 +91,33 @@ class VideoRecorderNotifier extends Notifier<VideoRecorderProviderState> {
       name: 'VideoRecorderNotifier',
       category: .video,
     );
-    await _cameraService.initialize();
+
+    try {
+      await _cameraService.initialize();
+    } catch (e) {
+      Log.error(
+        '📹 Camera service initialization threw exception: $e',
+        name: 'VideoRecorderNotifier',
+        category: .video,
+      );
+      state = state.copyWith(
+        initializationErrorMessage: 'Camera initialization failed: $e',
+      );
+      return;
+    }
+
+    // Check if camera initialization failed
+    if (!_cameraService.isInitialized) {
+      final error =
+          _cameraService.initializationError ?? 'Camera initialization failed';
+      Log.warning(
+        '⚠️ Camera failed to initialize: $error',
+        name: 'VideoRecorderNotifier',
+        category: .video,
+      );
+      state = state.copyWith(initializationErrorMessage: error);
+      return;
+    }
 
     // If the user has recorded clips in the clip manager, we use this
     // aspect-ratio to prevent mixing different ratios.

--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -56,10 +56,24 @@ class _VideoRecorderScreenState extends ConsumerState<VideoRecorderScreen>
 
   /// Initialize camera and handle permission failures
   Future<void> _initializeCamera() async {
+    Log.info(
+      '📹 _initializeCamera called',
+      name: 'VideoRecorderScreen',
+      category: LogCategory.video,
+    );
+
     _disposeVideoControllers();
 
-    _notifier = ref.read(videoRecorderProvider.notifier);
-    await _notifier!.initialize(context: context);
+    try {
+      _notifier = ref.read(videoRecorderProvider.notifier);
+      await _notifier!.initialize(context: context);
+    } catch (e) {
+      Log.error(
+        '📹 Camera initialization exception: $e',
+        name: 'VideoRecorderScreen',
+        category: LogCategory.video,
+      );
+    }
   }
 
   Future<void> _checkAutosavedChanges() async {

--- a/mobile/lib/services/video_recorder/camera/camera_base_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_base_service.dart
@@ -92,4 +92,7 @@ abstract class CameraService {
 
   /// Whether the device can active the camera-flash.
   bool get hasFlash;
+
+  /// Error message if initialization failed, null if successful.
+  String? get initializationError;
 }

--- a/mobile/lib/services/video_recorder/camera/camera_mobile_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_mobile_service.dart
@@ -19,10 +19,14 @@ class CameraMobileService extends CameraService {
   });
 
   bool _isInitialized = false;
+  String? _initializationError;
   final _camera = DivineCamera.instance;
 
   @override
   Future<void> initialize() async {
+    // Clear any previous error
+    _initializationError = null;
+
     Log.info(
       '📷 Initializing mobile camera',
       name: 'CameraMobileService',
@@ -33,7 +37,9 @@ class CameraMobileService extends CameraService {
       _camera.onRecordingAutoStopped = (result) {
         onAutoStopped(EditorVideo.file(result.filePath));
       };
+      _isInitialized = true;
     } catch (e) {
+      _initializationError = 'Camera initialization failed: $e';
       Log.error(
         '📷 Failed to initialize camera: $e',
         name: 'CameraMobileService',
@@ -41,7 +47,6 @@ class CameraMobileService extends CameraService {
       );
     }
 
-    _isInitialized = true;
     onUpdateState(forceCameraRebuild: true);
   }
 
@@ -278,4 +283,7 @@ class CameraMobileService extends CameraService {
 
   @override
   bool get canSwitchCamera => _camera.canSwitchCamera;
+
+  @override
+  String? get initializationError => _initializationError;
 }

--- a/mobile/lib/widgets/camera_permission_gate.dart
+++ b/mobile/lib/widgets/camera_permission_gate.dart
@@ -7,6 +7,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/camera_permission/camera_permission_bloc.dart';
 import 'package:openvine/screens/home_screen_router.dart';
+import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_bottom_bar.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_record_button.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_segment_bar.dart';
@@ -40,12 +41,28 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
     super.initState();
     WidgetsBinding.instance.addObserver(this);
 
+    Log.info(
+      '🔐 CameraPermissionGate initState',
+      name: 'CameraPermissionGate',
+      category: LogCategory.video,
+    );
+
     // Always refresh permission check when screen opens
     // This handles cases where user denied previously and is returning
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       final bloc = context.read<CameraPermissionBloc>();
+      Log.info(
+        '🔐 Current permission state: ${bloc.state.runtimeType}',
+        name: 'CameraPermissionGate',
+        category: LogCategory.video,
+      );
       if (bloc.state is! CameraPermissionLoaded) {
+        Log.info(
+          '🔐 Triggering permission refresh',
+          name: 'CameraPermissionGate',
+          category: LogCategory.video,
+        );
         bloc.add(const CameraPermissionRefresh());
       }
     });
@@ -93,12 +110,22 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
   Widget build(BuildContext context) {
     return BlocConsumer<CameraPermissionBloc, CameraPermissionState>(
       listener: (context, state) {
+        Log.info(
+          '🔐 Permission state changed: ${state.runtimeType}',
+          name: 'CameraPermissionGate',
+          category: LogCategory.video,
+        );
         // When user denies native permission dialog, pop back to home
         if (state is CameraPermissionDenied) {
           _popBack();
         }
       },
       builder: (context, state) {
+        Log.debug(
+          '🔐 Building with state: ${state.runtimeType}',
+          name: 'CameraPermissionGate',
+          category: LogCategory.video,
+        );
         return switch (state) {
           CameraPermissionInitial() => _CameraPlaceholderScaffold(
             onClose: _popBack,

--- a/mobile/lib/widgets/video_recorder/preview/video_recorder_camera_preview.dart
+++ b/mobile/lib/widgets/video_recorder/preview/video_recorder_camera_preview.dart
@@ -77,6 +77,7 @@ class _StackItems extends ConsumerWidget {
         (s) => (
           isCameraInitialized: s.isCameraInitialized,
           cameraRebuildCount: s.cameraRebuildCount,
+          initializationErrorMessage: s.initializationErrorMessage,
         ),
       ),
     );
@@ -87,7 +88,9 @@ class _StackItems extends ConsumerWidget {
         if (state.isCameraInitialized)
           const _CameraPreview()
         else
-          const VideoRecorderCameraPlaceholder(),
+          VideoRecorderCameraPlaceholder(
+            errorMessage: state.initializationErrorMessage,
+          ),
         const _OverlayGrid(),
         const VideoRecorderFocusPoint(),
       ],

--- a/mobile/lib/widgets/video_recorder/video_recorder_camera_placeholder.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_camera_placeholder.dart
@@ -1,22 +1,46 @@
 // ABOUTME: Fallback placeholder widget displayed when camera is unavailable
-// ABOUTME: Shows idle icon
+// ABOUTME: Shows idle icon or error message when camera initialization fails
 
 import 'package:flutter/material.dart';
 
 /// Fallback preview widget for when camera is not available
 class VideoRecorderCameraPlaceholder extends StatelessWidget {
   /// Creates a camera placeholder widget.
-  const VideoRecorderCameraPlaceholder({super.key});
+  const VideoRecorderCameraPlaceholder({super.key, this.errorMessage});
+
+  /// Optional error message to display when camera initialization fails.
+  final String? errorMessage;
 
   @override
   Widget build(BuildContext context) {
     return ColoredBox(
       color: const Color(0xFF141414),
       child: Center(
-        child: const Icon(
-          Icons.videocam_rounded,
-          size: 56,
-          color: Color(0xB3FFFFFF),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              errorMessage != null
+                  ? Icons.videocam_off_rounded
+                  : Icons.videocam_rounded,
+              size: 56,
+              color: const Color(0xB3FFFFFF),
+            ),
+            if (errorMessage != null) ...[
+              const SizedBox(height: 16),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 32),
+                child: Text(
+                  errorMessage!,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                    color: Color(0xB3FFFFFF),
+                    fontSize: 14,
+                  ),
+                ),
+              ),
+            ],
+          ],
         ),
       ),
     );

--- a/mobile/lib/widgets/video_recorder/video_recorder_top_bar.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_top_bar.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_recorder_provider.dart';
+import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/divine_icon_button.dart';
 
 /// Top bar with close button, segment bar, and forward button.
@@ -15,9 +16,18 @@ class VideoRecorderTopBar extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final notifier = ref.read(videoRecorderProvider.notifier);
-    final hasClips = ref.watch(clipManagerProvider.select((s) => s.hasClips));
+    final clipCount = ref.watch(clipManagerProvider.select((s) => s.clipCount));
+    final hasClips = clipCount > 0;
     final isRecording = ref.watch(
       videoRecorderProvider.select((s) => s.isRecording),
+    );
+
+    // Debug logging for Next button visibility
+    Log.debug(
+      '🔝 TopBar build: hasClips=$hasClips, clipCount=$clipCount, '
+      'isRecording=$isRecording',
+      name: 'VideoRecorderTopBar',
+      category: LogCategory.video,
     );
 
     return Align(

--- a/mobile/test/blocs/camera_permission/camera_permission_bloc_test.dart
+++ b/mobile/test/blocs/camera_permission/camera_permission_bloc_test.dart
@@ -26,16 +26,20 @@ void main() {
     group('CameraPermissionRequest', () {
       blocTest<CameraPermissionBloc, CameraPermissionState>(
         'does nothing when state is CameraPermissionInitial',
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
         expect: () => <CameraPermissionState>[],
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
         'does nothing when state is CameraPermissionLoading',
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         seed: () => const CameraPermissionLoading(),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
         expect: () => <CameraPermissionState>[],
@@ -43,8 +47,10 @@ void main() {
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
         'does nothing when status is authorized',
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.authorized),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
@@ -56,8 +62,10 @@ void main() {
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
         'does nothing when status is requiresSettings',
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         seed: () => const CameraPermissionLoaded(
           CameraPermissionStatus.requiresSettings,
         ),
@@ -78,8 +86,10 @@ void main() {
             () => mockPermissionsService.requestMicrophonePermission(),
           ).thenAnswer((_) async => PermissionStatus.granted);
         },
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
@@ -95,8 +105,10 @@ void main() {
             () => mockPermissionsService.requestCameraPermission(),
           ).thenAnswer((_) async => PermissionStatus.canRequest);
         },
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
@@ -113,8 +125,10 @@ void main() {
             () => mockPermissionsService.requestMicrophonePermission(),
           ).thenAnswer((_) async => PermissionStatus.canRequest);
         },
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
@@ -128,8 +142,10 @@ void main() {
             () => mockPermissionsService.requestCameraPermission(),
           ).thenAnswer((_) async => PermissionStatus.requiresSettings);
         },
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
@@ -146,8 +162,10 @@ void main() {
             () => mockPermissionsService.requestMicrophonePermission(),
           ).thenAnswer((_) async => PermissionStatus.requiresSettings);
         },
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
@@ -161,8 +179,10 @@ void main() {
             () => mockPermissionsService.requestCameraPermission(),
           ).thenThrow(Exception('Platform error'));
         },
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
@@ -179,8 +199,10 @@ void main() {
             () => mockPermissionsService.requestMicrophonePermission(),
           ).thenThrow(Exception('Platform error'));
         },
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
@@ -199,8 +221,10 @@ void main() {
             () => mockPermissionsService.checkMicrophoneStatus(),
           ).thenAnswer((_) async => PermissionStatus.canRequest);
         },
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         act: (bloc) => bloc.add(const CameraPermissionRefresh()),
         expect: () => [
           const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
@@ -217,8 +241,10 @@ void main() {
             () => mockPermissionsService.checkMicrophoneStatus(),
           ).thenAnswer((_) async => PermissionStatus.granted);
         },
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         act: (bloc) => bloc.add(const CameraPermissionRefresh()),
         expect: () => [
           const CameraPermissionLoaded(CameraPermissionStatus.authorized),
@@ -235,8 +261,10 @@ void main() {
             () => mockPermissionsService.checkMicrophoneStatus(),
           ).thenAnswer((_) async => PermissionStatus.granted);
         },
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         act: (bloc) => bloc.add(const CameraPermissionRefresh()),
         expect: () => [
           const CameraPermissionLoaded(CameraPermissionStatus.requiresSettings),
@@ -253,8 +281,10 @@ void main() {
             () => mockPermissionsService.checkMicrophoneStatus(),
           ).thenAnswer((_) async => PermissionStatus.granted);
         },
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         act: (bloc) => bloc.add(const CameraPermissionRefresh()),
         expect: () => [const CameraPermissionError()],
       );
@@ -268,8 +298,10 @@ void main() {
             () => mockPermissionsService.openAppSettings(),
           ).thenAnswer((_) async => true);
         },
-        build: () =>
-            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
         act: (bloc) => bloc.add(const CameraPermissionOpenSettings()),
         expect: () => <CameraPermissionState>[],
         verify: (_) {
@@ -291,6 +323,7 @@ void main() {
 
           final bloc = CameraPermissionBloc(
             permissionsService: mockPermissionsService,
+            skipMacOSBypass: true,
           );
           final result = await bloc.checkPermissions();
 
@@ -326,6 +359,7 @@ void main() {
 
           final bloc = CameraPermissionBloc(
             permissionsService: mockPermissionsService,
+            skipMacOSBypass: true,
           );
           final result = await bloc.checkPermissions();
 
@@ -361,6 +395,7 @@ void main() {
 
           final bloc = CameraPermissionBloc(
             permissionsService: mockPermissionsService,
+            skipMacOSBypass: true,
           );
           final result = await bloc.checkPermissions();
 

--- a/mobile/test/mocks/mock_camera_service.dart
+++ b/mobile/test/mocks/mock_camera_service.dart
@@ -98,4 +98,7 @@ class MockCameraService extends CameraService {
 
   @override
   bool get hasFlash => true;
+
+  @override
+  String? get initializationError => null;
 }

--- a/mobile/test/widgets/video_recorder/video_recorder_camera_placeholder_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_camera_placeholder_test.dart
@@ -18,5 +18,58 @@ void main() {
 
       expect(find.byType(VideoRecorderCameraPlaceholder), findsOneWidget);
     });
+
+    testWidgets('shows videocam icon when no error', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: VideoRecorderCameraPlaceholder()),
+        ),
+      );
+
+      expect(find.byIcon(Icons.videocam_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.videocam_off_rounded), findsNothing);
+    });
+
+    testWidgets('shows videocam_off icon when error message provided', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: VideoRecorderCameraPlaceholder(
+              errorMessage: 'No camera found',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.videocam_off_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.videocam_rounded), findsNothing);
+    });
+
+    testWidgets('displays error message text when provided', (tester) async {
+      const errorMessage = 'No camera found. Please connect a camera.';
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: VideoRecorderCameraPlaceholder(errorMessage: errorMessage),
+          ),
+        ),
+      );
+
+      expect(find.text(errorMessage), findsOneWidget);
+    });
+
+    testWidgets('does not display error text when no error', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: VideoRecorderCameraPlaceholder()),
+        ),
+      );
+
+      // Should not find any Text widget other than potential debug text
+      final textWidgets = find.byType(Text);
+      expect(textWidgets, findsNothing);
+    });
   });
 }


### PR DESCRIPTION
## Summary

- **Permission handler bypass**: The `permission_handler` plugin throws exceptions on macOS desktop, causing the camera screen to never render. Added platform check to bypass permission checking on macOS and assume authorized (macOS handles permissions at system level with native dialogs).

- **Video file fallback**: macOS camera recording via `camera_macos_plus` returns null bytes but provides a file URL. Added fallback to read from file path when bytes are null, ensuring clips are properly saved and the "Next" button appears.

- **Error tracking**: Added `initializationError` getter to camera services to track and display initialization failures in the UI placeholder.

## Test plan

- [ ] Run app on macOS and navigate to camera screen
- [ ] Verify camera preview loads (macOS permission dialog should appear on first access)
- [ ] Record a video clip and verify the "Next" button appears
- [ ] Tap "Next" to navigate to video editor
- [ ] Verify bottom menu options are accessible when clips exist
- [ ] Test on iOS/Android to ensure no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)