### PR TITLE
feat(auth): connect to discovered NIP-65 relays when discovery completes

### DIFF
--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -50,7 +50,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'eafe15d22a620201390b7a5ef297107ebd247a3b';
+String _$nostrServiceHash() => r'fedc91de1bedcb5341a451bf67f0276899f75f8d';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/test/helpers/test_provider_overrides.mocks.dart
+++ b/mobile/test/helpers/test_provider_overrides.mocks.dart
@@ -457,6 +457,14 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i2.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/integration/account_deletion_flow_test.mocks.dart
+++ b/mobile/test/integration/account_deletion_flow_test.mocks.dart
@@ -669,6 +669,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/integration/upload_publish_e2e_comprehensive_test.mocks.dart
+++ b/mobile/test/integration/upload_publish_e2e_comprehensive_test.mocks.dart
@@ -365,6 +365,14 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i2.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/providers/curation_provider_lifecycle_test.mocks.dart
+++ b/mobile/test/providers/curation_provider_lifecycle_test.mocks.dart
@@ -1830,6 +1830,14 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i4.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/providers/curation_provider_tab_refresh_test.mocks.dart
+++ b/mobile/test/providers/curation_provider_tab_refresh_test.mocks.dart
@@ -1830,6 +1830,14 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i4.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/providers/home_feed_loading_fix_test.mocks.dart
+++ b/mobile/test/providers/home_feed_loading_fix_test.mocks.dart
@@ -2022,6 +2022,14 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i4.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/screens/auth/secure_account_screen_test.mocks.dart
+++ b/mobile/test/screens/auth/secure_account_screen_test.mocks.dart
@@ -482,6 +482,14 @@ class MockAuthService extends _i1.Mock implements _i5.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i5.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/screens/profile_setup_relay_confirmation_test.mocks.dart
+++ b/mobile/test/screens/profile_setup_relay_confirmation_test.mocks.dart
@@ -665,6 +665,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/screens/settings_screen_audio_sharing_test.mocks.dart
+++ b/mobile/test/screens/settings_screen_audio_sharing_test.mocks.dart
@@ -152,6 +152,14 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i2.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/screens/welcome_screen_auth_state_test.mocks.dart
+++ b/mobile/test/screens/welcome_screen_auth_state_test.mocks.dart
@@ -150,6 +150,14 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i2.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/account_deletion_service_test.mocks.dart
+++ b/mobile/test/services/account_deletion_service_test.mocks.dart
@@ -662,6 +662,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/content_deletion_service_test.mocks.dart
+++ b/mobile/test/services/content_deletion_service_test.mocks.dart
@@ -662,6 +662,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/content_reporting_service_test.mocks.dart
+++ b/mobile/test/services/content_reporting_service_test.mocks.dart
@@ -662,6 +662,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curated_list_service_collaboration_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_collaboration_test.mocks.dart
@@ -662,6 +662,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curated_list_service_crud_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_crud_test.mocks.dart
@@ -744,6 +744,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curated_list_service_initialization_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_initialization_test.mocks.dart
@@ -662,6 +662,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curated_list_service_persistence_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_persistence_test.mocks.dart
@@ -662,6 +662,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curated_list_service_playlist_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_playlist_test.mocks.dart
@@ -662,6 +662,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curated_list_service_query_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_query_test.mocks.dart
@@ -662,6 +662,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curated_list_service_stream_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_stream_test.mocks.dart
@@ -662,6 +662,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curated_list_service_video_management_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_video_management_test.mocks.dart
@@ -662,6 +662,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curation_publish_test.mocks.dart
+++ b/mobile/test/services/curation_publish_test.mocks.dart
@@ -1684,6 +1684,14 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i4.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curation_service_analytics_test.mocks.dart
+++ b/mobile/test/services/curation_service_analytics_test.mocks.dart
@@ -1684,6 +1684,14 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i4.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curation_service_create_test.mocks.dart
+++ b/mobile/test/services/curation_service_create_test.mocks.dart
@@ -1852,6 +1852,14 @@ class MockAuthService extends _i1.Mock implements _i5.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i5.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curation_service_editors_picks_test.mocks.dart
+++ b/mobile/test/services/curation_service_editors_picks_test.mocks.dart
@@ -1684,6 +1684,14 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i4.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curation_service_kind_30005_test.mocks.dart
+++ b/mobile/test/services/curation_service_kind_30005_test.mocks.dart
@@ -1684,6 +1684,14 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i4.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curation_service_test.mocks.dart
+++ b/mobile/test/services/curation_service_test.mocks.dart
@@ -1684,6 +1684,14 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i4.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/curation_service_trending_fetch_test.mocks.dart
+++ b/mobile/test/services/curation_service_trending_fetch_test.mocks.dart
@@ -1684,6 +1684,14 @@ class MockAuthService extends _i1.Mock implements _i4.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i4.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/profile_editing_test.mocks.dart
+++ b/mobile/test/services/profile_editing_test.mocks.dart
@@ -666,6 +666,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/services/video_sharing_service_test.mocks.dart
+++ b/mobile/test/services/video_sharing_service_test.mocks.dart
@@ -665,6 +665,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/unit/curated_list_relay_sync_test.mocks.dart
+++ b/mobile/test/unit/curated_list_relay_sync_test.mocks.dart
@@ -744,6 +744,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/widgets/settings_delete_account_test.mocks.dart
+++ b/mobile/test/widgets/settings_delete_account_test.mocks.dart
@@ -198,6 +198,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/widgets/settings_screen_scaffold_test.mocks.dart
+++ b/mobile/test/widgets/settings_screen_scaffold_test.mocks.dart
@@ -150,6 +150,14 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i2.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/widgets/settings_screen_test.mocks.dart
+++ b/mobile/test/widgets/settings_screen_test.mocks.dart
@@ -150,6 +150,14 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i2.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/widgets/share_menu_safety_section_test.mocks.dart
+++ b/mobile/test/widgets/share_menu_safety_section_test.mocks.dart
@@ -447,6 +447,14 @@ class MockAuthService extends _i1.Mock implements _i3.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i3.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/widgets/tabbed_settings_screen_test.mocks.dart
+++ b/mobile/test/widgets/tabbed_settings_screen_test.mocks.dart
@@ -197,6 +197,14 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i2.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/widgets/vine_drawer_test.mocks.dart
+++ b/mobile/test/widgets/vine_drawer_test.mocks.dart
@@ -150,6 +150,14 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i2.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,

--- a/mobile/test/widgets/welcome_screen_font_test.mocks.dart
+++ b/mobile/test/widgets/welcome_screen_font_test.mocks.dart
@@ -150,6 +150,14 @@ class MockAuthService extends _i1.Mock implements _i2.AuthService {
           as String);
 
   @override
+  void registerUserRelaysDiscoveredCallback(
+    _i2.UserRelaysDiscoveredCallback? callback,
+  ) => super.noSuchMethod(
+    Invocation.method(#registerUserRelaysDiscoveredCallback, [callback]),
+    returnValueForMissingStub: null,
+  );
+
+  @override
   void clearError() => super.noSuchMethod(
     Invocation.method(#clearError, []),
     returnValueForMissingStub: null,


### PR DESCRIPTION
## Description

When a Nostr-native user signs in (nsec or bunker), NIP-65 relay discovery runs in the background. The NostrClient was built as soon as the user was authenticated, so it often had empty `userRelays` and never received the discovered relays when discovery finished later.

This change adds a callback from AuthService to NostrService: when relay discovery completes with a non-empty list, the callback is invoked and the current NostrClient adds those relays via `addRelays()`. No blocking — non-Nostr-native users are unchanged. Nostr-native users now get their relays connected automatically when discovery completes.

**Changes:**
- AuthService: `UserRelaysDiscoveredCallback`, `registerUserRelaysDiscoveredCallback()`; invoke callback after successful NIP-65 discovery; clear callback and `_userRelays` on signOut.
- NostrService provider: register callback that calls `client.addRelays(relayUrls)`; unregister on dispose; re-register for new client on identity change.

**Related Issue:** N/A

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

Made with [Cursor](https://cursor.com)