### PR TITLE
fix: bunker auth flow, auth pre-fetch cycle, relay stats, and follower counts

### DIFF
--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -432,20 +432,38 @@ final class RelayStatisticsStreamProvider
 String _$relayStatisticsStreamHash() =>
     r'0ab9617467aabccc62b36b0de4d79a0ce9d01c5e';
 
-/// Bridge provider that connects NostrClient relay status updates to RelayStatisticsService
-/// Must be watched at app level to activate the bridge
+/// Bridge provider that connects NostrClient relay status updates to
+/// RelayStatisticsService.
+///
+/// Tracks connection/disconnection events via the relay status stream and
+/// periodically syncs per-relay SDK counters (events received, queries sent,
+/// errors) so each relay displays its own real statistics.
+///
+/// Must be watched at app level to activate the bridge.
 
 @ProviderFor(relayStatisticsBridge)
 const relayStatisticsBridgeProvider = RelayStatisticsBridgeProvider._();
 
-/// Bridge provider that connects NostrClient relay status updates to RelayStatisticsService
-/// Must be watched at app level to activate the bridge
+/// Bridge provider that connects NostrClient relay status updates to
+/// RelayStatisticsService.
+///
+/// Tracks connection/disconnection events via the relay status stream and
+/// periodically syncs per-relay SDK counters (events received, queries sent,
+/// errors) so each relay displays its own real statistics.
+///
+/// Must be watched at app level to activate the bridge.
 
 final class RelayStatisticsBridgeProvider
     extends $FunctionalProvider<void, void, void>
     with $Provider<void> {
-  /// Bridge provider that connects NostrClient relay status updates to RelayStatisticsService
-  /// Must be watched at app level to activate the bridge
+  /// Bridge provider that connects NostrClient relay status updates to
+  /// RelayStatisticsService.
+  ///
+  /// Tracks connection/disconnection events via the relay status stream and
+  /// periodically syncs per-relay SDK counters (events received, queries sent,
+  /// errors) so each relay displays its own real statistics.
+  ///
+  /// Must be watched at app level to activate the bridge.
   const RelayStatisticsBridgeProvider._()
     : super(
         from: null,
@@ -480,7 +498,7 @@ final class RelayStatisticsBridgeProvider
 }
 
 String _$relayStatisticsBridgeHash() =>
-    r'8e5867762c8201c7244d2f44ba3bc84cbc63f012';
+    r'4c105f2e370e769b48b77ac90ca08bca6f95a385';
 
 /// Bridge provider that detects when the configured relay set changes
 /// (relays added or removed) and triggers a full feed reset+resubscribe.
@@ -1869,7 +1887,7 @@ final class AuthServiceProvider
   }
 }
 
-String _$authServiceHash() => r'50e8112a7c95a9a9ebff6f4fb649131e9874e676';
+String _$authServiceHash() => r'f02dd0b46777ee8df7d43b2adec9e16462611ac2';
 
 /// Provider that returns current auth state and rebuilds when it changes.
 /// Widgets should watch this instead of authService.authState directly
@@ -2425,7 +2443,7 @@ final class FollowRepositoryProvider
   }
 }
 
-String _$followRepositoryHash() => r'dadc0598cb6bc48a4a6a1776f8c72117610aef2d';
+String _$followRepositoryHash() => r'cc2cdaa9ac69fd09c9131f43f2068f533ff3e593';
 
 /// Provider for ProfileRepository instance
 ///

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -538,28 +538,8 @@ class _UniqueIdentifier extends ConsumerWidget {
             ),
           ],
         ),
-        // Show warning for own profile when NIP-05 verification fails
-        if (isOwnProfile && hasNip05 && verificationFailed)
-          Padding(
-            padding: const EdgeInsets.only(top: 4),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  Icons.warning_amber_rounded,
-                  color: Colors.orange,
-                  size: 14,
-                ),
-                const SizedBox(width: 4),
-                Flexible(
-                  child: Text(
-                    'Username not verifying - contact support',
-                    style: VineTheme.bodySmallFont(color: Colors.orange),
-                  ),
-                ),
-              ],
-            ),
-          ),
+        // NIP-05 verification failure is silently ignored for now.
+        // TODO(#1658): surface NIP-05 verification errors once backend is fixed.
       ],
     );
   }

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -83,7 +83,12 @@ void main() {
     // Set up default mock behavior
     when(() => mockRelayPool.activeRelays()).thenReturn([]);
     when(() => mockRelayPool.getRelay(any())).thenReturn(null);
-    when(() => mockRelayPool.add(any())).thenAnswer((_) async => true);
+    when(
+      () => mockRelayPool.add(
+        any(),
+        autoSubscribe: any(named: 'autoSubscribe'),
+      ),
+    ).thenAnswer((_) async => true);
     when(() => mockRelayPool.remove(any())).thenReturn(null);
 
     manager = RelayManager(
@@ -191,7 +196,12 @@ void main() {
         await manager.initialize();
 
         // Should only add relay once
-        verify(() => mockRelayPool.add(any())).called(1);
+        verify(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).called(1);
       });
 
       test('connects to all configured relays', () async {
@@ -209,7 +219,12 @@ void main() {
         await managerWithStorage.initialize();
 
         // Should connect to default + 2 custom relays
-        verify(() => mockRelayPool.add(any())).called(3);
+        verify(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).called(3);
       });
 
       test('initializes status for all configured relays', () async {
@@ -247,7 +262,12 @@ void main() {
       test('connects to the relay via RelayPool', () async {
         await manager.addRelay(testCustomRelayUrl);
 
-        verify(() => mockRelayPool.add(any())).called(greaterThan(1));
+        verify(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).called(greaterThan(1));
       });
 
       test('returns false for empty URL', () async {
@@ -298,7 +318,12 @@ void main() {
       });
 
       test('updates status to connected on success', () async {
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => true);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => true);
 
         await manager.addRelay(testCustomRelayUrl);
 
@@ -307,7 +332,12 @@ void main() {
       });
 
       test('updates status to error on failure', () async {
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => false);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => false);
 
         await manager.addRelay(testCustomRelayUrl);
 
@@ -351,7 +381,12 @@ void main() {
       });
 
       test('emits both connecting and final error state on failure', () async {
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => false);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => false);
 
         final statusUpdates = <Map<String, RelayConnectionStatus>>[];
         manager.statusStream.listen(statusUpdates.add);
@@ -392,6 +427,7 @@ void main() {
       });
 
       test('disconnects from the relay via RelayPool', () async {
+        clearInteractions(mockRelayPool);
         await manager.removeRelay(testCustomRelayUrl);
 
         verify(() => mockRelayPool.remove(testCustomRelayUrl)).called(1);
@@ -486,14 +522,24 @@ void main() {
       });
 
       test('returns true for connected relay', () async {
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => true);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => true);
         await manager.addRelay(testCustomRelayUrl);
 
         expect(manager.isRelayConnected(testCustomRelayUrl), isTrue);
       });
 
       test('returns false for disconnected relay', () async {
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => false);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => false);
         await manager.addRelay(testCustomRelayUrl);
 
         expect(manager.isRelayConnected(testCustomRelayUrl), isFalse);
@@ -577,7 +623,12 @@ void main() {
 
       test('returns empty when all relays fail to connect', () async {
         // Create manager where connection fails
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => false);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => false);
 
         final failingManager = RelayManager(
           config: config,
@@ -596,23 +647,48 @@ void main() {
 
       test('retries connection to disconnected relays', () async {
         // First connection fails
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => false);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => false);
         await manager.addRelay(testCustomRelayUrl);
 
         // Reset and make retry succeed
         clearInteractions(mockRelayPool);
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => true);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => true);
 
         await manager.retryDisconnectedRelays();
 
-        verify(() => mockRelayPool.add(any())).called(greaterThan(0));
+        verify(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).called(greaterThan(0));
       });
 
       test('updates status after successful retry', () async {
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => false);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => false);
         await manager.addRelay(testCustomRelayUrl);
 
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => true);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => true);
         await manager.retryDisconnectedRelays();
 
         final status = manager.getRelayStatus(testCustomRelayUrl);
