### PR TITLE
fix: email verification deep link not calling server API

### DIFF
--- a/mobile/lib/screens/auth/email_verification_screen.dart
+++ b/mobile/lib/screens/auth/email_verification_screen.dart
@@ -56,6 +56,7 @@ class EmailVerificationScreen extends ConsumerStatefulWidget {
 class _EmailVerificationScreenState
     extends ConsumerState<EmailVerificationScreen> {
   bool _isTokenMode = false;
+  String? _tokenModeError;
 
   /// Get the app-level cubit provided in main.dart
   EmailVerificationCubit get _cubit => context.read<EmailVerificationCubit>();
@@ -167,7 +168,8 @@ class _EmailVerificationScreenState
         );
         if (mounted) {
           setState(() {
-            // Show error in UI
+            _tokenModeError =
+                result.error ?? result.message ?? 'Verification failed';
           });
         }
       }
@@ -177,6 +179,11 @@ class _EmailVerificationScreenState
         name: 'EmailVerificationScreen',
         category: LogCategory.auth,
       );
+      if (mounted) {
+        setState(() {
+          _tokenModeError = 'Verification failed. Please try again.';
+        });
+      }
     }
   }
 
@@ -286,6 +293,11 @@ class _EmailVerificationScreenState
   }
 
   Widget _buildContent(EmailVerificationState state) {
+    // Token-mode error takes priority when in token mode
+    if (_isTokenMode && _tokenModeError != null) {
+      return _buildErrorContent(_tokenModeError!);
+    }
+
     switch (state.status) {
       case EmailVerificationStatus.initial:
         return _buildLoadingContent(null);
@@ -363,16 +375,14 @@ class _EmailVerificationScreenState
             ),
           ],
         ),
-        if (isPollingMode) ...[
-          const SizedBox(height: 32),
-          TextButton(
-            onPressed: _handleCancel,
-            child: const Text(
-              'Cancel',
-              style: TextStyle(color: Colors.white70, fontSize: 16),
-            ),
+        const SizedBox(height: 32),
+        TextButton(
+          onPressed: isPollingMode ? _handleCancel : _handleGoBack,
+          child: Text(
+            'Cancel',
+            style: TextStyle(color: VineTheme.onSurfaceVariant, fontSize: 16),
           ),
-        ],
+        ),
       ],
     );
   }

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -359,7 +359,9 @@ class _IdentityNotRecoverableBanner extends StatelessWidget {
   Widget _buildAction(BuildContext context, EmailVerificationState state) {
     switch (state.status) {
       case EmailVerificationStatus.polling:
-        // No action button while polling - user should check email
+        // No action needed — polling auto-expires after 15 minutes
+        // (matching the server's token lifetime), then transitions to
+        // failure state with a Retry button.
         return const SizedBox.shrink();
       case EmailVerificationStatus.failure:
         return ElevatedButton(

--- a/mobile/test/services/email_verification_listener_test.dart
+++ b/mobile/test/services/email_verification_listener_test.dart
@@ -1,0 +1,136 @@
+// ABOUTME: Tests for EmailVerificationListener
+// ABOUTME: Verifies that deep links trigger verifyEmail() API call
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/services/email_verification_listener.dart';
+
+import '../helpers/go_router.dart';
+
+class _MockKeycastOAuth extends Mock implements KeycastOAuth {}
+
+void main() {
+  group(EmailVerificationListener, () {
+    late _MockKeycastOAuth mockOAuth;
+    late MockGoRouter mockRouter;
+    late ProviderContainer container;
+    late EmailVerificationListener listener;
+
+    setUp(() {
+      mockOAuth = _MockKeycastOAuth();
+      mockRouter = MockGoRouter();
+
+      container = ProviderContainer(
+        overrides: [
+          oauthClientProvider.overrideWithValue(mockOAuth),
+          goRouterProvider.overrideWith((ref) => mockRouter),
+        ],
+      );
+
+      // Read the listener via its provider so it receives a proper Ref
+      listener = container.read(emailVerificationListenerProvider);
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('calls verifyEmail when URI contains a token', () async {
+      const token = 'test-verification-token-abc123';
+      when(
+        () => mockOAuth.verifyEmail(token: token),
+      ).thenAnswer((_) async => VerifyEmailResult(success: true));
+      when(() => mockRouter.go(any())).thenReturn(null);
+
+      await listener.handleUri(
+        Uri.parse('https://login.divine.video/verify-email?token=$token'),
+      );
+
+      // Allow the fire-and-forget future to complete
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => mockOAuth.verifyEmail(token: token)).called(1);
+    });
+
+    test('attempts navigation after calling verifyEmail', () async {
+      const token = 'test-token-xyz';
+      when(
+        () => mockOAuth.verifyEmail(token: token),
+      ).thenAnswer((_) async => VerifyEmailResult(success: true));
+      when(() => mockRouter.go(any())).thenReturn(null);
+
+      await listener.handleUri(
+        Uri.parse('https://login.divine.video/verify-email?token=$token'),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => mockRouter.go('/verify-email?token=$token')).called(1);
+    });
+
+    test('calls verifyEmail even when server returns error', () async {
+      const token = 'expired-token';
+      when(() => mockOAuth.verifyEmail(token: token)).thenAnswer(
+        (_) async => VerifyEmailResult(success: false, error: 'Token expired'),
+      );
+      when(() => mockRouter.go(any())).thenReturn(null);
+
+      await listener.handleUri(
+        Uri.parse('https://login.divine.video/verify-email?token=$token'),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => mockOAuth.verifyEmail(token: token)).called(1);
+    });
+
+    test('handles verifyEmail network exception gracefully', () async {
+      const token = 'network-error-token';
+      when(
+        () => mockOAuth.verifyEmail(token: token),
+      ).thenAnswer((_) async => throw Exception('Network error'));
+      when(() => mockRouter.go(any())).thenReturn(null);
+
+      // Should not throw
+      await listener.handleUri(
+        Uri.parse('https://login.divine.video/verify-email?token=$token'),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => mockOAuth.verifyEmail(token: token)).called(1);
+      verify(() => mockRouter.go(any())).called(1);
+    });
+
+    test('ignores URIs with wrong host', () async {
+      await listener.handleUri(
+        Uri.parse('https://evil.com/verify-email?token=stolen-token'),
+      );
+
+      verifyNever(() => mockOAuth.verifyEmail(token: any(named: 'token')));
+      verifyNever(() => mockRouter.go(any()));
+    });
+
+    test('ignores URIs with wrong path', () async {
+      await listener.handleUri(
+        Uri.parse('https://login.divine.video/other-path?token=some-token'),
+      );
+
+      verifyNever(() => mockOAuth.verifyEmail(token: any(named: 'token')));
+      verifyNever(() => mockRouter.go(any()));
+    });
+
+    test('ignores URIs without token parameter', () async {
+      await listener.handleUri(
+        Uri.parse('https://login.divine.video/verify-email'),
+      );
+
+      verifyNever(() => mockOAuth.verifyEmail(token: any(named: 'token')));
+      verifyNever(() => mockRouter.go(any()));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Email verification deep links now actually call `verifyEmail()` on the server, fixing the stuck "Verifying..." screen and the persistent profile banner
- Token-mode verification screen no longer hangs forever on errors — shows error UI with a Cancel button
- Added 7 unit tests for `EmailVerificationListener`

## Problem

When a user clicked the verification link on the same device where the app is installed, the OS could route it to the app instead of the browser. The app intercepted it but only tried to navigate to `/verify-email` — the router redirect blocks that route for all users (a locally-generated nsec means everyone is "authenticated"), so `verifyEmail()` was never called. The server never completed the key backup flow, the poll never succeeded, and users were stuck on a "Verifying..." screen with no way out, or saw a "Verifying Email..." banner on their profile that never went away.

Verification worked when the link was opened elsewhere (laptop browser, different device) because the server handled it directly and the app's poll picked it up.

## Fix

The `EmailVerificationListener` now calls `verifyEmail(token)` directly when it intercepts a deep link, before attempting navigation. This triggers the server-side flow (stores keys, puts OAuth code in Redis), which the already-running poll detects to complete the login.

Additionally, the token-mode verification screen now properly handles errors (was silently swallowing them) and shows a Cancel button so users aren't trapped if the request hangs.

## Test plan

- [x] 7 new unit tests for `EmailVerificationListener`
- [x] All 4256 existing tests pass
- [x] Verified on Android emulator: registered account, sent real verification deep link, poll completed, user signed in, banner disappeared