### PR TITLE
feat: Improving background upload progress handling

### DIFF
--- a/mobile/lib/blocs/background_publish/background_publish_bloc.dart
+++ b/mobile/lib/blocs/background_publish/background_publish_bloc.dart
@@ -71,6 +71,20 @@ class BackgroundPublishBloc
     BackgroundPublishProgressChanged event,
     Emitter<BackgroundPublishState> emit,
   ) {
+    final upload = state.uploads.cast<BackgroundUpload?>().firstWhere(
+      (upload) => upload!.draft.id == event.draftId,
+      orElse: () => null,
+    );
+
+    // Disregard progress events if the upload already has a result
+    // or if the progress is not greater than the current value,
+    // since events can arrive out of order.
+    if (upload == null ||
+        upload.result != null ||
+        event.progress <= upload.progress) {
+      return;
+    }
+
     final updatedUploads = state.uploads.map((upload) {
       if (upload.draft.id == event.draftId) {
         return upload.copyWith(progress: event.progress);

--- a/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
+++ b/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
@@ -196,6 +196,73 @@ void main() {
           ),
         ],
       );
+
+      blocTest(
+        'ignores progress when it is less than current progress',
+        build: () => BackgroundPublishBloc(
+          videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+        ),
+        seed: () => BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(draft: draft, result: null, progress: 0.5),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          BackgroundPublishProgressChanged(draftId: draftId, progress: .3),
+        ),
+        expect: () => <BackgroundPublishState>[],
+      );
+
+      blocTest(
+        'ignores progress when it is equal to the current progress',
+        build: () => BackgroundPublishBloc(
+          videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+        ),
+        seed: () => BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(draft: draft, result: null, progress: 0.5),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          BackgroundPublishProgressChanged(draftId: draftId, progress: .5),
+        ),
+        expect: () => <BackgroundPublishState>[],
+      );
+
+      blocTest(
+        'ignores progress when the upload already has a result',
+        build: () => BackgroundPublishBloc(
+          videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+        ),
+        seed: () => BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(
+              draft: draft,
+              result: const PublishError('error'),
+              progress: 1.0,
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          BackgroundPublishProgressChanged(draftId: draftId, progress: .5),
+        ),
+        expect: () => <BackgroundPublishState>[],
+      );
+
+      blocTest(
+        'ignores progress when the draft is not found',
+        build: () => BackgroundPublishBloc(
+          videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+        ),
+        seed: () => const BackgroundPublishState(),
+        act: (bloc) => bloc.add(
+          BackgroundPublishProgressChanged(
+            draftId: 'non-existent',
+            progress: .5,
+          ),
+        ),
+        expect: () => <BackgroundPublishState>[],
+      );
     });
 
     group('BackgroundPublishVanished', () {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

It has been reported that some users are seeing the upload error snackbar pop multiple times, or seeing the uploading indicator (the pie one) goes back.

I was not able to reproduce the issue, but after some investigation in the code, my theory is that, giving the async nature of the upload process, the order of the progress events are not guaranteed, so we might be receiving "outdated" events, causing the UI to show inaccurate changes to the user.

This change mas the background upload bloc to be smarter, and disregard events if they are considered outdated, since there is no point into using them once they are old data.

Part of #1531

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore