### PR TITLE
fix(profile): use temp NostrClient for indexer queries to avoid relay churn

### DIFF
--- a/mobile/test/profile_fetching_test.dart
+++ b/mobile/test/profile_fetching_test.dart
@@ -36,6 +36,7 @@ void main() {
     profileService = UserProfileService(
       mockNostrService,
       subscriptionManager: mockSubscriptionManager,
+      skipIndexerFallback: true, // Avoid real WebSocket in tests
     );
     profileService.setPersistentCache(mockCacheService);
   });

--- a/mobile/test/services/profile_update_test.dart
+++ b/mobile/test/services/profile_update_test.dart
@@ -27,6 +27,7 @@ void main() {
       service = UserProfileService(
         mockNostrService,
         subscriptionManager: mockSubscriptionManager,
+        skipIndexerFallback: true, // Avoid temp client in mocked tests
       );
     });
 


### PR DESCRIPTION
## Summary
Use a temporary NostrClient for profile indexer (purplepag.es, user.kindpag.es) queries instead of the main client. This prevents relay set changes that triggered RelaySetChangeBridge, forceReconnectAll, and feed resets.

## Changes
- `UserProfileService._queryIndexersForProfile` now creates a temp NostrClient, queries indexers, then disposes it
- Main relay set is never modified → no churn, no reconnections for non-Nostr-native users
- Add `skipIndexerFallback` param for tests that mock NostrClient
- Tests: profile_fetching_test, profile_update_test use `skipIndexerFallback: true`

## Impact
- Non-Nostr-native users: no longer slowed when viewing videos from authors whose profiles aren't on divine
- Nostr-native users: relay discovery (NIP-65) unchanged; relay lists still discovered and connected
- Divine relay connection: unaffected (never touched by this change)

Made with [Cursor](https://cursor.com)