### PR TITLE
fix: handle existing GitHub releases in Codemagic publish step

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -78,14 +78,25 @@ definitions:
         fi
         VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
         TAG="$VERSION"
-        echo "Creating GitHub Release $TAG"
-        gh release create "$TAG" \
-          --repo "$CM_REPO_SLUG" \
-          --title "$TAG" \
-          --prerelease \
-          --generate-notes \
-          build/app/outputs/apk/release/*arm64*.apk \
-          build/app/outputs/apk/release/*armeabi*.apk
+        echo "Publishing to GitHub Release $TAG"
+        # If release already exists, upload assets to it; otherwise create new
+        if gh release view "$TAG" --repo "$CM_REPO_SLUG" > /dev/null 2>&1; then
+          echo "Release $TAG exists, uploading assets (replacing existing)"
+          gh release upload "$TAG" \
+            --repo "$CM_REPO_SLUG" \
+            --clobber \
+            build/app/outputs/apk/release/*arm64*.apk \
+            build/app/outputs/apk/release/*armeabi*.apk
+        else
+          echo "Creating new release $TAG"
+          gh release create "$TAG" \
+            --repo "$CM_REPO_SLUG" \
+            --title "$TAG" \
+            --prerelease \
+            --generate-notes \
+            build/app/outputs/apk/release/*arm64*.apk \
+            build/app/outputs/apk/release/*armeabi*.apk
+        fi
     - &build_ios
       name: Build and sign iOS
       script: |


### PR DESCRIPTION
## Summary
- Fix Codemagic `Publish to GitHub Release` step failing when a release with the same tag already exists
- Now checks if release exists first: uploads assets with `--clobber` to existing release, or creates new one
- Triggered by build #130 failing with "a release with the same tag name already exists: 1.0.5"

## Test plan
- [ ] Re-run Android build with `PUBLISH_TO_GITHUB=YES` — should upload split APKs to existing 1.0.5 release
- [ ] Verify new version (after pubspec bump) creates a fresh release

🤖 Generated with [Claude Code](https://claude.com/claude-code)