### PR TITLE
fix: remove bottom bar when seeing someone else profile

### DIFF
--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -19,7 +19,6 @@ import 'package:openvine/widgets/profile/more_sheet/more_sheet_content.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_result.dart';
 import 'package:openvine/widgets/profile/profile_grid_view.dart';
 import 'package:openvine/widgets/profile/profile_loading_view.dart';
-import 'package:openvine/widgets/vine_bottom_nav.dart';
 
 /// Fullscreen profile screen for viewing other users' profiles.
 ///
@@ -401,7 +400,6 @@ class _OtherProfileScreenState extends ConsumerState<OtherProfileScreen> {
           refreshNotifier: _refreshNotifier,
         ),
       },
-      bottomNavigationBar: const VineBottomNav(currentIndex: 3),
     );
   }
 }
@@ -457,7 +455,6 @@ class _ProfileErrorScreen extends StatelessWidget {
       body: Center(
         child: Text(message, style: const TextStyle(color: Colors.white)),
       ),
-      bottomNavigationBar: const VineBottomNav(currentIndex: 3),
     );
   }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

**Related Issue:** Related to #974

According to designs bottom bar should be present only for your own profile, not someone else profile. This was creating strange behaviour in navigation.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore