### PR TITLE
feat: impl curated lists logic in home feed

### DIFF
--- a/mobile/lib/screens/feed/feed_video_overlay.dart
+++ b/mobile/lib/screens/feed/feed_video_overlay.dart
@@ -7,11 +7,12 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/subtitle_providers.dart';
+import 'package:openvine/router/routes/route_extras.dart';
+import 'package:openvine/screens/curated_list_feed_screen.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
@@ -30,6 +31,7 @@ import 'package:openvine/widgets/video_feed_item/audio_attribution_row.dart';
 import 'package:openvine/widgets/video_feed_item/collaborator_avatar_row.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/inspired_by_attribution_row.dart';
+import 'package:openvine/widgets/video_feed_item/list_attribution_chip.dart';
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/video_feed_item/video_follow_button.dart';
@@ -46,12 +48,14 @@ class FeedVideoOverlay extends ConsumerStatefulWidget {
     required this.video,
     required this.isActive,
     required this.player,
+    this.listSources,
     super.key,
   });
 
   final VideoEvent video;
   final bool isActive;
   final Player player;
+  final Set<String>? listSources;
 
   @override
   ConsumerState<FeedVideoOverlay> createState() => _FeedVideoOverlayState();
@@ -130,6 +134,7 @@ class _FeedVideoOverlayState extends ConsumerState<FeedVideoOverlay> {
           child: _AuthorInfoSection(
             video: video,
             hasTextContent: hasTextContent,
+            listSources: widget.listSources,
           ),
         ),
         // Action buttons column (bottom-right)
@@ -144,10 +149,15 @@ class _FeedVideoOverlayState extends ConsumerState<FeedVideoOverlay> {
 }
 
 class _AuthorInfoSection extends ConsumerWidget {
-  const _AuthorInfoSection({required this.video, required this.hasTextContent});
+  const _AuthorInfoSection({
+    required this.video,
+    required this.hasTextContent,
+    this.listSources,
+  });
 
   final VideoEvent video;
   final bool hasTextContent;
+  final Set<String>? listSources;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -178,7 +188,9 @@ class _AuthorInfoSection extends ConsumerWidget {
                 onTap: () {
                   final npub = normalizeToNpub(video.pubkey);
                   if (npub != null) {
-                    context.push(OtherProfileScreen.pathForNpub(npub));
+                    context.pushWithVideoPause(
+                      OtherProfileScreen.pathForNpub(npub),
+                    );
                   }
                 },
                 child: Column(
@@ -245,6 +257,11 @@ class _AuthorInfoSection extends ConsumerWidget {
             const SizedBox(height: 4),
             AudioAttributionRow(video: video),
           ],
+          // List attribution (curated lists)
+          if (listSources != null && listSources!.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            _ListAttribution(listSources: listSources!),
+          ],
           const SizedBox(height: 8),
         ],
       ],
@@ -265,22 +282,48 @@ class _AuthorAvatar extends StatelessWidget {
       child: Stack(
         clipBehavior: Clip.none,
         children: [
-          Container(
-            width: 48,
-            height: 48,
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: VineTheme.whiteText, width: 2),
-            ),
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(14),
-              child: avatarUrl != null && avatarUrl!.isNotEmpty
-                  ? CachedNetworkImage(
-                      imageUrl: avatarUrl!,
-                      width: 44,
-                      height: 44,
-                      fit: BoxFit.cover,
-                      placeholder: (context, url) => const ColoredBox(
+          GestureDetector(
+            onTap: () {
+              final npub = normalizeToNpub(pubkey);
+              if (npub != null) {
+                context.pushWithVideoPause(
+                  OtherProfileScreen.pathForNpub(npub),
+                );
+              }
+            },
+            child: Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(color: VineTheme.whiteText, width: 2),
+              ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(14),
+                child: avatarUrl != null && avatarUrl!.isNotEmpty
+                    ? CachedNetworkImage(
+                        imageUrl: avatarUrl!,
+                        width: 44,
+                        height: 44,
+                        fit: BoxFit.cover,
+                        placeholder: (context, url) => const ColoredBox(
+                          color: VineTheme.cardBackground,
+                          child: Icon(
+                            Icons.person,
+                            color: VineTheme.onSurfaceMuted,
+                            size: 24,
+                          ),
+                        ),
+                        errorWidget: (context, url, error) => const ColoredBox(
+                          color: VineTheme.cardBackground,
+                          child: Icon(
+                            Icons.person,
+                            color: VineTheme.onSurfaceMuted,
+                            size: 24,
+                          ),
+                        ),
+                      )
+                    : const ColoredBox(
                         color: VineTheme.cardBackground,
                         child: Icon(
                           Icons.person,
@@ -288,23 +331,7 @@ class _AuthorAvatar extends StatelessWidget {
                           size: 24,
                         ),
                       ),
-                      errorWidget: (context, url, error) => const ColoredBox(
-                        color: VineTheme.cardBackground,
-                        child: Icon(
-                          Icons.person,
-                          color: VineTheme.onSurfaceMuted,
-                          size: 24,
-                        ),
-                      ),
-                    )
-                  : const ColoredBox(
-                      color: VineTheme.cardBackground,
-                      child: Icon(
-                        Icons.person,
-                        color: VineTheme.onSurfaceMuted,
-                        size: 24,
-                      ),
-                    ),
+              ),
             ),
           ),
           Positioned(
@@ -380,6 +407,33 @@ class _Nip05Badge extends ConsumerWidget {
       },
       loading: () => const SizedBox.shrink(),
       error: (_, _) => const SizedBox.shrink(),
+    );
+  }
+}
+
+/// Displays curated list attribution chips and handles navigation.
+class _ListAttribution extends ConsumerWidget {
+  const _ListAttribution({required this.listSources});
+
+  final Set<String> listSources;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final curatedListRepository = ref.watch(curatedListRepositoryProvider);
+
+    return ListAttributionChip(
+      listIds: listSources,
+      listLookup: curatedListRepository.getListById,
+      onListTap: (listId, listName) {
+        final list = curatedListRepository.getListById(listId);
+        context.pushWithVideoPause(
+          CuratedListFeedScreen.pathForId(listId),
+          extra: CuratedListRouteExtra(
+            listName: listName,
+            videoIds: list?.videoEventIds,
+          ),
+        );
+      },
     );
   }
 }

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -258,11 +258,16 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                   controller: controller,
                   itemBuilder: (context, video, index, {required isActive}) {
                     final originalEvent = state.videos[index];
+                    final listSources =
+                        state.listOnlyVideoIds.contains(originalEvent.id)
+                        ? state.videoListSources[originalEvent.id]
+                        : null;
                     return _PooledVideoFeedItem(
                       video: originalEvent,
                       index: index,
                       isActive: isActive,
                       contextTitle: state.mode.name,
+                      listSources: listSources,
                     );
                   },
                   onActiveVideoChanged: (video, index) {
@@ -383,12 +388,14 @@ class _PooledVideoFeedItem extends ConsumerWidget {
     required this.index,
     required this.isActive,
     this.contextTitle,
+    this.listSources,
   });
 
   final VideoEvent video;
   final int index;
   final bool isActive;
   final String? contextTitle;
+  final Set<String>? listSources;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -419,6 +426,7 @@ class _PooledVideoFeedItem extends ConsumerWidget {
         index: index,
         isActive: isActive,
         contextTitle: contextTitle,
+        listSources: listSources,
       ),
     );
   }
@@ -430,12 +438,14 @@ class _PooledVideoFeedItemContent extends StatelessWidget {
     required this.index,
     required this.isActive,
     this.contextTitle,
+    this.listSources,
   });
 
   final VideoEvent video;
   final int index;
   final bool isActive;
   final String? contextTitle;
+  final Set<String>? listSources;
 
   @override
   Widget build(BuildContext context) {
@@ -457,8 +467,12 @@ class _PooledVideoFeedItemContent extends StatelessWidget {
           thumbnailUrl: video.thumbnailUrl,
           isPortrait: isPortrait,
         ),
-        overlayBuilder: (context, videoController, player) =>
-            FeedVideoOverlay(video: video, isActive: isActive, player: player),
+        overlayBuilder: (context, videoController, player) => FeedVideoOverlay(
+          video: video,
+          isActive: isActive,
+          player: player,
+          listSources: listSources,
+        ),
       ),
     );
   }

--- a/mobile/lib/utils/pause_aware_modals.dart
+++ b/mobile/lib/utils/pause_aware_modals.dart
@@ -1,32 +1,49 @@
-// ABOUTME: BuildContext extensions for showing modals that pause video playback
-// ABOUTME: Automatically calls setModalOpen(true/false) to pause/resume videos
+// ABOUTME: BuildContext extensions for showing modals/navigating that pause
+// ABOUTME: video playback. Calls setModalOpen(true/false) to pause/resume.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
 
-/// Extension methods for showing modals that automatically pause video
-/// playback.
+/// Extension methods for showing modals and navigating that automatically
+/// pause video playback.
 ///
-/// These methods wrap [VineBottomSheet.show] and [showDialog] to integrate with
-/// [OverlayVisibility], ensuring videos pause when modals open and resume when
-/// they close.
+/// These methods wrap [VineBottomSheet.show], [showDialog], and
+/// [GoRouter.push] to integrate with [OverlayVisibility], ensuring videos
+/// pause when overlays/routes open and resume when they close.
 ///
 /// Example:
 /// ```dart
+/// // Push a route with video pause:
+/// context.pushWithVideoPause('/profile/npub1...');
+///
 /// // Standard VineBottomSheet with video pause:
 /// context.showVideoPausingVineBottomSheet(
 ///   title: Text('Options'),
 ///   children: [...],
 /// );
-///
-/// // Custom bottom sheet widget with video pause:
-/// context.showVideoPausingVineBottomSheet(
-///   builder: (context) => MyCustomSheet(),
-/// );
 /// ```
 extension PauseAwareModals on BuildContext {
+  /// Pushes a route that automatically pauses video playback.
+  ///
+  /// Calls [OverlayVisibility.setModalOpen(true)] before pushing and
+  /// [setModalOpen(false)] when the pushed route is popped.
+  Future<T?> pushWithVideoPause<T extends Object?>(
+    String location, {
+    Object? extra,
+  }) {
+    final container = ProviderScope.containerOf(this, listen: false);
+    final overlayNotifier = container.read(overlayVisibilityProvider.notifier);
+
+    overlayNotifier.setModalOpen(true);
+
+    return push<T>(location, extra: extra).whenComplete(() {
+      overlayNotifier.setModalOpen(false);
+    });
+  }
+
   /// Shows a dialog that automatically pauses video playback.
   ///
   /// Calls [OverlayVisibility.setModalOpen(true)] before showing and

--- a/mobile/test/screens/feed/feed_video_overlay_test.dart
+++ b/mobile/test/screens/feed/feed_video_overlay_test.dart
@@ -1,0 +1,186 @@
+// ABOUTME: Tests for FeedVideoOverlay list attribution integration
+// ABOUTME: Verifies ListAttributionChip display for curated list videos
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:curated_list_repository/curated_list_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/screens/feed/feed_video_overlay.dart';
+import 'package:openvine/widgets/video_feed_item/list_attribution_chip.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockVideoInteractionsBloc
+    extends MockBloc<VideoInteractionsEvent, VideoInteractionsState>
+    implements VideoInteractionsBloc {}
+
+class _MockPlayer extends Mock implements Player {}
+
+class _MockPlayerStream extends Mock implements PlayerStream {}
+
+class _MockCuratedListRepository extends Mock
+    implements CuratedListRepository {}
+
+// Full 64-character test IDs (never truncate Nostr IDs)
+const _testVideoId =
+    'a1b2c3d4e5f6789012345678901234567890abcdef123456789012345678901234';
+const _testPubkey =
+    'd4e5f6789012345678901234567890abcdef123456789012345678901234a1b2c3';
+
+void main() {
+  group(FeedVideoOverlay, () {
+    late VideoInteractionsBloc mockInteractionsBloc;
+    late Player mockPlayer;
+    late PlayerStream mockStream;
+    late CuratedListRepository mockCuratedListRepository;
+    late VideoEvent testVideo;
+
+    setUpAll(() {
+      registerFallbackValue(
+        const VideoInteractionsSubscriptionRequested(),
+      );
+    });
+
+    setUp(() {
+      mockInteractionsBloc = _MockVideoInteractionsBloc();
+      mockPlayer = _MockPlayer();
+      mockStream = _MockPlayerStream();
+      mockCuratedListRepository = _MockCuratedListRepository();
+
+      // Stub Player.stream for subtitle layer
+      when(() => mockPlayer.stream).thenReturn(mockStream);
+      when(() => mockStream.position).thenAnswer(
+        (_) => const Stream<Duration>.empty(),
+      );
+
+      // Stub interactions bloc state
+      when(() => mockInteractionsBloc.state).thenReturn(
+        const VideoInteractionsState(),
+      );
+
+      testVideo = VideoEvent(
+        id: _testVideoId,
+        pubkey: _testPubkey,
+        createdAt: 1704067200,
+        content: 'Test video content',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
+        videoUrl: 'https://example.com/video.mp4',
+      );
+    });
+
+    Widget buildSubject({Set<String>? listSources}) {
+      return testMaterialApp(
+        additionalOverrides: [
+          curatedListRepositoryProvider.overrideWithValue(
+            mockCuratedListRepository,
+          ),
+          userProfileServiceProvider.overrideWithValue(
+            createMockUserProfileService(),
+          ),
+        ],
+        home: Scaffold(
+          body: BlocProvider<VideoInteractionsBloc>.value(
+            value: mockInteractionsBloc,
+            child: FeedVideoOverlay(
+              video: testVideo,
+              isActive: true,
+              player: mockPlayer,
+              listSources: listSources,
+            ),
+          ),
+        ),
+      );
+    }
+
+    group('list attribution', () {
+      testWidgets(
+        'renders $ListAttributionChip when listSources is provided',
+        (tester) async {
+          final testList = CuratedList(
+            id: 'list-1',
+            name: 'Cool Videos',
+            videoEventIds: const ['v1', 'v2'],
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          );
+
+          when(
+            () => mockCuratedListRepository.getListById('list-1'),
+          ).thenReturn(testList);
+
+          await tester.pumpWidget(
+            buildSubject(listSources: {'list-1'}),
+          );
+          await tester.pump();
+
+          expect(find.byType(ListAttributionChip), findsOneWidget);
+          expect(find.text('Cool Videos'), findsOneWidget);
+          expect(find.byIcon(Icons.playlist_play), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'does not render $ListAttributionChip when listSources is null',
+        (tester) async {
+          await tester.pumpWidget(buildSubject());
+          await tester.pump();
+
+          expect(find.byType(ListAttributionChip), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'does not render $ListAttributionChip when listSources is empty',
+        (tester) async {
+          await tester.pumpWidget(buildSubject(listSources: {}));
+          await tester.pump();
+
+          expect(find.byType(ListAttributionChip), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'renders multiple list chips for multiple sources',
+        (tester) async {
+          final list1 = CuratedList(
+            id: 'list-1',
+            name: 'Cool Videos',
+            videoEventIds: const [],
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          );
+          final list2 = CuratedList(
+            id: 'list-2',
+            name: 'Funny Clips',
+            videoEventIds: const [],
+            createdAt: DateTime.now(),
+            updatedAt: DateTime.now(),
+          );
+
+          when(
+            () => mockCuratedListRepository.getListById('list-1'),
+          ).thenReturn(list1);
+          when(
+            () => mockCuratedListRepository.getListById('list-2'),
+          ).thenReturn(list2);
+
+          await tester.pumpWidget(
+            buildSubject(listSources: {'list-1', 'list-2'}),
+          );
+          await tester.pump();
+
+          expect(find.byType(ListAttributionChip), findsOneWidget);
+          expect(find.byIcon(Icons.playlist_play), findsNWidgets(2));
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
- Fix video audio continuing when navigating to profile from home feed — Added pushWithVideoPause() extension to PauseAwareModals that wraps GoRouter.push() with overlay pause/resume signals. The home feed's PooledVideoFeed is    
  self-managed (bypasses activeVideoIdProvider), so push navigation didn't trigger a pause. Both the avatar tap and author name tap in FeedVideoOverlay now use pushWithVideoPause() instead of context.push(), matching the behavior 
  already working on the explore page.
  - Fix avatar tap not navigating to profile — Wrapped the author avatar in _AuthorAvatar with a GestureDetector that navigates to OtherProfileScreen using pushWithVideoPause(). Previously only the author name was tappable.
  - Add curated list attribution to home feed (Phase 4) — When the home feed includes videos from subscribed curated lists (list-only videos), a ListAttributionChip now appears in the video overlay showing which list(s) the video
  came from. Tapping a chip navigates to the CuratedListFeedScreen with video pause. Attribution data flows from VideoFeedState.videoListSources/listOnlyVideoIds through _PooledVideoFeedItem → _PooledVideoFeedItemContent →
  FeedVideoOverlay → _AuthorInfoSection. List lookup uses curatedListRepositoryProvider (new architecture).

**Related Issue:** #1813

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore