### PR TITLE
feat(profile): claim username before publishing Kind 0 with nip05

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -1,10 +1,9 @@
 // ABOUTME: BLoC for orchestrating profile save and username claiming
-// ABOUTME: Handles rollback when username claim fails
+// ABOUTME: Claims username first, then publishes Kind 0 with nip05
 
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:models/models.dart';
 import 'package:openvine/models/user_profile.dart' as app_models;
 import 'package:openvine/services/user_profile_service.dart';
 import 'package:openvine/utils/unified_logger.dart';
@@ -192,6 +191,12 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
   }
 
   /// Core profile save logic (extracted for reuse)
+  ///
+  /// Claim-first strategy: when a username is provided, we claim it on
+  /// names.divine.video BEFORE publishing Kind 0. This ensures the nip05
+  /// field is only set after the registration is confirmed. If the claim
+  /// fails, we still publish the profile with other changes but keep the
+  /// existing nip05.
   Future<void> _saveProfile(
     ProfileSaved event,
     Emitter<ProfileEditorState> emit,
@@ -211,7 +216,6 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     final currentProfile = await _profileRepository.getCachedProfile(
       pubkey: event.pubkey,
     );
-    final nip05 = username != null ? '_@$username.divine.video' : null;
 
     Log.info(
       '📝 saveProfile: displayName=$displayName, '
@@ -219,10 +223,34 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       name: 'ProfileEditorBloc',
     );
 
-    // 1. Publish profile
-    UserProfile savedProfile;
+    // 1. Claim username first (if provided)
+    ProfileEditorError? claimError;
+    if (username != null) {
+      Log.info(
+        '📝 Attempting to claim username: $username',
+        name: 'ProfileEditorBloc',
+      );
+
+      final result = await _profileRepository.claimUsername(username: username);
+
+      Log.info('📝 Username claim result: $result', name: 'ProfileEditorBloc');
+
+      claimError = switch (result) {
+        UsernameClaimSuccess() => null,
+        UsernameClaimTaken() => ProfileEditorError.usernameTaken,
+        UsernameClaimReserved() => ProfileEditorError.usernameReserved,
+        UsernameClaimError() => ProfileEditorError.claimFailed,
+      };
+    }
+
+    // 2. Determine nip05 based on claim result
+    final nip05 = (username != null && claimError == null)
+        ? '_@$username.divine.video'
+        : currentProfile?.nip05;
+
+    // 3. Publish profile with correct nip05
     try {
-      savedProfile = await _profileRepository.saveProfileEvent(
+      final savedProfile = await _profileRepository.saveProfileEvent(
         displayName: displayName,
         about: about,
         nip05: nip05,
@@ -249,71 +277,28 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       return;
     }
 
-    // 2. No username to claim - done
-    if (username == null) {
-      Log.info('📝 No username to claim, SUCCESS', name: 'ProfileEditorBloc');
+    // 4. Report result
+    if (claimError == null) {
+      Log.info('📝 Profile save SUCCESS', name: 'ProfileEditorBloc');
       emit(state.copyWith(status: ProfileEditorStatus.success));
       return;
     }
 
-    // 3. Claim username
-    Log.info(
-      '📝 Attempting to claim username: $username',
-      name: 'ProfileEditorBloc',
-    );
-
-    final result = await _profileRepository.claimUsername(username: username);
-
-    Log.info('📝 Username claim result: $result', name: 'ProfileEditorBloc');
-
-    final error = switch (result) {
-      UsernameClaimSuccess() => null,
-      UsernameClaimTaken() => ProfileEditorError.usernameTaken,
-      UsernameClaimReserved() => ProfileEditorError.usernameReserved,
-      UsernameClaimError() => ProfileEditorError.claimFailed,
-    };
-
-    if (error == null) {
-      Log.info('📝 Username claim SUCCESS', name: 'ProfileEditorBloc');
-      emit(state.copyWith(status: ProfileEditorStatus.success));
-      return;
-    }
-
-    // 4. Rollback on failure
-    Log.info(
-      '📝 Rolling back to nip05=${currentProfile?.nip05}',
-      name: 'ProfileEditorBloc',
-    );
-    try {
-      final rolledBack = await _profileRepository.saveProfileEvent(
-        displayName: displayName,
-        about: about,
-        nip05: currentProfile?.nip05,
-        picture: picture,
-        banner: banner,
-        currentProfile: currentProfile,
-      );
-      final appProfile = app_models.UserProfile.fromJson(rolledBack.toJson());
-      await _userProfileService.updateCachedProfile(appProfile);
-      Log.info('📝 Rollback complete', name: 'ProfileEditorBloc');
-    } catch (e) {
-      Log.error('Rollback failed: $e', name: 'ProfileEditorBloc');
-    }
-
-    final usernameStatus = switch (error) {
+    // Username claim failed - profile was saved with old nip05
+    final usernameStatus = switch (claimError) {
       ProfileEditorError.usernameReserved => UsernameStatus.reserved,
       ProfileEditorError.usernameTaken => UsernameStatus.taken,
       _ => null,
     };
 
     final reservedUsernames = usernameStatus == UsernameStatus.reserved
-        ? {...state.reservedUsernames, username}
+        ? {...state.reservedUsernames, username!}
         : null;
 
     emit(
       state.copyWith(
         status: ProfileEditorStatus.failure,
-        error: error,
+        error: claimError,
         usernameStatus: usernameStatus,
         reservedUsernames: reservedUsernames,
       ),

--- a/mobile/lib/models/environment_config.dart
+++ b/mobile/lib/models/environment_config.dart
@@ -41,11 +41,11 @@ class EnvironmentConfig {
   String get relayUrl {
     switch (environment) {
       case AppEnvironment.poc:
-        return 'wss://relay.poc.dvines.org';
+        return 'wss://relay.poc.divine.video';
       case AppEnvironment.staging:
-        return 'wss://relay.staging.dvines.org';
+        return 'wss://relay.staging.divine.video';
       case AppEnvironment.test:
-        return 'wss://relay.test.dvines.org';
+        return 'wss://relay.test.divine.video';
       case AppEnvironment.production:
         return 'wss://relay.divine.video';
     }

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Unit tests for ProfileEditorBloc
-// ABOUTME: Tests profile publishing and username claiming with rollback on failure
+// ABOUTME: Tests claim-first profile publishing (claim username, then Kind 0)
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -138,7 +138,7 @@ void main() {
         );
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'publishes profile with existing profile data',
+          'preserves existing nip05 when no username provided',
           setUp: () {
             final existingProfile = createTestProfile(nip05: testOriginalNip05);
             when(
@@ -148,7 +148,7 @@ void main() {
               () => mockProfileRepository.saveProfileEvent(
                 displayName: testDisplayName,
                 about: testAbout,
-                nip05: null,
+                nip05: testOriginalNip05,
                 picture: testPicture,
                 currentProfile: existingProfile,
               ),
@@ -175,6 +175,17 @@ void main() {
               ProfileEditorStatus.success,
             ),
           ],
+          verify: (_) {
+            verify(
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: testAbout,
+                nip05: testOriginalNip05,
+                picture: testPicture,
+                currentProfile: any(named: 'currentProfile'),
+              ),
+            ).called(1);
+          },
         );
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(
@@ -231,11 +242,14 @@ void main() {
 
       group('with username', () {
         blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'emits [loading, success] when profile and username claim succeed',
+          'claims username first then publishes Kind 0 with nip05',
           setUp: () {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
+            when(
+              () => mockProfileRepository.claimUsername(username: testUsername),
+            ).thenAnswer((_) async => const UsernameClaimSuccess());
             when(
               () => mockProfileRepository.saveProfileEvent(
                 displayName: testDisplayName,
@@ -244,10 +258,7 @@ void main() {
                 picture: testPicture,
                 currentProfile: null,
               ),
-            ).thenAnswer((_) async => createTestProfile());
-            when(
-              () => mockProfileRepository.claimUsername(username: testUsername),
-            ).thenAnswer((_) async => const UsernameClaimSuccess());
+            ).thenAnswer((_) async => createTestProfile(nip05: testNip05));
           },
           build: createBloc,
           act: (bloc) => bloc.add(
@@ -272,7 +283,8 @@ void main() {
             ),
           ],
           verify: (_) {
-            verify(
+            verifyInOrder([
+              () => mockProfileRepository.claimUsername(username: testUsername),
               () => mockProfileRepository.saveProfileEvent(
                 displayName: testDisplayName,
                 about: testAbout,
@@ -280,10 +292,7 @@ void main() {
                 picture: testPicture,
                 currentProfile: null,
               ),
-            ).called(1);
-            verify(
-              () => mockProfileRepository.claimUsername(username: testUsername),
-            ).called(1);
+            ]);
           },
         );
       });
@@ -331,11 +340,14 @@ void main() {
         );
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'does not attempt username claim when profile publish fails',
+          'claims username but fails to publish profile',
           setUp: () {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
+            when(
+              () => mockProfileRepository.claimUsername(username: testUsername),
+            ).thenAnswer((_) async => const UsernameClaimSuccess());
             when(
               () => mockProfileRepository.saveProfileEvent(
                 displayName: testDisplayName,
@@ -356,13 +368,20 @@ void main() {
               username: testUsername,
             ),
           ),
-          verify: (_) {
-            verifyNever(
-              () => mockProfileRepository.claimUsername(
-                username: any(named: 'username'),
-              ),
-            );
-          },
+          expect: () => [
+            isA<ProfileEditorState>().having(
+              (s) => s.status,
+              'status',
+              ProfileEditorStatus.loading,
+            ),
+            isA<ProfileEditorState>()
+                .having((s) => s.status, 'status', ProfileEditorStatus.failure)
+                .having(
+                  (s) => s.error,
+                  'error',
+                  ProfileEditorError.publishFailed,
+                ),
+          ],
         );
       });
 
@@ -374,15 +393,6 @@ void main() {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => existingProfile);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                nip05: testNip05,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
             when(
               () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimTaken());
@@ -423,22 +433,13 @@ void main() {
         );
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'rolls back profile with original nip05',
+          'publishes profile with original nip05 when claim fails',
           setUp: () {
             final existingProfile = createTestProfile(nip05: testOriginalNip05);
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => existingProfile);
             when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                nip05: testNip05,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-            when(
               () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimTaken());
             when(
@@ -462,14 +463,8 @@ void main() {
             ),
           ),
           verify: (_) {
-            verifyInOrder([
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                nip05: testNip05,
-                picture: testPicture,
-                currentProfile: any(named: 'currentProfile'),
-              ),
+            // Should publish profile once with original nip05 (not new one)
+            verify(
               () => mockProfileRepository.saveProfileEvent(
                 displayName: testDisplayName,
                 about: testAbout,
@@ -477,26 +472,27 @@ void main() {
                 picture: testPicture,
                 currentProfile: any(named: 'currentProfile'),
               ),
-            ]);
+            ).called(1);
+            // Should never publish with the new nip05
+            verifyNever(
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: testAbout,
+                nip05: testNip05,
+                picture: testPicture,
+                currentProfile: any(named: 'currentProfile'),
+              ),
+            );
           },
         );
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'rolls back to null nip05 when no existing profile',
+          'publishes with null nip05 when no existing profile and claim fails',
           setUp: () {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
             when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                nip05: testNip05,
-                picture: testPicture,
-                currentProfile: null,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-            when(
               () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimTaken());
             when(
@@ -520,14 +516,8 @@ void main() {
             ),
           ),
           verify: (_) {
-            verifyInOrder([
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                nip05: testNip05,
-                picture: testPicture,
-                currentProfile: null,
-              ),
+            // Only one profile publish - with null nip05
+            verify(
               () => mockProfileRepository.saveProfileEvent(
                 displayName: testDisplayName,
                 about: testAbout,
@@ -535,7 +525,7 @@ void main() {
                 picture: testPicture,
                 currentProfile: null,
               ),
-            ]);
+            ).called(1);
           },
         );
       });
@@ -548,15 +538,6 @@ void main() {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => existingProfile);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                nip05: testNip05,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
             when(
               () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimReserved());
@@ -597,21 +578,12 @@ void main() {
         );
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'rolls back profile when username is reserved',
+          'publishes profile with original nip05 when reserved',
           setUp: () {
             final existingProfile = createTestProfile(nip05: testOriginalNip05);
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => existingProfile);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                nip05: testNip05,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
             when(
               () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimReserved());
@@ -636,14 +608,8 @@ void main() {
             ),
           ),
           verify: (_) {
-            verifyInOrder([
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                nip05: testNip05,
-                picture: testPicture,
-                currentProfile: any(named: 'currentProfile'),
-              ),
+            // Only one profile publish - with original nip05
+            verify(
               () => mockProfileRepository.saveProfileEvent(
                 displayName: testDisplayName,
                 about: testAbout,
@@ -651,7 +617,7 @@ void main() {
                 picture: testPicture,
                 currentProfile: any(named: 'currentProfile'),
               ),
-            ]);
+            ).called(1);
           },
         );
       });
@@ -664,15 +630,6 @@ void main() {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => existingProfile);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                nip05: testNip05,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
             when(
               () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer(
@@ -710,63 +667,6 @@ void main() {
                   (s) => s.error,
                   'error',
                   ProfileEditorError.claimFailed,
-                ),
-          ],
-        );
-      });
-
-      group('rollback failure', () {
-        blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'still returns correct error when rollback fails',
-          setUp: () {
-            final existingProfile = createTestProfile(nip05: testOriginalNip05);
-            when(
-              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
-            ).thenAnswer((_) async => existingProfile);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                nip05: testNip05,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-            when(
-              () => mockProfileRepository.claimUsername(username: testUsername),
-            ).thenAnswer((_) async => const UsernameClaimTaken());
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                nip05: testOriginalNip05,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenThrow(const ProfilePublishFailedException('Rollback failed'));
-          },
-          build: createBloc,
-          act: (bloc) => bloc.add(
-            const ProfileSaved(
-              pubkey: testPubkey,
-              displayName: testDisplayName,
-              about: testAbout,
-              picture: testPicture,
-              username: testUsername,
-            ),
-          ),
-          expect: () => [
-            isA<ProfileEditorState>().having(
-              (s) => s.status,
-              'status',
-              ProfileEditorStatus.loading,
-            ),
-            isA<ProfileEditorState>()
-                .having((s) => s.status, 'status', ProfileEditorStatus.failure)
-                .having(
-                  (s) => s.error,
-                  'error',
-                  ProfileEditorError.usernameTaken,
                 ),
           ],
         );
@@ -977,7 +877,7 @@ void main() {
         },
         wait: debounceDuration,
         verify: (_) {
-          // Should only call API once for the final username due to restartable transformer
+          // Should only call API once for the final username
           verify(
             () => mockProfileRepository.checkUsernameAvailability(
               username: 'test3',
@@ -999,20 +899,10 @@ void main() {
       blocTest<ProfileEditorBloc, ProfileEditorState>(
         'checks reserved cache before making API call',
         setUp: () {
-          // First, trigger a ProfileSaved that returns UsernameClaimReserved
           final existingProfile = createTestProfile(nip05: testOriginalNip05);
           when(
             () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
           ).thenAnswer((_) async => existingProfile);
-          when(
-            () => mockProfileRepository.saveProfileEvent(
-              displayName: testDisplayName,
-              about: testAbout,
-              nip05: testNip05,
-              picture: testPicture,
-              currentProfile: existingProfile,
-            ),
-          ).thenAnswer((_) async => createTestProfile());
           when(
             () => mockProfileRepository.claimUsername(username: testUsername),
           ).thenAnswer((_) async => const UsernameClaimReserved());

--- a/mobile/test/debug_relay_auth.dart
+++ b/mobile/test/debug_relay_auth.dart
@@ -12,7 +12,7 @@ void main() async {
 
   try {
     // Connect to the relay
-    final wsUrl = Uri.parse('wss://staging-relay.divine.video');
+    final wsUrl = Uri.parse('wss://relay.poc.divine.video');
     final channel = IOWebSocketChannel.connect(wsUrl);
 
     Log.debug('1. Connecting to $wsUrl...');

--- a/mobile/test/helpers/test_nostr_service.dart
+++ b/mobile/test/helpers/test_nostr_service.dart
@@ -274,7 +274,7 @@ class TestNostrService implements NostrClient {
   }
 
   bool get isVineRelayAuthenticated =>
-      isRelayAuthenticated('wss://staging-relay.divine.video');
+      isRelayAuthenticated('wss://relay.poc.divine.video');
 
   void setAuthTimeout(Duration timeout) {
     // No-op for tests

--- a/mobile/test/integration/real_nostr_video_integration_test.dart
+++ b/mobile/test/integration/real_nostr_video_integration_test.dart
@@ -32,9 +32,9 @@ void main() {
     });
 
     testWidgets(
-      'can fetch real video events from staging-relay.divine.video relay',
+      'can fetch real video events from relay.poc.divine.video relay',
       (tester) async {
-        // This test uses REAL network connections to staging-relay.divine.video
+        // This test uses REAL network connections to relay.poc.divine.video
         // No mocking of NostrService, network, or relay connections
 
         // Subscribe to video feed

--- a/mobile/test/integration/relay_pagination_integration_test.dart
+++ b/mobile/test/integration/relay_pagination_integration_test.dart
@@ -77,7 +77,7 @@ void main() {
     });
 
     test(
-      'should get real kind 34236 video events from staging-relay.divine.video',
+      'should get real kind 34236 video events from relay.poc.divine.video',
       () async {
         // Subscribe to discovery feed
         await videoEventService.subscribeToVideoFeed(

--- a/mobile/test/integration/relay_video_subscription_test.dart
+++ b/mobile/test/integration/relay_video_subscription_test.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Real world test to verify VideoEventService works with actual staging-relay.divine.video relay
+// ABOUTME: Real world test to verify VideoEventService works with actual relay.poc.divine.video relay
 // ABOUTME: This test connects to the real relay to debug why videos aren't showing in app
 
 // TODO(any): Fix and re-enable this test
@@ -112,10 +112,10 @@ void main() {}
 //    });
 //
 //    test(
-//      'VideoEventService should receive videos from staging-relay.divine.video relay',
+//      'VideoEventService should receive videos from relay.poc.divine.video relay',
 //      () async {
 //        Log.debug(
-//          '🔍 Testing VideoEventService with real staging-relay.divine.video relay...',
+//          '🔍 Testing VideoEventService with real relay.poc.divine.video relay...',
 //          name: 'RealVideoSubscriptionTest',
 //          category: LogCategory.system,
 //        );
@@ -220,7 +220,7 @@ void main() {}
 //            receivedVideos.length,
 //            greaterThan(0),
 //            reason:
-//                'Should receive videos from staging-relay.divine.video relay',
+//                'Should receive videos from relay.poc.divine.video relay',
 //          );
 //
 //          // Verify the videos have proper URLs

--- a/mobile/test/integration/video_event_service_relay_test.dart
+++ b/mobile/test/integration/video_event_service_relay_test.dart
@@ -56,7 +56,7 @@ void main() {}
 //    });
 //
 //    test(
-//      'VideoEventService receives events from wss://staging-relay.divine.video',
+//      'VideoEventService receives events from wss://relay.poc.divine.video',
 //      () async {
 //        Log.info('🧪 Starting VideoEventService relay test');
 //
@@ -126,7 +126,7 @@ void main() {}
 //          videoEventService.hasEvents(SubscriptionType.discovery),
 //          true,
 //          reason:
-//              'VideoEventService should receive at least one kind 22 video event from wss://staging-relay.divine.video relay within 15 seconds. '
+//              'VideoEventService should receive at least one kind 22 video event from wss://relay.poc.divine.video relay within 15 seconds. '
 //              'This test confirms the relay connection and event subscription pipeline is working correctly. '
 //              'Events received: ${videoEventService.getEventCount(SubscriptionType.discovery)}',
 //        );

--- a/mobile/test/integration/video_event_service_simple_test.dart
+++ b/mobile/test/integration/video_event_service_simple_test.dart
@@ -45,7 +45,7 @@ void main() {
       when(mockNostrService.isInitialized).thenReturn(true);
       when(
         mockNostrService.connectedRelays,
-      ).thenReturn(['wss://staging-relay.divine.video']);
+      ).thenReturn(['wss://relay.poc.divine.video']);
       when(mockNostrService.hasKeys).thenReturn(true);
       when(mockNostrService.publicKey).thenReturn('test_pubkey');
       when(mockNostrService.connectedRelayCount).thenReturn(1);

--- a/mobile/test/models/environment_config_test.dart
+++ b/mobile/test/models/environment_config_test.dart
@@ -19,17 +19,17 @@ void main() {
     group('relayUrl', () {
       test('poc returns poc relay', () {
         final config = EnvironmentConfig(environment: AppEnvironment.poc);
-        expect(config.relayUrl, 'wss://relay.poc.dvines.org');
+        expect(config.relayUrl, 'wss://relay.poc.divine.video');
       });
 
       test('staging returns staging relay', () {
         final config = EnvironmentConfig(environment: AppEnvironment.staging);
-        expect(config.relayUrl, 'wss://relay.staging.dvines.org');
+        expect(config.relayUrl, 'wss://relay.staging.divine.video');
       });
 
       test('test returns test relay', () {
         final config = EnvironmentConfig(environment: AppEnvironment.test);
-        expect(config.relayUrl, 'wss://relay.test.dvines.org');
+        expect(config.relayUrl, 'wss://relay.test.divine.video');
       });
 
       test('production returns divine.video relay', () {
@@ -45,17 +45,17 @@ void main() {
       // This ensures the API URL always matches the relay being used
       test('poc derives from relay URL', () {
         final config = EnvironmentConfig(environment: AppEnvironment.poc);
-        expect(config.apiBaseUrl, 'https://relay.poc.dvines.org');
+        expect(config.apiBaseUrl, 'https://relay.poc.divine.video');
       });
 
       test('staging derives from relay URL', () {
         final config = EnvironmentConfig(environment: AppEnvironment.staging);
-        expect(config.apiBaseUrl, 'https://relay.staging.dvines.org');
+        expect(config.apiBaseUrl, 'https://relay.staging.divine.video');
       });
 
       test('test derives from relay URL', () {
         final config = EnvironmentConfig(environment: AppEnvironment.test);
-        expect(config.apiBaseUrl, 'https://relay.test.dvines.org');
+        expect(config.apiBaseUrl, 'https://relay.test.divine.video');
       });
 
       test('production derives from relay URL', () {

--- a/mobile/test/providers/profile_feed_providers_test.dart
+++ b/mobile/test/providers/profile_feed_providers_test.dart
@@ -70,7 +70,7 @@ void main() {
     late FakeVideoEventService fakeService;
     late ProviderContainer container;
 
-    // Real Nostr user from staging-relay.divine.video - @BJFrankowski
+    // Real Nostr user from relay.poc.divine.video - @BJFrankowski
     const testHex =
         '1363966ad89a17df0711e270658153c2dbe5e163e06cdd6f9dba36b616846ee0';
     late String testNpub;

--- a/mobile/test/services/relay_capability_service_test.dart
+++ b/mobile/test/services/relay_capability_service_test.dart
@@ -26,7 +26,7 @@ void main() {
 
     group('NIP-11 Information Document', () {
       test('parses divine.video relay capabilities correctly', () async {
-        // NIP-11 response from staging-relay.divine.video
+        // NIP-11 response from relay.poc.divine.video
         const nip11Response = '''
 {
   "name": "Divine Video Relay",
@@ -65,16 +65,16 @@ void main() {
 
         when(
           mockHttpClient.get(
-            Uri.parse('https://staging-relay.divine.video'),
+            Uri.parse('https://relay.poc.divine.video'),
             headers: {'Accept': 'application/nostr+json'},
           ),
         ).thenAnswer((_) async => http.Response(nip11Response, 200));
 
         final capabilities = await service.getRelayCapabilities(
-          'wss://staging-relay.divine.video',
+          'wss://relay.poc.divine.video',
         );
 
-        expect(capabilities.relayUrl, 'wss://staging-relay.divine.video');
+        expect(capabilities.relayUrl, 'wss://relay.poc.divine.video');
         expect(capabilities.name, 'Divine Video Relay');
         expect(capabilities.supportedNips, contains(71));
         expect(capabilities.hasDivineExtensions, true);
@@ -124,16 +124,16 @@ void main() {
       test('converts wss:// to https:// for NIP-11 fetch', () async {
         when(
           mockHttpClient.get(
-            Uri.parse('https://staging-relay.divine.video'),
+            Uri.parse('https://relay.poc.divine.video'),
             headers: {'Accept': 'application/nostr+json'},
           ),
         ).thenAnswer((_) async => http.Response('{"name": "Test Relay"}', 200));
 
-        await service.getRelayCapabilities('wss://staging-relay.divine.video');
+        await service.getRelayCapabilities('wss://relay.poc.divine.video');
 
         verify(
           mockHttpClient.get(
-            Uri.parse('https://staging-relay.divine.video'),
+            Uri.parse('https://relay.poc.divine.video'),
             headers: {'Accept': 'application/nostr+json'},
           ),
         ).called(1);
@@ -179,21 +179,21 @@ void main() {
 
         when(
           mockHttpClient.get(
-            Uri.parse('https://staging-relay.divine.video'),
+            Uri.parse('https://relay.poc.divine.video'),
             headers: {'Accept': 'application/nostr+json'},
           ),
         ).thenAnswer((_) async => http.Response(nip11Response, 200));
 
         // First call - should fetch from network
-        await service.getRelayCapabilities('wss://staging-relay.divine.video');
+        await service.getRelayCapabilities('wss://relay.poc.divine.video');
 
         // Second call - should use cache
-        await service.getRelayCapabilities('wss://staging-relay.divine.video');
+        await service.getRelayCapabilities('wss://relay.poc.divine.video');
 
         // Should only fetch once
         verify(
           mockHttpClient.get(
-            Uri.parse('https://staging-relay.divine.video'),
+            Uri.parse('https://relay.poc.divine.video'),
             headers: {'Accept': 'application/nostr+json'},
           ),
         ).called(1);
@@ -209,14 +209,14 @@ void main() {
 
         when(
           mockHttpClient.get(
-            Uri.parse('https://staging-relay.divine.video'),
+            Uri.parse('https://relay.poc.divine.video'),
             headers: {'Accept': 'application/nostr+json'},
           ),
         ).thenAnswer((_) async => http.Response(nip11Response, 200));
 
         // First call
         await shortTtlService.getRelayCapabilities(
-          'wss://staging-relay.divine.video',
+          'wss://relay.poc.divine.video',
         );
 
         // Wait for cache to expire
@@ -224,13 +224,13 @@ void main() {
 
         // Second call after expiration
         await shortTtlService.getRelayCapabilities(
-          'wss://staging-relay.divine.video',
+          'wss://relay.poc.divine.video',
         );
 
         // Should fetch twice
         verify(
           mockHttpClient.get(
-            Uri.parse('https://staging-relay.divine.video'),
+            Uri.parse('https://relay.poc.divine.video'),
             headers: {'Accept': 'application/nostr+json'},
           ),
         ).called(2);
@@ -246,17 +246,17 @@ void main() {
         ).thenAnswer((_) async => http.Response(nip11Response, 200));
 
         // Fetch and cache
-        await service.getRelayCapabilities('wss://staging-relay.divine.video');
+        await service.getRelayCapabilities('wss://relay.poc.divine.video');
 
         // Clear cache
         service.clearCache();
 
         // Should fetch again
-        await service.getRelayCapabilities('wss://staging-relay.divine.video');
+        await service.getRelayCapabilities('wss://relay.poc.divine.video');
 
         verify(
           mockHttpClient.get(
-            Uri.parse('https://staging-relay.divine.video'),
+            Uri.parse('https://relay.poc.divine.video'),
             headers: {'Accept': 'application/nostr+json'},
           ),
         ).called(2);
@@ -280,7 +280,7 @@ void main() {
         ).thenAnswer((_) async => http.Response(nip11Response, 200));
 
         final capabilities = await service.getRelayCapabilities(
-          'wss://staging-relay.divine.video',
+          'wss://relay.poc.divine.video',
         );
 
         expect(capabilities.supportsMetric('loop_count'), true);
@@ -304,7 +304,7 @@ void main() {
         ).thenAnswer((_) async => http.Response(nip11Response, 200));
 
         final capabilities = await service.getRelayCapabilities(
-          'wss://staging-relay.divine.video',
+          'wss://relay.poc.divine.video',
         );
 
         expect(capabilities.supportsSortBy('loop_count'), true);

--- a/mobile/test/services/video_filter_builder_test.dart
+++ b/mobile/test/services/video_filter_builder_test.dart
@@ -17,7 +17,7 @@ void main() {
     late VideoFilterBuilder builder;
     late MockRelayCapabilityService mockCapabilityService;
 
-    const testRelayUrl = 'wss://staging-relay.divine.video';
+    const testRelayUrl = 'wss://relay.poc.divine.video';
 
     setUp(() {
       mockCapabilityService = MockRelayCapabilityService();

--- a/mobile/test/services/vine_tag_requirement_test.dart
+++ b/mobile/test/services/vine_tag_requirement_test.dart
@@ -1,11 +1,11 @@
 // ABOUTME: Test that ALL events include the required ['h', 'vine'] tag
-// ABOUTME: Verifies AuthService automatically adds staging-relay.divine.video relay requirement
+// ABOUTME: Verifies AuthService automatically adds relay.poc.divine.video relay requirement
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/utils/unified_logger.dart';
 
 void main() {
-  group('staging-relay.divine.video Relay Tag Requirement', () {
+  group('relay.poc.divine.video Relay Tag Requirement', () {
     test('Kind 0 (profile) events should include h:vine tag', () async {
       // This test verifies the concept - actual AuthService requires secure storage
 
@@ -93,8 +93,8 @@ void main() {
 
     test('vine tag requirement documentation', () {
       const relayRequirement = '''
-CRITICAL: staging-relay.divine.video Relay Requirement
-ALL events published to the staging-relay.divine.video relay MUST include the tag ['h', 'vine'] 
+CRITICAL: relay.poc.divine.video Relay Requirement
+ALL events published to the relay.poc.divine.video relay MUST include the tag ['h', 'vine'] 
 for the relay to store them. Events without this tag will be accepted (relay 
 returns OK) but will NOT be stored or retrievable.
 ''';

--- a/mobile/test/test_relay_subscriptions.dart
+++ b/mobile/test/test_relay_subscriptions.dart
@@ -14,7 +14,7 @@ void main() async {
   final ourSubscriptions = <String>{};
 
   try {
-    final wsUrl = Uri.parse('wss://staging-relay.divine.video');
+    final wsUrl = Uri.parse('wss://relay.poc.divine.video');
     final channel = IOWebSocketChannel.connect(wsUrl);
 
     Log.debug('1. Connecting to $wsUrl...');

--- a/mobile/test/unit/nostr_sdk/filter_h_tag_test.dart
+++ b/mobile/test/unit/nostr_sdk/filter_h_tag_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Test that nostr_sdk Filter class properly supports h tag filtering
-// ABOUTME: Verifies the extended Filter functionality for staging-relay.divine.video relay compatibility
+// ABOUTME: Verifies the extended Filter functionality for relay.poc.divine.video relay compatibility
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_sdk/event.dart';

--- a/mobile/test/unit/video_event_real_parsing_test.dart
+++ b/mobile/test/unit/video_event_real_parsing_test.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Test to verify VideoEvent parsing of real kind 34236 events from staging-relay.divine.video
+// ABOUTME: Test to verify VideoEvent parsing of real kind 34236 events from relay.poc.divine.video
 // ABOUTME: This tests the actual parsing logic with real relay data
 
 import 'package:flutter_test/flutter_test.dart';
@@ -10,12 +10,12 @@ void main() {
   group('VideoEvent Parsing - Real Relay Data', () {
     test('should parse kind 34236 event with url tag correctly', () {
       Log.debug(
-        '🔍 Testing VideoEvent parsing with real staging-relay.divine.video data...',
+        '🔍 Testing VideoEvent parsing with real relay.poc.divine.video data...',
         name: 'VideoEventRealParsingTest',
         category: LogCategory.system,
       );
 
-      // Real event from staging-relay.divine.video relay with url tag
+      // Real event from relay.poc.divine.video relay with url tag
       final event = Event(
         'd95aa8fc0eff8e488952495b8064991d27fb96ed8652f12cdedc5a4e8b5ae540',
         34236,
@@ -64,7 +64,7 @@ void main() {
         category: LogCategory.system,
       );
 
-      // Real event from staging-relay.divine.video relay with r tag
+      // Real event from relay.poc.divine.video relay with r tag
       final event = Event(
         '033877f4080835f162880482590762c0a7508851e88fe164dd89028743914da5',
         34236,


### PR DESCRIPTION
## Summary
- Reorders profile save to claim username on `names.divine.video` **first**, then publish Kind 0 with nip05 only after confirmed registration — eliminates optimistic publish + rollback
- Updates `EnvironmentConfig` relay URLs from stale `dvines.org` domain to `divine.video` for poc/staging/test environments
- Standardizes all test relay URLs to `relay.poc.divine.video`

## Test plan
- [x] 22 profile editor BLoC tests pass (rewritten for claim-first flow)
- [x] Verifies claim happens before Kind 0 publish via `verifyInOrder`
- [x] Verifies failed claim still publishes profile with original nip05
- [ ] Manual: register a new username and confirm Kind 0 contains correct nip05
- [ ] Manual: verify NIP-05 resolution works at `username.divine.video/.well-known/nostr.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)