### PR TITLE
feat: add macOS build workflow and GitHub Release for all platforms

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -19,8 +19,8 @@
 # 7 - Create environment variable group "proofmode_credentials" with:
 #   - PROOFMODE_SIGNING_SERVER_ENDPOINT
 #   - PROOFMODE_SIGNING_SERVER_TOKEN
-# 8 - PUBLISH_TO_GITHUB is configured via build inputs (dropdown) when starting Android builds
-#   - Set to YES to create a GitHub Release with APK artifacts (for Zapstore distribution)
+# 8 - PUBLISH_TO_GITHUB is configured via build inputs (dropdown) when starting builds
+#   - Set to YES to upload artifacts to a GitHub Release (for Zapstore / direct distribution)
 #   - Defaults to NO
 #   - Requires GITHUB_TOKEN in "github_credentials" environment variable group
 
@@ -69,6 +69,25 @@ definitions:
           --dart-define=DEFAULT_ENV=${{ inputs.DEFAULT_ENV }} \
           --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
           --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN
+    - &build_macos
+      name: Build macOS app
+      script: |
+        flutter build macos --release \
+          --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
+          --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \
+          --dart-define=ZENDESK_URL=$ZENDESK_URL \
+          --dart-define=DEFAULT_ENV=${{ inputs.DEFAULT_ENV }} \
+          --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT=$PROOFMODE_SIGNING_SERVER_ENDPOINT \
+          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=$PROOFMODE_SIGNING_SERVER_TOKEN
+    - &package_macos_dmg
+      name: Package macOS DMG
+      script: |
+        APP_PATH="build/macos/Build/Products/Release"
+        APP_NAME=$(ls "$APP_PATH" | grep '\.app$' | head -1)
+        DMG_NAME="diVine-macOS.dmg"
+        echo "Packaging $APP_NAME as $DMG_NAME"
+        hdiutil create -volname "diVine" -srcfolder "$APP_PATH/$APP_NAME" \
+          -ov -format UDZO "$APP_PATH/$DMG_NAME"
     - &publish_github_release
       name: Publish to GitHub Release
       script: |
@@ -79,14 +98,32 @@ definitions:
         VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
         TAG="$VERSION"
         echo "Publishing to GitHub Release $TAG"
+        # Collect artifacts that exist for this platform
+        ARTIFACTS=()
+        # Android APKs
+        for f in build/app/outputs/apk/release/*arm64*.apk build/app/outputs/apk/release/*armeabi*.apk; do
+          [ -f "$f" ] && ARTIFACTS+=("$f")
+        done
+        # iOS IPA
+        for f in build/ios/ipa/*.ipa; do
+          [ -f "$f" ] && ARTIFACTS+=("$f")
+        done
+        # macOS DMG
+        for f in build/macos/Build/Products/Release/*.dmg; do
+          [ -f "$f" ] && ARTIFACTS+=("$f")
+        done
+        if [ ${#ARTIFACTS[@]} -eq 0 ]; then
+          echo "No artifacts found to upload"
+          exit 1
+        fi
+        echo "Uploading ${#ARTIFACTS[@]} artifact(s): ${ARTIFACTS[*]}"
         # If release already exists, upload assets to it; otherwise create new
         if gh release view "$TAG" --repo "$CM_REPO_SLUG" > /dev/null 2>&1; then
           echo "Release $TAG exists, uploading assets (replacing existing)"
           gh release upload "$TAG" \
             --repo "$CM_REPO_SLUG" \
             --clobber \
-            build/app/outputs/apk/release/*arm64*.apk \
-            build/app/outputs/apk/release/*armeabi*.apk
+            "${ARTIFACTS[@]}"
         else
           echo "Creating new release $TAG"
           gh release create "$TAG" \
@@ -94,8 +131,7 @@ definitions:
             --title "$TAG" \
             --prerelease \
             --generate-notes \
-            build/app/outputs/apk/release/*arm64*.apk \
-            build/app/outputs/apk/release/*armeabi*.apk
+            "${ARTIFACTS[@]}"
         fi
     - &build_ios
       name: Build and sign iOS
@@ -138,6 +174,13 @@ workflows:
           - STAGING
           - TEST
           - POC
+      PUBLISH_TO_GITHUB:
+        description: Upload IPA to GitHub Release (for direct distribution)
+        type: choice
+        default: "NO"
+        options:
+          - "NO"
+          - "YES"
     environment:
       flutter: 3.41.1
       xcode: latest
@@ -145,6 +188,7 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
+        - github_credentials
       vars:
         BUNDLE_ID: co.openvine.app
       ios_signing:
@@ -162,6 +206,7 @@ workflows:
       - *enable_spm
       - *pod_install
       - *build_ios
+      - *publish_github_release
     artifacts:
       - build/ios/ipa/*.ipa
       - /tmp/xcodebuild_logs/*.log
@@ -263,3 +308,51 @@ workflows:
       google_play:
         credentials: $GCLOUD_SERVICE_ACCOUNT_CREDENTIALS
         track: internal
+
+  macos-build:
+    name: macOS Build
+    working_directory: mobile
+    max_build_duration: 60
+    instance_type: mac_mini_m2
+    inputs:
+      DEFAULT_ENV:
+        description: Default environment for fresh app installs
+        type: choice
+        default: PRODUCTION
+        options:
+          - PRODUCTION
+          - STAGING
+          - TEST
+          - POC
+      PUBLISH_TO_GITHUB:
+        description: Upload DMG to GitHub Release (for direct distribution)
+        type: choice
+        default: "NO"
+        options:
+          - "NO"
+          - "YES"
+    environment:
+      flutter: 3.41.1
+      xcode: latest
+      cocoapods: default
+      groups:
+        - zendesk_credentials
+        - proofmode_credentials
+        - github_credentials
+    cache:
+      cache_paths:
+        - $HOME/Library/Caches/CocoaPods
+        - $HOME/.pub-cache
+    triggering:
+      events: []
+    scripts:
+      - *install_flutterfire
+      - *enable_spm
+      - *flutter_pub_get
+      - *pod_install
+      - *build_macos
+      - *package_macos_dmg
+      - *publish_github_release
+    artifacts:
+      - build/macos/Build/Products/Release/*.dmg
+      - build/macos/Build/Products/Release/*.app


### PR DESCRIPTION
## Summary
- Add new **macOS Build** workflow with DMG packaging via `hdiutil`
- Add `PUBLISH_TO_GITHUB` toggle to **iOS Build** workflow for uploading IPA to GitHub Releases
- Make the publish script platform-aware: auto-detects APKs, IPA, or DMG and uploads whatever exists
- All three platforms (Android, iOS, macOS) can now upload to the same GitHub Release

## How it works
Each platform build runs independently. When `PUBLISH_TO_GITHUB=YES`:
- Android uploads split APKs (arm64 + armeabi)
- iOS uploads the signed IPA
- macOS uploads a DMG

All upload to the same version-tagged release (e.g. `1.0.5`), using `--clobber` to replace existing assets.

## Test plan
- [ ] Run macOS Build in Codemagic — verify it builds and produces a DMG
- [ ] Run macOS Build with `PUBLISH_TO_GITHUB=YES` — verify DMG appears on GitHub Release
- [ ] Run iOS Build with `PUBLISH_TO_GITHUB=YES` — verify IPA appears on GitHub Release
- [ ] Verify Android Build still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)