### PR TITLE
fix(video): correct video orientation handling in fullscreen feed

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -459,7 +459,7 @@ class _PooledFullscreenItemContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isPortrait = video.dimensions != null ? video.isPortrait : true;
+    final isPortrait = video.dimensions != null ? video.isPortrait : false;
 
     return ColoredBox(
       color: Colors.black,


### PR DESCRIPTION
## Description

The new `video_metadata_preview_screen` stretches videos depending on their metadata dimensions. However, older videos did not include that metadata, so they would always use BoxFit.cover instead of BoxFit.contain. The problem is that all the old videos in the "Classic" tab would also be stretched, even if they were recorded with a 1:1 aspect ratio.  

This PR ensures that, when the dimensions are unknown, we fall back to BoxFit.contain, which ensures the video is completely visible.

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore