### PR TITLE
chore: update zapstore.yaml format and add release source

### DIFF
--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,28 +1,27 @@
-# Zapstore publishing configuration for diVine
-# Usage: zsp publish zapstore.yaml
-# Docs: https://github.com/zapstore/zsp
-
 repository: https://github.com/divinevideo/divine-mobile
+release_source: https://github.com/divinevideo/divine-mobile/releases/tag/1.0.5
+match: .*arm64.*\.apk$
 name: diVine
-summary: Decentralized short-form video sharing powered by Nostr
 description: |
-  diVine is a decentralized vine-like video sharing app built on Nostr.
-  Create, share, and discover short looping videos with full ownership
-  of your content and social graph. No algorithms, no gatekeepers.
+    diVine is a decentralized vine-like video sharing app built on Nostr.
+    Create, share, and discover short looping videos with full ownership
+    of your content and social graph. No algorithms, no gatekeepers.
+summary: Decentralized short-form video sharing powered by Nostr
 tags:
-  - social
-  - video
-  - nostr
-  - decentralized
+    - social
+    - video
+    - nostr
+    - decentralized
 license: MPL-2.0
 website: https://divine.video
-match: ".*arm64.*\\.apk$"
 icon: ./mobile/assets/icon/divine_icon_transparent_512.png
 supported_nips:
-  - "01"
-  - "02"
-  - "18"
-  - "25"
-  - "46"
-  - "71"
-  - "94"
+    - "01"
+    - "02"
+    - "18"
+    - "25"
+    - "46"
+    - "71"
+    - "94"
+metadata_sources:
+    - github


### PR DESCRIPTION
## Summary
- Add `release_source` URL pointing to GitHub release tag for zapstore publishing
- Reformat YAML to standard indentation style
- Move `match` pattern to top level for clarity

## Test plan
- [ ] Verify `zsp publish zapstore.yaml` works with updated format
- [ ] Confirm release_source URL resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)