### PR TITLE
fix(profile): use VineTheme brand colors for profile color picker

### DIFF
--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -1724,16 +1724,16 @@ class _ProfileColorPicker extends StatelessWidget {
   final Color? selectedColor;
   final ValueChanged<Color?> onColorChanged;
 
-  // Preset colors inspired by classic Vine profile colors
+  // Preset colors from VineTheme brand accent palette
   static const _presetColors = [
-    Color(0xFF33CCBF), // Teal (Vine default)
-    Color(0xFF6B93D6), // Blue
-    Color(0xFF9B59B6), // Purple
-    Color(0xFFE74C3C), // Red
-    Color(0xFFF39C12), // Orange
-    Color(0xFF2ECC71), // Green
-    Color(0xFFE91E63), // Pink
-    Color(0xFF00BCD4), // Cyan
+    VineTheme.vineGreen, // Green (brand primary)
+    VineTheme.accentBlue, // Blue
+    VineTheme.accentPurple, // Purple
+    VineTheme.likeRed, // Red
+    VineTheme.accentOrange, // Orange
+    VineTheme.accentLime, // Lime
+    VineTheme.accentPink, // Pink
+    VineTheme.accentViolet, // Violet
   ];
 
   @override
@@ -1843,7 +1843,7 @@ class _CustomColorButton extends StatelessWidget {
   }
 
   Future<void> _showColorPicker(BuildContext context) async {
-    Color pickerColor = currentColor ?? const Color(0xFF33CCBF);
+    Color pickerColor = currentColor ?? VineTheme.vineGreen;
 
     final result = await showDialog<Color>(
       context: context,


### PR DESCRIPTION
## Summary

- Replace 8 generic hardcoded hex colors in the profile color picker with VineTheme brand accent constants
- Update custom color picker default fallback from hardcoded `#33CCBF` to `VineTheme.vineGreen`

## Before / After

| Slot | Before (generic) | After (brand) |
|------|-------------------|---------------|
| 1 | `#33CCBF` (random teal) | `vineGreen` |
| 2 | `#6B93D6` (random blue) | `accentBlue` |
| 3 | `#9B59B6` (random purple) | `accentPurple` |
| 4 | `#E74C3C` (random red) | `likeRed` |
| 5 | `#F39C12` (random orange) | `accentOrange` |
| 6 | `#2ECC71` (random green) | `accentLime` |
| 7 | `#E91E63` (random pink) | `accentPink` |
| 8 | `#00BCD4` (random cyan) | `accentViolet` |

Existing users who already picked a color are unaffected — their hex value is stored in the profile and renders correctly regardless of preset changes.

## Test plan

- [x] `dart analyze` passes
- [ ] Manual: open profile setup, verify 8 color swatches match brand palette
- [ ] Manual: select a brand color, verify it applies to profile header

🤖 Generated with [Claude Code](https://claude.com/claude-code)