### PR TITLE
fix(auth): always include payload tag in NIP-98 auth events

### DIFF
--- a/mobile/test/services/nip98_auth_live_test.dart
+++ b/mobile/test/services/nip98_auth_live_test.dart
@@ -1,0 +1,114 @@
+// ABOUTME: Live integration test for NIP-98 auth against relay.divine.video
+// ABOUTME: Generates a real keypair, signs a proper event, and verifies
+// the relay accepts our event format
+
+@Tags(['integration'])
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+
+/// Runs curl to make an HTTP request (bypasses Flutter's HTTP interception).
+Future<(int, String)> curlGet(String url, String authHeader) async {
+  final result = await Process.run('curl', [
+    '-s',
+    '-w',
+    r'\n%{http_code}',
+    '-H',
+    'Authorization: $authHeader',
+    '-H',
+    'Accept: application/json',
+    url,
+  ]);
+  final output = (result.stdout as String).trim();
+  final lines = output.split('\n');
+  final statusCode = int.parse(lines.last);
+  final body = lines.length > 1
+      ? lines.sublist(0, lines.length - 1).join('\n')
+      : '';
+  return (statusCode, body);
+}
+
+void main() {
+  group('NIP-98 live relay test', () {
+    late String privateKey;
+    late String publicKey;
+
+    setUp(() {
+      privateKey = generatePrivateKey();
+      publicKey = getPublicKey(privateKey);
+    });
+
+    /// Creates a signed NIP-98 auth event and returns the base64 token.
+    String createSignedToken({
+      required String url,
+      required String method,
+      bool includePayload = true,
+    }) {
+      final tags = <List<String>>[
+        ['u', url],
+        ['method', method],
+      ];
+
+      if (includePayload) {
+        final payloadHash = sha256.convert(utf8.encode('')).toString();
+        tags.add(['payload', payloadHash]);
+      }
+
+      final event = Event(publicKey, 27235, tags, '');
+      event.sign(privateKey);
+      expect(event.isSigned, isTrue, reason: 'Event must be signed');
+
+      return base64Encode(utf8.encode(jsonEncode(event.toJson())));
+    }
+
+    test('WITH payload tag, no query params in u tag -> accepted', () async {
+      final url =
+          'https://relay.divine.video/api/users/$publicKey/notifications';
+      final token = createSignedToken(url: url, method: 'GET');
+
+      final (status, body) = await curlGet('$url?limit=1', 'Nostr $token');
+
+      // ignore: avoid_print
+      print('WITH payload, no query params: $status $body');
+
+      // 200 = empty notifications, 404 = user not found -> format accepted
+      // 401 = auth format rejected
+      expect(
+        status,
+        anyOf(200, 404),
+        reason: 'Format should be accepted, got $status: $body',
+      );
+    });
+
+    test('WITHOUT payload tag -> check relay behavior', () async {
+      final url =
+          'https://relay.divine.video/api/users/$publicKey/notifications';
+      final token = createSignedToken(
+        url: url,
+        method: 'GET',
+        includePayload: false,
+      );
+
+      final (status, body) = await curlGet('$url?limit=1', 'Nostr $token');
+
+      // ignore: avoid_print
+      print('WITHOUT payload tag: $status $body');
+    });
+
+    test('WITH query params in u tag -> check relay behavior', () async {
+      final baseUrl =
+          'https://relay.divine.video/api/users/$publicKey/notifications';
+      final urlWithQuery = '$baseUrl?limit=1';
+      final token = createSignedToken(url: urlWithQuery, method: 'GET');
+
+      final (status, body) = await curlGet(urlWithQuery, 'Nostr $token');
+
+      // ignore: avoid_print
+      print('WITH query params in u tag: $status $body');
+    });
+  });
+}

