### PR TITLE
fix(video-editor): pause video playback before navigating to other screens

### DIFF
--- a/mobile/lib/widgets/video_clip_editor/video_clip_editor_top_bar.dart
+++ b/mobile/lib/widgets/video_clip_editor/video_clip_editor_top_bar.dart
@@ -87,11 +87,12 @@ class VideoClipEditorTopBar extends ConsumerWidget {
                       alignment: .centerRight,
                       child: _NextButton(
                         onTap: () {
-                          unawaited(
-                            ref
-                                .read(videoEditorProvider.notifier)
-                                .startRenderVideo(),
+                          final notifier = ref.read(
+                            videoEditorProvider.notifier,
                           );
+
+                          notifier.pauseVideo();
+                          unawaited(notifier.startRenderVideo());
                           // TODO(@hm21): Replace with VideoEditorScreen.path
                           context.push(VideoMetadataScreen.path);
                         },


### PR DESCRIPTION
## Description

This PR ensures that when a user plays a clip in the clip editor and switches to the meta screen, the clip stops playing. Currently, clips continue to play in the background even after the user can no longer see the video.

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore