### PR TITLE
docs: sync well-known files with production server

### DIFF
--- a/mobile/docs/apple-app-site-association
+++ b/mobile/docs/apple-app-site-association
@@ -3,14 +3,33 @@
     "apps": [],
     "details": [
       {
-        "appID": "GZCZBKH7MY.co.openvine.app",
-        "paths": [
-          "/video/*",
-          "/profile/*",
-          "/hashtag/*",
-          "/search/*"
+        "appIDs": ["GZCZBKH7MY.co.openvine.app"],
+        "components": [
+          {
+            "/": "/video/*",
+            "comment": "Video deep links"
+          },
+          {
+            "/": "/profile/*",
+            "comment": "Profile deep links"
+          },
+          {
+            "/": "/hashtag/*",
+            "comment": "Hashtag deep links"
+          },
+          {
+            "/": "/search/*",
+            "comment": "Search deep links"
+          },
+          {
+            "/": "/app/callback",
+            "comment": "OAuth callback for Divine app"
+          }
         ]
       }
     ]
+  },
+  "webcredentials": {
+    "apps": ["GZCZBKH7MY.co.openvine.app"]
   }
 }

--- a/mobile/docs/assetlinks.json
+++ b/mobile/docs/assetlinks.json
@@ -5,7 +5,10 @@
       "namespace": "android_app",
       "package_name": "co.openvine.app",
       "sha256_cert_fingerprints": [
-        "6F:36:C3:68:74:18:5E:03:B4:79:3D:82:EF:54:CE:34:26:ED:6E:C8:12:B7:CD:E2:F4:FA:9C:81:2F:C7:14:F4"
+        "6F:36:C3:68:74:18:5E:03:B4:79:3D:82:EF:54:CE:34:26:ED:6E:C8:12:B7:CD:E2:F4:FA:9C:81:2F:C7:14:F4",
+        "ED:9D:A6:BF:1A:D1:5B:D1:02:AF:0C:DB:4E:90:F0:3C:1B:8C:7F:EB:AA:9C:C8:F1:15:97:EB:9C:2C:41:B1:75",
+        "10:B8:04:F9:48:FC:91:EC:28:27:B9:67:15:C3:21:2E:AB:1A:0B:46:AF:52:1B:3A:31:6C:9D:78:BF:A4:39:6E",
+        "CF:7E:6A:A4:99:A8:00:A8:0E:93:E4:07:03:60:38:4F:2F:9C:22:81:3B:3D:7B:81:88:15:A0:1B:37:6F:ED:B1"
       ]
     }
   }


### PR DESCRIPTION
## Summary

Closes #939 (documentation portion)

The repo copies of `assetlinks.json` and `apple-app-site-association` in `mobile/docs/` were stale and out of sync with what's deployed on `divine.video` and `login.divine.video`.

**`assetlinks.json`:**
- Added 3 missing SHA256 certificate fingerprints (release, CI, demo builds)

**`apple-app-site-association`:**
- Upgraded from legacy format (`appID` + `paths`) to modern format (`appIDs` + `components`)
- Added `/app/callback` path for OAuth deep links
- Added `webcredentials` section

## Context

As part of investigating #939, we found that `divine.video/.well-known/` was returning 404 for both files. Rabble deployed and cache-purged the fix server-side. This PR syncs the repo reference copies to match production so they don't drift again.

## Test plan

- [ ] Verify `divine.video/.well-known/assetlinks.json` returns 200 with 4 fingerprints
- [ ] Verify `divine.video/.well-known/apple-app-site-association` returns 200 with correct paths
- [ ] QA: Android email verification deep link opens app (after reinstall to re-verify App Links)
- [ ] QA: iOS email verification deep link opens app