@@ -620,13 +696,23 @@ void main() {
       });
 
       test('emits status updates during retry', () async {
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => false);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => false);
         await manager.addRelay(testCustomRelayUrl);
 
         final statusUpdates = <Map<String, RelayConnectionStatus>>[];
         manager.statusStream.listen(statusUpdates.add);
 
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => true);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => true);
         await manager.retryDisconnectedRelays();
         await Future<void>.delayed(Duration.zero);
 
@@ -642,16 +728,32 @@ void main() {
 
       test('disconnects and reconnects to relay', () async {
         clearInteractions(mockRelayPool);
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => true);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => true);
 
         await manager.reconnectRelay(testCustomRelayUrl);
 
-        verify(() => mockRelayPool.remove(testCustomRelayUrl)).called(1);
-        verify(() => mockRelayPool.add(any())).called(1);
+        // Called twice: once by reconnectRelay and once by _connectToRelay
+        verify(() => mockRelayPool.remove(testCustomRelayUrl)).called(2);
+        verify(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).called(1);
       });
 
       test('returns true on successful reconnection', () async {
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => true);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => true);
 
         final result = await manager.reconnectRelay(testCustomRelayUrl);
 
@@ -659,7 +761,12 @@ void main() {
       });
 
       test('returns false on failed reconnection', () async {
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => false);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => false);
 
         final result = await manager.reconnectRelay(testCustomRelayUrl);
 
@@ -687,7 +794,12 @@ void main() {
           }
         });
 
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => true);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => true);
         await manager.reconnectRelay(testCustomRelayUrl);
         await Future<void>.delayed(Duration.zero);
 
@@ -704,28 +816,49 @@ void main() {
 
       test('disconnects all relays before reconnecting', () async {
         clearInteractions(mockRelayPool);
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => true);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => true);
 
         await manager.forceReconnectAll();
 
-        // Should remove all 3 relays (default + 2 custom)
-        verify(() => mockRelayPool.remove(testDefaultRelayUrl)).called(1);
-        verify(() => mockRelayPool.remove(testCustomRelayUrl)).called(1);
-        verify(() => mockRelayPool.remove(testCustomRelayUrl2)).called(1);
+        // Each relay is removed twice: once by forceReconnectAll and once
+        // by _connectToRelay (which clears the stale pool entry before add).
+        verify(() => mockRelayPool.remove(testDefaultRelayUrl)).called(2);
+        verify(() => mockRelayPool.remove(testCustomRelayUrl)).called(2);
+        verify(() => mockRelayPool.remove(testCustomRelayUrl2)).called(2);
       });
 
       test('reconnects all relays after disconnecting', () async {
         clearInteractions(mockRelayPool);
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => true);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => true);
 
         await manager.forceReconnectAll();
 
         // Should reconnect all 3 relays
-        verify(() => mockRelayPool.add(any())).called(3);
+        verify(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).called(3);
       });
 
       test('updates status to connected on successful reconnection', () async {
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => true);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => true);
 
         await manager.forceReconnectAll();
 
@@ -744,7 +877,12 @@ void main() {
       });
 
       test('updates status to error on failed reconnection', () async {
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => false);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => false);
 
         await manager.forceReconnectAll();
 
@@ -767,7 +905,12 @@ void main() {
           }
         });
 
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async => true);
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async => true);
         await manager.forceReconnectAll();
         await Future<void>.delayed(Duration.zero);
 
@@ -778,7 +921,12 @@ void main() {
       test('handles mixed success and failure', () async {
         // First relay succeeds, second fails
         var callCount = 0;
-        when(() => mockRelayPool.add(any())).thenAnswer((_) async {
+        when(
+          () => mockRelayPool.add(
+            any(),
+            autoSubscribe: any(named: 'autoSubscribe'),
+          ),
+        ).thenAnswer((_) async {
           callCount++;
           return callCount != 2; // Fail on second call
         });
@@ -1072,7 +1220,12 @@ void main() {
       mockRelayPool = _MockRelayPool();
       when(() => mockRelayPool.activeRelays()).thenReturn([]);
       when(() => mockRelayPool.getRelay(any())).thenReturn(null);
-      when(() => mockRelayPool.add(any())).thenAnswer((_) async => true);
+      when(
+        () => mockRelayPool.add(
+          any(),
+          autoSubscribe: any(named: 'autoSubscribe'),
+        ),
+      ).thenAnswer((_) async => true);
       when(() => mockRelayPool.remove(any())).thenReturn(null);
     });
 

--- a/mobile/test/helpers/test_provider_overrides.mocks.dart
+++ b/mobile/test/helpers/test_provider_overrides.mocks.dart
@@ -791,6 +791,14 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -849,6 +857,13 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i4.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i11.Future<void> initialize() =>
@@ -1031,6 +1046,16 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
             returnValue: _i11.Future<bool>.value(false),
           )
           as _i11.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i11.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/integration/account_deletion_flow_test.mocks.dart
+++ b/mobile/test/integration/account_deletion_flow_test.mocks.dart
@@ -89,6 +89,14 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -147,6 +155,13 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i6.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i8.Future<void> initialize() =>
@@ -329,6 +344,16 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             returnValue: _i8.Future<bool>.value(false),
           )
           as _i8.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i8.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/integration/home_feed_seen_videos_test.mocks.dart
+++ b/mobile/test/integration/home_feed_seen_videos_test.mocks.dart
@@ -879,6 +879,14 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -937,6 +945,13 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i2.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i11.Future<void> initialize() =>
@@ -1119,6 +1134,16 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             returnValue: _i11.Future<bool>.value(false),
           )
           as _i11.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i11.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/integration/reactive_pagination_test.mocks.dart
+++ b/mobile/test/integration/reactive_pagination_test.mocks.dart
@@ -67,6 +67,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -125,6 +133,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -307,6 +322,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/integration/search_navigation_integration_test.mocks.dart
+++ b/mobile/test/integration/search_navigation_integration_test.mocks.dart
@@ -878,6 +878,14 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -936,6 +944,13 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i2.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i11.Future<void> initialize() =>
@@ -1118,6 +1133,16 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             returnValue: _i11.Future<bool>.value(false),
           )
           as _i11.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i11.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/integration/upload_publish_e2e_comprehensive_test.mocks.dart
+++ b/mobile/test/integration/upload_publish_e2e_comprehensive_test.mocks.dart
@@ -699,6 +699,14 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -757,6 +765,13 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i6.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -939,6 +954,16 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/integration/video_event_service_simple_test.mocks.dart
+++ b/mobile/test/integration/video_event_service_simple_test.mocks.dart
@@ -67,6 +67,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -125,6 +133,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -307,6 +322,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/profile_fetching_test.mocks.dart
+++ b/mobile/test/profile_fetching_test.mocks.dart
@@ -69,6 +69,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -127,6 +135,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -309,6 +324,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/providers/curation_provider_lifecycle_test.mocks.dart
+++ b/mobile/test/providers/curation_provider_lifecycle_test.mocks.dart
@@ -116,6 +116,14 @@ class MockNostrClient extends _i1.Mock implements _i7.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -174,6 +182,13 @@ class MockNostrClient extends _i1.Mock implements _i7.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i7.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i9.Future<void> initialize() =>
@@ -356,6 +371,16 @@ class MockNostrClient extends _i1.Mock implements _i7.NostrClient {
             returnValue: _i9.Future<bool>.value(false),
           )
           as _i9.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i9.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/providers/curation_provider_tab_refresh_test.mocks.dart
+++ b/mobile/test/providers/curation_provider_tab_refresh_test.mocks.dart
@@ -116,6 +116,14 @@ class MockNostrClient extends _i1.Mock implements _i7.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -174,6 +182,13 @@ class MockNostrClient extends _i1.Mock implements _i7.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i7.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i9.Future<void> initialize() =>
@@ -356,6 +371,16 @@ class MockNostrClient extends _i1.Mock implements _i7.NostrClient {
             returnValue: _i9.Future<bool>.value(false),
           )
           as _i9.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i9.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/providers/home_feed_loading_fix_test.mocks.dart
+++ b/mobile/test/providers/home_feed_loading_fix_test.mocks.dart
@@ -915,6 +915,14 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -973,6 +981,13 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i2.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i14.Future<void> initialize() =>
@@ -1155,6 +1170,16 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             returnValue: _i14.Future<bool>.value(false),
           )
           as _i14.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i14.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/providers/home_feed_provider_test.mocks.dart
+++ b/mobile/test/providers/home_feed_provider_test.mocks.dart
@@ -898,6 +898,14 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -956,6 +964,13 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i2.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i12.Future<void> initialize() =>
@@ -1138,6 +1153,16 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             returnValue: _i12.Future<bool>.value(false),
           )
           as _i12.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i12.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/providers/readiness_gate_providers_test.mocks.dart
+++ b/mobile/test/providers/readiness_gate_providers_test.mocks.dart
@@ -66,6 +66,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -124,6 +132,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -306,6 +321,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/providers/video_events_listener_simple_test.mocks.dart
+++ b/mobile/test/providers/video_events_listener_simple_test.mocks.dart
@@ -878,6 +878,14 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -936,6 +944,13 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i2.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i11.Future<void> initialize() =>
@@ -1118,6 +1133,16 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             returnValue: _i11.Future<bool>.value(false),
           )
           as _i11.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i11.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/providers/video_events_provider_listener_test.mocks.dart
+++ b/mobile/test/providers/video_events_provider_listener_test.mocks.dart
@@ -878,6 +878,14 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -936,6 +944,13 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i2.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i11.Future<void> initialize() =>
@@ -1118,6 +1133,16 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             returnValue: _i11.Future<bool>.value(false),
           )
           as _i11.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i11.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/repositories/follow_repository_test.dart
+++ b/mobile/test/repositories/follow_repository_test.dart
@@ -178,8 +178,9 @@ void main() {
         await repository.initialize();
         expect(repository.isInitialized, isTrue);
 
-        // Verify subscribe was called once during first init
-        // for real-time cross-device sync subscription
+        // Verify subscribe was called twice during first init:
+        // 1. _loadFromRelay() (relay kind 3 query when list is empty)
+        // 2. _subscribeToContactList() (real-time cross-device sync)
         verify(
           () => mockNostrClient.subscribe(
             any(),
@@ -190,7 +191,7 @@ void main() {
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
           ),
-        ).called(1);
+        ).called(2);
       });
     });
 

--- a/mobile/test/screens/explore_screen_video_display_test.mocks.dart
+++ b/mobile/test/screens/explore_screen_video_display_test.mocks.dart
@@ -878,6 +878,14 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -936,6 +944,13 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i2.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i11.Future<void> initialize() =>
@@ -1118,6 +1133,16 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             returnValue: _i11.Future<bool>.value(false),
           )
           as _i11.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i11.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/screens/profile_setup_relay_confirmation_test.mocks.dart
+++ b/mobile/test/screens/profile_setup_relay_confirmation_test.mocks.dart
@@ -85,6 +85,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -143,6 +151,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -325,6 +340,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/screens/search_screen_pure_url_test.mocks.dart
+++ b/mobile/test/screens/search_screen_pure_url_test.mocks.dart
@@ -878,6 +878,14 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -936,6 +944,13 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i2.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i11.Future<void> initialize() =>
@@ -1118,6 +1133,16 @@ class MockNostrClient extends _i1.Mock implements _i2.NostrClient {
             returnValue: _i11.Future<bool>.value(false),
           )
           as _i11.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i11.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/screens/sound_detail_screen_test.mocks.dart
+++ b/mobile/test/screens/sound_detail_screen_test.mocks.dart
@@ -217,6 +217,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -275,6 +283,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i4.Future<void> initialize() =>
@@ -457,6 +472,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i4.Future<bool>.value(false),
           )
           as _i4.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i4.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/account_deletion_service_test.mocks.dart
+++ b/mobile/test/services/account_deletion_service_test.mocks.dart
@@ -82,6 +82,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -140,6 +148,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -322,6 +337,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/content_blocklist_service_test.mocks.dart
+++ b/mobile/test/services/content_blocklist_service_test.mocks.dart
@@ -66,6 +66,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -124,6 +132,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -306,6 +321,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/content_deletion_service_test.mocks.dart
+++ b/mobile/test/services/content_deletion_service_test.mocks.dart
@@ -82,6 +82,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -140,6 +148,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -322,6 +337,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/content_reporting_service_test.mocks.dart
+++ b/mobile/test/services/content_reporting_service_test.mocks.dart
@@ -82,6 +82,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -140,6 +148,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -322,6 +337,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curated_list_service_collaboration_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_collaboration_test.mocks.dart
@@ -82,6 +82,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -140,6 +148,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -322,6 +337,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curated_list_service_crud_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_crud_test.mocks.dart
@@ -94,6 +94,15 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+            returnValueForMissingStub: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -163,6 +172,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -370,6 +386,18 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValueForMissingStub: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+            returnValueForMissingStub:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curated_list_service_initialization_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_initialization_test.mocks.dart
@@ -82,6 +82,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -140,6 +148,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -322,6 +337,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curated_list_service_persistence_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_persistence_test.mocks.dart
@@ -82,6 +82,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -140,6 +148,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -322,6 +337,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curated_list_service_playlist_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_playlist_test.mocks.dart
@@ -82,6 +82,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -140,6 +148,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -322,6 +337,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curated_list_service_query_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_query_test.mocks.dart
@@ -82,6 +82,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -140,6 +148,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -322,6 +337,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curated_list_service_stream_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_stream_test.mocks.dart
@@ -82,6 +82,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -140,6 +148,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -322,6 +337,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curated_list_service_video_management_test.mocks.dart
+++ b/mobile/test/services/curated_list_service_video_management_test.mocks.dart
@@ -82,6 +82,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -140,6 +148,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -322,6 +337,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curation_publish_test.mocks.dart
+++ b/mobile/test/services/curation_publish_test.mocks.dart
@@ -96,6 +96,14 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -154,6 +162,13 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i6.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i8.Future<void> initialize() =>
@@ -336,6 +351,16 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             returnValue: _i8.Future<bool>.value(false),
           )
           as _i8.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i8.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curation_service_analytics_test.mocks.dart
+++ b/mobile/test/services/curation_service_analytics_test.mocks.dart
@@ -96,6 +96,14 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -154,6 +162,13 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i6.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i8.Future<void> initialize() =>
@@ -336,6 +351,16 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             returnValue: _i8.Future<bool>.value(false),
           )
           as _i8.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i8.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curation_service_create_test.mocks.dart
+++ b/mobile/test/services/curation_service_create_test.mocks.dart
@@ -102,6 +102,14 @@ class MockNostrClient extends _i1.Mock implements _i7.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -160,6 +168,13 @@ class MockNostrClient extends _i1.Mock implements _i7.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i7.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i9.Future<void> initialize() =>
@@ -342,6 +357,16 @@ class MockNostrClient extends _i1.Mock implements _i7.NostrClient {
             returnValue: _i9.Future<bool>.value(false),
           )
           as _i9.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i9.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curation_service_editors_picks_test.mocks.dart
+++ b/mobile/test/services/curation_service_editors_picks_test.mocks.dart
@@ -96,6 +96,14 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -154,6 +162,13 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i6.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i8.Future<void> initialize() =>
@@ -336,6 +351,16 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             returnValue: _i8.Future<bool>.value(false),
           )
           as _i8.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i8.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curation_service_kind_30005_test.mocks.dart
+++ b/mobile/test/services/curation_service_kind_30005_test.mocks.dart
@@ -96,6 +96,14 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -154,6 +162,13 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i6.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i8.Future<void> initialize() =>
@@ -336,6 +351,16 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             returnValue: _i8.Future<bool>.value(false),
           )
           as _i8.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i8.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curation_service_test.mocks.dart
+++ b/mobile/test/services/curation_service_test.mocks.dart
@@ -96,6 +96,14 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -154,6 +162,13 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i6.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i8.Future<void> initialize() =>
@@ -336,6 +351,16 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             returnValue: _i8.Future<bool>.value(false),
           )
           as _i8.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i8.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/curation_service_trending_fetch_test.mocks.dart
+++ b/mobile/test/services/curation_service_trending_fetch_test.mocks.dart
@@ -96,6 +96,14 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -154,6 +162,13 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i6.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i8.Future<void> initialize() =>
@@ -336,6 +351,16 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             returnValue: _i8.Future<bool>.value(false),
           )
           as _i8.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i8.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/nostr_key_manager_profile_fetch_test.mocks.dart
+++ b/mobile/test/services/nostr_key_manager_profile_fetch_test.mocks.dart
@@ -70,6 +70,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -128,6 +136,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -310,6 +325,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/notification_service_enhanced_test.mocks.dart
+++ b/mobile/test/services/notification_service_enhanced_test.mocks.dart
@@ -75,6 +75,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -133,6 +141,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -315,6 +330,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/profile_editing_test.mocks.dart
+++ b/mobile/test/services/profile_editing_test.mocks.dart
@@ -86,6 +86,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -144,6 +152,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -326,6 +341,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/profile_update_test.mocks.dart
+++ b/mobile/test/services/profile_update_test.mocks.dart
@@ -67,6 +67,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -125,6 +133,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -307,6 +322,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/subscribed_list_video_cache_test.mocks.dart
+++ b/mobile/test/services/subscribed_list_video_cache_test.mocks.dart
@@ -75,6 +75,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -133,6 +141,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -315,6 +330,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/subscription_manager_cache_test.mocks.dart
+++ b/mobile/test/services/subscription_manager_cache_test.mocks.dart
@@ -78,6 +78,15 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+            returnValueForMissingStub: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -147,6 +156,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -354,6 +370,18 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValueForMissingStub: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+            returnValueForMissingStub:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/video_event_service_consolidation_test.mocks.dart
+++ b/mobile/test/services/video_event_service_consolidation_test.mocks.dart
@@ -67,6 +67,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -125,6 +133,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -307,6 +322,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/video_event_service_deduplication_test.mocks.dart
+++ b/mobile/test/services/video_event_service_deduplication_test.mocks.dart
@@ -67,6 +67,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -125,6 +133,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -307,6 +322,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/video_event_service_pagination_test.mocks.dart
+++ b/mobile/test/services/video_event_service_pagination_test.mocks.dart
@@ -67,6 +67,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -125,6 +133,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -307,6 +322,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/video_event_service_replaceable_test.mocks.dart
+++ b/mobile/test/services/video_event_service_replaceable_test.mocks.dart
@@ -67,6 +67,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -125,6 +133,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -307,6 +322,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/video_event_service_repost_test.mocks.dart
+++ b/mobile/test/services/video_event_service_repost_test.mocks.dart
@@ -67,6 +67,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -125,6 +133,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -307,6 +322,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/video_event_service_reposters_test.mocks.dart
+++ b/mobile/test/services/video_event_service_reposters_test.mocks.dart
@@ -67,6 +67,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -125,6 +133,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -307,6 +322,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/video_event_service_sorted_queries_integration_test.mocks.dart
+++ b/mobile/test/services/video_event_service_sorted_queries_integration_test.mocks.dart
@@ -85,6 +85,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -143,6 +151,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -325,6 +340,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/services/video_sharing_service_test.mocks.dart
+++ b/mobile/test/services/video_sharing_service_test.mocks.dart
@@ -85,6 +85,14 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -143,6 +151,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -325,6 +340,16 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValue: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/unit/curated_list_relay_sync_test.mocks.dart
+++ b/mobile/test/unit/curated_list_relay_sync_test.mocks.dart
@@ -94,6 +94,15 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+            returnValueForMissingStub: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -163,6 +172,13 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i5.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i7.Future<void> initialize() =>
@@ -370,6 +386,18 @@ class MockNostrClient extends _i1.Mock implements _i5.NostrClient {
             returnValueForMissingStub: _i7.Future<bool>.value(false),
           )
           as _i7.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+            returnValueForMissingStub:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i7.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/unit/services/nip17_message_service_test.mocks.dart
+++ b/mobile/test/unit/services/nip17_message_service_test.mocks.dart
@@ -234,6 +234,14 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -292,6 +300,13 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i6.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i4.Future<void> initialize() =>
@@ -474,6 +489,16 @@ class MockNostrClient extends _i1.Mock implements _i6.NostrClient {
             returnValue: _i4.Future<bool>.value(false),
           )
           as _i4.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i4.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/unit/services/subscription_manager_filter_test.mocks.dart
