### PR TITLE
fix: pause player when dispose and set initial index when open

### DIFF
--- a/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_feed.dart
+++ b/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_feed.dart
@@ -102,6 +102,7 @@ class PooledVideoFeedState extends State<PooledVideoFeed> {
       _controller = VideoFeedController(
         videos: widget.videos,
         pool: _effectivePool,
+        initialIndex: _currentIndex,
         preloadAhead: widget.preloadAhead,
         preloadBehind: widget.preloadBehind,
       );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
                                                                                                                                                                                                                                        
  - Added initialIndex parameter: The controller now accepts an initialIndex to start playback at a specific position in the video list. The preload window is centered around this index instead of always starting at 0. The value is 
  clamped to valid bounds.                                                                                                                                                                                                              
  - Fixed dispose to properly release players: On dispose, the controller now calls pool.release(url) for all loaded players instead of just pausing them. This ensures players are fully stopped and removed from the pool, so fresh players are created when the screen is reopened. This fixes the issue where sound continued playing after navigating back, and videos wouldn't replay when returning to the feed. 

Part of#1269

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore