### PR TITLE
fix: video deep link bug

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -740,7 +740,12 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                   category: LogCategory.ui,
                 );
                 try {
-                  router.go(targetPath);
+                  // Skip if already showing this video (getInitialLink
+                  // and uriLinkStream can both fire for the same URL).
+                  if (currentLocation == targetPath) break;
+                  // Push (not go) so the home route stays underneath,
+                  // allowing back navigation to return to the main screen.
+                  router.push(targetPath);
                   Log.info(
                     '✅ Navigation completed to: $targetPath',
                     name: 'DeepLinkHandler',

--- a/mobile/lib/providers/active_video_provider.dart
+++ b/mobile/lib/providers/active_video_provider.dart
@@ -85,6 +85,7 @@ final activeVideoIdProvider = Provider<String?>((ref) {
       break;
     case RouteType.videoFeed:
     case RouteType.pooledVideoFeed:
+    case RouteType.videoDetail:
       // videoFeed routes manage their own playback via passed videos
       // Return null to let the screen handle it internally
       Log.debug(

--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -29,6 +29,7 @@ import 'package:openvine/screens/relay_settings_screen.dart';
 import 'package:openvine/screens/safety_settings_screen.dart';
 import 'package:openvine/screens/settings_screen.dart';
 import 'package:openvine/screens/sound_detail_screen.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/screens/video_editor/video_clip_editor_screen.dart';
 import 'package:openvine/screens/video_editor/video_editor_screen.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
@@ -75,6 +76,7 @@ enum RouteType {
   secureAccount,
   newVideoFeed,
   pooledVideoFeed, // Pooled fullscreen video feed (uses pooled_video_player)
+  videoDetail, // Video detail screen (deep link to specific video)
 }
 
 /// Structured representation of a route
@@ -87,6 +89,7 @@ class RouteContext {
     this.searchTerm,
     this.listId,
     this.soundId,
+    this.videoId,
   });
 
   final RouteType type;
@@ -96,6 +99,7 @@ class RouteContext {
   final String? searchTerm;
   final String? listId;
   final String? soundId;
+  final String? videoId;
 }
 
 /// Parse a URL path into a structured RouteContext
@@ -303,6 +307,13 @@ RouteContext parseRoute(String path) {
     case 'pooled-video-feed':
       return const RouteContext(type: RouteType.pooledVideoFeed);
 
+    case 'video':
+      if (segments.length < 2) {
+        return const RouteContext(type: RouteType.home);
+      }
+      final videoId = Uri.decodeComponent(segments[1]);
+      return RouteContext(type: RouteType.videoDetail, videoId: videoId);
+
     default:
       return const RouteContext(type: RouteType.home, videoIndex: 0);
   }
@@ -462,6 +473,9 @@ String buildRoute(RouteContext context) {
 
     case RouteType.pooledVideoFeed:
       return PooledFullscreenVideoFeedScreen.path;
+
+    case RouteType.videoDetail:
+      return VideoDetailScreen.pathForId(context.videoId ?? '');
   }
 }
 

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -1,13 +1,15 @@
 // ABOUTME: Screen for viewing a specific video by ID (from deep links)
 // ABOUTME: Fetches video from Nostr and displays it in full-screen player
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
-import 'package:openvine/screens/video_feed_screen.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:openvine/utils/unified_logger.dart';
 
@@ -195,7 +197,11 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
       );
     }
 
-    // Display video in full-screen player (with navigation disabled to preserve /video/:id route)
-    return VideoFeedScreen(startingVideo: _video!, disableNavigation: true);
+    // Display video in full-screen pooled player
+    return PooledFullscreenVideoFeedScreen(
+      videosStream: Stream.value([_video!]),
+      initialIndex: 0,
+      contextTitle: 'Shared Video',
+    );
   }
 }

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -1,0 +1,185 @@
+// ABOUTME: Widget tests for VideoDetailScreen deep link video display
+// ABOUTME: Verifies correct video is shown and error/blocked states handled
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:openvine/services/content_blocklist_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:pooled_video_player/pooled_video_player.dart';
+
+import '../helpers/test_provider_overrides.dart';
+import '../test_data/video_test_data.dart';
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockContentBlocklistService extends Mock
+    implements ContentBlocklistService {}
+
+void main() {
+  group(VideoDetailScreen, () {
+    late _MockVideoEventService mockVideoEventService;
+    late _MockContentBlocklistService mockBlocklistService;
+    late _MockNostrClient mockNostrClient;
+
+    setUp(() async {
+      await PlayerPool.init();
+
+      mockVideoEventService = _MockVideoEventService();
+      mockNostrClient = _MockNostrClient();
+      mockBlocklistService = _MockContentBlocklistService();
+
+      // Default: no authors blocked
+      when(
+        () => mockBlocklistService.shouldFilterFromFeeds(any()),
+      ).thenReturn(false);
+    });
+
+    tearDown(() async {
+      await PlayerPool.reset();
+    });
+
+    Widget buildSubject({String videoId = 'test_video_id'}) {
+      return testMaterialApp(
+        mockNostrService: mockNostrClient,
+        additionalOverrides: [
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          contentBlocklistServiceProvider.overrideWithValue(
+            mockBlocklistService,
+          ),
+        ],
+        home: VideoDetailScreen(videoId: videoId),
+      );
+    }
+
+    group('loading state', () {
+      testWidgets('renders $CircularProgressIndicator while fetching video', (
+        tester,
+      ) async {
+        // Cache miss, Nostr fetch stays pending
+        when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
+        final completer = Completer<Event?>();
+        when(
+          () => mockNostrClient.fetchEventById(any()),
+        ).thenAnswer((_) => completer.future);
+
+        await tester.pumpWidget(buildSubject());
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      });
+    });
+
+    group('video found in cache', () {
+      testWidgets(
+        'renders $PooledFullscreenVideoFeedScreen with cached video',
+        (tester) async {
+          final video = createTestVideoEvent(
+            id: 'test_video_id',
+            pubkey: 'test_pubkey',
+            title: 'Deep Link Video',
+            videoUrl: 'https://example.com/video.mp4',
+          );
+
+          when(
+            () => mockVideoEventService.getVideoById('test_video_id'),
+          ).thenReturn(video);
+
+          await tester.pumpWidget(buildSubject());
+          await tester.pump();
+
+          expect(find.byType(PooledFullscreenVideoFeedScreen), findsOneWidget);
+        },
+      );
+    });
+
+    group('video not found', () {
+      testWidgets('renders error when video not found in cache or Nostr', (
+        tester,
+      ) async {
+        when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
+        when(
+          () => mockNostrClient.fetchEventById(any()),
+        ).thenAnswer((_) async => null);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        expect(find.text('Video not found'), findsOneWidget);
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      });
+    });
+
+    group('fetch error', () {
+      testWidgets('renders error message when Nostr fetch fails', (
+        tester,
+      ) async {
+        when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
+        when(
+          () => mockNostrClient.fetchEventById(any()),
+        ).thenAnswer((_) => Future<Event?>.error(Exception('Network error')));
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        expect(find.textContaining('Failed to load video'), findsOneWidget);
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      });
+    });
+
+    group('blocked author', () {
+      testWidgets('renders blocked message for filtered author', (
+        tester,
+      ) async {
+        final video = createTestVideoEvent(
+          id: 'blocked_video_id',
+          pubkey: 'blocked_pubkey',
+          title: 'Blocked Video',
+          videoUrl: 'https://example.com/blocked.mp4',
+        );
+
+        when(
+          () => mockVideoEventService.getVideoById('blocked_video_id'),
+        ).thenReturn(video);
+        when(
+          () => mockBlocklistService.shouldFilterFromFeeds('blocked_pubkey'),
+        ).thenReturn(true);
+
+        await tester.pumpWidget(buildSubject(videoId: 'blocked_video_id'));
+        await tester.pump();
+
+        expect(find.text('This account is not available'), findsOneWidget);
+        expect(find.byType(PooledFullscreenVideoFeedScreen), findsNothing);
+      });
+
+      testWidgets('renders back button for blocked author', (tester) async {
+        final video = createTestVideoEvent(
+          id: 'blocked_video_id',
+          pubkey: 'blocked_pubkey',
+          title: 'Blocked Video',
+          videoUrl: 'https://example.com/blocked.mp4',
+        );
+
+        when(
+          () => mockVideoEventService.getVideoById('blocked_video_id'),
+        ).thenReturn(video);
+        when(
+          () => mockBlocklistService.shouldFilterFromFeeds('blocked_pubkey'),
+        ).thenReturn(true);
+
+        await tester.pumpWidget(buildSubject(videoId: 'blocked_video_id'));
+        await tester.pump();
+
+        expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Opening a shared video deep link (divine.video/video/{eventId}) displayed the wrong video instead of the linked one.

Three bugs were fixed:

Wrong video displayed: VideoDetailScreen delegated to VideoFeedScreen, which completely ignored the startingVideo parameter and always showed the home feed. Replaced with PooledFullscreenVideoFeedScreen wrapping the single deep-linked video.

Route normalization redirect: parseRoute() had no case 'video': handler, so /video/{id} fell through to the default case (RouteType.home). The routeNormalizationProvider then silently redirected to /home/0. Added RouteType.videoDetail with full parseRoute/buildRoute support.

Back navigation: router.go() replaced the entire navigation stack, so pressing back exited the app. Changed to router.push() so the home route stays underneath. Also added a dedup guard since app_links can fire both getInitialLink() and uriLinkStream for the same URL on cold start.

Changes
video_detail_screen.dart — Use PooledFullscreenVideoFeedScreen instead of VideoFeedScreen
page_context_provider.dart — Add RouteType.videoDetail, videoId field on RouteContext, and parseRoute/buildRoute cases for /video/:id
main.dart — Change router.go() to router.push() for deep links; add dedup guard for duplicate URL emissions
active_video_provider.dart — Add RouteType.videoDetail to exhaustive switch
Test plan
 Added video_detail_screen_test.dart — widget tests for loading, cache hit, not found, fetch error, and blocked author states
 Added video detail route parsing tests to route_coverage_test.dart
 Added normalization round-trip tests (buildRoute(parseRoute(path)) == path) for video detail and other key routes
 Manual: share a video link, open it on another device — correct video plays in fullscreen
 Manual: press back from deep-linked video — returns to home screen (single press)
 Manual: deep link to a blocked user's video — shows "This account is not available"

**Related Issue:** Closes #1375 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore