### PR TITLE
fix: resolve home screen blank after logout/re-login

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -100,6 +100,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
 
     _feedTracker?.startFeedLoad(mode.name);
 
+    await _followRepository.initialized;
+
     await _loadVideos(mode, emit);
 
     // Subscribe to following list changes.

--- a/mobile/lib/repositories/follow_repository.dart
+++ b/mobile/lib/repositories/follow_repository.dart
@@ -108,6 +108,13 @@ class FollowRepository {
   Event? _currentUserContactListEvent;
   bool _isInitialized = false;
 
+  final Completer<void> _initCompleter = Completer<void>();
+
+  /// A future that completes when [initialize] has finished (successfully or
+  /// with an error). Await this before reading [followingPubkeys] to avoid a
+  /// race condition where the list appears empty.
+  Future<void> get initialized => _initCompleter.future;
+
   // Real-time sync subscription for cross-device synchronization
   StreamSubscription<Event>? _contactListSubscription;
   String? _contactListSubscriptionId;
@@ -141,6 +148,9 @@ class FollowRepository {
 
   /// Dispose resources (idempotent — safe to call multiple times).
   Future<void> dispose() async {
+    if (!_initCompleter.isCompleted) {
+      _initCompleter.complete();
+    }
     _contactListSubscription?.cancel();
     if (_contactListSubscriptionId != null) {
       await _nostrClient.unsubscribe(_contactListSubscriptionId!);
@@ -559,6 +569,10 @@ class FollowRepository {
         name: 'FollowRepository',
         category: LogCategory.system,
       );
+    } finally {
+      if (!_initCompleter.isCompleted) {
+        _initCompleter.complete();
+      }
     }
   }
 

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -2,6 +2,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide AspectRatio;
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
@@ -9,6 +10,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/providers/page_context_provider.dart';
+import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/feed/feed_mode_switch.dart';
 import 'package:openvine/screens/feed/feed_video_overlay.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
@@ -392,6 +394,10 @@ class FeedEmptyWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isNoFollowedUsers =
+        state.mode == FeedMode.home &&
+        state.error == VideoFeedError.noFollowedUsers;
+
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -407,6 +413,18 @@ class FeedEmptyWidget extends StatelessWidget {
             style: const TextStyle(color: VineTheme.whiteText, fontSize: 18),
             textAlign: TextAlign.center,
           ),
+          if (isNoFollowedUsers) ...[
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: () => context.go(ExploreScreen.path),
+              icon: const Icon(Icons.explore),
+              label: const Text('Explore Videos'),
+              style: FilledButton.styleFrom(
+                backgroundColor: VineTheme.vineGreen,
+                foregroundColor: VineTheme.backgroundColor,
+              ),
+            ),
+          ],
         ],
       ),
     );

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -45,6 +45,9 @@ void main() {
         () => mockFollowRepository.followingStream,
       ).thenAnswer((_) => followingController.stream);
       when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
+      when(
+        () => mockFollowRepository.initialized,
+      ).thenAnswer((_) async {});
 
       when(
         () => mockCuratedListRepository.subscribedListsStream,

--- a/mobile/test/repositories/follow_repository_test.dart
+++ b/mobile/test/repositories/follow_repository_test.dart
@@ -1188,6 +1188,41 @@ void main() {
       });
     });
 
+    group('initialized completer', () {
+      test('completes after successful initialize()', () async {
+        await repository.initialize();
+
+        // initialized should complete immediately since initialize() finished
+        await expectLater(repository.initialized, completes);
+      });
+
+      test('completes even when initialization fails', () async {
+        // Force SharedPreferences to throw during load
+        SharedPreferences.setMockInitialValues({
+          'following_list_$testCurrentUserPubkey': 'invalid json{{{',
+        });
+
+        repository = FollowRepository(
+          nostrClient: mockNostrClient,
+          personalEventCache: mockPersonalEventCache,
+          indexerRelayUrls: const [],
+        );
+
+        await repository.initialize();
+
+        // initialized should still complete despite the error
+        await expectLater(repository.initialized, completes);
+      });
+
+      test('completes when dispose() called before initialize()', () async {
+        // dispose without ever calling initialize
+        await repository.dispose();
+
+        // initialized should complete because dispose completes the Completer
+        await expectLater(repository.initialized, completes);
+      });
+    });
+
     group('getSocialCounts', () {
       late _MockFunnelcakeApiClient mockFunnelcakeClient;
 


### PR DESCRIPTION
Closes #1127

## Summary
- Add `Completer<void>` to `FollowRepository` so callers can await initialization before reading `followingPubkeys`, preventing a race condition where `VideoFeedBloc` emits `noFollowedUsers` before the follow list loads
- Await `_followRepository.initialized` in `VideoFeedBloc._onStarted` before calling `_loadVideos`
- Add "Explore Videos" CTA button to the empty home feed state when `noFollowedUsers`, navigating to `/explore`

## Test plan
- [x] `FollowRepository` tests: `initialized` completes after success, after failure, and when `dispose()` is called before `initialize()`
- [x] `VideoFeedBloc` tests: all 53 existing tests pass with the new `initialized` stub
- [x] `FollowRepository` tests: all 64 tests pass
- [ ] Manual: anonymous login -> follow user -> logout -> re-login anonymously -> home tab shows followed user's videos (not blank)
- [ ] Manual: fresh anonymous login with no follows -> empty state shows "Explore Videos" button -> tapping navigates to explore