### PR TITLE
feat(#1529): NIP-30 sticker comments research prototype

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -72,3 +72,4 @@ linter:
     use_named_constants: false
     omit_local_variable_types: false
     use_setters_to_change_properties: false
+

--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -72,4 +72,3 @@ linter:
     use_named_constants: false
     omit_local_variable_types: false
     use_setters_to_change_properties: false
-

--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -86,6 +86,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
     );
     on<MentionRegistered>(_onMentionRegistered);
     on<MentionSuggestionsCleared>(_onMentionSuggestionsCleared);
+    on<StickerCommentSubmitted>(_onStickerCommentSubmitted);
     on<CommentEditModeEntered>(_onEditModeEntered);
     on<CommentEditModeCancelled>(_onEditModeCancelled);
     on<CommentEditSubmitted>(_onEditSubmitted);
@@ -693,6 +694,57 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
         category: LogCategory.ui,
       );
       emit(state.copyWith(error: CommentsError.blockFailed));
+    }
+  }
+
+  Future<void> _onStickerCommentSubmitted(
+    StickerCommentSubmitted event,
+    Emitter<CommentsState> emit,
+  ) async {
+    if (!_authService.isAuthenticated) {
+      emit(state.copyWith(error: CommentsError.notAuthenticated));
+      return;
+    }
+
+    emit(state.copyWith(isPosting: true));
+
+    try {
+      final postedComment = await _commentsRepository.postStickerComment(
+        stickerShortcode: event.stickerShortcode,
+        stickerImageUrl: event.stickerImageUrl,
+        rootEventId: state.rootEventId,
+        rootEventKind: state.rootEventKind,
+        rootEventAuthorPubkey: state.rootAuthorPubkey,
+        rootAddressableId: state.rootAddressableId,
+        replyToEventId: event.parentCommentId,
+        replyToAuthorPubkey: event.parentAuthorPubkey,
+      );
+
+      final updatedCommentsById = {
+        ...state.commentsById,
+        postedComment.id: postedComment,
+      };
+
+      emit(
+        state.copyWith(
+          commentsById: updatedCommentsById,
+          isPosting: false,
+          replyCountsByCommentId: _computeReplyCounts(updatedCommentsById),
+        ),
+      );
+    } catch (e) {
+      Log.error(
+        'Error posting sticker comment: $e',
+        name: 'CommentsBloc',
+        category: LogCategory.ui,
+      );
+
+      emit(
+        state.copyWith(
+          isPosting: false,
+          error: CommentsError.postCommentFailed,
+        ),
+      );
     }
   }
 

--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -706,8 +706,6 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
       return;
     }
 
-    emit(state.copyWith(isPosting: true));
-
     try {
       final postedComment = await _commentsRepository.postStickerComment(
         stickerShortcode: event.stickerShortcode,
@@ -728,7 +726,6 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
       emit(
         state.copyWith(
           commentsById: updatedCommentsById,
-          isPosting: false,
           replyCountsByCommentId: _computeReplyCounts(updatedCommentsById),
         ),
       );
@@ -740,10 +737,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
       );
 
       emit(
-        state.copyWith(
-          isPosting: false,
-          error: CommentsError.postCommentFailed,
-        ),
+        state.copyWith(error: CommentsError.postCommentFailed),
       );
     }
   }

--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -729,12 +729,13 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
           replyCountsByCommentId: _computeReplyCounts(updatedCommentsById),
         ),
       );
-    } catch (e) {
+    } catch (e, stackTrace) {
       Log.error(
         'Error posting sticker comment: $e',
         name: 'CommentsBloc',
         category: LogCategory.ui,
       );
+      addError(e, stackTrace);
 
       emit(
         state.copyWith(error: CommentsError.postCommentFailed),

--- a/mobile/lib/blocs/comments/comments_event.dart
+++ b/mobile/lib/blocs/comments/comments_event.dart
@@ -192,6 +192,30 @@ final class MentionSuggestionsCleared extends CommentsEvent {
   const MentionSuggestionsCleared();
 }
 
+/// Submit a sticker comment (NIP-30 custom emoji).
+///
+/// Posts a Kind 1111 event with `:shortcode:` content and an emoji tag.
+final class StickerCommentSubmitted extends CommentsEvent {
+  const StickerCommentSubmitted({
+    required this.stickerShortcode,
+    required this.stickerImageUrl,
+    this.parentCommentId,
+    this.parentAuthorPubkey,
+  });
+
+  /// The sticker shortcode (e.g., "fire").
+  final String stickerShortcode;
+
+  /// URL of the sticker image.
+  final String stickerImageUrl;
+
+  /// Parent comment ID if this is a reply, null for top-level.
+  final String? parentCommentId;
+
+  /// Parent comment author's pubkey (for Nostr threading).
+  final String? parentAuthorPubkey;
+}
+
 /// A new comment was received from the real-time subscription
 final class NewCommentReceived extends CommentsEvent {
   const NewCommentReceived(this.comment);

--- a/mobile/lib/blocs/sticker_picker/sticker_picker_bloc.dart
+++ b/mobile/lib/blocs/sticker_picker/sticker_picker_bloc.dart
@@ -1,0 +1,85 @@
+// ABOUTME: BLoC for managing sticker picker state
+// ABOUTME: Handles loading sticker packs and filtering by search query
+
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:sticker_pack_repository/sticker_pack_repository.dart';
+
+part 'sticker_picker_event.dart';
+part 'sticker_picker_state.dart';
+
+/// BLoC for the sticker picker bottom sheet.
+///
+/// Handles:
+/// - Loading sticker packs from [StickerPackRepository]
+/// - Filtering stickers by shortcode search query
+class StickerPickerBloc extends Bloc<StickerPickerEvent, StickerPickerState> {
+  StickerPickerBloc({
+    required StickerPackRepository stickerPackRepository,
+  }) : _stickerPackRepository = stickerPackRepository,
+       super(const StickerPickerInitial()) {
+    on<StickerPacksLoadRequested>(_onLoadRequested);
+    on<StickerSearchChanged>(_onSearchChanged, transformer: restartable());
+  }
+
+  final StickerPackRepository _stickerPackRepository;
+
+  Future<void> _onLoadRequested(
+    StickerPacksLoadRequested event,
+    Emitter<StickerPickerState> emit,
+  ) async {
+    emit(const StickerPickerLoading());
+
+    try {
+      final packs = await _stickerPackRepository.loadStickerPacks();
+      final allStickers = packs.expand((pack) => pack.stickers).toList();
+
+      emit(
+        StickerPickerLoaded(
+          packs: packs,
+          filteredStickers: allStickers,
+        ),
+      );
+    } on Exception catch (e) {
+      emit(StickerPickerError('Failed to load stickers: $e'));
+    }
+  }
+
+  void _onSearchChanged(
+    StickerSearchChanged event,
+    Emitter<StickerPickerState> emit,
+  ) {
+    final currentState = state;
+    if (currentState is! StickerPickerLoaded) return;
+
+    final query = event.query.toLowerCase().trim();
+
+    if (query.isEmpty) {
+      emit(
+        StickerPickerLoaded(
+          packs: currentState.packs,
+          filteredStickers: currentState.packs
+              .expand((pack) => pack.stickers)
+              .toList(),
+        ),
+      );
+      return;
+    }
+
+    final filtered = currentState.packs
+        .expand((pack) => pack.stickers)
+        .where(
+          (sticker) => sticker.shortcode.toLowerCase().contains(query),
+        )
+        .toList();
+
+    emit(
+      StickerPickerLoaded(
+        packs: currentState.packs,
+        filteredStickers: filtered,
+        searchQuery: query,
+      ),
+    );
+  }
+}

--- a/mobile/lib/blocs/sticker_picker/sticker_picker_bloc.dart
+++ b/mobile/lib/blocs/sticker_picker/sticker_picker_bloc.dart
@@ -38,6 +38,7 @@ class StickerPickerBloc extends Bloc<StickerPickerEvent, StickerPickerState> {
       emit(
         StickerPickerLoaded(
           packs: packs,
+          allStickers: allStickers,
           filteredStickers: allStickers,
         ),
       );
@@ -60,16 +61,14 @@ class StickerPickerBloc extends Bloc<StickerPickerEvent, StickerPickerState> {
       emit(
         StickerPickerLoaded(
           packs: currentState.packs,
-          filteredStickers: currentState.packs
-              .expand((pack) => pack.stickers)
-              .toList(),
+          allStickers: currentState.allStickers,
+          filteredStickers: currentState.allStickers,
         ),
       );
       return;
     }
 
-    final filtered = currentState.packs
-        .expand((pack) => pack.stickers)
+    final filtered = currentState.allStickers
         .where(
           (sticker) => sticker.shortcode.toLowerCase().contains(query),
         )
@@ -78,6 +77,7 @@ class StickerPickerBloc extends Bloc<StickerPickerEvent, StickerPickerState> {
     emit(
       StickerPickerLoaded(
         packs: currentState.packs,
+        allStickers: currentState.allStickers,
         filteredStickers: filtered,
         searchQuery: query,
       ),

--- a/mobile/lib/blocs/sticker_picker/sticker_picker_bloc.dart
+++ b/mobile/lib/blocs/sticker_picker/sticker_picker_bloc.dart
@@ -41,8 +41,9 @@ class StickerPickerBloc extends Bloc<StickerPickerEvent, StickerPickerState> {
           filteredStickers: allStickers,
         ),
       );
-    } on Exception catch (e) {
-      emit(StickerPickerError('Failed to load stickers: $e'));
+    } on Exception catch (e, stackTrace) {
+      addError(e, stackTrace);
+      emit(const StickerPickerError(StickerPickerErrorType.loadFailed));
     }
   }
 

--- a/mobile/lib/blocs/sticker_picker/sticker_picker_event.dart
+++ b/mobile/lib/blocs/sticker_picker/sticker_picker_event.dart
@@ -1,0 +1,22 @@
+// ABOUTME: Events for the StickerPickerBloc
+// ABOUTME: Defines actions for loading sticker packs and searching stickers
+
+part of 'sticker_picker_bloc.dart';
+
+/// Base class for all sticker picker events.
+sealed class StickerPickerEvent {
+  const StickerPickerEvent();
+}
+
+/// Request to load sticker packs from relays.
+final class StickerPacksLoadRequested extends StickerPickerEvent {
+  const StickerPacksLoadRequested();
+}
+
+/// Search query changed for filtering stickers by shortcode.
+final class StickerSearchChanged extends StickerPickerEvent {
+  const StickerSearchChanged(this.query);
+
+  /// The search query string.
+  final String query;
+}

--- a/mobile/lib/blocs/sticker_picker/sticker_picker_state.dart
+++ b/mobile/lib/blocs/sticker_picker/sticker_picker_state.dart
@@ -1,0 +1,58 @@
+// ABOUTME: State classes for the StickerPickerBloc
+// ABOUTME: Sealed state hierarchy for loading, loaded, and error states
+
+part of 'sticker_picker_bloc.dart';
+
+/// Base state for the sticker picker.
+sealed class StickerPickerState extends Equatable {
+  const StickerPickerState();
+}
+
+/// Initial state before any loading.
+final class StickerPickerInitial extends StickerPickerState {
+  const StickerPickerInitial();
+
+  @override
+  List<Object> get props => [];
+}
+
+/// Loading sticker packs from relays.
+final class StickerPickerLoading extends StickerPickerState {
+  const StickerPickerLoading();
+
+  @override
+  List<Object> get props => [];
+}
+
+/// Sticker packs loaded successfully.
+final class StickerPickerLoaded extends StickerPickerState {
+  const StickerPickerLoaded({
+    required this.packs,
+    required this.filteredStickers,
+    this.searchQuery = '',
+  });
+
+  /// All loaded sticker packs.
+  final List<StickerPack> packs;
+
+  /// Flat list of stickers matching the current search query.
+  /// When search is empty, contains all stickers from all packs.
+  final List<Sticker> filteredStickers;
+
+  /// Current search query.
+  final String searchQuery;
+
+  @override
+  List<Object> get props => [packs, filteredStickers, searchQuery];
+}
+
+/// Error loading sticker packs.
+final class StickerPickerError extends StickerPickerState {
+  const StickerPickerError(this.message);
+
+  /// Error message.
+  final String message;
+
+  @override
+  List<Object> get props => [message];
+}

--- a/mobile/lib/blocs/sticker_picker/sticker_picker_state.dart
+++ b/mobile/lib/blocs/sticker_picker/sticker_picker_state.dart
@@ -3,6 +3,9 @@
 
 part of 'sticker_picker_bloc.dart';
 
+/// Typed error categories for the sticker picker.
+enum StickerPickerErrorType { loadFailed }
+
 /// Base state for the sticker picker.
 sealed class StickerPickerState extends Equatable {
   const StickerPickerState();
@@ -48,11 +51,11 @@ final class StickerPickerLoaded extends StickerPickerState {
 
 /// Error loading sticker packs.
 final class StickerPickerError extends StickerPickerState {
-  const StickerPickerError(this.message);
+  const StickerPickerError(this.errorType);
 
-  /// Error message.
-  final String message;
+  /// The type of error that occurred.
+  final StickerPickerErrorType errorType;
 
   @override
-  List<Object> get props => [message];
+  List<Object> get props => [errorType];
 }

--- a/mobile/lib/blocs/sticker_picker/sticker_picker_state.dart
+++ b/mobile/lib/blocs/sticker_picker/sticker_picker_state.dart
@@ -31,12 +31,16 @@ final class StickerPickerLoading extends StickerPickerState {
 final class StickerPickerLoaded extends StickerPickerState {
   const StickerPickerLoaded({
     required this.packs,
+    required this.allStickers,
     required this.filteredStickers,
     this.searchQuery = '',
   });
 
   /// All loaded sticker packs.
   final List<StickerPack> packs;
+
+  /// All stickers flattened from all packs (computed once on load).
+  final List<Sticker> allStickers;
 
   /// Flat list of stickers matching the current search query.
   /// When search is empty, contains all stickers from all packs.
@@ -46,7 +50,7 @@ final class StickerPickerLoaded extends StickerPickerState {
   final String searchQuery;
 
   @override
-  List<Object> get props => [packs, filteredStickers, searchQuery];
+  List<Object> get props => [packs, allStickers, filteredStickers, searchQuery];
 }
 
 /// Error loading sticker packs.

--- a/mobile/lib/constants/app_constants.dart
+++ b/mobile/lib/constants/app_constants.dart
@@ -117,6 +117,14 @@ class AppConstants {
   /// Maximum subscription limit per relay
   static const int maxSubscriptionsPerRelay = 100;
 
+  /// General-purpose Nostr relays used to discover NIP-51 emoji sets
+  /// (Kind 30030) outside the app's primary video relay.
+  static const List<String> emojiSetDiscoveryRelays = [
+    'wss://relay.damus.io',
+    'wss://nos.lol',
+    'wss://relay.nostr.band',
+  ];
+
   // ============================================================================
   // UI CONFIGURATION
   // ============================================================================

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -706,6 +706,10 @@
   "videoActionRemoveRepost": "Remove repost",
   "videoActionRepost": "Repost video",
   "videoActionViewComments": "View comments",
+  "commentsStickerOpenSemanticLabel": "Open sticker picker",
+  "@commentsStickerOpenSemanticLabel": {
+    "description": "Screen-reader label for the sticker button next to the comment composer text field. Action-oriented: describes what tapping does (opens the sticker picker bottom sheet)."
+  },
   "videoActionMoreOptions": "More options",
   "videoActionHideSubtitles": "Hide subtitles",
   "videoActionShowSubtitles": "Show subtitles",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2606,6 +2606,12 @@ abstract class AppLocalizations {
   /// **'View comments'**
   String get videoActionViewComments;
 
+  /// Screen-reader label for the sticker button next to the comment composer text field. Action-oriented: describes what tapping does (opens the sticker picker bottom sheet).
+  ///
+  /// In en, this message translates to:
+  /// **'Open sticker picker'**
+  String get commentsStickerOpenSemanticLabel;
+
   /// No description provided for @videoActionMoreOptions.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1404,6 +1404,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoActionViewComments => 'አስተያየቶችን ይመልከቱ';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'ተጨማሪ አማራጮች';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1423,6 +1423,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoActionViewComments => 'عرض التعليقات';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'خيارات إضافية';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1464,6 +1464,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoActionViewComments => 'Виж коментарите';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'Още опции';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1462,6 +1462,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoActionViewComments => 'Kommentare ansehen';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'Weitere Optionen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1441,6 +1441,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoActionViewComments => 'View comments';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'More options';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1460,6 +1460,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videoActionViewComments => 'Ver comentarios';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'Más opciones';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1468,6 +1468,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get videoActionViewComments => 'Voir les commentaires';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'Plus d\'options';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1416,6 +1416,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoActionViewComments => 'Lihat komentar';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'Opsi lainnya';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1464,6 +1464,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoActionViewComments => 'Vedi commenti';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'Altre opzioni';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1351,6 +1351,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoActionViewComments => 'コメントを見る';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'その他のオプション';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1359,6 +1359,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoActionViewComments => '댓글 보기';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => '더 많은 옵션';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1450,6 +1450,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoActionViewComments => 'Reacties bekijken';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'Meer opties';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1463,6 +1463,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoActionViewComments => 'Zobacz komentarze';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'Więcej opcji';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1458,6 +1458,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoActionViewComments => 'Ver comentários';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'Mais opções';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1476,6 +1476,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoActionViewComments => 'Vezi comentariile';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'Mai multe opțiuni';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1437,6 +1437,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoActionViewComments => 'Visa kommentarer';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'Fler alternativ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1423,6 +1423,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoActionViewComments => 'Yorumları görüntüle';
 
   @override
+  String get commentsStickerOpenSemanticLabel => 'Open sticker picker';
+
+  @override
   String get videoActionMoreOptions => 'Daha fazla seçenek';
 
   @override

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -2108,7 +2108,10 @@ PeopleListsRepository peopleListsRepository(Ref ref) {
   final cache = LocalPeopleListsCache(
     openBox: () => Hive.openBox<dynamic>(_peopleListsBoxName),
   );
-  return PeopleListsRepositoryImpl(nostrClient: nostrClient, cache: cache);
+  return PeopleListsRepositoryImpl(
+    nostrClient: nostrClient,
+    cache: cache,
+  );
 }
 
 /// Bookmark service for NIP-51 bookmarks
@@ -2371,11 +2374,7 @@ StickerPackRepository stickerPackRepository(Ref ref) {
       ...AppConstants.divineTeamPubkeys,
     ],
     userPubkey: authService.currentPublicKeyHex,
-    discoveryRelays: const [
-      'wss://relay.damus.io',
-      'wss://nos.lol',
-      'wss://relay.nostr.band',
-    ],
+    discoveryRelays: AppConstants.emojiSetDiscoveryRelays,
   );
 }
 

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -37,7 +37,6 @@ import 'package:openvine/features/feature_flags/providers/feature_flag_providers
 import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/models/known_account.dart';
-import 'package:sticker_pack_repository/sticker_pack_repository.dart';
 import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
@@ -122,6 +121,7 @@ import 'package:profile_repository/profile_repository.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:sound_service/sound_service.dart';
+import 'package:sticker_pack_repository/sticker_pack_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:videos_repository/videos_repository.dart';
 

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -37,6 +37,7 @@ import 'package:openvine/features/feature_flags/providers/feature_flag_providers
 import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/models/known_account.dart';
+import 'package:sticker_pack_repository/sticker_pack_repository.dart';
 import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
@@ -2107,10 +2108,7 @@ PeopleListsRepository peopleListsRepository(Ref ref) {
   final cache = LocalPeopleListsCache(
     openBox: () => Hive.openBox<dynamic>(_peopleListsBoxName),
   );
-  return PeopleListsRepositoryImpl(
-    nostrClient: nostrClient,
-    cache: cache,
-  );
+  return PeopleListsRepositoryImpl(nostrClient: nostrClient, cache: cache);
 }
 
 /// Bookmark service for NIP-51 bookmarks
@@ -2343,6 +2341,40 @@ CommentsRepository commentsRepository(Ref ref) {
   );
   ref.onDispose(repository.clearCommentCountCache);
   return repository;
+}
+
+// =============================================================================
+// STICKER PACK REPOSITORY
+// =============================================================================
+
+/// Provider for [StickerPackRepository].
+///
+/// Loads sticker packs from multiple sources:
+/// 1. Curated packs from Divine team pubkeys
+/// 2. User-subscribed packs from the user's Kind 10030 emoji list
+///
+/// Uses:
+/// - NostrClient from nostrServiceProvider (for relay communication)
+/// - [AppConstants.classicVinesPubkey] and [AppConstants.divineTeamPubkeys]
+///   as curator pubkeys
+/// - AuthService for the current user's pubkey
+@Riverpod(keepAlive: true)
+StickerPackRepository stickerPackRepository(Ref ref) {
+  final nostrClient = ref.watch(nostrServiceProvider);
+  final authService = ref.watch(authServiceProvider);
+  return StickerPackRepository(
+    nostrClient: nostrClient,
+    curatorPubkeys: [
+      AppConstants.classicVinesPubkey,
+      ...AppConstants.divineTeamPubkeys,
+    ],
+    userPubkey: authService.currentPublicKeyHex,
+    discoveryRelays: const [
+      'wss://relay.damus.io',
+      'wss://nos.lol',
+      'wss://relay.nostr.band',
+    ],
+  );
 }
 
 // =============================================================================

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -2362,6 +2362,8 @@ CommentsRepository commentsRepository(Ref ref) {
 StickerPackRepository stickerPackRepository(Ref ref) {
   final nostrClient = ref.watch(nostrServiceProvider);
   final authService = ref.watch(authServiceProvider);
+  // Rebuild on auth changes to clear stale user-subscribed pack cache.
+  ref.watch(currentAuthStateProvider);
   return StickerPackRepository(
     nostrClient: nostrClient,
     curatorPubkeys: [

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -4719,6 +4719,89 @@ final class CommentsRepositoryProvider
 String _$commentsRepositoryHash() =>
     r'c93d13851e0a4299c19edc87d439f767237ecc72';
 
+/// Provider for [StickerPackRepository].
+///
+/// Loads sticker packs from multiple sources:
+/// 1. Curated packs from Divine team pubkeys
+/// 2. User-subscribed packs from the user's Kind 10030 emoji list
+///
+/// Uses:
+/// - NostrClient from nostrServiceProvider (for relay communication)
+/// - [AppConstants.classicVinesPubkey] and [AppConstants.divineTeamPubkeys]
+///   as curator pubkeys
+/// - AuthService for the current user's pubkey
+
+@ProviderFor(stickerPackRepository)
+const stickerPackRepositoryProvider = StickerPackRepositoryProvider._();
+
+/// Provider for [StickerPackRepository].
+///
+/// Loads sticker packs from multiple sources:
+/// 1. Curated packs from Divine team pubkeys
+/// 2. User-subscribed packs from the user's Kind 10030 emoji list
+///
+/// Uses:
+/// - NostrClient from nostrServiceProvider (for relay communication)
+/// - [AppConstants.classicVinesPubkey] and [AppConstants.divineTeamPubkeys]
+///   as curator pubkeys
+/// - AuthService for the current user's pubkey
+
+final class StickerPackRepositoryProvider
+    extends
+        $FunctionalProvider<
+          StickerPackRepository,
+          StickerPackRepository,
+          StickerPackRepository
+        >
+    with $Provider<StickerPackRepository> {
+  /// Provider for [StickerPackRepository].
+  ///
+  /// Loads sticker packs from multiple sources:
+  /// 1. Curated packs from Divine team pubkeys
+  /// 2. User-subscribed packs from the user's Kind 10030 emoji list
+  ///
+  /// Uses:
+  /// - NostrClient from nostrServiceProvider (for relay communication)
+  /// - [AppConstants.classicVinesPubkey] and [AppConstants.divineTeamPubkeys]
+  ///   as curator pubkeys
+  /// - AuthService for the current user's pubkey
+  const StickerPackRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'stickerPackRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$stickerPackRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<StickerPackRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  StickerPackRepository create(Ref ref) {
+    return stickerPackRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(StickerPackRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<StickerPackRepository>(value),
+    );
+  }
+}
+
+String _$stickerPackRepositoryHash() =>
+    r'f939e8a0937a37c3cee2cfd9ca1f100b1c9a65f8';
+
 /// Provider for VideoLocalStorage instance (SQLite-backed)
 ///
 /// Creates a DbVideoLocalStorage for caching video events locally.

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -4800,7 +4800,7 @@ final class StickerPackRepositoryProvider
 }
 
 String _$stickerPackRepositoryHash() =>
-    r'66405a65ed2bc3327476ac3e8caafc935ebfe2e1';
+    r'2373f948d9ea98f85382d3d233dc7843536baaa9';
 
 /// Provider for VideoLocalStorage instance (SQLite-backed)
 ///

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -4800,7 +4800,7 @@ final class StickerPackRepositoryProvider
 }
 
 String _$stickerPackRepositoryHash() =>
-    r'f939e8a0937a37c3cee2cfd9ca1f100b1c9a65f8';
+    r'66405a65ed2bc3327476ac3e8caafc935ebfe2e1';
 
 /// Provider for VideoLocalStorage instance (SQLite-backed)
 ///

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -8,11 +8,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:models/models.dart' hide NIP71VideoKinds;
 import 'package:openvine/blocs/comments/comments_bloc.dart';
+import 'package:openvine/blocs/sticker_picker/sticker_picker_bloc.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/comments/widgets/widgets.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
+import 'package:sticker_pack_repository/sticker_pack_repository.dart';
 
 /// Maps [CommentsError] to user-facing strings.
 /// TODO(l10n): Replace with context.l10n when localization is added.
@@ -245,6 +247,44 @@ class _MainCommentInputState extends ConsumerState<_MainCommentInput> {
     super.dispose();
   }
 
+  Future<void> _openStickerPicker(
+    BuildContext context, {
+    String? parentCommentId,
+    String? parentAuthorPubkey,
+  }) async {
+    final stickerPackRepository = ref.read(stickerPackRepositoryProvider);
+    final bloc = context.read<CommentsBloc>();
+
+    final sticker = await VineBottomSheet.show<Sticker>(
+      context: context,
+      title: Text(
+        'Stickers',
+        style: VineTheme.bodyFont(
+          fontSize: 18,
+          fontWeight: FontWeight.w800,
+          color: VineTheme.onSurface,
+        ),
+      ),
+      body: BlocProvider(
+        create: (_) =>
+            StickerPickerBloc(stickerPackRepository: stickerPackRepository)
+              ..add(const StickerPacksLoadRequested()),
+        child: const StickerPickerSheet(),
+      ),
+    );
+
+    if (sticker == null || !mounted) return;
+
+    bloc.add(
+      StickerCommentSubmitted(
+        stickerShortcode: sticker.shortcode,
+        stickerImageUrl: sticker.imageUrl,
+        parentCommentId: parentCommentId,
+        parentAuthorPubkey: parentAuthorPubkey,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return BlocConsumer<CommentsBloc, CommentsState>(
@@ -311,6 +351,11 @@ class _MainCommentInputState extends ConsumerState<_MainCommentInput> {
           replyToDisplayName: replyToDisplayName,
           isEditing: isEditMode,
           mentionSuggestions: state.mentionSuggestions,
+          onStickerTap: () => _openStickerPicker(
+            context,
+            parentCommentId: isReplyMode ? state.activeReplyCommentId : null,
+            parentAuthorPubkey: replyToAuthorPubkey,
+          ),
           onMentionQuery: (query) {
             if (query.isEmpty) {
               context.read<CommentsBloc>().add(

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -259,11 +259,7 @@ class _MainCommentInputState extends ConsumerState<_MainCommentInput> {
       context: context,
       title: Text(
         'Stickers',
-        style: VineTheme.bodyFont(
-          fontSize: 18,
-          fontWeight: FontWeight.w800,
-          color: VineTheme.onSurface,
-        ),
+        style: VineTheme.titleMediumFont(color: VineTheme.onSurface),
       ),
       body: BlocProvider(
         create: (_) =>

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -10,6 +10,7 @@ import 'package:models/models.dart' hide NIP71VideoKinds;
 import 'package:openvine/blocs/comments/comments_bloc.dart';
 import 'package:openvine/blocs/sticker_picker/sticker_picker_bloc.dart';
 import 'package:openvine/constants/nip71_migration.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/comments/widgets/widgets.dart';
@@ -258,7 +259,7 @@ class _MainCommentInputState extends ConsumerState<_MainCommentInput> {
     final sticker = await VineBottomSheet.show<Sticker>(
       context: context,
       title: Text(
-        'Stickers',
+        context.l10n.videoEditorStickers,
         style: VineTheme.titleMediumFont(color: VineTheme.onSurface),
       ),
       body: BlocProvider(

--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -28,6 +28,7 @@ class CommentInput extends StatefulWidget {
     this.mentionSuggestions = const [],
     this.onMentionQuery,
     this.onMentionSelected,
+    this.onStickerTap,
     super.key,
   });
 
@@ -63,6 +64,9 @@ class CommentInput extends StatefulWidget {
 
   /// Callback fired with (npub, displayName) when a mention is selected.
   final void Function(String npub, String displayName)? onMentionSelected;
+
+  /// Callback when the sticker button is tapped.
+  final VoidCallback? onStickerTap;
 
   @override
   State<CommentInput> createState() => _CommentInputState();
@@ -205,6 +209,8 @@ class _CommentInputState extends State<CommentInput> {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
+                  if (widget.onStickerTap != null && !_hasText)
+                    _StickerButton(onTap: widget.onStickerTap!),
                   Expanded(
                     child: Column(
                       mainAxisSize: MainAxisSize.min,
@@ -446,6 +452,36 @@ class _EditIndicator extends StatelessWidget {
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Button to open the sticker picker.
+class _StickerButton extends StatelessWidget {
+  const _StickerButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      identifier: 'sticker_button',
+      button: true,
+      label: 'Open sticker picker',
+      child: Container(
+        width: 40,
+        height: 40,
+        margin: const EdgeInsets.only(left: 4, bottom: 4),
+        child: IconButton(
+          onPressed: onTap,
+          padding: EdgeInsets.zero,
+          icon: const Icon(
+            Icons.emoji_emotions_outlined,
+            color: VineTheme.onSurfaceMuted,
+            size: 22,
+          ),
         ),
       ),
     );

--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -469,16 +469,15 @@ class _StickerButton extends StatelessWidget {
     return Semantics(
       identifier: 'sticker_button',
       button: true,
-      label: 'Open sticker picker',
+      label: context.l10n.commentsStickerOpenSemanticLabel,
       child: Container(
-        width: 40,
-        height: 40,
         margin: const EdgeInsets.only(left: 4, bottom: 4),
+        constraints: const BoxConstraints(minWidth: 48, minHeight: 48),
         child: IconButton(
           onPressed: onTap,
           padding: EdgeInsets.zero,
-          icon: const Icon(
-            Icons.emoji_emotions_outlined,
+          icon: const DivineIcon(
+            icon: DivineIconName.sticker,
             color: VineTheme.onSurfaceMuted,
             size: 22,
           ),

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -547,11 +547,9 @@ class _MentionLink extends ConsumerWidget {
       onTap: () => context.push(OtherProfileScreen.pathForNpub(npub)),
       child: Text(
         '@$displayText',
-        style: VineTheme.bodyFont(
-          fontSize: 14,
+        style: VineTheme.bodyMediumFont(
           color: VineTheme.tabIndicatorGreen,
-          fontWeight: FontWeight.w600,
-        ),
+        ).copyWith(fontWeight: FontWeight.w600),
       ),
     );
   }

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math';
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:count_formatter/count_formatter.dart';
 import 'package:divine_ui/divine_ui.dart';
@@ -149,6 +150,7 @@ class _CommentItemState extends ConsumerState<CommentItem> {
                           child: _CommentContent(
                             commentId: widget.comment.id,
                             content: widget.comment.content,
+                            emojiTags: widget.comment.emojiTags,
                           ),
                         ),
                         const SizedBox(height: 12),
@@ -360,9 +362,14 @@ bool _isEmojiOnly(String text) {
 /// Font size for emoji-only comments (1-3 emoji with no text).
 const _emojiOnlyFontSize = 40.0;
 
-/// Content section of a comment showing text with parsed @mentions.
+/// Content section of a comment showing text with parsed @mentions
+/// and NIP-30 custom emoji (sticker) rendering.
 class _CommentContent extends StatelessWidget {
-  const _CommentContent({required this.commentId, required this.content});
+  const _CommentContent({
+    required this.commentId,
+    required this.content,
+    this.emojiTags = const {},
+  });
 
   /// ID of the comment (for reply targeting)
   final String commentId;
@@ -370,8 +377,40 @@ class _CommentContent extends StatelessWidget {
   /// Text content of the comment
   final String content;
 
+  /// NIP-30 emoji tags mapping shortcode to image URL.
+  final Map<String, String> emojiTags;
+
+  /// Pattern matching a single `:shortcode:` with nothing else.
+  static final _stickerOnlyPattern = RegExp(r'^:(\w+):$');
+
   @override
   Widget build(BuildContext context) {
+    final trimmed = content.trim();
+
+    // Check for sticker-only comment: content is `:shortcode:` with a
+    // matching NIP-30 emoji tag.
+    if (emojiTags.isNotEmpty) {
+      final stickerMatch = _stickerOnlyPattern.firstMatch(trimmed);
+      if (stickerMatch != null) {
+        final shortcode = stickerMatch.group(1)!;
+        final imageUrl = emojiTags[shortcode];
+        if (imageUrl != null) {
+          return CachedNetworkImage(
+            imageUrl: imageUrl,
+            width: 120,
+            height: 120,
+            fit: BoxFit.contain,
+            placeholder: (_, _) => const SizedBox(width: 120, height: 120),
+            errorWidget: (_, _, _) => const Icon(
+              Icons.broken_image_outlined,
+              color: VineTheme.onSurfaceMuted,
+              size: 48,
+            ),
+          );
+        }
+      }
+    }
+
     final isEmoji = _isEmojiOnly(content);
     final baseStyle = TextStyle(
       color: VineTheme.onSurface,

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -396,7 +396,7 @@ class _CommentContent extends StatelessWidget {
   /// Combined pattern for nostr:npub1... mentions and NIP-30 :shortcode:
   /// emoji. Compiled once and reused across builds.
   static final _combinedPattern = RegExp(
-    'nostr:(npub1[a-zA-Z0-9]{58,})|:([a-zA-Z0-9_]+):',
+    'nostr:(npub1[a-zA-Z0-9]{58,65})|:([a-zA-Z0-9_]+):',
   );
 
   @override

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -381,7 +381,7 @@ class _CommentContent extends StatelessWidget {
   final Map<String, String> emojiTags;
 
   /// Pattern matching a single `:shortcode:` with nothing else.
-  static final _stickerOnlyPattern = RegExp(r'^:(\w+):$');
+  static final _stickerOnlyPattern = RegExp(r'^:([\w-]+):$');
 
   @override
   Widget build(BuildContext context) {
@@ -417,6 +417,13 @@ class _CommentContent extends StatelessWidget {
       fontSize: isEmoji ? _emojiOnlyFontSize : 14,
       height: isEmoji ? null : 20 / 14,
     );
+
+    if (emojiTags.isNotEmpty && RegExp(r':[\w-]+:').hasMatch(content)) {
+      return RichText(
+        text: TextSpan(style: baseStyle, children: _buildContentSpans()),
+      );
+    }
+
     return ClickableHashtagText(
       text: content,
       style: baseStyle,
@@ -427,6 +434,97 @@ class _CommentContent extends StatelessWidget {
       mentionStyle: baseStyle.copyWith(
         color: VineTheme.tabIndicatorGreen,
         fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+
+  List<InlineSpan> _buildContentSpans() {
+    final combinedPattern = RegExp(r'nostr:(npub1[a-zA-Z0-9]{58,})|:([\w-]+):');
+    final spans = <InlineSpan>[];
+    var lastEnd = 0;
+
+    for (final match in combinedPattern.allMatches(content)) {
+      if (match.start > lastEnd) {
+        spans.add(TextSpan(text: content.substring(lastEnd, match.start)));
+      }
+
+      final npub = match.group(1);
+      final shortcode = match.group(2);
+
+      if (npub != null) {
+        spans.add(
+          WidgetSpan(
+            alignment: PlaceholderAlignment.baseline,
+            baseline: TextBaseline.alphabetic,
+            child: _MentionLink(npub: npub),
+          ),
+        );
+      } else if (shortcode != null) {
+        final imageUrl = emojiTags[shortcode];
+        if (imageUrl != null) {
+          spans.add(
+            WidgetSpan(
+              alignment: PlaceholderAlignment.middle,
+              child: CachedNetworkImage(
+                imageUrl: imageUrl,
+                width: 24,
+                height: 24,
+                fit: BoxFit.contain,
+                placeholder: (_, _) => const SizedBox(width: 24, height: 24),
+                errorWidget: (_, _, _) => const Icon(
+                  Icons.broken_image_outlined,
+                  size: 16,
+                  color: VineTheme.onSurfaceMuted,
+                ),
+              ),
+            ),
+          );
+        } else {
+          spans.add(TextSpan(text: match.group(0)));
+        }
+      }
+
+      lastEnd = match.end;
+    }
+
+    if (lastEnd < content.length) {
+      spans.add(TextSpan(text: content.substring(lastEnd)));
+    }
+
+    if (spans.isEmpty) {
+      spans.add(TextSpan(text: content));
+    }
+
+    return spans;
+  }
+}
+
+/// Inline mention link that resolves profile name and navigates to profile.
+class _MentionLink extends ConsumerWidget {
+  const _MentionLink({required this.npub});
+
+  final String npub;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    String displayText;
+    try {
+      final hexPubkey = NostrKeyUtils.decode(npub);
+      final profile = ref.watch(userProfileReactiveProvider(hexPubkey)).value;
+      displayText = profile?.displayName ?? profile?.name ?? npub;
+    } catch (_) {
+      displayText = npub;
+    }
+
+    return GestureDetector(
+      onTap: () => context.push(OtherProfileScreen.pathForNpub(npub)),
+      child: Text(
+        '@$displayText',
+        style: VineTheme.bodyFont(
+          fontSize: 14,
+          color: VineTheme.tabIndicatorGreen,
+          fontWeight: FontWeight.w600,
+        ),
       ),
     );
   }

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -4,7 +4,6 @@
 
 import 'dart:math';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:count_formatter/count_formatter.dart';
 import 'package:divine_ui/divine_ui.dart';
@@ -25,6 +24,7 @@ import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/clickable_hashtag_text.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_name.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Widget that renders a single comment in a flat list.
 ///
@@ -389,6 +389,13 @@ class _CommentContent extends StatelessWidget {
   /// Size of error icon for failed inline sticker loads.
   static const double _inlineStickerErrorSize = 16;
 
+  /// Memory-cache decode width/height for the 120 px standalone sticker.
+  /// 240 px gives 2x retina headroom over the rendered size.
+  static const int _stickerMemCachePx = 240;
+
+  /// Memory-cache decode width/height for the 24 px inline sticker.
+  static const int _inlineStickerMemCachePx = 64;
+
   /// NIP-30 compliant pattern matching a single `:shortcode:` with nothing
   /// else. Shortcodes contain only alphanumeric characters and underscores.
   static final _stickerOnlyPattern = RegExp(r'^:([a-zA-Z0-9_]+):$');
@@ -414,11 +421,13 @@ class _CommentContent extends StatelessWidget {
           return Semantics(
             label: shortcode,
             image: true,
-            child: CachedNetworkImage(
+            child: VineCachedImage(
               imageUrl: imageUrl,
               width: _stickerSize,
               height: _stickerSize,
               fit: BoxFit.contain,
+              memCacheWidth: _stickerMemCachePx,
+              memCacheHeight: _stickerMemCachePx,
               placeholder: (_, _) =>
                   const SizedBox(width: _stickerSize, height: _stickerSize),
               errorWidget: (_, _, _) => const Icon(
@@ -488,11 +497,13 @@ class _CommentContent extends StatelessWidget {
               child: Semantics(
                 label: shortcode,
                 image: true,
-                child: CachedNetworkImage(
+                child: VineCachedImage(
                   imageUrl: imageUrl,
                   width: _inlineStickerSize,
                   height: _inlineStickerSize,
                   fit: BoxFit.contain,
+                  memCacheWidth: _inlineStickerMemCachePx,
+                  memCacheHeight: _inlineStickerMemCachePx,
                   placeholder: (_, _) => const SizedBox(
                     width: _inlineStickerSize,
                     height: _inlineStickerSize,

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -380,8 +380,24 @@ class _CommentContent extends StatelessWidget {
   /// NIP-30 emoji tags mapping shortcode to image URL.
   final Map<String, String> emojiTags;
 
-  /// Pattern matching a single `:shortcode:` with nothing else.
-  static final _stickerOnlyPattern = RegExp(r'^:([\w-]+):$');
+  /// Size of standalone sticker images (sticker-only comments).
+  static const double _stickerSize = 120;
+
+  /// Size of inline sticker images within mixed text.
+  static const double _inlineStickerSize = 24;
+
+  /// Size of error icon for failed inline sticker loads.
+  static const double _inlineStickerErrorSize = 16;
+
+  /// NIP-30 compliant pattern matching a single `:shortcode:` with nothing
+  /// else. Shortcodes contain only alphanumeric characters and underscores.
+  static final _stickerOnlyPattern = RegExp(r'^:([a-zA-Z0-9_]+):$');
+
+  /// Combined pattern for nostr:npub1... mentions and NIP-30 :shortcode:
+  /// emoji. Compiled once and reused across builds.
+  static final _combinedPattern = RegExp(
+    r'nostr:(npub1[a-zA-Z0-9]{58,})|:([a-zA-Z0-9_]+):',
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -395,16 +411,21 @@ class _CommentContent extends StatelessWidget {
         final shortcode = stickerMatch.group(1)!;
         final imageUrl = emojiTags[shortcode];
         if (imageUrl != null) {
-          return CachedNetworkImage(
-            imageUrl: imageUrl,
-            width: 120,
-            height: 120,
-            fit: BoxFit.contain,
-            placeholder: (_, _) => const SizedBox(width: 120, height: 120),
-            errorWidget: (_, _, _) => const Icon(
-              Icons.broken_image_outlined,
-              color: VineTheme.onSurfaceMuted,
-              size: 48,
+          return Semantics(
+            label: shortcode,
+            image: true,
+            child: CachedNetworkImage(
+              imageUrl: imageUrl,
+              width: _stickerSize,
+              height: _stickerSize,
+              fit: BoxFit.contain,
+              placeholder: (_, _) =>
+                  const SizedBox(width: _stickerSize, height: _stickerSize),
+              errorWidget: (_, _, _) => const Icon(
+                Icons.broken_image_outlined,
+                color: VineTheme.onSurfaceMuted,
+                size: 48,
+              ),
             ),
           );
         }
@@ -418,7 +439,7 @@ class _CommentContent extends StatelessWidget {
       height: isEmoji ? null : 20 / 14,
     );
 
-    if (emojiTags.isNotEmpty && RegExp(r':[\w-]+:').hasMatch(content)) {
+    if (emojiTags.isNotEmpty && _combinedPattern.hasMatch(content)) {
       return RichText(
         text: TextSpan(style: baseStyle, children: _buildContentSpans()),
       );
@@ -439,11 +460,10 @@ class _CommentContent extends StatelessWidget {
   }
 
   List<InlineSpan> _buildContentSpans() {
-    final combinedPattern = RegExp(r'nostr:(npub1[a-zA-Z0-9]{58,})|:([\w-]+):');
     final spans = <InlineSpan>[];
     var lastEnd = 0;
 
-    for (final match in combinedPattern.allMatches(content)) {
+    for (final match in _combinedPattern.allMatches(content)) {
       if (match.start > lastEnd) {
         spans.add(TextSpan(text: content.substring(lastEnd, match.start)));
       }
@@ -465,16 +485,23 @@ class _CommentContent extends StatelessWidget {
           spans.add(
             WidgetSpan(
               alignment: PlaceholderAlignment.middle,
-              child: CachedNetworkImage(
-                imageUrl: imageUrl,
-                width: 24,
-                height: 24,
-                fit: BoxFit.contain,
-                placeholder: (_, _) => const SizedBox(width: 24, height: 24),
-                errorWidget: (_, _, _) => const Icon(
-                  Icons.broken_image_outlined,
-                  size: 16,
-                  color: VineTheme.onSurfaceMuted,
+              child: Semantics(
+                label: shortcode,
+                image: true,
+                child: CachedNetworkImage(
+                  imageUrl: imageUrl,
+                  width: _inlineStickerSize,
+                  height: _inlineStickerSize,
+                  fit: BoxFit.contain,
+                  placeholder: (_, _) => const SizedBox(
+                    width: _inlineStickerSize,
+                    height: _inlineStickerSize,
+                  ),
+                  errorWidget: (_, _, _) => const Icon(
+                    Icons.broken_image_outlined,
+                    size: _inlineStickerErrorSize,
+                    color: VineTheme.onSurfaceMuted,
+                  ),
                 ),
               ),
             ),

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -337,7 +337,6 @@ bool _isEmojiOnly(String text) {
   // Check each grapheme is emoji (no ASCII text, no nostr: mentions).
   // Includes Emoji_Component for keycap (\u20e3) and tag sequences,
   // and Regional_Indicator for flag emojis.
-  // ignore: valid_regexps
   final emojiRegex = RegExp(
     // Emoji component chars (ZWJ, VS-16, keycap, skin tones, digits/#/*)
     r'^[\u200d\ufe0f\u20e30-9#*\u{1F3FB}-\u{1F3FF}'

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -337,6 +337,7 @@ bool _isEmojiOnly(String text) {
   // Check each grapheme is emoji (no ASCII text, no nostr: mentions).
   // Includes Emoji_Component for keycap (\u20e3) and tag sequences,
   // and Regional_Indicator for flag emojis.
+  // ignore: valid_regexps
   final emojiRegex = RegExp(
     // Emoji component chars (ZWJ, VS-16, keycap, skin tones, digits/#/*)
     r'^[\u200d\ufe0f\u20e30-9#*\u{1F3FB}-\u{1F3FF}'

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -396,7 +396,7 @@ class _CommentContent extends StatelessWidget {
   /// Combined pattern for nostr:npub1... mentions and NIP-30 :shortcode:
   /// emoji. Compiled once and reused across builds.
   static final _combinedPattern = RegExp(
-    r'nostr:(npub1[a-zA-Z0-9]{58,})|:([a-zA-Z0-9_]+):',
+    'nostr:(npub1[a-zA-Z0-9]{58,})|:([a-zA-Z0-9_]+):',
   );
 
   @override

--- a/mobile/lib/screens/comments/widgets/sticker_picker_sheet.dart
+++ b/mobile/lib/screens/comments/widgets/sticker_picker_sheet.dart
@@ -9,6 +9,12 @@ import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/sticker_picker/sticker_picker_bloc.dart';
 import 'package:sticker_pack_repository/sticker_pack_repository.dart';
 
+String _stickerErrorToString(StickerPickerErrorType errorType) {
+  return switch (errorType) {
+    StickerPickerErrorType.loadFailed => 'Failed to load stickers',
+  };
+}
+
 /// Bottom sheet for browsing and selecting stickers.
 ///
 /// Renders a searchable grid of sticker images from curated packs.
@@ -26,7 +32,9 @@ class StickerPickerSheet extends StatelessWidget {
           StickerPickerLoaded(:final filteredStickers) => _StickerContent(
             stickers: filteredStickers,
           ),
-          StickerPickerError(:final message) => _ErrorState(message: message),
+          StickerPickerError(:final errorType) => _ErrorState(
+            message: _stickerErrorToString(errorType),
+          ),
         };
       },
     );
@@ -79,6 +87,9 @@ class _StickerContent extends StatelessWidget {
 
   final List<Sticker> stickers;
 
+  static const double _gridMaxCrossAxisExtent = 100;
+  static const double _gridSpacing = 8;
+
   @override
   Widget build(BuildContext context) {
     return CustomScrollView(
@@ -104,9 +115,9 @@ class _StickerContent extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
             sliver: SliverGrid(
               gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
-                maxCrossAxisExtent: 100,
-                mainAxisSpacing: 8,
-                crossAxisSpacing: 8,
+                maxCrossAxisExtent: _gridMaxCrossAxisExtent,
+                mainAxisSpacing: _gridSpacing,
+                crossAxisSpacing: _gridSpacing,
               ),
               delegate: SliverChildBuilderDelegate(
                 (context, index) {

--- a/mobile/lib/screens/comments/widgets/sticker_picker_sheet.dart
+++ b/mobile/lib/screens/comments/widgets/sticker_picker_sheet.dart
@@ -1,0 +1,205 @@
+// ABOUTME: Bottom sheet UI for browsing and selecting stickers from curated packs.
+// ABOUTME: Displays a searchable grid of sticker images with BLoC-driven state.
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/sticker_picker/sticker_picker_bloc.dart';
+import 'package:sticker_pack_repository/sticker_pack_repository.dart';
+
+/// Bottom sheet for browsing and selecting stickers.
+///
+/// Renders a searchable grid of sticker images from curated packs.
+/// Returns the selected [Sticker] via `context.pop(sticker)`.
+class StickerPickerSheet extends StatelessWidget {
+  const StickerPickerSheet({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<StickerPickerBloc, StickerPickerState>(
+      builder: (context, state) {
+        return switch (state) {
+          StickerPickerInitial() ||
+          StickerPickerLoading() => const _LoadingState(),
+          StickerPickerLoaded(:final filteredStickers) => _StickerContent(
+            stickers: filteredStickers,
+          ),
+          StickerPickerError(:final message) => _ErrorState(message: message),
+        };
+      },
+    );
+  }
+}
+
+class _LoadingState extends StatelessWidget {
+  const _LoadingState();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(48),
+        child: CircularProgressIndicator(color: VineTheme.vineGreen),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.error_outline, color: VineTheme.error, size: 48),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              style: VineTheme.bodyFont(color: VineTheme.secondaryText),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StickerContent extends StatelessWidget {
+  const _StickerContent({required this.stickers});
+
+  final List<Sticker> stickers;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScrollView(
+      slivers: [
+        SliverAppBar(
+          floating: true,
+          snap: true,
+          automaticallyImplyLeading: false,
+          backgroundColor: VineTheme.surfaceBackground,
+          toolbarHeight: 56,
+          title: _SearchBar(
+            onChanged: (query) {
+              context.read<StickerPickerBloc>().add(
+                StickerSearchChanged(query),
+              );
+            },
+          ),
+        ),
+        if (stickers.isEmpty)
+          const SliverFillRemaining(child: _EmptyState())
+        else
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            sliver: SliverGrid(
+              gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+                maxCrossAxisExtent: 100,
+                mainAxisSpacing: 8,
+                crossAxisSpacing: 8,
+              ),
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  final sticker = stickers[index];
+                  return _StickerTile(sticker: sticker);
+                },
+                childCount: stickers.length,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _SearchBar extends StatelessWidget {
+  const _SearchBar({required this.onChanged});
+
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      onChanged: onChanged,
+      style: VineTheme.bodyFont(color: VineTheme.onSurface),
+      cursorColor: VineTheme.tabIndicatorGreen,
+      decoration: InputDecoration(
+        hintText: 'Search stickers...',
+        hintStyle: VineTheme.bodyFont(color: VineTheme.onSurfaceMuted),
+        prefixIcon: const Icon(
+          Icons.search,
+          color: VineTheme.onSurfaceMuted,
+          size: 20,
+        ),
+        filled: true,
+        fillColor: VineTheme.containerLow,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: BorderSide.none,
+        ),
+        contentPadding: const EdgeInsets.symmetric(vertical: 8),
+        isDense: true,
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        'No stickers found',
+        style: VineTheme.bodyFont(color: VineTheme.onSurfaceMuted),
+      ),
+    );
+  }
+}
+
+class _StickerTile extends StatelessWidget {
+  const _StickerTile({required this.sticker});
+
+  final Sticker sticker;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      identifier: 'sticker_${sticker.shortcode}',
+      button: true,
+      label: sticker.shortcode,
+      child: InkWell(
+        onTap: () => context.pop(sticker),
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          decoration: BoxDecoration(
+            color: VineTheme.containerLow,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          padding: const EdgeInsets.all(8),
+          child: CachedNetworkImage(
+            imageUrl: sticker.imageUrl,
+            fit: BoxFit.contain,
+            placeholder: (_, _) => const SizedBox.shrink(),
+            errorWidget: (_, _, _) => const Icon(
+              Icons.broken_image_outlined,
+              color: VineTheme.onSurfaceMuted,
+              size: 24,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/comments/widgets/sticker_picker_sheet.dart
+++ b/mobile/lib/screens/comments/widgets/sticker_picker_sheet.dart
@@ -72,7 +72,7 @@ class _ErrorState extends StatelessWidget {
             const SizedBox(height: 16),
             Text(
               message,
-              style: VineTheme.bodyFont(color: VineTheme.secondaryText),
+              style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
               textAlign: TextAlign.center,
             ),
           ],
@@ -138,11 +138,11 @@ class _SearchBar extends StatelessWidget {
   Widget build(BuildContext context) {
     return TextField(
       onChanged: onChanged,
-      style: VineTheme.bodyFont(color: VineTheme.onSurface),
+      style: VineTheme.bodyMediumFont(color: VineTheme.onSurface),
       cursorColor: VineTheme.tabIndicatorGreen,
       decoration: InputDecoration(
         hintText: 'Search stickers...',
-        hintStyle: VineTheme.bodyFont(color: VineTheme.onSurfaceMuted),
+        hintStyle: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted),
         prefixIcon: const Icon(
           Icons.search,
           color: VineTheme.onSurfaceMuted,
@@ -169,7 +169,7 @@ class _EmptyState extends StatelessWidget {
     return Center(
       child: Text(
         'No stickers found',
-        style: VineTheme.bodyFont(color: VineTheme.onSurfaceMuted),
+        style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted),
       ),
     );
   }

--- a/mobile/lib/screens/comments/widgets/sticker_picker_sheet.dart
+++ b/mobile/lib/screens/comments/widgets/sticker_picker_sheet.dart
@@ -99,7 +99,6 @@ class _StickerContent extends StatelessWidget {
           snap: true,
           automaticallyImplyLeading: false,
           backgroundColor: VineTheme.surfaceBackground,
-          toolbarHeight: 56,
           title: _SearchBar(
             onChanged: (query) {
               context.read<StickerPickerBloc>().add(
@@ -119,13 +118,10 @@ class _StickerContent extends StatelessWidget {
                 mainAxisSpacing: _gridSpacing,
                 crossAxisSpacing: _gridSpacing,
               ),
-              delegate: SliverChildBuilderDelegate(
-                (context, index) {
-                  final sticker = stickers[index];
-                  return _StickerTile(sticker: sticker);
-                },
-                childCount: stickers.length,
-              ),
+              delegate: SliverChildBuilderDelegate((context, index) {
+                final sticker = stickers[index];
+                return _StickerTile(sticker: sticker);
+              }, childCount: stickers.length),
             ),
           ),
       ],

--- a/mobile/lib/screens/comments/widgets/sticker_picker_sheet.dart
+++ b/mobile/lib/screens/comments/widgets/sticker_picker_sheet.dart
@@ -1,17 +1,22 @@
 // ABOUTME: Bottom sheet UI for browsing and selecting stickers from curated packs.
 // ABOUTME: Displays a searchable grid of sticker images with BLoC-driven state.
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/sticker_picker/sticker_picker_bloc.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:sticker_pack_repository/sticker_pack_repository.dart';
 
-String _stickerErrorToString(StickerPickerErrorType errorType) {
+String _stickerErrorToString(
+  BuildContext context,
+  StickerPickerErrorType errorType,
+) {
   return switch (errorType) {
-    StickerPickerErrorType.loadFailed => 'Failed to load stickers',
+    StickerPickerErrorType.loadFailed =>
+      context.l10n.videoEditorFailedLoadStickers,
   };
 }
 
@@ -33,7 +38,7 @@ class StickerPickerSheet extends StatelessWidget {
             stickers: filteredStickers,
           ),
           StickerPickerError(:final errorType) => _ErrorState(
-            message: _stickerErrorToString(errorType),
+            message: _stickerErrorToString(context, errorType),
           ),
         };
       },
@@ -68,7 +73,11 @@ class _ErrorState extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(Icons.error_outline, color: VineTheme.error, size: 48),
+            const DivineIcon(
+              icon: DivineIconName.warningCircle,
+              color: VineTheme.error,
+              size: 48,
+            ),
             const SizedBox(height: 16),
             Text(
               message,
@@ -141,13 +150,17 @@ class _SearchBar extends StatelessWidget {
       style: VineTheme.bodyMediumFont(color: VineTheme.onSurface),
       cursorColor: VineTheme.tabIndicatorGreen,
       decoration: InputDecoration(
-        hintText: 'Search stickers...',
+        hintText: context.l10n.videoEditorStickerSearchHint,
         hintStyle: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted),
-        prefixIcon: const Icon(
-          Icons.search,
-          color: VineTheme.onSurfaceMuted,
-          size: 20,
+        prefixIcon: const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 8),
+          child: DivineIcon(
+            icon: DivineIconName.search,
+            color: VineTheme.onSurfaceMuted,
+            size: 20,
+          ),
         ),
+        prefixIconConstraints: const BoxConstraints(minWidth: 36),
         filled: true,
         fillColor: VineTheme.containerLow,
         border: OutlineInputBorder(
@@ -168,7 +181,7 @@ class _EmptyState extends StatelessWidget {
   Widget build(BuildContext context) {
     return Center(
       child: Text(
-        'No stickers found',
+        context.l10n.videoEditorNoStickersFound,
         style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted),
       ),
     );
@@ -179,6 +192,10 @@ class _StickerTile extends StatelessWidget {
   const _StickerTile({required this.sticker});
 
   final Sticker sticker;
+
+  /// Cap mem-decoded width for grid tiles. Tiles render at ~84-100 px;
+  /// 200 px gives a 2x retina headroom without holding 4K source decodes.
+  static const int _memCacheSizePx = 200;
 
   @override
   Widget build(BuildContext context) {
@@ -195,9 +212,11 @@ class _StickerTile extends StatelessWidget {
             borderRadius: BorderRadius.circular(12),
           ),
           padding: const EdgeInsets.all(8),
-          child: CachedNetworkImage(
+          child: VineCachedImage(
             imageUrl: sticker.imageUrl,
             fit: BoxFit.contain,
+            memCacheWidth: _memCacheSizePx,
+            memCacheHeight: _memCacheSizePx,
             placeholder: (_, _) => const SizedBox.shrink(),
             errorWidget: (_, _, _) => const Icon(
               Icons.broken_image_outlined,

--- a/mobile/lib/screens/comments/widgets/widgets.dart
+++ b/mobile/lib/screens/comments/widgets/widgets.dart
@@ -11,3 +11,4 @@ export 'comments_header.dart';
 export 'comments_list.dart';
 export 'mention_overlay.dart';
 export 'new_comments_pill.dart';
+export 'sticker_picker_sheet.dart';

--- a/mobile/lib/widgets/video_editor/sticker_editor/video_editor_sticker.dart
+++ b/mobile/lib/widgets/video_editor/sticker_editor/video_editor_sticker.dart
@@ -14,7 +14,10 @@ import 'package:openvine/widgets/vine_cached_image.dart';
 /// `WidgetLayer.fromMap` so sticker layers survive the editor's
 /// export/reopen round-trip. Returns an empty box when [meta] is
 /// `null` (legacy widget layers without sticker metadata).
-Widget videoEditorStickerWidgetLoader(String id, {Map<String, dynamic>? meta}) {
+Widget videoEditorStickerWidgetLoader(
+  String id, {
+  Map<String, dynamic>? meta,
+}) {
   if (meta == null) return const SizedBox.shrink();
 
   return VideoEditorSticker(

--- a/mobile/lib/widgets/video_editor/sticker_editor/video_editor_sticker.dart
+++ b/mobile/lib/widgets/video_editor/sticker_editor/video_editor_sticker.dart
@@ -14,10 +14,7 @@ import 'package:openvine/widgets/vine_cached_image.dart';
 /// `WidgetLayer.fromMap` so sticker layers survive the editor's
 /// export/reopen round-trip. Returns an empty box when [meta] is
 /// `null` (legacy widget layers without sticker metadata).
-Widget videoEditorStickerWidgetLoader(
-  String id, {
-  Map<String, dynamic>? meta,
-}) {
+Widget videoEditorStickerWidgetLoader(String id, {Map<String, dynamic>? meta}) {
   if (meta == null) return const SizedBox.shrink();
 
   return VideoEditorSticker(

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -343,6 +343,9 @@ class CommentsRepository {
         );
       }
 
+      final cached = _commentCountCache[rootEventId];
+      if (cached != null) _commentCountCache[rootEventId] = cached + 1;
+
       return Comment(
         id: sentEvent.id,
         content: content,

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -58,6 +58,9 @@ class CommentsRepository {
   /// server or relay (so callers never need to push counts back in).
   final Map<String, int> _commentCountCache = {};
 
+  /// NIP-30 shortcode validation: alphanumeric + underscores only.
+  static final _shortcodePattern = RegExp(r'^[a-zA-Z0-9_]+$');
+
   /// Active comment-watch subscription ID, if any.
   ///
   /// Limitation: only one watch can be active at a time. If two comment
@@ -303,7 +306,7 @@ class CommentsRepository {
     String? replyToAuthorPubkey,
   }) async {
     if (stickerShortcode.isEmpty ||
-        !RegExp(r'^[a-zA-Z0-9_]+$').hasMatch(stickerShortcode)) {
+        !_shortcodePattern.hasMatch(stickerShortcode)) {
       throw const PostCommentFailedException(
         'Sticker shortcode must be non-empty and contain only '
         'alphanumeric characters and underscores',

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -172,11 +172,7 @@ class CommentsRepository {
       } else {
         // No addressable ID - just query by E tag
         final events = await _nostrClient.queryEvents([filterByE]);
-        thread = _buildThreadFromEvents(
-          events,
-          rootEventId,
-          rootEventKind,
-        );
+        thread = _buildThreadFromEvents(events, rootEventId, rootEventKind);
       }
 
       // Auto-update the count cache with the authoritative total so that
@@ -289,6 +285,87 @@ class CommentsRepository {
       rethrow;
     } on Exception catch (e) {
       throw PostCommentFailedException('Failed to post comment: $e');
+    }
+  }
+
+  /// Posts a sticker comment using NIP-30 custom emoji syntax.
+  ///
+  /// Creates a Kind 1111 event with `:shortcode:` as content and an
+  /// `["emoji", shortcode, imageUrl]` tag for NIP-30 rendering.
+  ///
+  /// Parameters:
+  /// - [stickerShortcode]: The emoji shortcode (e.g., "fire")
+  /// - [stickerImageUrl]: URL of the sticker image
+  /// - [rootEventId]: The ID of the root event (e.g., video)
+  /// - [rootEventKind]: The kind of the root event (e.g., 34236)
+  /// - [rootEventAuthorPubkey]: Public key of the root event author
+  /// - [rootAddressableId]: Optional addressable identifier
+  /// - [replyToEventId]: ID of parent comment (for nested replies)
+  /// - [replyToAuthorPubkey]: Public key of parent comment author
+  ///
+  /// Returns the created [Comment].
+  ///
+  /// Throws [PostCommentFailedException] if broadcasting fails.
+  Future<Comment> postStickerComment({
+    required String stickerShortcode,
+    required String stickerImageUrl,
+    required String rootEventId,
+    required int rootEventKind,
+    required String rootEventAuthorPubkey,
+    String? rootAddressableId,
+    String? replyToEventId,
+    String? replyToAuthorPubkey,
+  }) async {
+    final content = ':$stickerShortcode:';
+
+    // Build NIP-22 threading tags (same as postComment)
+    final tags = <List<String>>[
+      ['E', rootEventId, '', rootEventAuthorPubkey],
+      if (rootAddressableId != null && rootAddressableId.isNotEmpty)
+        ['A', rootAddressableId, ''],
+      ['K', rootEventKind.toString()],
+      ['P', rootEventAuthorPubkey],
+      if (replyToEventId != null && replyToAuthorPubkey != null) ...[
+        ['e', replyToEventId, '', replyToAuthorPubkey],
+        ['k', _commentKind.toString()],
+        ['p', replyToAuthorPubkey],
+      ] else ...[
+        ['e', rootEventId, '', rootEventAuthorPubkey],
+        if (rootAddressableId != null && rootAddressableId.isNotEmpty)
+          ['a', rootAddressableId, ''],
+        ['k', rootEventKind.toString()],
+        ['p', rootEventAuthorPubkey],
+      ],
+      // NIP-30 custom emoji tag
+      ['emoji', stickerShortcode, stickerImageUrl],
+    ];
+
+    final event = Event(_nostrClient.publicKey, _commentKind, tags, content);
+
+    try {
+      final sentEvent = await _nostrClient.publishEvent(event);
+
+      if (sentEvent == null) {
+        throw const PostCommentFailedException(
+          'Failed to publish sticker comment',
+        );
+      }
+
+      return Comment(
+        id: sentEvent.id,
+        content: content,
+        authorPubkey: sentEvent.pubkey,
+        createdAt: event.createdAtDateTime,
+        rootEventId: rootEventId,
+        rootAuthorPubkey: rootEventAuthorPubkey,
+        replyToEventId: replyToEventId,
+        replyToAuthorPubkey: replyToAuthorPubkey,
+        emojiTags: {stickerShortcode: stickerImageUrl},
+      );
+    } on CommentsRepositoryException {
+      rethrow;
+    } on Exception catch (e) {
+      throw PostCommentFailedException('Failed to post sticker comment: $e');
     }
   }
 
@@ -609,6 +686,7 @@ class CommentsRepository {
       String? rootAuthorPubkey;
       String? replyToAuthorPubkey;
       String? parentKind;
+      final emojiTags = <String, String>{};
 
       // Parse NIP-22 tags to determine comment relationships
       // Uppercase tags (E, A, K, P) = root scope
@@ -646,6 +724,11 @@ class CommentsRepository {
           case 'p':
             // Parent author pubkey (lowercase = parent item)
             replyToAuthorPubkey ??= tagValue;
+          case 'emoji':
+            // NIP-30 custom emoji tag: ["emoji", shortcode, url]
+            if (tag.length >= 3) {
+              emojiTags[tagValue] = tag[2] as String;
+            }
         }
       }
 
@@ -715,6 +798,7 @@ class CommentsRepository {
         videoDimensions: videoDimensions,
         videoDuration: videoDuration,
         videoBlurhash: videoBlurhash,
+        emojiTags: emojiTags,
       );
     } on Exception {
       return null;

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -58,7 +58,13 @@ class CommentsRepository {
   /// server or relay (so callers never need to push counts back in).
   final Map<String, int> _commentCountCache = {};
 
-  /// Subscription ID for the active comment watch, if any.
+  /// Active comment-watch subscription ID, if any.
+  ///
+  /// Limitation: only one watch can be active at a time. If two comment
+  /// screens run simultaneously, the second [watchComments] call overwrites
+  /// this field, causing [stopWatchingComments] to cancel only the second
+  /// subscription while the first leaks. Fixing requires a map keyed by
+  /// rootEventId.
   String? _watchSubscriptionId;
 
   /// Default page size for author comment queries.
@@ -296,6 +302,21 @@ class CommentsRepository {
     String? replyToEventId,
     String? replyToAuthorPubkey,
   }) async {
+    if (stickerShortcode.isEmpty ||
+        !RegExp(r'^[a-zA-Z0-9_]+$').hasMatch(stickerShortcode)) {
+      throw const PostCommentFailedException(
+        'Sticker shortcode must be non-empty and contain only '
+        'alphanumeric characters and underscores',
+      );
+    }
+
+    final uri = Uri.tryParse(stickerImageUrl);
+    if (uri == null || uri.scheme != 'https') {
+      throw const PostCommentFailedException(
+        'Sticker image URL must be a valid https URL',
+      );
+    }
+
     final content = ':$stickerShortcode:';
 
     // Build NIP-22 threading tags via shared helper, then append NIP-30 emoji

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -222,35 +222,15 @@ class CommentsRepository {
       throw const InvalidCommentContentException('Comment cannot be empty');
     }
 
-    // Build tags for NIP-22 threading
-    // Uppercase tags point to root scope, lowercase to parent item
-    final tags = <List<String>>[
-      // Root scope tags (uppercase) - always point to the original event
-      ['E', rootEventId, '', rootEventAuthorPubkey],
-      // Include A tag for addressable events (Kind 30000-39999)
-      // This ensures comments can be found by clients querying by either E or A
-      // NIP-22: A tags use 3 elements [A, address, relay_hint]
-      if (rootAddressableId != null && rootAddressableId.isNotEmpty)
-        ['A', rootAddressableId, ''],
-      ['K', rootEventKind.toString()],
-      ['P', rootEventAuthorPubkey],
-      // Parent item tags (lowercase)
-      if (replyToEventId != null && replyToAuthorPubkey != null) ...[
-        // Replying to another comment
-        ['e', replyToEventId, '', replyToAuthorPubkey],
-        ['k', _commentKind.toString()],
-        ['p', replyToAuthorPubkey],
-      ] else ...[
-        // Top-level comment - parent is the same as root
-        ['e', rootEventId, '', rootEventAuthorPubkey],
-        // Include lowercase 'a' tag for addressable events too
-        // NIP-22: a tags use 3 elements [a, address, relay_hint]
-        if (rootAddressableId != null && rootAddressableId.isNotEmpty)
-          ['a', rootAddressableId, ''],
-        ['k', rootEventKind.toString()],
-        ['p', rootEventAuthorPubkey],
-      ],
-    ];
+    // Build NIP-22 threading tags via shared helper
+    final tags = _buildNip22ThreadingTags(
+      rootEventId: rootEventId,
+      rootEventKind: rootEventKind,
+      rootEventAuthorPubkey: rootEventAuthorPubkey,
+      rootAddressableId: rootAddressableId,
+      replyToEventId: replyToEventId,
+      replyToAuthorPubkey: replyToAuthorPubkey,
+    );
 
     // Create the event
     final event = Event(
@@ -318,27 +298,15 @@ class CommentsRepository {
   }) async {
     final content = ':$stickerShortcode:';
 
-    // Build NIP-22 threading tags (same as postComment)
-    final tags = <List<String>>[
-      ['E', rootEventId, '', rootEventAuthorPubkey],
-      if (rootAddressableId != null && rootAddressableId.isNotEmpty)
-        ['A', rootAddressableId, ''],
-      ['K', rootEventKind.toString()],
-      ['P', rootEventAuthorPubkey],
-      if (replyToEventId != null && replyToAuthorPubkey != null) ...[
-        ['e', replyToEventId, '', replyToAuthorPubkey],
-        ['k', _commentKind.toString()],
-        ['p', replyToAuthorPubkey],
-      ] else ...[
-        ['e', rootEventId, '', rootEventAuthorPubkey],
-        if (rootAddressableId != null && rootAddressableId.isNotEmpty)
-          ['a', rootAddressableId, ''],
-        ['k', rootEventKind.toString()],
-        ['p', rootEventAuthorPubkey],
-      ],
-      // NIP-30 custom emoji tag
-      ['emoji', stickerShortcode, stickerImageUrl],
-    ];
+    // Build NIP-22 threading tags via shared helper, then append NIP-30 emoji
+    final tags = _buildNip22ThreadingTags(
+      rootEventId: rootEventId,
+      rootEventKind: rootEventKind,
+      rootEventAuthorPubkey: rootEventAuthorPubkey,
+      rootAddressableId: rootAddressableId,
+      replyToEventId: replyToEventId,
+      replyToAuthorPubkey: replyToAuthorPubkey,
+    )..add(['emoji', stickerShortcode, stickerImageUrl]);
 
     final event = Event(_nostrClient.publicKey, _commentKind, tags, content);
 
@@ -676,6 +644,46 @@ class CommentsRepository {
       return null;
     }
   }
+
+  /// Builds NIP-22 threading tags shared by [postComment] and
+  /// [postStickerComment].
+  ///
+  /// Uppercase tags (`E`, `K`, `P`, `A`) point to the root scope.
+  /// Lowercase tags (`e`, `k`, `p`, `a`) point to the parent item.
+  List<List<String>> _buildNip22ThreadingTags({
+    required String rootEventId,
+    required int rootEventKind,
+    required String rootEventAuthorPubkey,
+    String? rootAddressableId,
+    String? replyToEventId,
+    String? replyToAuthorPubkey,
+  }) => <List<String>>[
+    // Root scope tags (uppercase) - always point to the original event
+    ['E', rootEventId, '', rootEventAuthorPubkey],
+    // Include A tag for addressable events (Kind 30000-39999)
+    // This ensures comments can be found by clients querying by either
+    // E or A. NIP-22: A tags use 3 elements [A, address, relay_hint]
+    if (rootAddressableId != null && rootAddressableId.isNotEmpty)
+      ['A', rootAddressableId, ''],
+    ['K', rootEventKind.toString()],
+    ['P', rootEventAuthorPubkey],
+    // Parent item tags (lowercase)
+    if (replyToEventId != null && replyToAuthorPubkey != null) ...[
+      // Replying to another comment
+      ['e', replyToEventId, '', replyToAuthorPubkey],
+      ['k', _commentKind.toString()],
+      ['p', replyToAuthorPubkey],
+    ] else ...[
+      // Top-level comment - parent is the same as root
+      ['e', rootEventId, '', rootEventAuthorPubkey],
+      // Include lowercase 'a' tag for addressable events too
+      // NIP-22: a tags use 3 elements [a, address, relay_hint]
+      if (rootAddressableId != null && rootAddressableId.isNotEmpty)
+        ['a', rootAddressableId, ''],
+      ['k', rootEventKind.toString()],
+      ['p', rootEventAuthorPubkey],
+    ],
+  ];
 
   /// Converts a Nostr event to a Comment model using NIP-22 format.
   Comment? _eventToComment(Event event, String rootEventId, int rootEventKind) {

--- a/mobile/packages/comments_repository/lib/src/models/comment.dart
+++ b/mobile/packages/comments_repository/lib/src/models/comment.dart
@@ -29,6 +29,7 @@ class Comment extends Equatable {
     this.videoDimensions,
     this.videoDuration,
     this.videoBlurhash,
+    this.emojiTags = const {},
   });
 
   /// Unique comment ID (Nostr event ID).
@@ -60,6 +61,12 @@ class Comment extends Equatable {
   /// URL of an attached video (NIP-92 imeta).
   final String? videoUrl;
 
+  /// NIP-30 custom emoji tags: shortcode → imageUrl.
+  ///
+  /// Populated from `["emoji", shortcode, url]` tags in the Nostr event.
+  /// Used to render sticker comments as images instead of text.
+  final Map<String, String> emojiTags;
+
   /// Thumbnail URL for the attached video (NIP-92 imeta `image` field).
   final String? thumbnailUrl;
 
@@ -90,6 +97,7 @@ class Comment extends Equatable {
     String? videoDimensions,
     int? videoDuration,
     String? videoBlurhash,
+    Map<String, String>? emojiTags,
   }) => Comment(
     id: id ?? this.id,
     content: content ?? this.content,
@@ -104,6 +112,7 @@ class Comment extends Equatable {
     videoDimensions: videoDimensions ?? this.videoDimensions,
     videoDuration: videoDuration ?? this.videoDuration,
     videoBlurhash: videoBlurhash ?? this.videoBlurhash,
+    emojiTags: emojiTags ?? this.emojiTags,
   );
 
   @override
@@ -121,5 +130,6 @@ class Comment extends Equatable {
     videoDimensions,
     videoDuration,
     videoBlurhash,
+    emojiTags,
   ];
 }

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -1286,6 +1286,178 @@ void main() {
           throwsA(isA<PostCommentFailedException>()),
         );
       });
+
+      group('input validation', () {
+        test('throws for empty shortcode', () {
+          expect(
+            () => repository.postStickerComment(
+              stickerShortcode: '',
+              stickerImageUrl: 'https://cdn.example.com/fire.png',
+              rootEventId: testRootEventId,
+              rootEventKind: _testRootEventKind,
+              rootEventAuthorPubkey: testRootAuthorPubkey,
+            ),
+            throwsA(isA<PostCommentFailedException>()),
+          );
+        });
+
+        test('throws for shortcode with hyphens', () {
+          expect(
+            () => repository.postStickerComment(
+              stickerShortcode: 'my-sticker',
+              stickerImageUrl: 'https://cdn.example.com/fire.png',
+              rootEventId: testRootEventId,
+              rootEventKind: _testRootEventKind,
+              rootEventAuthorPubkey: testRootAuthorPubkey,
+            ),
+            throwsA(isA<PostCommentFailedException>()),
+          );
+        });
+
+        test('throws for shortcode with spaces', () {
+          expect(
+            () => repository.postStickerComment(
+              stickerShortcode: 'my sticker',
+              stickerImageUrl: 'https://cdn.example.com/fire.png',
+              rootEventId: testRootEventId,
+              rootEventKind: _testRootEventKind,
+              rootEventAuthorPubkey: testRootAuthorPubkey,
+            ),
+            throwsA(isA<PostCommentFailedException>()),
+          );
+        });
+
+        test('accepts valid shortcode', () async {
+          when(
+            () => mockNostrClient.publishEvent(any()),
+          ).thenAnswer(
+            (inv) async => inv.positionalArguments.first as Event,
+          );
+
+          final result = await repository.postStickerComment(
+            stickerShortcode: 'my_sticker_123',
+            stickerImageUrl: 'https://cdn.example.com/fire.png',
+            rootEventId: testRootEventId,
+            rootEventKind: _testRootEventKind,
+            rootEventAuthorPubkey: testRootAuthorPubkey,
+          );
+
+          expect(result.content, equals(':my_sticker_123:'));
+        });
+
+        test('throws for http URL (non-https)', () {
+          expect(
+            () => repository.postStickerComment(
+              stickerShortcode: 'fire',
+              stickerImageUrl: 'http://cdn.example.com/fire.png',
+              rootEventId: testRootEventId,
+              rootEventKind: _testRootEventKind,
+              rootEventAuthorPubkey: testRootAuthorPubkey,
+            ),
+            throwsA(isA<PostCommentFailedException>()),
+          );
+        });
+
+        test('throws for unparseable URL', () {
+          expect(
+            () => repository.postStickerComment(
+              stickerShortcode: 'fire',
+              stickerImageUrl: ':::not-a-url',
+              rootEventId: testRootEventId,
+              rootEventKind: _testRootEventKind,
+              rootEventAuthorPubkey: testRootAuthorPubkey,
+            ),
+            throwsA(isA<PostCommentFailedException>()),
+          );
+        });
+      });
+    });
+
+    group('NIP-30 emoji tag parsing', () {
+      test('parses single emoji tag from comment event', () async {
+        final commentEvent = _createCommentEvent(
+          id: 'emoji_comment_1',
+          content: ':fire:',
+          pubkey: testUserPubkey,
+          rootEventId: testRootEventId,
+          rootAuthorPubkey: testRootAuthorPubkey,
+          rootEventKind: _testRootEventKind,
+          extraTags: [
+            ['emoji', 'fire', 'https://cdn.example.com/fire.png'],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [commentEvent]);
+
+        final thread = await repository.loadComments(
+          rootEventId: testRootEventId,
+          rootEventKind: _testRootEventKind,
+        );
+
+        expect(thread.comments, hasLength(1));
+        expect(
+          thread.comments.first.emojiTags,
+          equals({'fire': 'https://cdn.example.com/fire.png'}),
+        );
+      });
+
+      test('parses multiple emoji tags from comment event', () async {
+        final commentEvent = _createCommentEvent(
+          id: 'emoji_comment_2',
+          content: ':fire: :wave:',
+          pubkey: testUserPubkey,
+          rootEventId: testRootEventId,
+          rootAuthorPubkey: testRootAuthorPubkey,
+          rootEventKind: _testRootEventKind,
+          extraTags: [
+            ['emoji', 'fire', 'https://cdn.example.com/fire.png'],
+            ['emoji', 'wave', 'https://cdn.example.com/wave.png'],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [commentEvent]);
+
+        final thread = await repository.loadComments(
+          rootEventId: testRootEventId,
+          rootEventKind: _testRootEventKind,
+        );
+
+        expect(thread.comments, hasLength(1));
+        expect(
+          thread.comments.first.emojiTags,
+          equals({
+            'fire': 'https://cdn.example.com/fire.png',
+            'wave': 'https://cdn.example.com/wave.png',
+          }),
+        );
+      });
+
+      test('returns empty emojiTags when no emoji tags present', () async {
+        final commentEvent = _createCommentEvent(
+          id: 'no_emoji_comment',
+          content: 'Just a regular comment',
+          pubkey: testUserPubkey,
+          rootEventId: testRootEventId,
+          rootAuthorPubkey: testRootAuthorPubkey,
+          rootEventKind: _testRootEventKind,
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [commentEvent]);
+
+        final thread = await repository.loadComments(
+          rootEventId: testRootEventId,
+          rootEventKind: _testRootEventKind,
+        );
+
+        expect(thread.comments, hasLength(1));
+        expect(thread.comments.first.emojiTags, isEmpty);
+      });
     });
 
     group('getCommentsCount', () {
@@ -2054,6 +2226,7 @@ Event _createCommentEvent({
   String? replyToEventId,
   String? replyToAuthorPubkey,
   int createdAt = 1000,
+  List<List<String>> extraTags = const [],
 }) {
   // NIP-22 tags:
   // Uppercase tags (E, K, P) = root scope
@@ -2075,6 +2248,7 @@ Event _createCommentEvent({
       ['k', rootEventKind.toString()],
       ['p', rootAuthorPubkey],
     ],
+    ...extraTags,
   ];
 
   return Event(pubkey, _commentKind, tags, content, createdAt: createdAt)

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -1071,6 +1071,223 @@ void main() {
       });
     });
 
+    group('postStickerComment', () {
+      const testShortcode = 'fire';
+      const testStickerUrl = 'https://blossom.example.com/fire.webp';
+
+      test('posts sticker comment with correct :shortcode: content', () async {
+        Event? capturedEvent;
+
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
+          return capturedEvent = inv.positionalArguments.first as Event;
+        });
+
+        await repository.postStickerComment(
+          stickerShortcode: testShortcode,
+          stickerImageUrl: testStickerUrl,
+          rootEventId: testRootEventId,
+          rootEventKind: _testRootEventKind,
+          rootEventAuthorPubkey: testRootAuthorPubkey,
+        );
+
+        expect(capturedEvent, isNotNull);
+        expect(capturedEvent!.kind, equals(_commentKind));
+        expect(capturedEvent!.content, equals(':$testShortcode:'));
+      });
+
+      test('includes NIP-30 emoji tag', () async {
+        Event? capturedEvent;
+
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
+          return capturedEvent = inv.positionalArguments.first as Event;
+        });
+
+        await repository.postStickerComment(
+          stickerShortcode: testShortcode,
+          stickerImageUrl: testStickerUrl,
+          rootEventId: testRootEventId,
+          rootEventKind: _testRootEventKind,
+          rootEventAuthorPubkey: testRootAuthorPubkey,
+        );
+
+        final emojiTags = capturedEvent!.tags
+            .cast<List<dynamic>>()
+            .where((t) => t[0] == 'emoji')
+            .toList();
+
+        expect(emojiTags, hasLength(1));
+        expect(emojiTags.first[1], equals(testShortcode));
+        expect(emojiTags.first[2], equals(testStickerUrl));
+      });
+
+      test('includes correct NIP-22 threading tags (top-level)', () async {
+        Event? capturedEvent;
+
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
+          return capturedEvent = inv.positionalArguments.first as Event;
+        });
+
+        await repository.postStickerComment(
+          stickerShortcode: testShortcode,
+          stickerImageUrl: testStickerUrl,
+          rootEventId: testRootEventId,
+          rootEventKind: _testRootEventKind,
+          rootEventAuthorPubkey: testRootAuthorPubkey,
+        );
+
+        // Root scope tags (uppercase)
+        final uppercaseETags = capturedEvent!.tags
+            .cast<List<dynamic>>()
+            .where((t) => t[0] == 'E')
+            .toList();
+        final uppercaseKTags = capturedEvent!.tags
+            .cast<List<dynamic>>()
+            .where((t) => t[0] == 'K')
+            .toList();
+        final uppercasePTags = capturedEvent!.tags
+            .cast<List<dynamic>>()
+            .where((t) => t[0] == 'P')
+            .toList();
+
+        expect(uppercaseETags, hasLength(1));
+        expect(uppercaseETags.first[1], equals(testRootEventId));
+        expect(uppercaseKTags, hasLength(1));
+        expect(
+          uppercaseKTags.first[1],
+          equals(_testRootEventKind.toString()),
+        );
+        expect(uppercasePTags, hasLength(1));
+        expect(uppercasePTags.first[1], equals(testRootAuthorPubkey));
+
+        // Parent item tags (lowercase) - same as root for top-level
+        final lowercaseETags = capturedEvent!.tags
+            .cast<List<dynamic>>()
+            .where((t) => t[0] == 'e')
+            .toList();
+        final lowercaseKTags = capturedEvent!.tags
+            .cast<List<dynamic>>()
+            .where((t) => t[0] == 'k')
+            .toList();
+        final lowercasePTags = capturedEvent!.tags
+            .cast<List<dynamic>>()
+            .where((t) => t[0] == 'p')
+            .toList();
+
+        expect(lowercaseETags, hasLength(1));
+        expect(lowercaseETags.first[1], equals(testRootEventId));
+        expect(lowercaseKTags, hasLength(1));
+        expect(
+          lowercaseKTags.first[1],
+          equals(_testRootEventKind.toString()),
+        );
+        expect(lowercasePTags, hasLength(1));
+        expect(lowercasePTags.first[1], equals(testRootAuthorPubkey));
+      });
+
+      test('includes correct NIP-22 threading tags (reply)', () async {
+        Event? capturedEvent;
+        const parentCommentId =
+            'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+            'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+        const parentAuthorPubkey =
+            'ffffffffffffffffffffffffffffffff'
+            'ffffffffffffffffffffffffffffffff';
+
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
+          return capturedEvent = inv.positionalArguments.first as Event;
+        });
+
+        await repository.postStickerComment(
+          stickerShortcode: testShortcode,
+          stickerImageUrl: testStickerUrl,
+          rootEventId: testRootEventId,
+          rootEventKind: _testRootEventKind,
+          rootEventAuthorPubkey: testRootAuthorPubkey,
+          replyToEventId: parentCommentId,
+          replyToAuthorPubkey: parentAuthorPubkey,
+        );
+
+        // Parent item tags (lowercase) - point to parent comment
+        final lowercaseETags = capturedEvent!.tags
+            .cast<List<dynamic>>()
+            .where((t) => t[0] == 'e')
+            .toList();
+        final lowercaseKTags = capturedEvent!.tags
+            .cast<List<dynamic>>()
+            .where((t) => t[0] == 'k')
+            .toList();
+        final lowercasePTags = capturedEvent!.tags
+            .cast<List<dynamic>>()
+            .where((t) => t[0] == 'p')
+            .toList();
+
+        expect(lowercaseETags, hasLength(1));
+        expect(lowercaseETags.first[1], equals(parentCommentId));
+        expect(lowercaseKTags, hasLength(1));
+        expect(lowercaseKTags.first[1], equals(_commentKind.toString()));
+        expect(lowercasePTags, hasLength(1));
+        expect(lowercasePTags.first[1], equals(parentAuthorPubkey));
+      });
+
+      test('returns Comment with emojiTags populated', () async {
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
+          return inv.positionalArguments.first as Event
+            ..id = 'sticker_event_id';
+        });
+
+        final result = await repository.postStickerComment(
+          stickerShortcode: testShortcode,
+          stickerImageUrl: testStickerUrl,
+          rootEventId: testRootEventId,
+          rootEventKind: _testRootEventKind,
+          rootEventAuthorPubkey: testRootAuthorPubkey,
+        );
+
+        expect(result.content, equals(':$testShortcode:'));
+        expect(result.rootEventId, equals(testRootEventId));
+        expect(result.rootAuthorPubkey, equals(testRootAuthorPubkey));
+        expect(result.authorPubkey, equals(testUserPubkey));
+        expect(result.emojiTags, equals({testShortcode: testStickerUrl}));
+      });
+
+      test(
+        'throws PostCommentFailedException when publish returns null',
+        () async {
+          when(
+            () => mockNostrClient.publishEvent(any()),
+          ).thenAnswer((_) async => null);
+
+          expect(
+            () => repository.postStickerComment(
+              stickerShortcode: testShortcode,
+              stickerImageUrl: testStickerUrl,
+              rootEventId: testRootEventId,
+              rootEventKind: _testRootEventKind,
+              rootEventAuthorPubkey: testRootAuthorPubkey,
+            ),
+            throwsA(isA<PostCommentFailedException>()),
+          );
+        },
+      );
+
+      test('throws PostCommentFailedException on exception', () async {
+        when(
+          () => mockNostrClient.publishEvent(any()),
+        ).thenThrow(Exception('Network error'));
+
+        expect(
+          () => repository.postStickerComment(
+            stickerShortcode: testShortcode,
+            stickerImageUrl: testStickerUrl,
+            rootEventId: testRootEventId,
+            rootEventKind: _testRootEventKind,
+            rootEventAuthorPubkey: testRootAuthorPubkey,
+          ),
+          throwsA(isA<PostCommentFailedException>()),
+        );
+      });
+    });
+
     group('getCommentsCount', () {
       test('returns count from NIP-45', () async {
         when(() => mockNostrClient.countEvents(any())).thenAnswer(

--- a/mobile/packages/comments_repository/test/src/models/comment_test.dart
+++ b/mobile/packages/comments_repository/test/src/models/comment_test.dart
@@ -199,6 +199,7 @@ void main() {
             '1080x1920',
             30,
             'LEHV6nWB2y',
+            <String, String>{},
           ]),
         );
       });

--- a/mobile/packages/nostr_sdk/lib/event_kind.dart
+++ b/mobile/packages/nostr_sdk/lib/event_kind.dart
@@ -93,6 +93,8 @@ class EventKind {
 
   static const int emojisList = 10030;
 
+  static const int emojiSet = 30030;
+
   static const int nwcInfoEvent = 13194;
 
   static const int authentication = 22242;

--- a/mobile/packages/sticker_pack_repository/analysis_options.yaml
+++ b/mobile/packages/sticker_pack_repository/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:very_good_analysis/analysis_options.yaml

--- a/mobile/packages/sticker_pack_repository/lib/src/exceptions.dart
+++ b/mobile/packages/sticker_pack_repository/lib/src/exceptions.dart
@@ -1,0 +1,26 @@
+// ABOUTME: Custom exceptions for the sticker pack repository.
+// ABOUTME: Provides typed exceptions for specific failure cases
+// ABOUTME: to enable precise error handling by consumers.
+
+/// Base exception for all sticker pack repository errors.
+abstract class StickerPackRepositoryException implements Exception {
+  /// Creates a new sticker pack repository exception.
+  const StickerPackRepositoryException([this.message]);
+
+  /// The error message.
+  final String? message;
+
+  @override
+  String toString() {
+    if (message != null) {
+      return '$runtimeType: $message';
+    }
+    return runtimeType.toString();
+  }
+}
+
+/// Exception thrown when loading sticker packs fails.
+class LoadStickerPacksFailedException extends StickerPackRepositoryException {
+  /// Creates a new load sticker packs failed exception.
+  const LoadStickerPacksFailedException([super.message]);
+}

--- a/mobile/packages/sticker_pack_repository/lib/src/models/models.dart
+++ b/mobile/packages/sticker_pack_repository/lib/src/models/models.dart
@@ -1,0 +1,2 @@
+export 'sticker.dart';
+export 'sticker_pack.dart';

--- a/mobile/packages/sticker_pack_repository/lib/src/models/sticker.dart
+++ b/mobile/packages/sticker_pack_repository/lib/src/models/sticker.dart
@@ -1,0 +1,31 @@
+// ABOUTME: Model representing a single sticker within a sticker pack.
+// ABOUTME: Contains a shortcode (NIP-30 emoji name) and the image URL
+// ABOUTME: hosted on a Blossom server.
+
+import 'package:equatable/equatable.dart';
+
+/// A single sticker from a sticker pack.
+///
+/// Maps to a single `emoji` tag in a Kind 30030 event:
+/// `["emoji", shortcode, imageUrl]`
+///
+/// Used in comments as NIP-30 custom emoji: `:shortcode:` in content
+/// with a corresponding `["emoji", shortcode, imageUrl]` tag.
+class Sticker extends Equatable {
+  /// Creates a new sticker.
+  const Sticker({
+    required this.shortcode,
+    required this.imageUrl,
+  });
+
+  /// The emoji shortcode (e.g., "fire", "love").
+  ///
+  /// Used in NIP-30 syntax as `:shortcode:` in event content.
+  final String shortcode;
+
+  /// URL of the sticker image, typically hosted on a Blossom server.
+  final String imageUrl;
+
+  @override
+  List<Object> get props => [shortcode, imageUrl];
+}

--- a/mobile/packages/sticker_pack_repository/lib/src/models/sticker_pack.dart
+++ b/mobile/packages/sticker_pack_repository/lib/src/models/sticker_pack.dart
@@ -1,0 +1,42 @@
+// ABOUTME: Model representing a curated sticker pack (Kind 30030 emoji set).
+// ABOUTME: Contains pack metadata and a list of Sticker models parsed from
+// ABOUTME: emoji tags in the Nostr event.
+
+import 'package:equatable/equatable.dart';
+import 'package:sticker_pack_repository/src/models/sticker.dart';
+
+/// A sticker pack parsed from a Kind 30030 addressable event (NIP-51).
+///
+/// Each pack is published by Divine's pubkey and contains:
+/// - A `d` tag as the unique identifier
+/// - A `title` tag for the human-readable name
+/// - An optional `image` tag for the pack thumbnail
+/// - Multiple `emoji` tags, each defining a sticker
+class StickerPack extends Equatable {
+  /// Creates a new sticker pack.
+  const StickerPack({
+    required this.id,
+    required this.title,
+    required this.stickers,
+    required this.authorPubkey,
+    this.imageUrl,
+  });
+
+  /// Unique identifier from the `d` tag of the Kind 30030 event.
+  final String id;
+
+  /// Human-readable title from the `title` tag.
+  final String title;
+
+  /// Optional pack thumbnail URL from the `image` tag.
+  final String? imageUrl;
+
+  /// Stickers in this pack, parsed from `emoji` tags.
+  final List<Sticker> stickers;
+
+  /// Public key of the pack author (hex format).
+  final String authorPubkey;
+
+  @override
+  List<Object?> get props => [id, title, imageUrl, stickers, authorPubkey];
+}

--- a/mobile/packages/sticker_pack_repository/lib/src/sticker_pack_repository.dart
+++ b/mobile/packages/sticker_pack_repository/lib/src/sticker_pack_repository.dart
@@ -1,0 +1,297 @@
+// ABOUTME: Repository for loading sticker packs from Nostr relays.
+// ABOUTME: Discovers emoji sets from multiple curator pubkeys AND the user's
+// ABOUTME: Kind 10030 emoji list (NIP-51 "a" tag pointers to Kind 30030 sets).
+
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:sticker_pack_repository/src/exceptions.dart';
+import 'package:sticker_pack_repository/src/models/models.dart';
+
+/// Kind 30030 is a NIP-51 emoji set (addressable event).
+const int _emojiSetKind = 30030;
+
+/// Kind 10030 is a NIP-51 user emoji list (replaceable event).
+///
+/// Contains `"a"` tags pointing to Kind 30030 emoji sets the user subscribes
+/// to, formatted as `["a", "30030:<pubkey>:<d-tag>"]`.
+const int _userEmojiListKind = 10030;
+
+/// A parsed `"a"` tag reference from a Kind 10030 event.
+///
+/// Format: `["a", "30030:<pubkey>:<d-tag>"]`
+class _ATagReference {
+  const _ATagReference({required this.pubkey, required this.dTag});
+
+  final String pubkey;
+  final String dTag;
+}
+
+/// Default limit for broad discovery queries.
+///
+/// Caps the number of Kind 30030 events fetched from relays when discovering
+/// packs without author restrictions.
+const int _discoveryLimit = 50;
+
+/// Repository for loading Nostr sticker packs from multiple sources.
+///
+/// Discovers Kind 30030 emoji sets from three sources (in parallel):
+/// 1. **Curated packs** — queried by curator pubkeys (e.g. Divine team)
+/// 2. **User-subscribed packs** — resolved from the user's Kind 10030 emoji
+///    list, which contains `"a"` tag pointers to Kind 30030 sets
+/// 3. **Broad discovery** — queries Kind 30030 from all connected relays
+///    without author restriction (capped at [_discoveryLimit])
+///
+/// Sticker packs are parsed from Nostr event tags:
+/// - `d` tag: unique pack identifier
+/// - `name` or `title` tag: human-readable name
+/// - `picture` or `image` tag: optional pack thumbnail
+/// - `emoji` tags: individual stickers (`["emoji", shortcode, imageUrl]`)
+class StickerPackRepository {
+  /// Creates a new sticker pack repository.
+  ///
+  /// Parameters:
+  /// - [nostrClient]: Client for Nostr relay communication
+  /// - [curatorPubkeys]: Hex pubkeys of sticker pack curators
+  /// - [userPubkey]: Optional hex pubkey of the current user; when provided,
+  ///   the repository also fetches packs from the user's Kind 10030 emoji list
+  StickerPackRepository({
+    required NostrClient nostrClient,
+    required List<String> curatorPubkeys,
+    String? userPubkey,
+    List<String> discoveryRelays = const [],
+  }) : _nostrClient = nostrClient,
+       _curatorPubkeys = curatorPubkeys,
+       _userPubkey = userPubkey,
+       _discoveryRelays = discoveryRelays;
+
+  final NostrClient _nostrClient;
+  final List<String> _curatorPubkeys;
+  final String? _userPubkey;
+
+  /// General-purpose relay URLs used for discovering Kind 30030 emoji sets.
+  ///
+  /// The app's primary relay may be specialized (e.g. video-only) and not
+  /// store emoji sets. These relays are queried via `tempRelays` to find
+  /// packs from the broader Nostr network.
+  final List<String> _discoveryRelays;
+
+  /// Cached sticker packs from the last successful load.
+  List<StickerPack>? _cachedPacks;
+
+  /// Loads sticker packs from all sources.
+  ///
+  /// Queries three sources in parallel:
+  /// 1. Curated packs from [_curatorPubkeys]
+  /// 2. User-subscribed packs from Kind 10030 emoji list
+  /// 3. Broad discovery from connected relays (no author filter)
+  ///
+  /// Results are merged and deduplicated by `authorPubkey:id` composite key.
+  /// Curated and user-subscribed packs take priority over discovered packs.
+  ///
+  /// Returns a list of [StickerPack] models.
+  ///
+  /// Throws [LoadStickerPacksFailedException] if the query fails.
+  Future<List<StickerPack>> loadStickerPacks() async {
+    if (_cachedPacks != null) return _cachedPacks!;
+
+    try {
+      final results = await Future.wait([
+        _loadCuratedPacks(),
+        _loadUserSubscribedPacks(),
+        _discoverPacks(),
+      ]);
+
+      final allPacks = <String, StickerPack>{};
+      for (final packList in results) {
+        for (final pack in packList) {
+          final key = '${pack.authorPubkey}:${pack.id}';
+          allPacks.putIfAbsent(key, () => pack);
+        }
+      }
+
+      _cachedPacks = allPacks.values.toList();
+      return _cachedPacks!;
+    } on Exception catch (e) {
+      throw LoadStickerPacksFailedException(
+        'Failed to load sticker packs: $e',
+      );
+    }
+  }
+
+  /// Loads curated packs from all curator pubkeys.
+  Future<List<StickerPack>> _loadCuratedPacks() async {
+    if (_curatorPubkeys.isEmpty) return [];
+
+    final filter = Filter(
+      kinds: const [_emojiSetKind],
+      authors: _curatorPubkeys,
+    );
+
+    final events = await _nostrClient.queryEvents([filter]);
+    return _eventsToStickerPacks(events);
+  }
+
+  /// Loads packs the user subscribes to via their Kind 10030 emoji list.
+  ///
+  /// 1. Fetches the user's Kind 10030 event
+  /// 2. Parses `"a"` tags to get Kind 30030 references
+  /// 3. Groups references by author pubkey and queries Kind 30030 events
+  Future<List<StickerPack>> _loadUserSubscribedPacks() async {
+    final userPubkey = _userPubkey;
+    if (userPubkey == null) return [];
+
+    final emojiListFilter = Filter(
+      kinds: const [_userEmojiListKind],
+      authors: [userPubkey],
+    );
+
+    final emojiListEvents = await _nostrClient.queryEvents([emojiListFilter]);
+    if (emojiListEvents.isEmpty) return [];
+
+    // Use the most recent Kind 10030 event (replaceable event).
+    emojiListEvents.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    final refs = _parseATagReferences(emojiListEvents.first);
+    if (refs.isEmpty) return [];
+
+    // Group by author pubkey so we can batch queries.
+    final byAuthor = <String, List<String>>{};
+    for (final ref in refs) {
+      byAuthor.putIfAbsent(ref.pubkey, () => []).add(ref.dTag);
+    }
+
+    final packs = <StickerPack>[];
+    for (final entry in byAuthor.entries) {
+      final filter = Filter(
+        kinds: const [_emojiSetKind],
+        authors: [entry.key],
+        d: entry.value,
+      );
+      final events = await _nostrClient.queryEvents([filter]);
+      packs.addAll(_eventsToStickerPacks(events));
+    }
+
+    return packs;
+  }
+
+  /// Discovers packs from general-purpose relays without author restriction.
+  ///
+  /// Queries [_discoveryRelays] via `tempRelays` since the app's primary
+  /// relay may be specialized (video-only) and not store Kind 30030 events.
+  /// Limited to [_discoveryLimit] events to avoid overwhelming the UI.
+  Future<List<StickerPack>> _discoverPacks() async {
+    if (_discoveryRelays.isEmpty) return [];
+
+    final filter = Filter(
+      kinds: const [_emojiSetKind],
+      limit: _discoveryLimit,
+    );
+
+    final events = await _nostrClient.queryEvents(
+      [filter],
+      tempRelays: List.of(_discoveryRelays),
+    );
+    return _eventsToStickerPacks(events);
+  }
+
+  /// Parses `"a"` tags from a Kind 10030 event into [_ATagReference]s.
+  ///
+  /// Only tags matching the format `"30030:<pubkey>:<d-tag>"` are returned.
+  /// Malformed tags are silently skipped.
+  List<_ATagReference> _parseATagReferences(Event event) {
+    final refs = <_ATagReference>[];
+    for (final rawTag in event.tags) {
+      final tag = rawTag as List<dynamic>;
+      if (tag.length < 2) continue;
+      if (tag[0] as String != 'a') continue;
+
+      final value = tag[1] as String;
+      final parts = value.split(':');
+      if (parts.length < 3) continue;
+      if (parts[0] != '$_emojiSetKind') continue;
+
+      final pubkey = parts[1];
+      final dTag = parts.sublist(2).join(':');
+      if (pubkey.isEmpty || dTag.isEmpty) continue;
+
+      refs.add(_ATagReference(pubkey: pubkey, dTag: dTag));
+    }
+    return refs;
+  }
+
+  /// Converts a list of events to sticker packs, filtering out invalid ones.
+  List<StickerPack> _eventsToStickerPacks(List<Event> events) {
+    return events
+        .map(_eventToStickerPack)
+        .where((pack) => pack != null && pack.stickers.isNotEmpty)
+        .cast<StickerPack>()
+        .toList();
+  }
+
+  /// Returns a specific sticker pack by its `d` tag identifier.
+  ///
+  /// Requires [loadStickerPacks] to have been called first.
+  /// Returns `null` if no pack with the given [id] exists.
+  StickerPack? getStickerPack(String id) {
+    if (_cachedPacks == null) return null;
+    for (final pack in _cachedPacks!) {
+      if (pack.id == id) return pack;
+    }
+    return null;
+  }
+
+  /// Clears the cached sticker packs, forcing a fresh fetch on next load.
+  void clearCache() {
+    _cachedPacks = null;
+  }
+
+  /// Parses a Kind 30030 Nostr event into a [StickerPack].
+  ///
+  /// Returns `null` if the event cannot be parsed.
+  StickerPack? _eventToStickerPack(Event event) {
+    try {
+      String? dTag;
+      String? title;
+      String? imageUrl;
+      final stickers = <Sticker>[];
+
+      for (final rawTag in event.tags) {
+        final tag = rawTag as List<dynamic>;
+        if (tag.length < 2) continue;
+
+        final tagType = tag[0] as String;
+
+        switch (tagType) {
+          case 'd':
+            dTag = tag[1] as String;
+          // NIP-51 spec uses `name`; some clients use `title`.
+          case 'name' || 'title':
+            title ??= tag[1] as String;
+          // NIP-51 spec uses `picture`; some clients use `image`.
+          case 'picture' || 'image':
+            imageUrl ??= tag[1] as String;
+          case 'emoji':
+            if (tag.length >= 3) {
+              stickers.add(
+                Sticker(
+                  shortcode: tag[1] as String,
+                  imageUrl: tag[2] as String,
+                ),
+              );
+            }
+        }
+      }
+
+      if (dTag == null || dTag.isEmpty) return null;
+
+      return StickerPack(
+        id: dTag,
+        title: title ?? dTag,
+        imageUrl: imageUrl,
+        stickers: stickers,
+        authorPubkey: event.pubkey,
+      );
+    } on Exception {
+      return null;
+    }
+  }
+}

--- a/mobile/packages/sticker_pack_repository/lib/src/sticker_pack_repository.dart
+++ b/mobile/packages/sticker_pack_repository/lib/src/sticker_pack_repository.dart
@@ -7,15 +7,6 @@ import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:sticker_pack_repository/src/exceptions.dart';
 import 'package:sticker_pack_repository/src/models/models.dart';
 
-/// Kind 30030 is a NIP-51 emoji set (addressable event).
-const int _emojiSetKind = 30030;
-
-/// Kind 10030 is a NIP-51 user emoji list (replaceable event).
-///
-/// Contains `"a"` tags pointing to Kind 30030 emoji sets the user subscribes
-/// to, formatted as `["a", "30030:<pubkey>:<d-tag>"]`.
-const int _userEmojiListKind = 10030;
-
 /// A parsed `"a"` tag reference from a Kind 10030 event.
 ///
 /// Format: `["a", "30030:<pubkey>:<d-tag>"]`
@@ -90,32 +81,49 @@ class StickerPackRepository {
   ///
   /// Returns a list of [StickerPack] models.
   ///
-  /// Throws [LoadStickerPacksFailedException] if the query fails.
+  /// Individual source failures are tolerated — partial results are returned
+  /// when at least one source succeeds.
+  ///
+  /// Throws [LoadStickerPacksFailedException] only when ALL sources fail.
   Future<List<StickerPack>> loadStickerPacks() async {
     if (_cachedPacks != null) return _cachedPacks!;
 
-    try {
-      final results = await Future.wait([
-        _loadCuratedPacks(),
-        _loadUserSubscribedPacks(),
-        _discoverPacks(),
-      ]);
+    final futures = [
+      _loadCuratedPacks(),
+      _loadUserSubscribedPacks(),
+      _discoverPacks(),
+    ];
 
-      final allPacks = <String, StickerPack>{};
-      for (final packList in results) {
-        for (final pack in packList) {
-          final key = '${pack.authorPubkey}:${pack.id}';
-          allPacks.putIfAbsent(key, () => pack);
-        }
+    final results = await Future.wait(
+      futures.map(
+        (f) => f
+            .then<(List<StickerPack>, Object?)>((packs) => (packs, null))
+            .onError<Object>((e, _) => (const <StickerPack>[], e)),
+      ),
+    );
+
+    final allPacks = <String, StickerPack>{};
+    var failureCount = 0;
+
+    for (final (packList, error) in results) {
+      if (error != null) {
+        failureCount++;
+        continue;
       }
+      for (final pack in packList) {
+        final key = '${pack.authorPubkey}:${pack.id}';
+        allPacks.putIfAbsent(key, () => pack);
+      }
+    }
 
-      _cachedPacks = allPacks.values.toList();
-      return _cachedPacks!;
-    } on Exception catch (e) {
-      throw LoadStickerPacksFailedException(
-        'Failed to load sticker packs: $e',
+    if (failureCount == futures.length) {
+      throw const LoadStickerPacksFailedException(
+        'All sticker pack sources failed',
       );
     }
+
+    _cachedPacks = allPacks.values.toList();
+    return _cachedPacks!;
   }
 
   /// Loads curated packs from all curator pubkeys.
@@ -123,7 +131,7 @@ class StickerPackRepository {
     if (_curatorPubkeys.isEmpty) return [];
 
     final filter = Filter(
-      kinds: const [_emojiSetKind],
+      kinds: const [EventKind.emojiSet],
       authors: _curatorPubkeys,
     );
 
@@ -141,7 +149,7 @@ class StickerPackRepository {
     if (userPubkey == null) return [];
 
     final emojiListFilter = Filter(
-      kinds: const [_userEmojiListKind],
+      kinds: const [EventKind.emojisList],
       authors: [userPubkey],
     );
 
@@ -159,18 +167,18 @@ class StickerPackRepository {
       byAuthor.putIfAbsent(ref.pubkey, () => []).add(ref.dTag);
     }
 
-    final packs = <StickerPack>[];
-    for (final entry in byAuthor.entries) {
-      final filter = Filter(
-        kinds: const [_emojiSetKind],
-        authors: [entry.key],
-        d: entry.value,
-      );
-      final events = await _nostrClient.queryEvents([filter]);
-      packs.addAll(_eventsToStickerPacks(events));
-    }
-
-    return packs;
+    final perAuthorPacks = await Future.wait(
+      byAuthor.entries.map((entry) async {
+        final filter = Filter(
+          kinds: const [EventKind.emojiSet],
+          authors: [entry.key],
+          d: entry.value,
+        );
+        final events = await _nostrClient.queryEvents([filter]);
+        return _eventsToStickerPacks(events);
+      }),
+    );
+    return [for (final list in perAuthorPacks) ...list];
   }
 
   /// Discovers packs from general-purpose relays without author restriction.
@@ -182,7 +190,7 @@ class StickerPackRepository {
     if (_discoveryRelays.isEmpty) return [];
 
     final filter = Filter(
-      kinds: const [_emojiSetKind],
+      kinds: const [EventKind.emojiSet],
       limit: _discoveryLimit,
     );
 
@@ -207,7 +215,7 @@ class StickerPackRepository {
       final value = tag[1] as String;
       final parts = value.split(':');
       if (parts.length < 3) continue;
-      if (parts[0] != '$_emojiSetKind') continue;
+      if (parts[0] != '${EventKind.emojiSet}') continue;
 
       final pubkey = parts[1];
       final dTag = parts.sublist(2).join(':');

--- a/mobile/packages/sticker_pack_repository/lib/src/sticker_pack_repository.dart
+++ b/mobile/packages/sticker_pack_repository/lib/src/sticker_pack_repository.dart
@@ -196,7 +196,7 @@ class StickerPackRepository {
 
     final events = await _nostrClient.queryEvents(
       [filter],
-      tempRelays: List.of(_discoveryRelays),
+      tempRelays: _discoveryRelays,
     );
     return _eventsToStickerPacks(events);
   }
@@ -276,15 +276,24 @@ class StickerPackRepository {
             title ??= tag[1] as String;
           // NIP-51 spec uses `picture`; some clients use `image`.
           case 'picture' || 'image':
-            imageUrl ??= tag[1] as String;
+            if (imageUrl == null) {
+              final url = tag[1] as String;
+              final uri = Uri.tryParse(url);
+              if (uri != null &&
+                  (uri.scheme == 'https' || uri.scheme == 'http')) {
+                imageUrl = url;
+              }
+            }
           case 'emoji':
             if (tag.length >= 3) {
-              stickers.add(
-                Sticker(
-                  shortcode: tag[1] as String,
-                  imageUrl: tag[2] as String,
-                ),
-              );
+              final url = tag[2] as String;
+              final uri = Uri.tryParse(url);
+              if (uri != null &&
+                  (uri.scheme == 'https' || uri.scheme == 'http')) {
+                stickers.add(
+                  Sticker(shortcode: tag[1] as String, imageUrl: url),
+                );
+              }
             }
         }
       }

--- a/mobile/packages/sticker_pack_repository/lib/src/sticker_pack_repository.dart
+++ b/mobile/packages/sticker_pack_repository/lib/src/sticker_pack_repository.dart
@@ -23,6 +23,9 @@ class _ATagReference {
 /// packs without author restrictions.
 const int _discoveryLimit = 50;
 
+/// NIP-30 shortcode validation: alphanumeric and underscores only.
+final _shortcodePattern = RegExp(r'^[a-zA-Z0-9_]+$');
+
 /// Repository for loading Nostr sticker packs from multiple sources.
 ///
 /// Discovers Kind 30030 emoji sets from three sources (in parallel):
@@ -279,19 +282,19 @@ class StickerPackRepository {
             if (imageUrl == null) {
               final url = tag[1] as String;
               final uri = Uri.tryParse(url);
-              if (uri != null &&
-                  (uri.scheme == 'https' || uri.scheme == 'http')) {
+              if (uri != null && uri.scheme == 'https') {
                 imageUrl = url;
               }
             }
           case 'emoji':
             if (tag.length >= 3) {
+              final shortcode = tag[1] as String;
+              if (!_shortcodePattern.hasMatch(shortcode)) continue;
               final url = tag[2] as String;
               final uri = Uri.tryParse(url);
-              if (uri != null &&
-                  (uri.scheme == 'https' || uri.scheme == 'http')) {
+              if (uri != null && uri.scheme == 'https') {
                 stickers.add(
-                  Sticker(shortcode: tag[1] as String, imageUrl: url),
+                  Sticker(shortcode: shortcode, imageUrl: url),
                 );
               }
             }

--- a/mobile/packages/sticker_pack_repository/lib/sticker_pack_repository.dart
+++ b/mobile/packages/sticker_pack_repository/lib/sticker_pack_repository.dart
@@ -1,0 +1,3 @@
+export 'src/exceptions.dart';
+export 'src/models/models.dart';
+export 'src/sticker_pack_repository.dart';

--- a/mobile/packages/sticker_pack_repository/pubspec.yaml
+++ b/mobile/packages/sticker_pack_repository/pubspec.yaml
@@ -1,0 +1,20 @@
+name: sticker_pack_repository
+description: Repository for loading curated Nostr sticker packs (Kind 30030 emoji sets).
+version: 0.1.0+1
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.11.0
+
+dependencies:
+  equatable: ^2.0.5
+  nostr_client:
+    path: ../nostr_client
+  nostr_sdk:
+    path: ../nostr_sdk
+
+dev_dependencies:
+  mocktail: ^1.0.4
+  test: ^1.26.3
+  very_good_analysis: ^10.0.0

--- a/mobile/packages/sticker_pack_repository/test/src/sticker_pack_repository_test.dart
+++ b/mobile/packages/sticker_pack_repository/test/src/sticker_pack_repository_test.dart
@@ -1029,7 +1029,7 @@ void main() {
           ],
         );
         // Append a title tag after name
-        (event.tags as List<List<String>>).add(['title', 'Title Tag']);
+        event.tags.add(['title', 'Title Tag']);
 
         when(
           () => mockNostrClient.queryEvents(any()),

--- a/mobile/packages/sticker_pack_repository/test/src/sticker_pack_repository_test.dart
+++ b/mobile/packages/sticker_pack_repository/test/src/sticker_pack_repository_test.dart
@@ -1,0 +1,976 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:sticker_pack_repository/sticker_pack_repository.dart';
+import 'package:test/test.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+const _testCuratorPubkey1 =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _testCuratorPubkey2 =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _testUserPubkey =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+const _externalAuthorPubkey =
+    'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+/// Kind 30030 — NIP-51 emoji set.
+const int _emojiSetKind = 30030;
+
+/// Kind 10030 — NIP-51 user emoji list.
+const int _userEmojiListKind = 10030;
+
+/// Counter to generate unique 64-char hex event IDs.
+int _eventIdCounter = 0;
+
+/// Generates a unique full-length 64-character hex event ID.
+String _generateEventId() {
+  _eventIdCounter++;
+  return _eventIdCounter.toRadixString(16).padLeft(64, '0');
+}
+
+Event _createEmojiSetEvent({
+  required String pubkey,
+  required String dTag,
+  String? title,
+  String? imageUrl,
+  List<List<String>> emojiTags = const [],
+  List<List<String>> extraTags = const [],
+  int createdAt = 1000,
+}) {
+  final tags = <List<String>>[
+    ['d', dTag],
+    if (title != null) ['title', title],
+    if (imageUrl != null) ['image', imageUrl],
+    ...emojiTags,
+    ...extraTags,
+  ];
+  return Event(pubkey, _emojiSetKind, tags, '', createdAt: createdAt)
+    ..id = _generateEventId();
+}
+
+/// Creates a Kind 30030 event using NIP-51 canonical tag names (`name`,
+/// `picture`) instead of the legacy `title`/`image` variants.
+Event _createNip51EmojiSetEvent({
+  required String pubkey,
+  required String dTag,
+  String? name,
+  String? pictureUrl,
+  List<List<String>> emojiTags = const [],
+  int createdAt = 1000,
+}) {
+  final tags = <List<String>>[
+    ['d', dTag],
+    if (name != null) ['name', name],
+    if (pictureUrl != null) ['picture', pictureUrl],
+    ...emojiTags,
+  ];
+  return Event(pubkey, _emojiSetKind, tags, '', createdAt: createdAt)
+    ..id = _generateEventId();
+}
+
+Event _createUserEmojiListEvent({
+  required String pubkey,
+  required List<String> aTagValues,
+  int createdAt = 1000,
+}) {
+  final tags = <List<String>>[
+    for (final value in aTagValues) ['a', value],
+  ];
+  return Event(pubkey, _userEmojiListKind, tags, '', createdAt: createdAt)
+    ..id = _generateEventId();
+}
+
+void main() {
+  group(StickerPackRepository, () {
+    late _MockNostrClient mockNostrClient;
+
+    setUpAll(() {
+      registerFallbackValue(<Filter>[]);
+    });
+
+    setUp(() {
+      mockNostrClient = _MockNostrClient();
+      _eventIdCounter = 0;
+    });
+
+    group('constructor', () {
+      test('creates repository with required parameters', () {
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+        expect(repo, isNotNull);
+      });
+
+      test('creates repository with optional userPubkey', () {
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+          userPubkey: _testUserPubkey,
+        );
+        expect(repo, isNotNull);
+      });
+    });
+
+    group('loadStickerPacks', () {
+      group('curated packs', () {
+        test('returns packs from a single curator', () async {
+          final event = _createEmojiSetEvent(
+            pubkey: _testCuratorPubkey1,
+            dTag: 'fire-pack',
+            title: 'Fire Pack',
+            emojiTags: [
+              ['emoji', 'fire', 'https://cdn.example.com/fire.png'],
+            ],
+          );
+
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [event]);
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: [_testCuratorPubkey1],
+          );
+
+          final packs = await repo.loadStickerPacks();
+
+          expect(packs, hasLength(1));
+          expect(packs.first.id, equals('fire-pack'));
+          expect(packs.first.title, equals('Fire Pack'));
+          expect(packs.first.authorPubkey, equals(_testCuratorPubkey1));
+          expect(packs.first.stickers, hasLength(1));
+          expect(packs.first.stickers.first.shortcode, equals('fire'));
+        });
+
+        test('returns packs from multiple curators', () async {
+          final event1 = _createEmojiSetEvent(
+            pubkey: _testCuratorPubkey1,
+            dTag: 'pack-a',
+            title: 'Pack A',
+            emojiTags: [
+              ['emoji', 'smile', 'https://cdn.example.com/smile.png'],
+            ],
+          );
+          final event2 = _createEmojiSetEvent(
+            pubkey: _testCuratorPubkey2,
+            dTag: 'pack-b',
+            title: 'Pack B',
+            emojiTags: [
+              ['emoji', 'wave', 'https://cdn.example.com/wave.png'],
+            ],
+          );
+
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [event1, event2]);
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: [_testCuratorPubkey1, _testCuratorPubkey2],
+          );
+
+          final packs = await repo.loadStickerPacks();
+
+          expect(packs, hasLength(2));
+          final ids = packs.map((p) => p.id).toSet();
+          expect(ids, containsAll(['pack-a', 'pack-b']));
+        });
+
+        test('returns empty list when no curators have packs', () async {
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => []);
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: [_testCuratorPubkey1],
+          );
+
+          final packs = await repo.loadStickerPacks();
+
+          expect(packs, isEmpty);
+        });
+
+        test('returns empty list when curatorPubkeys is empty', () async {
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => []);
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: const [],
+          );
+
+          final packs = await repo.loadStickerPacks();
+
+          expect(packs, isEmpty);
+        });
+
+        test('filters out packs with no stickers', () async {
+          final emptyPack = _createEmojiSetEvent(
+            pubkey: _testCuratorPubkey1,
+            dTag: 'empty-pack',
+            title: 'Empty',
+          );
+          final validPack = _createEmojiSetEvent(
+            pubkey: _testCuratorPubkey1,
+            dTag: 'valid-pack',
+            title: 'Valid',
+            emojiTags: [
+              ['emoji', 'ok', 'https://cdn.example.com/ok.png'],
+            ],
+          );
+
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [emptyPack, validPack]);
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: [_testCuratorPubkey1],
+          );
+
+          final packs = await repo.loadStickerPacks();
+
+          expect(packs, hasLength(1));
+          expect(packs.first.id, equals('valid-pack'));
+        });
+      });
+
+      group('user-subscribed packs', () {
+        test('resolves packs from Kind 10030 a-tag references', () async {
+          final emojiListEvent = _createUserEmojiListEvent(
+            pubkey: _testUserPubkey,
+            aTagValues: [
+              '$_emojiSetKind:$_externalAuthorPubkey:external-pack',
+            ],
+          );
+
+          final externalPack = _createEmojiSetEvent(
+            pubkey: _externalAuthorPubkey,
+            dTag: 'external-pack',
+            title: 'External Pack',
+            emojiTags: [
+              ['emoji', 'star', 'https://cdn.example.com/star.png'],
+            ],
+          );
+
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer((inv) {
+            final filters = inv.positionalArguments[0] as List<Filter>;
+            final filter = filters.first;
+
+            if (filter.kinds?.contains(_emojiSetKind) == true &&
+                filter.authors?.contains(_testUserPubkey) != true) {
+              // Curated pack query or resolved a-tag query
+              if (filter.authors?.contains(_externalAuthorPubkey) == true) {
+                return Future.value([externalPack]);
+              }
+              return Future.value([]);
+            }
+            if (filter.kinds?.contains(_userEmojiListKind) == true) {
+              return Future.value([emojiListEvent]);
+            }
+            return Future.value([]);
+          });
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: const [],
+            userPubkey: _testUserPubkey,
+          );
+
+          final packs = await repo.loadStickerPacks();
+
+          expect(packs, hasLength(1));
+          expect(packs.first.id, equals('external-pack'));
+          expect(packs.first.authorPubkey, equals(_externalAuthorPubkey));
+        });
+
+        test('skips user-subscribed when userPubkey is null', () async {
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => []);
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: [_testCuratorPubkey1],
+          );
+
+          final packs = await repo.loadStickerPacks();
+
+          expect(packs, isEmpty);
+
+          // Curated only (no discoveryRelays, no userPubkey)
+          verify(() => mockNostrClient.queryEvents(any())).called(1);
+        });
+
+        test('handles empty Kind 10030 event', () async {
+          final emojiListEvent = _createUserEmojiListEvent(
+            pubkey: _testUserPubkey,
+            aTagValues: const [],
+          );
+
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer((inv) {
+            final filters = inv.positionalArguments[0] as List<Filter>;
+            final filter = filters.first;
+
+            if (filter.kinds?.contains(_userEmojiListKind) == true) {
+              return Future.value([emojiListEvent]);
+            }
+            return Future.value([]);
+          });
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: const [],
+            userPubkey: _testUserPubkey,
+          );
+
+          final packs = await repo.loadStickerPacks();
+
+          expect(packs, isEmpty);
+        });
+
+        test('handles malformed a-tag values gracefully', () async {
+          final emojiListEvent = _createUserEmojiListEvent(
+            pubkey: _testUserPubkey,
+            aTagValues: [
+              // Missing d-tag
+              '$_emojiSetKind:$_externalAuthorPubkey',
+              // Wrong kind prefix
+              '99999:$_externalAuthorPubkey:some-pack',
+              // Empty pubkey
+              '$_emojiSetKind::some-pack',
+              // Empty d-tag
+              '$_emojiSetKind:$_externalAuthorPubkey:',
+              // Completely malformed
+              'garbage',
+            ],
+          );
+
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer((inv) {
+            final filters = inv.positionalArguments[0] as List<Filter>;
+            final filter = filters.first;
+
+            if (filter.kinds?.contains(_userEmojiListKind) == true) {
+              return Future.value([emojiListEvent]);
+            }
+            return Future.value([]);
+          });
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: const [],
+            userPubkey: _testUserPubkey,
+          );
+
+          final packs = await repo.loadStickerPacks();
+
+          expect(packs, isEmpty);
+        });
+
+        test('uses most recent Kind 10030 event when multiple exist', () async {
+          final olderEmojiList = _createUserEmojiListEvent(
+            pubkey: _testUserPubkey,
+            aTagValues: [
+              '$_emojiSetKind:$_externalAuthorPubkey:old-pack',
+            ],
+            createdAt: 500,
+          );
+
+          final newerEmojiList = _createUserEmojiListEvent(
+            pubkey: _testUserPubkey,
+            aTagValues: [
+              '$_emojiSetKind:$_externalAuthorPubkey:new-pack',
+            ],
+          );
+
+          final newPack = _createEmojiSetEvent(
+            pubkey: _externalAuthorPubkey,
+            dTag: 'new-pack',
+            title: 'New Pack',
+            emojiTags: [
+              ['emoji', 'new', 'https://cdn.example.com/new.png'],
+            ],
+          );
+
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer((inv) {
+            final filters = inv.positionalArguments[0] as List<Filter>;
+            final filter = filters.first;
+
+            if (filter.kinds?.contains(_userEmojiListKind) == true) {
+              return Future.value([olderEmojiList, newerEmojiList]);
+            }
+            if (filter.kinds?.contains(_emojiSetKind) == true &&
+                filter.authors?.contains(_externalAuthorPubkey) == true) {
+              return Future.value([newPack]);
+            }
+            return Future.value([]);
+          });
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: const [],
+            userPubkey: _testUserPubkey,
+          );
+
+          final packs = await repo.loadStickerPacks();
+
+          expect(packs, hasLength(1));
+          expect(packs.first.id, equals('new-pack'));
+        });
+
+        test('handles d-tags containing colons', () async {
+          final emojiListEvent = _createUserEmojiListEvent(
+            pubkey: _testUserPubkey,
+            aTagValues: [
+              '$_emojiSetKind:$_externalAuthorPubkey:pack:with:colons',
+            ],
+          );
+
+          final pack = _createEmojiSetEvent(
+            pubkey: _externalAuthorPubkey,
+            dTag: 'pack:with:colons',
+            title: 'Colon Pack',
+            emojiTags: [
+              ['emoji', 'colon', 'https://cdn.example.com/colon.png'],
+            ],
+          );
+
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer((inv) {
+            final filters = inv.positionalArguments[0] as List<Filter>;
+            final filter = filters.first;
+
+            if (filter.kinds?.contains(_userEmojiListKind) == true) {
+              return Future.value([emojiListEvent]);
+            }
+            if (filter.kinds?.contains(_emojiSetKind) == true &&
+                filter.authors?.contains(_externalAuthorPubkey) == true) {
+              return Future.value([pack]);
+            }
+            return Future.value([]);
+          });
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: const [],
+            userPubkey: _testUserPubkey,
+          );
+
+          final packs = await repo.loadStickerPacks();
+
+          expect(packs, hasLength(1));
+          expect(packs.first.id, equals('pack:with:colons'));
+        });
+      });
+
+      group('deduplication', () {
+        test('deduplicates packs by authorPubkey:id', () async {
+          final curatedPack = _createEmojiSetEvent(
+            pubkey: _testCuratorPubkey1,
+            dTag: 'shared-pack',
+            title: 'Curated Version',
+            emojiTags: [
+              ['emoji', 'dup', 'https://cdn.example.com/dup.png'],
+            ],
+          );
+
+          final emojiListEvent = _createUserEmojiListEvent(
+            pubkey: _testUserPubkey,
+            aTagValues: [
+              '$_emojiSetKind:$_testCuratorPubkey1:shared-pack',
+            ],
+          );
+
+          // Same pack returned from user subscription query
+          final userSubscribedPack = _createEmojiSetEvent(
+            pubkey: _testCuratorPubkey1,
+            dTag: 'shared-pack',
+            title: 'Curated Version',
+            emojiTags: [
+              ['emoji', 'dup', 'https://cdn.example.com/dup.png'],
+            ],
+          );
+
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer((inv) {
+            final filters = inv.positionalArguments[0] as List<Filter>;
+            final filter = filters.first;
+
+            if (filter.kinds?.contains(_emojiSetKind) == true &&
+                filter.authors?.contains(_testCuratorPubkey1) == true &&
+                filter.d != null) {
+              return Future.value([userSubscribedPack]);
+            }
+            if (filter.kinds?.contains(_emojiSetKind) == true) {
+              return Future.value([curatedPack]);
+            }
+            if (filter.kinds?.contains(_userEmojiListKind) == true) {
+              return Future.value([emojiListEvent]);
+            }
+            return Future.value([]);
+          });
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: [_testCuratorPubkey1],
+            userPubkey: _testUserPubkey,
+          );
+
+          final packs = await repo.loadStickerPacks();
+
+          // Should only have 1 pack, not 2 duplicates
+          expect(packs, hasLength(1));
+          expect(packs.first.id, equals('shared-pack'));
+        });
+
+        test('keeps packs with same id but different authors', () async {
+          final pack1 = _createEmojiSetEvent(
+            pubkey: _testCuratorPubkey1,
+            dTag: 'same-id',
+            title: 'From Curator 1',
+            emojiTags: [
+              ['emoji', 'a', 'https://cdn.example.com/a.png'],
+            ],
+          );
+          final pack2 = _createEmojiSetEvent(
+            pubkey: _testCuratorPubkey2,
+            dTag: 'same-id',
+            title: 'From Curator 2',
+            emojiTags: [
+              ['emoji', 'b', 'https://cdn.example.com/b.png'],
+            ],
+          );
+
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [pack1, pack2]);
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: [_testCuratorPubkey1, _testCuratorPubkey2],
+          );
+
+          final packs = await repo.loadStickerPacks();
+
+          expect(packs, hasLength(2));
+        });
+      });
+
+      group('caching', () {
+        test('returns cached result on second call', () async {
+          final event = _createEmojiSetEvent(
+            pubkey: _testCuratorPubkey1,
+            dTag: 'cached-pack',
+            title: 'Cached',
+            emojiTags: [
+              ['emoji', 'cache', 'https://cdn.example.com/cache.png'],
+            ],
+          );
+
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [event]);
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: [_testCuratorPubkey1],
+          );
+
+          final first = await repo.loadStickerPacks();
+          final second = await repo.loadStickerPacks();
+
+          expect(first, hasLength(1));
+          expect(second, hasLength(1));
+          // First load triggers 1 query (curated; no discoveryRelays).
+          // Second load uses cache — no additional queries.
+          verify(() => mockNostrClient.queryEvents(any())).called(1);
+        });
+
+        test('fetches fresh data after clearCache', () async {
+          final event = _createEmojiSetEvent(
+            pubkey: _testCuratorPubkey1,
+            dTag: 'pack',
+            title: 'Pack',
+            emojiTags: [
+              ['emoji', 'x', 'https://cdn.example.com/x.png'],
+            ],
+          );
+
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [event]);
+
+          final repo = StickerPackRepository(
+            nostrClient: mockNostrClient,
+            curatorPubkeys: [_testCuratorPubkey1],
+          );
+
+          await repo.loadStickerPacks();
+          repo.clearCache();
+          await repo.loadStickerPacks();
+
+          // Each load triggers 1 query (curated; no discoveryRelays).
+          // Two loads = 2 total queries.
+          verify(() => mockNostrClient.queryEvents(any())).called(2);
+        });
+      });
+
+      group('error handling', () {
+        test(
+          'throws $LoadStickerPacksFailedException on query failure',
+          () async {
+            when(
+              () => mockNostrClient.queryEvents(any()),
+            ).thenThrow(Exception('Network error'));
+
+            final repo = StickerPackRepository(
+              nostrClient: mockNostrClient,
+              curatorPubkeys: [_testCuratorPubkey1],
+            );
+
+            expect(
+              repo.loadStickerPacks,
+              throwsA(isA<LoadStickerPacksFailedException>()),
+            );
+          },
+        );
+      });
+    });
+
+    group('broad discovery', () {
+      test('returns packs from relays without author filter', () async {
+        final discoveredPack = _createEmojiSetEvent(
+          pubkey: _externalAuthorPubkey,
+          dTag: 'discovered',
+          title: 'Discovered Pack',
+          emojiTags: [
+            ['emoji', 'found', 'https://cdn.example.com/found.png'],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+          ),
+        ).thenAnswer((_) async => [discoveredPack]);
+
+        // Default mock for curated (no tempRelays)
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => []);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: const [],
+          discoveryRelays: const ['wss://test.relay'],
+        );
+
+        final packs = await repo.loadStickerPacks();
+
+        expect(packs, hasLength(1));
+        expect(packs.first.id, equals('discovered'));
+      });
+
+      test('deduplicates discovered packs against curated', () async {
+        final pack = _createEmojiSetEvent(
+          pubkey: _testCuratorPubkey1,
+          dTag: 'overlap',
+          title: 'Overlap',
+          emojiTags: [
+            ['emoji', 'x', 'https://cdn.example.com/x.png'],
+          ],
+        );
+
+        // Both curated and discovery return the same pack
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [pack]);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        final packs = await repo.loadStickerPacks();
+
+        expect(packs, hasLength(1));
+      });
+    });
+
+    group('getStickerPack', () {
+      test('returns null before loadStickerPacks is called', () {
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        expect(repo.getStickerPack('some-pack'), isNull);
+      });
+
+      test('returns pack by id after loading', () async {
+        final event = _createEmojiSetEvent(
+          pubkey: _testCuratorPubkey1,
+          dTag: 'target',
+          title: 'Target Pack',
+          emojiTags: [
+            ['emoji', 'ok', 'https://cdn.example.com/ok.png'],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        await repo.loadStickerPacks();
+        final pack = repo.getStickerPack('target');
+
+        expect(pack, isNotNull);
+        expect(pack!.title, equals('Target Pack'));
+      });
+
+      test('returns null for non-existent id', () async {
+        final event = _createEmojiSetEvent(
+          pubkey: _testCuratorPubkey1,
+          dTag: 'exists',
+          title: 'Exists',
+          emojiTags: [
+            ['emoji', 'ok', 'https://cdn.example.com/ok.png'],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        await repo.loadStickerPacks();
+
+        expect(repo.getStickerPack('nope'), isNull);
+      });
+    });
+
+    group('clearCache', () {
+      test('clears cached packs', () async {
+        final event = _createEmojiSetEvent(
+          pubkey: _testCuratorPubkey1,
+          dTag: 'pack',
+          title: 'Pack',
+          emojiTags: [
+            ['emoji', 'x', 'https://cdn.example.com/x.png'],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        await repo.loadStickerPacks();
+        expect(repo.getStickerPack('pack'), isNotNull);
+
+        repo.clearCache();
+        expect(repo.getStickerPack('pack'), isNull);
+      });
+    });
+
+    group('event parsing', () {
+      test('uses d-tag as title fallback when title tag is missing', () async {
+        final event = _createEmojiSetEvent(
+          pubkey: _testCuratorPubkey1,
+          dTag: 'fallback-title',
+          emojiTags: [
+            ['emoji', 'x', 'https://cdn.example.com/x.png'],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        final packs = await repo.loadStickerPacks();
+
+        expect(packs.first.title, equals('fallback-title'));
+      });
+
+      test('parses image tag when present', () async {
+        final event = _createEmojiSetEvent(
+          pubkey: _testCuratorPubkey1,
+          dTag: 'with-image',
+          imageUrl: 'https://cdn.example.com/thumb.png',
+          emojiTags: [
+            ['emoji', 'x', 'https://cdn.example.com/x.png'],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        final packs = await repo.loadStickerPacks();
+
+        expect(
+          packs.first.imageUrl,
+          equals('https://cdn.example.com/thumb.png'),
+        );
+      });
+
+      test('skips events with missing d-tag', () async {
+        // Create an event with no d-tag manually
+        final event = Event(
+          _testCuratorPubkey1,
+          _emojiSetKind,
+          <List<String>>[
+            ['emoji', 'x', 'https://cdn.example.com/x.png'],
+          ],
+          '',
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        final packs = await repo.loadStickerPacks();
+
+        expect(packs, isEmpty);
+      });
+
+      test('parses NIP-51 name tag as title', () async {
+        final event = _createNip51EmojiSetEvent(
+          pubkey: _testCuratorPubkey1,
+          dTag: 'nip51-pack',
+          name: 'NIP-51 Name',
+          emojiTags: [
+            ['emoji', 'x', 'https://cdn.example.com/x.png'],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        final packs = await repo.loadStickerPacks();
+
+        expect(packs.first.title, equals('NIP-51 Name'));
+      });
+
+      test('parses NIP-51 picture tag as imageUrl', () async {
+        final event = _createNip51EmojiSetEvent(
+          pubkey: _testCuratorPubkey1,
+          dTag: 'nip51-pic',
+          pictureUrl: 'https://cdn.example.com/pic.png',
+          emojiTags: [
+            ['emoji', 'x', 'https://cdn.example.com/x.png'],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        final packs = await repo.loadStickerPacks();
+
+        expect(
+          packs.first.imageUrl,
+          equals('https://cdn.example.com/pic.png'),
+        );
+      });
+
+      test('prefers first-seen tag when both name and title present', () async {
+        // name appears before title — name wins via ??= semantics
+        final event = _createNip51EmojiSetEvent(
+          pubkey: _testCuratorPubkey1,
+          dTag: 'both-tags',
+          name: 'Name Tag',
+          emojiTags: [
+            ['emoji', 'x', 'https://cdn.example.com/x.png'],
+          ],
+        );
+        // Append a title tag after name
+        (event.tags as List<List<String>>).add(['title', 'Title Tag']);
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        final packs = await repo.loadStickerPacks();
+
+        expect(packs.first.title, equals('Name Tag'));
+      });
+
+      test('skips emoji tags with fewer than 3 elements', () async {
+        final event = Event(
+          _testCuratorPubkey1,
+          _emojiSetKind,
+          <List<String>>[
+            ['d', 'pack'],
+            ['emoji', 'only-shortcode'], // missing URL
+            ['emoji', 'valid', 'https://cdn.example.com/valid.png'],
+          ],
+          '',
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        final packs = await repo.loadStickerPacks();
+
+        expect(packs, hasLength(1));
+        expect(packs.first.stickers, hasLength(1));
+        expect(packs.first.stickers.first.shortcode, equals('valid'));
+      });
+    });
+  });
+}

--- a/mobile/packages/sticker_pack_repository/test/src/sticker_pack_repository_test.dart
+++ b/mobile/packages/sticker_pack_repository/test/src/sticker_pack_repository_test.dart
@@ -1045,6 +1045,68 @@ void main() {
         expect(packs.first.title, equals('Name Tag'));
       });
 
+      test('filters out emoji tags with non-http(s) URLs', () async {
+        final event = Event(
+          _testCuratorPubkey1,
+          _emojiSetKind,
+          <List<String>>[
+            ['d', 'xss-pack'],
+            ['emoji', 'xss', 'javascript:alert(1)'],
+            ['emoji', 'ftp', 'ftp://cdn.example.com/ftp.png'],
+            ['emoji', 'safe', 'https://cdn.example.com/safe.png'],
+            ['emoji', 'http', 'http://cdn.example.com/http.png'],
+          ],
+          '',
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        final packs = await repo.loadStickerPacks();
+
+        expect(packs, hasLength(1));
+        expect(packs.first.stickers, hasLength(2));
+        final shortcodes = packs.first.stickers
+            .map((s) => s.shortcode)
+            .toList();
+        expect(shortcodes, containsAll(['safe', 'http']));
+        expect(shortcodes, isNot(contains('xss')));
+        expect(shortcodes, isNot(contains('ftp')));
+      });
+
+      test('filters out pack thumbnail with non-https URL', () async {
+        final event = Event(
+          _testCuratorPubkey1,
+          _emojiSetKind,
+          <List<String>>[
+            ['d', 'bad-thumb'],
+            ['image', 'javascript:alert(1)'],
+            ['emoji', 'ok', 'https://cdn.example.com/ok.png'],
+          ],
+          '',
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        final packs = await repo.loadStickerPacks();
+
+        expect(packs, hasLength(1));
+        expect(packs.first.imageUrl, isNull);
+      });
+
       test('skips emoji tags with fewer than 3 elements', () async {
         final event = Event(
           _testCuratorPubkey1,

--- a/mobile/packages/sticker_pack_repository/test/src/sticker_pack_repository_test.dart
+++ b/mobile/packages/sticker_pack_repository/test/src/sticker_pack_repository_test.dart
@@ -620,21 +620,122 @@ void main() {
 
       group('error handling', () {
         test(
-          'throws $LoadStickerPacksFailedException on query failure',
+          'throws $LoadStickerPacksFailedException when all sources fail',
           () async {
             when(
               () => mockNostrClient.queryEvents(any()),
             ).thenThrow(Exception('Network error'));
 
+            when(
+              () => mockNostrClient.queryEvents(
+                any(),
+                tempRelays: any(named: 'tempRelays'),
+              ),
+            ).thenThrow(Exception('Discovery also fails'));
+
             final repo = StickerPackRepository(
               nostrClient: mockNostrClient,
               curatorPubkeys: [_testCuratorPubkey1],
+              userPubkey: _testUserPubkey,
+              discoveryRelays: const ['wss://fail.relay'],
             );
 
             expect(
               repo.loadStickerPacks,
               throwsA(isA<LoadStickerPacksFailedException>()),
             );
+          },
+        );
+
+        test(
+          'returns curated packs when discovery fails',
+          () async {
+            final curatedEvent = _createEmojiSetEvent(
+              pubkey: _testCuratorPubkey1,
+              dTag: 'curated-only',
+              title: 'Curated Only',
+              emojiTags: [
+                ['emoji', 'ok', 'https://cdn.example.com/ok.png'],
+              ],
+            );
+
+            var callCount = 0;
+            when(() => mockNostrClient.queryEvents(any())).thenAnswer((_) {
+              callCount++;
+              // First call is curated, second is user-subscribed (empty),
+              // third is discovery — make it fail
+              if (callCount == 1) return Future.value([curatedEvent]);
+              if (callCount == 3) throw Exception('Discovery failed');
+              return Future.value([]);
+            });
+
+            // No discoveryRelays → discovery returns [], so we need them
+            when(
+              () => mockNostrClient.queryEvents(
+                any(),
+                tempRelays: any(named: 'tempRelays'),
+              ),
+            ).thenThrow(Exception('Discovery relay failed'));
+
+            // Default mock for curated (no tempRelays)
+            when(
+              () => mockNostrClient.queryEvents(any()),
+            ).thenAnswer((inv) async {
+              final filters = inv.positionalArguments[0] as List<Filter>;
+              final filter = filters.first;
+              if (filter.authors?.contains(_testCuratorPubkey1) == true) {
+                return [curatedEvent];
+              }
+              return [];
+            });
+
+            final repo = StickerPackRepository(
+              nostrClient: mockNostrClient,
+              curatorPubkeys: [_testCuratorPubkey1],
+              discoveryRelays: const ['wss://failing.relay'],
+            );
+
+            final packs = await repo.loadStickerPacks();
+
+            expect(packs, hasLength(1));
+            expect(packs.first.id, equals('curated-only'));
+          },
+        );
+
+        test(
+          'returns discovered packs when curated fails',
+          () async {
+            final discoveredEvent = _createEmojiSetEvent(
+              pubkey: _externalAuthorPubkey,
+              dTag: 'discovered-only',
+              title: 'Discovered Only',
+              emojiTags: [
+                ['emoji', 'star', 'https://cdn.example.com/star.png'],
+              ],
+            );
+
+            // Curated query throws, discovery succeeds
+            when(
+              () => mockNostrClient.queryEvents(any()),
+            ).thenThrow(Exception('Curated failed'));
+
+            when(
+              () => mockNostrClient.queryEvents(
+                any(),
+                tempRelays: any(named: 'tempRelays'),
+              ),
+            ).thenAnswer((_) async => [discoveredEvent]);
+
+            final repo = StickerPackRepository(
+              nostrClient: mockNostrClient,
+              curatorPubkeys: [_testCuratorPubkey1],
+              discoveryRelays: const ['wss://good.relay'],
+            );
+
+            final packs = await repo.loadStickerPacks();
+
+            expect(packs, hasLength(1));
+            expect(packs.first.id, equals('discovered-only'));
           },
         );
       });

--- a/mobile/packages/sticker_pack_repository/test/src/sticker_pack_repository_test.dart
+++ b/mobile/packages/sticker_pack_repository/test/src/sticker_pack_repository_test.dart
@@ -1045,7 +1045,7 @@ void main() {
         expect(packs.first.title, equals('Name Tag'));
       });
 
-      test('filters out emoji tags with non-http(s) URLs', () async {
+      test('filters out emoji tags with non-https URLs', () async {
         final event = Event(
           _testCuratorPubkey1,
           _emojiSetKind,
@@ -1071,13 +1071,38 @@ void main() {
         final packs = await repo.loadStickerPacks();
 
         expect(packs, hasLength(1));
-        expect(packs.first.stickers, hasLength(2));
-        final shortcodes = packs.first.stickers
-            .map((s) => s.shortcode)
-            .toList();
-        expect(shortcodes, containsAll(['safe', 'http']));
-        expect(shortcodes, isNot(contains('xss')));
-        expect(shortcodes, isNot(contains('ftp')));
+        expect(packs.first.stickers, hasLength(1));
+        expect(packs.first.stickers.first.shortcode, equals('safe'));
+      });
+
+      test('filters out emoji tags with invalid shortcodes', () async {
+        final event = Event(
+          _testCuratorPubkey1,
+          _emojiSetKind,
+          <List<String>>[
+            ['d', 'mixed-pack'],
+            ['emoji', 'has-hyphen', 'https://cdn.example.com/h.png'],
+            ['emoji', 'has space', 'https://cdn.example.com/s.png'],
+            ['emoji', 'has:colon', 'https://cdn.example.com/c.png'],
+            ['emoji', 'valid_123', 'https://cdn.example.com/v.png'],
+          ],
+          '',
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = StickerPackRepository(
+          nostrClient: mockNostrClient,
+          curatorPubkeys: [_testCuratorPubkey1],
+        );
+
+        final packs = await repo.loadStickerPacks();
+
+        expect(packs, hasLength(1));
+        expect(packs.first.stickers, hasLength(1));
+        expect(packs.first.stickers.first.shortcode, equals('valid_123'));
       });
 
       test('filters out pack thumbnail with non-https URL', () async {

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -62,6 +62,7 @@ workspace:
   - packages/reposts_repository
   - packages/sound_service
   - packages/sounds_repository
+  - packages/sticker_pack_repository
   - packages/text_sanitizer
   - packages/time_formatter
   - packages/tv_static_effect
@@ -181,6 +182,9 @@ dependencies:
 
   # Sounds Repository - Kind 1063 audio events from Nostr relays
   sounds_repository:
+
+  # Sticker Pack Repository - Curated Nostr sticker packs
+  sticker_pack_repository:
 
   # Notification Repository - Notification enrichment and grouping
   notification_repository:

--- a/mobile/test/blocs/comments/comments_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_bloc_test.dart
@@ -1106,6 +1106,7 @@ void main() {
             stickerImageUrl: testStickerUrl,
           ),
         ),
+        errors: () => [isA<Exception>()],
         expect: () => [
           isA<CommentsState>().having(
             (s) => s.error,

--- a/mobile/test/blocs/comments/comments_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_bloc_test.dart
@@ -1010,7 +1010,7 @@ void main() {
       const testStickerUrl = 'https://blossom.example.com/fire.webp';
 
       blocTest<CommentsBloc, CommentsState>(
-        'emits posting state and adds sticker comment on success',
+        'adds sticker comment on success',
         setUp: () {
           when(() => mockAuthService.isAuthenticated).thenReturn(true);
           when(
@@ -1047,13 +1047,7 @@ void main() {
           ),
         ),
         expect: () => [
-          isA<CommentsState>().having(
-            (s) => s.isPosting,
-            'isPosting',
-            isTrue,
-          ),
           isA<CommentsState>()
-              .having((s) => s.isPosting, 'isPosting', isFalse)
               .having((s) => s.comments, 'comments', hasLength(1))
               .having(
                 (s) => s.comments.first.content,
@@ -1114,17 +1108,10 @@ void main() {
         ),
         expect: () => [
           isA<CommentsState>().having(
-            (s) => s.isPosting,
-            'isPosting',
-            isTrue,
+            (s) => s.error,
+            'error',
+            CommentsError.postCommentFailed,
           ),
-          isA<CommentsState>()
-              .having((s) => s.isPosting, 'isPosting', isFalse)
-              .having(
-                (s) => s.error,
-                'error',
-                CommentsError.postCommentFailed,
-              ),
         ],
       );
 

--- a/mobile/test/blocs/comments/comments_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_bloc_test.dart
@@ -1005,6 +1005,186 @@ void main() {
       );
     });
 
+    group('StickerCommentSubmitted', () {
+      const testShortcode = 'fire';
+      const testStickerUrl = 'https://blossom.example.com/fire.webp';
+
+      blocTest<CommentsBloc, CommentsState>(
+        'emits posting state and adds sticker comment on success',
+        setUp: () {
+          when(() => mockAuthService.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthService.currentPublicKeyHex,
+          ).thenReturn(validId('currentuser'));
+
+          final postedComment = Comment(
+            id: validId('sticker_posted'),
+            content: ':$testShortcode:',
+            authorPubkey: validId('currentuser'),
+            createdAt: DateTime.now(),
+            rootEventId: validId('root'),
+            rootAuthorPubkey: validId('author'),
+            emojiTags: const {testShortcode: testStickerUrl},
+          );
+          when(
+            () => mockCommentsRepository.postStickerComment(
+              stickerShortcode: any(named: 'stickerShortcode'),
+              stickerImageUrl: any(named: 'stickerImageUrl'),
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+              replyToEventId: any(named: 'replyToEventId'),
+              replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+            ),
+          ).thenAnswer((_) async => postedComment);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          const StickerCommentSubmitted(
+            stickerShortcode: testShortcode,
+            stickerImageUrl: testStickerUrl,
+          ),
+        ),
+        expect: () => [
+          isA<CommentsState>().having(
+            (s) => s.isPosting,
+            'isPosting',
+            isTrue,
+          ),
+          isA<CommentsState>()
+              .having((s) => s.isPosting, 'isPosting', isFalse)
+              .having((s) => s.comments, 'comments', hasLength(1))
+              .having(
+                (s) => s.comments.first.content,
+                'content',
+                equals(':$testShortcode:'),
+              ),
+        ],
+      );
+
+      blocTest<CommentsBloc, CommentsState>(
+        'emits error when not authenticated',
+        setUp: () {
+          when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          const StickerCommentSubmitted(
+            stickerShortcode: testShortcode,
+            stickerImageUrl: testStickerUrl,
+          ),
+        ),
+        expect: () => [
+          isA<CommentsState>().having(
+            (s) => s.error,
+            'error',
+            CommentsError.notAuthenticated,
+          ),
+        ],
+      );
+
+      blocTest<CommentsBloc, CommentsState>(
+        'emits error when postStickerComment throws',
+        setUp: () {
+          when(() => mockAuthService.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthService.currentPublicKeyHex,
+          ).thenReturn(validId('currentuser'));
+
+          when(
+            () => mockCommentsRepository.postStickerComment(
+              stickerShortcode: any(named: 'stickerShortcode'),
+              stickerImageUrl: any(named: 'stickerImageUrl'),
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+              replyToEventId: any(named: 'replyToEventId'),
+              replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+            ),
+          ).thenThrow(Exception('Network error'));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          const StickerCommentSubmitted(
+            stickerShortcode: testShortcode,
+            stickerImageUrl: testStickerUrl,
+          ),
+        ),
+        expect: () => [
+          isA<CommentsState>().having(
+            (s) => s.isPosting,
+            'isPosting',
+            isTrue,
+          ),
+          isA<CommentsState>()
+              .having((s) => s.isPosting, 'isPosting', isFalse)
+              .having(
+                (s) => s.error,
+                'error',
+                CommentsError.postCommentFailed,
+              ),
+        ],
+      );
+
+      blocTest<CommentsBloc, CommentsState>(
+        'calls postStickerComment with correct params including threading',
+        setUp: () {
+          when(() => mockAuthService.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthService.currentPublicKeyHex,
+          ).thenReturn(validId('currentuser'));
+
+          final postedComment = Comment(
+            id: validId('sticker_reply'),
+            content: ':$testShortcode:',
+            authorPubkey: validId('currentuser'),
+            createdAt: DateTime.now(),
+            rootEventId: validId('root'),
+            rootAuthorPubkey: validId('author'),
+            replyToEventId: validId('parent'),
+            emojiTags: const {testShortcode: testStickerUrl},
+          );
+          when(
+            () => mockCommentsRepository.postStickerComment(
+              stickerShortcode: any(named: 'stickerShortcode'),
+              stickerImageUrl: any(named: 'stickerImageUrl'),
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+              replyToEventId: any(named: 'replyToEventId'),
+              replyToAuthorPubkey: any(named: 'replyToAuthorPubkey'),
+            ),
+          ).thenAnswer((_) async => postedComment);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          StickerCommentSubmitted(
+            stickerShortcode: testShortcode,
+            stickerImageUrl: testStickerUrl,
+            parentCommentId: validId('parent'),
+            parentAuthorPubkey: validId('parentauthor'),
+          ),
+        ),
+        verify: (_) {
+          verify(
+            () => mockCommentsRepository.postStickerComment(
+              stickerShortcode: testShortcode,
+              stickerImageUrl: testStickerUrl,
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: testRootEventKind,
+              rootEventAuthorPubkey: any(named: 'rootEventAuthorPubkey'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+              replyToEventId: validId('parent'),
+              replyToAuthorPubkey: validId('parentauthor'),
+            ),
+          ).called(1);
+        },
+      );
+    });
+
     group('CommentEditModeEntered', () {
       blocTest<CommentsBloc, CommentsState>(
         'sets activeEditCommentId and pre-populates editInputText',

--- a/mobile/test/blocs/sticker_picker/sticker_picker_bloc_test.dart
+++ b/mobile/test/blocs/sticker_picker/sticker_picker_bloc_test.dart
@@ -125,6 +125,10 @@ void main() {
         'filters stickers by shortcode (case-insensitive contains)',
         seed: () => StickerPickerLoaded(
           packs: const [testPack1, testPack2],
+          allStickers: [
+            ...testPack1.stickers,
+            ...testPack2.stickers,
+          ],
           filteredStickers: [
             ...testPack1.stickers,
             ...testPack2.stickers,
@@ -154,9 +158,13 @@ void main() {
 
       blocTest<StickerPickerBloc, StickerPickerState>(
         'empty query resets to all stickers',
-        seed: () => const StickerPickerLoaded(
-          packs: [testPack1, testPack2],
-          filteredStickers: [],
+        seed: () => StickerPickerLoaded(
+          packs: const [testPack1, testPack2],
+          allStickers: [
+            ...testPack1.stickers,
+            ...testPack2.stickers,
+          ],
+          filteredStickers: const [],
           searchQuery: 'old-query',
         ),
         build: buildBloc,

--- a/mobile/test/blocs/sticker_picker/sticker_picker_bloc_test.dart
+++ b/mobile/test/blocs/sticker_picker/sticker_picker_bloc_test.dart
@@ -1,0 +1,179 @@
+// ABOUTME: Tests for StickerPickerBloc - loading sticker packs and filtering
+// ABOUTME: Tests load success/failure and search filtering by shortcode
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/sticker_picker/sticker_picker_bloc.dart';
+import 'package:sticker_pack_repository/sticker_pack_repository.dart';
+
+class _MockStickerPackRepository extends Mock
+    implements StickerPackRepository {}
+
+void main() {
+  group(StickerPickerBloc, () {
+    late _MockStickerPackRepository mockStickerPackRepository;
+
+    const testPack1 = StickerPack(
+      id: 'reactions',
+      title: 'Reactions',
+      stickers: [
+        Sticker(
+          shortcode: 'fire',
+          imageUrl: 'https://blossom.example.com/fire.webp',
+        ),
+        Sticker(
+          shortcode: 'thumbs-up',
+          imageUrl: 'https://blossom.example.com/thumbs-up.webp',
+        ),
+      ],
+      authorPubkey:
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    );
+
+    const testPack2 = StickerPack(
+      id: 'animals',
+      title: 'Animals',
+      stickers: [
+        Sticker(
+          shortcode: 'cat',
+          imageUrl: 'https://blossom.example.com/cat.webp',
+        ),
+      ],
+      authorPubkey:
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    );
+
+    setUp(() {
+      mockStickerPackRepository = _MockStickerPackRepository();
+    });
+
+    StickerPickerBloc buildBloc() => StickerPickerBloc(
+      stickerPackRepository: mockStickerPackRepository,
+    );
+
+    test('initial state is $StickerPickerInitial', () {
+      final bloc = buildBloc();
+      expect(bloc.state, isA<StickerPickerInitial>());
+      bloc.close();
+    });
+
+    group('StickerPacksLoadRequested', () {
+      blocTest<StickerPickerBloc, StickerPickerState>(
+        'emits [loading, loaded] on success',
+        setUp: () {
+          when(
+            () => mockStickerPackRepository.loadStickerPacks(),
+          ).thenAnswer((_) async => [testPack1, testPack2]);
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const StickerPacksLoadRequested()),
+        expect: () => [
+          isA<StickerPickerLoading>(),
+          isA<StickerPickerLoaded>()
+              .having((s) => s.packs, 'packs', hasLength(2))
+              .having(
+                (s) => s.filteredStickers,
+                'filteredStickers',
+                hasLength(3),
+              ),
+        ],
+      );
+
+      blocTest<StickerPickerBloc, StickerPickerState>(
+        'emits [loading, error] on exception',
+        setUp: () {
+          when(
+            () => mockStickerPackRepository.loadStickerPacks(),
+          ).thenThrow(Exception('Network error'));
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const StickerPacksLoadRequested()),
+        expect: () => [
+          isA<StickerPickerLoading>(),
+          isA<StickerPickerError>(),
+        ],
+      );
+
+      blocTest<StickerPickerBloc, StickerPickerState>(
+        'loaded state contains all stickers from all packs '
+        'in filteredStickers',
+        setUp: () {
+          when(
+            () => mockStickerPackRepository.loadStickerPacks(),
+          ).thenAnswer((_) async => [testPack1, testPack2]);
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const StickerPacksLoadRequested()),
+        expect: () => [
+          isA<StickerPickerLoading>(),
+          isA<StickerPickerLoaded>().having(
+            (s) => s.filteredStickers.map((st) => st.shortcode).toList(),
+            'shortcodes',
+            containsAll(['fire', 'thumbs-up', 'cat']),
+          ),
+        ],
+      );
+    });
+
+    group('StickerSearchChanged', () {
+      blocTest<StickerPickerBloc, StickerPickerState>(
+        'filters stickers by shortcode (case-insensitive contains)',
+        seed: () => StickerPickerLoaded(
+          packs: const [testPack1, testPack2],
+          filteredStickers: [
+            ...testPack1.stickers,
+            ...testPack2.stickers,
+          ],
+        ),
+        build: buildBloc,
+        act: (bloc) => bloc.add(const StickerSearchChanged('FIR')),
+        expect: () => [
+          isA<StickerPickerLoaded>()
+              .having(
+                (s) => s.filteredStickers,
+                'filteredStickers',
+                hasLength(1),
+              )
+              .having(
+                (s) => s.filteredStickers.first.shortcode,
+                'shortcode',
+                equals('fire'),
+              )
+              .having(
+                (s) => s.searchQuery,
+                'searchQuery',
+                equals('fir'),
+              ),
+        ],
+      );
+
+      blocTest<StickerPickerBloc, StickerPickerState>(
+        'empty query resets to all stickers',
+        seed: () => const StickerPickerLoaded(
+          packs: [testPack1, testPack2],
+          filteredStickers: [],
+          searchQuery: 'old-query',
+        ),
+        build: buildBloc,
+        act: (bloc) => bloc.add(const StickerSearchChanged('')),
+        expect: () => [
+          isA<StickerPickerLoaded>()
+              .having(
+                (s) => s.filteredStickers,
+                'filteredStickers',
+                hasLength(3),
+              )
+              .having((s) => s.searchQuery, 'searchQuery', isEmpty),
+        ],
+      );
+
+      blocTest<StickerPickerBloc, StickerPickerState>(
+        'no-op when state is not loaded',
+        build: buildBloc,
+        act: (bloc) => bloc.add(const StickerSearchChanged('fire')),
+        expect: () => <StickerPickerState>[],
+      );
+    });
+  });
+}

--- a/mobile/test/blocs/sticker_picker/sticker_picker_bloc_test.dart
+++ b/mobile/test/blocs/sticker_picker/sticker_picker_bloc_test.dart
@@ -81,7 +81,7 @@ void main() {
       );
 
       blocTest<StickerPickerBloc, StickerPickerState>(
-        'emits [loading, error] on exception',
+        'emits [loading, error] with loadFailed type on exception',
         setUp: () {
           when(
             () => mockStickerPackRepository.loadStickerPacks(),
@@ -91,7 +91,11 @@ void main() {
         act: (bloc) => bloc.add(const StickerPacksLoadRequested()),
         expect: () => [
           isA<StickerPickerLoading>(),
-          isA<StickerPickerError>(),
+          isA<StickerPickerError>().having(
+            (s) => s.errorType,
+            'errorType',
+            equals(StickerPickerErrorType.loadFailed),
+          ),
         ],
       );
 

--- a/mobile/test/builders/comment_builder.dart
+++ b/mobile/test/builders/comment_builder.dart
@@ -26,6 +26,7 @@ class CommentBuilder {
       'd4e5f6789012345678901234567890abcdef123456789012345678901234abc';
   String? _replyToEventId;
   String? _replyToAuthorPubkey;
+  Map<String, String> _emojiTags = const {};
 
   /// Set the comment ID.
   CommentBuilder withId(String id) {
@@ -75,6 +76,12 @@ class CommentBuilder {
     return this;
   }
 
+  /// Set NIP-30 custom emoji tags (shortcode → imageUrl).
+  CommentBuilder withEmojiTags(Map<String, String> emojiTags) {
+    _emojiTags = emojiTags;
+    return this;
+  }
+
   /// Make this comment a reply to another comment.
   CommentBuilder asReplyTo({
     required String parentEventId,
@@ -107,6 +114,7 @@ class CommentBuilder {
     rootAuthorPubkey: _rootAuthorPubkey,
     replyToEventId: _replyToEventId,
     replyToAuthorPubkey: _replyToAuthorPubkey,
+    emojiTags: _emojiTags,
   );
 }
 

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -317,6 +317,9 @@ const _knownUntranslatedDebt = {
   // next pass.
   'relaySettingsInsecureUrl',
   'keyImportInsecureBunkerRelay',
+  // Added by the sticker comments spike (#1529). Non-English locales fall
+  // back to English until translations are picked up in a follow-up pass.
+  'commentsStickerOpenSemanticLabel',
   // Added by the badges dashboard in #3825. Translations are tracked in
   // #3864; until that lands, non-English locales fall back to English.
   'settingsBadgesTitle',


### PR DESCRIPTION
Related to #2265 (NIP-30 stickers tracking issue)
Supersedes #1529

## Summary

Spike research branch for Giphy-style sticker comments using NIP-30 custom emoji on Kind 1111 (NIP-22) events.

- Prototype NIP-30 sticker comments: `:shortcode:` content with `["emoji", shortcode, url]` tags on Kind 1111 events
- New `sticker_pack_repository` package: discovers Kind 30030 emoji sets from curated pubkeys, user Kind 10030 subscriptions, and broad relay discovery
- `StickerPickerBloc` + `StickerPickerSheet` UI for browsing/searching sticker packs
- Sticker comment rendering in `CommentItem`: standalone 120px stickers and inline 24px emoji in mixed text
- Error isolation in `loadStickerPacks` so partial results are returned when individual sources fail
- Parallelized per-author queries in `_loadUserSubscribedPacks`
- Input validation for sticker shortcodes (NIP-30 compliant `[a-zA-Z0-9_]+`) and https URLs
- `EventKind.emojiSet = 30030` constant replacing local magic numbers
- Typed `StickerPickerErrorType` enum replacing raw error strings
- VineTheme color compliance and `Semantics` wrappers for accessibility
- Auth state watching on sticker pack provider to clear stale cache on account switch

## Test plan

- [x] `sticker_pack_repository` tests (33 passing): curated/user/discovery loading, partial failure, deduplication, caching, event parsing
- [x] `comments_repository` tests (63 passing): sticker comment posting, input validation, NIP-30 emoji tag parsing, NIP-22 threading
- [x] `sticker_picker_bloc` tests (7 passing): load success/error with typed enum, search filtering