### PR TITLE
fix(video-preview): improve aspect ratio handling for vertical videos

### DIFF
--- a/mobile/lib/constants/video_editor_constants.dart
+++ b/mobile/lib/constants/video_editor_constants.dart
@@ -107,6 +107,9 @@ class VideoEditorConstants {
 
   /// Height of the bottom action bar in the video editor.
   static const double bottomBarHeight = 90;
+
+  /// Hero animation tag for the back button in the video editor.
+  static const heroBackButtonId = 'Video-Editor-Back-Button';
 }
 
 /// Constants for the video editor clip gallery layout and animations.

--- a/mobile/lib/screens/video_metadata/video_metadata_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_bottom_bar.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_clip_preview.dart';
@@ -74,22 +75,25 @@ class _VideoMetadataScreenState extends ConsumerState<VideoMetadataScreen> {
         child: Stack(
           children: [
             Scaffold(
-              backgroundColor: const Color(0xFF000A06),
+              backgroundColor: VineTheme.surfaceContainerHigh,
               appBar: AppBar(
                 backgroundColor: Colors.transparent,
                 surfaceTintColor: Colors.transparent,
-                leading: IconButton(
-                  padding: const .all(8),
-                  icon: SizedBox(
-                    width: 32,
-                    height: 32,
-                    child: SvgPicture.asset(
-                      'assets/icon/CaretLeft.svg',
-                      colorFilter: const .mode(Colors.white, .srcIn),
+                leading: Hero(
+                  tag: VideoEditorConstants.heroBackButtonId,
+                  child: IconButton(
+                    padding: const .all(8),
+                    icon: SizedBox(
+                      width: 32,
+                      height: 32,
+                      child: SvgPicture.asset(
+                        'assets/icon/CaretLeft.svg',
+                        colorFilter: const .mode(Colors.white, .srcIn),
+                      ),
                     ),
+                    onPressed: () => context.pop(),
+                    tooltip: 'Back',
                   ),
-                  onPressed: () => context.pop(),
-                  tooltip: 'Back',
                 ),
                 title: Text(
                   'Post details',


### PR DESCRIPTION
## Description

Until now, when users opened the metadata screen to see what the recorded/edited video would look like in their feed, the video was forced to be 9:16, rather than the available screen size, as it would be in the feed. This PR changed that behavior so that it now matches how it will look in the user's feed, except for when users use the square aspect ratio. In that case, it will not be stretched.

In addition, it adds a hero animation to the back button so that it does not conflict with the preview video.

**Related Issue:** Closes #1423

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore