### PR TITLE
fix: save clips to gallery at recording stop

### DIFF
--- a/mobile/test/screens/video_metadata_screen_test.dart
+++ b/mobile/test/screens/video_metadata_screen_test.dart
@@ -1,57 +1,15 @@
-// ABOUTME: Tests for VideoMetadataScreen gallery save and permission banner
-// ABOUTME: Verifies auto-save to gallery and permission denied UX flow
+// ABOUTME: Tests for VideoMetadataScreen basic rendering and structure
+// ABOUTME: Verifies screen renders with expected UI elements
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as models;
 import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/recording_clip.dart';
-import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
-import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
-
-/// Sets up a mock handler for the `gal` MethodChannel.
-///
-/// [hasAccess] controls what `Gal.hasAccess()` returns.
-/// [requestAccessGranted] controls what `Gal.requestAccess()` returns.
-/// [putVideoSucceeds] controls whether `Gal.putVideo()` succeeds.
-void _setupGalMock({
-  required TestWidgetsFlutterBinding binding,
-  bool hasAccess = true,
-  bool requestAccessGranted = true,
-  bool putVideoSucceeds = true,
-}) {
-  binding.defaultBinaryMessenger.setMockMethodCallHandler(
-    const MethodChannel('gal'),
-    (MethodCall methodCall) async {
-      switch (methodCall.method) {
-        case 'hasAccess':
-          return hasAccess;
-        case 'requestAccess':
-          return requestAccessGranted;
-        case 'putVideo':
-          if (!putVideoSucceeds) {
-            throw PlatformException(code: 'ERROR', message: 'Save failed');
-          }
-          return null;
-        default:
-          return null;
-      }
-    },
-  );
-}
-
-/// Removes the mock handler for the `gal` MethodChannel.
-void _teardownGalMock(TestWidgetsFlutterBinding binding) {
-  binding.defaultBinaryMessenger.setMockMethodCallHandler(
-    const MethodChannel('gal'),
-    null,
-  );
-}
 
 RecordingClip _createTestClip({String id = 'test-clip'}) {
   return RecordingClip(
@@ -66,24 +24,16 @@ RecordingClip _createTestClip({String id = 'test-clip'}) {
 
 void main() {
   group(VideoMetadataScreen, () {
-    late TestWidgetsFlutterBinding binding;
     late RecordingClip testClip;
 
     setUp(() {
-      binding = TestWidgetsFlutterBinding.ensureInitialized();
       testClip = _createTestClip();
-    });
-
-    tearDown(() {
-      _teardownGalMock(binding);
     });
 
     group('renders', () {
       testWidgets('renders $VideoMetadataScreen with basic structure', (
         tester,
       ) async {
-        _setupGalMock(binding: binding);
-
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
@@ -100,213 +50,6 @@ void main() {
         expect(find.text('Post'), findsOneWidget);
       });
     });
-
-    group('gallery save', () {
-      testWidgets('saves video to gallery when finalRenderedClip exists', (
-        tester,
-      ) async {
-        var putVideoCalled = false;
-
-        binding.defaultBinaryMessenger.setMockMethodCallHandler(
-          const MethodChannel('gal'),
-          (MethodCall methodCall) async {
-            switch (methodCall.method) {
-              case 'hasAccess':
-                return true;
-              case 'putVideo':
-                putVideoCalled = true;
-                return null;
-              default:
-                return null;
-            }
-          },
-        );
-
-        final state = VideoEditorProviderState(
-          title: 'Test Video',
-          finalRenderedClip: testClip,
-        );
-
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              clipManagerProvider.overrideWith(
-                () => _MockClipManagerNotifier([testClip]),
-              ),
-              videoEditorProvider.overrideWith(
-                () => _MockVideoEditorNotifier(state),
-              ),
-            ],
-            child: const MaterialApp(home: VideoMetadataScreen()),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        expect(putVideoCalled, isTrue);
-      });
-
-      testWidgets('does not attempt gallery save when no finalRenderedClip', (
-        tester,
-      ) async {
-        var putVideoCalled = false;
-
-        binding.defaultBinaryMessenger.setMockMethodCallHandler(
-          const MethodChannel('gal'),
-          (MethodCall methodCall) async {
-            if (methodCall.method == 'putVideo') {
-              putVideoCalled = true;
-            }
-            return null;
-          },
-        );
-
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              clipManagerProvider.overrideWith(
-                () => _MockClipManagerNotifier([testClip]),
-              ),
-              videoEditorProvider.overrideWith(
-                () => _MockVideoEditorNotifier(VideoEditorProviderState()),
-              ),
-            ],
-            child: const MaterialApp(home: VideoMetadataScreen()),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        expect(putVideoCalled, isFalse);
-      });
-    });
-
-    group('gallery permission banner', () {
-      testWidgets('shows banner when permission is denied', (tester) async {
-        _setupGalMock(
-          binding: binding,
-          hasAccess: false,
-          requestAccessGranted: false,
-        );
-
-        final state = VideoEditorProviderState(
-          title: 'Test Video',
-          finalRenderedClip: testClip,
-        );
-
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              clipManagerProvider.overrideWith(
-                () => _MockClipManagerNotifier([testClip]),
-              ),
-              videoEditorProvider.overrideWith(
-                () => _MockVideoEditorNotifier(state),
-              ),
-            ],
-            child: const MaterialApp(home: VideoMetadataScreen()),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        expect(
-          find.text('Allow access to save a copy to your photo library.'),
-          findsOneWidget,
-        );
-        expect(find.text('Allow'), findsOneWidget);
-        expect(find.byIcon(Icons.photo_library_outlined), findsOneWidget);
-      });
-
-      testWidgets('does not show banner when permission is granted', (
-        tester,
-      ) async {
-        _setupGalMock(binding: binding);
-
-        final state = VideoEditorProviderState(
-          title: 'Test Video',
-          finalRenderedClip: testClip,
-        );
-
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              clipManagerProvider.overrideWith(
-                () => _MockClipManagerNotifier([testClip]),
-              ),
-              videoEditorProvider.overrideWith(
-                () => _MockVideoEditorNotifier(state),
-              ),
-            ],
-            child: const MaterialApp(home: VideoMetadataScreen()),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        expect(
-          find.text('Allow access to save a copy to your photo library.'),
-          findsNothing,
-        );
-      });
-
-      testWidgets('tapping Allow retries and hides banner on success', (
-        tester,
-      ) async {
-        var hasAccessCallCount = 0;
-
-        binding.defaultBinaryMessenger.setMockMethodCallHandler(
-          const MethodChannel('gal'),
-          (MethodCall methodCall) async {
-            switch (methodCall.method) {
-              case 'hasAccess':
-                hasAccessCallCount++;
-                // First two calls (initial check + re-check): denied
-                // Third call onwards (retry after tap): granted
-                return hasAccessCallCount > 2;
-              case 'requestAccess':
-                return null;
-              case 'putVideo':
-                return null;
-              default:
-                return null;
-            }
-          },
-        );
-
-        final state = VideoEditorProviderState(
-          title: 'Test Video',
-          finalRenderedClip: testClip,
-        );
-
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              clipManagerProvider.overrideWith(
-                () => _MockClipManagerNotifier([testClip]),
-              ),
-              videoEditorProvider.overrideWith(
-                () => _MockVideoEditorNotifier(state),
-              ),
-            ],
-            child: const MaterialApp(home: VideoMetadataScreen()),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        // Banner should be visible initially
-        expect(
-          find.text('Allow access to save a copy to your photo library.'),
-          findsOneWidget,
-        );
-
-        // Tap the Allow button
-        await tester.tap(find.text('Allow'));
-        await tester.pumpAndSettle();
-
-        // Banner should be gone after permission granted
-        expect(
-          find.text('Allow access to save a copy to your photo library.'),
-          findsNothing,
-        );
-      });
-    });
   });
 }
 
