### PR TITLE
fix(collaborators): prevent selecting the same collaborator twice

### DIFF
--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -27,6 +27,7 @@ Future<UserProfile?> showUserPickerSheet(
   BuildContext context, {
   required UserPickerFilterMode filterMode,
   String? title,
+  Set<String> excludePubkeys = const {},
 }) {
   return showModalBottomSheet<UserProfile>(
     context: context,
@@ -44,6 +45,7 @@ Future<UserProfile?> showUserPickerSheet(
         filterMode: filterMode,
         title: title,
         scrollController: scrollController,
+        excludePubkeys: excludePubkeys,
       ),
     ),
   );
@@ -56,6 +58,7 @@ class UserPickerSheet extends ConsumerStatefulWidget {
     required this.filterMode,
     this.title,
     this.scrollController,
+    this.excludePubkeys = const {},
     super.key,
   });
 
@@ -64,6 +67,9 @@ class UserPickerSheet extends ConsumerStatefulWidget {
 
   /// Optional title displayed at the top.
   final String? title;
+
+  /// Pubkeys to exclude from results (e.g. already-selected collaborators).
+  final Set<String> excludePubkeys;
 
   /// Scroll controller for the draggable sheet.
   final ScrollController? scrollController;
@@ -122,9 +128,15 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     );
 
     if (mounted) {
+      // Remove already-selected users from results
+      final filtered = widget.excludePubkeys.isEmpty
+          ? profiles
+          : profiles
+                .where((p) => !widget.excludePubkeys.contains(p.pubkey))
+                .toList();
       setState(() {
-        _followProfiles = profiles;
-        _filteredFollowProfiles = profiles;
+        _followProfiles = filtered;
+        _filteredFollowProfiles = filtered;
         _followListLoaded = true;
       });
     }
@@ -338,12 +350,17 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   }
 
   Widget _buildResultsList(UserSearchState state) {
+    final results = widget.excludePubkeys.isEmpty
+        ? state.results
+        : state.results
+              .where((p) => !widget.excludePubkeys.contains(p.pubkey))
+              .toList();
     return ListView.builder(
       controller: widget.scrollController,
-      itemCount: state.results.length,
+      itemCount: results.length,
       padding: const EdgeInsets.symmetric(horizontal: 16),
       itemBuilder: (context, index) {
-        final profile = state.results[index];
+        final profile = results[index];
         return _UserSearchTile(
           profile: profile,
           onTap: () => _onUserSelected(profile),

--- a/mobile/lib/widgets/video_metadata/video_metadata_collaborators_input.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_collaborators_input.dart
@@ -126,9 +126,13 @@ class VideoMetadataCollaboratorsInput extends ConsumerWidget {
   }
 
   Future<void> _addCollaborator(BuildContext context, WidgetRef ref) async {
+    final currentCollaborators = ref.read(
+      videoEditorProvider.select((s) => s.collaboratorPubkeys),
+    );
     final profile = await showUserPickerSheet(
       context,
       filterMode: UserPickerFilterMode.mutualFollowsOnly,
+      excludePubkeys: currentCollaborators.toSet(),
       // TODO(l10n): Replace with context.l10n
       //   when localization is added.
       title: 'Add collaborator',


### PR DESCRIPTION
Closes #1628

## Problem
When adding collaborators to a video, users could select the same person multiple times from the picker. The provider silently ignored duplicates (`contains` check) but the UI still showed them, making it confusing when tapping had no effect.

## Fix
Added `excludePubkeys` parameter to `showUserPickerSheet` and `UserPickerSheet`. Already-selected collaborators are filtered out of:
- The mutual follows list (on load)
- Network search results

They simply don't appear in the picker, so there's no way to select them again.

## Files Changed
- `lib/widgets/user_picker_sheet.dart` — new `excludePubkeys` parameter, filter logic in follow list + search results
- `lib/widgets/video_metadata/video_metadata_collaborators_input.dart` — passes current collaborators as exclude set