### PR TITLE
fix: sort notifications by timestamp descending (#286)

### DIFF
--- a/mobile/lib/providers/relay_notifications_provider.dart
+++ b/mobile/lib/providers/relay_notifications_provider.dart
@@ -593,7 +593,9 @@ bool relayNotificationsLoading(Ref ref) {
   return state.isLoadingMore || state.isInitialLoad;
 }
 
-/// Provider to get notifications filtered by type
+/// Provider to get notifications filtered by type.
+///
+/// Results are sorted by timestamp (newest first).
 @riverpod
 List<NotificationModel> relayNotificationsByType(
   Ref ref,
@@ -604,5 +606,13 @@ List<NotificationModel> relayNotificationsByType(
       asyncState.whenOrNull(data: (state) => state.notifications) ?? [];
 
   if (type == null) return notifications;
-  return notifications.where((n) => n.type == type).toList();
+
+  // Filter and sort to ensure chronological order
+  final filtered = notifications.where((n) => n.type == type).toList();
+  filtered.sort((a, b) {
+    final timeCompare = b.timestamp.compareTo(a.timestamp);
+    if (timeCompare != 0) return timeCompare;
+    return a.id.compareTo(b.id);
+  });
+  return filtered;
 }

--- a/mobile/lib/providers/relay_notifications_provider.g.dart
+++ b/mobile/lib/providers/relay_notifications_provider.g.dart
@@ -263,12 +263,16 @@ final class RelayNotificationsLoadingProvider
 String _$relayNotificationsLoadingHash() =>
     r'6dbafbb77abca10ee0e84310a5a97641c321fa69';
 
-/// Provider to get notifications filtered by type
+/// Provider to get notifications filtered by type.
+///
+/// Results are sorted by timestamp (newest first).
 
 @ProviderFor(relayNotificationsByType)
 const relayNotificationsByTypeProvider = RelayNotificationsByTypeFamily._();
 
-/// Provider to get notifications filtered by type
+/// Provider to get notifications filtered by type.
+///
+/// Results are sorted by timestamp (newest first).
 
 final class RelayNotificationsByTypeProvider
     extends
@@ -278,7 +282,9 @@ final class RelayNotificationsByTypeProvider
           List<NotificationModel>
         >
     with $Provider<List<NotificationModel>> {
-  /// Provider to get notifications filtered by type
+  /// Provider to get notifications filtered by type.
+  ///
+  /// Results are sorted by timestamp (newest first).
   const RelayNotificationsByTypeProvider._({
     required RelayNotificationsByTypeFamily super.from,
     required NotificationType? super.argument,
@@ -333,9 +339,11 @@ final class RelayNotificationsByTypeProvider
 }
 
 String _$relayNotificationsByTypeHash() =>
-    r'faa52ccaefc04204d6f9a4b698a82a6e664cdfed';
+    r'13c8dced839d456ca845419081916dcd46c059bc';
 
-/// Provider to get notifications filtered by type
+/// Provider to get notifications filtered by type.
+///
+/// Results are sorted by timestamp (newest first).
 
 final class RelayNotificationsByTypeFamily extends $Family
     with $FunctionalFamilyOverride<List<NotificationModel>, NotificationType?> {
@@ -348,7 +356,9 @@ final class RelayNotificationsByTypeFamily extends $Family
         isAutoDispose: true,
       );
 
-  /// Provider to get notifications filtered by type
+  /// Provider to get notifications filtered by type.
+  ///
+  /// Results are sorted by timestamp (newest first).
 
   RelayNotificationsByTypeProvider call(NotificationType? type) =>
       RelayNotificationsByTypeProvider._(argument: type, from: this);


### PR DESCRIPTION
## Summary
- Sort notifications by timestamp (newest first) when adding new notifications
- Sort filtered results in `getNotificationsByType()` 
- Sort filtered results in `relayNotificationsByType` provider

Fixes #286

## Test plan
- [x] Added 3 new tests for chronological ordering
- [x] All existing tests pass