### PR TITLE
fix(proofmode_badge): fix proofMode badge positioned behind status bar

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -455,13 +455,18 @@ class _PooledFullscreenItemContent extends StatelessWidget {
           isPortrait: isPortrait,
         ),
         overlayBuilder: (context, videoController, player) =>
-            VideoOverlayActions(
-              video: video,
-              isVisible: isActive,
-              isActive: isActive,
-              hasBottomNavigation: false,
-              contextTitle: contextTitle,
-              isFullscreen: true,
+            // Restore original system view padding that may have been
+            // consumed by SafeArea or other widgets up the tree.
+            MediaQuery(
+              data: MediaQueryData.fromView(View.of(context)),
+              child: VideoOverlayActions(
+                video: video,
+                isVisible: isActive,
+                isActive: isActive,
+                hasBottomNavigation: false,
+                contextTitle: contextTitle,
+                isFullscreen: true,
+              ),
             ),
       ),
     );

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -1311,18 +1311,10 @@ class VideoOverlayActions extends ConsumerWidget {
     // so the badge just needs the same base offset - no extra list header padding
     final hasListHeader =
         !isFullscreen && contextTitle != null && contextTitle!.isNotEmpty;
-    final topOffset = hasListHeader ? 80.0 : 16.0;
+    final topOffset = hasListHeader ? 80.0 : 8.0;
 
     // Calculate bottom offset based on navigation state
-    final bottomOffset = hasBottomNavigation
-        ? 14.0
-        : (isFullscreen ? 48.0 : 14.0);
-
-    // Read system view padding directly from the platform view, not from
-    // MediaQuery which may have been modified by SafeArea or other widgets.
-    final systemViewPadding = MediaQueryData.fromView(
-      View.of(context),
-    ).viewPadding;
+    final bottomOffset = 14.0;
 
     return Stack(
       children: [
@@ -1355,7 +1347,7 @@ class VideoOverlayActions extends ConsumerWidget {
         // ProofMode and Vine badges in upper right corner (tappable)
         if (!isPreviewMode)
           Positioned(
-            top: systemViewPadding.top + topOffset,
+            top: MediaQuery.viewPaddingOf(context).top + topOffset,
             right: 16,
             child: GestureDetector(
               onTap: () {


### PR DESCRIPTION
## Description

The ProofMode or Vine badge was positioned behind the status bar, meaning that users could not see or interact with it properly. Next to that there was a big gap between the bottom controls and the bottom of the screen, but that gap was only in the Explore route and not in the Home route.

| Before | After   |
| ------- | ------- |
| ![before](https://github.com/user-attachments/assets/88d353e8-d9e6-4752-900b-bdf0b3720e18) | ![after](https://github.com/user-attachments/assets/14546a22-6e1a-48e5-abc3-47ecc4a38413) |


**Related Issue:** Closes #1609

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore