### PR TITLE
fix: resolve multiple issues in the drafts-library

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -513,10 +513,14 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   }
 
   /// Create a VineDraft from the rendered clip with metadata.
-  VineDraft getActiveDraft({bool isAutosave = false}) {
+  VineDraft getActiveDraft({
+    bool isAutosave = false,
+    bool enforceSeparatedClips = false,
+  }) {
     return VineDraft.create(
       id: isAutosave ? VideoEditorConstants.autoSaveId : draftId,
-      clips: state.finalRenderedClip == null || isAutosave
+      clips:
+          state.finalRenderedClip == null || isAutosave || enforceSeparatedClips
           ? _clips
           : [state.finalRenderedClip!],
       title: state.title,
@@ -646,7 +650,9 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     );
 
     try {
-      await _draftService.saveDraft(getActiveDraft());
+      await _draftService.saveDraft(
+        getActiveDraft(enforceSeparatedClips: true),
+      );
 
       // Remove the autosaved draft
       await removeAutosavedDraft();

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -58,17 +58,30 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
   /// Resets all video-related providers.
   ///
   /// Clears recorder, editor, clip manager, sound selection, and publish state.
-  void clearAll() {
+  Future<void> clearAll() async {
     Log.debug(
       '🧹 Clearing all video providers',
       name: 'VideoPublishNotifier',
       category: LogCategory.video,
     );
-    ref.read(videoRecorderProvider.notifier).reset();
-    ref.read(videoEditorProvider.notifier).reset();
-    ref.read(clipManagerProvider.notifier).clearAll();
-    ref.read(selectedSoundProvider.notifier).clear();
-    reset();
+    try {
+      ref.read(videoRecorderProvider.notifier).reset();
+      ref.read(selectedSoundProvider.notifier).clear();
+      reset();
+
+      await Future.wait([
+        ref.read(clipManagerProvider.notifier).clearAll(),
+        ref.read(videoEditorProvider.notifier).reset(),
+      ]);
+    } catch (error, stackTrace) {
+      Log.error(
+        '❌ Failed to clear video providers: $error',
+        name: 'VideoPublishNotifier',
+        category: LogCategory.video,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   /// Resumes any pending publish drafts that were interrupted.

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -745,9 +745,12 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           // The draft ID is optional if the user wants to continue editing
           // the draft.
           final draftId = st.pathParameters['draftId'];
+          final extra = st.extra as Map<String, dynamic>?;
+          final fromLibrary = extra?['fromLibrary'] as bool? ?? false;
 
           return VideoClipEditorScreen(
             draftId: draftId == null || draftId.isEmpty ? null : draftId,
+            fromLibrary: fromLibrary,
           );
         },
       ),

--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -90,6 +90,7 @@ class RouteContext {
     this.listId,
     this.soundId,
     this.videoId,
+    this.draftId,
   });
 
   final RouteType type;
@@ -100,6 +101,7 @@ class RouteContext {
   final String? listId;
   final String? soundId;
   final String? videoId;
+  final String? draftId;
 }
 
 /// Parse a URL path into a structured RouteContext
@@ -214,6 +216,10 @@ RouteContext parseRoute(String path) {
       return const RouteContext(type: RouteType.videoEditor);
 
     case 'video-clip-editor':
+      if (segments.length > 1) {
+        final draftId = Uri.decodeComponent(segments[1]);
+        return RouteContext(type: RouteType.videoClipEditor, draftId: draftId);
+      }
       return const RouteContext(type: RouteType.videoClipEditor);
 
     case 'video-metadata':
@@ -396,6 +402,9 @@ String buildRoute(RouteContext context) {
       return VideoEditorScreen.path;
 
     case RouteType.videoClipEditor:
+      if (context.draftId != null) {
+        return '${VideoClipEditorScreen.path}/${Uri.encodeComponent(context.draftId!)}';
+      }
       return VideoClipEditorScreen.path;
 
     case RouteType.videoMetadata:


### PR DESCRIPTION
## Description

Resolve the following issues:


1. Fixed an issue where saving a draft stored only the final rendered video.  
   Drafts now correctly store all clips separately, allowing users to continue editing later.

2. Fixed an issue where loading a draft created a new "autosave" session.  
   The editor now continues working directly on the selected draft session.

3. Fixed an issue where opening the draft library could delete clips from an autosaved session.  
   Clips are now preserved until the user explicitly opens another draft.

4. Fixed an issue where saving an edited draft created a new draft every time.  
   The existing draft is now properly updated instead of duplicated.

5. Removed incorrect logic where pressing **"Save as Draft"** duplicated only the first recorded clip in the device library.  
   If the intended behavior is to store the final rendered video at this point, rendering must complete before allowing the user to save it to the library.

6. Fixed an issue where pressing **"Save for Later"** unnecessarily saved every clip again to the clip library.  
   A draft now stores all clip references correctly without duplicating media files.

7. Fixed an issue where the video editor initialized twice when loading a draft.


**Related Issue:** Closes #1507

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore