### PR TITLE
fix(metadata-screen): resolve issues in the preview video

### DIFF
--- a/mobile/lib/widgets/video_feed_item/actions/like_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/like_action_button.dart
@@ -15,30 +15,58 @@ import 'package:openvine/widgets/video_feed_item/actions/video_action_button.dar
 ///
 /// Requires [VideoInteractionsBloc] to be provided in the widget tree.
 class LikeActionButton extends StatelessWidget {
-  const LikeActionButton({required this.video, super.key});
+  const LikeActionButton({
+    required this.video,
+    super.key,
+    this.isPreviewMode = false,
+  });
 
   final VideoEvent video;
+  final bool isPreviewMode;
 
   @override
   Widget build(BuildContext context) {
+    if (isPreviewMode) return const _ActionButton();
+
     return BlocBuilder<VideoInteractionsBloc, VideoInteractionsState>(
       builder: (context, state) {
         final isLiked = state.isLiked;
         final likeCount = state.likeCount ?? 0;
         final totalLikes = likeCount + (video.originalLikes ?? 0);
 
-        return VideoActionButton(
-          iconAsset: 'assets/icon/content-controls/like.svg',
-          semanticIdentifier: 'like_button',
-          semanticLabel: isLiked ? 'Unlike video' : 'Like video',
-          iconColor: isLiked ? VineTheme.likeRed : VineTheme.whiteText,
-          isLoading: state.isLikeInProgress,
-          count: totalLikes,
-          onPressed: () {
-            context.read<VideoInteractionsBloc>().add(
-              const VideoInteractionsLikeToggled(),
-            );
-          },
+        return _ActionButton(
+          isLiked: isLiked,
+          isLikeInProgress: state.isLikeInProgress,
+          totalLikes: totalLikes,
+        );
+      },
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    this.isLiked = false,
+    this.isLikeInProgress = false,
+    this.totalLikes = 1,
+  });
+
+  final bool isLiked;
+  final bool isLikeInProgress;
+  final int totalLikes;
+
+  @override
+  Widget build(BuildContext context) {
+    return VideoActionButton(
+      iconAsset: 'assets/icon/content-controls/like.svg',
+      semanticIdentifier: 'like_button',
+      semanticLabel: isLiked ? 'Unlike video' : 'Like video',
+      iconColor: isLiked ? VineTheme.likeRed : VineTheme.whiteText,
+      isLoading: isLikeInProgress,
+      count: totalLikes,
+      onPressed: () {
+        context.read<VideoInteractionsBloc>().add(
+          const VideoInteractionsLikeToggled(),
         );
       },
     );

--- a/mobile/lib/widgets/video_feed_item/actions/repost_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/repost_action_button.dart
@@ -15,12 +15,19 @@ import 'package:openvine/widgets/video_feed_item/actions/video_action_button.dar
 ///
 /// Requires [VideoInteractionsBloc] to be provided in the widget tree.
 class RepostActionButton extends StatelessWidget {
-  const RepostActionButton({required this.video, super.key});
+  const RepostActionButton({
+    required this.video,
+    super.key,
+    this.isPreviewMode = false,
+  });
 
   final VideoEvent video;
+  final bool isPreviewMode;
 
   @override
   Widget build(BuildContext context) {
+    if (isPreviewMode) return const _ActionButton();
+
     return BlocBuilder<VideoInteractionsBloc, VideoInteractionsState>(
       builder: (context, state) {
         final isReposted = state.isReposted;
@@ -28,18 +35,39 @@ class RepostActionButton extends StatelessWidget {
             state.repostCount ?? (video.reposterPubkeys?.length ?? 0);
         final totalReposts = nostrReposts + (video.originalReposts ?? 0);
 
-        return VideoActionButton(
-          iconAsset: 'assets/icon/content-controls/repost.svg',
-          semanticIdentifier: 'repost_button',
-          semanticLabel: isReposted ? 'Remove repost' : 'Repost video',
-          iconColor: isReposted ? VineTheme.vineGreen : VineTheme.whiteText,
-          isLoading: state.isRepostInProgress,
-          count: totalReposts,
-          onPressed: () {
-            context.read<VideoInteractionsBloc>().add(
-              const VideoInteractionsRepostToggled(),
-            );
-          },
+        return _ActionButton(
+          isReposted: isReposted,
+          isRepostInProgress: state.isRepostInProgress,
+          totalReposts: totalReposts,
+        );
+      },
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    this.isReposted = false,
+    this.isRepostInProgress = false,
+    this.totalReposts = 1,
+  });
+
+  final bool isReposted;
+  final bool isRepostInProgress;
+  final int totalReposts;
+
+  @override
+  Widget build(BuildContext context) {
+    return VideoActionButton(
+      iconAsset: 'assets/icon/content-controls/repost.svg',
+      semanticIdentifier: 'repost_button',
+      semanticLabel: isReposted ? 'Remove repost' : 'Repost video',
+      iconColor: isReposted ? VineTheme.vineGreen : VineTheme.whiteText,
+      isLoading: isRepostInProgress,
+      count: totalReposts,
+      onPressed: () {
+        context.read<VideoInteractionsBloc>().add(
+          const VideoInteractionsRepostToggled(),
         );
       },
     );

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -1778,7 +1778,10 @@ class VideoOverlayActions extends ConsumerWidget {
                     const SizedBox(height: 4),
 
                     // Repost button
-                    RepostActionButton(video: video),
+                    RepostActionButton(
+                      video: video,
+                      isPreviewMode: isPreviewMode,
+                    ),
 
                     const SizedBox(height: 4),
 
@@ -1788,7 +1791,10 @@ class VideoOverlayActions extends ConsumerWidget {
                     const SizedBox(height: 4),
 
                     // Like button
-                    LikeActionButton(video: video),
+                    LikeActionButton(
+                      video: video,
+                      isPreviewMode: isPreviewMode,
+                    ),
                   ],
                 ),
               ),

--- a/mobile/test/widgets/video_feed_item/actions/like_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/like_action_button_test.dart
@@ -1,0 +1,138 @@
+// ABOUTME: Tests for LikeActionButton widget.
+// ABOUTME: Verifies rendering in preview mode without VideoInteractionsBloc.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/widgets/video_feed_item/actions/like_action_button.dart';
+import 'package:openvine/widgets/video_feed_item/actions/video_action_button.dart';
+
+class _MockVideoInteractionsBloc extends Mock
+    implements VideoInteractionsBloc {}
+
+void main() {
+  const testPubkey =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+  late VideoEvent testVideo;
+
+  setUp(() {
+    testVideo = VideoEvent(
+      id: 'test-video-0123456789abcdef0123456789abcdef0123456789abcdef0123',
+      pubkey: testPubkey,
+      createdAt: 1757385263,
+      content: 'Test video',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+      originalLikes: 42,
+    );
+  });
+
+  Widget buildSubject({
+    required VideoEvent video,
+    bool isPreviewMode = false,
+    VideoInteractionsBloc? bloc,
+  }) {
+    final widget = MaterialApp(
+      home: Scaffold(
+        body: LikeActionButton(video: video, isPreviewMode: isPreviewMode),
+      ),
+    );
+
+    if (bloc != null) {
+      return BlocProvider<VideoInteractionsBloc>.value(
+        value: bloc,
+        child: widget,
+      );
+    }
+
+    return widget;
+  }
+
+  group(LikeActionButton, () {
+    group('preview mode', () {
+      testWidgets(
+        'renders without VideoInteractionsBloc when isPreviewMode is true',
+        (tester) async {
+          // This test ensures the widget can render in preview mode
+          // WITHOUT a VideoInteractionsBloc in the widget tree.
+          // This is critical for the video metadata preview screen.
+          await tester.pumpWidget(
+            buildSubject(video: testVideo, isPreviewMode: true),
+          );
+
+          // Should render successfully without throwing ProviderNotFoundError
+          expect(find.byType(LikeActionButton), findsOneWidget);
+          expect(find.byType(VideoActionButton), findsOneWidget);
+        },
+      );
+
+      testWidgets('displays default like count of 1 in preview mode', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildSubject(video: testVideo, isPreviewMode: true),
+        );
+
+        // The default _ActionButton shows totalLikes = 1
+        expect(find.text('1'), findsOneWidget);
+      });
+
+      testWidgets('has correct semantics label in preview mode', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildSubject(video: testVideo, isPreviewMode: true),
+        );
+
+        final semantics = tester.widget<Semantics>(
+          find.byWidgetPredicate(
+            (w) => w is Semantics && w.properties.identifier == 'like_button',
+          ),
+        );
+        expect(semantics.properties.label, equals('Like video'));
+      });
+    });
+
+    group('normal mode with bloc', () {
+      late _MockVideoInteractionsBloc mockBloc;
+
+      setUp(() {
+        mockBloc = _MockVideoInteractionsBloc();
+        when(
+          () => mockBloc.state,
+        ).thenReturn(const VideoInteractionsState(likeCount: 10));
+        when(() => mockBloc.stream).thenAnswer((_) => const Stream.empty());
+      });
+
+      testWidgets(
+        'renders with VideoInteractionsBloc when isPreviewMode is false',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(
+              video: testVideo,
+              isPreviewMode: false,
+              bloc: mockBloc,
+            ),
+          );
+
+          expect(find.byType(LikeActionButton), findsOneWidget);
+          expect(find.byType(VideoActionButton), findsOneWidget);
+        },
+      );
+
+      testWidgets('displays combined like count from bloc and video metadata', (
+        tester,
+      ) async {
+        // Bloc has 10 likes, video has 42 originalLikes = 52 total
+        await tester.pumpWidget(
+          buildSubject(video: testVideo, isPreviewMode: false, bloc: mockBloc),
+        );
+
+        expect(find.text('52'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/mobile/test/widgets/video_feed_item/actions/repost_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/repost_action_button_test.dart
@@ -1,0 +1,143 @@
+// ABOUTME: Tests for RepostActionButton widget.
+// ABOUTME: Verifies rendering in preview mode without VideoInteractionsBloc.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/widgets/video_feed_item/actions/repost_action_button.dart';
+import 'package:openvine/widgets/video_feed_item/actions/video_action_button.dart';
+
+class _MockVideoInteractionsBloc extends Mock
+    implements VideoInteractionsBloc {}
+
+void main() {
+  const testPubkey =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+  late VideoEvent testVideo;
+
+  setUp(() {
+    testVideo = VideoEvent(
+      id: 'test-video-0123456789abcdef0123456789abcdef0123456789abcdef0123',
+      pubkey: testPubkey,
+      createdAt: 1757385263,
+      content: 'Test video',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+      originalReposts: 15,
+    );
+  });
+
+  Widget buildSubject({
+    required VideoEvent video,
+    bool isPreviewMode = false,
+    VideoInteractionsBloc? bloc,
+  }) {
+    final widget = MaterialApp(
+      home: Scaffold(
+        body: RepostActionButton(video: video, isPreviewMode: isPreviewMode),
+      ),
+    );
+
+    if (bloc != null) {
+      return BlocProvider<VideoInteractionsBloc>.value(
+        value: bloc,
+        child: widget,
+      );
+    }
+
+    return widget;
+  }
+
+  group(RepostActionButton, () {
+    group('preview mode', () {
+      testWidgets(
+        'renders without VideoInteractionsBloc when isPreviewMode is true',
+        (tester) async {
+          // This test ensures the widget can render in preview mode
+          // WITHOUT a VideoInteractionsBloc in the widget tree.
+          // This is critical for the video metadata preview screen.
+          await tester.pumpWidget(
+            buildSubject(video: testVideo, isPreviewMode: true),
+          );
+
+          // Should render successfully without throwing ProviderNotFoundError
+          expect(find.byType(RepostActionButton), findsOneWidget);
+          expect(find.byType(VideoActionButton), findsOneWidget);
+        },
+      );
+
+      testWidgets('displays default repost count of 1 in preview mode', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildSubject(video: testVideo, isPreviewMode: true),
+        );
+
+        // The default _ActionButton shows totalReposts = 1
+        expect(find.text('1'), findsOneWidget);
+      });
+
+      testWidgets('has correct semantics label in preview mode', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildSubject(video: testVideo, isPreviewMode: true),
+        );
+
+        final semantics = tester.widget<Semantics>(
+          find.byWidgetPredicate(
+            (w) => w is Semantics && w.properties.identifier == 'repost_button',
+          ),
+        );
+        expect(semantics.properties.label, equals('Repost video'));
+      });
+    });
+
+    group('normal mode with bloc', () {
+      late _MockVideoInteractionsBloc mockBloc;
+
+      setUp(() {
+        mockBloc = _MockVideoInteractionsBloc();
+        when(
+          () => mockBloc.state,
+        ).thenReturn(const VideoInteractionsState(repostCount: 5));
+        when(() => mockBloc.stream).thenAnswer((_) => const Stream.empty());
+      });
+
+      testWidgets(
+        'renders with VideoInteractionsBloc when isPreviewMode is false',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(
+              video: testVideo,
+              isPreviewMode: false,
+              bloc: mockBloc,
+            ),
+          );
+
+          expect(find.byType(RepostActionButton), findsOneWidget);
+          expect(find.byType(VideoActionButton), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'displays combined repost count from bloc and video metadata',
+        (tester) async {
+          // Bloc has 5 reposts, video has 15 originalReposts = 20 total
+          await tester.pumpWidget(
+            buildSubject(
+              video: testVideo,
+              isPreviewMode: false,
+              bloc: mockBloc,
+            ),
+          );
+
+          expect(find.text('20'), findsOneWidget);
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

The preview video on the metadata screen showed broken buttons because there are new providers that caused this issue.

<img width="260" alt="image" src="https://github.com/user-attachments/assets/eb44e54a-42ed-41bc-9180-c502d2f2181f" />


**Related Issue:** Closes #1698

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore