### PR TITLE
feat: use embedded author data from REST API responses

### DIFF
--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -541,6 +541,7 @@ class _VideoInfoSection extends ConsumerWidget {
           if (hasUsername)
             UserName.fromPubKey(
               video.pubkey,
+              embeddedName: video.authorName,
               maxLines: 1,
               style: VineTheme.titleTinyFont(color: Colors.white).copyWith(
                 shadows: const [

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -1224,9 +1224,13 @@ class VideoOverlayActions extends ConsumerWidget {
                     final profile = userProfileService.getCachedProfile(
                       video.pubkey,
                     );
-                    final avatarUrl = profile?.picture;
+                    // Use embedded author data from REST API as fallback
+                    // This avoids WebSocket profile fetches for videos
+                    // that already have author_name/author_avatar embedded
+                    final avatarUrl = profile?.picture ?? video.authorAvatar;
                     final displayName =
                         profile?.bestDisplayName ??
+                        video.authorName ??
                         NostrKeyUtils.truncateNpub(video.pubkey);
                     final loopCount = video.originalLoops ?? 0;
 
@@ -1859,6 +1863,7 @@ class VideoAuthorRow extends ConsumerWidget {
                 const SizedBox(width: 6),
                 UserName.fromPubKey(
                   video.pubkey,
+                  embeddedName: video.authorName,
                   style: const TextStyle(color: Colors.white, fontSize: 12),
                   overflow: TextOverflow.ellipsis,
                 ),


### PR DESCRIPTION
## Summary
- Use `author_name` and `author_avatar` from Funnelcake REST API responses as fallbacks before making WebSocket profile fetches
- Add `embeddedName` parameter to `UserName` widget to accept pre-fetched author names
- Reduces unnecessary profile lookups for videos that already have embedded author data

## Changes
- **UserName widget**: Added `embeddedName` parameter that serves as fallback before truncated npub
- **video_feed_item.dart**: Pass `video.authorName` to UserName, use `video.authorAvatar` for avatar
- **composable_video_grid.dart**: Pass `video.authorName` to UserName

## Performance Impact
When REST API returns videos with embedded author data:
- Immediate display of author name (no waiting for WebSocket profile fetch)
- Reduced WebSocket traffic for profile lookups
- Better UX with instant author info display

## Test plan
- [ ] Verify videos from REST API show author names immediately
- [ ] Verify profile pictures fall back to embedded avatar URL
- [ ] Verify WebSocket profile fetches still work when REST data not available
- [ ] Verify grid view shows embedded author names

🤖 Generated with [Claude Code](https://claude.com/claude-code)