### PR TITLE
fix(video): add isPreviewMode to Repost and Like action buttons

### DIFF
--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -1815,7 +1815,10 @@ class VideoOverlayActions extends ConsumerWidget {
                   const SizedBox(height: 4),
 
                   // Repost button
-                  RepostActionButton(video: video),
+                  RepostActionButton(
+                    video: video,
+                    isPreviewMode: isPreviewMode,
+                  ),
 
                   const SizedBox(height: 4),
 
@@ -1825,7 +1828,7 @@ class VideoOverlayActions extends ConsumerWidget {
                   const SizedBox(height: 4),
 
                   // Like button
-                  LikeActionButton(video: video),
+                  LikeActionButton(video: video, isPreviewMode: isPreviewMode),
                 ],
               ),
             ),


### PR DESCRIPTION
## Description

The video preview in the metascreen shows issues. That was actually fixed in PR #1697 but another PR seems to have undone that flag marking it as a preview.

<img width="250px" src="https://github.com/user-attachments/assets/36241f44-e4e2-4e5e-9560-747e3bd12963"/>


## Type of Change


<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore