### PR TITLE
fix(reports): ensure publishEvent connects to target relays

### DIFF
--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -233,6 +233,11 @@ class NostrClient {
     final sentEvent = await _nostr.sendEvent(
       event,
       targetRelays: targetRelays,
+      // Also pass as tempRelays so the SDK creates temporary connections
+      // to target relays not already in the connected pool. Without this,
+      // targetRelays only filters the existing pool and the event could
+      // be sent to zero relays.
+      tempRelays: targetRelays,
     );
 
     if (sentEvent == null) {

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -158,6 +158,7 @@ void main() {
           () => mockNostr.sendEvent(
             event,
             targetRelays: targetRelays,
+            tempRelays: targetRelays,
           ),
         ).called(1);
       });


### PR DESCRIPTION
## Summary
- Follow-up to #1392. `publishEvent` passes `targetRelays` as `tempRelays` to the SDK so it creates temporary connections to relays not already in the pool.
- Without this, `targetRelays` only filters the existing pool and events (e.g. content reports) could be sent to zero relays if the moderation relay isn't connected.

## Test plan
- [x] Existing `nostr_client` tests updated and passing (226/226)
- [x] `content_reporting_service` tests passing (11/11)
- [x] `dart analyze` clean