### PR TITLE
fix(home-feed): prevent snap-back at end of feed and show end card

### DIFF
--- a/mobile/lib/providers/home_feed_provider.dart
+++ b/mobile/lib/providers/home_feed_provider.dart
@@ -586,10 +586,16 @@ class HomeFeed extends _$HomeFeed {
     // This prevents showing "empty" while subscribed list cache is still syncing
     final stillLoadingLists = followingVideos.isEmpty && hasSubscribedLists;
 
+    // Determine if there's more content:
+    // - REST API mode: use the API's hasMore response
+    // - Nostr mode: use threshold heuristic
+    final hasMoreContent = _usingRestApi
+        ? _hasMoreFromApi
+        : followingVideos.length >= AppConstants.hasMoreContentThreshold;
+
     final feedState = VideoFeedState(
       videos: followingVideos,
-      hasMoreContent:
-          followingVideos.length >= AppConstants.hasMoreContentThreshold,
+      hasMoreContent: hasMoreContent,
       isLoadingMore: false,
       isInitialLoad: stillLoadingLists,
       error: null,
@@ -891,11 +897,15 @@ class HomeFeed extends _$HomeFeed {
       return a.id.compareTo(b.id);
     });
 
+    // Preserve hasMore from API mode, otherwise use threshold heuristic
+    final hasMoreContent = _usingRestApi
+        ? _hasMoreFromApi
+        : updatedVideos.length >= AppConstants.hasMoreContentThreshold;
+
     state = AsyncData(
       VideoFeedState(
         videos: updatedVideos,
-        hasMoreContent:
-            updatedVideos.length >= AppConstants.hasMoreContentThreshold,
+        hasMoreContent: hasMoreContent,
         isLoadingMore: false,
         lastUpdated: DateTime.now(),
         videoListSources: videoListSources,

--- a/mobile/lib/providers/home_feed_provider.g.dart
+++ b/mobile/lib/providers/home_feed_provider.g.dart
@@ -116,7 +116,7 @@ final class HomeFeedProvider
   HomeFeed create() => HomeFeed();
 }
 
-String _$homeFeedHash() => r'dd398f87a657e69700d1db5fd0bdceec0f2e6e05';
+String _$homeFeedHash() => r'40f79f1abcbbca7d1791b1814f6fe8e3cb12036e';
 
 /// Home feed provider - shows videos only from people you follow
 ///


### PR DESCRIPTION
## Summary
- Fix home feed "snap-back" issue where scrolling to the end causes the feed to reset position
- Use REST API's `hasMore` response instead of threshold heuristic to accurately detect end of content
- Add `PageStorageKey` to preserve scroll position across Riverpod provider rebuilds
- Show friendly end-of-feed card with "Explore to find more videos" button when user reaches end

## Root Cause
The home feed provider was ignoring the Funnelcake API's `has_more: false` response and instead using a threshold check (`videos.length >= 10`). With 80 videos in the feed, `hasMoreContent` was always `true` even when the API indicated no more content was available, causing:
1. Users couldn't scroll past video 80 (invisible wall)
2. Pagination kept trying to load more (no-op)
3. PageView position wasn't being preserved across state updates

## Test plan
- [ ] Scroll through home feed until reaching the end
- [ ] Verify end-of-feed card appears with correct text: "You've reached the end, my friend"
- [ ] Verify "Explore to find more videos" button navigates to Explore screen
- [ ] Verify no snap-back occurs when reaching end of content
- [ ] Verify scroll position is preserved when switching tabs and returning

🤖 Generated with [Claude Code](https://claude.com/claude-code)