### PR TITLE
fix(video): preserve chronological position when editing videos

### DIFF
--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -1651,6 +1651,7 @@ class AuthService implements BackgroundAwareService {
     required String content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) async {
     if (!isAuthenticated || _currentKeyContainer == null) {
       Log.error(
@@ -1682,7 +1683,8 @@ class AuthService implements BackgroundAwareService {
         kind,
         eventTags,
         content,
-        createdAt: NostrTimestamp.now(driftTolerance: driftTolerance),
+        createdAt:
+            createdAt ?? NostrTimestamp.now(driftTolerance: driftTolerance),
       );
 
       // 2. Branch Signing Logic (Local vs RPC)

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -2524,11 +2524,14 @@ class _EditVideoDialogState extends ConsumerState<_EditVideoDialog> {
       tags.add(['client', 'diVine']);
 
       // Create and sign the updated event
+      // Use original created_at + 1 so relays treat this as a replacement
+      // while preserving the video's chronological position in feeds.
       final content = _descriptionController.text.trim();
       final event = await authService.createAndSignEvent(
         kind: NIP71VideoKinds.addressableShortVideo, // Kind 34236
         content: content,
         tags: tags,
+        createdAt: widget.video.createdAt + 1,
       );
 
       if (event == null) {

--- a/mobile/test/helpers/test_provider_overrides.mocks.dart
+++ b/mobile/test/helpers/test_provider_overrides.mocks.dart
@@ -686,6 +686,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -693,6 +694,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i11.Future<_i3.Event?>.value(),
           )

--- a/mobile/test/integration/account_deletion_flow_test.mocks.dart
+++ b/mobile/test/integration/account_deletion_flow_test.mocks.dart
@@ -903,6 +903,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -910,6 +911,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i8.Future<_i4.Event?>.value(),
           )

--- a/mobile/test/integration/bug_report_blossom_upload_test.dart
+++ b/mobile/test/integration/bug_report_blossom_upload_test.dart
@@ -35,6 +35,7 @@ class MockAuthService implements AuthService {
     required String content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) async {
     final event = Event(_keychain.public, kind, tags ?? [], content);
     event.sign(_keychain.private);

--- a/mobile/test/integration/upload_publish_e2e_comprehensive_test.mocks.dart
+++ b/mobile/test/integration/upload_publish_e2e_comprehensive_test.mocks.dart
@@ -599,6 +599,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -606,6 +607,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i14.Event?>.value(),
           )

--- a/mobile/test/integration/video_thumbnail_publish_e2e_test.dart
+++ b/mobile/test/integration/video_thumbnail_publish_e2e_test.dart
@@ -39,6 +39,7 @@ class MockAuthService implements AuthService {
     required String content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) async {
     // Create a test event with deterministic ID
     final timestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;

--- a/mobile/test/providers/curation_provider_lifecycle_test.mocks.dart
+++ b/mobile/test/providers/curation_provider_lifecycle_test.mocks.dart
@@ -2062,6 +2062,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -2069,6 +2070,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i9.Future<_i5.Event?>.value(),
           )

--- a/mobile/test/providers/curation_provider_tab_refresh_test.mocks.dart
+++ b/mobile/test/providers/curation_provider_tab_refresh_test.mocks.dart
@@ -2062,6 +2062,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -2069,6 +2070,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i9.Future<_i5.Event?>.value(),
           )

--- a/mobile/test/providers/home_feed_loading_fix_test.mocks.dart
+++ b/mobile/test/providers/home_feed_loading_fix_test.mocks.dart
@@ -2214,6 +2214,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -2221,6 +2222,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i14.Future<_i13.Event?>.value(),
           )

--- a/mobile/test/screens/auth/secure_account_screen_test.mocks.dart
+++ b/mobile/test/screens/auth/secure_account_screen_test.mocks.dart
@@ -716,6 +716,7 @@ class MockAuthService extends _i1.Mock implements _i5.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -723,6 +724,7 @@ class MockAuthService extends _i1.Mock implements _i5.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i8.Future<_i6.Event?>.value(),
           )

--- a/mobile/test/screens/profile_setup_relay_confirmation_test.mocks.dart
+++ b/mobile/test/screens/profile_setup_relay_confirmation_test.mocks.dart
@@ -899,6 +899,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -906,6 +907,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
           )

--- a/mobile/test/screens/settings_screen_audio_sharing_test.mocks.dart
+++ b/mobile/test/screens/settings_screen_audio_sharing_test.mocks.dart
@@ -386,6 +386,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -393,6 +394,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i4.Future<_i3.Event?>.value(),
           )

--- a/mobile/test/screens/welcome_screen_auth_state_test.mocks.dart
+++ b/mobile/test/screens/welcome_screen_auth_state_test.mocks.dart
@@ -384,6 +384,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -391,6 +392,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i4.Future<_i3.Event?>.value(),
           )

--- a/mobile/test/services/account_deletion_service_test.mocks.dart
+++ b/mobile/test/services/account_deletion_service_test.mocks.dart
@@ -896,6 +896,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -903,6 +904,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
           )

--- a/mobile/test/services/content_deletion_service_test.mocks.dart
+++ b/mobile/test/services/content_deletion_service_test.mocks.dart
@@ -896,6 +896,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -903,6 +904,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
           )

--- a/mobile/test/services/content_reporting_service_test.mocks.dart
+++ b/mobile/test/services/content_reporting_service_test.mocks.dart
@@ -896,6 +896,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -903,6 +904,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
           )

--- a/mobile/test/services/curated_list_service_collaboration_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_collaboration_test.mocks.dart
@@ -896,6 +896,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -903,6 +904,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
           )

--- a/mobile/test/services/curated_list_service_crud_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_crud_test.mocks.dart
@@ -1040,6 +1040,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -1047,6 +1048,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
             returnValueForMissingStub: _i7.Future<_i4.Event?>.value(),

--- a/mobile/test/services/curated_list_service_initialization_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_initialization_test.mocks.dart
@@ -896,6 +896,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -903,6 +904,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
           )

--- a/mobile/test/services/curated_list_service_persistence_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_persistence_test.mocks.dart
@@ -896,6 +896,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -903,6 +904,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
           )

--- a/mobile/test/services/curated_list_service_playlist_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_playlist_test.mocks.dart
@@ -896,6 +896,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -903,6 +904,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
           )

--- a/mobile/test/services/curated_list_service_query_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_query_test.mocks.dart
@@ -896,6 +896,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -903,6 +904,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
           )

--- a/mobile/test/services/curated_list_service_stream_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_stream_test.mocks.dart
@@ -896,6 +896,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -903,6 +904,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
           )

--- a/mobile/test/services/curated_list_service_video_management_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_video_management_test.mocks.dart
@@ -896,6 +896,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -903,6 +904,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
           )

--- a/mobile/test/services/curation_publish_test.mocks.dart
+++ b/mobile/test/services/curation_publish_test.mocks.dart
@@ -1916,6 +1916,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -1923,6 +1924,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i8.Future<_i5.Event?>.value(),
           )

--- a/mobile/test/services/curation_service_analytics_test.mocks.dart
+++ b/mobile/test/services/curation_service_analytics_test.mocks.dart
@@ -1916,6 +1916,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -1923,6 +1924,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i8.Future<_i5.Event?>.value(),
           )

--- a/mobile/test/services/curation_service_create_test.mocks.dart
+++ b/mobile/test/services/curation_service_create_test.mocks.dart
@@ -2084,6 +2084,7 @@ class MockAuthService extends _i1.Mock implements _i5.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -2091,6 +2092,7 @@ class MockAuthService extends _i1.Mock implements _i5.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i9.Future<_i6.Event?>.value(),
           )

--- a/mobile/test/services/curation_service_editors_picks_test.mocks.dart
+++ b/mobile/test/services/curation_service_editors_picks_test.mocks.dart
@@ -1916,6 +1916,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -1923,6 +1924,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i8.Future<_i5.Event?>.value(),
           )

--- a/mobile/test/services/curation_service_kind_30005_test.mocks.dart
+++ b/mobile/test/services/curation_service_kind_30005_test.mocks.dart
@@ -1916,6 +1916,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -1923,6 +1924,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i8.Future<_i5.Event?>.value(),
           )

