### PR TITLE
feat: add message for error widget instead of orange box

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -346,21 +346,32 @@ Future<void> _startOpenVineApp() async {
   };
 
   // Configure global error widget builder for user-friendly error display
-  // IMPORTANT: Use only the most basic widgets - even Text requires directionality context
-  // This is only for early startup errors before MaterialApp is ready
+  // Wrap in Directionality to enable Text widgets even before MaterialApp is ready
   ErrorWidget.builder = (FlutterErrorDetails details) {
-    // Use only basic Container and Decoration - no Text widgets at all
-    return Container(
-      color: const Color(0xFF1A1A1A),
-      child: const Center(
-        child: SizedBox(
-          width: 100,
-          height: 100,
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: Colors.orange,
-              borderRadius: BorderRadius.all(Radius.circular(8)),
-            ),
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Container(
+        color: VineTheme.backgroundColor,
+        child: const Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.error_outline_rounded,
+                color: VineTheme.accentOrange,
+                size: 48,
+              ),
+              SizedBox(height: 16),
+              Text(
+                'Oops, something went wrong',
+                style: TextStyle(
+                  color: VineTheme.whiteText,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                  decoration: TextDecoration.none,
+                ),
+              ),
+            ],
           ),
         ),
       ),
@@ -523,6 +534,7 @@ Future<void> _startOpenVineApp() async {
 
   // Initialize the player pool singleton
   await PlayerPool.init();
+
   runApp(
     UncontrolledProviderScope(container: container, child: const DivineApp()),
   );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

Closes #1419 

Square orange was displayed when something went wrong during build method. Changed that to a text message so at least user knows something went wrong.

<img width="504" height="996" alt="image" src="https://github.com/user-attachments/assets/e34e818a-d0a2-4942-8f1d-f23acebf6ebf" />

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore