### PR TITLE
fix(profile): allow viewing blocked user profiles

### DIFF
--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -401,8 +401,10 @@ class _ProfileContentView extends ConsumerWidget {
     final isOwnProfile = userIdHex == currentUserHex;
 
     // Check if this user has muted us (mutual mute blocking)
+    // Note: We only block profile viewing for users who muted US, not users WE blocked.
+    // Users can still view profiles of people they blocked (to unblock them).
     final blocklistService = ref.watch(contentBlocklistServiceProvider);
-    if (blocklistService.shouldFilterFromFeeds(userIdHex)) {
+    if (blocklistService.hasMutedUs(userIdHex)) {
       return BlockedUserScreen(onBack: context.pop);
     }
 

--- a/mobile/lib/services/content_blocklist_service.dart
+++ b/mobile/lib/services/content_blocklist_service.dart
@@ -58,6 +58,13 @@ class ContentBlocklistService {
         _mutualMuteBlocklist.contains(pubkey);
   }
 
+  /// Check if another user has muted us (mutual mute blocking)
+  ///
+  /// This is different from [isBlocked] which checks users WE blocked.
+  /// Use this for profile viewing - users can view profiles they blocked,
+  /// but cannot view profiles of users who muted them.
+  bool hasMutedUs(String pubkey) => _mutualMuteBlocklist.contains(pubkey);
+
   /// Add a public key to the runtime blocklist
   ///
   /// If [ourPubkey] is provided, it will be used to prevent self-blocking.

--- a/mobile/test/screens/profile_screen_block_button_test.mocks.dart
+++ b/mobile/test/screens/profile_screen_block_button_test.mocks.dart
@@ -79,6 +79,14 @@ class MockContentBlocklistService extends _i1.Mock
           as bool);
 
   @override
+  bool hasMutedUs(String? pubkey) =>
+      (super.noSuchMethod(
+            Invocation.method(#hasMutedUs, [pubkey]),
+            returnValue: false,
+          )
+          as bool);
+
+  @override
   void blockUser(String? pubkey, {String? ourPubkey}) => super.noSuchMethod(
     Invocation.method(#blockUser, [pubkey], {#ourPubkey: ourPubkey}),
     returnValueForMissingStub: null,

--- a/mobile/test/widgets/report_content_dialog_test.mocks.dart
+++ b/mobile/test/widgets/report_content_dialog_test.mocks.dart
@@ -255,6 +255,14 @@ class MockContentBlocklistService extends _i1.Mock
           as bool);
 
   @override
+  bool hasMutedUs(String? pubkey) =>
+      (super.noSuchMethod(
+            Invocation.method(#hasMutedUs, [pubkey]),
+            returnValue: false,
+          )
+          as bool);
+
+  @override
   void blockUser(String? pubkey, {String? ourPubkey}) => super.noSuchMethod(
     Invocation.method(#blockUser, [pubkey], {#ourPubkey: ourPubkey}),
     returnValueForMissingStub: null,

--- a/mobile/test/widgets/share_menu_safety_section_test.mocks.dart
+++ b/mobile/test/widgets/share_menu_safety_section_test.mocks.dart
@@ -266,6 +266,14 @@ class MockContentBlocklistService extends _i1.Mock
           as bool);
 
   @override
+  bool hasMutedUs(String? pubkey) =>
+      (super.noSuchMethod(
+            Invocation.method(#hasMutedUs, [pubkey]),
+            returnValue: false,
+          )
+          as bool);
+
+  @override
   void blockUser(String? pubkey, {String? ourPubkey}) => super.noSuchMethod(
     Invocation.method(#blockUser, [pubkey], {#ourPubkey: ourPubkey}),
     returnValueForMissingStub: null,


### PR DESCRIPTION
## Summary
- Add `hasMutedUs()` method to distinguish mutual mutes from user-initiated blocks
- Profile router now only blocks viewing for users who muted YOU, not users YOU blocked
- Users can now view and unblock profiles they previously blocked

Fixes #950

## Test plan
- [x] Unit tests for new `hasMutedUs()` method
- [ ] Block a user, navigate away, return to their profile - should show profile with Unblock button
- [ ] Verify mutual mute blocking still works (users who muted you show error screen)