### PR TITLE
fix: route sendProfile through publishEvent for relay health checks

### DIFF
--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -690,19 +690,19 @@ class NostrClient {
 
   /// Sends a user profile (Kind 0 metadata event).
   ///
-  /// Successfully sent events are cached locally with 1-day expiry.
+  /// Routes through [publishEvent] to ensure relay health checks and
+  /// reconnection logic run before broadcasting. Kind 0 is replaceable,
+  /// so the event is cached only on successful publish.
   Future<Event?> sendProfile({
     required Map<String, dynamic> profileContent,
   }) async {
-    final profileEvent = await _nostr.sendProfile(
-      content: jsonEncode(profileContent),
+    final event = Event(
+      publicKey,
+      EventKind.metadata,
+      [],
+      jsonEncode(profileContent),
     );
-
-    if (profileEvent != null) {
-      _cacheEvent(profileEvent);
-    }
-
-    return profileEvent;
+    return publishEvent(event);
   }
 
   /// Sends a repost

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -88,19 +88,6 @@ class Nostr {
     );
   }
 
-  Future<Event?> sendProfile({
-    required String content,
-    List<String>? tempRelays,
-    List<String>? targetRelays,
-  }) async {
-    Event event = Event(_cachedPublicKey, EventKind.metadata, [], content);
-    return await sendEvent(
-      event,
-      tempRelays: tempRelays,
-      targetRelays: targetRelays,
-    );
-  }
-
   Future<Event?> deleteEvent(
     String eventId, {
     List<String>? tempRelays,


### PR DESCRIPTION
## Summary
- `NostrClient.sendProfile()` was bypassing `publishEvent()` and calling `_nostr.sendProfile()` directly, skipping relay health checks and reconnection logic
- If relays were disconnected when the user saved their profile, the Kind 0 event silently failed to publish — but the local cache updated, so the user saw their changes while nobody else did
- Now `sendProfile()` routes through `publishEvent()`, which checks relay connectivity, retries disconnected relays, and only caches on successful send
- Deleted `Nostr.sendProfile()` from the SDK (no other callers)

Closes #1258

## Test plan
- [ ] Manual: edit profile, save, verify update visible on another Nostr client