### PR TITLE
fix: progress indicator stuck at Discover Lists bottom

### DIFF
--- a/mobile/lib/screens/discover_lists_screen.dart
+++ b/mobile/lib/screens/discover_lists_screen.dart
@@ -30,6 +30,7 @@ class DiscoverListsScreen extends ConsumerStatefulWidget {
 
 class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen> {
   bool _isLoadingMore = false;
+  bool _hasReachedEnd = false;
   String? _errorMessage;
   StreamSubscription<List<CuratedList>>? _subscription;
   final _scrollController = ScrollController();
@@ -70,9 +71,10 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen> {
   }
 
   void _onScroll() {
-    // Load more when near bottom
-    if (_scrollController.position.pixels >=
-        _scrollController.position.maxScrollExtent - 200) {
+    // Load more when near bottom, but not if we already exhausted results
+    if (!_hasReachedEnd &&
+        _scrollController.position.pixels >=
+            _scrollController.position.maxScrollExtent - 200) {
       _loadMoreLists();
     }
   }
@@ -88,6 +90,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen> {
       _errorMessage = null;
       _isRefreshing = isRefresh;
       _autoPaginationAttempts = 0;
+      _hasReachedEnd = false;
     });
 
     // Set loading state in provider
@@ -200,7 +203,11 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen> {
 
   Future<void> _loadMoreLists() async {
     final providerState = ref.read(discoveredListsProvider);
-    if (_isLoadingMore || providerState.oldestTimestamp == null) return;
+    if (_isLoadingMore ||
+        _hasReachedEnd ||
+        providerState.oldestTimestamp == null) {
+      return;
+    }
 
     setState(() {
       _isLoadingMore = true;
@@ -208,6 +215,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen> {
 
     StreamSubscription<List<CuratedList>>? subscription;
     Timer? timeoutTimer;
+    var foundNewLists = false;
 
     try {
       final service = await ref
@@ -235,6 +243,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen> {
           category: LogCategory.ui,
         );
         subscription?.cancel();
+        subscription = null; // Prevent double-cancel in finally
         if (!completer.isCompleted) completer.complete();
       });
 
@@ -253,6 +262,7 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen> {
               .toList();
 
           if (newLists.isNotEmpty) {
+            foundNewLists = true;
             for (final list in newLists) {
               existingIds.add(list.id);
               // Update oldest timestamp in provider
@@ -265,6 +275,9 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen> {
         },
         onError: (error) {
           Log.error('Pagination error: $error', category: LogCategory.ui);
+          if (!completer.isCompleted) completer.complete();
+        },
+        onDone: () {
           if (!completer.isCompleted) completer.complete();
         },
       );
@@ -280,13 +293,18 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen> {
       timeoutTimer?.cancel();
       await subscription?.cancel();
       if (mounted) {
+        if (!foundNewLists) {
+          _hasReachedEnd = true;
+        }
+
         setState(() {
           _isLoadingMore = false;
         });
 
         // Continue auto-paginating if we still have few results
         final finalState = ref.read(discoveredListsProvider);
-        if (finalState.lists.length < _minListsBeforeAutoPaginate &&
+        if (!_hasReachedEnd &&
+            finalState.lists.length < _minListsBeforeAutoPaginate &&
             finalState.oldestTimestamp != null &&
             _autoPaginationAttempts < _maxAutoPaginationAttempts) {
           _autoPaginationAttempts++;

--- a/mobile/test/screens/discover_lists_screen_test.dart
+++ b/mobile/test/screens/discover_lists_screen_test.dart
@@ -1,0 +1,172 @@
+// ABOUTME: Tests for DiscoverListsScreen pagination behavior
+// ABOUTME: Verifies pagination stops re-triggering when no more lists found
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/list_providers.dart';
+import 'package:openvine/screens/discover_lists_screen.dart';
+import 'package:openvine/services/curated_list_service.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+class _MockCuratedListService extends Mock implements CuratedListService {}
+
+/// Test subclass that exposes a mock service without requiring
+/// the real async initialization (NostrClient, AuthService, etc.).
+class _TestCuratedListsState extends CuratedListsState {
+  _TestCuratedListsState(this._mockService);
+  final CuratedListService? _mockService;
+
+  @override
+  CuratedListService? get service => _mockService;
+
+  @override
+  Future<List<CuratedList>> build() async => [];
+}
+
+/// Pre-populated DiscoveredLists notifier so the screen skips the
+/// initial stream fetch (it only fetches when lists are empty).
+class _PreloadedDiscoveredLists extends DiscoveredLists {
+  _PreloadedDiscoveredLists(this._initialState);
+  final DiscoveredListsState _initialState;
+
+  @override
+  DiscoveredListsState build() => _initialState;
+}
+
+CuratedList _makeList(String id, {DateTime? createdAt}) {
+  return CuratedList(
+    id: id,
+    name: 'List $id',
+    videoEventIds: ['video_$id'],
+    createdAt: createdAt ?? DateTime(2025),
+    updatedAt: createdAt ?? DateTime(2025),
+  );
+}
+
+void main() {
+  group(DiscoverListsScreen, () {
+    late _MockCuratedListService mockService;
+    late List<CuratedList> preloadedLists;
+
+    setUp(() {
+      mockService = _MockCuratedListService();
+
+      // Create enough lists so auto-pagination doesn't kick in
+      // (_minListsBeforeAutoPaginate = 10)
+      preloadedLists = List.generate(
+        15,
+        (i) => _makeList(
+          'list_$i',
+          createdAt: DateTime(2025).subtract(Duration(hours: i)),
+        ),
+      );
+
+      // Default: isSubscribedToList returns false
+      when(() => mockService.isSubscribedToList(any())).thenReturn(false);
+    });
+
+    Widget buildSubject({
+      List<CuratedList>? initialLists,
+      DateTime? oldestTimestamp,
+    }) {
+      final lists = initialLists ?? preloadedLists;
+      final oldest =
+          oldestTimestamp ?? DateTime(2025).subtract(const Duration(hours: 14));
+
+      return ProviderScope(
+        overrides: [
+          ...getStandardTestOverrides(),
+          discoveredListsProvider.overrideWith(
+            () => _PreloadedDiscoveredLists(
+              DiscoveredListsState(lists: lists, oldestTimestamp: oldest),
+            ),
+          ),
+          curatedListsStateProvider.overrideWith(
+            () => _TestCuratedListsState(mockService),
+          ),
+        ],
+        child: const MaterialApp(home: DiscoverListsScreen()),
+      );
+    }
+
+    testWidgets(
+      'scrolling to bottom again after finding no new lists should not '
+      're-trigger pagination',
+      (tester) async {
+        // Each call gets a fresh StreamController. The stream stays open
+        // (no data, no close) so _loadMoreLists relies on its 3-second
+        // timeout timer to complete. The timeout fires within FakeAsync,
+        // resolving the Completer and running the finally block.
+        final controllers = <StreamController<List<CuratedList>>>[];
+
+        when(
+          () => mockService.streamPublicListsFromRelays(
+            until: any(named: 'until'),
+            excludeIds: any(named: 'excludeIds'),
+          ),
+        ).thenAnswer((_) {
+          final c = StreamController<List<CuratedList>>();
+          controllers.add(c);
+          return c.stream;
+        });
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+        await tester.pump();
+
+        // Verify lists are shown and no spinner yet
+        expect(find.byType(Card), findsWidgets);
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+
+        // --- First scroll: triggers pagination ---
+        await tester.drag(find.byType(ListView), const Offset(0, -5000));
+
+        // pump() processes microtasks: _loadMoreLists starts, calls mock,
+        // listens to stream, awaits completer. Stream stays open.
+        await tester.pump();
+        expect(controllers, hasLength(1));
+
+        // Advance past the 3-second timeout. The timer fires within
+        // FakeAsync: cancels subscription, completes the Completer.
+        // elapse() also flushes microtasks after each timer, so the
+        // continuation runs: finally block → _isLoadingMore = false.
+        await tester.pump(const Duration(seconds: 4));
+        // Extra pump to process any remaining microtasks + rebuild
+        await tester.pump();
+
+        // _loadMoreLists should have completed: spinner gone
+        expect(
+          find.byType(CircularProgressIndicator),
+          findsNothing,
+          reason: '_loadMoreLists should have completed via timeout',
+        );
+
+        // --- Second scroll: should NOT trigger pagination again ---
+        // Scroll UP first so the subsequent scroll DOWN actually changes
+        // the position and fires the _onScroll listener at the bottom.
+        await tester.drag(find.byType(ListView), const Offset(0, 500));
+        await tester.pump();
+        await tester.drag(find.byType(ListView), const Offset(0, -5000));
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 4));
+        await tester.pump();
+
+        // With _hasReachedEnd: _onScroll returns early → 1 controller
+        // Without _hasReachedEnd: _loadMoreLists is called again → 2+
+        expect(
+          controllers.length,
+          1,
+          reason:
+              '_loadMoreLists should not be called again after finding '
+              'no new lists (controllers created: ${controllers.length})',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
Bug: Circular spinner stuck at bottom of Discover Lists when scrolling to load more lists that don't exist.

Root cause: _loadMoreLists was re-triggered every time the user scrolled to the bottom, even after finding no new lists.

Fix (2 files):

[discover_lists_screen.dart](vscode-webview://0448oj8gk4lcb8tmqabitic31rj5idg10hh97fmjoshfgcti5d7r/mobile/lib/screens/discover_lists_screen.dart) — Added _hasReachedEnd flag that:

Guards _onScroll from triggering pagination after end is reached
Guards _loadMoreLists entry
Gets set in the finally block when no new lists were found
Gets reset when a fresh stream subscription starts
Also fixed a double-cancel bug on StreamSubscription where the timeout timer and finally block both called cancel(), causing hangs
[discover_lists_screen_test.dart](vscode-webview://0448oj8gk4lcb8tmqabitic31rj5idg10hh97fmjoshfgcti5d7r/mobile/test/screens/discover_lists_screen_test.dart) — New test that:

Validates scrolling to bottom triggers pagination once
Validates scrolling to bottom again after finding no new lists does not re-trigger pagination
Confirmed as non-false-positive (fails without the fix, passes with it)

**Related Issue:** Closes #1374 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore