### PR TITLE
fix: broken notifications for comments and reposts

### DIFF
--- a/mobile/lib/services/notification_service_enhanced.dart
+++ b/mobile/lib/services/notification_service_enhanced.dart
@@ -206,7 +206,7 @@ class NotificationServiceEnhanced {
   /// Subscribe to reposts
   void _subscribeToReposts(String userPubkey) {
     final filter = Filter(
-      kinds: [16], // Kind 16 = Generic Reposts (NIP-18)
+      kinds: [6, 16], // Kind 6 = Repost, Kind 16 = Generic Repost (NIP-18)
       // NO h filter - we query all relays
     );
 
@@ -225,13 +225,7 @@ class NotificationServiceEnhanced {
     if (event.content != '+') return;
 
     // Get the video that was liked
-    String? videoEventId;
-    for (final tag in event.tags) {
-      if (tag.isNotEmpty && tag[0] == 'e' && tag.length > 1) {
-        videoEventId = tag[1];
-        break;
-      }
-    }
+    final videoEventId = extractVideoEventId(event);
     if (videoEventId == null) return;
 
     // Get video info
@@ -264,14 +258,9 @@ class NotificationServiceEnhanced {
 
   /// Handle comment events
   Future<void> _handleCommentEvent(Event event) async {
-    // Check if this is a reply to a video
-    String? videoEventId;
-    for (final tag in event.tags) {
-      if (tag.isNotEmpty && tag[0] == 'e' && tag.length > 1) {
-        videoEventId = tag[1];
-        break;
-      }
-    }
+    // Extract video ID using helper that checks uppercase 'E' tag first
+    // (NIP-22 root scope for comments), then falls back to lowercase 'e'
+    final videoEventId = extractVideoEventId(event);
     if (videoEventId == null) return;
 
     // Get video info
@@ -380,14 +369,8 @@ class NotificationServiceEnhanced {
 
   /// Handle repost events
   Future<void> _handleRepostEvent(Event event) async {
-    // Get the video that was reposted
-    String? videoEventId;
-    for (final tag in event.tags) {
-      if (tag.isNotEmpty && tag[0] == 'e' && tag.length > 1) {
-        videoEventId = tag[1];
-        break;
-      }
-    }
+    // Get the video that was reposted using helper
+    final videoEventId = extractVideoEventId(event);
     if (videoEventId == null) return;
 
     // Get video info


### PR DESCRIPTION
## Summary
- **Comments (kind 1111)**: Was only checking lowercase `e` tag for video ID, but NIP-22 comments use uppercase `E` tag for root scope. Used the existing `extractVideoEventId()` helper which already handles this correctly.
- **Reposts**: Was only subscribing to kind 16 (generic repost), now also subscribes to kind 6 (standard repost per NIP-18).
- **Reactions**: Switched to use `extractVideoEventId()` helper for consistency — removes duplicated tag-extraction logic.

Net result: -24 lines of duplicated inline tag parsing, replaced with 3 calls to the existing helper function.

## Test plan
- [x] Existing notification_helpers_test.dart passes (covers `extractVideoEventId` with uppercase E, lowercase e, missing tags)
- [x] Existing notification_service_enhanced_test.dart passes (dedup, ordering)
- [ ] Manual test: comment on a video, verify notification appears for video owner
- [ ] Manual test: repost a video (kind 6), verify notification appears for video owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)