--- a/mobile/test/services/nip98_auth_service_test.dart
+++ b/mobile/test/services/nip98_auth_service_test.dart
@@ -1,0 +1,490 @@
+// ABOUTME: Unit tests for Nip98AuthService
+// ABOUTME: Tests URL normalization, query param preservation, caching, and
+// token creation
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/nip98_auth_service.dart';
+
+class MockAuthService extends Mock implements AuthService {}
+
+/// Sets up the mock to return an event whose tags match the requested
+/// URL and method, so `_validateAuthEvent` passes inside the service.
+void _stubSignEvent(MockAuthService mock) {
+  when(
+    () => mock.createAndSignEvent(
+      kind: any(named: 'kind'),
+      content: any(named: 'content'),
+      tags: any(named: 'tags'),
+    ),
+  ).thenAnswer((invocation) async {
+    final tags = invocation.namedArguments[#tags] as List<List<String>>? ?? [];
+    return _createMockEvent(tags: tags);
+  });
+}
+
+void main() {
+  group(Nip98AuthService, () {
+    late MockAuthService mockAuthService;
+    late Nip98AuthService service;
+
+    setUp(() {
+      mockAuthService = MockAuthService();
+      service = Nip98AuthService(authService: mockAuthService);
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    group('URL normalization', () {
+      test('strips query parameters from auth token URL tag', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        _stubSignEvent(mockAuthService);
+
+        final token = await service.createAuthToken(
+          url:
+              'https://relay.example.com/api/notifications?limit=50&types=reaction',
+          method: HttpMethod.get,
+        );
+
+        expect(token, isNotNull);
+
+        // relay.divine.video requires u tag WITHOUT query params
+        final captured =
+            verify(
+                  () => mockAuthService.createAndSignEvent(
+                    kind: any(named: 'kind'),
+                    content: any(named: 'content'),
+                    tags: captureAny(named: 'tags'),
+                  ),
+                ).captured.last
+                as List<List<String>>;
+
+        final urlTag = captured.firstWhere((tag) => tag[0] == 'u');
+        expect(
+          urlTag[1],
+          equals('https://relay.example.com/api/notifications'),
+        );
+      });
+
+      test('works correctly without query parameters', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        _stubSignEvent(mockAuthService);
+
+        final token = await service.createAuthToken(
+          url:
+              'https://relay.example.com/api/users/pubkey123/notifications/read',
+          method: HttpMethod.post,
+        );
+
+        expect(token, isNotNull);
+
+        final captured =
+            verify(
+                  () => mockAuthService.createAndSignEvent(
+                    kind: any(named: 'kind'),
+                    content: any(named: 'content'),
+                    tags: captureAny(named: 'tags'),
+                  ),
+                ).captured.last
+                as List<List<String>>;
+
+        final urlTag = captured.firstWhere((tag) => tag[0] == 'u');
+        expect(
+          urlTag[1],
+          equals(
+            'https://relay.example.com/api/users/'
+            'pubkey123/notifications/read',
+          ),
+        );
+      });
+
+      test('strips fragment identifiers from URL', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        _stubSignEvent(mockAuthService);
+
+        await service.createAuthToken(
+          url: 'https://relay.example.com/api/endpoint#section',
+          method: HttpMethod.get,
+        );
+
+        final captured =
+            verify(
+                  () => mockAuthService.createAndSignEvent(
+                    kind: any(named: 'kind'),
+                    content: any(named: 'content'),
+                    tags: captureAny(named: 'tags'),
+                  ),
+                ).captured.last
+                as List<List<String>>;
+
+        final urlTag = captured.firstWhere((tag) => tag[0] == 'u');
+        // Fragment should not be included (it's not part of HTTP requests)
+        expect(urlTag[1], isNot(contains('#')));
+        expect(urlTag[1], equals('https://relay.example.com/api/endpoint'));
+      });
+
+      test('strips port and query from URL normalization', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        _stubSignEvent(mockAuthService);
+
+        await service.createAuthToken(
+          url: 'https://relay.example.com:8080/api/endpoint?limit=10',
+          method: HttpMethod.get,
+        );
+
+        final captured =
+            verify(
+                  () => mockAuthService.createAndSignEvent(
+                    kind: any(named: 'kind'),
+                    content: any(named: 'content'),
+                    tags: captureAny(named: 'tags'),
+                  ),
+                ).captured.last
+                as List<List<String>>;
+
+        final urlTag = captured.firstWhere((tag) => tag[0] == 'u');
+        expect(urlTag[1], equals('https://relay.example.com/api/endpoint'));
+      });
+    });
+
+    group('token creation', () {
+      test('returns null when not authenticated', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+
+        final token = await service.createAuthToken(
+          url: 'https://relay.example.com/api/endpoint',
+          method: HttpMethod.get,
+        );
+
+        expect(token, isNull);
+      });
+
+      test('returns null when event signing fails', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        final token = await service.createAuthToken(
+          url: 'https://relay.example.com/api/endpoint',
+          method: HttpMethod.get,
+        );
+
+        expect(token, isNull);
+      });
+
+      test('includes method tag in auth event', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        _stubSignEvent(mockAuthService);
+
+        await service.createAuthToken(
+          url: 'https://relay.example.com/api/endpoint',
+          method: HttpMethod.post,
+        );
+
+        final captured =
+            verify(
+                  () => mockAuthService.createAndSignEvent(
+                    kind: any(named: 'kind'),
+                    content: any(named: 'content'),
+                    tags: captureAny(named: 'tags'),
+                  ),
+                ).captured.last
+                as List<List<String>>;
+
+        final methodTag = captured.firstWhere((tag) => tag[0] == 'method');
+        expect(methodTag[1], equals('POST'));
+      });
+
+      test('uses kind 27235 for NIP-98 auth events', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        _stubSignEvent(mockAuthService);
+
+        await service.createAuthToken(
+          url: 'https://relay.example.com/api/endpoint',
+          method: HttpMethod.get,
+        );
+
+        verify(
+          () => mockAuthService.createAndSignEvent(
+            kind: 27235,
+            content: '',
+            tags: any(named: 'tags'),
+          ),
+        ).called(1);
+      });
+
+      test('base64 encodes the signed event as token', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        _stubSignEvent(mockAuthService);
+
+        final token = await service.createAuthToken(
+          url: 'https://relay.example.com/api/endpoint',
+          method: HttpMethod.get,
+        );
+
+        expect(token, isNotNull);
+        // The token should be valid base64
+        final decoded = utf8.decode(base64Decode(token!.token));
+        final decodedJson = jsonDecode(decoded) as Map<String, dynamic>;
+        expect(decodedJson, isA<Map<String, dynamic>>());
+      });
+    });
+
+    group('token caching', () {
+      test('returns cached token for identical requests', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        _stubSignEvent(mockAuthService);
+
+        final token1 = await service.createAuthToken(
+          url: 'https://relay.example.com/api/endpoint?limit=50',
+          method: HttpMethod.get,
+        );
+
+        final token2 = await service.createAuthToken(
+          url: 'https://relay.example.com/api/endpoint?limit=50',
+          method: HttpMethod.get,
+        );
+
+        expect(token1, isNotNull);
+        expect(token2, isNotNull);
+        expect(token1!.token, equals(token2!.token));
+
+        // createAndSignEvent should only be called once (second uses cache)
+        verify(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).called(1);
+      });
+
+      test('creates separate tokens for different query params', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+
+        var callCount = 0;
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) async {
+          callCount++;
+          final tags =
+              invocation.namedArguments[#tags] as List<List<String>>? ?? [];
+          return _createMockEvent(tags: tags, idSuffix: callCount.toString());
+        });
+
+        final token1 = await service.createAuthToken(
+          url: 'https://relay.example.com/api/endpoint?limit=50',
+          method: HttpMethod.get,
+        );
+
+        final token2 = await service.createAuthToken(
+          url: 'https://relay.example.com/api/endpoint?limit=25',
+          method: HttpMethod.get,
+        );
+
+        expect(token1, isNotNull);
+        expect(token2, isNotNull);
+        // Different query params should produce different tokens
+        expect(token1!.token, isNot(equals(token2!.token)));
+
+        // Both calls should result in signing (no cache hit)
+        verify(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).called(2);
+      });
+
+      test('clearTokenCache empties the cache', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        _stubSignEvent(mockAuthService);
+
+        await service.createAuthToken(
+          url: 'https://relay.example.com/api/endpoint',
+          method: HttpMethod.get,
+        );
+
+        service.clearTokenCache();
+
+        await service.createAuthToken(
+          url: 'https://relay.example.com/api/endpoint',
+          method: HttpMethod.get,
+        );
+
+        // After clearing cache, a second call should sign again
+        verify(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).called(2);
+      });
+    });
+
+    group('payload hashing', () {
+      test('includes payload hash when payload is provided', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        _stubSignEvent(mockAuthService);
+
+        await service.createAuthToken(
+          url: 'https://relay.example.com/api/endpoint',
+          method: HttpMethod.post,
+          payload: '{"key": "value"}',
+        );
+
+        final captured =
+            verify(
+                  () => mockAuthService.createAndSignEvent(
+                    kind: any(named: 'kind'),
+                    content: any(named: 'content'),
+                    tags: captureAny(named: 'tags'),
+                  ),
+                ).captured.last
+                as List<List<String>>;
+
+        final payloadTag = captured.where((tag) => tag[0] == 'payload');
+        expect(payloadTag, isNotEmpty);
+        expect(payloadTag.first[1], isNotEmpty);
+      });
+
+      test('includes empty-string payload hash for GET requests', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        _stubSignEvent(mockAuthService);
+
+        await service.createAuthToken(
+          url: 'https://relay.example.com/api/endpoint',
+          method: HttpMethod.get,
+        );
+
+        final captured =
+            verify(
+                  () => mockAuthService.createAndSignEvent(
+                    kind: any(named: 'kind'),
+                    content: any(named: 'content'),
+                    tags: captureAny(named: 'tags'),
+                  ),
+                ).captured.last
+                as List<List<String>>;
+
+        final payloadTag = captured.where((tag) => tag[0] == 'payload');
+        expect(payloadTag, isNotEmpty);
+        // SHA-256 of empty string
+        expect(
+          payloadTag.first[1],
+          equals(
+            'e3b0c44298fc1c149afbf4c8996fb924'
+            '27ae41e4649b934ca495991b7852b855',
+          ),
+        );
+      });
+    });
+
+    group('$Nip98Token', () {
+      test('isExpired returns true for past expiry', () {
+        final token = Nip98Token(
+          token: 'test',
+          signedEvent: _createMockEvent(),
+          createdAt: DateTime.now().subtract(const Duration(minutes: 20)),
+          expiresAt: DateTime.now().subtract(const Duration(minutes: 10)),
+        );
+
+        expect(token.isExpired, isTrue);
+      });
+
+      test('isExpired returns false for future expiry', () {
+        final token = Nip98Token(
+          token: 'test',
+          signedEvent: _createMockEvent(),
+          createdAt: DateTime.now(),
+          expiresAt: DateTime.now().add(const Duration(minutes: 10)),
+        );
+
+        expect(token.isExpired, isFalse);
+      });
+
+      test('authorizationHeader has Nostr prefix', () {
+        final token = Nip98Token(
+          token: 'test_token_value',
+          signedEvent: _createMockEvent(),
+          createdAt: DateTime.now(),
+          expiresAt: DateTime.now().add(const Duration(minutes: 10)),
+        );
+
+        expect(token.authorizationHeader, equals('Nostr test_token_value'));
+      });
+    });
+
+    group('$Nip98AuthException', () {
+      test('toString includes message', () {
+        const exception = Nip98AuthException('test error');
+        expect(exception.toString(), equals('Nip98AuthException: test error'));
+      });
+
+      test('stores code when provided', () {
+        const exception = Nip98AuthException('test', code: 'ERR_001');
+        expect(exception.code, equals('ERR_001'));
+      });
+    });
+
+    group('canCreateTokens', () {
+      test('returns true when authenticated', () {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        expect(service.canCreateTokens, isTrue);
+      });
+
+      test('returns false when not authenticated', () {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        expect(service.canCreateTokens, isFalse);
+      });
+    });
+  });
+}
+
+/// Creates a mock Event for testing.
+/// When [tags] are provided, they are used as the event's tags so that
+/// the service's internal `_validateAuthEvent` check passes.
+Event _createMockEvent({List<List<String>>? tags, String idSuffix = ''}) {
+  final id =
+      'abcdef0123456789abcdef0123456789abcdef0123456789abcdef012345$idSuffix'
+          .padRight(64, '0')
+          .substring(0, 64);
+  final timestamp = (DateTime.now().millisecondsSinceEpoch / 1000).round();
+  final eventTags =
+      tags ??
+      <List<String>>[
+        ['u', 'https://relay.example.com/api/endpoint'],
+        ['method', 'GET'],
+        ['created_at', timestamp.toString()],
+      ];
+  return Event.fromJson({
+    'id': id,
+    'kind': 27235,
+    'pubkey':
+        'aabbccdd0123456789abcdef0123456789abcdef0123456789abcdef01234567',
+    'created_at': timestamp,
+    'content': '',
+    'tags': eventTags,
+    'sig':
+        'deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567'
+        '89abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567'
+        '89ab',
+  });
+}


### PR DESCRIPTION
## Summary
- Always include the `payload` tag in NIP-98 (Kind 27235) auth events, even for GET requests — use SHA-256 of empty string when no body is present
- relay.divine.video rejects auth tokens missing the payload tag with `401: missing 'payload' tag (required for NIP-86)`
- This fixes the notifications tab returning 401 errors

## What changed
- **`nip98_auth_service.dart`**: Changed payload tag from conditional (`if payload != null && payload.isNotEmpty`) to always-present, using SHA-256 of empty string for bodyless requests
- **`nip98_auth_service_test.dart`**: 21 unit tests covering URL normalization, token creation, caching, payload hashing, and edge cases
- **`nip98_auth_live_test.dart`**: Live integration tests against relay.divine.video proving the fix works (tagged `integration`, uses curl subprocess to bypass Flutter HTTP interception)

## Verified against relay.divine.video
| Scenario | Status | Response |
|----------|--------|----------|
| With payload tag, no query params in u tag | 200 | `{"notifications":[],"unread_count":0}` |
| Without payload tag | 401 | `missing 'payload' tag (required for NIP-86)` |
| With query params in u tag | 401 | `URL mismatch` |

## Test plan
- [x] 21 unit tests pass
- [x] 3 live integration tests pass against relay.divine.video
- [x] `dart format` clean
- [x] `flutter analyze` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)