### PR TITLE
fix(auth): preserve pending verification data on cancel

### DIFF
--- a/mobile/lib/screens/auth/email_verification_screen.dart
+++ b/mobile/lib/screens/auth/email_verification_screen.dart
@@ -214,14 +214,23 @@ class _EmailVerificationScreenState
   void _handleTokenModeSuccess() {
     // Clear persisted verification data
     ref.read(pendingVerificationServiceProvider).clear();
+    // Show feedback message before redirecting to login
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Email verified! Please log in to continue.'),
+        backgroundColor: VineTheme.vineGreen,
+        duration: Duration(seconds: 3),
+      ),
+    );
     // Redirect to login screen
     context.go(WelcomeScreen.authNativePath);
   }
 
   void _handleCancel() {
     _cubit.stopPolling();
-    // Clear persisted verification data on cancel
-    ref.read(pendingVerificationServiceProvider).clear();
+    // Don't clear pending verification data - user may still verify via email
+    // link later. Data will be cleared on: successful login, logout, or
+    // expiration (30 minutes).
     // Go back to previous screen (registration form)
     if (context.canPop()) {
       context.pop();

--- a/mobile/lib/services/pending_verification_service.dart
+++ b/mobile/lib/services/pending_verification_service.dart
@@ -10,11 +10,21 @@ class PendingVerification {
     required this.deviceCode,
     required this.verifier,
     required this.email,
+    required this.createdAt,
   });
 
   final String deviceCode;
   final String verifier;
   final String email;
+  final DateTime createdAt;
+
+  /// Expiration duration for pending verification data (30 minutes).
+  /// OAuth device codes typically expire in 15-30 minutes.
+  static const expirationDuration = Duration(minutes: 30);
+
+  /// Check if this pending verification has expired
+  bool get isExpired =>
+      DateTime.now().difference(createdAt) > expirationDuration;
 }
 
 /// Service to persist and retrieve pending email verification data.
@@ -31,6 +41,7 @@ class PendingVerificationService {
   static const _keyDeviceCode = 'pending_verification_device_code';
   static const _keyVerifier = 'pending_verification_verifier';
   static const _keyEmail = 'pending_verification_email';
+  static const _keyCreatedAt = 'pending_verification_created_at';
 
   /// Save pending verification data to secure storage.
   ///
@@ -41,10 +52,12 @@ class PendingVerificationService {
     required String email,
   }) async {
     try {
+      final createdAt = DateTime.now().toIso8601String();
       await Future.wait([
         _storage.write(key: _keyDeviceCode, value: deviceCode),
         _storage.write(key: _keyVerifier, value: verifier),
         _storage.write(key: _keyEmail, value: email),
+        _storage.write(key: _keyCreatedAt, value: createdAt),
       ]);
       Log.info(
         'Saved pending verification for $email',
@@ -63,21 +76,48 @@ class PendingVerificationService {
 
   /// Load pending verification data from secure storage.
   ///
-  /// Returns null if no pending verification exists or data is incomplete.
+  /// Returns null if no pending verification exists, data is incomplete,
+  /// or data has expired (after 30 minutes).
   Future<PendingVerification?> load() async {
     try {
       final results = await Future.wait([
         _storage.read(key: _keyDeviceCode),
         _storage.read(key: _keyVerifier),
         _storage.read(key: _keyEmail),
+        _storage.read(key: _keyCreatedAt),
       ]);
 
       final deviceCode = results[0];
       final verifier = results[1];
       final email = results[2];
+      final createdAtStr = results[3];
 
       // All fields required
       if (deviceCode == null || verifier == null || email == null) {
+        return null;
+      }
+
+      // Parse createdAt, default to epoch if missing (legacy data)
+      final createdAt = createdAtStr != null
+          ? DateTime.tryParse(createdAtStr) ??
+                DateTime.fromMillisecondsSinceEpoch(0)
+          : DateTime.fromMillisecondsSinceEpoch(0);
+
+      final pending = PendingVerification(
+        deviceCode: deviceCode,
+        verifier: verifier,
+        email: email,
+        createdAt: createdAt,
+      );
+
+      // Check expiration
+      if (pending.isExpired) {
+        Log.info(
+          'Pending verification for $email has expired, clearing',
+          name: 'PendingVerificationService',
+          category: LogCategory.auth,
+        );
+        await clear();
         return null;
       }
 
@@ -87,11 +127,7 @@ class PendingVerificationService {
         category: LogCategory.auth,
       );
 
-      return PendingVerification(
-        deviceCode: deviceCode,
-        verifier: verifier,
-        email: email,
-      );
+      return pending;
     } catch (e) {
       Log.error(
         'Failed to load pending verification: $e',
@@ -104,13 +140,16 @@ class PendingVerificationService {
 
   /// Clear pending verification data from secure storage.
   ///
-  /// Call this after successful login, cancellation, or logout.
+  /// Call this after successful login or logout. Note: This is NOT called
+  /// when user taps Cancel on the verification screen - they may still
+  /// verify via email link later.
   Future<void> clear() async {
     try {
       await Future.wait([
         _storage.delete(key: _keyDeviceCode),
         _storage.delete(key: _keyVerifier),
         _storage.delete(key: _keyEmail),
+        _storage.delete(key: _keyCreatedAt),
       ]);
       Log.info(
         'Cleared pending verification',


### PR DESCRIPTION
## Summary
- Cancel button no longer clears pending verification data, allowing users to verify via email link later
- Added 30-minute expiration to pending verification data with auto-cleanup
- Token-only verification now shows feedback message before redirecting to login

## Test plan
- [ ] Register with email, tap Cancel before verifying, then click email link → should auto-login
- [ ] Register with email, wait 30+ minutes, then click email link → should show "please log in" message
- [ ] Register with email, keep app open, click email link → should auto-login (existing behavior)

Closes #939