### PR TITLE
fix(ui): remove black corners on bottom sheet

### DIFF
--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -95,6 +95,7 @@ class CommentsScreen extends ConsumerWidget {
       isScrollControlled: true,
       useRootNavigator: true,
       backgroundColor: Colors.transparent,
+      elevation: 0,
       builder: (builderContext) {
         final keyboardHeight = MediaQuery.of(builderContext).viewInsets.bottom;
         final isKeyboardOpen = keyboardHeight > 0;
@@ -105,19 +106,10 @@ class CommentsScreen extends ConsumerWidget {
           maxChildSize: 0.93,
           snap: true,
           snapSizes: [0.7, 0.93],
-          builder: (context, scrollController) => DecoratedBox(
-            decoration: const BoxDecoration(
-              color: Colors.black87,
-              borderRadius: BorderRadius.only(
-                topLeft: Radius.circular(20),
-                topRight: Radius.circular(20),
-              ),
-            ),
-            child: CommentsScreen(
-              videoEvent: video,
-              sheetScrollController: scrollController,
-              initialCommentCount: initialCommentCount,
-            ),
+          builder: (context, scrollController) => CommentsScreen(
+            videoEvent: video,
+            sheetScrollController: scrollController,
+            initialCommentCount: initialCommentCount,
           ),
         );
       },

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
@@ -128,6 +128,7 @@ class VineBottomSheet extends StatelessWidget {
         isScrollControlled: true,
         useSafeArea: true,
         backgroundColor: Colors.transparent,
+        elevation: 0,
         builder: (_) => DraggableScrollableSheet(
           initialChildSize: initialChildSize,
           minChildSize: minChildSize,
@@ -153,6 +154,7 @@ class VineBottomSheet extends StatelessWidget {
         isScrollControlled: isScrollControlled ?? expanded,
         useSafeArea: true,
         backgroundColor: Colors.transparent,
+        elevation: 0,
         builder: (_) => VineBottomSheet(
           scrollable: false,
           title: title,


### PR DESCRIPTION
## Summary

- Remove redundant `DecoratedBox` wrapper in `CommentsScreen.show()` that had mismatched border radius (`20px`) and color (`Colors.black87`) vs the inner `VineBottomSheet` (`32px`, `surfaceBackground`)
- Add `elevation: 0` to `showModalBottomSheet` calls in `VineBottomSheet.show()` to prevent Material shadow artifacts

Closes #1413