### PR TITLE
fix: unused app_device_integrity

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -65,14 +65,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.2+1"
-  app_device_integrity:
-    dependency: "direct main"
-    description:
-      name: app_device_integrity
-      sha256: "626e4f94ce393866e9aeb2d2c989817e13722ce5e5c93f81aae967f187f96dda"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
   app_links:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -141,7 +141,6 @@ dependencies:
   firebase_core: ^4.1.1
   firebase_crashlytics: ^5.0.2
   firebase_analytics: ^12.0.2
-  app_device_integrity: ^1.1.0
   go_router: ^16.2.4
   flutter_local_notifications: ^19.4.2
   package_info_plus: ^9.0.0


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

Removes the `app_device_integrity` package which was added but never integrated. This closes #962 where Android users occasionally see a "verify on Google Play" error screen at launch.

This should topic should be redefined while tackling this related issue https://github.com/divinevideo/divine-mobile/issues/183

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore