### PR TITLE
fix(profile): remove max-width constraint causing black bars in header

### DIFF
--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -268,39 +268,27 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
         headerSliverBuilder: (context, innerBoxIsScrolled) => [
           // Profile Header
           SliverToBoxAdapter(
-            child: Align(
-              alignment: Alignment.topCenter,
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 600),
-                child: ProfileHeaderWidget(
-                  userIdHex: widget.userIdHex,
-                  isOwnProfile: widget.isOwnProfile,
-                  videoCount: widget.videos.length,
-                  profileStatsAsync: widget.profileStatsAsync,
-                  onSetupProfile: widget.onSetupProfile,
-                  displayNameHint: widget.displayNameHint,
-                  avatarUrlHint: widget.avatarUrlHint,
-                ),
-              ),
+            child: ProfileHeaderWidget(
+              userIdHex: widget.userIdHex,
+              isOwnProfile: widget.isOwnProfile,
+              videoCount: widget.videos.length,
+              profileStatsAsync: widget.profileStatsAsync,
+              onSetupProfile: widget.onSetupProfile,
+              displayNameHint: widget.displayNameHint,
+              avatarUrlHint: widget.avatarUrlHint,
             ),
           ),
 
           // Action Buttons
           SliverToBoxAdapter(
-            child: Align(
-              alignment: Alignment.topCenter,
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 600),
-                child: ProfileActionButtons(
-                  userIdHex: widget.userIdHex,
-                  isOwnProfile: widget.isOwnProfile,
-                  displayName: widget.displayName,
-                  onEditProfile: widget.onEditProfile,
-                  onOpenClips: widget.onOpenClips,
-                  onOpenAnalytics: widget.onOpenAnalytics,
-                  onBlockedTap: widget.onBlockedTap,
-                ),
-              ),
+            child: ProfileActionButtons(
+              userIdHex: widget.userIdHex,
+              isOwnProfile: widget.isOwnProfile,
+              displayName: widget.displayName,
+              onEditProfile: widget.onEditProfile,
+              onOpenClips: widget.onOpenClips,
+              onOpenAnalytics: widget.onOpenAnalytics,
+              onBlockedTap: widget.onBlockedTap,
             ),
           ),
 


### PR DESCRIPTION
## Summary
- Removed `ConstrainedBox(maxWidth: 600)` + `Align` wrappers around `ProfileHeaderWidget` and `ProfileActionButtons` in `ProfileGridView`
- Both widgets already use `width: double.infinity` internally, so they now fill the screen naturally
- Eliminates black bars on either side of the profile header on macOS, tablets, and large phones

Fixes #1244
Related: #1727

## Test plan
- [ ] Open profile page on macOS — header and action buttons should span full width with no black bars
- [ ] Open profile page on iOS/Android phone — verify header still looks correct (no regression)
- [ ] Open profile page on tablet/wide screen — verify header fills width
- [ ] Test both own profile and other user profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)