### PR TITLE
fix(likes): prevent double-count race on like/unlike

### DIFF
--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -68,14 +68,10 @@ class VideoInteractionsBloc
           final isLiked = likedIds.contains(_eventId);
           if (isLiked == state.isLiked) return state;
 
-          // Update like status and adjust count
-          final currentCount = state.likeCount ?? 0;
-          final newCount = isLiked ? currentCount + 1 : currentCount - 1;
-
-          return state.copyWith(
-            isLiked: isLiked,
-            likeCount: newCount < 0 ? 0 : newCount,
-          );
+          // Only sync like status here — count is owned by _onLikeToggled.
+          // This prevents a double-count race where both this subscription
+          // and the toggle handler adjust likeCount for the same action.
+          return state.copyWith(isLiked: isLiked);
         },
       ),
       if (_addressableId != null)

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -106,7 +106,11 @@ class LikesRepository {
   bool _isInitialized = false;
 
   /// Emits the current set of liked event IDs.
+  ///
+  /// Guards against emitting after the controller has been closed, which can
+  /// happen if [clearCache] runs during or after [dispose] (e.g. on logout).
   void _emitLikedIds() {
+    if (_likedIdsController.isClosed) return;
     _likedIdsController.add(_likeRecords.keys.toSet());
   }
 

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -1120,6 +1120,16 @@ void main() {
         verify(() => mockLocalStorage.clearAll()).called(1);
         expect(await repository.getLikedEventIds(), isEmpty);
       });
+
+      test('does not throw when called after dispose', () async {
+        when(() => mockLocalStorage.clearAll()).thenAnswer((_) async {});
+
+        repository = createRepository()..dispose();
+
+        // clearCache after dispose should not throw "Cannot add new events
+        // after calling close" on the BehaviorSubject.
+        await expectLater(repository.clearCache(), completes);
+      });
     });
 
     group('watchLikedEventIds', () {

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -101,7 +101,11 @@ class RepostsRepository {
   bool _isInitialized = false;
 
   /// Emits the current set of reposted addressable IDs.
+  ///
+  /// Guards against emitting after the controller has been closed, which can
+  /// happen if [clearCache] runs during or after [dispose] (e.g. on logout).
   void _emitRepostedIds() {
+    if (_repostedIdsController.isClosed) return;
     _repostedIdsController.add(_repostRecords.keys.toSet());
   }
 

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -948,6 +948,16 @@ void main() {
 
         verify(() => mockLocalStorage.clearAll()).called(1);
       });
+
+      test('does not throw when called after dispose', () async {
+        final repository = RepostsRepository(
+          nostrClient: mockNostrClient,
+        )..dispose();
+
+        // clearCache after dispose should not throw "Cannot add new events
+        // after calling close" on the BehaviorSubject.
+        await expectLater(repository.clearCache(), completes);
+      });
     });
 
     group('watchRepostedAddressableIds', () {

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -786,7 +786,7 @@ void main() {
 
     group('VideoInteractionsSubscriptionRequested', () {
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'updates like status when stream emits with this event liked',
+        'updates isLiked without adjusting likeCount when stream emits liked',
         build: createBloc,
         seed: () => const VideoInteractionsState(
           status: VideoInteractionsStatus.success,
@@ -800,16 +800,18 @@ void main() {
         },
         wait: const Duration(milliseconds: 100),
         expect: () => [
+          // likeCount stays at 10 — count is only adjusted by _onLikeToggled
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
             isLiked: true,
-            likeCount: 11,
+            likeCount: 10,
           ),
         ],
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'updates like status when stream emits without this event',
+        'updates isLiked without adjusting likeCount when stream emits '
+        'unliked',
         build: createBloc,
         seed: () => const VideoInteractionsState(
           status: VideoInteractionsStatus.success,
@@ -823,16 +825,17 @@ void main() {
         },
         wait: const Duration(milliseconds: 100),
         expect: () => [
+          // likeCount stays at 10 — count is only adjusted by _onLikeToggled
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
             isLiked: false,
-            likeCount: 9,
+            likeCount: 10,
           ),
         ],
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'does not emit when status unchanged',
+        'does not emit when like status unchanged',
         build: createBloc,
         seed: () => const VideoInteractionsState(
           status: VideoInteractionsStatus.success,


### PR DESCRIPTION
## Summary

Closes #1293

- Remove `likeCount` adjustment from the subscription stream handler in `VideoInteractionsBloc` — count is now exclusively owned by `_onLikeToggled`, eliminating a double-count race between concurrent BLoC handlers
- Guard `_emitLikedIds` / `_emitRepostedIds` against emitting on closed `BehaviorSubject` (fixes Crashlytics `b01f464a` and `b3cd68e1` on logout)

## Root cause

The likes subscription handler (`emit.forEach` on `watchLikedEventIds`) and the toggle handler (`_onLikeToggled`) both adjusted `likeCount` by +1/-1. Since they handle different event types, BLoC processes them concurrently — creating a timing-dependent double-increment on like that doesn't fully reverse on unlike, causing the count to drift upward.

The repost subscription handler already only syncs `isReposted` (no count adjustment). This PR makes the likes handler consistent.

## Test plan

- [x] Updated `VideoInteractionsSubscriptionRequested` tests to verify subscription does NOT adjust count
- [x] Added `clearCache` after `dispose` tests for both `LikesRepository` and `RepostsRepository`
- [x] All 3 test suites pass (33 + 64 + 58 = 155 tests)
- [x] `dart analyze` clean, `dart format` clean
- [ ] Manual: like → count +1, unlike → count -1, rapid toggle stays consistent
- [ ] Manual: logout without Crashlytics errors