### PR TITLE
fix(video): show combined loop count for migrated videos

### DIFF
--- a/mobile/lib/widgets/video_feed_item/actions/video_description_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/video_description_overlay.dart
@@ -87,7 +87,7 @@ class VideoDescriptionOverlay extends StatelessWidget {
               explicitChildNodes: true,
               label: 'Video loop count',
               child: Text(
-                '🔁 ${StringUtils.formatCompactNumber(video.originalLoops!)} loops',
+                '🔁 ${StringUtils.formatCompactNumber((video.originalLoops ?? 0) + (int.tryParse(video.rawTags['views'] ?? '') ?? 0))} loops',
                 style: const TextStyle(
                   color: Colors.white,
                   fontSize: 12,

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -11,7 +11,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory, NIP71VideoKinds;
-import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -1475,11 +1474,9 @@ class VideoOverlayActions extends ConsumerWidget {
                     final archivedLoops = video.originalLoops ?? 0;
                     final liveViews =
                         int.tryParse(video.rawTags['views'] ?? '') ?? 0;
-                    final isClassicVine =
-                        video.pubkey == AppConstants.classicVinesPubkey;
-                    final loopCount = isClassicVine
-                        ? archivedLoops + liveViews
-                        : (archivedLoops > 0 ? archivedLoops : liveViews);
+                    // Always sum archived (original Vine) and live (new diVine)
+                    // loops so migrated videos show their full combined count.
+                    final loopCount = archivedLoops + liveViews;
                     final hasLoopMetadata =
                         video.originalLoops != null ||
                         video.rawTags.containsKey('loops') ||


### PR DESCRIPTION
## Problem

Migrated videos show either the archived Vine loop count OR the new diVine view count, but not the sum. For example:

- Justin Bieber piano video: shows **4 loops** (new) but has **20,140,526** archived → should show **20,140,530**
- Justin Bieber basketball video: shows **10M loops** (new) but has **11,798,580** archived → should show **~21.8M**

The logic was:
```dart
// Old: only summed for classicVines pubkey
final loopCount = isClassicVine
    ? archivedLoops + liveViews
    : (archivedLoops > 0 ? archivedLoops : liveViews);
```

## Fix

Always sum archived + live loops for all videos:
```dart
final loopCount = archivedLoops + liveViews;
```

This matches how likes already work (`like_action_button.dart` already sums `likeCount + originalLikes`).

Also updated the description overlay loop count to show the combined total.

## Files Changed
- `lib/widgets/video_feed_item/video_feed_item.dart` — sum loop counts, remove unused AppConstants import
- `lib/widgets/video_feed_item/actions/video_description_overlay.dart` — sum archived + live in overlay display