### PR TITLE
feat(hashtag): use PooledFullscreenVideoFeedScreen for hashtag feeds

### DIFF
--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -378,23 +378,6 @@ final goRouterProvider = Provider<GoRouter>((ref) {
               ),
             ),
           ),
-
-          // HASHTAG route - feed mode (with video index)
-          GoRoute(
-            path: HashtagScreenRouter.pathWithIndex,
-            pageBuilder: (ctx, st) => NoTransitionPage(
-              key: st.pageKey,
-              child: Navigator(
-                key: NavigatorKeys.hashtagFeed,
-                onGenerateRoute: (r) => MaterialPageRoute(
-                  builder: (_) => const HashtagScreenRouter(),
-                  settings: const RouteSettings(
-                    name: HashtagScreenRouter.routeName,
-                  ),
-                ),
-              ),
-            ),
-          ),
         ],
       ),
 

--- a/mobile/lib/screens/hashtag_feed_screen.dart
+++ b/mobile/lib/screens/hashtag_feed_screen.dart
@@ -1,13 +1,15 @@
 // ABOUTME: Screen displaying videos filtered by a specific hashtag
 // ABOUTME: Allows users to explore all videos with a particular hashtag
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/curation_providers.dart';
-import 'package:openvine/screens/hashtag_screen_router.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/hashtag_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:divine_ui/divine_ui.dart';
@@ -15,6 +17,7 @@ import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
+import 'package:rxdart/rxdart.dart';
 
 class HashtagFeedScreen extends ConsumerStatefulWidget {
   const HashtagFeedScreen({
@@ -42,15 +45,26 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
   /// When available, these provide engagement-based sorting.
   List<VideoEvent>? _popularVideos;
 
+  /// Stream controller for pushing video list updates to the fullscreen feed.
+  /// Uses broadcast so the stream can be listened to after navigation.
+  late final StreamController<List<VideoEvent>> _videosStreamController;
+
   @override
   void initState() {
     super.initState();
+    _videosStreamController = StreamController<List<VideoEvent>>.broadcast();
     // Subscribe to videos with this hashtag
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return; // Safety check: don't use ref if widget is disposed
 
       _loadHashtagVideos();
     });
+  }
+
+  @override
+  void dispose() {
+    _videosStreamController.close();
+    super.dispose();
   }
 
   /// Load videos from both Funnelcake REST API and WebSocket in parallel.
@@ -244,6 +258,29 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
     return [..._popularVideos!, ...additionalVideos];
   }
 
