### PR TITLE
chore(video): add debug logging to PlayerPool and VideoFeedController

### DIFF
--- a/mobile/packages/pooled_video_player/lib/src/controllers/player_pool.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/player_pool.dart
@@ -184,6 +184,7 @@ class PlayerPool {
     // Check if player already exists
     if (_players.containsKey(url)) {
       _touch(url);
+      debugPrint('PlayerPool: reusing player for $url');
       return _players[url]!;
     }
 
@@ -196,6 +197,11 @@ class PlayerPool {
     final player = await _createPlayer();
     _players[url] = player;
     _lruOrder.add(url);
+
+    debugPrint(
+      'PlayerPool: created player for $url '
+      '(${_players.length}/$maxPlayers players)',
+    );
 
     return player;
   }
@@ -226,6 +232,10 @@ class PlayerPool {
     final url = _lruOrder.removeAt(0);
     final player = _players.remove(url);
     if (player != null && !player.isDisposed) {
+      debugPrint(
+        'PlayerPool: LRU evicting $url '
+        '(${_players.length}/$maxPlayers players remain)',
+      );
       await player.dispose();
     }
   }
@@ -235,6 +245,10 @@ class PlayerPool {
     final player = _players.remove(url);
     _lruOrder.remove(url);
     if (player != null && !player.isDisposed) {
+      debugPrint(
+        'PlayerPool: releasing $url '
+        '(${_players.length}/$maxPlayers players remain)',
+      );
       await player.dispose();
     }
   }

--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -201,6 +201,11 @@ class VideoFeedController extends ChangeNotifier {
     if (_isActive == active) return;
     _isActive = active;
 
+    debugPrint(
+      'VideoFeedController: setActive($active) '
+      '(${_loadedPlayers.length} loaded players)',
+    );
+
     if (!active) {
       // Pause and release all players to free memory
       _pauseVideo(_currentIndex);
@@ -309,6 +314,12 @@ class VideoFeedController extends ChangeNotifier {
   Future<void> _loadPlayer(int index) async {
     if (_isDisposed || _loadingIndices.contains(index)) return;
     if (index < 0 || index >= _videos.length) return;
+
+    debugPrint(
+      'VideoFeedController: loading player at index $index '
+      '(${_loadedPlayers.length} loaded, '
+      '${_indexNotifiers.length} notifiers)',
+    );
 
     _loadingIndices.add(index);
     _loadStates[index] = LoadState.loading;
@@ -428,6 +439,12 @@ class VideoFeedController extends ChangeNotifier {
   }
 
   void _releasePlayer(int index) {
+    debugPrint(
+      'VideoFeedController: releasing player at index $index '
+      '(${_loadedPlayers.length} loaded, '
+      '${_indexNotifiers.length} notifiers)',
+    );
+
     _stopPositionTimer(index);
     unawaited(_bufferSubscriptions[index]?.cancel());
     _bufferSubscriptions.remove(index);
@@ -440,6 +457,15 @@ class VideoFeedController extends ChangeNotifier {
   @override
   void dispose() {
     if (_isDisposed) return;
+
+    debugPrint(
+      'VideoFeedController: dispose() called '
+      '(${_loadedPlayers.length} loaded players, '
+      '${_indexNotifiers.length} notifiers, '
+      '${_positionTimers.length} timers, '
+      '${_bufferSubscriptions.length} subscriptions)',
+    );
+
     _isDisposed = true;
 
     // Release all players back to pool (stops playback and removes from pool)


### PR DESCRIPTION
## Summary
- Add `debugPrint` statements to `PlayerPool` for player reuse, creation, LRU eviction, and release events
- Add `debugPrint` statements to `VideoFeedController` for `setActive`, `_loadPlayer`, `_releasePlayer`, and `dispose` lifecycle events
- Includes player counts and notifier counts for easier debugging of pool state

## Test plan
- [x] All 289 existing tests pass (no behavior changes, logging only)
- [ ] Verify debug output appears in console during video feed navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)