### PR TITLE
fix: adjust badge positioning and offsets in video overlay components

### DIFF
--- a/mobile/lib/screens/feed/feed_mode_switch.dart
+++ b/mobile/lib/screens/feed/feed_mode_switch.dart
@@ -47,7 +47,7 @@ class FeedModeSwitch extends StatelessWidget {
           bottom: false,
           child: Padding(
             padding: const EdgeInsets.only(
-              top: 18,
+              top: 8,
               bottom: 16,
               left: 20,
               right: 20,

--- a/mobile/lib/screens/feed/feed_video_overlay.dart
+++ b/mobile/lib/screens/feed/feed_video_overlay.dart
@@ -117,7 +117,7 @@ class _FeedVideoOverlayState extends ConsumerState<FeedVideoOverlay> {
           ),
         // ProofMode and Vine badges (top-right)
         Positioned(
-          top: MediaQuery.viewPaddingOf(context).top + 8,
+          top: MediaQuery.viewPaddingOf(context).top + 64,
           right: 16,
           child: GestureDetector(
             onTap: () => context.showVideoPausingDialog<void>(

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -345,10 +345,19 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
             );
           }
 
+          final authService = ref.watch(authServiceProvider);
+          final currentUserPubkey = authService.currentPublicKeyHex;
+          final isOwnVideo =
+              currentUserPubkey != null &&
+              currentUserPubkey == state.currentVideo?.pubkey;
+
           return Scaffold(
             backgroundColor: Colors.black,
             extendBodyBehindAppBar: true,
-            appBar: _FullscreenAppBar(currentVideo: state.currentVideo),
+            appBar: _FullscreenAppBar(
+              currentVideo: state.currentVideo,
+              isOwnVideo: isOwnVideo,
+            ),
             body: PooledVideoFeed(
               videos: state.pooledVideos,
               controller: _controller,
@@ -392,6 +401,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                   contextTitle: widget.contextTitle,
                   trafficSource: widget.trafficSource,
                   sourceDetail: widget.sourceDetail,
+                  isOwnVideo: isOwnVideo,
                 );
               },
             ),
@@ -403,57 +413,68 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
 }
 
 class _FullscreenAppBar extends ConsumerWidget implements PreferredSizeWidget {
-  const _FullscreenAppBar({this.currentVideo});
+  const _FullscreenAppBar({this.isOwnVideo = false, this.currentVideo});
 
   final VideoEvent? currentVideo;
-
-  static const _style = DiVineAppBarStyle(
-    iconButtonBackgroundColor: Color(0x4D000000), // black with 0.3 alpha
-  );
+  final bool isOwnVideo;
 
   @override
   Size get preferredSize => const Size.fromHeight(72);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return DiVineAppBar(
-      titleWidget: const SizedBox.shrink(),
-      showBackButton: true,
-      onBackPressed: context.pop,
-      backgroundMode: DiVineAppBarBackgroundMode.transparent,
-      style: _style,
-      actions: _buildEditAction(context, ref),
+    return SafeArea(
+      bottom: false,
+      child: Padding(
+        padding: const EdgeInsets.only(
+          top: 8,
+          left: 16,
+          right: 16,
+        ),
+        child: Row(
+          mainAxisAlignment: .spaceBetween,
+          crossAxisAlignment: .start,
+          children: [
+            DiVineAppBarIconButton(
+              icon: SvgIconSource(
+                'assets/icon/${DivineIconName.caretLeft.fileName}.svg',
+              ),
+              onPressed: context.pop,
+              iconSize: 24,
+              semanticLabel: 'Go back',
+              backgroundColor: VineTheme.scrim30,
+            ),
+
+            ?_buildEditAction(context, ref),
+          ],
+        ),
+      ),
     );
   }
 
   // TODO(any) : update to use bloc instead of riverpod
-  List<DiVineAppBarAction> _buildEditAction(
+  Widget? _buildEditAction(
     BuildContext context,
     WidgetRef ref,
   ) {
     final video = currentVideo;
-    if (video == null) return const [];
+    if (video == null) return null;
 
     final featureFlagService = ref.watch(featureFlagServiceProvider);
     final isEditorEnabled = featureFlagService.isEnabled(
       FeatureFlag.enableVideoEditorV1,
     );
-    if (!isEditorEnabled) return const [];
+    if (!isEditorEnabled || !isOwnVideo) return null;
 
-    final authService = ref.watch(authServiceProvider);
-    final currentUserPubkey = authService.currentPublicKeyHex;
-    final isOwnVideo =
-        currentUserPubkey != null && currentUserPubkey == video.pubkey;
-    if (!isOwnVideo) return const [];
-
-    return [
-      DiVineAppBarAction(
-        icon: const SvgIconSource('assets/icon/content-controls/pencil.svg'),
-        onPressed: () => showEditDialogForVideo(context, video),
-        tooltip: 'Edit video',
-        semanticLabel: 'Edit video',
+    return DiVineAppBarIconButton(
+      icon: SvgIconSource(
+        'assets/icon/${DivineIconName.pencilSimpleLine.fileName}.svg',
       ),
-    ];
+      onPressed: () => showEditDialogForVideo(context, video),
+      iconSize: 24,
+      semanticLabel: 'Edit video',
+      backgroundColor: VineTheme.scrim30,
+    );
   }
 }
 
@@ -462,6 +483,7 @@ class _PooledFullscreenItem extends ConsumerWidget {
     required this.video,
     required this.index,
     required this.isActive,
+    required this.isOwnVideo,
     this.contextTitle,
     this.trafficSource = ViewTrafficSource.unknown,
     this.sourceDetail,
@@ -470,6 +492,7 @@ class _PooledFullscreenItem extends ConsumerWidget {
   final VideoEvent video;
   final int index;
   final bool isActive;
+  final bool isOwnVideo;
   final String? contextTitle;
   final ViewTrafficSource trafficSource;
   final String? sourceDetail;
@@ -504,6 +527,7 @@ class _PooledFullscreenItem extends ConsumerWidget {
         contextTitle: contextTitle,
         trafficSource: trafficSource,
         sourceDetail: sourceDetail,
+        isOwnVideo: isOwnVideo,
       ),
     );
   }
@@ -514,6 +538,7 @@ class _PooledFullscreenItemContent extends StatefulWidget {
     required this.video,
     required this.index,
     required this.isActive,
+    required this.isOwnVideo,
     this.contextTitle,
     this.trafficSource = ViewTrafficSource.unknown,
     this.sourceDetail,
@@ -522,6 +547,7 @@ class _PooledFullscreenItemContent extends StatefulWidget {
   final VideoEvent video;
   final int index;
   final bool isActive;
+  final bool isOwnVideo;
   final String? contextTitle;
   final ViewTrafficSource trafficSource;
   final String? sourceDetail;
@@ -572,25 +598,29 @@ class _PooledFullscreenItemContentState
               }),
             );
           }
-          return Stack(
-            children: [
-              // Subtitle overlay — needs player position stream
-              if (video.hasSubtitles)
-                Positioned.fill(
-                  child: _SubtitleLayer(
-                    video: video,
-                    player: player,
+          return MediaQuery(
+            data: MediaQueryData.fromView(View.of(context)),
+            child: Stack(
+              children: [
+                // Subtitle overlay — needs player position stream
+                if (video.hasSubtitles)
+                  Positioned.fill(
+                    child: _SubtitleLayer(
+                      video: video,
+                      player: player,
+                    ),
                   ),
+                VideoOverlayActions(
+                  video: video,
+                  isVisible: widget.isActive,
+                  isActive: widget.isActive,
+                  hasBottomNavigation: false,
+                  contextTitle: widget.contextTitle,
+                  isFullscreen: true,
+                  topOffset: widget.isOwnVideo ? 64 : 8,
                 ),
-              VideoOverlayActions(
-                video: video,
-                isVisible: widget.isActive,
-                isActive: widget.isActive,
-                hasBottomNavigation: false,
-                contextTitle: widget.contextTitle,
-                isFullscreen: true,
-              ),
-            ],
+              ],
+            ),
           );
         },
       ),

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -1321,6 +1321,7 @@ class VideoOverlayActions extends ConsumerWidget {
     this.showListAttribution = false,
     this.isPreviewMode = false,
     this.hideFollowButtonIfFollowing = false,
+    this.topOffset = 8.0,
   });
 
   final VideoEvent video;
@@ -1329,6 +1330,7 @@ class VideoOverlayActions extends ConsumerWidget {
   final bool hasBottomNavigation;
   final String? contextTitle;
   final bool isFullscreen;
+  final double topOffset;
 
   /// Displays the overlay in preview mode during video creation.
   /// When true, users can preview how their video will appear to other users
@@ -1353,16 +1355,6 @@ class VideoOverlayActions extends ConsumerWidget {
         video.content.isNotEmpty ||
         (video.title != null && video.title!.isNotEmpty);
 
-    // Stack does not block pointer events by default - taps pass through to GestureDetector below
-    // Only interactive elements (buttons, chips with GestureDetector) absorb taps
-    // When contextTitle is non-empty, a list header exists above - add extra offset to avoid overlap
-    // List header is roughly 64px tall (8px padding + 48px content + 8px padding), add clearance
-    // In fullscreen mode, the AppBar floats transparently over the content
-    // so the badge just needs the same base offset - no extra list header padding
-    final hasListHeader =
-        !isFullscreen && contextTitle != null && contextTitle!.isNotEmpty;
-    final topOffset = hasListHeader ? 80.0 : 16.0;
-
     // In fullscreen mode, ensure badges clear the status bar icons
     // (battery, wifi, clock). viewPaddingOf may return 0 if a parent
     // widget (Scaffold, SafeArea) has already consumed the safe area.
@@ -1371,15 +1363,12 @@ class VideoOverlayActions extends ConsumerWidget {
     final safeAreaTop = isFullscreen
         ? (viewPaddingTop > 0
               ? viewPaddingTop
-              : MediaQuery.of(context).padding.top > 0
-              ? MediaQuery.of(context).padding.top
+              : MediaQuery.paddingOf(context).top > 0
+              ? MediaQuery.paddingOf(context).top
               : 54.0) // Fallback for Dynamic Island iPhones
         : viewPaddingTop;
 
-    // Calculate bottom offset based on navigation state
-    final bottomOffset = hasBottomNavigation
-        ? 14.0
-        : (isFullscreen ? 48.0 : 14.0);
+    const bottomOffset = 14.0;
 
     return Stack(
       children: [


### PR DESCRIPTION
## Description

- Proofmode badge layout fixes: Resolved an issue where the Proofmode badge appeared behind various buttons and, in some cases, had a large unintended offset from the top of the screen.
- Back button styling and sizing: Fixed the back button being stretched to the full AppBar height (72px) and aligned its appearance with the styling used on the new home screen.
- Explore screen spacing: Removed excessive bottom padding that caused overly large spacing at the bottom of the Explore screen.


### Explore

| Before | After |
| ------- | ------ |
| ![WhatsApp Image 2026-02-28 at 13 37 53](https://github.com/user-attachments/assets/41123095-107f-4a53-8986-51b9ea740fb3) | ![WhatsApp Image 2026-02-28 at 13 37 53 (2)](https://github.com/user-attachments/assets/846ce0e9-cbe5-42a6-8451-a8cd4f92925c) |

### Profile-Screen

| Before | After |
| ------- | ------ |
| ![WhatsApp Image 2026-02-28 at 13 28 05 (1)](https://github.com/user-attachments/assets/fd7e69fb-0465-4bdc-9066-26e02379f452) | ![WhatsApp Image 2026-02-28 at 13 28 04 (1)](https://github.com/user-attachments/assets/ec860165-8da5-441e-ae66-6bb12db9c595) |

### Home

| Before | After |
| ------- | ------ |
| ![WhatsApp Image 2026-02-28 at 13 37 53 (1)](https://github.com/user-attachments/assets/ff5b73a7-b386-4ddc-a86e-c8a6c6bfcd53) | ![WhatsApp Image 2026-02-28 at 13 37 53 (3)](https://github.com/user-attachments/assets/85c444e3-ac50-4f58-adf2-a5afe84db48f) |

**Related Issue:** Closes #1609

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore