### PR TITLE
fix: prevent self-follow and self-block

### DIFF
--- a/mobile/lib/repositories/follow_repository.dart
+++ b/mobile/lib/repositories/follow_repository.dart
@@ -180,6 +180,16 @@ class FollowRepository {
       throw Exception('User not authenticated');
     }
 
+    // Guard: Prevent following self
+    if (pubkey == _nostrClient.publicKey) {
+      Log.warning(
+        'Attempted to follow self - ignoring',
+        name: 'FollowRepository',
+        category: LogCategory.system,
+      );
+      return;
+    }
+
     if (_followingPubkeys.contains(pubkey)) {
       Log.debug(
         'Already following user: $pubkey',
@@ -237,6 +247,16 @@ class FollowRepository {
         category: LogCategory.system,
       );
       throw Exception('User not authenticated');
+    }
+
+    // Guard: Prevent unfollowing self
+    if (pubkey == _nostrClient.publicKey) {
+      Log.warning(
+        'Attempted to unfollow self - ignoring',
+        name: 'FollowRepository',
+        category: LogCategory.system,
+      );
+      return;
     }
 
     if (!_followingPubkeys.contains(pubkey)) {

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/profile_feed_provider.dart';
 import 'package:openvine/providers/profile_stats_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
@@ -130,7 +131,8 @@ class _OtherProfileScreenState extends ConsumerState<OtherProfileScreen> {
         await _unfollowUser();
       case MoreSheetResult.blockConfirmed:
         final blocklistService = ref.read(contentBlocklistServiceProvider);
-        blocklistService.blockUser(userIdHex);
+        final nostrClient = ref.read(nostrServiceProvider);
+        blocklistService.blockUser(userIdHex, ourPubkey: nostrClient.publicKey);
         ref.read(blocklistVersionProvider.notifier).increment();
         if (mounted) {
           context.pop();

--- a/mobile/lib/services/content_blocklist_service.dart
+++ b/mobile/lib/services/content_blocklist_service.dart
@@ -59,12 +59,26 @@ class ContentBlocklistService {
   }
 
   /// Add a public key to the runtime blocklist
-  void blockUser(String pubkey) {
+  ///
+  /// If [ourPubkey] is provided, it will be used to prevent self-blocking.
+  /// Otherwise falls back to [_ourPubkey] set during [syncMuteListsInBackground].
+  void blockUser(String pubkey, {String? ourPubkey}) {
+    // Guard: Prevent blocking self
+    final selfPubkey = ourPubkey ?? _ourPubkey;
+    if (selfPubkey != null && pubkey == selfPubkey) {
+      Log.warning(
+        'Attempted to block self - ignoring',
+        name: 'ContentBlocklistService',
+        category: LogCategory.system,
+      );
+      return;
+    }
+
     if (!_runtimeBlocklist.contains(pubkey)) {
       _runtimeBlocklist.add(pubkey);
 
       Log.debug(
-        'Added user to blocklist: ${pubkey}...',
+        'Added user to blocklist: $pubkey...',
         name: 'ContentBlocklistService',
         category: LogCategory.system,
       );

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -984,6 +984,7 @@ class _ShareVideoMenuState extends ConsumerState<ShareVideoMenu> {
 
   void _handleBlockUser(WidgetRef ref, bool currentlyBlocked) {
     final blocklistService = ref.read(contentBlocklistServiceProvider);
+    final nostrClient = ref.read(nostrServiceProvider);
 
     if (currentlyBlocked) {
       // Unblock without confirmation
@@ -1014,7 +1015,10 @@ class _ShareVideoMenuState extends ConsumerState<ShareVideoMenu> {
             ),
             TextButton(
               onPressed: () {
-                blocklistService.blockUser(widget.video.pubkey);
+                blocklistService.blockUser(
+                  widget.video.pubkey,
+                  ourPubkey: nostrClient.publicKey,
+                );
                 context.pop();
                 if (mounted) {
                   ScaffoldMessenger.of(
@@ -2070,7 +2074,11 @@ class ReportContentDialogState extends ConsumerState<ReportContentDialog> {
 
             // 3. Also add to local blocklist for immediate filtering
             final blocklistService = ref.read(contentBlocklistServiceProvider);
-            blocklistService.blockUser(widget.video.pubkey);
+            final nostrClient = ref.read(nostrServiceProvider);
+            blocklistService.blockUser(
+              widget.video.pubkey,
+              ourPubkey: nostrClient.publicKey,
+            );
 
             Log.info(
               'User blocked with Nostr events: kind 1984 user report + kind 10000 mute list: ${widget.video.pubkey}',

--- a/mobile/test/repositories/follow_repository_test.dart
+++ b/mobile/test/repositories/follow_repository_test.dart
@@ -539,6 +539,64 @@ void main() {
       });
     });
 
+    group('self-follow prevention', () {
+      test('follow() silently ignores when target is self', () async {
+        await repository.initialize();
+
+        // Attempt to follow self (testCurrentUserPubkey is the mock's publicKey)
+        await repository.follow(testCurrentUserPubkey);
+
+        expect(repository.isFollowing(testCurrentUserPubkey), isFalse);
+        expect(repository.followingCount, 0);
+
+        // Verify sendContactList was never called
+        verifyNever(
+          () => mockNostrClient.sendContactList(
+            any(),
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      });
+
+      test('unfollow() silently ignores when target is self', () async {
+        await repository.initialize();
+
+        // Attempt to unfollow self
+        await repository.unfollow(testCurrentUserPubkey);
+
+        // Verify sendContactList was never called
+        verifyNever(
+          () => mockNostrClient.sendContactList(
+            any(),
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      });
+
+      test('toggleFollow() silently ignores when target is self', () async {
+        await repository.initialize();
+
+        // Attempt to toggle follow on self
+        await repository.toggleFollow(testCurrentUserPubkey);
+
+        expect(repository.isFollowing(testCurrentUserPubkey), isFalse);
+
+        // Verify sendContactList was never called
+        verifyNever(
+          () => mockNostrClient.sendContactList(
+            any(),
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      });
+    });
+
     group('getFollowers', () {
       test('returns empty list when pubkey is empty', () async {
         final followers = await repository.getFollowers('');

--- a/mobile/test/screens/profile_screen_block_button_test.mocks.dart
+++ b/mobile/test/screens/profile_screen_block_button_test.mocks.dart
@@ -79,8 +79,8 @@ class MockContentBlocklistService extends _i1.Mock
           as bool);
 
   @override
-  void blockUser(String? pubkey) => super.noSuchMethod(
-    Invocation.method(#blockUser, [pubkey]),
+  void blockUser(String? pubkey, {String? ourPubkey}) => super.noSuchMethod(
+    Invocation.method(#blockUser, [pubkey], {#ourPubkey: ourPubkey}),
     returnValueForMissingStub: null,
   );
 

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -19,7 +19,7 @@ class MockContentBlocklistService extends Mock
   Set<String> get runtimeBlockedUsers => Set.unmodifiable(_runtimeBlocklist);
 
   @override
-  void blockUser(String pubkey) {
+  void blockUser(String pubkey, {String? ourPubkey}) {
     _runtimeBlocklist.add(pubkey);
   }
 

--- a/mobile/test/services/content_blocklist_service_test.dart
+++ b/mobile/test/services/content_blocklist_service_test.dart
@@ -97,6 +97,37 @@ void main() {
       expect(stats['runtime_blocks'], isA<int>());
       expect(stats['internal_blocks'], isA<int>());
     });
+
+    group('self-block prevention', () {
+      test('blockUser() ignores when pubkey matches ourPubkey parameter', () {
+        const ourPubkey = 'test_our_pubkey';
+
+        service.blockUser(ourPubkey, ourPubkey: ourPubkey);
+
+        expect(service.isBlocked(ourPubkey), isFalse);
+        expect(service.totalBlockedCount, equals(0));
+      });
+
+      test('blockUser() allows blocking other users', () {
+        const ourPubkey = 'our_pubkey';
+        const otherPubkey = 'other_pubkey';
+
+        service.blockUser(otherPubkey, ourPubkey: ourPubkey);
+
+        expect(service.isBlocked(otherPubkey), isTrue);
+        expect(service.totalBlockedCount, equals(1));
+      });
+
+      test('blockUser() allows blocking when ourPubkey is null', () {
+        const otherPubkey = 'other_pubkey';
+
+        // No ourPubkey provided - should allow blocking
+        service.blockUser(otherPubkey);
+
+        expect(service.isBlocked(otherPubkey), isTrue);
+        expect(service.totalBlockedCount, equals(1));
+      });
+    });
   });
 
   group('ContentBlocklistService - Mutual Mute Sync', () {

--- a/mobile/test/widgets/report_content_dialog_test.mocks.dart
+++ b/mobile/test/widgets/report_content_dialog_test.mocks.dart
@@ -255,8 +255,8 @@ class MockContentBlocklistService extends _i1.Mock
           as bool);
 
   @override
-  void blockUser(String? pubkey) => super.noSuchMethod(
-    Invocation.method(#blockUser, [pubkey]),
+  void blockUser(String? pubkey, {String? ourPubkey}) => super.noSuchMethod(
+    Invocation.method(#blockUser, [pubkey], {#ourPubkey: ourPubkey}),
     returnValueForMissingStub: null,
   );
 

--- a/mobile/test/widgets/share_menu_safety_section_test.mocks.dart
+++ b/mobile/test/widgets/share_menu_safety_section_test.mocks.dart
@@ -266,8 +266,8 @@ class MockContentBlocklistService extends _i1.Mock
           as bool);
 
   @override
-  void blockUser(String? pubkey) => super.noSuchMethod(
-    Invocation.method(#blockUser, [pubkey]),
+  void blockUser(String? pubkey, {String? ourPubkey}) => super.noSuchMethod(
+    Invocation.method(#blockUser, [pubkey], {#ourPubkey: ourPubkey}),
     returnValueForMissingStub: null,
   );
 


### PR DESCRIPTION
## Summary
- Add guards in FollowRepository to prevent following/unfollowing self
- Add guards in ContentBlocklistService to prevent blocking self
- Add router widget to redirect own-profile visits via OtherProfileScreen to profile tab

## Test plan
- [x] Unit tests for self-follow prevention in FollowRepository
- [x] Unit tests for self-block prevention in ContentBlocklistService
- [x] All existing tests pass

Closes #997