### PR TITLE
fix: comments sort toggle overflow by 2.8px

### DIFF
--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_header.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_header.dart
@@ -71,7 +71,7 @@ class VineBottomSheetHeader extends StatelessWidget {
                       if (trailing != null)
                         Positioned(
                           right: 0,
-                          child: SizedBox(width: 62, child: trailing),
+                          child: trailing!,
                         ),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- Removes the hardcoded `SizedBox(width: 62)` constraint on the trailing widget in `VineBottomSheetHeader`
- The "New" sort label (icon + text + padding) needs ~65px, causing a 2.8px RenderFlex overflow
- The trailing widget now sizes itself naturally via `MainAxisSize.min`

Fixes #1394

<img width="220" height="1768" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-02-08 at 18 54 23" src="https://github.com/user-attachments/assets/4f547c66-4eb4-4d81-87f5-e3f40e6dee32" />
<img width="220" height="1768" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-02-08 at 18 54 25" src="https://github.com/user-attachments/assets/d30872c7-dc72-4a69-86cd-2457e1a8980a" />
<img width="220" height="1768" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-02-08 at 18 54 26" src="https://github.com/user-attachments/assets/45eeab74-e677-4eb8-a360-374259f7b72d" />


## Test plan
- [ ] Open comments sheet, cycle through all sort modes (New / Top / Old) — no overflow
- [ ] Verify sort toggle stays right-aligned in the header