### PR TITLE
fix(comments): use live count in sheet header during loading

### DIFF
--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -64,14 +64,25 @@ class CommentsScreen extends ConsumerWidget {
   const CommentsScreen({
     required this.videoEvent,
     required this.sheetScrollController,
+    this.initialCommentCount,
     super.key,
   });
 
   final VideoEvent videoEvent;
   final ScrollController sheetScrollController;
 
+  /// Optional live comment count from the caller (e.g. from
+  /// [VideoInteractionsBloc]).  When provided this value is shown in the
+  /// header while comments are still loading, avoiding the stale count
+  /// stored in the video event metadata.
+  final int? initialCommentCount;
+
   /// Shows comments as a modal bottom sheet overlay
-  static Future<void> show(BuildContext context, VideoEvent video) {
+  static Future<void> show(
+    BuildContext context,
+    VideoEvent video, {
+    int? initialCommentCount,
+  }) {
     final container = ProviderScope.containerOf(context, listen: false);
     final overlayNotifier = container.read(overlayVisibilityProvider.notifier);
     overlayNotifier.setModalOpen(true);
@@ -102,6 +113,7 @@ class CommentsScreen extends ConsumerWidget {
             child: CommentsScreen(
               videoEvent: video,
               sheetScrollController: scrollController,
+              initialCommentCount: initialCommentCount,
             ),
           ),
         );
@@ -131,7 +143,9 @@ class CommentsScreen extends ConsumerWidget {
         initialTotalCount: initialCount,
       )..add(const CommentsLoadRequested()),
       child: VineBottomSheet(
-        title: _CommentsTitle(initialCount: videoEvent.originalComments ?? 0),
+        title: _CommentsTitle(
+          initialCount: initialCommentCount ?? videoEvent.originalComments ?? 0,
+        ),
         body: _CommentsScreenBody(
           videoEvent: videoEvent,
           sheetScrollController: sheetScrollController,

--- a/mobile/lib/widgets/video_feed_item/actions/comment_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/comment_action_button.dart
@@ -105,6 +105,10 @@ class CommentActionButton extends ConsumerWidget {
       }
     }
 
-    CommentsScreen.show(context, video);
+    CommentsScreen.show(
+      context,
+      video,
+      initialCommentCount: video.originalComments ?? 0,
+    );
   }
 }

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -2017,7 +2017,11 @@ class _CommentActionButton extends StatelessWidget {
                   }
                 }
               }
-              CommentsScreen.show(context, video);
+              CommentsScreen.show(
+                context,
+                video,
+                initialCommentCount: totalComments,
+              );
             },
             icon: DecoratedBox(
               decoration: BoxDecoration(


### PR DESCRIPTION
## Summary
- Thread the live `commentCount` from `VideoInteractionsBloc` into `CommentsScreen.show()` so the header displays the correct count immediately during loading, instead of the stale `originalComments` metadata tag

Closes #1376

## Test plan
- [ ] Open a video with 3+ comments — verify the sheet header matches the feed badge count instantly (no flash of "1 Comment")
- [ ] Verify header switches to actual loaded count once comments finish loading
- [ ] `flutter test test/screens/comments/` passes (3 new title-count tests added)