### PR TITLE
fix(delete): remove videos from all feeds after deletion

### DIFF
--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -407,6 +407,12 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid> {
         reason: DeleteReason.personalChoice,
       );
 
+      // Remove video from local feeds after successful deletion
+      if (result.success) {
+        final videoEventService = ref.read(videoEventServiceProvider);
+        videoEventService.removeVideoCompletely(video.id);
+      }
+
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -1271,15 +1271,12 @@ class _ShareVideoMenuState extends ConsumerState<ShareVideoMenu> {
           ),
         );
 
-        // Remove video from local feeds after successful deletion
+        // Remove video from all local feeds after successful deletion
         if (result.success) {
           final videoEventService = ref.read(videoEventServiceProvider);
-          videoEventService.removeVideoFromAuthorList(
-            widget.video.pubkey,
-            widget.video.id,
-          );
+          videoEventService.removeVideoCompletely(widget.video.id);
           Log.info(
-            'Video removed from local feeds after deletion: ${widget.video.id}',
+            'Video removed from all local feeds after deletion: ${widget.video.id}',
             name: 'ShareVideoMenu',
             category: LogCategory.ui,
           );

--- a/mobile/test/helpers/video_feed_builder_test.mocks.dart
+++ b/mobile/test/helpers/video_feed_builder_test.mocks.dart
@@ -281,6 +281,12 @@ class MockVideoEventService extends _i1.Mock implements _i2.VideoEventService {
           as List<_i3.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/integration/home_feed_seen_videos_test.mocks.dart
+++ b/mobile/test/integration/home_feed_seen_videos_test.mocks.dart
@@ -290,6 +290,12 @@ class MockVideoEventService extends _i1.Mock implements _i3.VideoEventService {
           as List<_i4.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/integration/search_navigation_integration_test.mocks.dart
+++ b/mobile/test/integration/search_navigation_integration_test.mocks.dart
@@ -289,6 +289,12 @@ class MockVideoEventService extends _i1.Mock implements _i3.VideoEventService {
           as List<_i4.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/providers/curation_provider_lifecycle_test.mocks.dart
+++ b/mobile/test/providers/curation_provider_lifecycle_test.mocks.dart
@@ -816,6 +816,12 @@ class MockVideoEventService extends _i1.Mock implements _i10.VideoEventService {
           as List<_i11.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/providers/curation_provider_tab_refresh_test.mocks.dart
+++ b/mobile/test/providers/curation_provider_tab_refresh_test.mocks.dart
@@ -816,6 +816,12 @@ class MockVideoEventService extends _i1.Mock implements _i10.VideoEventService {
           as List<_i11.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/providers/home_feed_provider_test.mocks.dart
+++ b/mobile/test/providers/home_feed_provider_test.mocks.dart
@@ -309,6 +309,12 @@ class MockVideoEventService extends _i1.Mock implements _i4.VideoEventService {
           as List<_i5.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/providers/popular_now_feed_provider_test.mocks.dart
+++ b/mobile/test/providers/popular_now_feed_provider_test.mocks.dart
@@ -281,6 +281,12 @@ class MockVideoEventService extends _i1.Mock implements _i2.VideoEventService {
           as List<_i3.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/providers/profile_stats_calculation_test.mocks.dart
+++ b/mobile/test/providers/profile_stats_calculation_test.mocks.dart
@@ -408,6 +408,12 @@ class MockVideoEventService extends _i1.Mock implements _i4.VideoEventService {
           as List<_i5.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/providers/video_events_listener_simple_test.mocks.dart
+++ b/mobile/test/providers/video_events_listener_simple_test.mocks.dart
@@ -289,6 +289,12 @@ class MockVideoEventService extends _i1.Mock implements _i3.VideoEventService {
           as List<_i4.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/providers/video_events_provider_listener_test.mocks.dart
+++ b/mobile/test/providers/video_events_provider_listener_test.mocks.dart
@@ -289,6 +289,12 @@ class MockVideoEventService extends _i1.Mock implements _i3.VideoEventService {
           as List<_i4.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/router/search_navigation_test.mocks.dart
+++ b/mobile/test/router/search_navigation_test.mocks.dart
@@ -1117,6 +1117,12 @@ class MockVideoEventService extends _i1.Mock implements _i11.VideoEventService {
           as List<_i12.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/screens/explore_screen_pull_to_refresh_test.mocks.dart
+++ b/mobile/test/screens/explore_screen_pull_to_refresh_test.mocks.dart
@@ -281,6 +281,12 @@ class MockVideoEventService extends _i1.Mock implements _i2.VideoEventService {
           as List<_i3.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/screens/explore_screen_video_display_test.mocks.dart
+++ b/mobile/test/screens/explore_screen_video_display_test.mocks.dart
@@ -289,6 +289,12 @@ class MockVideoEventService extends _i1.Mock implements _i3.VideoEventService {
           as List<_i4.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/screens/hashtag_feed_embedded_navigation_test.mocks.dart
+++ b/mobile/test/screens/hashtag_feed_embedded_navigation_test.mocks.dart
@@ -373,6 +373,12 @@ class MockVideoEventService extends _i1.Mock implements _i5.VideoEventService {
           as List<_i3.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/screens/hashtag_feed_loading_test.mocks.dart
+++ b/mobile/test/screens/hashtag_feed_loading_test.mocks.dart
@@ -282,6 +282,12 @@ class MockVideoEventService extends _i1.Mock implements _i2.VideoEventService {
           as List<_i3.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/screens/hashtag_feed_screen_tdd_test.mocks.dart
+++ b/mobile/test/screens/hashtag_feed_screen_tdd_test.mocks.dart
@@ -282,6 +282,12 @@ class MockVideoEventService extends _i1.Mock implements _i2.VideoEventService {
           as List<_i3.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/screens/search_screen_hybrid_search_test.mocks.dart
+++ b/mobile/test/screens/search_screen_hybrid_search_test.mocks.dart
@@ -317,6 +317,12 @@ class MockVideoEventService extends _i1.Mock implements _i2.VideoEventService {
           as List<_i3.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/screens/search_screen_pure_url_test.mocks.dart
+++ b/mobile/test/screens/search_screen_pure_url_test.mocks.dart
@@ -289,6 +289,12 @@ class MockVideoEventService extends _i1.Mock implements _i3.VideoEventService {
           as List<_i4.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/screens/sound_detail_screen_test.mocks.dart
+++ b/mobile/test/screens/sound_detail_screen_test.mocks.dart
@@ -923,6 +923,12 @@ class MockVideoEventService extends _i1.Mock implements _i8.VideoEventService {
           as List<_i9.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/services/curation_publish_test.mocks.dart
+++ b/mobile/test/services/curation_publish_test.mocks.dart
@@ -796,6 +796,12 @@ class MockVideoEventService extends _i1.Mock implements _i9.VideoEventService {
           as List<_i10.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/services/curation_service_analytics_test.mocks.dart
+++ b/mobile/test/services/curation_service_analytics_test.mocks.dart
@@ -796,6 +796,12 @@ class MockVideoEventService extends _i1.Mock implements _i9.VideoEventService {
           as List<_i10.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/services/curation_service_create_test.mocks.dart
+++ b/mobile/test/services/curation_service_create_test.mocks.dart
@@ -802,6 +802,12 @@ class MockVideoEventService extends _i1.Mock implements _i10.VideoEventService {
           as List<_i11.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/services/curation_service_editors_picks_test.mocks.dart
+++ b/mobile/test/services/curation_service_editors_picks_test.mocks.dart
@@ -796,6 +796,12 @@ class MockVideoEventService extends _i1.Mock implements _i9.VideoEventService {
           as List<_i10.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/services/curation_service_kind_30005_test.mocks.dart
+++ b/mobile/test/services/curation_service_kind_30005_test.mocks.dart
@@ -796,6 +796,12 @@ class MockVideoEventService extends _i1.Mock implements _i9.VideoEventService {
           as List<_i10.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/services/curation_service_test.mocks.dart
+++ b/mobile/test/services/curation_service_test.mocks.dart
@@ -796,6 +796,12 @@ class MockVideoEventService extends _i1.Mock implements _i9.VideoEventService {
           as List<_i10.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/services/curation_service_trending_fetch_test.mocks.dart
+++ b/mobile/test/services/curation_service_trending_fetch_test.mocks.dart
@@ -796,6 +796,12 @@ class MockVideoEventService extends _i1.Mock implements _i9.VideoEventService {
           as List<_i10.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/services/notification_service_enhanced_test.mocks.dart
+++ b/mobile/test/services/notification_service_enhanced_test.mocks.dart
@@ -960,6 +960,12 @@ class MockVideoEventService extends _i1.Mock implements _i11.VideoEventService {
           as List<_i12.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/services/subscribed_list_video_cache_test.mocks.dart
+++ b/mobile/test/services/subscribed_list_video_cache_test.mocks.dart
@@ -781,6 +781,12 @@ class MockVideoEventService extends _i1.Mock implements _i7.VideoEventService {
           as List<_i8.VideoEvent>);
 
   @override
+  void removeVideoCompletely(String? videoId) => super.noSuchMethod(
+    Invocation.method(#removeVideoCompletely, [videoId]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void removeVideoFromAuthorList(String? authorPubkey, String? videoId) =>
       super.noSuchMethod(
         Invocation.method(#removeVideoFromAuthorList, [authorPubkey, videoId]),

--- a/mobile/test/unit/services/video_event_service_deletion_test.dart
+++ b/mobile/test/unit/services/video_event_service_deletion_test.dart
@@ -1,0 +1,163 @@
+// ABOUTME: Unit tests for VideoEventService.removeVideoCompletely() method
+// ABOUTME: Tests comprehensive video removal from all data structures (issue #270)
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/repositories/video_repository.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+// Mock classes
+class MockNostrService extends Mock implements NostrClient {}
+
+class TestSubscriptionManager extends Mock implements SubscriptionManager {
+  TestSubscriptionManager(this.eventStreamController);
+  final StreamController<Event> eventStreamController;
+
+  @override
+  Future<String> createSubscription({
+    required String name,
+    required List<Filter> filters,
+    required Function(Event) onEvent,
+    Function(dynamic)? onError,
+    VoidCallback? onComplete,
+    Duration? timeout,
+    int priority = 5,
+  }) async {
+    return 'mock_sub_$name';
+  }
+
+  @override
+  Future<void> cancelSubscription(String subscriptionId) async {}
+}
+
+class FakeFilter extends Fake implements Filter {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeFilter());
+    registerFallbackValue(<Filter>[]);
+  });
+
+  group('VideoEventService.removeVideoCompletely()', () {
+    late VideoEventService videoEventService;
+    late MockNostrService mockNostrService;
+    late VideoRepository videoRepository;
+    late StreamController<Event> eventStreamController;
+
+    setUp(() {
+      mockNostrService = MockNostrService();
+      videoRepository = VideoRepository();
+      eventStreamController = StreamController<Event>.broadcast();
+
+      when(() => mockNostrService.isInitialized).thenReturn(true);
+      when(() => mockNostrService.connectedRelayCount).thenReturn(1);
+      when(
+        () => mockNostrService.subscribe(any()),
+      ).thenAnswer((_) => eventStreamController.stream);
+
+      final testSubscriptionManager = TestSubscriptionManager(
+        eventStreamController,
+      );
+
+      videoEventService = VideoEventService(
+        mockNostrService,
+        subscriptionManager: testSubscriptionManager,
+        videoRepository: videoRepository,
+      );
+    });
+
+    tearDown(() async {
+      await eventStreamController.close();
+      reset(mockNostrService);
+    });
+
+    test('marks video as locally deleted in VideoEventService', () {
+      const videoId = 'test-video-id-local-delete';
+
+      // Remove a video
+      videoEventService.removeVideoCompletely(videoId);
+
+      // Verify video is marked as locally deleted
+      expect(videoEventService.isVideoLocallyDeleted(videoId), isTrue);
+    });
+
+    test('marks video as locally deleted in VideoRepository', () {
+      const videoId = 'test-video-id-repo-delegate';
+
+      videoEventService.removeVideoCompletely(videoId);
+
+      // Verify VideoRepository has the video marked as deleted
+      expect(videoRepository.isVideoLocallyDeleted(videoId), isTrue);
+    });
+
+    test('handles non-existent video gracefully without throwing', () {
+      const videoId = 'non-existent-video-id';
+
+      // Should not throw
+      expect(
+        () => videoEventService.removeVideoCompletely(videoId),
+        returnsNormally,
+      );
+
+      // Video should still be marked as locally deleted
+      expect(videoEventService.isVideoLocallyDeleted(videoId), isTrue);
+      expect(videoRepository.isVideoLocallyDeleted(videoId), isTrue);
+    });
+
+    test(
+      'deprecated removeVideoFromAuthorList delegates to removeVideoCompletely',
+      () {
+        const videoId = 'test-video-deprecated';
+        const pubkey =
+            'c3dd74d68e414f0305db9f7dc96ec32e616502e6ccf5bbf5739de19a96b67f3e';
+
+        // Call deprecated method
+        // ignore: deprecated_member_use_from_same_package
+        videoEventService.removeVideoFromAuthorList(pubkey, videoId);
+
+        // Verify video is marked as deleted (proves delegation happened)
+        expect(videoEventService.isVideoLocallyDeleted(videoId), isTrue);
+        expect(videoRepository.isVideoLocallyDeleted(videoId), isTrue);
+      },
+    );
+
+    test(
+      'prevents resurrection of deleted videos via isVideoLocallyDeleted',
+      () {
+        const videoId = 'test-video-resurrection';
+
+        // Initially not deleted
+        expect(videoEventService.isVideoLocallyDeleted(videoId), isFalse);
+
+        // Delete the video
+        videoEventService.removeVideoCompletely(videoId);
+
+        // Now marked as deleted
+        expect(videoEventService.isVideoLocallyDeleted(videoId), isTrue);
+
+        // This check is used during pagination to filter out deleted videos
+        // ensuring they don't "resurrect" when new data loads
+      },
+    );
+
+    test('works with both service and repository deletion tracking', () {
+      const videoId = 'test-video-dual-tracking';
+
+      videoEventService.removeVideoCompletely(videoId);
+
+      // Both services should track deletion
+      expect(videoEventService.isVideoLocallyDeleted(videoId), isTrue);
+      expect(videoRepository.isVideoLocallyDeleted(videoId), isTrue);
+
+      // The isVideoLocallyDeleted method checks both sources
+      // This ensures comprehensive deletion tracking
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add `removeVideoCompletely()` method to remove videos from ALL data structures
- Fix ComposableVideoGrid to call removal after successful deletion
- Deprecate incomplete `removeVideoFromAuthorList()` method

## Test plan
- [x] Unit tests added (6 tests passing)
- [x] `flutter analyze` clean
- [x] Code formatted

Fixes #270