### PR TITLE
fix(back_button): handle back navigation for video editing routes

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -983,7 +983,13 @@ class _DivineAppState extends ConsumerState<DivineApp> {
           // Go back to explore
           router.go(ExploreScreen.path);
           return true; // Handled
-
+        case RouteType.videoRecorder:
+        case RouteType.videoClipEditor:
+        case RouteType.videoEditor:
+        case RouteType.videoMetadata:
+          // Pop the video editing flow screens
+          router.pop();
+          return true; // Handled
         default:
           break;
       }

--- a/mobile/lib/services/back_button_handler.dart
+++ b/mobile/lib/services/back_button_handler.dart
@@ -55,6 +55,13 @@ class BackButtonHandler {
         // Go back to explore
         _router!.go(ExploreScreen.path);
         return true; // Handled
+      case RouteType.videoRecorder:
+      case RouteType.videoClipEditor:
+      case RouteType.videoEditor:
+      case RouteType.videoMetadata:
+        // Pop the video editing flow screens
+        _router!.pop();
+        return true; // Handled
       default:
         break;
     }


### PR DESCRIPTION
## Description

This PR fixes an issue where pressing the Android system back button during video recording or editing would immediately navigate users back to the notifications screen instead of respecting the navigation stack.

**NOTE** In the future we should add e2e-tests covering the complete navigation flow including back navigation behavior across all routes. 

**Related Issue:** Closes #1675
 
## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore