### PR TITLE
fix(ui): rename 'Fully Verified' badge to 'Human Made'

### DIFF
--- a/mobile/lib/widgets/badge_explanation_modal.dart
+++ b/mobile/lib/widgets/badge_explanation_modal.dart
@@ -255,7 +255,7 @@ class _VerificationLevelCard extends StatelessWidget {
       return _VerificationConfig(
         icon: Icons.verified,
         color: Colors.green[700]!,
-        title: 'Fully Verified',
+        title: 'Human Made',
         description:
             'This video has the highest level of proof - captured on a real device with hardware security verification, and embedded Content Credentials (C2PA) in the video file. We can confirm it was recorded using DiVine on an actual phone.',
       );

--- a/mobile/lib/widgets/proofmode_badge.dart
+++ b/mobile/lib/widgets/proofmode_badge.dart
@@ -55,7 +55,7 @@ class ProofModeBadge extends StatelessWidget {
     switch (level) {
       case VerificationLevel.verifiedMobile:
         return const _BadgeConfig(
-          label: 'Fully Verified',
+          label: 'Human Made',
           icon: Icons.verified,
           backgroundColor: Color(0xFFD4EDDA), // Light green
           borderColor: Color(0xFF28A745), // Green

--- a/mobile/test/widgets/proofmode_badge_test.dart
+++ b/mobile/test/widgets/proofmode_badge_test.dart
@@ -23,7 +23,7 @@ void main() {
       expect(find.byIcon(Icons.verified), findsOneWidget);
 
       // Should display correct text
-      expect(find.text('Fully Verified'), findsOneWidget);
+      expect(find.text('Human Made'), findsOneWidget);
 
       // Check the badge container exists
       expect(find.byType(Container), findsWidgets);


### PR DESCRIPTION
## Summary

- Renames the top-tier ProofMode verification badge from "Fully Verified" to "Human Made"
- Updated in badge widget, explanation modal, and corresponding test
- Better communicates the badge's purpose: proving content was created by a real human on a real device, not just technically verified

## Test plan

- [x] `proofmode_badge_test.dart` — all 11 tests pass (1 skipped)
- [ ] Manual: verify badge displays "Human Made" on verified mobile videos

🤖 Generated with [Claude Code](https://claude.com/claude-code)