+++ b/mobile/test/unit/services/subscription_manager_filter_test.mocks.dart
@@ -66,6 +66,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -124,6 +132,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -306,6 +321,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/unit/services/video_event_service_infinite_scroll_test.mocks.dart
+++ b/mobile/test/unit/services/video_event_service_infinite_scroll_test.mocks.dart
@@ -67,6 +67,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -125,6 +133,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -307,6 +322,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/unit/services/video_event_service_pagination_test.mocks.dart
+++ b/mobile/test/unit/services/video_event_service_pagination_test.mocks.dart
@@ -67,6 +67,14 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -125,6 +133,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -307,6 +322,16 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValue: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/unit/services/video_event_service_search_test.mocks.dart
+++ b/mobile/test/unit/services/video_event_service_search_test.mocks.dart
@@ -79,6 +79,15 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+            returnValueForMissingStub: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -148,6 +157,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -355,6 +371,18 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValueForMissingStub: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+            returnValueForMissingStub:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/unit/subscription_manager_tdd_test.mocks.dart
+++ b/mobile/test/unit/subscription_manager_tdd_test.mocks.dart
@@ -78,6 +78,15 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+            returnValueForMissingStub: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -147,6 +156,13 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i3.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i5.Future<void> initialize() =>
@@ -354,6 +370,18 @@ class MockNostrClient extends _i1.Mock implements _i3.NostrClient {
             returnValueForMissingStub: _i5.Future<bool>.value(false),
           )
           as _i5.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+            returnValueForMissingStub:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i5.Future<Map<String, dynamic>?> getRelayStats() =>

--- a/mobile/test/widgets/tabbed_settings_screen_test.mocks.dart
+++ b/mobile/test/widgets/tabbed_settings_screen_test.mocks.dart
@@ -531,6 +531,14 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
           as bool);
 
   @override
+  int get activeSubscriptionCount =>
+      (super.noSuchMethod(
+            Invocation.getter(#activeSubscriptionCount),
+            returnValue: 0,
+          )
+          as int);
+
+  @override
   List<String> get configuredRelays =>
       (super.noSuchMethod(
             Invocation.getter(#configuredRelays),
@@ -589,6 +597,13 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
             ),
           )
           as String);
+
+  @override
+  set statisticsObserver(_i4.NostrClientStatisticsObserver? value) =>
+      super.noSuchMethod(
+        Invocation.setter(#statisticsObserver, value),
+        returnValueForMissingStub: null,
+      );
 
   @override
   _i8.Future<void> initialize() =>
@@ -771,6 +786,16 @@ class MockNostrClient extends _i1.Mock implements _i4.NostrClient {
             returnValue: _i8.Future<bool>.value(false),
           )
           as _i8.Future<bool>);
+
+  @override
+  Map<String, ({int errors, int eventsReceived, int queriesSent})>
+  getRelayPoolCounters() =>
+      (super.noSuchMethod(
+            Invocation.method(#getRelayPoolCounters, []),
+            returnValue:
+                <String, ({int errors, int eventsReceived, int queriesSent})>{},
+          )
+          as Map<String, ({int errors, int eventsReceived, int queriesSent})>);
 
   @override
   _i8.Future<Map<String, dynamic>?> getRelayStats() =>


### PR DESCRIPTION
## Summary

- **Bunker URL paste fix**: `Navigator.pop` instead of GoRouter `context.pop` so the pasted bunker URL is returned correctly from the bottom sheet; added `_switchedToBunker` flag to prevent nostrconnect callback interference; added visible "Connect" button
- **CircularDependencyError fix**: Auth pre-fetch callback triggered a provider cycle (`authService` -> `analyticsApi` -> `nostrService` -> `authService`). Fixed by instantiating `AnalyticsApiService` directly using `currentEnvironmentProvider`
- **Per-relay stats fix**: Replaced flawed `_RelayStatsBridgeObserver` (which split totals equally across relays) with periodic syncing from SDK's per-relay `RelayStatus` counters. Each relay now shows accurate individual stats
- **Follower/following improvements**: Added REST API as primary data source for followers with relay fallback, WebSocket fallback in `SocialService`, and diagnostic logging

## Test plan

- [x] `dart analyze` — no errors
- [x] nostr_client package tests — 229/229 passed
- [x] relay_manager tests — 94/94 passed
- [x] relay_statistics_service tests — 16/16 passed
- [x] follow_repository tests — 47/47 passed
- [x] Full mobile test suite — 4213 passed, 0 failed
- [x] Manual verification: relay settings shows different per-relay event counts
- [x] Manual verification: profile shows correct follower/following counts (48/123)
- [ ] Manual verification: bunker URL paste flow connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)