### PR TITLE
fix: resolve various issues in the home-screen 

### DIFF
--- a/mobile/lib/screens/home_screen_router.dart
+++ b/mobile/lib/screens/home_screen_router.dart
@@ -251,7 +251,6 @@ class _HomeScreenRouterState extends ConsumerState<HomeScreenRouter>
               final isActive = index == _currentPageIndex;
 
               return ClipRRect(
-                clipBehavior: .hardEdge,
                 child: VideoFeedItem(
                   key: ValueKey('video-${videos[index].id}'),
                   video: videos[index],


### PR DESCRIPTION
## Description

This PR resolves the following issues on the home screen:
- When scrolling to the next video, the overlay controls do not appear and the video player does not start.
- Scrolling to the next video shows a quick black screen while the video loads.
- Scrolling to the next video causes a flicker after the next video has loaded due to Boxfit.cover from the next video.

I have reproduced all of these issues with a real Galaxy S10, but users have also reported them on discord. One user posted a video showing every issue [here](https://discordapp.com/channels/1470168817589158040/1470255950408454164/1473494882344767498).

## IMPORTANT

There is still another issue which say something like => "The app is crashing due to an **OutOfMemoryError** because it has reached the maximum allowed heap size (~256 MB) and less than 1% of memory is free after garbage collection. Even a small 4 KB allocation fails, meaning the app is using too much memory or leaking resources."

It seems the Mediakit player is having trouble disposing of resources. This has been tested on a real Galaxy S10, but it will also appear on other devices because many users on Discord have reported this issue.


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore