### PR TITLE
fix(audio): pause/resume home feed on tab switches and clear manual pause on reactivation

### DIFF
--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -8,6 +8,7 @@ import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/router/providers/page_context_provider.dart';
 import 'package:openvine/screens/feed/feed_mode_switch.dart';
 import 'package:openvine/screens/feed/feed_video_overlay.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
@@ -82,6 +83,12 @@ class VideoFeedView extends ConsumerStatefulWidget {
 class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     with WidgetsBindingObserver {
   int? lastPrefetchIndex;
+
+  /// Whether the home tab is currently active.
+  ///
+  /// Used to prevent overlay-close from resuming playback when the user
+  /// has navigated away to another tab (e.g. Search).
+  bool _isOnHomeTab = true;
 
   /// Guards so startup milestones fire only once.
   bool _hasMarkedUIReady = false;
@@ -196,11 +203,24 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
 
   @override
   Widget build(BuildContext context) {
-    // Pause/resume the pooled video feed when overlays (drawer, modals)
-    // become visible or hidden. Without this, the home feed's
-    // PooledVideoFeed continues playing because activeVideoIdProvider
-    // returns null for RouteType.home (self-managed by the pool).
+    // Pause/resume when navigating away from/back to home tab.
+    // The home navigator's GlobalKey keeps this widget alive across
+    // tab switches, so we must explicitly pause on tab change.
+    ref.listen(pageContextProvider, (_, next) {
+      final routeType = next.asData?.value.type;
+      if (routeType == null) return;
+
+      final isHome = routeType == RouteType.home;
+      if (isHome == _isOnHomeTab) return;
+      _isOnHomeTab = isHome;
+      controller?.setActive(active: isHome);
+    });
+
+    // Pause/resume for overlays (drawer, modals), but only when on
+    // the home tab. Without this guard, closing an overlay while on
+    // another tab would incorrectly resume the home feed audio.
     ref.listen(hasVisibleOverlayProvider, (_, hasOverlay) {
+      if (!_isOnHomeTab) return;
       controller?.setActive(active: !hasOverlay);
     });
 

--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -221,6 +221,8 @@ class VideoFeedController extends ChangeNotifier {
       _pauseVideo(_currentIndex);
       _releaseAllPlayers();
     } else {
+      // Clear any manual pause so playback resumes with audio
+      _isPaused = false;
       // Reload preload window and play current video
       _updatePreloadWindow(_currentIndex);
     }

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -692,6 +692,21 @@ void main() {
           addTearDown(controller.dispose);
         });
 
+        test('resets isPaused when reactivated', () {
+          final controller = VideoFeedController(
+            videos: createTestVideos(),
+            pool: pool,
+          );
+          addTearDown(controller.dispose);
+
+          controller
+            ..pause()
+            ..setActive(active: false)
+            ..setActive(active: true);
+
+          expect(controller.isPaused, isFalse);
+        });
+
         test('does nothing when value unchanged', () {
           final controller = VideoFeedController(
             videos: createTestVideos(),

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -1,5 +1,8 @@
 // ABOUTME: Widget tests for VideoFeedPage overlay-to-playback integration
-// ABOUTME: Verifies that overlay visibility pauses/resumes the pooled video feed
+// ABOUTME: Verifies that overlay visibility and tab switches pause/resume the
+// ABOUTME: pooled video feed
+
+import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
@@ -9,6 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
+import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:pooled_video_player/pooled_video_player.dart';
 
@@ -43,12 +47,16 @@ void main() {
       registerFallbackValue(const VideoFeedAutoRefreshRequested());
     });
 
-    Widget buildSubject({ProviderContainer? container, VideoFeedState? state}) {
+    Widget buildSubject({
+      VideoFeedState? state,
+      List<dynamic>? additionalOverrides,
+    }) {
       when(
         () => videoFeedBloc.state,
       ).thenReturn(state ?? const VideoFeedState());
 
       return testMaterialApp(
+        additionalOverrides: additionalOverrides,
         home: BlocProvider<VideoFeedBloc>.value(
           value: videoFeedBloc,
           child: VideoFeedView(controller: videoFeedController),
@@ -106,5 +114,129 @@ void main() {
 
       verify(() => videoFeedController.setActive(active: true)).called(1);
     });
+  });
+
+  group('VideoFeedView tab switch integration', () {
+    late VideoFeedBloc videoFeedBloc;
+    late VideoFeedController videoFeedController;
+    late StreamController<String> locationController;
+
+    setUp(() {
+      videoFeedBloc = _MockVideoFeedBloc();
+      videoFeedController = _MockVideoFeedController();
+      locationController = StreamController<String>();
+
+      when(
+        () => videoFeedController.setActive(active: any(named: 'active')),
+      ).thenReturn(null);
+      when(() => videoFeedController.videoCount).thenReturn(0);
+      when(() => videoFeedController.videos).thenReturn([]);
+      when(() => videoFeedController.addListener(any())).thenReturn(null);
+      when(() => videoFeedController.removeListener(any())).thenReturn(null);
+      when(() => videoFeedController.dispose()).thenReturn(null);
+    });
+
+    tearDown(() {
+      locationController.close();
+    });
+
+    setUpAll(() {
+      registerFallbackValue(const VideoFeedStarted());
+      registerFallbackValue(const VideoFeedAutoRefreshRequested());
+    });
+
+    Widget buildSubject() {
+      when(
+        () => videoFeedBloc.state,
+      ).thenReturn(const VideoFeedState());
+
+      return testMaterialApp(
+        additionalOverrides: [
+          routerLocationStreamProvider.overrideWith(
+            (ref) => locationController.stream,
+          ),
+        ],
+        home: BlocProvider<VideoFeedBloc>.value(
+          value: videoFeedBloc,
+          child: VideoFeedView(controller: videoFeedController),
+        ),
+      );
+    }
+
+    testWidgets(
+      'calls setActive(active: false) when navigating away from home',
+      (tester) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        // Start on home tab
+        locationController.add('/home/0');
+        await tester.pump();
+
+        clearInteractions(videoFeedController);
+
+        // Navigate to search tab
+        locationController.add('/search');
+        await tester.pump();
+
+        verify(
+          () => videoFeedController.setActive(active: false),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'calls setActive(active: true) when returning to home',
+      (tester) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        // Start on home, navigate away
+        locationController.add('/home/0');
+        await tester.pump();
+        locationController.add('/search');
+        await tester.pump();
+
+        clearInteractions(videoFeedController);
+
+        // Return to home
+        locationController.add('/home/0');
+        await tester.pump();
+
+        verify(
+          () => videoFeedController.setActive(active: true),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'does not resume when overlay closes while on non-home tab',
+      (tester) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        final element = tester.element(find.byType(VideoFeedView));
+        final container = ProviderScope.containerOf(element);
+
+        // Start on home, navigate away
+        locationController.add('/home/0');
+        await tester.pump();
+        locationController.add('/search');
+        await tester.pump();
+
+        clearInteractions(videoFeedController);
+
+        // Open and close overlay while on search tab
+        container.read(overlayVisibilityProvider.notifier).setDrawerOpen(true);
+        await tester.pump();
+        container.read(overlayVisibilityProvider.notifier).setDrawerOpen(false);
+        await tester.pump();
+
+        // setActive(active: true) should NOT have been called
+        verifyNever(
+          () => videoFeedController.setActive(active: true),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description

When navigating away from the home tab and returning, the home feed video would either keep playing audio in the background or resume without sound after a manual pause. This adds a `pageContextProvider` listener to pause/resume the home feed on tab switches, guards overlay-close from resuming playback on non-home tabs, and resets the manual pause flag in `setActive` so returning to the feed resumes with audio.

**Related Issue:** Closes #1871 closes #1590

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore