### PR TITLE
fix: resolve video posting race condition causing blank screen (#1066)

### DIFF
--- a/mobile/lib/models/video_editor/video_editor_provider_state.dart
+++ b/mobile/lib/models/video_editor/video_editor_provider_state.dart
@@ -5,6 +5,10 @@ import 'package:flutter/widgets.dart';
 import 'package:openvine/models/recording_clip.dart';
 import 'package:openvine/models/video_metadata/video_metadata_expiration.dart';
 
+/// Sentinel value to distinguish between "not provided" and "explicitly null"
+/// in copyWith for nullable fields like renderErrorMessage.
+const _sentinel = Object();
+
 /// Immutable state model for the video editor.
 ///
 /// Manages the complete editing state including:
@@ -33,6 +37,7 @@ class VideoEditorProviderState {
     this.tags = const {},
     this.expiration = .notExpire,
     this.metadataLimitReached = false,
+    this.renderErrorMessage,
     this.finalRenderedClip,
     GlobalKey? deleteButtonKey,
   }) : deleteButtonKey = deleteButtonKey ?? GlobalKey();
@@ -96,6 +101,10 @@ class VideoEditorProviderState {
   /// Whether the 64KB metadata limit was reached during the last update.
   final bool metadataLimitReached;
 
+  /// Error message from the last render attempt, or null if no error.
+  /// Set when video rendering fails, cleared when a new render starts.
+  final String? renderErrorMessage;
+
   /// The final rendered clip after all editing and processing operations are
   /// complete.
   /// This represents the video output ready for publishing.
@@ -113,6 +122,9 @@ class VideoEditorProviderState {
   ///
   /// All parameters are optional. Only provided fields will be updated,
   /// others retain their current values.
+  /// Whether a render error occurred.
+  bool get hasRenderError => renderErrorMessage != null;
+
   VideoEditorProviderState copyWith({
     int? currentClipIndex,
     Duration? currentPosition,
@@ -133,6 +145,7 @@ class VideoEditorProviderState {
     Set<String>? tags,
     VideoMetadataExpiration? expiration,
     bool? metadataLimitReached,
+    Object? renderErrorMessage = _sentinel,
     RecordingClip? finalRenderedClip,
   }) {
     return VideoEditorProviderState(
@@ -155,6 +168,9 @@ class VideoEditorProviderState {
       tags: tags ?? this.tags,
       expiration: expiration ?? this.expiration,
       metadataLimitReached: metadataLimitReached ?? this.metadataLimitReached,
+      renderErrorMessage: renderErrorMessage == _sentinel
+          ? this.renderErrorMessage
+          : renderErrorMessage as String?,
       finalRenderedClip: finalRenderedClip ?? this.finalRenderedClip,
     );
   }

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -707,6 +707,9 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   ///
   /// Combines all clips, applies audio settings, generates proofmode
   /// attestation, and creates the final rendered clip for publishing.
+  ///
+  /// On success, sets [finalRenderedClip] and clears any previous error.
+  /// On failure, sets [renderErrorMessage] with the failure reason.
   Future<void> startRenderVideo() async {
     if (state.isProcessing) return;
 
@@ -715,14 +718,12 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       name: 'VideoEditorNotifier',
       category: .video,
     );
-    state = state.copyWith(isProcessing: true);
 
-    // Render video and get proofmode data
+    state = state.copyWith(isProcessing: true, renderErrorMessage: null);
+
     final (outputPath, proofManifestJson) = await _renderVideo();
-
     final validToPublish = outputPath != null;
 
-    // Extract metadata from rendered video
     final metaData = validToPublish
         ? await ProVideoEditor.instance.getMetadata(
             EditorVideo.file(outputPath),
@@ -735,6 +736,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         name: 'VideoEditorNotifier',
         category: .video,
       );
+      state = state.copyWith(
+        isProcessing: false,
+        renderErrorMessage: 'Video rendering failed. Please try again.',
+      );
       return;
     }
 
@@ -745,7 +750,6 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       category: .video,
     );
 
-    // Create final clip for publishing
     final finalRenderedClip = RecordingClip(
       id: 'clip-${DateTime.now()}',
       video: EditorVideo.file(outputPath),
@@ -757,7 +761,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     );
 
     Log.info(
-      '📤 Navigating to publish screen',
+      '📤 Ready to navigate to publish screen',
       name: 'VideoEditorNotifier',
       category: .video,
     );
@@ -765,7 +769,13 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     state = state.copyWith(
       isProcessing: false,
       finalRenderedClip: finalRenderedClip,
+      renderErrorMessage: null,
     );
+  }
+
+  /// Clear the render error message.
+  void clearRenderError() {
+    state = state.copyWith(renderErrorMessage: null);
   }
 
   /// Cancel an ongoing video render operation.

--- a/mobile/lib/screens/video_editor/video_clip_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_clip_editor_screen.dart
@@ -9,6 +9,7 @@ import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/video_clip_editor/gallery/video_editor_clip_gallery.dart';
 import 'package:openvine/widgets/video_clip_editor/video_clip_editor_bottom_bar.dart';
 import 'package:openvine/widgets/video_clip_editor/video_clip_editor_progress_bar.dart';
+import 'package:openvine/widgets/video_clip_editor/video_clip_editor_render_status.dart';
 import 'package:openvine/widgets/video_clip_editor/video_clip_editor_split_bar.dart';
 import 'package:openvine/widgets/video_clip_editor/video_clip_editor_top_bar.dart';
 
@@ -72,40 +73,49 @@ class _VideoClipEditorScreenState extends ConsumerState<VideoClipEditorScreen> {
       child: PopScope(
         canPop: !isProcessing,
         child: SafeArea(
-          child: Scaffold(
-            resizeToAvoidBottomInset: false,
-            backgroundColor: VineTheme.surfaceContainerHigh,
-            body: _isLoadingDraft
-                ? const Center(child: CircularProgressIndicator.adaptive())
-                : Column(
-                    children: [
-                      /// Top bar
-                      VideoClipEditorTopBar(fromLibrary: widget.fromLibrary),
+          child: Stack(
+            children: [
+              Scaffold(
+                resizeToAvoidBottomInset: false,
+                backgroundColor: VineTheme.surfaceContainerHigh,
+                body: _isLoadingDraft
+                    ? const Center(child: CircularProgressIndicator.adaptive())
+                    : Column(
+                        children: [
+                          /// Top bar
+                          VideoClipEditorTopBar(
+                            fromLibrary: widget.fromLibrary,
+                          ),
 
-                      /// Main content area with clips
-                      const Expanded(child: VideoEditorClipGallery()),
+                          /// Main content area with clips
+                          const Expanded(child: VideoEditorClipGallery()),
 
-                      /// Progress or Split bar
-                      Container(
-                        height: 40,
-                        padding: const .symmetric(horizontal: 16),
-                        child: Consumer(
-                          builder: (_, ref, _) {
-                            final isEditing = ref.watch(
-                              videoEditorProvider.select((p) => p.isEditing),
-                            );
+                          /// Progress or Split bar
+                          Container(
+                            height: 40,
+                            padding: const EdgeInsets.symmetric(horizontal: 16),
+                            child: Consumer(
+                              builder: (_, ref, _) {
+                                final isEditing = ref.watch(
+                                  videoEditorProvider.select(
+                                    (p) => p.isEditing,
+                                  ),
+                                );
 
-                            return isEditing
-                                ? const VideoClipEditorSplitBar()
-                                : const VideoClipEditorProgressBar();
-                          },
-                        ),
+                                return isEditing
+                                    ? const VideoClipEditorSplitBar()
+                                    : const VideoClipEditorProgressBar();
+                              },
+                            ),
+                          ),
+
+                          /// Bottom bar
+                          const VideoClipEditorBottomBar(),
+                        ],
                       ),
-
-                      /// Bottom bar
-                      const VideoClipEditorBottomBar(),
-                    ],
-                  ),
+              ),
+              const VideoClipEditorRenderStatus(),
+            ],
           ),
         ),
       ),

--- a/mobile/lib/widgets/video_clip_editor/video_clip_editor_render_status.dart
+++ b/mobile/lib/widgets/video_clip_editor/video_clip_editor_render_status.dart
@@ -1,0 +1,201 @@
+// ABOUTME: Full-screen overlay showing video render progress and error states
+// ABOUTME: Displays spinner during rendering and error message with retry on failure
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:pro_video_editor/core/models/video/progress_model.dart';
+import 'package:pro_video_editor/core/platform/platform_interface.dart';
+
+/// Full-screen overlay showing video render progress and error states.
+///
+/// Displays:
+/// - Processing indicator with progress bar during rendering
+/// - Error message with dismiss button on failure
+class VideoClipEditorRenderStatus extends ConsumerWidget {
+  /// Creates a video clip editor render status overlay.
+  const VideoClipEditorRenderStatus({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(
+      videoEditorProvider.select(
+        (s) => (
+          isProcessing: s.isProcessing,
+          renderErrorMessage: s.renderErrorMessage,
+        ),
+      ),
+    );
+
+    final isVisible = state.isProcessing || state.renderErrorMessage != null;
+
+    return Material(
+      type: MaterialType.transparency,
+      child: AnimatedOpacity(
+        opacity: isVisible ? 1.0 : 0.0,
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeInOut,
+        child: isVisible
+            ? ColoredBox(
+                color: const Color.fromARGB(200, 0, 0, 0),
+                child: Center(
+                  child: state.renderErrorMessage != null
+                      ? _ErrorDialog(errorMessage: state.renderErrorMessage!)
+                      : const _RenderingDialog(),
+                ),
+              )
+            : const SizedBox.shrink(),
+      ),
+    );
+  }
+}
+
+/// Dialog showing rendering progress.
+class _RenderingDialog extends ConsumerWidget {
+  const _RenderingDialog();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Get first clip ID to track render progress
+    final clipId = ref.watch(
+      clipManagerProvider.select((s) => s.clips.firstOrNull?.id),
+    );
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 32),
+      padding: const EdgeInsets.all(32),
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [Color(0xFF2A2A2A), Color(0xFF1A1A1A)],
+        ),
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: const [
+          BoxShadow(
+            color: Color.fromRGBO(0, 0, 0, 0.4),
+            blurRadius: 30,
+            spreadRadius: 5,
+            offset: Offset(0, 10),
+          ),
+        ],
+        border: Border.all(color: const Color(0x1A000000)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 20,
+        children: [
+          // Progress indicator
+          if (clipId != null)
+            RepaintBoundary(
+              child: StreamBuilder<ProgressModel>(
+                stream: ProVideoEditor.instance.progressStreamById(clipId),
+                builder: (context, snapshot) {
+                  final progress = snapshot.data?.progress ?? 0;
+                  return SizedBox(
+                    width: 64,
+                    height: 64,
+                    child: PartialCircleSpinner(progress: progress),
+                  );
+                },
+              ),
+            )
+          else
+            const SizedBox(
+              width: 48,
+              height: 48,
+              child: CircularProgressIndicator(
+                strokeWidth: 4,
+                valueColor: AlwaysStoppedAnimation<Color>(VineTheme.vineGreen),
+              ),
+            ),
+          // Status text
+          const Text(
+            // TODO(l10n): Replace with context.l10n when localization is added.
+            'Rendering video...',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.3,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Dialog showing render error with dismiss button.
+class _ErrorDialog extends ConsumerWidget {
+  const _ErrorDialog({required this.errorMessage});
+
+  final String errorMessage;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 32),
+      padding: const EdgeInsets.all(32),
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [Color(0xFF2A2A2A), Color(0xFF1A1A1A)],
+        ),
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: const [
+          BoxShadow(
+            color: Color.fromRGBO(0, 0, 0, 0.4),
+            blurRadius: 30,
+            spreadRadius: 5,
+            offset: Offset(0, 10),
+          ),
+        ],
+        border: Border.all(color: const Color(0x1A000000)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 20,
+        children: [
+          // Error icon
+          const Icon(Icons.error_outline, color: Colors.red, size: 48),
+          // Error message
+          Text(
+            errorMessage,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.3,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          // Dismiss button
+          TextButton(
+            onPressed: () =>
+                ref.read(videoEditorProvider.notifier).clearRenderError(),
+            style: TextButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+              backgroundColor: VineTheme.vineGreen.withAlpha(38),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+            // TODO(l10n): Replace with context.l10n when localization is added.
+            child: const Text(
+              'Dismiss',
+              style: TextStyle(
+                color: VineTheme.vineGreen,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_clip_editor/video_clip_editor_top_bar.dart
+++ b/mobile/lib/widgets/video_clip_editor/video_clip_editor_top_bar.dart
@@ -1,8 +1,6 @@
 // ABOUTME: Top bar with close, clip counter, and done buttons
 // ABOUTME: Displays current clip position and total clip count
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
@@ -86,14 +84,17 @@ class VideoClipEditorTopBar extends ConsumerWidget {
                   : Align(
                       alignment: .centerRight,
                       child: _NextButton(
-                        onTap: () {
-                          unawaited(
-                            ref
-                                .read(videoEditorProvider.notifier)
-                                .startRenderVideo(),
-                          );
-                          // TODO(@hm21): Replace with VideoEditorScreen.path
-                          context.push(VideoMetadataScreen.path);
+                        onTap: () async {
+                          await ref
+                              .read(videoEditorProvider.notifier)
+                              .startRenderVideo();
+
+                          if (!context.mounted) return;
+
+                          final editorState = ref.read(videoEditorProvider);
+                          if (editorState.finalRenderedClip != null) {
+                            context.push(VideoMetadataScreen.path);
+                          }
                         },
                       ),
                     ),


### PR DESCRIPTION
## Summary
- Fix race condition where `startRenderVideo()` was called with `unawaited()` causing navigation before render completed
- Add `renderErrorMessage` field to track and display render failures
- Create `VideoClipEditorRenderStatus` overlay showing progress and error states
- Only navigate to metadata screen when render succeeds

## Problem
Users tapping "Next" after recording would see a blank screen with spinner, then get silently returned to camera with no feedback.

## Root Cause
In `video_clip_editor_top_bar.dart`, the render was fire-and-forget:
```dart
unawaited(startRenderVideo());
context.push(VideoMetadataScreen.path); // Navigated immediately!
```

## Solution
Await the render and only navigate on success:
```dart
await startRenderVideo();
if (editorState.finalRenderedClip != null) {
  context.push(VideoMetadataScreen.path);
}
```

## Test plan
- [ ] Record a video and tap "Next" - should see render progress overlay
- [ ] Wait for render to complete - should navigate to metadata screen
- [ ] Force render failure (e.g., low disk space) - should see error dialog with dismiss button
- [ ] Dismiss error and retry - should work correctly

Fixes #1066