### PR TITLE
fix(video-editor): crash when merging clips on older iPhones (A11 devices)

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1684,10 +1684,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: c88b33c445569e544bf6b4d53392f8d66563394d56b1eb5c8a0dc9553843bf4c
+      sha256: "5aa37aed1399333a3ac4b78ce00c7dcba77c5e407b6420960bba43751895fa22"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.0"
+    version: "1.6.2"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -165,7 +165,7 @@ dependencies:
   convert: ^3.1.2
   just_audio: ^0.10.5
   audio_session: ^0.2.2
-  pro_video_editor: ^1.6.0
+  pro_video_editor: ^1.6.2
   pro_image_editor: ^12.0.0
   linked_scroll_controller: ^0.2.0
   flutter_colorpicker: ^1.1.0


### PR DESCRIPTION
## Description

A Discord user "PSBoy2012" reported that merging videos crashes the app. This issue only occurs on older phones. I fixed it by just updating the `pro_video_editor` cuz i had to fix it in that package.

Note: I exchanged a few text messages with "PSBoy2012" in DM's and I sent him some IPA files to test and he confirmed that everything works fine now!

**Related Issue:** Closes #1932

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore