### PR TITLE
fix(auth): show clear message when OAuth session expires

### DIFF
--- a/mobile/lib/blocs/welcome/welcome_bloc.dart
+++ b/mobile/lib/blocs/welcome/welcome_bloc.dart
@@ -5,6 +5,7 @@ import 'package:bloc/bloc.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:db_client/db_client.dart';
 import 'package:equatable/equatable.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:models/models.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/utils/unified_logger.dart';
@@ -171,6 +172,19 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
         'WelcomeBloc: sign-in completed for ${account.pubkeyHex}',
         name: 'WelcomeBloc',
         category: LogCategory.auth,
+      );
+    } on SessionExpiredException {
+      Log.warning(
+        'WelcomeBloc: session expired for ${account.pubkeyHex}',
+        name: 'WelcomeBloc',
+        category: LogCategory.auth,
+      );
+      emit(
+        state.copyWith(
+          status: WelcomeStatus.error,
+          error: 'Your session has expired. Please sign in again.',
+          clearSigningIn: true,
+        ),
       );
     } catch (e) {
       Log.error(

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -1224,6 +1224,13 @@ class AuthService implements BackgroundAwareService {
         final session = await KeycastSession.load(_flutterSecureStorage);
         if (session != null && session.hasRpcAccess) {
           await signInWithDivineOAuth(session);
+        } else if (session != null && session.isExpired) {
+          Log.warning(
+            'signInForAccount: OAuth session expired for $pubkeyHex',
+            name: 'AuthService',
+            category: LogCategory.auth,
+          );
+          throw SessionExpiredException();
         } else {
           Log.error(
             'signInForAccount: no archived OAuth session for $pubkeyHex '

--- a/mobile/test/blocs/welcome/welcome_bloc_test.dart
+++ b/mobile/test/blocs/welcome/welcome_bloc_test.dart
@@ -4,6 +4,7 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:db_client/db_client.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/welcome/welcome_bloc.dart';
@@ -305,6 +306,33 @@ void main() {
             status: WelcomeStatus.error,
             previousAccounts: [_testPreviousAccount],
             error: 'Failed to continue: Exception: Network error',
+          ),
+        ],
+      );
+
+      blocTest<WelcomeBloc, WelcomeState>(
+        'emits user-friendly error on $SessionExpiredException',
+        setUp: () {
+          when(
+            () => mockAuthService.signInForAccount(any(), any()),
+          ).thenThrow(SessionExpiredException());
+        },
+        build: buildBloc,
+        seed: () => const WelcomeState(
+          status: WelcomeStatus.loaded,
+          previousAccounts: [_testPreviousAccount],
+        ),
+        act: (bloc) => bloc.add(const WelcomeLogBackInRequested()),
+        expect: () => [
+          const WelcomeState(
+            status: WelcomeStatus.accepting,
+            previousAccounts: [_testPreviousAccount],
+            signingInPubkeyHex: _testPubkeyHex,
+          ),
+          const WelcomeState(
+            status: WelcomeStatus.error,
+            previousAccounts: [_testPreviousAccount],
+            error: 'Your session has expired. Please sign in again.',
           ),
         ],
       );

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:openvine/models/known_account.dart';
@@ -922,6 +923,33 @@ void main() {
               contains('No archived OAuth session found'),
             ),
           ),
+        );
+      },
+    );
+
+    test(
+      'throws $SessionExpiredException when OAuth session is expired',
+      () async {
+        final pubkeyHex = testKeyContainer.publicKeyHex;
+
+        // Store an expired session (expired 1 hour ago)
+        final expiredSession = KeycastSession(
+          bunkerUrl: 'wss://relay.example.com',
+          accessToken: 'expired-token',
+          expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+        );
+        when(
+          () => mockSecureStorage.read(key: 'keycast_session'),
+        ).thenAnswer((_) async => jsonEncode(expiredSession.toJson()));
+
+        await expectLater(
+          _ignoringDiscoveryErrors(
+            () => authService.signInForAccount(
+              pubkeyHex,
+              AuthenticationSource.divineOAuth,
+            ),
+          ),
+          throwsA(isA<SessionExpiredException>()),
         );
       },
     );


### PR DESCRIPTION
## Summary
- Distinguish expired OAuth sessions from missing ones when returning users tap "Sign Back In"
- Users now see **"Your session has expired. Please sign in again."** instead of the confusing `Exception: No archived OAuth session found for <64-char-pubkey>`
- Added `SessionExpiredException` catch in WelcomeBloc for user-friendly error handling

## Test plan
- [x] Auth service test: expired OAuth session throws `SessionExpiredException`
- [x] Auth service test: missing OAuth session still throws generic exception
- [x] Welcome bloc test: expired session shows friendly error message
- [x] Welcome bloc test: other failures still show generic error
- [ ] Manual: sign in with OAuth, wait for token to expire, tap "Sign Back In" → should see friendly message

🤖 Generated with [Claude Code](https://claude.com/claude-code)