### PR TITLE
fix(likes): resolve duplicate videos and infinite pagination in liked feed

### DIFF
--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_state.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_state.dart
@@ -46,6 +46,7 @@ final class ProfileLikedVideosState extends Equatable {
     this.error,
     this.isLoadingMore = false,
     this.hasMoreContent = true,
+    this.nextPageOffset = 0,
   });
 
   /// The current loading status
@@ -66,6 +67,13 @@ final class ProfileLikedVideosState extends Equatable {
   /// Whether there are more videos to load
   final bool hasMoreContent;
 
+  /// The offset into [likedEventIds] for the next page fetch.
+  ///
+  /// Tracks how many IDs have been consumed for pagination, independent of
+  /// how many videos were actually loaded (some IDs may not resolve to videos
+  /// due to relay unavailability or unsupported format filtering).
+  final int nextPageOffset;
+
   /// Whether data has been successfully loaded
   bool get isLoaded => status == ProfileLikedVideosStatus.success;
 
@@ -83,6 +91,7 @@ final class ProfileLikedVideosState extends Equatable {
     bool clearError = false,
     bool? isLoadingMore,
     bool? hasMoreContent,
+    int? nextPageOffset,
   }) {
     return ProfileLikedVideosState(
       status: status ?? this.status,
@@ -91,6 +100,7 @@ final class ProfileLikedVideosState extends Equatable {
       error: clearError ? null : (error ?? this.error),
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
       hasMoreContent: hasMoreContent ?? this.hasMoreContent,
+      nextPageOffset: nextPageOffset ?? this.nextPageOffset,
     );
   }
 
@@ -102,5 +112,6 @@ final class ProfileLikedVideosState extends Equatable {
     error,
     isLoadingMore,
     hasMoreContent,
+    nextPageOffset,
   ];
 }

--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -62,7 +62,7 @@ class VideoInteractionsBloc
     Emitter<VideoInteractionsState> emit,
   ) {
     final subscriptions = [
-      emit.forEach<Set<String>>(
+      emit.forEach<List<String>>(
         _likesRepository.watchLikedEventIds(),
         onData: (likedIds) {
           final isLiked = likedIds.contains(_eventId);

--- a/mobile/packages/db_client/lib/src/database/daos/personal_reactions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/personal_reactions_dao.dart
@@ -133,13 +133,15 @@ class PersonalReactionsDao extends DatabaseAccessor<AppDatabase>
 
   /// Watch all liked event IDs for a user (reactive stream).
   ///
-  /// Emits a new set whenever the user's likes change.
-  Stream<Set<String>> watchLikedEventIds(String userPubkey) {
+  /// Emits an ordered list (most recent first) whenever the user's likes
+  /// change. Ordering is critical for correct pagination in the UI.
+  Stream<List<String>> watchLikedEventIds(String userPubkey) {
     final query = select(personalReactions)
-      ..where((t) => t.userPubkey.equals(userPubkey));
+      ..where((t) => t.userPubkey.equals(userPubkey))
+      ..orderBy([(t) => OrderingTerm.desc(t.createdAt)]);
 
     return query.watch().map(
-      (rows) => rows.map((r) => r.targetEventId).toSet(),
+      (rows) => rows.map((r) => r.targetEventId).toList(),
     );
   }
 

--- a/mobile/packages/db_client/test/src/database/daos/personal_reactions_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/personal_reactions_dao_test.dart
@@ -526,6 +526,40 @@ void main() {
         expect(emissions[0], contains(testTargetEventId));
         expect(emissions[1], isEmpty);
       });
+
+      test('emits IDs ordered by createdAt descending', () async {
+        await dao.upsertReaction(
+          targetEventId: testTargetEventId,
+          reactionEventId: testReactionEventId,
+          userPubkey: testUserPubkey,
+          createdAt: 1000,
+        );
+        await dao.upsertReaction(
+          targetEventId: testTargetEventId2,
+          reactionEventId: testReactionEventId2,
+          userPubkey: testUserPubkey,
+          createdAt: 3000,
+        );
+        await dao.upsertReaction(
+          targetEventId: testTargetEventId3,
+          reactionEventId: testReactionEventId3,
+          userPubkey: testUserPubkey,
+          createdAt: 2000,
+        );
+
+        final stream = dao.watchLikedEventIds(testUserPubkey);
+        final result = await stream.first;
+
+        // Should be ordered by createdAt descending
+        expect(
+          result,
+          equals([
+            testTargetEventId2, // createdAt: 3000
+            testTargetEventId3, // createdAt: 2000
+            testTargetEventId, // createdAt: 1000
+          ]),
+        );
+      });
     });
 
     group('watchAllReactions', () {

--- a/mobile/packages/likes_repository/lib/src/db_likes_local_storage.dart
+++ b/mobile/packages/likes_repository/lib/src/db_likes_local_storage.dart
@@ -99,7 +99,7 @@ class DbLikesLocalStorage implements LikesLocalStorage {
   }
 
   @override
-  Stream<Set<String>> watchLikedEventIds() {
+  Stream<List<String>> watchLikedEventIds() {
     return _dao.watchLikedEventIds(_userPubkey);
   }
 

--- a/mobile/packages/likes_repository/lib/src/likes_local_storage.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_local_storage.dart
@@ -53,8 +53,8 @@ abstract class LikesLocalStorage {
 
   /// Watches all liked event IDs (reactive stream).
   ///
-  /// Emits a new set whenever likes change.
-  Stream<Set<String>> watchLikedEventIds();
+  /// Emits an ordered list (most recent first) whenever likes change.
+  Stream<List<String>> watchLikedEventIds();
 
   /// Clears all like records.
   ///

--- a/mobile/packages/likes_repository/test/src/db_likes_local_storage_test.dart
+++ b/mobile/packages/likes_repository/test/src/db_likes_local_storage_test.dart
@@ -354,7 +354,7 @@ void main() {
 
     group('watchLikedEventIds', () {
       test('returns stream from dao', () async {
-        final controller = StreamController<Set<String>>();
+        final controller = StreamController<List<String>>();
         when(
           () => mockDao.watchLikedEventIds(any()),
         ).thenAnswer((_) => controller.stream);
@@ -363,15 +363,15 @@ void main() {
 
         // Add values to controller
         controller
-          ..add({testTargetEventId})
-          ..add({testTargetEventId, testTargetEventId2});
+          ..add([testTargetEventId])
+          ..add([testTargetEventId, testTargetEventId2]);
 
         final emissions = await stream.take(2).toList();
 
-        expect(emissions[0], equals({testTargetEventId}));
+        expect(emissions[0], equals([testTargetEventId]));
         expect(
           emissions[1],
-          equals({testTargetEventId, testTargetEventId2}),
+          equals([testTargetEventId, testTargetEventId2]),
         );
 
         verify(() => mockDao.watchLikedEventIds(testUserPubkey)).called(1);

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -95,7 +95,7 @@ void main() {
       ).thenAnswer((_) async => []);
       when(
         () => mockLocalStorage.watchLikedEventIds(),
-      ).thenAnswer((_) => Stream.value(<String>{}));
+      ).thenAnswer((_) => Stream.value(<String>[]));
       when(
         () => mockLocalStorage.isLiked(any()),
       ).thenAnswer((_) async => false);
@@ -1136,7 +1136,7 @@ void main() {
       test('returns stream from local storage when available', () async {
         when(
           () => mockLocalStorage.watchLikedEventIds(),
-        ).thenAnswer((_) => Stream.value(<String>{'event1', 'event2'}));
+        ).thenAnswer((_) => Stream.value(<String>['event1', 'event2']));
 
         repository = createRepository();
         expect(

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -22,7 +22,7 @@ void main() {
     late _MockLikesRepository mockLikesRepository;
     late _MockCommentsRepository mockCommentsRepository;
     late _MockRepostsRepository mockRepostsRepository;
-    late StreamController<Set<String>> likedIdsController;
+    late StreamController<List<String>> likedIdsController;
     late StreamController<Set<String>> repostedIdsController;
 
     const testEventId = 'test-event-id';
@@ -33,7 +33,7 @@ void main() {
       mockLikesRepository = _MockLikesRepository();
       mockCommentsRepository = _MockCommentsRepository();
       mockRepostsRepository = _MockRepostsRepository();
-      likedIdsController = StreamController<Set<String>>.broadcast();
+      likedIdsController = StreamController<List<String>>.broadcast();
       repostedIdsController = StreamController<Set<String>>.broadcast();
 
       // Default stub for watchLikedEventIds
@@ -796,7 +796,7 @@ void main() {
         act: (bloc) async {
           bloc.add(const VideoInteractionsSubscriptionRequested());
           await Future<void>.delayed(const Duration(milliseconds: 50));
-          likedIdsController.add({testEventId});
+          likedIdsController.add([testEventId]);
         },
         wait: const Duration(milliseconds: 100),
         expect: () => [
@@ -821,7 +821,7 @@ void main() {
         act: (bloc) async {
           bloc.add(const VideoInteractionsSubscriptionRequested());
           await Future<void>.delayed(const Duration(milliseconds: 50));
-          likedIdsController.add(<String>{});
+          likedIdsController.add(<String>[]);
         },
         wait: const Duration(milliseconds: 100),
         expect: () => [
@@ -845,7 +845,7 @@ void main() {
         act: (bloc) async {
           bloc.add(const VideoInteractionsSubscriptionRequested());
           await Future<void>.delayed(const Duration(milliseconds: 50));
-          likedIdsController.add({testEventId});
+          likedIdsController.add([testEventId]);
         },
         wait: const Duration(milliseconds: 100),
         expect: () => <VideoInteractionsState>[],
@@ -860,7 +860,7 @@ void main() {
 
         // After closing, stream events should not affect anything
         // This mainly tests that no errors occur
-        expect(() => likedIdsController.add({testEventId}), returnsNormally);
+        expect(() => likedIdsController.add([testEventId]), returnsNormally);
       });
     });
   });

--- a/mobile/test/providers/curation_provider_lifecycle_test.mocks.dart
+++ b/mobile/test/providers/curation_provider_lifecycle_test.mocks.dart
@@ -1523,12 +1523,12 @@ class MockLikesRepository extends _i1.Mock implements _i3.LikesRepository {
   }
 
   @override
-  _i9.Stream<Set<String>> watchLikedEventIds() =>
+  _i9.Stream<List<String>> watchLikedEventIds() =>
       (super.noSuchMethod(
             Invocation.method(#watchLikedEventIds, []),
-            returnValue: _i9.Stream<Set<String>>.empty(),
+            returnValue: _i9.Stream<List<String>>.empty(),
           )
-          as _i9.Stream<Set<String>>);
+          as _i9.Stream<List<String>>);
 
   @override
   _i9.Future<Set<String>> getLikedEventIds() =>

--- a/mobile/test/providers/curation_provider_tab_refresh_test.mocks.dart
+++ b/mobile/test/providers/curation_provider_tab_refresh_test.mocks.dart
@@ -1523,12 +1523,12 @@ class MockLikesRepository extends _i1.Mock implements _i3.LikesRepository {
   }
 
   @override
-  _i9.Stream<Set<String>> watchLikedEventIds() =>
+  _i9.Stream<List<String>> watchLikedEventIds() =>
       (super.noSuchMethod(
             Invocation.method(#watchLikedEventIds, []),
-            returnValue: _i9.Stream<Set<String>>.empty(),
+            returnValue: _i9.Stream<List<String>>.empty(),
           )
-          as _i9.Stream<Set<String>>);
+          as _i9.Stream<List<String>>);
 
   @override
   _i9.Future<Set<String>> getLikedEventIds() =>

--- a/mobile/test/screens/profile_screen_router_test.dart
+++ b/mobile/test/screens/profile_screen_router_test.dart
@@ -259,7 +259,7 @@ void main() {
       mockLikesRepository = _MockLikesRepository();
       when(
         () => mockLikesRepository.watchLikedEventIds(),
-      ).thenAnswer((_) => const Stream<Set<String>>.empty());
+      ).thenAnswer((_) => const Stream<List<String>>.empty());
       when(
         () => mockLikesRepository.fetchUserLikes(any()),
       ).thenAnswer((_) async => <String>[]);

--- a/mobile/test/services/curation_publish_test.mocks.dart
+++ b/mobile/test/services/curation_publish_test.mocks.dart
@@ -1377,12 +1377,12 @@ class MockLikesRepository extends _i1.Mock implements _i3.LikesRepository {
   }
 
   @override
-  _i8.Stream<Set<String>> watchLikedEventIds() =>
+  _i8.Stream<List<String>> watchLikedEventIds() =>
       (super.noSuchMethod(
             Invocation.method(#watchLikedEventIds, []),
-            returnValue: _i8.Stream<Set<String>>.empty(),
+            returnValue: _i8.Stream<List<String>>.empty(),
           )
-          as _i8.Stream<Set<String>>);
+          as _i8.Stream<List<String>>);
 
   @override
   _i8.Future<Set<String>> getLikedEventIds() =>

--- a/mobile/test/services/curation_service_analytics_test.mocks.dart
+++ b/mobile/test/services/curation_service_analytics_test.mocks.dart
@@ -1377,12 +1377,12 @@ class MockLikesRepository extends _i1.Mock implements _i3.LikesRepository {
   }
 
   @override
-  _i8.Stream<Set<String>> watchLikedEventIds() =>
+  _i8.Stream<List<String>> watchLikedEventIds() =>
       (super.noSuchMethod(
             Invocation.method(#watchLikedEventIds, []),
-            returnValue: _i8.Stream<Set<String>>.empty(),
+            returnValue: _i8.Stream<List<String>>.empty(),
           )
-          as _i8.Stream<Set<String>>);
+          as _i8.Stream<List<String>>);
 
   @override
   _i8.Future<Set<String>> getLikedEventIds() =>

--- a/mobile/test/services/curation_service_create_test.mocks.dart
+++ b/mobile/test/services/curation_service_create_test.mocks.dart
@@ -1383,12 +1383,12 @@ class MockLikesRepository extends _i1.Mock implements _i3.LikesRepository {
   }
 
   @override
-  _i9.Stream<Set<String>> watchLikedEventIds() =>
+  _i9.Stream<List<String>> watchLikedEventIds() =>
       (super.noSuchMethod(
             Invocation.method(#watchLikedEventIds, []),
-            returnValue: _i9.Stream<Set<String>>.empty(),
+            returnValue: _i9.Stream<List<String>>.empty(),
           )
-          as _i9.Stream<Set<String>>);
+          as _i9.Stream<List<String>>);
 
   @override
   _i9.Future<Set<String>> getLikedEventIds() =>

--- a/mobile/test/services/curation_service_editors_picks_test.mocks.dart
+++ b/mobile/test/services/curation_service_editors_picks_test.mocks.dart
@@ -1377,12 +1377,12 @@ class MockLikesRepository extends _i1.Mock implements _i3.LikesRepository {
   }
 
   @override
-  _i8.Stream<Set<String>> watchLikedEventIds() =>
+  _i8.Stream<List<String>> watchLikedEventIds() =>
       (super.noSuchMethod(
             Invocation.method(#watchLikedEventIds, []),
-            returnValue: _i8.Stream<Set<String>>.empty(),
+            returnValue: _i8.Stream<List<String>>.empty(),
           )
-          as _i8.Stream<Set<String>>);
+          as _i8.Stream<List<String>>);
 
   @override
   _i8.Future<Set<String>> getLikedEventIds() =>

--- a/mobile/test/services/curation_service_kind_30005_test.mocks.dart
+++ b/mobile/test/services/curation_service_kind_30005_test.mocks.dart
@@ -1377,12 +1377,12 @@ class MockLikesRepository extends _i1.Mock implements _i3.LikesRepository {
   }
 
   @override
-  _i8.Stream<Set<String>> watchLikedEventIds() =>
+  _i8.Stream<List<String>> watchLikedEventIds() =>
       (super.noSuchMethod(
             Invocation.method(#watchLikedEventIds, []),
-            returnValue: _i8.Stream<Set<String>>.empty(),
+            returnValue: _i8.Stream<List<String>>.empty(),
           )
-          as _i8.Stream<Set<String>>);
+          as _i8.Stream<List<String>>);
 
   @override
   _i8.Future<Set<String>> getLikedEventIds() =>

--- a/mobile/test/services/curation_service_test.mocks.dart
+++ b/mobile/test/services/curation_service_test.mocks.dart
@@ -1377,12 +1377,12 @@ class MockLikesRepository extends _i1.Mock implements _i3.LikesRepository {
   }
 
   @override
-  _i8.Stream<Set<String>> watchLikedEventIds() =>
+  _i8.Stream<List<String>> watchLikedEventIds() =>
       (super.noSuchMethod(
             Invocation.method(#watchLikedEventIds, []),
-            returnValue: _i8.Stream<Set<String>>.empty(),
+            returnValue: _i8.Stream<List<String>>.empty(),
           )
-          as _i8.Stream<Set<String>>);
+          as _i8.Stream<List<String>>);
 
   @override
   _i8.Future<Set<String>> getLikedEventIds() =>

--- a/mobile/test/services/curation_service_trending_fetch_test.mocks.dart
+++ b/mobile/test/services/curation_service_trending_fetch_test.mocks.dart
@@ -1377,12 +1377,12 @@ class MockLikesRepository extends _i1.Mock implements _i3.LikesRepository {
   }
 
   @override
-  _i8.Stream<Set<String>> watchLikedEventIds() =>
+  _i8.Stream<List<String>> watchLikedEventIds() =>
       (super.noSuchMethod(
             Invocation.method(#watchLikedEventIds, []),
-            returnValue: _i8.Stream<Set<String>>.empty(),
+            returnValue: _i8.Stream<List<String>>.empty(),
           )
-          as _i8.Stream<Set<String>>);
+          as _i8.Stream<List<String>>);
 
   @override
   _i8.Future<Set<String>> getLikedEventIds() =>


### PR DESCRIPTION
## Summary
- **Ordered liked IDs**: Changed `watchLikedEventIds()` from unordered `Set<String>` to ordered `List<String>` (sorted by `createdAt` desc) through the entire chain: DAO → LocalStorage → Repository → BLoC
- **Fixed infinite pagination**: Added `nextPageOffset` to state to track ID consumption independently from video count, preventing endless load-more when some IDs don't resolve to videos
- **Added deduplication guard**: `_onLoadMoreRequested` now filters out videos already present in state before appending

Closes #1471

## Test plan
- [x] 26 profile liked videos bloc tests pass (6 new tests added)
- [x] All video interactions bloc tests pass
- [x] DAO ordering test added for `watchLikedEventIds`
- [x] `flutter analyze` clean
- [x] `dart format` clean