### PR TITLE
fix: upload individual dSYM bundles to Crashlytics

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -23,10 +23,6 @@
 #   - Set to YES to upload artifacts to a GitHub Release (for Zapstore / direct distribution)
 #   - Defaults to NO
 #   - Requires GITHUB_TOKEN in "github_credentials" environment variable group
-# 9 - Ensure environment variable group "firebase" contains:
-#   - FIREBASE_SERVICE_ACCOUNT (Google service account JSON key with Firebase Crashlytics access)
-#   - FIREBASE_IOS_APP_ID (Firebase iOS app ID, e.g. 1:123456:ios:abc123)
-#   - FIREBASE_ANDROID_APP_ID (Firebase Android app ID)
 
 definitions:
   environment:
@@ -226,7 +222,6 @@ workflows:
       groups:
         - zendesk_credentials
         - proofmode_credentials
-        - firebase
         - github_credentials
       vars:
         BUNDLE_ID: co.openvine.app


### PR DESCRIPTION
## Summary

Closes #1566

Fixes dSYM upload to Firebase Crashlytics in Codemagic CI builds. The existing Xcode build phase script was failing silently in CI. This adds a post-build step using the native `upload-symbols` tool from the Firebase Crashlytics SDK with `GoogleService-Info.plist` for auth. No Firebase credentials needed.

Also cleans up the unused `firebase` env group reference that #1792 left behind.

## Changes

- Replaces Firebase CLI-based upload (from #1792) with native `upload-symbols` tool
- Removes `install_firebase_cli` script and `firebase` env group (not needed)
- Finds `upload-symbols` binary from SPM build artifacts in DerivedData
- Uploads all dSYMs using `-gsp GoogleService-Info.plist -p ios`

## Test plan

- [x] Triggered iOS build in Codemagic from this branch
- [x] "Upload dSYMs to Firebase Crashlytics" step completed successfully
- [x] All 11 dSYM bundles uploaded (Runner, Flutter, Zendesk SDKs, etc.)
- [ ] Verify no "Missing dSYM" warnings in Firebase Console for the new build