### PR TITLE
fix(notifications): show badge on all tabs, not just profile

### DIFF
--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -26,7 +26,9 @@ import 'package:openvine/screens/notifications_screen.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/screens/pure/search_screen_pure.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/providers/relay_notifications_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
+import 'package:openvine/widgets/notification_badge.dart';
 
 class AppShell extends ConsumerWidget {
   const AppShell({super.key, required this.child, required this.currentIndex});
@@ -594,13 +596,16 @@ class AppShell extends ConsumerWidget {
                   ),
                 ),
               ),
-              _buildTabButton(
-                context,
-                ref,
-                'assets/icon/bell.svg',
-                2,
-                currentIndex,
-                'notifications_tab',
+              NotificationBadge(
+                count: ref.watch(relayNotificationUnreadCountProvider),
+                child: _buildTabButton(
+                  context,
+                  ref,
+                  'assets/icon/bell.svg',
+                  2,
+                  currentIndex,
+                  'notifications_tab',
+                ),
               ),
               _buildTabButton(
                 context,

--- a/mobile/test/router/app_shell_notification_badge_test.dart
+++ b/mobile/test/router/app_shell_notification_badge_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/environment_config.dart';
+import 'package:openvine/providers/active_video_provider.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/relay_notifications_provider.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/widgets/notification_badge.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+Widget _buildSubject({
+  required _MockAuthService mockAuthService,
+  required int unreadCount,
+}) {
+  return ProviderScope(
+    overrides: [
+      pageContextProvider.overrideWith(
+        (ref) => Stream.value(const RouteContext(type: RouteType.home)),
+      ),
+      videoControllerAutoCleanupProvider.overrideWithValue(null),
+      relayStatisticsBridgeProvider.overrideWithValue(null),
+      relaySetChangeBridgeProvider.overrideWithValue(null),
+      zendeskIdentitySyncProvider.overrideWithValue(null),
+      authServiceProvider.overrideWithValue(mockAuthService),
+      currentEnvironmentProvider.overrideWithValue(
+        EnvironmentConfig.production,
+      ),
+      relayNotificationUnreadCountProvider.overrideWithValue(unreadCount),
+    ],
+    child: const MaterialApp(
+      home: AppShell(currentIndex: 0, child: SizedBox.shrink()),
+    ),
+  );
+}
+
+void main() {
+  late _MockAuthService mockAuthService;
+
+  setUp(() {
+    mockAuthService = _MockAuthService();
+    when(() => mockAuthService.currentPublicKeyHex).thenReturn(null);
+    when(() => mockAuthService.currentNpub).thenReturn(null);
+    when(() => mockAuthService.isAuthenticated).thenReturn(false);
+    when(() => mockAuthService.authState).thenReturn(AuthState.unauthenticated);
+  });
+
+  group('$AppShell notification badge', () {
+    testWidgets(
+      'renders $NotificationBadge on bell tab when unread count > 0',
+      (tester) async {
+        await tester.pumpWidget(
+          _buildSubject(mockAuthService: mockAuthService, unreadCount: 3),
+        );
+        await tester.pump();
+
+        expect(find.byType(NotificationBadge), findsOneWidget);
+        expect(find.text('3'), findsOneWidget);
+      },
+    );
+
+    testWidgets('renders no badge when unread count is 0', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(mockAuthService: mockAuthService, unreadCount: 0),
+      );
+      await tester.pump();
+
+      expect(find.byType(NotificationBadge), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(NotificationBadge),
+          matching: find.byType(Positioned),
+        ),
+        findsNothing,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Wraps the bell icon in `AppShell` with `NotificationBadge`, matching the existing pattern in `VineBottomNav`
- The badge was only visible on the Profile tab because `VineBottomNav` (used only there) had the wrapper, while `AppShell` (used on Home, Explore, Notifications) did not
- Adds widget tests verifying badge renders with unread count > 0 and hides when count is 0

Closes #1627

<img width="302" height="655" alt="evidence-badge-explore-tab" src="https://github.com/user-attachments/assets/d8dee635-1889-4da5-92cd-911ec39e63e2" />

<img width="302" height="655" alt="evidence-badge-home-tab" src="https://github.com/user-attachments/assets/96494c90-b1ad-458d-891b-40f5560ff06c" />

<img width="302" height="655" alt="evidence-badge-profile-tab" src="https://github.com/user-attachments/assets/1f2a14c6-6bf8-4924-84ba-adc7814ed61e" />



