### PR TITLE
fix(share): correct video desync, simplify share text, use stable d-tag URLs

### DIFF
--- a/mobile/lib/services/share_service.dart
+++ b/mobile/lib/services/share_service.dart
@@ -34,26 +34,21 @@ class ShareService {
     }
   }
 
-  /// Generate a web app link for a video
+  /// Generate a web app link for a video.
+  ///
+  /// Uses [VideoEvent.stableId] (d-tag) for addressable events so the URL
+  /// remains valid even if the user edits the video metadata.
+  ///
+  /// Requires funnelcake API to support d-tag lookups on /api/videos/{id}.
   String generateWebLink(VideoEvent video) {
-    return '$_appUrl/video/${video.id}';
+    return '$_appUrl/video/${video.stableId}';
   }
 
-  /// Generate shareable text content
+  /// Generate shareable text content.
+  ///
+  /// Returns only the web link so users can add their own context.
   String generateShareText(VideoEvent video) {
-    final content = video.content;
-    final webLink = generateWebLink(video);
-
-    // Extract hashtags for better sharing
-    final hashtags = _extractHashtags(content);
-    final hashtagText = hashtags.isNotEmpty ? ' ${hashtags.join(' ')}' : '';
-
-    // Truncate content if too long
-    final truncatedContent = content.length > 100
-        ? '${content.substring(0, 100)}...'
-        : content;
-
-    return '$truncatedContent$hashtagText\n\n$webLink';
+    return generateWebLink(video);
   }
 
   /// Copy link to clipboard
@@ -119,12 +114,6 @@ class ShareService {
       builder: (context) =>
           _ShareOptionsBottomSheet(video: video, shareService: this),
     );
-  }
-
-  /// Extract hashtags from content
-  List<String> _extractHashtags(String content) {
-    final regex = RegExp(r'#\w+');
-    return regex.allMatches(content).map((match) => match.group(0)!).toList();
   }
 }
 

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -210,25 +210,22 @@ class VideoSharingService {
     }
   }
 
-  /// Generate external share URL for the video
+  /// Generate external share URL for the video.
+  ///
+  /// Uses [VideoEvent.stableId] (d-tag) for addressable events so the URL
+  /// remains valid even if the user edits the video metadata.
+  ///
+  /// Requires funnelcake API to support d-tag lookups on /api/videos/{id}.
   String generateShareUrl(VideoEvent video) {
     const baseUrl = 'https://divine.video';
-    return '$baseUrl/video/${video.id}';
+    return '$baseUrl/video/${video.stableId}';
   }
 
   /// Generate share text for external sharing (social media, etc.)
+  ///
+  /// Returns only the share URL so users can add their own context.
   String generateShareText(VideoEvent video) {
-    final title = video.title ?? 'Check out this vine!';
-    final url = generateShareUrl(video);
-
-    var shareText = title;
-    if (video.hashtags.isNotEmpty) {
-      final hashtags = video.hashtags.map((tag) => '#$tag').join(' ');
-      shareText += '\n\n$hashtags';
-    }
-    shareText += '\n\nWatch on divine: $url';
-
-    return shareText;
+    return generateShareUrl(video);
   }
 
   /// Check if user has been shared with recently


### PR DESCRIPTION
## Summary
- **Fix share getting wrong video**: `pooledVideos` filters out null-URL entries, causing index divergence with `state.videos`. Now resolves videos by ID instead of index in both `onActiveVideoChanged` and `itemBuilder`.
- **Simplify share text**: Share now sends just the URL — users add their own context.
- **Use stableId (d-tag) in share URLs**: Links use addressable event d-tag so they survive video metadata edits.

## Blocked on: Funnelcake API d-tag support

**DO NOT MERGE** until funnelcake `/api/videos/{id}` supports d-tag lookups.

Current state: the endpoint only queries `WHERE v.id = ?` (event ID). It needs to fall back to `WHERE v.d_tag = ?` when event ID lookup returns no results.

### Required funnelcake changes:
1. Add bloom filter index on `d_tag` column in `events_local`
2. Add `get_video_by_d_tag()` method to ClickHouseClient
3. Update `/api/videos/{id}` handler to try event ID first, then d-tag
4. The `d_tag` materialized column and `videos` view already exist

### Why d-tag URLs?
Kind 34236 videos are Nostr addressable events. When a user edits video metadata, a new event ID is created but the d-tag stays the same. Using d-tag in share URLs means links don't break after edits.

## Test plan
- [x] All 14 fullscreen feed screen tests pass
- [x] All video sharing service tests pass
- [ ] Verify funnelcake API resolves d-tag lookups (blocked)
- [ ] End-to-end: share video, open link in browser, confirm correct video loads (blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)