### PR TITLE
fix(navigation): blank screen when tapping back on profile from search

### DIFF
--- a/mobile/lib/router/nav_extensions.dart
+++ b/mobile/lib/router/nav_extensions.dart
@@ -3,28 +3,29 @@
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/screens/pure/search_screen_pure.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 
 /// Extension on BuildContext for common navigation patterns
 extension NavExtensions on BuildContext {
-  /// Navigate to another user's profile using their hex pubkey.
+  /// Navigate to another user's profile (fullscreen, no bottom nav).
   ///
-  /// Converts the hex pubkey to npub format and pushes the profile screen.
-  /// Use this for navigating to profiles from mentions, comments, etc.
+  /// Converts the hex pubkey to npub format and pushes the fullscreen profile.
+  /// Use this for tapping profiles from mentions, search, feeds, etc.
+  /// The user can navigate back to the previous screen.
   void pushOtherProfile(String hexPubkey) {
     final npub = NostrKeyUtils.encodePubKey(hexPubkey);
-    push(ProfileScreenRouter.pathForNpub(npub));
+    push(OtherProfileScreen.pathForNpub(npub));
   }
 
-  /// Navigate to another user's profile using their hex pubkey (using go).
+  /// Navigate to another user's profile using go (replaces stack).
   ///
-  /// Converts the hex pubkey to npub format and goes to the profile screen.
-  /// Use this when you want to replace the current route.
+  /// Converts the hex pubkey to npub format and goes to the fullscreen profile.
+  /// Use this when you want the profile to become the new root.
   void goOtherProfile(String hexPubkey) {
     final npub = NostrKeyUtils.encodePubKey(hexPubkey);
-    go(ProfileScreenRouter.pathForNpub(npub));
+    go(OtherProfileScreen.pathForNpub(npub));
   }
 
   /// Navigate to search with an optional pre-filled search term.

--- a/mobile/lib/screens/followers/my_followers_screen.dart
+++ b/mobile/lib/screens/followers/my_followers_screen.dart
@@ -153,7 +153,7 @@ class _FollowersListBody extends StatelessWidget {
             builder: (context, isFollowing) {
               return UserProfileTile(
                 pubkey: userPubkey,
-                onTap: () => context.goOtherProfile(userPubkey),
+                onTap: () => context.pushOtherProfile(userPubkey),
                 isFollowing: isFollowing,
                 onToggleFollow: () {
                   context.read<MyFollowingBloc>().add(

--- a/mobile/lib/screens/followers/others_followers_screen.dart
+++ b/mobile/lib/screens/followers/others_followers_screen.dart
@@ -170,7 +170,7 @@ class _FollowersListBody extends StatelessWidget {
             builder: (context, isFollowing) {
               return UserProfileTile(
                 pubkey: userPubkey,
-                onTap: () => context.goOtherProfile(userPubkey),
+                onTap: () => context.pushOtherProfile(userPubkey),
                 isFollowing: isFollowing,
                 onToggleFollow: () {
                   context.read<MyFollowingBloc>().add(

--- a/mobile/lib/screens/following/my_following_screen.dart
+++ b/mobile/lib/screens/following/my_following_screen.dart
@@ -142,7 +142,7 @@ class _FollowingListBody extends StatelessWidget {
             builder: (context, isFollowing) {
               return UserProfileTile(
                 pubkey: userPubkey,
-                onTap: () => context.goOtherProfile(userPubkey),
+                onTap: () => context.pushOtherProfile(userPubkey),
                 isFollowing: isFollowing,
                 onToggleFollow: () {
                   context.read<MyFollowingBloc>().add(

--- a/mobile/lib/screens/following/others_following_screen.dart
+++ b/mobile/lib/screens/following/others_following_screen.dart
@@ -172,7 +172,7 @@ class _FollowingListBody extends StatelessWidget {
             builder: (context, isFollowing) {
               return UserProfileTile(
                 pubkey: userPubkey,
-                onTap: () => context.goOtherProfile(userPubkey),
+                onTap: () => context.pushOtherProfile(userPubkey),
                 isFollowing: isFollowing,
                 onToggleFollow: () {
                   context.read<MyFollowingBloc>().add(

--- a/mobile/lib/screens/pure/search_screen_pure.dart
+++ b/mobile/lib/screens/pure/search_screen_pure.dart
@@ -15,9 +15,8 @@ import 'package:openvine/services/content_blocklist_service.dart';
 import 'package:openvine/services/user_profile_service.dart';
 import 'package:openvine/router/page_context_provider.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
-import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/router/nav_extensions.dart';
 import 'package:openvine/screens/pure/explore_video_screen_pure.dart';
-import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:openvine/utils/search_utils.dart';
 import 'package:openvine/utils/unified_logger.dart';
@@ -888,10 +887,7 @@ class _SearchScreenPureState extends ConsumerState<SearchScreenPure>
                           '🔍 SearchScreenPure: Tapped user: $userPubkey',
                           category: LogCategory.video,
                         );
-                        final npub = normalizeToNpub(userPubkey);
-                        if (npub != null) {
-                          context.push(ProfileScreenRouter.pathForNpub(npub));
-                        }
+                        context.pushOtherProfile(userPubkey);
                       },
                     );
                   },

--- a/mobile/test/screens/search_screen_navigation_test.dart
+++ b/mobile/test/screens/search_screen_navigation_test.dart
@@ -9,7 +9,7 @@ import 'package:openvine/providers/video_events_providers.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
-import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 
 // Mock VideoEvents stream provider
@@ -111,10 +111,10 @@ void main() {
       await tester.pump();
       await tester.pump();
 
-      // Assert: Verify router navigated to profile
+      // Assert: Verify router navigated to other user's profile (fullscreen)
       expect(
         currentLocation(c),
-        contains(ProfileScreenRouter.pathForNpub(user123Npub)),
+        contains(OtherProfileScreen.pathForNpub(user123Npub)),
       );
     });
 


### PR DESCRIPTION
## Summary
- Fix blank screen when tapping back on profile after finding user through search (#998)
- Use `OtherProfileScreen` route (fullscreen, no bottom nav) instead of `ProfileScreenRouter` (shell route)
- Change followers/following screens to use `push` instead of `go` for proper back navigation

## Test plan
- [ ] Search for a user and tap their profile
- [ ] Tap back button - should return to search results (not blank screen)
- [ ] Navigate to followers/following list
- [ ] Tap a user profile
- [ ] Tap back - should return to the list