### PR TITLE
feat(video-editor): improve video filters with custom preset

### DIFF
--- a/mobile/lib/blocs/video_editor/filter_editor/video_editor_filter_bloc.dart
+++ b/mobile/lib/blocs/video_editor/filter_editor/video_editor_filter_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
@@ -13,7 +14,7 @@ part 'video_editor_filter_state.dart';
 class VideoEditorFilterBloc
     extends Bloc<VideoEditorFilterEvent, VideoEditorFilterState> {
   VideoEditorFilterBloc()
-    : super(VideoEditorFilterState(filters: presetFiltersList)) {
+    : super(VideoEditorFilterState(filters: VideoEditorConstants.filters)) {
     on<VideoEditorFilterEditorInitialized>(_onEditorInitialized);
     on<VideoEditorFilterSelected>(_onFilterSelected);
     on<VideoEditorFilterOpacityChanged>(_onOpacityChanged);

--- a/mobile/lib/constants/video_editor_constants.dart
+++ b/mobile/lib/constants/video_editor_constants.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
 
 /// A text font with its style getter.
 typedef TextFont = TextStyle Function({double? fontSize, Color? color});
@@ -110,6 +111,165 @@ class VideoEditorConstants {
 
   /// Hero animation tag for the back button in the video editor.
   static const heroBackButtonId = 'Video-Editor-Back-Button';
+
+  /// List of filter presets sorted by popularity
+  static final filters = [
+    PresetFilters.none,
+
+    // Tier 1: Most popular filters
+    PresetFilters.clarendon,
+    PresetFilters.juno,
+    PresetFilters.ludwig,
+    PresetFilters.lark,
+    PresetFilters.gingham,
+
+    // Tier 2: Very popular
+    PresetFilters.valencia,
+    PresetFilters.xProII,
+    PresetFilters.loFi,
+    PresetFilters.amaro,
+    PresetFilters.hudson,
+
+    // Tier 3: Popular
+    PresetFilters.nashville,
+    PresetFilters.mayfair,
+    PresetFilters.rise,
+    PresetFilters.perpetua,
+    PresetFilters.aden,
+
+    // Tier 4: Vintage & artistic
+    PresetFilters.earlybird,
+    PresetFilters.f1977,
+    PresetFilters.kelvin,
+    PresetFilters.walden,
+    PresetFilters.toaster,
+
+    // Tier 5: Mood filters
+    PresetFilters.moon,
+    PresetFilters.inkwell,
+    PresetFilters.willow,
+    PresetFilters.slumber,
+    PresetFilters.reyes,
+
+    // Tier 6: Color boost
+    PresetFilters.hefe,
+    PresetFilters.sierra,
+    PresetFilters.sutro,
+    PresetFilters.brannan,
+    PresetFilters.maven,
+
+    // Tier 7: Specialty
+    PresetFilters.crema,
+    PresetFilters.ashby,
+    PresetFilters.charmes,
+    PresetFilters.helena,
+    PresetFilters.brooklyn,
+    PresetFilters.ginza,
+    PresetFilters.skyline,
+    PresetFilters.dogpatch,
+    PresetFilters.stinson,
+    PresetFilters.vesper,
+
+    // Essential filters
+    FilterModel(
+      name: 'Cinematic',
+      filters: [
+        ColorFilterAddons.colorOverlay(0, 140, 140, 0.08),
+        ColorFilterAddons.colorOverlay(255, 140, 50, 0.05),
+        ColorFilterAddons.contrast(0.1),
+        ColorFilterAddons.saturation(-0.1),
+      ],
+    ),
+    FilterModel(
+      name: 'Faded',
+      filters: [
+        ColorFilterAddons.contrast(-0.1),
+        ColorFilterAddons.brightness(0.08),
+        ColorFilterAddons.saturation(-0.15),
+      ],
+    ),
+    FilterModel(
+      name: 'Dramatic',
+      filters: [
+        ColorFilterAddons.contrast(0.25),
+        ColorFilterAddons.brightness(-0.05),
+        ColorFilterAddons.saturation(0.1),
+      ],
+    ),
+    FilterModel(
+      name: 'Dreamy',
+      filters: [
+        ColorFilterAddons.brightness(0.1),
+        ColorFilterAddons.saturation(-0.1),
+        ColorFilterAddons.contrast(-0.08),
+        ColorFilterAddons.colorOverlay(255, 220, 255, 0.05),
+      ],
+    ),
+    FilterModel(
+      name: 'Glow',
+      filters: [
+        ColorFilterAddons.brightness(0.12),
+        ColorFilterAddons.contrast(-0.05),
+        ColorFilterAddons.saturation(-0.05),
+      ],
+    ),
+    FilterModel(
+      name: 'Noir',
+      filters: [
+        ColorFilterAddons.grayscale(),
+        ColorFilterAddons.contrast(0.2),
+        ColorFilterAddons.brightness(-0.05),
+      ],
+    ),
+    FilterModel(
+      name: 'Vivid',
+      filters: [
+        ColorFilterAddons.saturation(0.4),
+        ColorFilterAddons.contrast(0.1),
+      ],
+    ),
+    FilterModel(
+      name: 'Muted',
+      filters: [
+        ColorFilterAddons.saturation(-0.3),
+        ColorFilterAddons.brightness(0.05),
+      ],
+    ),
+
+    // Simple color tints
+    FilterModel(
+      name: 'Ruby',
+      filters: [ColorFilterAddons.addictiveColor(50, 0, 0)],
+    ),
+    FilterModel(
+      name: 'Ocean',
+      filters: [ColorFilterAddons.addictiveColor(0, 0, 50)],
+    ),
+    FilterModel(
+      name: 'Forest',
+      filters: [ColorFilterAddons.addictiveColor(0, 40, 0)],
+    ),
+    FilterModel(
+      name: 'Sunset',
+      filters: [ColorFilterAddons.addictiveColor(60, 30, 0)],
+    ),
+    FilterModel(
+      name: 'Violet',
+      filters: [ColorFilterAddons.addictiveColor(40, 0, 50)],
+    ),
+    FilterModel(
+      name: 'Mint',
+      filters: [ColorFilterAddons.addictiveColor(0, 50, 40)],
+    ),
+    FilterModel(
+      name: 'Coral',
+      filters: [ColorFilterAddons.addictiveColor(50, 20, 10)],
+    ),
+    FilterModel(
+      name: 'Arctic',
+      filters: [ColorFilterAddons.addictiveColor(0, 30, 60)],
+    ),
+  ];
 }
 
 /// Constants for the video editor clip gallery layout and animations.

--- a/mobile/test/blocs/video_editor/filter_editor/video_editor_filter_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/filter_editor/video_editor_filter_bloc_test.dart
@@ -4,7 +4,8 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/blocs/video_editor/filter_editor/video_editor_filter_bloc.dart';
-import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:pro_image_editor/pro_image_editor.dart' show PresetFilters;
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -14,9 +15,9 @@ void main() {
       return VideoEditorFilterBloc();
     }
 
-    test('initial state has filters from presetFiltersList', () {
+    test('initial state has filters from [VideoEditorConstants.filters]', () {
       final bloc = buildBloc();
-      expect(bloc.state.filters, equals(presetFiltersList));
+      expect(bloc.state.filters, equals(VideoEditorConstants.filters));
       expect(bloc.state.selectedFilter, isNull);
       expect(bloc.state.opacity, 1.0);
       expect(bloc.state.hasFilter, isFalse);
@@ -24,7 +25,8 @@ void main() {
     });
 
     group('VideoEditorFilterSelected', () {
-      final testFilter = presetFiltersList[1]; // First non-None filter
+      final testFilter =
+          VideoEditorConstants.filters[1]; // First non-None filter
 
       blocTest<VideoEditorFilterBloc, VideoEditorFilterState>(
         'emits state with selected filter',
@@ -43,17 +45,18 @@ void main() {
         'updates selected filter when changed',
         build: buildBloc,
         seed: () => VideoEditorFilterState(
-          filters: presetFiltersList,
-          selectedFilter: presetFiltersList[1],
+          filters: VideoEditorConstants.filters,
+          selectedFilter: VideoEditorConstants.filters[1],
           opacity: 1.0,
         ),
-        act: (bloc) =>
-            bloc.add(VideoEditorFilterSelected(presetFiltersList[2])),
+        act: (bloc) => bloc.add(
+          VideoEditorFilterSelected(VideoEditorConstants.filters[2]),
+        ),
         expect: () => [
           isA<VideoEditorFilterState>().having(
             (s) => s.selectedFilter,
             'selectedFilter',
-            presetFiltersList[2],
+            VideoEditorConstants.filters[2],
           ),
         ],
       );
@@ -77,8 +80,8 @@ void main() {
         'updates opacity when filter is selected',
         build: buildBloc,
         seed: () => VideoEditorFilterState(
-          filters: presetFiltersList,
-          selectedFilter: presetFiltersList[1],
+          filters: VideoEditorConstants.filters,
+          selectedFilter: VideoEditorConstants.filters[1],
           opacity: 1.0,
         ),
         act: (bloc) => bloc.add(const VideoEditorFilterOpacityChanged(0.5)),
@@ -97,10 +100,10 @@ void main() {
         'restores to initial values from when editor was opened',
         build: buildBloc,
         seed: () => VideoEditorFilterState(
-          filters: presetFiltersList,
-          selectedFilter: presetFiltersList[2],
+          filters: VideoEditorConstants.filters,
+          selectedFilter: VideoEditorConstants.filters[2],
           opacity: 0.5,
-          initialSelectedFilter: presetFiltersList[1],
+          initialSelectedFilter: VideoEditorConstants.filters[1],
           initialOpacity: 0.8,
         ),
         act: (bloc) => bloc.add(const VideoEditorFilterCancelled()),
@@ -109,7 +112,7 @@ void main() {
               .having(
                 (s) => s.selectedFilter,
                 'selectedFilter',
-                presetFiltersList[1],
+                VideoEditorConstants.filters[1],
               )
               .having((s) => s.opacity, 'opacity', 0.8),
         ],
@@ -121,8 +124,8 @@ void main() {
         'stores current values as initial values for cancel',
         build: buildBloc,
         seed: () => VideoEditorFilterState(
-          filters: presetFiltersList,
-          selectedFilter: presetFiltersList[1],
+          filters: VideoEditorConstants.filters,
+          selectedFilter: VideoEditorConstants.filters[1],
           opacity: 0.7,
         ),
         act: (bloc) => bloc.add(const VideoEditorFilterEditorInitialized()),
@@ -131,14 +134,14 @@ void main() {
               .having(
                 (s) => s.initialSelectedFilter,
                 'initialSelectedFilter',
-                presetFiltersList[1],
+                VideoEditorConstants.filters[1],
               )
               .having((s) => s.initialOpacity, 'initialOpacity', 0.7)
               // Current values unchanged
               .having(
                 (s) => s.selectedFilter,
                 'selectedFilter',
-                presetFiltersList[1],
+                VideoEditorConstants.filters[1],
               )
               .having((s) => s.opacity, 'opacity', 0.7),
         ],
@@ -149,7 +152,7 @@ void main() {
   group('VideoEditorFilterState', () {
     test('hasFilter returns false when selectedFilter is null', () {
       final state = VideoEditorFilterState(
-        filters: presetFiltersList,
+        filters: VideoEditorConstants.filters,
         selectedFilter: null,
       );
       expect(state.hasFilter, isFalse);
@@ -159,7 +162,7 @@ void main() {
       'hasFilter returns false when selectedFilter is PresetFilters.none',
       () {
         final state = VideoEditorFilterState(
-          filters: presetFiltersList,
+          filters: VideoEditorConstants.filters,
           selectedFilter: PresetFilters.none,
         );
         expect(state.hasFilter, isFalse);
@@ -168,16 +171,16 @@ void main() {
 
     test('hasFilter returns true when a real filter is selected', () {
       final state = VideoEditorFilterState(
-        filters: presetFiltersList,
-        selectedFilter: presetFiltersList[1], // Non-None filter
+        filters: VideoEditorConstants.filters,
+        selectedFilter: VideoEditorConstants.filters[1], // Non-None filter
       );
       expect(state.hasFilter, isTrue);
     });
 
     test('isSelected returns true for matching filter', () {
-      final filter = presetFiltersList[1];
+      final filter = VideoEditorConstants.filters[1];
       final state = VideoEditorFilterState(
-        filters: presetFiltersList,
+        filters: VideoEditorConstants.filters,
         selectedFilter: filter,
       );
       expect(state.isSelected(filter), isTrue);
@@ -185,17 +188,17 @@ void main() {
 
     test('isSelected returns false for non-matching filter', () {
       final state = VideoEditorFilterState(
-        filters: presetFiltersList,
-        selectedFilter: presetFiltersList[1],
+        filters: VideoEditorConstants.filters,
+        selectedFilter: VideoEditorConstants.filters[1],
       );
-      expect(state.isSelected(presetFiltersList[2]), isFalse);
+      expect(state.isSelected(VideoEditorConstants.filters[2]), isFalse);
     });
 
     test(
       'isSelected returns true for None filter when selectedFilter is null',
       () {
         final state = VideoEditorFilterState(
-          filters: presetFiltersList,
+          filters: VideoEditorConstants.filters,
           selectedFilter: null,
         );
         expect(state.isSelected(PresetFilters.none), isTrue);
@@ -204,18 +207,18 @@ void main() {
 
     test('copyWith creates new state with updated values', () {
       final original = VideoEditorFilterState(
-        filters: presetFiltersList,
+        filters: VideoEditorConstants.filters,
         selectedFilter: null,
         opacity: 1.0,
       );
 
       final updated = original.copyWith(
-        selectedFilter: presetFiltersList[1],
+        selectedFilter: VideoEditorConstants.filters[1],
         opacity: 0.5,
       );
 
-      expect(updated.filters, equals(presetFiltersList));
-      expect(updated.selectedFilter, equals(presetFiltersList[1]));
+      expect(updated.filters, equals(VideoEditorConstants.filters));
+      expect(updated.selectedFilter, equals(VideoEditorConstants.filters[1]));
       expect(updated.opacity, 0.5);
       // Original unchanged
       expect(original.selectedFilter, isNull);
@@ -223,9 +226,9 @@ void main() {
     });
 
     test('copyWith preserves values when not specified', () {
-      final filter = presetFiltersList[1];
+      final filter = VideoEditorConstants.filters[1];
       final original = VideoEditorFilterState(
-        filters: presetFiltersList,
+        filters: VideoEditorConstants.filters,
         selectedFilter: filter,
         opacity: 0.7,
       );
@@ -239,36 +242,36 @@ void main() {
 
     test('props contains all fields for equality', () {
       final state = VideoEditorFilterState(
-        filters: presetFiltersList,
-        selectedFilter: presetFiltersList[1],
+        filters: VideoEditorConstants.filters,
+        selectedFilter: VideoEditorConstants.filters[1],
         opacity: 0.5,
-        initialSelectedFilter: presetFiltersList[2],
+        initialSelectedFilter: VideoEditorConstants.filters[2],
         initialOpacity: 0.8,
       );
 
       expect(state.props, [
-        presetFiltersList,
-        presetFiltersList[1],
+        VideoEditorConstants.filters,
+        VideoEditorConstants.filters[1],
         0.5,
-        presetFiltersList[2],
+        VideoEditorConstants.filters[2],
         0.8,
       ]);
     });
 
     test('equality works correctly', () {
       final state1 = VideoEditorFilterState(
-        filters: presetFiltersList,
-        selectedFilter: presetFiltersList[1],
+        filters: VideoEditorConstants.filters,
+        selectedFilter: VideoEditorConstants.filters[1],
         opacity: 0.5,
       );
       final state2 = VideoEditorFilterState(
-        filters: presetFiltersList,
-        selectedFilter: presetFiltersList[1],
+        filters: VideoEditorConstants.filters,
+        selectedFilter: VideoEditorConstants.filters[1],
         opacity: 0.5,
       );
       final state3 = VideoEditorFilterState(
-        filters: presetFiltersList,
-        selectedFilter: presetFiltersList[2],
+        filters: VideoEditorConstants.filters,
+        selectedFilter: VideoEditorConstants.filters[2],
         opacity: 0.5,
       );
 
@@ -279,7 +282,7 @@ void main() {
 
   group('VideoEditorFilterEvent', () {
     test('VideoEditorFilterSelected props contains filter', () {
-      final filter = presetFiltersList[1];
+      final filter = VideoEditorConstants.filters[1];
       final event = VideoEditorFilterSelected(filter);
       expect(event.props, [filter]);
     });
@@ -295,10 +298,10 @@ void main() {
     });
 
     test('event equality works correctly', () {
-      final filter = presetFiltersList[1];
+      final filter = VideoEditorConstants.filters[1];
       final event1 = VideoEditorFilterSelected(filter);
       final event2 = VideoEditorFilterSelected(filter);
-      final event3 = VideoEditorFilterSelected(presetFiltersList[2]);
+      final event3 = VideoEditorFilterSelected(VideoEditorConstants.filters[2]);
 
       expect(event1, equals(event2));
       expect(event1, isNot(equals(event3)));


### PR DESCRIPTION
## Description

The preset filters from pro_image_editor provide a basic selection, but we need a better-organized list and an extended range that includes several more popular filters.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore