### PR TITLE
fix(profile): add expandable bio with Show more/less

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -436,17 +436,65 @@ class _UniqueIdentifier extends StatelessWidget {
   }
 }
 
-/// About/bio text display.
-class _AboutText extends StatelessWidget {
+/// About/bio text display with expandable "Show more/less" functionality.
+class _AboutText extends StatefulWidget {
   const _AboutText({required this.about});
 
   final String about;
 
+  /// Maximum lines to show when collapsed.
+  static const int _collapsedMaxLines = 3;
+
+  @override
+  State<_AboutText> createState() => _AboutTextState();
+}
+
+class _AboutTextState extends State<_AboutText> {
+  bool _isExpanded = false;
+  bool _needsExpansion = false;
+
   @override
   Widget build(BuildContext context) {
-    return SelectableText(
-      about,
-      style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted),
+    final textStyle = VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // Measure if text exceeds max lines
+        final textSpan = TextSpan(text: widget.about, style: textStyle);
+        final textPainter = TextPainter(
+          text: textSpan,
+          maxLines: _AboutText._collapsedMaxLines,
+          textDirection: TextDirection.ltr,
+        )..layout(maxWidth: constraints.maxWidth);
+
+        _needsExpansion = textPainter.didExceedMaxLines;
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (_isExpanded)
+              SelectableText(widget.about, style: textStyle)
+            else
+              Text(
+                widget.about,
+                style: textStyle,
+                maxLines: _AboutText._collapsedMaxLines,
+                overflow: TextOverflow.ellipsis,
+              ),
+            if (_needsExpansion)
+              GestureDetector(
+                onTap: () => setState(() => _isExpanded = !_isExpanded),
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text(
+                    _isExpanded ? 'Show less' : 'Show more',
+                    style: VineTheme.bodySmallFont(color: VineTheme.vineGreen),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
     );
   }
 }

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -352,6 +352,131 @@ void main() {
       },
     );
 
+    group('Expandable Bio', () {
+      // Create a bio that will definitely exceed 3 lines on a phone screen
+      // Using many short words to ensure wrapping at narrow widths
+      final longBio = List.generate(
+        20,
+        (i) => 'This is line $i of the bio.',
+      ).join(' ');
+
+      testWidgets('short bio does not show "Show more" button', (tester) async {
+        final testProfile = createTestProfile(
+          displayName: 'Test User',
+          about: 'Short bio',
+        );
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profileStatsAsync: AsyncValue.data(createTestStats()),
+            profile: testProfile,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Short bio'), findsOneWidget);
+        expect(find.text('Show more'), findsNothing);
+        expect(find.text('Show less'), findsNothing);
+      });
+
+      testWidgets('long bio shows "Show more" button and truncates', (
+        tester,
+      ) async {
+        // Set a phone-like screen size to ensure text wraps
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(() => tester.view.resetPhysicalSize());
+
+        final testProfile = createTestProfile(
+          displayName: 'Test User',
+          about: longBio,
+        );
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profileStatsAsync: AsyncValue.data(createTestStats()),
+            profile: testProfile,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Show more'), findsOneWidget);
+        expect(find.text('Show less'), findsNothing);
+      });
+
+      testWidgets('tapping "Show more" expands bio and shows "Show less"', (
+        tester,
+      ) async {
+        // Set a phone-like screen size to ensure text wraps
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(() => tester.view.resetPhysicalSize());
+
+        final testProfile = createTestProfile(
+          displayName: 'Test User',
+          about: longBio,
+        );
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profileStatsAsync: AsyncValue.data(createTestStats()),
+            profile: testProfile,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Tap "Show more"
+        await tester.tap(find.text('Show more'));
+        await tester.pumpAndSettle();
+
+        // Should now show "Show less"
+        expect(find.text('Show less'), findsOneWidget);
+        expect(find.text('Show more'), findsNothing);
+      });
+
+      testWidgets('tapping "Show less" collapses bio and shows "Show more"', (
+        tester,
+      ) async {
+        // Set a phone-like screen size to ensure text wraps
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(() => tester.view.resetPhysicalSize());
+
+        final testProfile = createTestProfile(
+          displayName: 'Test User',
+          about: longBio,
+        );
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profileStatsAsync: AsyncValue.data(createTestStats()),
+            profile: testProfile,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // First expand
+        await tester.tap(find.text('Show more'));
+        await tester.pumpAndSettle();
+
+        // Then collapse
+        await tester.tap(find.text('Show less'));
+        await tester.pumpAndSettle();
+
+        // Should be back to "Show more"
+        expect(find.text('Show more'), findsOneWidget);
+        expect(find.text('Show less'), findsNothing);
+      });
+    });
+
     group('Secure Account Banner', () {
       testWidgets(
         'shows secure account banner for own profile when anonymous',


### PR DESCRIPTION
## Summary
- Adds expandable bio functionality to profile header
- Long bios (>3 lines) are truncated with "Show more" button
- Tapping toggles between expanded/collapsed states

Fixes #1063

## Test plan
- [x] Short bio displays fully without "Show more" button
- [x] Long bio truncates at 3 lines with "Show more" button
- [x] Tapping "Show more" expands bio and shows "Show less"
- [x] Tapping "Show less" collapses bio
- [x] All existing tests pass