@@ -318,24 +61,4 @@ class _MockClipManagerNotifier extends ClipManagerNotifier {
 
   @override
   ClipManagerState build() => ClipManagerState(clips: _clips);
-}
-
-/// Mock video editor notifier for testing.
-class _MockVideoEditorNotifier extends VideoEditorNotifier {
-  _MockVideoEditorNotifier(this._state);
-
-  final VideoEditorProviderState _state;
-
-  @override
-  VideoEditorProviderState build() => _state;
-
-  @override
-  Future<void> cancelRenderVideo() async {}
-
-  @override
-  void updateMetadata({
-    String? title,
-    String? description,
-    Set<String>? tags,
-  }) {}
 }


### PR DESCRIPTION
## Summary

- Move gallery save from `VideoMetadataScreen` to `VideoRecorderNotifier.stopRecording()` so each clip is saved individually and immediately after recording
- Save to named "diVine" album (like TikTok/WhatsApp) using `Gal.putVideo(path, album: 'diVine')`
- Remove all gallery-related code from metadata screen (fields, methods, permission banner, ref.listen)
- Clean up tests to remove gallery-specific test cases

## Fixes from PR #1252 / #1333 review feedback

| Issue | Before | After |
|-------|--------|-------|
| Only first clip saved | Gallery save triggered on metadata screen open (only rendered clip) | Each clip saved individually at recording stop |
| Duplicate saves | Re-opening metadata screen re-triggered save | Save happens once per clip in `stopRecording()` |
| No album name | `Gal.putVideo(path)` with no album | `Gal.putVideo(path, album: 'diVine')` |
| Permission banner coupling | Gallery permission UI in metadata screen | Permission handled silently in recorder provider |

Supersedes #1252 and #1333 per reviewer feedback from @hm21.

## Test plan

- [x] `dart format` passes
- [x] `flutter analyze` passes
- [x] Existing tests pass (26/26)
- [ ] Manual: Record clip -> check Photos app for "diVine" album
- [ ] Manual: Record multiple clips -> all appear in gallery
- [ ] Manual: Re-open metadata screen -> no duplicate saves
- [ ] Manual: Post video -> still publishes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)