--- a/mobile/test/services/curation_service_test.mocks.dart
+++ b/mobile/test/services/curation_service_test.mocks.dart
@@ -1916,6 +1916,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -1923,6 +1924,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i8.Future<_i5.Event?>.value(),
           )

--- a/mobile/test/services/curation_service_trending_fetch_test.mocks.dart
+++ b/mobile/test/services/curation_service_trending_fetch_test.mocks.dart
@@ -1916,6 +1916,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -1923,6 +1924,7 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i8.Future<_i5.Event?>.value(),
           )

--- a/mobile/test/services/profile_editing_test.mocks.dart
+++ b/mobile/test/services/profile_editing_test.mocks.dart
@@ -900,6 +900,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -907,6 +908,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
           )

--- a/mobile/test/services/video_sharing_service_test.mocks.dart
+++ b/mobile/test/services/video_sharing_service_test.mocks.dart
@@ -899,6 +899,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -906,6 +907,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
           )

--- a/mobile/test/unit/curated_list_relay_sync_test.mocks.dart
+++ b/mobile/test/unit/curated_list_relay_sync_test.mocks.dart
@@ -1040,6 +1040,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -1047,6 +1048,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i7.Future<_i4.Event?>.value(),
             returnValueForMissingStub: _i7.Future<_i4.Event?>.value(),

--- a/mobile/test/widgets/settings_delete_account_test.mocks.dart
+++ b/mobile/test/widgets/settings_delete_account_test.mocks.dart
@@ -432,6 +432,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -439,6 +440,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i5.Future<_i6.Event?>.value(),
           )

--- a/mobile/test/widgets/settings_screen_scaffold_test.mocks.dart
+++ b/mobile/test/widgets/settings_screen_scaffold_test.mocks.dart
@@ -384,6 +384,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -391,6 +392,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i4.Future<_i3.Event?>.value(),
           )

--- a/mobile/test/widgets/settings_screen_test.mocks.dart
+++ b/mobile/test/widgets/settings_screen_test.mocks.dart
@@ -384,6 +384,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -391,6 +392,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i4.Future<_i3.Event?>.value(),
           )

--- a/mobile/test/widgets/share_menu_safety_section_test.mocks.dart
+++ b/mobile/test/widgets/share_menu_safety_section_test.mocks.dart
@@ -681,6 +681,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -688,6 +689,7 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i5.Future<_i14.Event?>.value(),
           )

--- a/mobile/test/widgets/tabbed_settings_screen_test.mocks.dart
+++ b/mobile/test/widgets/tabbed_settings_screen_test.mocks.dart
@@ -433,6 +433,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -440,6 +441,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i9.Future<_i3.Event?>.value(),
           )

--- a/mobile/test/widgets/vine_drawer_test.mocks.dart
+++ b/mobile/test/widgets/vine_drawer_test.mocks.dart
@@ -384,6 +384,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -391,6 +392,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i4.Future<_i3.Event?>.value(),
           )

--- a/mobile/test/widgets/welcome_screen_font_test.mocks.dart
+++ b/mobile/test/widgets/welcome_screen_font_test.mocks.dart
@@ -384,6 +384,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
     required String? content,
     List<List<String>>? tags,
     String? biometricPrompt,
+    int? createdAt,
   }) =>
       (super.noSuchMethod(
             Invocation.method(#createAndSignEvent, [], {
@@ -391,6 +392,7 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
               #content: content,
               #tags: tags,
               #biometricPrompt: biometricPrompt,
+              #createdAt: createdAt,
             }),
             returnValue: _i4.Future<_i3.Event?>.value(),
           )


### PR DESCRIPTION
## Summary
- Adds optional `createdAt` parameter to `AuthService.createAndSignEvent()` so callers can override the default timestamp
- Video edit dialog now passes `createdAt: original + 1` instead of defaulting to "now", preserving the video's chronological position in feeds while still bumping the timestamp for relay replacement acceptance (NIP-71 addressable events)

## Test plan
- [x] `build_runner` regenerated all mocks (38 auto-generated + 2 manual)
- [x] `dart analyze` passes clean
- [ ] Verify edited video stays in correct chronological position in feeds
- [ ] Verify relays accept the replacement event (created_at > original)

🤖 Generated with [Claude Code](https://claude.com/claude-code)