### PR TITLE
fix: diverse fixes in page and bloc

### DIFF
--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -92,9 +92,12 @@ class _VideoFeedViewState extends State<VideoFeedView> {
                     contextTitle: 'BLoC Test (${state.mode.name})',
                   );
                 },
-                onActiveVideoChanged: (video, index) {
-                  // Trigger pagination when near end
-                  if (state.hasMore && index >= pooledVideos.length - 2) {
+                onNearEnd: (index) {
+                  // PooledVideoFeed fires this when the user is within
+                  // nearEndThreshold (default 3) of the end, using the
+                  // controller's actual video count (not the BlocBuilder's
+                  // list length, which may differ due to deduplication).
+                  if (state.hasMore) {
                     context.read<VideoFeedBloc>().add(
                       const VideoFeedLoadMoreRequested(),
                     );


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

 Fix video feed pagination getting stuck after ~12 scrolls. The root cause was a count mismatch between BLoC state (which could contain duplicate videos when Funnelcake falls through to Nostr) and PooledVideoFeed's internal        
  deduplication, making the pagination trigger unreachable. Also fixes premature pagination stops from server-side filtering and incorrect cursor/sort behavior for popular feed.                                                       
                                                                                                                                                                                                                                        
  Key fixes:                                                                                                                                                                                                                            
  - Deduplicate videos by event ID in BLoC to match PooledVideoFeed's internal dedup
  - Switch pagination trigger from `onActiveVideoChanged` to `onNearEnd` (uses controller's actual video count)
  - Use `droppable()` transformer to prevent concurrent load-more requests
  - Fix `hasMore` logic (`isNotEmpty` instead of `length == pageSize`) so server-side filtering doesn't stop pagination early
  - Use min `createdAt` across all videos for cursor (fixes popular feed skipping videos)
  - Preserve engagement-based sort order for popular feed during pagination

**Related Issue:** Closes #1664

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore