### PR TITLE
feat(android): enable Crashlytics symbol upload for crash reports

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
     id("com.google.gms.google-services")
+    id("com.google.firebase.crashlytics")
 }
 
 // Load key properties
@@ -71,6 +72,11 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            // Enable Crashlytics mapping file upload (for when R8 is re-enabled)
+            configure<com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension> {
+                mappingFileUploadEnabled = true
+                nativeSymbolUploadEnabled = true
+            }
         }
     }
 

--- a/mobile/android/settings.gradle.kts
+++ b/mobile/android/settings.gradle.kts
@@ -21,6 +21,7 @@ plugins {
     id("com.android.application") version "8.9.1" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
+    id("com.google.firebase.crashlytics") version "3.0.3" apply false
 }
 
 include(":app")


### PR DESCRIPTION
## Summary
- Add Firebase Crashlytics Gradle plugin to Android build configuration
- Enable native symbol upload for proper crash symbolication
- Enable mapping file upload for when R8 minification is re-enabled

## Changes
- `settings.gradle.kts`: Add Crashlytics plugin (v3.0.3)
- `app/build.gradle.kts`: Apply plugin and configure symbol uploads

## Why
Android crashes in Crashlytics were showing raw memory addresses instead of symbolicated stack traces. This was because:
1. The Crashlytics Gradle plugin wasn't applied
2. Native symbols weren't being uploaded during builds

## Test plan
- [x] Debug build succeeds
- [ ] Release build uploads symbols to Crashlytics (requires CI with signing keys)
- [ ] Verify new crashes show symbolicated stack traces

🤖 Generated with [Claude Code](https://claude.ai/code)