### PR TITLE
fix(profile): copy button shares profile URL instead of npub

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -519,11 +519,14 @@ class _UniqueIdentifier extends ConsumerWidget {
             Padding(
               padding: const EdgeInsets.only(left: 8),
               child: GestureDetector(
-                onTap: () => ClipboardUtils.copy(
-                  context,
-                  npub,
-                  message: 'Unique ID copied to clipboard',
-                ),
+                onTap: () {
+                  final profileUrl = buildProfileUrl(nip05, npub);
+                  ClipboardUtils.copy(
+                    context,
+                    profileUrl,
+                    message: 'Profile link copied',
+                  );
+                },
                 child: SvgPicture.asset(
                   'assets/icon/copy.svg',
                   width: 24,
@@ -559,6 +562,26 @@ class _UniqueIdentifier extends ConsumerWidget {
       ],
     );
   }
+}
+
+/// Build a shareable profile URL.
+///
+/// If the user has a `.divine.video` NIP-05 subdomain (e.g. `_@thomas.divine.video`),
+/// returns `https://thomas.divine.video`. Otherwise falls back to
+/// `https://divine.video/profile/{npub}`.
+@visibleForTesting
+String buildProfileUrl(String? nip05, String npub) {
+  if (nip05 != null && nip05.isNotEmpty) {
+    // NIP-05 format: `_@username.divine.video` or `user@domain.com`
+    final atIndex = nip05.indexOf('@');
+    if (atIndex != -1) {
+      final domain = nip05.substring(atIndex + 1);
+      if (domain.endsWith('.divine.video')) {
+        return 'https://$domain';
+      }
+    }
+  }
+  return 'https://divine.video/profile/$npub';
 }
 
 /// About/bio text display with expandable "Show more/less" functionality.

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -573,4 +573,44 @@ void main() {
       });
     });
   });
+
+  group('buildProfileUrl', () {
+    const testNpub =
+        'npub10z98cqe5kehs5wfnax59vqzuyd7puhr2dyy0g5ha5kxc83h38yts0z3mgg';
+
+    test('returns subdomain URL for divine.video NIP-05', () {
+      expect(
+        buildProfileUrl('_@thomassanders.divine.video', testNpub),
+        equals('https://thomassanders.divine.video'),
+      );
+    });
+
+    test('returns subdomain URL for user@subdomain.divine.video NIP-05', () {
+      expect(
+        buildProfileUrl('user@rabble.divine.video', testNpub),
+        equals('https://rabble.divine.video'),
+      );
+    });
+
+    test('returns npub profile URL for non-divine.video NIP-05', () {
+      expect(
+        buildProfileUrl('alice@example.com', testNpub),
+        equals('https://divine.video/profile/$testNpub'),
+      );
+    });
+
+    test('returns npub profile URL when NIP-05 is null', () {
+      expect(
+        buildProfileUrl(null, testNpub),
+        equals('https://divine.video/profile/$testNpub'),
+      );
+    });
+
+    test('returns npub profile URL when NIP-05 is empty', () {
+      expect(
+        buildProfileUrl('', testNpub),
+        equals('https://divine.video/profile/$testNpub'),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Profile copy button now copies a shareable URL instead of the raw npub
- For `*.divine.video` users: copies `https://username.divine.video`
- For others: copies `https://divine.video/profile/{npub}`
- Snackbar message updated to "Profile link copied"

## Test plan
- [x] 5 new unit tests for `buildProfileUrl` covering divine.video subdomains, non-divine NIP-05s, null, and empty
- [x] 16 existing profile header widget tests still pass
- [x] Static analysis clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)