### PR TITLE
fix: navigate to profile grid from follower/following lists

### DIFF
--- a/mobile/lib/screens/followers/my_followers_screen.dart
+++ b/mobile/lib/screens/followers/my_followers_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/my_followers/my_followers_bloc.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/providers/app_providers.dart';

--- a/mobile/lib/screens/followers/others_followers_screen.dart
+++ b/mobile/lib/screens/followers/others_followers_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/blocs/others_followers/others_followers_bloc.dart';
 import 'package:openvine/providers/app_providers.dart';

--- a/mobile/lib/screens/following/my_following_screen.dart
+++ b/mobile/lib/screens/following/my_following_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/nav_extensions.dart';

--- a/mobile/lib/screens/following/others_following_screen.dart
+++ b/mobile/lib/screens/following/others_following_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/blocs/others_following/others_following_bloc.dart';
 import 'package:openvine/providers/app_providers.dart';


### PR DESCRIPTION
## Summary
- Fixes tapping a user in Followers/Following lists navigating to video instead of profile

## Test plan
- [ ] Open followers list, tap a user → opens their profile grid
- [ ] Open following list, tap a user → opens their profile grid
- [ ] Verify both "my" and "others" variants work correctly

Closes #1077