### PR TITLE
fix: normalize Nostr IDs to lowercase at Funnelcake API boundary

### DIFF
--- a/mobile/lib/providers/home_feed_provider.dart
+++ b/mobile/lib/providers/home_feed_provider.dart
@@ -533,7 +533,10 @@ class HomeFeed extends _$HomeFeed {
     );
 
     // Track IDs of videos from followed users for deduplication
-    final followingVideoIds = followingVideos.map((v) => v.id).toSet();
+    // Use lowercase for case-insensitive comparison (NIP-01 normalization)
+    final followingVideoIds = followingVideos
+        .map((v) => v.id.toLowerCase())
+        .toSet();
 
     // Merge videos from subscribed curated lists
     final subscribedListCache = ref.read(subscribedListVideoCacheProvider);
@@ -549,7 +552,7 @@ class HomeFeed extends _$HomeFeed {
       if (listIds.isNotEmpty) {
         videoListSources[video.id] = listIds;
 
-        if (!followingVideoIds.contains(video.id)) {
+        if (!followingVideoIds.contains(video.id.toLowerCase())) {
           // Video is ONLY in feed because of subscribed list, not from follows
           listOnlyVideoIds.add(video.id);
           followingVideos.add(video);
@@ -922,7 +925,7 @@ class HomeFeed extends _$HomeFeed {
         // Merge subscribed list videos
         final subscribedListCache = ref.read(subscribedListVideoCacheProvider);
         final subscribedVideos = subscribedListCache?.getVideos() ?? [];
-        final followingVideoIds = videos.map((v) => v.id).toSet();
+        final followingVideoIds = videos.map((v) => v.id.toLowerCase()).toSet();
         final listOnlyVideoIds = <String>{};
         final videoListSources = <String, Set<String>>{};
 
@@ -930,7 +933,7 @@ class HomeFeed extends _$HomeFeed {
           final listIds = subscribedListCache?.getListsForVideo(video.id) ?? {};
           if (listIds.isNotEmpty) {
             videoListSources[video.id] = listIds;
-            if (!followingVideoIds.contains(video.id)) {
+            if (!followingVideoIds.contains(video.id.toLowerCase())) {
               listOnlyVideoIds.add(video.id);
               videos.add(video);
             }

--- a/mobile/lib/providers/home_feed_provider.g.dart
+++ b/mobile/lib/providers/home_feed_provider.g.dart
@@ -116,7 +116,7 @@ final class HomeFeedProvider
   HomeFeed create() => HomeFeed();
 }
 
-String _$homeFeedHash() => r'e6ea688eb641dc304e9a3e1b2d24cf9ce799ec41';
+String _$homeFeedHash() => r'6472ca82c11e0b63dff3b63eecb6a7381847eef5';
 
 /// Home feed provider - shows videos only from people you follow
 ///

--- a/mobile/lib/providers/list_providers.dart
+++ b/mobile/lib/providers/list_providers.dart
@@ -351,16 +351,16 @@ Stream<List<VideoEvent>> curatedListVideoEvents(Ref ref, String listId) async* {
 
     if (filters.isNotEmpty) {
       final eventStream = nostrService.subscribe(filters);
-      final seenIds = foundVideos.map((v) => v.id).toSet();
+      final seenIds = foundVideos.map((v) => v.id.toLowerCase()).toSet();
 
       await for (final event in eventStream) {
-        if (seenIds.contains(event.id)) continue;
+        if (seenIds.contains(event.id.toLowerCase())) continue;
 
         try {
           // Use permissive mode to accept all NIP-71 video kinds from curated lists
           final video = VideoEvent.fromNostrEvent(event, permissive: true);
           foundVideos.add(video);
-          seenIds.add(event.id);
+          seenIds.add(event.id.toLowerCase());
 
           // Also add to the video event service cache
           videoEventService.addVideoEvent(video);
@@ -550,16 +550,16 @@ Stream<List<VideoEvent>> videoEventsByIds(
 
     if (filters.isNotEmpty) {
       final eventStream = nostrService.subscribe(filters);
-      final seenIds = foundVideos.map((v) => v.id).toSet();
+      final seenIds = foundVideos.map((v) => v.id.toLowerCase()).toSet();
 
       await for (final event in eventStream) {
-        if (seenIds.contains(event.id)) continue;
+        if (seenIds.contains(event.id.toLowerCase())) continue;
 
         try {
           // Use permissive mode to accept all NIP-71 video kinds from external sources
           final video = VideoEvent.fromNostrEvent(event, permissive: true);
           foundVideos.add(video);
-          seenIds.add(event.id);
+          seenIds.add(event.id.toLowerCase());
 
           // Also add to the video event service cache
           videoEventService.addVideoEvent(video);

--- a/mobile/lib/providers/list_providers.g.dart
+++ b/mobile/lib/providers/list_providers.g.dart
@@ -548,7 +548,7 @@ final class CuratedListVideoEventsProvider
 }
 
 String _$curatedListVideoEventsHash() =>
-    r'ad1646f4833e31b7c0be36da69a8d583b117449a';
+    r'884920d241022e9862d38127445002e4ff2b2b87';
 
 /// Provider that fetches actual VideoEvent objects for a curated list
 /// Streams videos as they are fetched from cache or relays
@@ -637,7 +637,7 @@ final class VideoEventsByIdsProvider
   }
 }
 
-String _$videoEventsByIdsHash() => r'149abcf76b2ae57e82cdb4fd3b440c5866cb582a';
+String _$videoEventsByIdsHash() => r'efd36a7f43db4fc4ecf5dff816a40968f7d37423';
 
 /// Provider that fetches VideoEvent objects directly from a list of video IDs
 /// Use this for discovered lists that aren't in local storage

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -685,7 +685,7 @@ class ProfileFeed extends _$ProfileFeed {
           video.originalLikes != null ||
           video.originalComments != null ||
           video.originalReposts != null) {
-        _metadataCache[video.id] = _VideoMetadataCache(
+        _metadataCache[video.id.toLowerCase()] = _VideoMetadataCache(
           originalLoops: video.originalLoops,
           originalLikes: video.originalLikes,
           originalComments: video.originalComments,
@@ -698,7 +698,7 @@ class ProfileFeed extends _$ProfileFeed {
   /// Apply cached metadata to videos that may be missing it (from Nostr)
   List<VideoEvent> _applyMetadataCache(List<VideoEvent> videos) {
     return videos.map((video) {
-      final cached = _metadataCache[video.id];
+      final cached = _metadataCache[video.id.toLowerCase()];
       if (cached == null) return video;
 
       // Only apply if video is missing metadata but cache has it

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -89,7 +89,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'bcf0081ba23a169da17366803e788c9a59100902';
+String _$profileFeedHash() => r'2c060e6d417c415477654441146c0c72c1369f0f';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///

--- a/mobile/lib/services/analytics_api_service.dart
+++ b/mobile/lib/services/analytics_api_service.dart
@@ -65,6 +65,8 @@ class VideoStats {
     } else {
       id = rawId?.toString() ?? '';
     }
+    // Normalize to lowercase per NIP-01 (Funnelcake may return uppercase hex)
+    id = id.toLowerCase();
 
     // Parse pubkey - same format as id
     String pubkey;
@@ -74,6 +76,8 @@ class VideoStats {
     } else {
       pubkey = rawPubkey?.toString() ?? '';
     }
+    // Normalize to lowercase per NIP-01 (Funnelcake may return uppercase hex)
+    pubkey = pubkey.toLowerCase();
 
     // Parse created_at - funnelcake returns Unix timestamp (int), not ISO string
     DateTime createdAt;

--- a/mobile/lib/services/curation_service.dart
+++ b/mobile/lib/services/curation_service.dart
@@ -425,7 +425,7 @@ class CurationService {
 
           // First pass: collect videos we have locally and track missing ones
           for (final vineData in vinesData) {
-            final eventId = vineData['eventId'] as String?;
+            final eventId = (vineData['eventId'] as String?)?.toLowerCase();
             final viewCount = vineData['views'] ?? 0;
 
             if (eventId != null) {
@@ -445,9 +445,9 @@ class CurationService {
                 category: LogCategory.system,
               );
 
-              // Find the video in our local cache
+              // Find the video in our local cache (case-insensitive)
               final localVideo = allVideos.firstWhere(
-                (video) => video.id == eventId,
+                (video) => video.id.toLowerCase() == eventId,
                 orElse: () => VideoEvent(
                   id: '',
                   pubkey: '',
@@ -570,9 +570,11 @@ class CurationService {
               );
 
               // Track videos that we failed to fetch - they likely no longer exist on relays
-              final fetchedIds = fetchedVideos.map((v) => v.id).toSet();
+              final fetchedIds = fetchedVideos
+                  .map((v) => v.id.toLowerCase())
+                  .toSet();
               final actuallyMissingIds = missingEventIds
-                  .where((id) => !fetchedIds.contains(id))
+                  .where((id) => !fetchedIds.contains(id.toLowerCase()))
                   .toSet();
 
               if (actuallyMissingIds.isNotEmpty) {
@@ -596,10 +598,10 @@ class CurationService {
             // Sort by the order from analytics API
             final orderedTrending = <VideoEvent>[];
             for (final vineData in vinesData) {
-              final eventId = vineData['eventId'] as String?;
+              final eventId = (vineData['eventId'] as String?)?.toLowerCase();
               if (eventId != null) {
                 final video = trending.firstWhere(
-                  (v) => v.id == eventId,
+                  (v) => v.id.toLowerCase() == eventId,
                   orElse: () => VideoEvent(
                     id: '',
                     pubkey: '',


### PR DESCRIPTION
## Summary

Follow-up to #1205 addressing [Rabble's review feedback](https://github.com/divinevideo/divine-mobile/pull/1205#issuecomment-3831404101) — duplicates were still appearing because Funnelcake REST API returns uppercase hex IDs while Nostr relays return lowercase (NIP-01 requires lowercase).

- **Root cause fix**: Normalize `id` and `pubkey` to lowercase in `VideoStats.fromJson()` at the API boundary so all IDs enter the app correctly
- **Safety net**: Add `.toLowerCase()` to all remaining case-sensitive comparison points across `home_feed_provider`, `profile_feed_provider`, `list_providers`, and `curation_service`

5 files, ~20 line changes.

## Test plan

- [ ] Verify no duplicate videos in Explore/New tab
- [ ] Verify no duplicate videos in Profile feeds
- [ ] Verify trending videos display correctly (no missing videos)
- [ ] Verify home feed deduplication with subscribed list videos
- [ ] Existing tests pass with no regressions