### PR TITLE
fix(video-editor): move moov atom to beginning for progressive streaming

### DIFF
--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -306,6 +306,7 @@ class UploadManager {
               .map((clip) => VideoSegment(video: clip.video))
               .toList(),
           endTime: VideoEditorConstants.maxDuration,
+          shouldOptimizeForNetworkUse: true,
         ),
       );
     }

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -69,6 +69,7 @@ class VideoEditorRenderService {
         videoSegments: videoSegments,
         endTime: VideoEditorConstants.maxDuration,
         enableAudio: enableAudio,
+        shouldOptimizeForNetworkUse: true,
         transform: ExportTransform(
           x: cropParams.x,
           y: cropParams.y,

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1586,10 +1586,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "1b3229558edaf2b1c75d771a83c5ac8897d63d0dc9845f95de7b8428d5d6fbdf"
+      sha256: ce3c181983231917b51c0e1bf791e630b541764346c6f9db95a8d04b8c98bc1a
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -154,7 +154,7 @@ dependencies:
   convert: ^3.1.2
   just_audio: ^0.10.5
   audio_session: ^0.2.2
-  pro_video_editor: ^1.3.0
+  pro_video_editor: ^1.4.0
   pro_image_editor: ^11.18.4
   linked_scroll_controller: ^0.2.0
   flutter_colorpicker: ^1.1.0


### PR DESCRIPTION
## Description

To enable smoother network-based playback of MP4 files, we reposition the `moov` atom to the beginning of the file. This change allows video players to start streaming immediately without needing to download the entire file first.

## ✅ Pros
- **Faster playback start** for users over HTTP or streaming scenarios
- **Improved compatibility** with progressive download use cases
- **Better UX** in low-bandwidth environments

## ⚠️ Cons
- **Slightly increased processing time** during file export or post-processing
- **Increased RAM or temporary storage usage** during reordering for large files


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore