### PR TITLE
fix(ui): position proof badge in upper right corner in fullscreen mode

### DIFF
--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -1206,10 +1206,11 @@ class VideoOverlayActions extends ConsumerWidget {
     // Only interactive elements (buttons, chips with GestureDetector) absorb taps
     // When contextTitle is non-empty, a list header exists above - add extra offset to avoid overlap
     // List header is roughly 64px tall (8px padding + 48px content + 8px padding), add clearance
-    // In fullscreen mode, add extra offset to clear the back button row (AppBar ~56px + padding)
-    final hasListHeader = contextTitle != null && contextTitle!.isNotEmpty;
-    final fullscreenOffset = isFullscreen ? 48.0 : 0.0;
-    final topOffset = (hasListHeader ? 80.0 : 16.0) + fullscreenOffset;
+    // In fullscreen mode, the AppBar floats transparently over the content
+    // so the badge just needs the same base offset - no extra list header padding
+    final hasListHeader =
+        !isFullscreen && contextTitle != null && contextTitle!.isNotEmpty;
+    final topOffset = hasListHeader ? 80.0 : 16.0;
 
     // Calculate bottom offset based on navigation state
     final bottomOffset = hasBottomNavigation


### PR DESCRIPTION
## Summary
- Fixed the "Original" / proof badge floating mid-screen in fullscreen video detail view
- In fullscreen mode, `contextTitle` was incorrectly treated as a list header, adding 128px of offset (80px list header + 48px fullscreen) instead of just the base 16px
- The badge now sits in the upper-right corner, aligned with the back button

## Test plan
- [ ] Open a video in fullscreen detail view (tap from explore/home feed)
- [ ] Verify the "Original" badge appears in the upper-right corner, level with the back button
- [ ] Verify badge position is still correct in non-fullscreen feed views
- [ ] Verify badge position is correct when a list header/context title is present (e.g., hashtag feeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)