### PR TITLE
fix: remove redundant dSYM upload build phase

### DIFF
--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -205,7 +205,6 @@
 			buildPhases = (
 				734446FF76CEA5AE3EED7E5E /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
-				2DFC18242E7A40AB00C35B71 /* ShellScript */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
@@ -326,23 +325,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\n#!/bin/bash\nset -e  # Exit on error\n\necho \"========================================\"\necho \"FlutterFire: Starting dSYM upload\"\necho \"========================================\"\n\n# Set PATH with explicit locations, checking if directories exist\nPATH=\"$PATH:$HOME/.pub-cache/bin\"\n[ -d \"$FLUTTER_ROOT/bin\" ] && PATH=\"$PATH:$FLUTTER_ROOT/bin\"\n[ -d \"$PUB_CACHE/bin\" ] && PATH=\"$PATH:$PUB_CACHE/bin\"\n[ -d \"/usr/local/bin\" ] && PATH=\"$PATH:/usr/local/bin\"\n\n# Try common Flutter installation locations if FLUTTER_ROOT not set\nif [ -z \"$FLUTTER_ROOT\" ]; then\n  [ -d \"$HOME/fvm/default/bin\" ] && PATH=\"$PATH:$HOME/fvm/default/bin\"\n  [ -d \"$HOME/flutter/bin\" ] && PATH=\"$PATH:$HOME/flutter/bin\"\n  [ -d \"/usr/local/flutter/bin\" ] && PATH=\"$PATH:/usr/local/flutter/bin\"\nfi\n\necho \"PATH configured: $PATH\"\necho \"Checking for flutterfire command...\"\nwhich flutterfire || echo \"WARNING: flutterfire not found in PATH\"\n\nif [ -z \"$PODS_ROOT\" ] || [ ! -d \"$PODS_ROOT/FirebaseCrashlytics\" ]; then\n  # Cannot use \"BUILD_DIR%/Build/*\" as per Firebase documentation, it points to \"flutter-project/build/ios/*\" path which doesn't have run script\n  DERIVED_DATA_PATH=$(echo \"$BUILD_ROOT\" | sed -E 's|(.*DerivedData/[^/]+).*|\\1|')\n  PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT=\"${DERIVED_DATA_PATH}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n  echo \"Using SPM Crashlytics script: $PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT\"\nelse\n  PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT=\"$PODS_ROOT/FirebaseCrashlytics/run\"\n  echo \"Using CocoaPods Crashlytics script: $PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT\"\nfi\n\necho \"dSYM folder: ${DWARF_DSYM_FOLDER_PATH}\"\necho \"dSYM file: ${DWARF_DSYM_FILE_NAME}\"\necho \"Uploading dSYMs to Firebase Crashlytics...\"\n\n# Command to upload symbols script used to upload symbols to Firebase server\nflutterfire upload-crashlytics-symbols --upload-symbols-script-path=\"$PATH_TO_CRASHLYTICS_UPLOAD_SCRIPT\" --platform=ios --apple-project-path=\"${SRCROOT}\" --env-platform-name=\"${PLATFORM_NAME}\" --env-configuration=\"${CONFIGURATION}\" --env-project-dir=\"${PROJECT_DIR}\" --env-built-products-dir=\"${BUILT_PRODUCTS_DIR}\" --env-dwarf-dsym-folder-path=\"${DWARF_DSYM_FOLDER_PATH}\" --env-dwarf-dsym-file-name=\"${DWARF_DSYM_FILE_NAME}\" --env-infoplist-path=\"${INFOPLIST_PATH}\" --default-config=default\n\necho \"========================================\"\necho \"FlutterFire: dSYM upload completed successfully\"\necho \"========================================\"\n";
-		};
-		2DFC18242E7A40AB00C35B71 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#!/bin/bash\nif [ -d \"${PODS_ROOT}/FirebaseCrashlytics\" ]; then\n  \"${PODS_ROOT}/FirebaseCrashlytics/run\" -gsp \"${SRCROOT}/Runner/GoogleService-Info.plist\"\nelse\n  DERIVED_DATA_PATH=$(echo \"$BUILD_ROOT\" | sed -E 's|(.*DerivedData/[^/]+).*|\\1|')\n  CRASHLYTICS_RUN=\"${DERIVED_DATA_PATH}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\n  if [ -f \"$CRASHLYTICS_RUN\" ]; then\n    \"$CRASHLYTICS_RUN\" -gsp \"${SRCROOT}/Runner/GoogleService-Info.plist\"\n  fi\nfi\n";
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Description

Remove a redundant Xcode build phase that was running the Crashlytics `run` script before the binary was compiled (position 3, before Sources), when no dSYMs exist yet. The project already has the FlutterFire `upload-crashlytics-symbols` phase in the correct position (after Thin Binary), which is the recommended approach for Flutter projects and handles dSYM upload properly.

**Related Issue:** Closes #1566

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore