### PR TITLE
fix(auth): clear stale bunker/keycast keys on account switch

### DIFF
--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -1103,9 +1103,14 @@ class AuthService implements BackgroundAwareService {
         case AuthenticationSource.automatic:
         case AuthenticationSource.importedKeys:
         case AuthenticationSource.none:
+          // Clear any stale global signer keys so they don't hijack signing
+          // operations for the non-bunker/non-keycast account.
+          await _clearBunkerInfo();
+          await _clearAmberInfo();
+          await KeycastSession.clear(_flutterSecureStorage);
           Log.debug(
             '_restoreSignerInfo: local key-based auth — '
-            'no signer info to restore',
+            'cleared stale signer keys',
             name: 'AuthService',
             category: LogCategory.auth,
           );

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -777,6 +777,66 @@ void main() {
         () => mockSecureStorage.read(key: 'keycast_session_$pubkeyHex'),
       );
     });
+
+    test(
+      'clears stale global signer keys when switching to automatic',
+      () async {
+        final pubkeyHex = testKeyContainer.publicKeyHex;
+
+        await _ignoringDiscoveryErrors(
+          () => authService.signInForAccount(
+            pubkeyHex,
+            AuthenticationSource.automatic,
+          ),
+        );
+
+        // Bunker global key must be cleared
+        verify(
+          () => mockSecureStorage.delete(key: 'bunker_info'),
+        ).called(1);
+        // Amber global keys must be cleared
+        verify(
+          () => mockSecureStorage.delete(key: 'amber_pubkey'),
+        ).called(1);
+        verify(
+          () => mockSecureStorage.delete(key: 'amber_package'),
+        ).called(1);
+        // Keycast session global key must be cleared
+        verify(
+          () => mockSecureStorage.delete(key: 'keycast_session'),
+        ).called(1);
+      },
+    );
+
+    test(
+      'clears stale global signer keys when switching to importedKeys',
+      () async {
+        final pubkeyHex = testKeyContainer.publicKeyHex;
+
+        await _ignoringDiscoveryErrors(
+          () => authService.signInForAccount(
+            pubkeyHex,
+            AuthenticationSource.importedKeys,
+          ),
+        );
+
+        // Bunker global key must be cleared
+        verify(
+          () => mockSecureStorage.delete(key: 'bunker_info'),
+        ).called(1);
+        // Amber global keys must be cleared
+        verify(
+          () => mockSecureStorage.delete(key: 'amber_pubkey'),
+        ).called(1);
+        verify(
+          () => mockSecureStorage.delete(key: 'amber_package'),
+        ).called(1);
+        // Keycast session global key must be cleared
+        verify(
+          () => mockSecureStorage.delete(key: 'keycast_session'),
+        ).called(1);
+      },
+    );
   });
 
   group('signInForAccount', () {


### PR DESCRIPTION
## Summary
- Clears stale `bunker_info`, `amber_info`, and `KeycastSession` data when `_restoreSignerInfo()` switches to `automatic`, `importedKeys`, or `none` signer types
- Prevents stale NIP-46 bunker connections from hijacking signing when switching to anonymous/automatic accounts
- Root cause: the `automatic`/`importedKeys`/`none` branch in `_restoreSignerInfo()` didn't clear previous signer state, causing bunker RPC calls after switching away from bunker auth

Closes #1945

## Test plan
- [x] Existing 48 auth service tests pass
- [ ] Manual: Switch from bunker account to anonymous → verify no bunker RPC calls in logs
- [ ] Manual: Switch from bunker to imported keys → verify signing uses imported keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)