### PR TITLE
fix(video): preserve all imeta URLs when editing video metadata

### DIFF
--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -2632,10 +2632,54 @@ class _EditVideoDialogState extends ConsumerState<_EditVideoDialog> {
       // Required 'd' tag - must use the same identifier
       tags.add(['d', widget.video.stableId]);
 
-      // Build imeta tag components (preserve existing media data)
+      // Extract ALL valid HTTP video URLs from the original imeta tag.
+      // The original event may have multiple URL entries (streaming MP4,
+      // HLS, R2 fallback, etc.) which must all be preserved.
+      final videoUrls = <String>[];
+      for (final tag in widget.video.nostrEventTags) {
+        if (tag.isEmpty || tag[0] != 'imeta') continue;
+        if (tag.length > 1 && tag[1].contains(' ')) {
+          // Old imeta format: ['imeta', 'url https://...', 'm video/mp4', ...]
+          for (var i = 1; i < tag.length; i++) {
+            final spaceIdx = tag[i].indexOf(' ');
+            if (spaceIdx > 0) {
+              final key = tag[i].substring(0, spaceIdx);
+              final value = tag[i].substring(spaceIdx + 1);
+              if (key == 'url' &&
+                  _isHttpUrl(value) &&
+                  !videoUrls.contains(value)) {
+                videoUrls.add(value);
+              }
+            }
+          }
+        } else {
+          // New imeta format: ['imeta', 'url', 'https://...', 'm', 'video/mp4', ...]
+          for (var i = 1; i < tag.length - 1; i += 2) {
+            if (tag[i] == 'url' &&
+                _isHttpUrl(tag[i + 1]) &&
+                !videoUrls.contains(tag[i + 1])) {
+              videoUrls.add(tag[i + 1]);
+            }
+          }
+        }
+      }
+
+      // Fallback: if nostrEventTags is empty (e.g., loaded from JSON cache
+      // where nostrEventTags is not serialized), use the single videoUrl.
+      if (videoUrls.isEmpty && _isHttpUrl(widget.video.videoUrl)) {
+        videoUrls.add(widget.video.videoUrl!);
+      }
+
+      // Refuse to republish if no valid HTTP video URLs can be preserved.
+      // This prevents corrupt events with local file paths from being published.
+      if (videoUrls.isEmpty) {
+        throw Exception('Cannot update video: no valid HTTP video URLs found');
+      }
+
+      // Build imeta tag components (preserve all original media URLs)
       final imetaComponents = <String>[];
-      if (widget.video.videoUrl != null) {
-        imetaComponents.add('url ${widget.video.videoUrl!}');
+      for (final url in videoUrls) {
+        imetaComponents.add('url $url');
       }
       imetaComponents.add('m video/mp4');
 
@@ -2857,6 +2901,12 @@ class _EditVideoDialogState extends ConsumerState<_EditVideoDialog> {
         );
       }
     }
+  }
+
+  /// Check if a URL is a valid HTTP/HTTPS URL (not a local file path).
+  static bool _isHttpUrl(String? url) {
+    if (url == null || url.isEmpty) return false;
+    return url.startsWith('http://') || url.startsWith('https://');
   }
 
   @override

--- a/mobile/test/widgets/share_video_menu_edit_imeta_test.dart
+++ b/mobile/test/widgets/share_video_menu_edit_imeta_test.dart
@@ -1,0 +1,236 @@
+// ABOUTME: Unit tests for imeta URL preservation logic during video metadata edits
+// ABOUTME: Verifies all valid HTTP URLs are extracted from original Nostr event imeta tags
+
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Pure-logic helpers that mirror the production code in
+// _EditVideoDialogState._updateVideo(). They are declared here so we can
+// verify correctness on controlled inputs without requiring a full widget pump.
+// ---------------------------------------------------------------------------
+
+/// Returns true for HTTP / HTTPS URLs, false for local paths or empty strings.
+bool _isHttpUrl(String? url) {
+  if (url == null || url.isEmpty) return false;
+  return url.startsWith('http://') || url.startsWith('https://');
+}
+
+/// Extracts all valid HTTP video URLs from the imeta tag(s) in
+/// [nostrEventTags], mirroring the logic in _EditVideoDialogState._updateVideo.
+///
+/// Handles both the old space-separated format
+/// `['imeta', 'url https://…', 'm video/mp4', …]`
+/// and the new positional format
+/// `['imeta', 'url', 'https://…', 'm', 'video/mp4', …]`.
+List<String> _extractImetaUrls(List<List<String>> nostrEventTags) {
+  final urls = <String>[];
+  for (final tag in nostrEventTags) {
+    if (tag.isEmpty || tag[0] != 'imeta') continue;
+    if (tag.length > 1 && tag[1].contains(' ')) {
+      // Old format: each element is 'key value'
+      for (var i = 1; i < tag.length; i++) {
+        final spaceIdx = tag[i].indexOf(' ');
+        if (spaceIdx > 0) {
+          final key = tag[i].substring(0, spaceIdx);
+          final value = tag[i].substring(spaceIdx + 1);
+          if (key == 'url' && _isHttpUrl(value) && !urls.contains(value)) {
+            urls.add(value);
+          }
+        }
+      }
+    } else {
+      // New format: alternating key, value elements
+      for (var i = 1; i < tag.length - 1; i += 2) {
+        if (tag[i] == 'url' &&
+            _isHttpUrl(tag[i + 1]) &&
+            !urls.contains(tag[i + 1])) {
+          urls.add(tag[i + 1]);
+        }
+      }
+    }
+  }
+  return urls;
+}
+
+void main() {
+  group('HTTP URL validation (_isHttpUrl)', () {
+    test('accepts http:// URLs', () {
+      expect(_isHttpUrl('http://example.com/video.mp4'), isTrue);
+    });
+
+    test('accepts https:// URLs', () {
+      expect(_isHttpUrl('https://cdn.example.com/video.mp4'), isTrue);
+    });
+
+    test('rejects local file paths', () {
+      expect(_isHttpUrl('/data/user/0/cache/video.mp4'), isFalse);
+      expect(_isHttpUrl('file:///tmp/video.mp4'), isFalse);
+    });
+
+    test('rejects empty string', () {
+      expect(_isHttpUrl(''), isFalse);
+    });
+
+    test('rejects null', () {
+      expect(_isHttpUrl(null), isFalse);
+    });
+
+    test('rejects non-http schemes', () {
+      expect(_isHttpUrl('ftp://example.com/video.mp4'), isFalse);
+      expect(_isHttpUrl('rtmp://stream.example.com/live'), isFalse);
+    });
+  });
+
+  group(
+    'imeta URL extraction from nostrEventTags (old space-separated format)',
+    () {
+      test('extracts single URL', () {
+        final tags = [
+          ['imeta', 'url https://cdn.example.com/video.mp4', 'm video/mp4'],
+        ];
+        expect(
+          _extractImetaUrls(tags),
+          equals(['https://cdn.example.com/video.mp4']),
+        );
+      });
+
+      test('extracts multiple URLs (streaming MP4 + R2 fallback + HLS)', () {
+        final tags = [
+          [
+            'imeta',
+            'url https://stream.example.com/play_360p.mp4',
+            'url https://r2.example.com/fallback.mp4',
+            'url https://cdn.example.com/video.m3u8',
+            'm video/mp4',
+          ],
+        ];
+        final result = _extractImetaUrls(tags);
+        expect(result, hasLength(3));
+        expect(result, contains('https://stream.example.com/play_360p.mp4'));
+        expect(result, contains('https://r2.example.com/fallback.mp4'));
+        expect(result, contains('https://cdn.example.com/video.m3u8'));
+      });
+
+      test('filters out non-HTTP URLs', () {
+        final tags = [
+          [
+            'imeta',
+            'url https://valid.example.com/video.mp4',
+            'url /local/path/video.mp4',
+            'm video/mp4',
+          ],
+        ];
+        final result = _extractImetaUrls(tags);
+        expect(result, hasLength(1));
+        expect(result, contains('https://valid.example.com/video.mp4'));
+      });
+
+      test('deduplicates identical URLs', () {
+        final tags = [
+          [
+            'imeta',
+            'url https://cdn.example.com/video.mp4',
+            'url https://cdn.example.com/video.mp4',
+            'm video/mp4',
+          ],
+        ];
+        final result = _extractImetaUrls(tags);
+        expect(result, hasLength(1));
+      });
+
+      test('ignores non-imeta tags', () {
+        final tags = [
+          ['d', 'some-stable-id'],
+          ['title', 'My Video'],
+          ['t', 'hashtag'],
+        ];
+        expect(_extractImetaUrls(tags), isEmpty);
+      });
+
+      test('returns empty list when nostrEventTags is empty', () {
+        expect(_extractImetaUrls([]), isEmpty);
+      });
+    },
+  );
+
+  group('imeta URL extraction from nostrEventTags (new positional format)', () {
+    test('extracts single URL', () {
+      final tags = [
+        ['imeta', 'url', 'https://cdn.example.com/video.mp4', 'm', 'video/mp4'],
+      ];
+      expect(
+        _extractImetaUrls(tags),
+        equals(['https://cdn.example.com/video.mp4']),
+      );
+    });
+
+    test('extracts multiple URLs', () {
+      final tags = [
+        [
+          'imeta',
+          'url',
+          'https://mp4.example.com/video.mp4',
+          'url',
+          'https://hls.example.com/video.m3u8',
+          'm',
+          'video/mp4',
+        ],
+      ];
+      final result = _extractImetaUrls(tags);
+      expect(result, hasLength(2));
+      expect(result, contains('https://mp4.example.com/video.mp4'));
+      expect(result, contains('https://hls.example.com/video.m3u8'));
+    });
+
+    test('filters out non-HTTP URLs', () {
+      final tags = [
+        [
+          'imeta',
+          'url',
+          'https://valid.example.com/video.mp4',
+          'url',
+          'file:///local/video.mp4',
+          'm',
+          'video/mp4',
+        ],
+      ];
+      final result = _extractImetaUrls(tags);
+      expect(result, hasLength(1));
+      expect(result, contains('https://valid.example.com/video.mp4'));
+    });
+  });
+
+  group('imeta URL extraction - URL order preservation', () {
+    test('preserves the order URLs appear in the original tag', () {
+      final tags = [
+        [
+          'imeta',
+          'url https://stream.example.com/play_360p.mp4',
+          'url https://r2.example.com/fallback.mp4',
+          'url https://cdn.example.com/video.m3u8',
+          'm video/mp4',
+        ],
+      ];
+      final result = _extractImetaUrls(tags);
+      expect(result[0], equals('https://stream.example.com/play_360p.mp4'));
+      expect(result[1], equals('https://r2.example.com/fallback.mp4'));
+      expect(result[2], equals('https://cdn.example.com/video.m3u8'));
+    });
+  });
+
+  group('imeta URL extraction - no valid URLs guard', () {
+    test('returns empty list when all URLs are non-HTTP', () {
+      final tags = [
+        ['imeta', 'url /local/path/video.mp4', 'm video/mp4'],
+      ];
+      expect(_extractImetaUrls(tags), isEmpty);
+    });
+
+    test('returns empty list when imeta has no url entries', () {
+      final tags = [
+        ['imeta', 'm video/mp4', 'dim 720x1280'],
+      ];
+      expect(_extractImetaUrls(tags), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

When a user edits video metadata (e.g. adding 'inspired by'), the edit path in `share_video_menu.dart` rebuilds the Nostr event but was only preserving a single `videoUrl`, discarding all alternate URLs (streaming MP4, HLS, R2 fallback) from the original imeta tag. This caused videos to 'disappear' after metadata edits because clients that preferred a different URL format could no longer find a playable source.

Reported by user Oz in Discord — video vanished after adding 'inspired by' tag.

## Changes

- Extract ALL `url` entries from the original Nostr event tags when rebuilding imeta during edit
- Validate each URL is HTTP/HTTPS (matching `_isHttpUrl` pattern from PR #1722)
- Fall back to `widget.video.videoUrl` when original tags unavailable
- Refuse to publish if no valid HTTP video URLs can be preserved
- 18 unit tests covering old/new imeta formats, URL validation, deduplication, and the no-valid-URL guard

## Related

- Follows the defense-in-depth pattern from #1722 (local file path fix)
- Fixes the edit path that #1722 missed