### PR TITLE
fix(video): remove duplicate gallery saves causing 3 copies per recording

### DIFF
--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -48,7 +48,6 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       videoEventPublisher: ref.read(videoEventPublisherProvider),
       blossomService: ref.read(blossomUploadServiceProvider),
       draftService: _draftService,
-      gallerySaveService: ref.read(gallerySaveServiceProvider),
       onProgressChanged: ({required String draftId, required double progress}) {
         setUploadProgress(draftId: draftId, progress: progress);
         onProgressChanged(draftId: draftId, progress: progress);

--- a/mobile/lib/screens/video_metadata/video_metadata_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_screen.dart
@@ -9,11 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
-import 'package:openvine/services/gallery_save_service.dart';
-import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_bottom_bar.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_clip_preview.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_expiration_selector.dart';
@@ -52,44 +48,7 @@ class _VideoMetadataScreenState extends ConsumerState<VideoMetadataScreen> {
       final editorProvider = ref.read(videoEditorProvider);
       _titleController.text = editorProvider.title;
       _descriptionController.text = editorProvider.description;
-
-      // Auto-save to gallery as safety backup when screen loads
-      unawaited(_saveToGalleryOnLoad());
     });
-  }
-
-  /// Saves the first clip to gallery as a safety backup.
-  /// Runs silently in background - failures are logged but not shown to user.
-  Future<void> _saveToGalleryOnLoad() async {
-    try {
-      final clips = ref.read(clipManagerProvider).clips;
-      if (clips.isEmpty) return;
-
-      final videoPath = await clips.first.video.safeFilePath();
-      final gallerySaveService = ref.read(gallerySaveServiceProvider);
-      final result = await gallerySaveService.saveVideoToGallery(videoPath);
-
-      switch (result) {
-        case GallerySaveSuccess():
-          Log.info(
-            'Auto-saved video to gallery on screen load',
-            name: 'VideoMetadataScreen',
-            category: LogCategory.video,
-          );
-        case GallerySaveFailure(:final reason):
-          Log.warning(
-            'Auto-save to gallery failed: $reason',
-            name: 'VideoMetadataScreen',
-            category: LogCategory.video,
-          );
-      }
-    } catch (e) {
-      Log.warning(
-        'Auto-save to gallery error: $e',
-        name: 'VideoMetadataScreen',
-        category: LogCategory.video,
-      );
-    }
   }
 
   @override

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -10,7 +10,6 @@ import 'package:openvine/models/vine_draft.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/blossom_upload_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
-import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_publisher.dart';
 import 'package:openvine/utils/unified_logger.dart';
@@ -49,7 +48,6 @@ class VideoPublishService {
     required this.blossomService,
     required this.draftService,
     required this.onProgressChanged,
-    this.gallerySaveService,
   });
 
   /// Manages background video uploads.
@@ -70,9 +68,6 @@ class VideoPublishService {
   /// Callback when upload progress changes.
   final OnProgressChanged onProgressChanged;
 
-  /// Optional service to save videos to device camera roll.
-  final GallerySaveService? gallerySaveService;
-
   /// Tracks the current background upload ID.
   String? _backgroundUploadId;
 
@@ -91,10 +86,6 @@ class VideoPublishService {
 
       final videoPath = await draft.clips.first.video.safeFilePath();
       Log.info('📝 Publishing video: $videoPath', category: .video);
-
-      // Fire-and-forget: Save video to camera roll as backup
-      // This runs in parallel with the upload and doesn't block publishing
-      _saveVideoToCameraRoll(videoPath);
 
       // Verify user is fully authenticated
       if (!authService.isAuthenticated) {
@@ -323,31 +314,6 @@ class VideoPublishService {
 
     final userMessage = await _getUserFriendlyErrorMessage(e);
     return PublishError(userMessage);
-  }
-
-  /// Saves video to camera roll as a backup (fire-and-forget).
-  ///
-  /// This method runs asynchronously and does not block the publish flow.
-  /// Any errors are logged but do not affect the publishing process.
-  void _saveVideoToCameraRoll(String videoPath) {
-    if (gallerySaveService == null) return;
-
-    // Run async without awaiting - fire and forget
-    Future(() async {
-      final result = await gallerySaveService!.saveVideoToGallery(videoPath);
-      switch (result) {
-        case GallerySaveSuccess():
-          Log.info(
-            '📱 Video backup saved to camera roll',
-            category: LogCategory.video,
-          );
-        case GallerySaveFailure(:final reason):
-          Log.warning(
-            '📱 Camera roll backup skipped: $reason',
-            category: LogCategory.video,
-          );
-      }
-    });
   }
 
   /// Converts technical error messages into user-friendly descriptions.


### PR DESCRIPTION
## Summary

- Fixes bug where recording a video saved **3 copies** to the device gallery instead of 1
- PR #1341 added the correct gallery save at recording stop time but didn't remove two older save points
- Removes redundant save from `VideoMetadataScreen._saveToGalleryOnLoad()` (fired on metadata screen load)
- Removes redundant save from `VideoPublishService._saveVideoToCameraRoll()` (fired during publish)
- The correct save in `VideoRecorderNotifier.stopRecording()` (to "diVine" album) remains

## Test plan

- [ ] Record a video, go through metadata screen, and publish
- [ ] Verify only **1 copy** appears in the device gallery (in "diVine" album)
- [ ] Verify "Save for Later" button still saves to gallery (separate flow, unchanged)
- [ ] Verify publish flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)