### PR TITLE
fix: overflow issue with Profile page

### DIFF
--- a/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
+++ b/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
@@ -32,7 +32,7 @@ class ProfileActionButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Padding(
-    padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
     child: Row(
       children: [
         if (isOwnProfile) ...[

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -138,19 +138,25 @@ class ProfileHeaderWidget extends ConsumerWidget {
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                         children: [
-                          ProfileStatColumn(
-                            count: videoCount,
-                            label: 'Videos',
-                            isLoading: false,
-                            onTap: null, // Videos aren't tappable
+                          Flexible(
+                            child: ProfileStatColumn(
+                              count: videoCount,
+                              label: 'Videos',
+                              isLoading: false,
+                              onTap: null, // Videos aren't tappable
+                            ),
                           ),
-                          ProfileFollowersStat(
-                            pubkey: userIdHex,
-                            displayName: displayName,
+                          Flexible(
+                            child: ProfileFollowersStat(
+                              pubkey: userIdHex,
+                              displayName: displayName,
+                            ),
                           ),
-                          ProfileFollowingStat(
-                            pubkey: userIdHex,
-                            displayName: displayName,
+                          Flexible(
+                            child: ProfileFollowingStat(
+                              pubkey: userIdHex,
+                              displayName: displayName,
+                            ),
                           ),
                         ],
                       ),
@@ -541,9 +547,11 @@ class _UniqueIdentifier extends ConsumerWidget {
                   size: 14,
                 ),
                 const SizedBox(width: 4),
-                Text(
-                  'Username not verifying - contact support',
-                  style: VineTheme.bodySmallFont(color: Colors.orange),
+                Flexible(
+                  child: Text(
+                    'Username not verifying - contact support',
+                    style: VineTheme.bodySmallFont(color: Colors.orange),
+                  ),
                 ),
               ],
             ),

--- a/mobile/lib/widgets/profile/profile_stats_row_widget.dart
+++ b/mobile/lib/widgets/profile/profile_stats_row_widget.dart
@@ -15,7 +15,7 @@ class ProfileStatsRowWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => Container(
-    margin: const EdgeInsets.symmetric(horizontal: 20),
+    margin: const EdgeInsets.symmetric(horizontal: 24),
     padding: const EdgeInsets.all(16),
     decoration: BoxDecoration(
       color: VineTheme.cardBackground,


### PR DESCRIPTION
The profile page would overflow if accessibility options for larger fonts were enabled.

Before:
<img width="200" alt="before1" src="https://github.com/user-attachments/assets/620b0590-1d0c-4314-803e-b9f759cc60f3" />

After:
<img width="200"  alt="after1" src="https://github.com/user-attachments/assets/8b4515b0-a548-42e3-95ae-f869afd69a28" />

When using normal font size, the screen looks like this:
<img width="200"  alt="after2" src="https://github.com/user-attachments/assets/c3ec6b6b-1aaa-424a-a643-ef1b784cf878" />


**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore