### PR TITLE
fix: blossom server default not applied when custom toggle disabled

### DIFF
--- a/mobile/lib/services/blossom_upload_service.dart
+++ b/mobile/lib/services/blossom_upload_service.dart
@@ -115,8 +115,9 @@ class BlossomUploadService {
   Future<String?> getBlossomServer() async {
     final prefs = await SharedPreferences.getInstance();
     final stored = prefs.getString(_blossomServerKey);
-    // If nothing is stored, return default. If empty string is stored, return it.
-    return stored ?? defaultBlossomServer;
+    // If nothing is stored or empty string, return default.
+    if (stored == null || stored.isEmpty) return defaultBlossomServer;
+    return stored;
   }
 
   /// Set the Blossom server URL

--- a/mobile/test/services/blossom_upload_service_test.dart
+++ b/mobile/test/services/blossom_upload_service_test.dart
@@ -67,8 +67,8 @@ void main() {
         await service.setBlossomServer(null);
         final retrievedUrl = await service.getBlossomServer();
 
-        // Assert - Service returns empty string when explicitly cleared
-        expect(retrievedUrl, equals(''));
+        // Assert - Clearing falls back to default server
+        expect(retrievedUrl, equals(BlossomUploadService.defaultBlossomServer));
       });
 
       test('should save and retrieve Blossom enabled state', () async {


### PR DESCRIPTION
## Summary
- Fixed bug where disabling the custom Blossom server toggle caused "No Blossom server configured" error in Relay Diagnostics
- Root cause: `setBlossomServer(null)` stored empty string `''` in SharedPreferences, and `getBlossomServer()` returned `''` instead of falling back to the default `https://media.divine.video` (because `'' ?? default` evaluates to `''` — empty string is not null)
- Now treats empty string same as null, properly falling back to the default server

## Test plan
- [x] Existing blossom upload tests pass (14 pass, 3 skipped)
- [x] Updated test expectation for clearing server URL (now expects default instead of empty string)
- [ ] Manual: Toggle custom Blossom server off → Relay Diagnostics should show `media.divine.video` as healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)