### PR TITLE
fix(relays): blocklist dead relay hosts to prevent connection errors

### DIFF
--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -46,7 +46,7 @@ class RelayManager {
     try {
       final uri = Uri.parse(url);
       return _blockedRelayHosts.contains(uri.host);
-    } catch (_) {
+    } on FormatException {
       return false;
     }
   }

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -1080,7 +1080,7 @@ void main() {
       final manager = RelayManager(
         config: _createTestConfig(),
         relayPool: mockRelayPool,
-        relayFactory: (url) => _FakeRelay(url),
+        relayFactory: _FakeRelay.new,
       );
       await manager.initialize();
 
@@ -1098,7 +1098,7 @@ void main() {
       final manager = RelayManager(
         config: _createTestConfig(),
         relayPool: mockRelayPool,
-        relayFactory: (url) => _FakeRelay(url),
+        relayFactory: _FakeRelay.new,
       );
       await manager.initialize();
 
@@ -1118,7 +1118,7 @@ void main() {
       final manager = RelayManager(
         config: _createTestConfig(storage: storage),
         relayPool: mockRelayPool,
-        relayFactory: (url) => _FakeRelay(url),
+        relayFactory: _FakeRelay.new,
       );
 
       await manager.initialize();


### PR DESCRIPTION
## Summary

- Add blocklist mechanism to filter out known-dead relays (e.g., `index.coracle.social`)
- Prevents `SocketException: Failed host lookup` errors on app startup
- Filters blocked relays both when adding new relays AND when loading from storage

## Problem

Users with `index.coracle.social` in their NIP-65 relay list experience constant connection errors:
```
WebSocketChannelException: SocketException: Failed host lookup: 'index.coracle.social' 
(OS Error: nodename nor servname provided, or not known, errno = 8)
```

Even after removing the relay in settings, NIP-65 discovery would re-add it on next app restart.

## Solution

Add a static blocklist of known-dead relay hosts in `RelayManager`:
- `_blockedRelayHosts`: Set of dead relay hostnames
- `_isBlockedRelay()`: Helper to check if a URL is blocked
- Block check in `addRelay()`: Rejects blocked relays
- Block check in `initialize()`: Filters blocked relays from storage

## Test plan
- [x] Unit tests for blocklist functionality
- [ ] Manual test: Verify `index.coracle.social` is no longer added
- [ ] Verify no connection errors for blocked relays

🤖 Generated with [Claude Code](https://claude.com/claude-code)