### PR TITLE
fix(ui): ensure fullscreen badges clear status bar icons

### DIFF
--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -1374,6 +1374,19 @@ class VideoOverlayActions extends ConsumerWidget {
         !isFullscreen && contextTitle != null && contextTitle!.isNotEmpty;
     final topOffset = hasListHeader ? 80.0 : 16.0;
 
+    // In fullscreen mode, ensure badges clear the status bar icons
+    // (battery, wifi, clock). viewPaddingOf may return 0 if a parent
+    // widget (Scaffold, SafeArea) has already consumed the safe area.
+    // Use the window's actual padding as a fallback minimum.
+    final viewPaddingTop = MediaQuery.viewPaddingOf(context).top;
+    final safeAreaTop = isFullscreen
+        ? (viewPaddingTop > 0
+              ? viewPaddingTop
+              : MediaQuery.of(context).padding.top > 0
+              ? MediaQuery.of(context).padding.top
+              : 54.0) // Fallback for Dynamic Island iPhones
+        : viewPaddingTop;
+
     // Calculate bottom offset based on navigation state
     final bottomOffset = hasBottomNavigation
         ? 14.0
@@ -1410,7 +1423,7 @@ class VideoOverlayActions extends ConsumerWidget {
         // Content warning badge below back button area
         if (video.hasContentWarning)
           Positioned(
-            top: MediaQuery.viewPaddingOf(context).top + topOffset + 56,
+            top: safeAreaTop + topOffset + 56,
             left: 16,
             child: GestureDetector(
               onTap: () => _showContentWarningDetails(
@@ -1425,7 +1438,7 @@ class VideoOverlayActions extends ConsumerWidget {
         // ProofMode and Vine badges in upper right corner (tappable)
         if (!isPreviewMode)
           Positioned(
-            top: MediaQuery.viewPaddingOf(context).top + topOffset,
+            top: safeAreaTop + topOffset,
             right: 16,
             child: GestureDetector(
               onTap: () {


### PR DESCRIPTION
## Problem

In fullscreen video mode, the 🌿 Original / Human Made badges render behind the iOS status bar icons (battery, wifi, clock) on iPhones.

## Root Cause

The badge position uses `MediaQuery.viewPaddingOf(context).top + topOffset` to account for the safe area. However, in the fullscreen video feed, the overlay is built inside a widget tree where a parent `Scaffold` has already consumed the safe area inset, causing `viewPaddingOf(context).top` to return `0`.

## Fix

Added a cascading safe area calculation for fullscreen mode:
1. Try `viewPaddingOf(context).top` (works when safe area isn't consumed)
2. Fall back to `MediaQuery.of(context).padding.top` (works in some widget configurations)
3. Last resort: `54.0px` (covers Dynamic Island iPhones where neither reports correctly)

Applied to both the ProofMode/Vine badge row and the content warning badge.

## Files Changed
- `lib/widgets/video_feed_item/video_feed_item.dart` — safe area calculation for badge positioning