### PR TITLE
chore: bump version to 1.0.5+495

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.4+200
+version: 1.0.5+495
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
## Summary
- Bump version from 1.0.4+200 to 1.0.5+495 for release

## Test plan
- [x] Version-only change, no code modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)