### PR TITLE
fix(login-screen): resolve issue that users can scroll to the sign-in button

### DIFF
--- a/mobile/lib/screens/auth/divine_auth_screen.dart
+++ b/mobile/lib/screens/auth/divine_auth_screen.dart
@@ -211,7 +211,6 @@ class _DivineAuthScreenState extends ConsumerState<DivineAuthScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: VineTheme.surfaceBackground,
-      resizeToAvoidBottomInset: false,
       body: GestureDetector(
         onTap: () => FocusScope.of(context).unfocus(),
         behavior: HitTestBehavior.opaque,


### PR DESCRIPTION
## Description

When users enter their email and password to sign in or up, they cannot press the sign-in button as long as the keyboard is open. This PR fixes that.

| Before | After |
| ------- | ------ |
| ![before](https://github.com/user-attachments/assets/98bc6252-b780-4418-a5da-9f1b6b51f22c) | ![after](https://github.com/user-attachments/assets/1cfa5d61-817f-4791-bfe2-ad74841cac92) |

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore