### PR TITLE
fix: add missing dim tag to video Nostr events

### DIFF
--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -328,11 +328,23 @@ class UploadManager {
       );
     }
 
-    if (videoDuration == null) {
+    int? videoWidth;
+    int? videoHeight;
+
+    try {
       final meta = await ProVideoEditor.instance.getMetadata(
         EditorVideo.file(videoFilePath),
       );
-      videoDuration = meta.duration;
+      videoDuration ??= meta.duration;
+      final resolution = meta.resolution;
+      videoWidth = resolution.width.round();
+      videoHeight = resolution.height.round();
+    } catch (e) {
+      Log.warning(
+        '⚠️ Could not extract video metadata: $e',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
     }
 
     return _startUploadInternal(
@@ -341,6 +353,8 @@ class UploadManager {
       title: draft.title,
       description: draft.description,
       hashtags: draft.hashtags.toList(),
+      videoWidth: videoWidth,
+      videoHeight: videoHeight,
       videoDuration: videoDuration,
       proofManifestJson: draft.proofManifestJson,
       onProgress: onProgress,


### PR DESCRIPTION
## Summary
- Published Kind 34236 video events were missing the `dim` (dimensions) tag in their `imeta` metadata
- The `VideoEventPublisher` already had code to include `dim WxH` when `videoWidth`/`videoHeight` were set, but `startUploadFromDraft()` in `UploadManager` never extracted the resolution from `ProVideoEditor.getMetadata()` — only duration was read
- Now `getMetadata()` always runs and populates both width and height from `meta.resolution`, wrapped in try-catch so upload isn't blocked if extraction fails

## Test plan
- [x] Existing `upload_manager_from_draft_test.dart` tests pass (3/3)
- [x] `dart analyze` clean
- [ ] Publish a video and verify the Nostr event includes `dim WxH` in the `imeta` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)