### PR TITLE
fix: add missing BouncyCastle jdk18on dependencies

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -122,6 +122,10 @@ dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
     implementation("androidx.multidex:multidex:2.0.1")
 
+    // BouncyCastle jdk18on for CertificateSigningService (replaces excluded jdk15to18 versions)
+    implementation("org.bouncycastle:bcpkix-jdk18on:1.78.1")
+    implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
+
     // ProofMode library for cryptographic proof generation
     // Upgraded to 1.0.25 to fix duplicate class issues with java-opentimestamps fat JAR
     implementation("org.witness:android-libproofmode:1.0.25")


### PR DESCRIPTION
## Summary
- PR #1517 added `CertificateSigningService.kt` which imports `org.bouncycastle.*` classes
- It excluded the older `jdk15to18` BouncyCastle versions to avoid conflicts with c2pa
- But the replacement `jdk18on` dependencies were never added, causing unresolved reference errors during Android compilation (`flutter run` fails)
- Adds `bcpkix-jdk18on:1.78.1` and `bcprov-jdk18on:1.78.1` to resolve the imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)