+  /// Push the fullscreen pooled video feed for the tapped video.
+  void _pushFullscreenFeed(
+    BuildContext context,
+    List<VideoEvent> videoList,
+    int index,
+  ) {
+    context.push<String>(
+      PooledFullscreenVideoFeedScreen.path,
+      extra: PooledFullscreenVideoFeedArgs(
+        videosStream: _videosStreamController.stream.startWith(videoList),
+        initialIndex: index,
+        onLoadMore: () {
+          // Trigger more videos from the hashtag service
+          final hashtagService = ref.read(hashtagServiceProvider);
+          hashtagService.subscribeToHashtagVideos([widget.hashtag]);
+        },
+        contextTitle: '#${widget.hashtag}',
+        trafficSource: ViewTrafficSource.search,
+        sourceDetail: widget.hashtag,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final body = Builder(
@@ -333,6 +370,9 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
           );
         }
 
+        // Push video updates to the stream for fullscreen feed sync
+        _videosStreamController.add(videos);
+
         // Use grid view when embedded (in explore), full-screen list when standalone
         if (widget.embedded) {
           return ComposableVideoGrid(
@@ -340,14 +380,8 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
             useMasonryLayout: true,
             onVideoTap:
                 widget.onVideoTap ??
-                (videos, index) {
-                  // Default behavior: navigate to hashtag feed mode using GoRouter
-                  context.go(
-                    HashtagScreenRouter.pathForTag(
-                      widget.hashtag,
-                      index: index,
-                    ),
-                  );
+                (videoList, index) {
+                  _pushFullscreenFeed(context, videoList, index);
                 },
             onRefresh: () => _loadHashtagVideos(forceRefresh: true),
           );
@@ -401,13 +435,7 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
               final video = videos[index];
               return GestureDetector(
                 onTap: () {
-                  // Navigate to hashtag feed mode using GoRouter
-                  context.go(
-                    HashtagScreenRouter.pathForTag(
-                      widget.hashtag,
-                      index: index,
-                    ),
-                  );
+                  _pushFullscreenFeed(context, videos, index);
                 },
                 child: SizedBox(
                   height: MediaQuery.of(context).size.height,

--- a/mobile/lib/screens/hashtag_screen_router.dart
+++ b/mobile/lib/screens/hashtag_screen_router.dart
@@ -1,20 +1,18 @@
-// ABOUTME: Router-aware hashtag screen that shows grid or feed based on URL
-// ABOUTME: Reads route context to determine grid mode vs feed mode
+// ABOUTME: Router-aware hashtag screen that shows grid based on URL
+// ABOUTME: Caches hashtag so grid state survives pushed routes (e.g. fullscreen feed)
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-import 'package:openvine/mixins/async_value_ui_helpers_mixin.dart';
-import 'package:openvine/providers/hashtag_feed_providers.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/hashtag_feed_screen.dart';
-import 'package:openvine/screens/pure/explore_video_screen_pure.dart';
-import 'package:openvine/services/view_event_publisher.dart';
-import 'package:divine_ui/divine_ui.dart';
-import 'package:openvine/services/screen_analytics_service.dart';
 import 'package:openvine/utils/unified_logger.dart';
 
-/// Router-aware hashtag screen that shows grid or feed based on route
+/// Router-aware hashtag screen that shows the hashtag video grid.
+///
+/// Caches the hashtag value so the [HashtagFeedScreen] (and its scroll
+/// position) survives when a route is pushed on top (e.g. the fullscreen
+/// feed). Only updates the hashtag when [pageContextProvider] emits a
+/// [RouteType.hashtag] context.
 class HashtagScreenRouter extends ConsumerStatefulWidget {
   /// Route name for this screen.
   static const routeName = 'hashtag';
@@ -22,17 +20,13 @@ class HashtagScreenRouter extends ConsumerStatefulWidget {
   /// Base path for hashtag routes.
   static const basePath = '/hashtag';
 
-  /// Path for this route (grid mode).
+  /// Path for this route.
   static const path = '/hashtag/:tag';
 
-  /// Path for this route with video index (feed mode).
-  static const pathWithIndex = '/hashtag/:tag/:index';
-
-  /// Build path for a specific hashtag with optional video index.
-  static String pathForTag(String tag, {int? index}) {
+  /// Build path for a specific hashtag.
+  static String pathForTag(String tag) {
     final encodedTag = Uri.encodeComponent(tag);
-    if (index == null) return '$basePath/$encodedTag';
-    return '$basePath/$encodedTag/$index';
+    return '$basePath/$encodedTag';
   }
 
   const HashtagScreenRouter({super.key});
@@ -42,93 +36,40 @@ class HashtagScreenRouter extends ConsumerStatefulWidget {
       _HashtagScreenRouterState();
 }
 
-class _HashtagScreenRouterState extends ConsumerState<HashtagScreenRouter>
-    with AsyncValueUIHelpersMixin {
+class _HashtagScreenRouterState extends ConsumerState<HashtagScreenRouter> {
+  /// Cached hashtag value, preserved across route pushes.
+  String? _hashtag;
+
   @override
   Widget build(BuildContext context) {
     final routeCtx = ref.watch(pageContextProvider).asData?.value;
 
-    if (routeCtx == null || routeCtx.type != RouteType.hashtag) {
-      Log.warning(
-        'HashtagScreenRouter: Invalid route context',
-        name: 'HashtagRouter',
-        category: LogCategory.ui,
-      );
-      return const Scaffold(body: Center(child: Text('Invalid hashtag route')));
+    // Only update the cached hashtag when we receive a hashtag route context.
+    // This prevents the HashtagFeedScreen from being disposed when a route
+    // (e.g. fullscreen video feed) is pushed on top.
+    if (routeCtx != null && routeCtx.type == RouteType.hashtag) {
+      final newHashtag = routeCtx.hashtag ?? 'trending';
+      if (_hashtag != newHashtag) {
+        _hashtag = newHashtag;
+        Log.info(
+          'HashtagScreenRouter: Showing grid for #$_hashtag',
+          name: 'HashtagRouter',
+          category: LogCategory.ui,
+        );
+      }
     }
 
-    final hashtag = routeCtx.hashtag ?? 'trending';
-    final videoIndex = routeCtx.videoIndex;
-
-    // Grid mode: no video index
-    if (videoIndex == null) {
-      Log.info(
-        'HashtagScreenRouter: Showing grid for #$hashtag',
-        name: 'HashtagRouter',
-        category: LogCategory.ui,
-      );
-      return HashtagFeedScreen(hashtag: hashtag, embedded: true);
+    // Show the grid with the cached hashtag (survives pushed routes)
+    if (_hashtag != null) {
+      return HashtagFeedScreen(hashtag: _hashtag!, embedded: true);
     }
 
-    // Feed mode: show video at specific index
-    Log.info(
-      'HashtagScreenRouter: Showing feed for #$hashtag (index=$videoIndex)',
+    // Only shown briefly on initial load before pageContextProvider emits
+    Log.warning(
+      'HashtagScreenRouter: Waiting for route context',
       name: 'HashtagRouter',
       category: LogCategory.ui,
     );
-
-    // Watch the hashtag feed provider to get videos
-    final feedStateAsync = ref.watch(hashtagFeedProvider);
-
-    return buildAsyncUI(
-      feedStateAsync,
-      onLoading: () => const Center(
-        child: CircularProgressIndicator(color: VineTheme.vineGreen),
-      ),
-      onError: (err, stack) => Center(
-        child: Text(
-          'Error loading hashtag videos: $err',
-          style: const TextStyle(color: VineTheme.whiteText),
-        ),
-      ),
-      onData: (feedState) {
-        ScreenAnalyticsService().markDataLoaded(
-          'hashtag_feed',
-          dataMetrics: {'video_count': feedState.videos.length},
-        );
-        final videos = feedState.videos;
-
-        if (videos.isEmpty) {
-          // Empty state - show centered message
-          // AppShell already provides AppBar with back button
-          return Center(
-            child: Text(
-              'No videos found for #$hashtag',
-              style: const TextStyle(color: VineTheme.whiteText),
-            ),
-          );
-        }
-
-        // Determine target index from route context (index-based routing)
-        final safeIndex = videoIndex.clamp(0, videos.length - 1);
-
-        // Feed mode - show fullscreen video player
-        // AppShell already provides AppBar with back button, so no need for Scaffold here
-        return ExploreVideoScreenPure(
-          startingVideo: videos[safeIndex],
-          videoList: videos,
-          contextTitle: '#$hashtag',
-          startingIndex: safeIndex,
-          useLocalActiveState: true,
-          trafficSource: ViewTrafficSource.search,
-          sourceDetail: hashtag,
-          // Add pagination callback
-          onLoadMore: () => ref.read(hashtagFeedProvider.notifier).loadMore(),
-          // Add navigation callback to keep hashtag context when swiping
-          onNavigate: (index) =>
-              context.go(HashtagScreenRouter.pathForTag(hashtag, index: index)),
-        );
-      },
-    );
+    return const Scaffold(body: Center(child: Text('Loading...')));
   }
 }


### PR DESCRIPTION
## Summary
- Replace the old `ExploreVideoScreenPure`-based hashtag feed mode with `PooledFullscreenVideoFeedScreen`, giving hashtag videos the same 5-player pool and swipe experience as other feed tabs
- Remove `HashtagScreenRouter` feed mode (`pathWithIndex` route) and simplify to grid-only with cached hashtag state
- Add `StreamController` + `PooledFullscreenVideoFeedScreen` navigation to `HashtagFeedScreen` for both embedded and standalone modes

Closes part of #1752

## Test plan
- [ ] Open Explore → tap a hashtag pill → verify grid loads
- [ ] Tap a video in the hashtag grid → verify fullscreen pooled feed opens with correct video
- [ ] Swipe through videos in fullscreen → verify smooth playback
- [ ] Press back → verify return to hashtag grid
- [ ] Repeat in standalone hashtag screen (non-embedded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)