### PR TITLE
fix: handle double-typed numeric fields in VideoStats REST API parsing

### DIFF
--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -91,6 +91,8 @@ class VideoStats {
         statsData['loops'] ?? json['loops'] ?? json['original_loops'];
     if (directLoops is int) {
       loops = directLoops;
+    } else if (directLoops is double) {
+      loops = directLoops.toInt();
     } else if (directLoops is String) {
       loops = int.tryParse(directLoops);
     }
@@ -123,6 +125,8 @@ class VideoStats {
         statsData['views'] ?? json['views'] ?? json['view_count'];
     if (directViews is int) {
       views = directViews;
+    } else if (directViews is double) {
+      views = directViews.toInt();
     } else if (directViews is String) {
       views = int.tryParse(directViews);
     }
@@ -231,12 +235,12 @@ class VideoStats {
       authorName: authorName,
       authorAvatar: authorAvatar,
       blurhash: blurhash,
-      reactions: reactions is int ? reactions : 0,
-      comments: comments is int ? comments : 0,
-      reposts: reposts is int ? reposts : 0,
-      engagementScore:
-          (statsData['engagement_score'] ?? json['engagement_score'] ?? 0)
-              as int,
+      reactions: _parseInt(reactions),
+      comments: _parseInt(comments),
+      reposts: _parseInt(reposts),
+      engagementScore: _parseInt(
+        statsData['engagement_score'] ?? json['engagement_score'],
+      ),
       trendingScore: _parseDouble(
         statsData['trending_score'] ?? json['trending_score'],
       ),
@@ -374,4 +378,11 @@ double? _parseDouble(dynamic value) {
   if (value is int) return value.toDouble();
   if (value is String) return double.tryParse(value);
   return null;
+}
+
+int _parseInt(dynamic value) {
+  if (value is int) return value;
+  if (value is double) return value.toInt();
+  if (value is String) return int.tryParse(value) ?? 0;
+  return 0;
 }

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -446,6 +446,33 @@ void main() {
         );
       });
 
+      test('handles numeric fields as doubles from REST API', () {
+        final json = {
+          'id': 'test-id',
+          'pubkey': 'test-pubkey',
+          'created_at': 1700000000,
+          'kind': 34236,
+          'd_tag': 'video-1',
+          'title': 'Test',
+          'thumbnail': 'https://example.com/thumb.jpg',
+          'video_url': 'https://example.com/video.mp4',
+          'reactions': 10.0,
+          'comments': 5.0,
+          'reposts': 2.0,
+          'engagement_score': 125.0,
+          'loops': 42.0,
+          'views': 100.0,
+        };
+
+        final stats = VideoStats.fromJson(json);
+        expect(stats.reactions, equals(10));
+        expect(stats.comments, equals(5));
+        expect(stats.reposts, equals(2));
+        expect(stats.engagementScore, equals(125));
+        expect(stats.loops, equals(42));
+        expect(stats.views, equals(100));
+      });
+
       test('normalizes empty values to null', () {
         final json = {
           'id': 'test-id',


### PR DESCRIPTION
## Summary
- Fix `type 'double' is not a subtype of type 'int' in type cast` crash in `VideoStats.fromJson()` when parsing REST API responses
- The Funnelcake REST API returns numeric fields (`engagement_score`, `reactions`, `comments`, `reposts`, `loops`, `views`) as JSON doubles (e.g. `125.0`), but the parser used unsafe `as int` casts
- This crash caused profile feeds to fall back to the slow Nostr WebSocket path, adding ~5s to profile load time

## Test plan
- [x] Added test `handles numeric fields as doubles from REST API` covering all six affected fields
- [x] All 25 existing `VideoStats` tests continue to pass
- [ ] Verify profile screen loads quickly without falling back to Nostr WebSocket (check logs for absence of "REST API returned empty... falling back to Nostr")

🤖 Generated with [Claude Code](https://claude.com/claude-code)