### PR TITLE
fix: add close button to upload failed banner and clean up dead drafts

### DIFF
--- a/mobile/lib/blocs/background_publish/background_publish_bloc.dart
+++ b/mobile/lib/blocs/background_publish/background_publish_bloc.dart
@@ -26,6 +26,7 @@ class BackgroundPublishBloc
     on<BackgroundPublishProgressChanged>(_onBackgroundPublishProgressChanged);
     on<BackgroundPublishVanished>(_onBackgroundPublishVanished);
     on<BackgroundPublishRetryRequested>(_onBackgroundPublishRetryRequested);
+    on<BackgroundPublishDismissAllFailed>(_onBackgroundPublishDismissAllFailed);
   }
 
   final Future<VideoPublishService> Function({
@@ -118,6 +119,16 @@ class BackgroundPublishBloc
   ) {
     final remainingUploads = state.uploads.where((upload) {
       return upload.draft.id != event.draftId;
+    }).toList();
+    emit(state.copyWith(uploads: remainingUploads));
+  }
+
+  void _onBackgroundPublishDismissAllFailed(
+    BackgroundPublishDismissAllFailed event,
+    Emitter<BackgroundPublishState> emit,
+  ) {
+    final remainingUploads = state.uploads.where((upload) {
+      return upload.result == null;
     }).toList();
     emit(state.copyWith(uploads: remainingUploads));
   }

--- a/mobile/lib/blocs/background_publish/background_publish_event.dart
+++ b/mobile/lib/blocs/background_publish/background_publish_event.dart
@@ -48,3 +48,5 @@ class BackgroundPublishRetryRequested extends BackgroundPublishEvent {
   @override
   List<Object?> get props => [draftId];
 }
+
+class BackgroundPublishDismissAllFailed extends BackgroundPublishEvent {}

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -128,6 +128,22 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
     final backgroundPublishBloc = context.read<BackgroundPublishBloc>();
 
     for (final draft in pendingDrafts) {
+      // Check if the video file still exists before re-queuing
+      final hasValidClip = draft.clips.any((clip) {
+        final videoPath = clip.video.file?.path;
+        return videoPath != null && File(videoPath).existsSync();
+      });
+
+      if (!hasValidClip) {
+        Log.warning(
+          '🗑️ Skipping draft ${draft.id}: video file no longer exists',
+          name: 'VideoPublishNotifier',
+          category: LogCategory.video,
+        );
+        await _draftService.deleteDraft(draft.id);
+        continue;
+      }
+
       Log.info(
         '📤 Resuming upload for draft: ${draft.id}',
         name: 'VideoPublishNotifier',

--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -711,22 +711,48 @@ class _ProfileDataView extends ConsumerWidget {
       );
     }
 
-    return BlocListener<BackgroundPublishBloc, BackgroundPublishState>(
-      listenWhen: (previous, current) {
-        // Listen only for upload completions
-        final prevCompleted = previous.uploads
-            .where((upload) => upload.result != null)
-            .length;
-        final currCompleted = current.uploads
-            .where((upload) => upload.result != null)
-            .length;
-        return currCompleted > prevCompleted;
-      },
-      listener: (context, state) {
-        // We don't need the value here, we just want to refresh the feed
-        // when background uploads complete
-        final _ = ref.refresh(profileFeedProvider(userIdHex));
-      },
+    return MultiBlocListener(
+      listeners: [
+        BlocListener<BackgroundPublishBloc, BackgroundPublishState>(
+          listenWhen: (previous, current) {
+            // Detect successful upload completion:
+            // in-progress count decreased AND total uploads decreased
+            // (failure only changes result, doesn't remove from list)
+            final prevInProgress = previous.uploads
+                .where((u) => u.result == null)
+                .length;
+            final currInProgress = current.uploads
+                .where((u) => u.result == null)
+                .length;
+            return currInProgress < prevInProgress &&
+                current.uploads.length < previous.uploads.length;
+          },
+          listener: (context, state) {
+            ref.invalidate(profileFeedProvider(userIdHex));
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Video published!'),
+                duration: Duration(seconds: 2),
+              ),
+            );
+          },
+        ),
+        BlocListener<BackgroundPublishBloc, BackgroundPublishState>(
+          listenWhen: (previous, current) {
+            // Detect new failures
+            final prevFailed = previous.uploads
+                .where((u) => u.result != null)
+                .length;
+            final currFailed = current.uploads
+                .where((u) => u.result != null)
+                .length;
+            return currFailed > prevFailed;
+          },
+          listener: (context, state) {
+            ref.invalidate(profileFeedProvider(userIdHex));
+          },
+        ),
+      ],
       child: switch (videosAsync) {
         AsyncLoading() => const ProfileLoadingView(),
         AsyncError(:final error) => Center(child: Text('Error: $error')),
@@ -821,12 +847,16 @@ class ProfileViewSwitcher extends StatelessWidget {
             refreshNotifier: refreshNotifier,
           );
 
-    final completedWithErrorUploads = backgroundPublishBloc.state.uploads
+    final failedUploads = backgroundPublishBloc.state.uploads
         .where((upload) => upload.result != null)
         .toList();
 
-    if (completedWithErrorUploads.isNotEmpty) {
-      final faultUpload = completedWithErrorUploads.first;
+    if (failedUploads.isNotEmpty) {
+      final failureCount = failedUploads.length;
+      final firstFailed = failedUploads.first;
+      final label = failureCount == 1
+          ? 'Video upload failed.'
+          : '$failureCount uploads failed.';
 
       return Stack(
         children: [
@@ -836,22 +866,40 @@ class ProfileViewSwitcher extends StatelessWidget {
             left: 16,
             right: 16,
             child: Dismissible(
-              key: ValueKey(faultUpload.draft.id),
+              key: ValueKey(firstFailed.draft.id),
+              direction: DismissDirection.horizontal,
               onDismissed: (_) {
-                backgroundPublishBloc.add(
-                  BackgroundPublishVanished(draftId: faultUpload.draft.id),
-                );
+                if (failureCount == 1) {
+                  backgroundPublishBloc.add(
+                    BackgroundPublishVanished(draftId: firstFailed.draft.id),
+                  );
+                } else {
+                  backgroundPublishBloc.add(
+                    BackgroundPublishDismissAllFailed(),
+                  );
+                }
               },
               child: DivineSnackbarContainer(
-                label: 'Video upload failed.',
+                label: label,
                 error: true,
                 actionLabel: 'Retry',
                 onActionPressed: () {
                   backgroundPublishBloc.add(
                     BackgroundPublishRetryRequested(
-                      draftId: faultUpload.draft.id,
+                      draftId: firstFailed.draft.id,
                     ),
                   );
+                },
+                onDismissed: () {
+                  if (failureCount == 1) {
+                    backgroundPublishBloc.add(
+                      BackgroundPublishVanished(draftId: firstFailed.draft.id),
+                    );
+                  } else {
+                    backgroundPublishBloc.add(
+                      BackgroundPublishDismissAllFailed(),
+                    );
+                  }
                 },
               ),
             ),

--- a/mobile/packages/divine_ui/lib/src/divine_snackbar_container.dart
+++ b/mobile/packages/divine_ui/lib/src/divine_snackbar_container.dart
@@ -11,6 +11,7 @@ class DivineSnackbarContainer extends StatelessWidget {
     this.error = false,
     this.actionLabel,
     this.onActionPressed,
+    this.onDismissed,
     super.key,
   });
 
@@ -44,6 +45,10 @@ class DivineSnackbarContainer extends StatelessWidget {
 
   /// Callback when the action button is pressed.
   final VoidCallback? onActionPressed;
+
+  /// Callback when the dismiss (X) button is pressed.
+  /// When provided, a close icon button is shown at the trailing edge.
+  final VoidCallback? onDismissed;
 
   @override
   Widget build(BuildContext context) {
@@ -86,6 +91,17 @@ class DivineSnackbarContainer extends StatelessWidget {
                     fontWeight: FontWeight.w800,
                     color: error ? VineTheme.likeRed : VineTheme.vineGreen,
                   ),
+                ),
+              ),
+            if (onDismissed != null)
+              IconButton(
+                onPressed: onDismissed,
+                icon: const Icon(Icons.close, color: VineTheme.whiteText),
+                iconSize: 20,
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(
+                  minWidth: 32,
+                  minHeight: 32,
                 ),
               ),
           ],

--- a/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
+++ b/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
@@ -325,6 +325,88 @@ void main() {
       );
     });
 
+    group('BackgroundPublishDismissAllFailed', () {
+      late _MockVineDraft draft1;
+      late _MockVineDraft draft2;
+      late _MockVineDraft draft3;
+
+      setUp(() {
+        draft1 = _MockVineDraft();
+        draft2 = _MockVineDraft();
+        draft3 = _MockVineDraft();
+        when(() => draft1.id).thenReturn('1');
+        when(() => draft2.id).thenReturn('2');
+        when(() => draft3.id).thenReturn('3');
+      });
+
+      blocTest<BackgroundPublishBloc, BackgroundPublishState>(
+        'removes all failed uploads but keeps in-progress ones',
+        build: () => BackgroundPublishBloc(
+          videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+        ),
+        seed: () => BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(
+              draft: draft1,
+              result: const PublishError('error 1'),
+              progress: 1.0,
+            ),
+            BackgroundUpload(draft: draft2, result: null, progress: 0.5),
+            BackgroundUpload(
+              draft: draft3,
+              result: const PublishError('error 2'),
+              progress: 1.0,
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(BackgroundPublishDismissAllFailed()),
+        expect: () => [
+          BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(draft: draft2, result: null, progress: 0.5),
+            ],
+          ),
+        ],
+      );
+
+      blocTest<BackgroundPublishBloc, BackgroundPublishState>(
+        'emits empty state when all uploads are failed',
+        build: () => BackgroundPublishBloc(
+          videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+        ),
+        seed: () => BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(
+              draft: draft1,
+              result: const PublishError('error 1'),
+              progress: 1.0,
+            ),
+            BackgroundUpload(
+              draft: draft2,
+              result: const PublishError('error 2'),
+              progress: 1.0,
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(BackgroundPublishDismissAllFailed()),
+        expect: () => [BackgroundPublishState(uploads: [])],
+      );
+
+      blocTest<BackgroundPublishBloc, BackgroundPublishState>(
+        'emits no new state when no failed uploads exist',
+        build: () => BackgroundPublishBloc(
+          videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+        ),
+        seed: () => BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(draft: draft1, result: null, progress: 0.3),
+          ],
+        ),
+        act: (bloc) => bloc.add(BackgroundPublishDismissAllFailed()),
+        expect: () => <BackgroundPublishState>[],
+      );
+    });
+
     group('BackgroundPublishRetryRequested', () {
       late _MockVineDraft draft;
       late _MockVideoPublishService mockPublishService;


### PR DESCRIPTION
## Summary
- Add close (X) button to the "Video upload failed" banner on the profile screen so users can dismiss it
- Add `BackgroundPublishDismissAllFailed` event to dismiss all failed uploads at once
- Show "Video published!" success toast when background upload completes
- Clean up permanently-failed drafts (missing video files) on app restart in `resumePendingPublishes()`

## Test plan
- [ ] Trigger a failed upload → verify X button appears and dismisses banner
- [ ] Trigger multiple failed uploads → verify banner shows count ("N uploads failed") with X button
- [ ] Trigger successful upload → verify "Video published!" toast appears
- [ ] Kill app with failed draft, delete video file, reopen → verify dead draft is cleaned up
- [ ] Run `test/blocs/background_publish_bloc/background_publish_bloc_test.dart` - all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)