### PR TITLE
fix(profile): username not displayed in block confirmation

### DIFF
--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -101,9 +101,10 @@ class _OtherProfileScreenState extends ConsumerState<OtherProfileScreen> {
     // If NostrClient doesn't have keys yet, treat as not following
     final isFollowing = followRepository?.isFollowing(userIdHex) ?? false;
 
-    // Get display name for actions
+    // Get display name for actions (match pattern from build())
     final profile = ref.read(userProfileReactiveProvider(userIdHex)).value;
-    final displayName = profile?.bestDisplayName ?? 'user';
+    final displayName =
+        profile?.bestDisplayName ?? widget.displayNameHint ?? 'user';
 
     final result = await VineBottomSheet.show<MoreSheetResult>(
       context: context,
@@ -147,7 +148,8 @@ class _OtherProfileScreenState extends ConsumerState<OtherProfileScreen> {
   Future<void> _unfollowUser() async {
     final userIdHex = _userIdHex!;
     final profile = ref.read(userProfileReactiveProvider(userIdHex)).value;
-    final displayName = profile?.bestDisplayName ?? 'user';
+    final displayName =
+        profile?.bestDisplayName ?? widget.displayNameHint ?? 'user';
 
     final followRepository = ref.read(followRepositoryProvider);
     // Can't unfollow if NostrClient doesn't have keys yet
@@ -164,7 +166,8 @@ class _OtherProfileScreenState extends ConsumerState<OtherProfileScreen> {
   Future<void> _showUnblockConfirmation() async {
     final userIdHex = _userIdHex!;
     final profile = ref.read(userProfileReactiveProvider(userIdHex)).value;
-    final displayName = profile?.bestDisplayName ?? 'user';
+    final displayName =
+        profile?.bestDisplayName ?? widget.displayNameHint ?? 'user';
 
     final result = await VineBottomSheet.show<MoreSheetResult>(
       context: context,


### PR DESCRIPTION
## Summary
- Adds `displayNameHint` fallback when deriving `displayName` for block/unblock confirmation dialogs
- Ensures consistency with AppBar title display name derivation

Fixes #947

## Test plan
- [ ] Navigate to a profile via search results
- [ ] Tap the 3-dots menu → Block option
- [ ] Verify the confirmation dialog shows the correct username (not just "@" or "user")