### PR TITLE
fix: use go_router push for profile navigation from comments

### DIFF
--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -7,12 +7,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/comments/comments_bloc.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
-import 'package:openvine/router/nav_extensions.dart';
 import 'package:openvine/screens/comments/widgets/comment_options_modal.dart';
+import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_name.dart';
@@ -189,7 +190,10 @@ class _CommentHeader extends ConsumerWidget {
                 ],
               ),
               GestureDetector(
-                onTap: () => context.pushOtherProfile(authorPubkey),
+                onTap: () {
+                  final npub = NostrKeyUtils.encodePubKey(authorPubkey);
+                  context.push(OtherProfileScreen.pathForNpub(npub));
+                },
                 child: profile == null
                     ? Text(
                         NostrKeyUtils.encodePubKey(authorPubkey),

--- a/mobile/lib/screens/curated_list_feed_screen.dart
+++ b/mobile/lib/screens/curated_list_feed_screen.dart
@@ -9,8 +9,9 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/list_providers.dart';
-import 'package:openvine/router/nav_extensions.dart';
+import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/screens/pure/explore_video_screen_pure.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/services/curated_list_service.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/utils/video_controller_cleanup.dart';
@@ -293,7 +294,10 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
 
     if (authorPubkey != null) {
       return GestureDetector(
-        onTap: () => context.pushOtherProfile(authorPubkey),
+        onTap: () {
+          final npub = NostrKeyUtils.encodePubKey(authorPubkey);
+          context.push(OtherProfileScreen.pathForNpub(npub));
+        },
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/mobile/lib/screens/notifications_screen.dart
+++ b/mobile/lib/screens/notifications_screen.dart
@@ -4,10 +4,12 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:openvine/models/notification_model.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/router/nav_extensions.dart';
+import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/screens/pure/explore_video_screen_pure.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/notification_list_item.dart';
 
@@ -360,6 +362,7 @@ class _NotificationsScreenState extends ConsumerState<NotificationsScreen>
       category: LogCategory.ui,
     );
 
-    context.pushOtherProfile(userPubkey);
+    final npub = NostrKeyUtils.encodePubKey(userPubkey);
+    context.push(OtherProfileScreen.pathForNpub(npub));
   }
 }

--- a/mobile/lib/screens/user_list_people_screen.dart
+++ b/mobile/lib/screens/user_list_people_screen.dart
@@ -8,7 +8,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/list_providers.dart';
-import 'package:openvine/router/nav_extensions.dart';
+import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/screens/pure/explore_video_screen_pure.dart';
 import 'package:openvine/services/user_list_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
@@ -413,7 +413,10 @@ class _PeopleCarousel extends ConsumerWidget {
                   label: 'View profile for $displayName',
                   button: true,
                   child: GestureDetector(
-                    onTap: () => context.pushOtherProfile(pubkey),
+                    onTap: () {
+                      final npub = NostrKeyUtils.encodePubKey(pubkey);
+                      context.push(OtherProfileScreen.pathForNpub(npub));
+                    },
                     child: Padding(
                       padding: const EdgeInsets.only(right: 12),
                       child: Column(


### PR DESCRIPTION
## Summary

Fixes "No videos available" blank screen when pressing back after tapping a profile from the comments section.

**Root cause:** Used `context.go(ProfileScreenRouter...)` instead of `context.push(OtherProfileScreen...)`. This replaced the nav stack instead of pushing onto it, and used a shell route instead of the fullscreen profile route.

https://github.com/user-attachments/assets/17ef5f8d-5d97-41b5-b162-ca1a695c3d4a


## Changes

- **comment_item.dart**: Use `context.push(OtherProfileScreen.pathForNpub(...))` for tapping commenter profiles (confirmed fix)

Also fixed the same pattern in 3 other places:
- **notifications_screen.dart**
- **curated_list_feed_screen.dart**  
- **user_list_people_screen.dart**

## Related Issues

- Closes #966