### PR TITLE
fix: scope comments to correct video via uppercase A tag filter

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
@@ -361,6 +361,17 @@ class NostrEventsDao extends DatabaseAccessor<AppDatabase>
       conditions.add('(${eTagConditions.join(' OR ')})');
     }
 
+    // Uppercase A tags (NIP-22 root addressable event reference)
+    // Use GLOB for case-sensitive matching (LIKE is case-insensitive in SQLite)
+    final uppercaseATags = filter.uppercaseA;
+    if (uppercaseATags != null && uppercaseATags.isNotEmpty) {
+      final aTagConditions = uppercaseATags.map((addressableId) {
+        variables.add(Variable.withString('*"A"*"$addressableId"*'));
+        return 'tags GLOB ?';
+      }).toList();
+      conditions.add('(${aTagConditions.join(' OR ')})');
+    }
+
     // Uppercase K tags (NIP-22 root event kind)
     // Use GLOB for case-sensitive matching (LIKE is case-insensitive in SQLite)
     final uppercaseKTags = filter.uppercaseK;


### PR DESCRIPTION
## Summary
- Add case-sensitive uppercase `A` tag GLOB filter to `NostrEventsDao` so comments on addressable events (Kind 34236 videos) are scoped to the correct video
- Query comments by both `E` and `A` tags in parallel with deduplication, so comments from clients using either reference style are found
- Use NIP-22 compliant 3-element `A`/`a` tags when posting comments
- Extract `rootAuthorPubkey` from `A` tag's `kind:pubkey:d-tag` format as fallback

Fixes #977

## Test plan
- [x] DAO: uppercase A tag filter is case-sensitive (excludes lowercase `a`)
- [x] DAO: combined `uppercaseA` + `kinds` filters work for NIP-22 comment queries
- [x] Repository: parallel E+A queries with deduplication
- [x] Repository: A-tag-only comments from other clients parsed correctly
- [x] Repository: posted top-level comments include both `A` and `a` tags; replies omit `a`
- [x] Repository: comment count uses `max(E, A)` logic
- [x] All 73 DAO tests pass
- [x] All 36 repository tests pass
- [x] `dart analyze` — no errors
- [x] `dart format` — no changes needed