### PR TITLE
feat: Disabling the record button while background uploads are in progress

### DIFF
--- a/mobile/lib/blocs/background_publish/background_publish_state.dart
+++ b/mobile/lib/blocs/background_publish/background_publish_state.dart
@@ -32,6 +32,10 @@ class BackgroundPublishState extends Equatable {
 
   final List<BackgroundUpload> uploads;
 
+  /// Returns true if there is any upload in progress (no result yet).
+  bool get hasUploadInProgress =>
+      uploads.any((upload) => upload.result == null);
+
   BackgroundPublishState copyWith({List<BackgroundUpload>? uploads}) {
     return BackgroundPublishState(uploads: uploads ?? this.uploads);
   }

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -2,11 +2,13 @@
 // ABOUTME: Header title uses Bricolage Grotesque font, camera button in bottom nav
 
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:divine_ui/divine_ui.dart';
+import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/vine_drawer.dart';
@@ -579,37 +581,58 @@ class AppShell extends ConsumerWidget {
                 'explore_tab',
               ),
               // Camera button in center of bottom nav
-              Semantics(
-                identifier: 'camera_button',
-                button: true,
-                label: 'Open camera',
-                child: GestureDetector(
-                  onTap: () {
-                    Log.info(
-                      '👆 User tapped camera button',
-                      name: 'Navigation',
-                      category: LogCategory.ui,
-                    );
-                    context.push(VideoRecorderScreen.path);
-                  },
-                  child: Container(
-                    width: 72,
-                    height: 48,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 20,
-                      vertical: 8,
+              BlocBuilder<BackgroundPublishBloc, BackgroundPublishState>(
+                builder: (context, state) {
+                  final isDisabled = state.hasUploadInProgress;
+
+                  return Semantics(
+                    identifier: 'camera_button',
+                    button: true,
+                    label: isDisabled
+                        ? 'Camera disabled during upload'
+                        : 'Open camera',
+                    child: GestureDetector(
+                      onTap: isDisabled
+                          ? null
+                          : () {
+                              Log.info(
+                                '👆 User tapped camera button',
+                                name: 'Navigation',
+                                category: LogCategory.ui,
+                              );
+                              context.push(VideoRecorderScreen.path);
+                            },
+                      child: Opacity(
+                        opacity: isDisabled ? 0.5 : 1.0,
+                        child: Container(
+                          width: 72,
+                          height: 48,
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 20,
+                            vertical: 8,
+                          ),
+                          decoration: BoxDecoration(
+                            color: isDisabled
+                                ? VineTheme.tabIconInactive
+                                : VineTheme.cameraButtonGreen,
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                          child: SvgPicture.asset(
+                            'assets/icon/retro-camera.svg',
+                            width: 32,
+                            height: 32,
+                            colorFilter: isDisabled
+                                ? const ColorFilter.mode(
+                                    Colors.grey,
+                                    BlendMode.srcIn,
+                                  )
+                                : null,
+                          ),
+                        ),
+                      ),
                     ),
-                    decoration: BoxDecoration(
-                      color: VineTheme.cameraButtonGreen,
-                      borderRadius: BorderRadius.circular(20),
-                    ),
-                    child: SvgPicture.asset(
-                      'assets/icon/retro-camera.svg',
-                      width: 32,
-                      height: 32,
-                    ),
-                  ),
-                ),
+                  );
+                },
               ),
               _buildTabButton(
                 context,

--- a/mobile/lib/widgets/vine_bottom_nav.dart
+++ b/mobile/lib/widgets/vine_bottom_nav.dart
@@ -2,10 +2,12 @@
 // ABOUTME: Provides consistent bottom nav across screens with/without shell
 
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:divine_ui/divine_ui.dart';
+import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/router/last_tab_position_provider.dart';
 import 'package:openvine/router/page_context_provider.dart';
 import 'package:openvine/screens/explore_screen.dart';
@@ -126,37 +128,15 @@ class VineBottomNav extends ConsumerWidget {
               'explore_tab',
             ),
             // Camera button in center of bottom nav
-            Semantics(
-              identifier: 'camera_button',
-              button: true,
-              label: 'Open camera',
-              child: GestureDetector(
-                onTap: () {
-                  Log.info(
-                    '👆 User tapped camera button',
-                    name: 'Navigation',
-                    category: LogCategory.ui,
-                  );
-                  context.push(VideoRecorderScreen.path);
-                },
-                child: Container(
-                  width: 72,
-                  height: 48,
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 20,
-                    vertical: 8,
-                  ),
-                  decoration: BoxDecoration(
-                    color: VineTheme.cameraButtonGreen,
-                    borderRadius: BorderRadius.circular(20),
-                  ),
-                  child: SvgPicture.asset(
-                    'assets/icon/retro-camera.svg',
-                    width: 32,
-                    height: 32,
-                  ),
-                ),
-              ),
+            _CameraButton(
+              onTap: () {
+                Log.info(
+                  '👆 User tapped camera button',
+                  name: 'Navigation',
+                  category: LogCategory.ui,
+                );
+                context.push(VideoRecorderScreen.path);
+              },
             ),
             _buildTabButton(
               context,
@@ -175,6 +155,56 @@ class VineBottomNav extends ConsumerWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Camera button widget that disables when a background upload is in progress.
+class _CameraButton extends StatelessWidget {
+  const _CameraButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<BackgroundPublishBloc, BackgroundPublishState>(
+      builder: (context, state) {
+        final isDisabled = state.hasUploadInProgress;
+
+        return Semantics(
+          identifier: 'camera_button',
+          button: true,
+          label: isDisabled ? 'Camera disabled during upload' : 'Open camera',
+          child: GestureDetector(
+            onTap: isDisabled ? null : onTap,
+            child: Opacity(
+              opacity: isDisabled ? 0.5 : 1.0,
+              child: Container(
+                width: 72,
+                height: 48,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 20,
+                  vertical: 8,
+                ),
+                decoration: BoxDecoration(
+                  color: isDisabled
+                      ? VineTheme.tabIconInactive
+                      : VineTheme.cameraButtonGreen,
+                  borderRadius: BorderRadius.circular(20),
+                ),
+                child: SvgPicture.asset(
+                  'assets/icon/retro-camera.svg',
+                  width: 32,
+                  height: 32,
+                  colorFilter: isDisabled
+                      ? const ColorFilter.mode(Colors.grey, BlendMode.srcIn)
+                      : null,
+                ),
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
+++ b/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
@@ -13,6 +13,63 @@ void main() {
   final defaultVieoPublishServiceFactory =
       ({required OnProgressChanged onProgress}) =>
           Future.value(_MockVideoPublishService());
+
+  group('BackgroundPublishState', () {
+    group('hasUploadInProgress', () {
+      test('returns false when uploads list is empty', () {
+        const state = BackgroundPublishState();
+        expect(state.hasUploadInProgress, isFalse);
+      });
+
+      test('returns true when there is an upload with null result', () {
+        final draft = _MockVineDraft();
+        when(() => draft.id).thenReturn('1');
+
+        final state = BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(draft: draft, result: null, progress: 0.5),
+          ],
+        );
+        expect(state.hasUploadInProgress, isTrue);
+      });
+
+      test('returns false when all uploads have a result', () {
+        final draft = _MockVineDraft();
+        when(() => draft.id).thenReturn('1');
+
+        final state = BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(
+              draft: draft,
+              result: const PublishError('error'),
+              progress: 1.0,
+            ),
+          ],
+        );
+        expect(state.hasUploadInProgress, isFalse);
+      });
+
+      test('returns true when at least one upload has null result', () {
+        final draft1 = _MockVineDraft();
+        final draft2 = _MockVineDraft();
+        when(() => draft1.id).thenReturn('1');
+        when(() => draft2.id).thenReturn('2');
+
+        final state = BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(
+              draft: draft1,
+              result: const PublishError('error'),
+              progress: 1.0,
+            ),
+            BackgroundUpload(draft: draft2, result: null, progress: 0.3),
+          ],
+        );
+        expect(state.hasUploadInProgress, isTrue);
+      });
+    });
+  });
+
   group('BackgroundBlocUpload', () {
     test('can be instantiated', () {
       expect(


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

**Related Issue:** Closes #

Disables the record button while an upload is being performed in the background.

This is a temporary measure until we implement the ability for the app to handle multiple drafts.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore