### PR TITLE
fix(video): pause videos on dispose to prevent iOS audio leak

### DIFF
--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -367,15 +367,11 @@ class _VideoFeedItemState extends ConsumerState<VideoFeedItem> {
     // Close the interactions bloc
     _interactionsBloc.close();
 
-    // When using override mode, we need to stop playback manually on dispose
-    // (provider mode handles this automatically via provider cleanup)
-    if (widget.isActiveOverride == true && widget.video.videoUrl != null) {
-      Log.info(
-        '🛑 VideoFeedItem.dispose: stopping playback for ${widget.video.id} (override mode)',
-        name: 'VideoFeedItem',
-        category: LogCategory.video,
-      );
-
+    // Always pause video on dispose - defensive cleanup required because:
+    // 1. iOS back gesture may dispose widget before reactive listeners fire
+    // 2. Provider cleanup only triggers on route TYPE changes, not videoIndex changes
+    // 3. Feed→grid transition stays on same route type (e.g., explore)
+    if (widget.video.videoUrl != null) {
       // Directly pause the controller - don't rely on _handlePlaybackChange
       // which might fail if ref is in an inconsistent state during dispose
       // Use safePause to handle "No active player with ID" errors gracefully


### PR DESCRIPTION
## Summary
- Remove `isActiveOverride == true` condition from `VideoFeedItem.dispose()` so videos always pause on widget disposal

## Test plan
- [ ] Open Classic Vines on iOS
- [ ] Tap a video to enter feed mode
- [ ] Perform iOS back gesture (swipe from left edge)
- [ ] Verify no audio continues playing

Fixes #1103