### PR TITLE
fix: prevent auto-start of recording during camera switch

### DIFF
--- a/mobile/lib/providers/video_recorder_provider.dart
+++ b/mobile/lib/providers/video_recorder_provider.dart
@@ -525,7 +525,21 @@ class VideoRecorderNotifier extends Notifier<VideoRecorderProviderState> {
   ///
   /// Convenience method for record button - starts recording when idle,
   /// stops when recording.
+  /// Ignores triggers while the camera is switching to prevent
+  /// spurious Bluetooth/volume events from auto-starting recording.
   Future<void> toggleRecording() async {
+    // Block recording triggers during camera switch - audio route changes
+    // can cause spurious Bluetooth events that reach here despite native
+    // suppression (e.g. events queued before suppression took effect).
+    if (_cameraService.isSwitchingCamera) {
+      Log.debug(
+        '🎮 toggleRecording ignored - camera switch in progress',
+        name: 'VideoRecorderNotifier',
+        category: .video,
+      );
+      return;
+    }
+
     switch (state.recordingState) {
       case .idle:
         await startRecording();

--- a/mobile/lib/services/video_recorder/camera/camera_base_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_base_service.dart
@@ -109,6 +109,10 @@ abstract class CameraService {
   /// Whether the device has multiple cameras to switch between.
   bool get canSwitchCamera;
 
+  /// Whether a camera switch is currently in progress.
+  /// Used to block recording triggers during the switch.
+  bool get isSwitchingCamera;
+
   /// Whether the device can active the camera-flash.
   bool get hasFlash;
 

--- a/mobile/lib/services/video_recorder/camera/camera_linux_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_linux_service.dart
@@ -37,6 +37,9 @@ class CameraLinuxService extends CameraService {
   bool get canSwitchCamera => false;
 
   @override
+  bool get isSwitchingCamera => false;
+
+  @override
   bool get hasFlash => false;
 
   @override

--- a/mobile/lib/services/video_recorder/camera/camera_macos_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_macos_service.dart
@@ -706,6 +706,9 @@ class CameraMacOSService extends CameraService {
       _videoDevices != null && _videoDevices!.length > 1;
 
   @override
+  bool get isSwitchingCamera => false;
+
+  @override
   Future<bool> setLens(DivineCameraLens lens) async {
     // macOS doesn't support different lens types like mobile
     // Only basic camera switching is supported

--- a/mobile/lib/services/video_recorder/camera/camera_mobile_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_mobile_service.dart
@@ -178,6 +178,7 @@ class CameraMobileService extends CameraService {
   @override
   Future<bool> switchCamera() async {
     if (!_isInitialized) return false;
+    _isSwitchingCamera = true;
     try {
       Log.info(
         '📷 Switching camera',
@@ -201,6 +202,8 @@ class CameraMobileService extends CameraService {
         category: .video,
       );
       return false;
+    } finally {
+      _isSwitchingCamera = false;
     }
   }
 
@@ -345,6 +348,11 @@ class CameraMobileService extends CameraService {
 
   @override
   bool get canSwitchCamera => _camera.canSwitchCamera;
+
+  bool _isSwitchingCamera = false;
+
+  @override
+  bool get isSwitchingCamera => _isSwitchingCamera;
 
   @override
   DivineCameraLens get currentLens => _camera.state.lens;

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
@@ -243,6 +243,11 @@ class DivineCameraPlugin :
             return
         }
         try {
+            // Suppress volume/Bluetooth triggers during camera switch.
+            // Camera reconfiguration can cause connected Bluetooth devices
+            // to send spurious play/pause events that would start recording.
+            volumeKeyHandler?.suppressTemporarily(3000)
+
             controller.switchCamera(lens) { state, error ->
                 if (error != null) {
                     result.error("SWITCH_ERROR", error, null)

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/VolumeKeyHandler.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/VolumeKeyHandler.kt
@@ -38,6 +38,16 @@ class VolumeKeyHandler(
     private var enabledTimestamp: Long = 0
     private val activationCooldownMs: Long = 800
 
+    // Temporary suppression during camera switch / audio route changes
+    @Volatile
+    private var isSuppressed = false
+    private val suppressHandler = android.os.Handler(android.os.Looper.getMainLooper())
+    private var suppressRunnable: Runnable? = null
+
+    // Debounce between Bluetooth triggers to prevent rapid-fire events
+    private var lastBluetoothTriggerTimestamp: Long = 0
+    private val bluetoothDebounceMs: Long = 1000
+
     /**
      * Enables volume button listening.
      * Sets up Window.Callback wrapper for physical buttons and MediaSession for Bluetooth.
@@ -136,20 +146,28 @@ class VolumeKeyHandler(
         
         return when (event.keyCode) {
             KeyEvent.KEYCODE_VOLUME_UP -> {
-                // Only intercept volume keys if enabled
+                // Only intercept volume keys if enabled and not suppressed
                 if (!volumeKeysEnabled) {
                     Log.d(TAG, "Volume up pressed but volume keys disabled - passing through")
                     return false
+                }
+                if (isSuppressed) {
+                    Log.d(TAG, "Volume up pressed but suppressed (camera switch) - consuming")
+                    return true  // Consume to prevent volume change, but don't trigger
                 }
                 Log.d(TAG, "Volume up button pressed")
                 onTrigger("volumeUp")
                 true
             }
             KeyEvent.KEYCODE_VOLUME_DOWN -> {
-                // Only intercept volume keys if enabled
+                // Only intercept volume keys if enabled and not suppressed
                 if (!volumeKeysEnabled) {
                     Log.d(TAG, "Volume down pressed but volume keys disabled - passing through")
                     return false
+                }
+                if (isSuppressed) {
+                    Log.d(TAG, "Volume down pressed but suppressed (camera switch) - consuming")
+                    return true  // Consume to prevent volume change, but don't trigger
                 }
                 Log.d(TAG, "Volume down button pressed")
                 onTrigger("volumeDown")
@@ -192,16 +210,51 @@ class VolumeKeyHandler(
             return true
         }
         
+        // Check suppression (camera switch in progress)
+        if (isSuppressed) {
+            Log.d(TAG, "Media button ignored - suppressed (camera switch in progress)")
+            return true
+        }
+
         // Check cooldown after activation
         val timeSinceEnabled = System.currentTimeMillis() - enabledTimestamp
         if (timeSinceEnabled < activationCooldownMs) {
             Log.d(TAG, "Media button ignored - within ${activationCooldownMs}ms cooldown (${timeSinceEnabled}ms since enabled)")
             return true
         }
-        
+
+        // Check debounce between triggers
+        val now = System.currentTimeMillis()
+        val timeSinceLastTrigger = now - lastBluetoothTriggerTimestamp
+        if (timeSinceLastTrigger < bluetoothDebounceMs) {
+            Log.d(TAG, "Media button ignored - debounce (${timeSinceLastTrigger}ms since last)")
+            return true
+        }
+
+        lastBluetoothTriggerTimestamp = now
         Log.d(TAG, "Media button triggered: ${event.keyCode}")
         onTrigger("bluetooth")
         return true
+    }
+
+    /**
+     * Temporarily suppress all triggers for the given duration.
+     *
+     * Used during camera switch and other operations that cause
+     * audio route changes, which can trigger spurious Bluetooth
+     * play/pause events from connected devices.
+     */
+    fun suppressTemporarily(durationMs: Long = 3000) {
+        isSuppressed = true
+        Log.d(TAG, "Suppressed for ${durationMs}ms")
+
+        // Cancel any pending unsuppress
+        suppressRunnable?.let { suppressHandler.removeCallbacks(it) }
+        suppressRunnable = Runnable {
+            isSuppressed = false
+            Log.d(TAG, "Suppression ended")
+        }
+        suppressHandler.postDelayed(suppressRunnable!!, durationMs)
     }
 
     /**
@@ -286,14 +339,26 @@ class VolumeKeyHandler(
     }
     
     /**
-     * Trigger callback with cooldown check for direct MediaSession callbacks.
+     * Trigger callback with cooldown, debounce and suppression check
+     * for direct MediaSession callbacks.
      */
     private fun triggerWithCooldownCheck() {
+        if (isSuppressed) {
+            Log.d(TAG, "MediaSession callback ignored - suppressed")
+            return
+        }
         val timeSinceEnabled = System.currentTimeMillis() - enabledTimestamp
         if (timeSinceEnabled < activationCooldownMs) {
             Log.d(TAG, "MediaSession callback ignored - within cooldown")
             return
         }
+        val now = System.currentTimeMillis()
+        val timeSinceLastTrigger = now - lastBluetoothTriggerTimestamp
+        if (timeSinceLastTrigger < bluetoothDebounceMs) {
+            Log.d(TAG, "MediaSession callback ignored - debounce")
+            return
+        }
+        lastBluetoothTriggerTimestamp = now
         onTrigger("bluetooth")
     }
 
@@ -301,6 +366,8 @@ class VolumeKeyHandler(
      * Cleanup resources.
      */
     fun release() {
+        suppressRunnable?.let { suppressHandler.removeCallbacks(it) }
+        suppressRunnable = null
         disable()
     }
 }

--- a/mobile/packages/divine_camera/ios/Classes/VolumeKeyHandler.swift
+++ b/mobile/packages/divine_camera/ios/Classes/VolumeKeyHandler.swift
@@ -284,8 +284,11 @@ class VolumeKeyHandler: NSObject {
             return
         }
         
-        // Only trigger if volume keys are enabled and this is an external change
-        if !isInternalVolumeChange && isEnabled && volumeKeysEnabled {
+        // Only trigger if volume keys are enabled, not suppressed,
+        // and this is an external change.
+        // The isSuppressed check prevents audio route changes during camera
+        // switch from being misinterpreted as volume button presses.
+        if !isInternalVolumeChange && isEnabled && volumeKeysEnabled && !isSuppressed {
             if newValue > oldValue {
                 NSLog("DivineCameraVolumeKeyHandler: Volume up button pressed")
                 onTrigger?("volumeUp")
@@ -299,6 +302,10 @@ class VolumeKeyHandler: NSObject {
                 // Restore volume to prevent actual volume change
                 restoreVolume(to: oldValue)
             }
+        } else if isSuppressed && !isInternalVolumeChange && newValue != oldValue {
+            NSLog("DivineCameraVolumeKeyHandler: Volume change ignored - suppressed (camera switch in progress)")
+            // Still restore volume during suppression to prevent drift
+            restoreVolume(to: oldValue)
         }
         // If volume keys are disabled, let the volume change through (don't restore)
     }

--- a/mobile/test/mocks/mock_camera_service.dart
+++ b/mobile/test/mocks/mock_camera_service.dart
@@ -114,6 +114,9 @@ class MockCameraService extends CameraService {
   bool get canSwitchCamera => true;
 
   @override
+  bool get isSwitchingCamera => false;
+
+  @override
   bool get hasFlash => true;
 
   @override


### PR DESCRIPTION
## Description

On iOS, the recording session unexpectedly restarts when switching between cameras or when deleting clips during a recording workflow.

This interrupts the recording process and can lead to unintended recording states or loss of workflow continuity. It seems that issues arise when a Bluetooth device, such as an Apple Watch, is connected.


Reported on discord [here](https://discordapp.com/channels/1470168817589158040/1470255950408454164/1475053099344461977) and [here](https://discordapp.com/channels/1470168817589158040/1470255950408454164/1475173401885937685)

**Related Issue:** Closes #1742

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore