### PR TITLE
fix: crashlytics round 2 — WebSocket guard, ProofMode ANR, diagnostic noise

### DIFF
--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -4515,21 +4515,15 @@ class VideoEventService extends ChangeNotifier {
       );
       context.writeln('  Has subscription: ${isSubscribed(subscriptionType)}');
 
-      // Log locally
-      Log.error(
-        '🚨 EMPTY FEED - Reporting to Crashlytics:\n${context.toString()}',
+      // Log locally — this is a normal condition (new user, sparse relay, etc.)
+      // so we log as warning instead of flooding Crashlytics with non-fatal errors.
+      Log.warning(
+        '⚠️ EMPTY FEED for ${subscriptionType.name}:\n${context.toString()}',
         name: 'VideoEventService',
         category: LogCategory.video,
       );
 
-      // Report to Crashlytics as non-fatal error
-      CrashReportingService.instance.recordError(
-        Exception('Empty feed after EOSE: ${subscriptionType.name}'),
-        StackTrace.current,
-        reason: context.toString(),
-      );
-
-      // Set custom keys for filtering in Crashlytics
+      // Set custom keys for filtering if needed later
       CrashReportingService.instance.setCustomKey(
         'last_empty_feed_type',
         subscriptionType.name,
@@ -4652,21 +4646,15 @@ class VideoEventService extends ChangeNotifier {
         context.writeln('  ⚠️ Filter may match no events on this relay');
       }
 
-      // Log locally
-      Log.error(
-        '⏰ FEED TIMEOUT - Reporting to Crashlytics:\n${context.toString()}',
+      // Log locally — timeouts are expected on slow networks, backgrounded apps,
+      // etc. Log as warning instead of flooding Crashlytics with non-fatal errors.
+      Log.warning(
+        '⏰ FEED TIMEOUT for ${subscriptionType.name}:\n${context.toString()}',
         name: 'VideoEventService',
         category: LogCategory.video,
       );
 
-      // Report to Crashlytics as non-fatal error
-      CrashReportingService.instance.recordError(
-        Exception('Feed loading timeout after 30s: ${subscriptionType.name}'),
-        StackTrace.current,
-        reason: context.toString(),
-      );
-
-      // Set custom keys for filtering in Crashlytics
+      // Set custom keys for filtering if needed later
       CrashReportingService.instance.setCustomKey(
         'last_timeout_feed_type',
         subscriptionType.name,

--- a/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/web_socket_connection_manager.dart
@@ -225,6 +225,7 @@ class WebSocketConnectionManager {
 
   void _onMessage(dynamic message) {
     _lastActivityAt = DateTime.now();
+    if (_messageController.isClosed) return;
     if (message is String) {
       _messageController.add(message);
     } else {
@@ -234,7 +235,9 @@ class WebSocketConnectionManager {
 
   void _onStreamError(dynamic error) {
     log('Stream error: $error');
-    _errorController.add('Stream error: $error');
+    if (!_errorController.isClosed) {
+      _errorController.add('Stream error: $error');
+    }
     _handleDisconnect();
   }
 
@@ -471,7 +474,9 @@ class WebSocketConnectionManager {
   void _setState(ConnectionState newState) {
     if (_state != newState) {
       _state = newState;
-      _stateController.add(newState);
+      if (!_stateController.isClosed) {
+        _stateController.add(newState);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Addresses three categories of Crashlytics issues found during the Feb 10 triage:

- **WebSocket add-after-close guard** (15 events/week): `WebSocketConnectionManager._onMessage` was calling `.add()` on closed `StreamController` when app gets backgrounded during an active relay connection. Added `isClosed` guards on all three stream controllers (message, error, state).

- **ProofMode ANR fix** (Android): `ProofMode.generateProof()` runs BouncyCastle RSA key generation (`BN_primality_test`) on the main thread in `MainActivity.setupProofModeChannel`, causing Application Not Responding. Moved proof generation to a background `Thread` with result posted back via `Handler(Looper.getMainLooper())`.

- **Diagnostic noise reduction** (652 events/week): Empty feed after EOSE (375 events) and feed loading timeout (277 events) were being reported as Crashlytics non-fatal errors. These are normal operational conditions (new users, sparse relays, slow networks, backgrounded apps) — downgraded from `CrashReportingService.recordError()` to `Log.warning()`. Custom keys still set for correlation.

## Test plan

- [x] Existing WebSocket connection manager tests pass (22/22)
- [x] `dart analyze` clean
- [x] Pre-commit hooks pass
- [ ] Manual: Android — verify ProofMode proof generation still works after recording
- [ ] Manual: Background/foreground app during relay connection — no crash
- [ ] Verify: Crashlytics noise drops after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)