### PR TITLE
chore: add semantics to video thumbnails in ComposableVideoGrid

### DIFF
--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -469,38 +469,43 @@ class _VideoItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () => onVideoTap(displayedVideos, index),
-      onLongPress: onLongPress,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(4),
-        child: Stack(
-          children: [
-            _VideoThumbnail(video: video),
-            Positioned(
-              left: 0,
-              right: 0,
-              bottom: 0,
-              child: _VideoInfoSection(video: video),
-            ),
-            if (isInSubscribedList)
+    return Semantics(
+      identifier: 'video_thumbnail_$index',
+      button: true,
+      label: 'Video thumbnail',
+      child: GestureDetector(
+        onTap: () => onVideoTap(displayedVideos, index),
+        onLongPress: onLongPress,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: Stack(
+            children: [
+              _VideoThumbnail(video: video),
               Positioned(
-                top: 6,
-                left: 6,
-                child: Container(
-                  padding: const EdgeInsets.all(4),
-                  decoration: BoxDecoration(
-                    color: VineTheme.vineGreen.withValues(alpha: 0.9),
-                    borderRadius: BorderRadius.circular(4),
-                  ),
-                  child: const Icon(
-                    Icons.collections,
-                    size: 14,
-                    color: Colors.white,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                child: _VideoInfoSection(video: video),
+              ),
+              if (isInSubscribedList)
+                Positioned(
+                  top: 6,
+                  left: 6,
+                  child: Container(
+                    padding: const EdgeInsets.all(4),
+                    decoration: BoxDecoration(
+                      color: VineTheme.vineGreen.withValues(alpha: 0.9),
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: const Icon(
+                      Icons.collections,
+                      size: 14,
+                      color: Colors.white,
+                    ),
                   ),
                 ),
-              ),
-          ],
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Add Semantics widget with unique identifier (video_thumbnail_$index) and label for accessibility and maestro testing support.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

  - Add `Semantics` widget to video thumbnails in `ComposableVideoGrid`                                     
  - Each thumbnail has a unique identifier (`video_thumbnail_$index`) for e2e testing                       
  - Includes accessibility label for screen readers 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore