### PR TITLE
perf(profile): reduce profile load time from 16s to ~1-2s

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -791,17 +791,19 @@ UserProfileService userProfileService(Ref ref) {
   return service;
 }
 
-/// Social service depends on Nostr service and Auth service
+/// Social service depends on Nostr service, Auth service, and Analytics API
 @Riverpod(keepAlive: true)
 SocialService socialService(Ref ref) {
   final nostrService = ref.watch(nostrServiceProvider);
   final authService = ref.watch(authServiceProvider);
   final personalEventCache = ref.watch(personalEventCacheServiceProvider);
+  final analyticsApiService = ref.watch(analyticsApiServiceProvider);
 
   return SocialService(
     nostrService,
     authService,
     personalEventCache: personalEventCache,
+    analyticsApiService: analyticsApiService,
   );
 }
 

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -2301,17 +2301,17 @@ final class UserProfileServiceProvider
 String _$userProfileServiceHash() =>
     r'c794efc557e51b13c9cf3ff59fd3f56f1582cbd0';
 
-/// Social service depends on Nostr service and Auth service
+/// Social service depends on Nostr service, Auth service, and Analytics API
 
 @ProviderFor(socialService)
 const socialServiceProvider = SocialServiceProvider._();
 
-/// Social service depends on Nostr service and Auth service
+/// Social service depends on Nostr service, Auth service, and Analytics API
 
 final class SocialServiceProvider
     extends $FunctionalProvider<SocialService, SocialService, SocialService>
     with $Provider<SocialService> {
-  /// Social service depends on Nostr service and Auth service
+  /// Social service depends on Nostr service, Auth service, and Analytics API
   const SocialServiceProvider._()
     : super(
         from: null,
@@ -2345,7 +2345,7 @@ final class SocialServiceProvider
   }
 }
 
-String _$socialServiceHash() => r'5b4d5751d3f2ef22c9ee2610cda1c4e70b2302a7';
+String _$socialServiceHash() => r'f3e43d187c9560fd9db5fe9925238eeb18048fff';
 
 /// Provider for FollowRepository instance
 ///

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -89,7 +89,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'9b4c130c01f1a064163e13a3bd75b1c73b105a68';
+String _$profileFeedHash() => r'bcf0081ba23a169da17366803e788c9a59100902';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -18,7 +18,6 @@ import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_content.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_result.dart';
 import 'package:openvine/widgets/profile/profile_grid_view.dart';
-import 'package:openvine/widgets/profile/profile_loading_view.dart';
 
 /// Fullscreen profile screen for viewing other users' profiles.
 ///
@@ -379,27 +378,22 @@ class _OtherProfileScreenState extends ConsumerState<OtherProfileScreen> {
           ),
         ],
       ),
-      body: switch (videosAsync) {
-        AsyncLoading() => const ProfileLoadingView(),
-        AsyncError(:final error) => Center(
-          child: Text(
-            'Error: $error',
-            style: const TextStyle(color: Colors.white),
-          ),
-        ),
-        AsyncData(:final value) => ProfileGridView(
-          userIdHex: userIdHex,
-          isOwnProfile: false,
-          displayName: displayName,
-          videos: value.videos,
-          profileStatsAsync: profileStatsAsync,
-          scrollController: _scrollController,
-          onBlockedTap: _showUnblockConfirmation,
-          displayNameHint: widget.displayNameHint,
-          avatarUrlHint: widget.avatarUrlHint,
-          refreshNotifier: _refreshNotifier,
-        ),
-      },
+      body: ProfileGridView(
+        userIdHex: userIdHex,
+        isOwnProfile: false,
+        displayName: displayName,
+        videos: videosAsync.asData?.value.videos ?? [],
+        profileStatsAsync: profileStatsAsync,
+        scrollController: _scrollController,
+        onBlockedTap: _showUnblockConfirmation,
+        displayNameHint: widget.displayNameHint,
+        avatarUrlHint: widget.avatarUrlHint,
+        refreshNotifier: _refreshNotifier,
+        isLoadingVideos: videosAsync is AsyncLoading,
+        videoLoadError: videosAsync is AsyncError
+            ? (videosAsync as AsyncError).error.toString()
+            : null,
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/profile/profile_grid_view.dart
+++ b/mobile/lib/widgets/profile/profile_grid_view.dart
@@ -35,6 +35,8 @@ class ProfileGridView extends ConsumerStatefulWidget {
     this.displayNameHint,
     this.avatarUrlHint,
     this.refreshNotifier,
+    this.isLoadingVideos = false,
+    this.videoLoadError,
     super.key,
   });
 
@@ -77,6 +79,14 @@ class ProfileGridView extends ConsumerStatefulWidget {
   /// Notifier that triggers BLoC refresh when its value changes.
   /// Parent should call `notifier.value++` to trigger refresh.
   final ValueNotifier<int>? refreshNotifier;
+
+  /// Whether videos are currently being loaded.
+  /// When true and [videos] is empty, shows a loading indicator
+  /// in the videos tab instead of the empty state.
+  final bool isLoadingVideos;
+
+  /// Error message if video loading failed, shown in the videos tab.
+  final String? videoLoadError;
 
   @override
   ConsumerState<ProfileGridView> createState() => _ProfileGridViewState();
@@ -211,7 +221,12 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
       child: TabBarView(
         controller: _tabController,
         children: [
-          ProfileVideosGrid(videos: widget.videos, userIdHex: widget.userIdHex),
+          ProfileVideosGrid(
+            videos: widget.videos,
+            userIdHex: widget.userIdHex,
+            isLoading: widget.isLoadingVideos,
+            errorMessage: widget.videoLoadError,
+          ),
           ProfileLikedGrid(isOwnProfile: widget.isOwnProfile),
           ProfileRepostsGrid(isOwnProfile: widget.isOwnProfile),
         ],

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -37,11 +37,19 @@ class ProfileVideosGrid extends ConsumerWidget {
   const ProfileVideosGrid({
     required this.videos,
     required this.userIdHex,
+    this.isLoading = false,
+    this.errorMessage,
     super.key,
   });
 
   final List<VideoEvent> videos;
   final String userIdHex;
+
+  /// Whether videos are currently being loaded.
+  final bool isLoading;
+
+  /// Error message if video loading failed.
+  final String? errorMessage;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -55,7 +63,14 @@ class ProfileVideosGrid extends ConsumerWidget {
       ...videos.map(_GridVideoEventEntry.new),
     ];
 
+    if (errorMessage != null && allVideos.isEmpty) {
+      return _ProfileVideosErrorState(errorMessage: errorMessage!);
+    }
+
     if (allVideos.isEmpty) {
+      if (isLoading) {
+        return const _ProfileVideosLoadingState();
+      }
       return _ProfileVideosEmptyState(
         userIdHex: userIdHex,
         isOwnProfile:
@@ -246,6 +261,72 @@ class _VideoThumbnail extends StatelessWidget {
     }
     return const _ThumbnailPlaceholder();
   }
+}
+
+/// Loading state shown while videos are being fetched.
+class _ProfileVideosLoadingState extends StatelessWidget {
+  const _ProfileVideosLoadingState();
+
+  @override
+  Widget build(BuildContext context) => const CustomScrollView(
+    slivers: [
+      SliverFillRemaining(
+        hasScrollBody: false,
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CircularProgressIndicator(color: VineTheme.vineGreen),
+              SizedBox(height: 16),
+              Text(
+                'Loading videos...',
+                style: TextStyle(color: VineTheme.secondaryText, fontSize: 14),
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  );
+}
+
+/// Error state shown when video loading fails.
+class _ProfileVideosErrorState extends StatelessWidget {
+  const _ProfileVideosErrorState({required this.errorMessage});
+
+  final String errorMessage;
+
+  @override
+  Widget build(BuildContext context) => CustomScrollView(
+    slivers: [
+      SliverFillRemaining(
+        hasScrollBody: false,
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                Icons.error_outline,
+                color: VineTheme.secondaryText,
+                size: 48,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Error: $errorMessage',
+                style: const TextStyle(
+                  color: VineTheme.primaryText,
+                  fontSize: 14,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    ],
+  );
 }
 
 /// Flat color placeholder for thumbnails


### PR DESCRIPTION
## Summary

- **Use Funnelcake REST API for follower/following counts** — `getSocialCounts()` endpoint already existed but was never called. Replaces two sequential WebSocket queries with 8-second fallback timeouts each. WebSocket fallback now runs in parallel.
- **Reduce Nostr fallback timeouts** — Initial wait 3s→1.5s, retry skipped entirely when EOSE arrives fast with 0 results (user has no videos), retry timeout 5s→2s. For 0-video profiles: ~8s→~0.3s.
- **Progressive profile rendering** — Profile header (name, avatar, bio, stats) renders immediately (~800ms) instead of blocking behind a full-screen spinner until video feed resolves. Video grid shows its own loading indicator.

### Before
Profile tap → 16 seconds of loading spinner → profile appears

### After
Profile tap → ~800ms header visible → videos load independently in background

### Root cause breakdown

| Bottleneck | Before | After |
|------------|--------|-------|
| Follower stats (WebSocket 8s timeout x2, sequential) | 8-16s | ~300ms (REST API) |
| Video feed for 0-video users (3s + 5s retry) | 8s | ~0.3s (skip useless retry) |
| Full-screen loading spinner blocking header | 16s perceived | ~800ms (progressive) |

### Files changed

| File | Change |
|------|--------|
| `social_service.dart` | REST-first follower stats, parallel WebSocket fallback |
| `app_providers.dart` | Pass AnalyticsApiService to SocialService |
| `profile_feed_provider.dart` | Reduced timeouts, smart retry skip |
| `other_profile_screen.dart` | Progressive rendering, no full-screen block |
| `profile_grid_view.dart` | Added isLoadingVideos + videoLoadError params |
| `profile_videos_grid.dart` | Loading/error states for video grid area |

## Test plan

- [ ] Open profile of user WITH videos — header appears fast, video grid loads shortly after
- [ ] Open profile of user WITHOUT videos — header appears fast, empty state shown quickly (no 16s wait)
- [ ] Verify follower/following counts display correctly via REST API
- [ ] Test with airplane mode / poor connectivity — should fall back to WebSocket gracefully
- [ ] Verify existing profile feed tests pass (22 passed, 0 failed)
- [ ] Verify profile stats tests pass (4 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)