### PR TITLE
fix: correct GitHub URLs and directory names in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,14 +35,14 @@ Thank you for your interest in contributing to diVine! This guide will help you 
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/your-org/openvine.git
-cd openvine
+git clone https://github.com/divinevideo/divine-mobile.git
+cd divine-mobile
 ```
 
 ### 2. Install Flutter Dependencies
 
 ```bash
-cd openvine/mobile
+cd divine-mobile/mobile
 flutter pub get
 ```
 
@@ -326,7 +326,7 @@ ls -la ../flutter_embedded_nostr_relay
 # Recreate if needed
 cd ..
 ln -s /path/to/flutter_embedded_nostr_relay flutter_embedded_nostr_relay
-cd openvine/mobile
+cd divine-mobile/mobile
 flutter pub get
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ flutter doctor
 
 ```bash
 # Clone the repository
-git clone https://github.com/ArcadeLabsInc/divine-mobile.git
+git clone https://github.com/divinevideo/divine-mobile.git
 cd divine-mobile
 
 # Navigate to the mobile app


### PR DESCRIPTION
## Summary
Fixes incorrect URLs and directory names in README.md and CONTRIBUTING.md

## Changes
- `https://github.com/ArcadeLabsInc/divine-mobile.git` → `https://github.com/divinevideo/divine-mobile.git`
- `https://github.com/your-org/openvine.git` → `https://github.com/divinevideo/divine-mobile.git`
- `cd openvine` → `cd divine-mobile`
- `cd openvine/mobile` → `cd divine-mobile/mobile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)