### PR TITLE
fix(reports): send content reports to moderation relay

### DIFF
--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -175,7 +175,10 @@ class ContentReportingService {
         return ReportResult.failure('Failed to create report event');
       }
 
-      final sentEvent = await _nostrService.publishEvent(reportEvent);
+      final sentEvent = await _nostrService.publishEvent(
+        reportEvent,
+        targetRelays: [moderationRelayUrl],
+      );
       if (sentEvent == null) {
         Log.error(
           'Failed to publish report to relays',

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -136,7 +136,10 @@ void main() {
         ).thenAnswer((_) async => reportEvent);
 
         when(
-          mockNostrService.publishEvent(any),
+          mockNostrService.publishEvent(
+            any,
+            targetRelays: anyNamed('targetRelays'),
+          ),
         ).thenAnswer((_) async => reportEvent);
 
         // Act
@@ -160,8 +163,13 @@ void main() {
           ),
         ).called(1);
 
-        // Verify Nostr event was published
-        verify(mockNostrService.publishEvent(any)).called(1);
+        // Verify Nostr event was published to moderation relay
+        verify(
+          mockNostrService.publishEvent(
+            any,
+            targetRelays: anyNamed('targetRelays'),
+          ),
+        ).called(1);
       },
     );
 
@@ -185,7 +193,10 @@ void main() {
         ).thenAnswer((_) async => reportEvent);
 
         when(
-          mockNostrService.publishEvent(any),
+          mockNostrService.publishEvent(
+            any,
+            targetRelays: anyNamed('targetRelays'),
+          ),
         ).thenAnswer((_) async => reportEvent);
 
         final reasons = ContentFilterReason.values;
@@ -237,7 +248,10 @@ void main() {
       ).thenAnswer((_) async => reportEvent);
 
       when(
-        mockNostrService.publishEvent(any),
+        mockNostrService.publishEvent(
+          any,
+          targetRelays: anyNamed('targetRelays'),
+        ),
       ).thenAnswer((_) async => reportEvent);
 
       // Act - This should not throw an exception due to missing switch case
@@ -271,7 +285,12 @@ void main() {
       ).thenAnswer((_) async => reportEvent);
 
       // Mock failed publish - returns null on failure
-      when(mockNostrService.publishEvent(any)).thenAnswer((_) async => null);
+      when(
+        mockNostrService.publishEvent(
+          any,
+          targetRelays: anyNamed('targetRelays'),
+        ),
+      ).thenAnswer((_) async => null);
 
       // Act
       final result = await service.reportContent(
@@ -308,7 +327,10 @@ void main() {
       ).thenAnswer((_) async => reportEvent);
 
       when(
-        mockNostrService.publishEvent(any),
+        mockNostrService.publishEvent(
+          any,
+          targetRelays: anyNamed('targetRelays'),
+        ),
       ).thenAnswer((_) async => reportEvent);
 
       // Act
@@ -378,7 +400,12 @@ void main() {
         expect(result.error, contains('Failed to create report event'));
 
         // Verify publishEvent was NOT called
-        verifyNever(mockNostrService.publishEvent(any));
+        verifyNever(
+          mockNostrService.publishEvent(
+            any,
+            targetRelays: anyNamed('targetRelays'),
+          ),
+        );
       },
     );
   });
@@ -429,7 +456,10 @@ void main() {
       ).thenAnswer((_) async => reportEvent);
 
       when(
-        mockNostrService.publishEvent(any),
+        mockNostrService.publishEvent(
+          any,
+          targetRelays: anyNamed('targetRelays'),
+        ),
       ).thenAnswer((_) async => reportEvent);
 
       // Now reportContent should work


### PR DESCRIPTION
## Summary
- Content reports (NIP-56 kind 1984) were not reaching `relay.divine.video` because `publishEvent()` was called without `targetRelays`
- Added `targetRelays: [moderationRelayUrl]` so reports are sent to the moderation relay regardless of user's configured relays

Closes #1168

## Test plan
- [x] All 11 existing tests pass with updated mock stubs