### PR TITLE
perf: parallelize service init and deduplicate follow emissions

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -567,26 +567,14 @@ Future<void> _initializeCoreServices(ProviderContainer container) async {
     category: LogCategory.system,
   );
 
-  // Initialize seen videos service
-  await container.read(seenVideosServiceProvider).initialize();
+  // Initialize independent services in parallel
+  await Future.wait([
+    container.read(seenVideosServiceProvider).initialize(),
+    bandwidthTracker.initialize(),
+    container.read(uploadManagerProvider).initialize(),
+  ]);
   Log.info(
-    '[INIT] ✅ SeenVideosService initialized',
-    name: 'Main',
-    category: LogCategory.system,
-  );
-
-  // Initialize bandwidth tracker for adaptive quality selection
-  await bandwidthTracker.initialize();
-  Log.info(
-    '[INIT] ✅ BandwidthTracker initialized',
-    name: 'Main',
-    category: LogCategory.system,
-  );
-
-  // Initialize upload manager
-  await container.read(uploadManagerProvider).initialize();
-  Log.info(
-    '[INIT] ✅ UploadManager initialized',
+    '[INIT] ✅ SeenVideosService, BandwidthTracker, UploadManager initialized',
     name: 'Main',
     category: LogCategory.system,
   );

--- a/mobile/lib/repositories/follow_repository.dart
+++ b/mobile/lib/repositories/follow_repository.dart
@@ -73,11 +73,26 @@ class FollowRepository {
   bool get isInitialized => _isInitialized;
   int get followingCount => _followingPubkeys.length;
 
-  /// Emit current state to stream
+  /// Emit current state to stream (only if the list actually changed)
   void _emitFollowingList() {
     if (!_followingSubject.isClosed) {
-      _followingSubject.add(List.unmodifiable(_followingPubkeys));
+      final newList = List<String>.unmodifiable(_followingPubkeys);
+      final currentList = _followingSubject.valueOrNull;
+      if (currentList == null ||
+          newList.length != currentList.length ||
+          !_listsEqual(newList, currentList)) {
+        _followingSubject.add(newList);
+      }
     }
+  }
+
+  /// Compare two lists for equality by value
+  bool _listsEqual(List<String> a, List<String> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
   }
 
   /// Dispose resources


### PR DESCRIPTION
## Summary

- **Parallel service init**: `SeenVideosService`, `BandwidthTracker`, and `UploadManager` now initialize concurrently via `Future.wait()` instead of sequentially, reducing startup time
- **Follow list dedup**: `FollowRepository._emitFollowingList()` now compares the new list against the current `BehaviorSubject` value before emitting, preventing unnecessary downstream rebuilds when the list hasn't actually changed

## Test plan

- [x] All 40 follow repository tests pass
- [x] `dart analyze` clean
- [x] Pre-commit hooks pass
- [ ] Manual: app startup still works correctly
- [ ] Manual: follow/unfollow still updates UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)