### PR TITLE
fix(video): point media_kit_video to iOS simulator crash fix branch

### DIFF
--- a/mobile/packages/pooled_video_player/pubspec.yaml
+++ b/mobile/packages/pooled_video_player/pubspec.yaml
@@ -16,13 +16,13 @@ dependencies:
     sdk: flutter
   media_kit: ^1.2.6
   media_kit_libs_video: ^1.0.7
-  # Temporary override to include texture rotation fix
-  # https://github.com/media-kit/media-kit/issues/627
+  # Temporary override to fix iOS simulator crash
+  # https://github.com/divinevideo/divine-mobile/issues/1578
   # Will be removed once the fix is merged and released
   media_kit_video:
     git:
       url: https://github.com/divinevideo/media-kit
-      ref: fix/texture-rotation
+      ref: worktree-ios_simulator_video_crash
       path: media_kit_video
 
 dev_dependencies:

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1395,8 +1395,8 @@ packages:
     dependency: "direct main"
     description:
       path: media_kit_video
-      ref: "fix/texture-rotation"
-      resolved-ref: "6b718491261e40ddebf1fe9b880b3d5d30205ee0"
+      ref: worktree-ios_simulator_video_crash
+      resolved-ref: "961a2401bfe9d9a941631c4319ac640fbe28cbf0"
       url: "https://github.com/divinevideo/media-kit"
     source: git
     version: "2.0.1"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -173,13 +173,13 @@ dependencies:
   sensors_plus: ^7.0.0
   media_kit: ^1.2.6
   media_kit_libs_video: ^1.0.7
-  # Temporary override to include texture rotation fix
-  # https://github.com/media-kit/media-kit/issues/627
+  # Temporary override to fix iOS simulator crash
+  # https://github.com/divinevideo/divine-mobile/issues/1578
   # Will be removed once the fix is merged and released
   media_kit_video:
     git:
       url: https://github.com/divinevideo/media-kit
-      ref: fix/texture-rotation
+      ref: worktree-ios_simulator_video_crash
       path: media_kit_video
   stream_transform: ^2.1.1
   flutter_staggered_grid_view: ^0.7.0


### PR DESCRIPTION
## Description

Points `media_kit_video` git dependency to the `worktree-ios_simulator_video_crash` branch on our media-kit fork, which includes a fix for the iOS simulator crash caused by mpv's software renderer.

**Note:** Videos on the iOS simulator will appear rotated. The software-based texture rotation is intentionally disabled to avoid the crash — this only affects the simulator, not physical devices.

**Related Issue:** Closes #1578

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore