### PR TITLE
fix(profiles): treat FunnelCake all-null profile as confirmed missing

### DIFF
--- a/mobile/lib/services/analytics_api_service.dart
+++ b/mobile/lib/services/analytics_api_service.dart
@@ -1030,12 +1030,15 @@ class AnalyticsApiService {
             'lud16': profile['lud16'],
           };
         }
+        // User exists in FunnelCake but has no Kind 0 profile data.
+        // Return sentinel so caller can skip the relay/indexer fallback.
         Log.debug(
-          'FunnelCake returned user but no profile data',
+          'FunnelCake returned user but no profile data for $pubkey'
+          ' - returning confirmed-missing sentinel',
           name: 'AnalyticsApiService',
           category: LogCategory.system,
         );
-        return null;
+        return {'_noProfile': true, 'pubkey': pubkey};
       } else if (response.statusCode == 404) {
         Log.debug(
           'Profile not found in FunnelCake: $pubkey',
@@ -1646,9 +1649,22 @@ class AnalyticsApiService {
         for (final user in usersData) {
           if (user is Map<String, dynamic>) {
             final pubkey = user['pubkey']?.toString();
+            if (pubkey == null || pubkey.isEmpty) continue;
+
             final profile = user['profile'] as Map<String, dynamic>?;
-            if (pubkey != null && pubkey.isNotEmpty && profile != null) {
-              result[pubkey] = profile;
+            if (profile != null) {
+              // Check if profile has any real data
+              final hasProfileData =
+                  profile['name'] != null ||
+                  profile['display_name'] != null ||
+                  profile['picture'] != null ||
+                  profile['about'] != null;
+              if (hasProfileData) {
+                result[pubkey] = profile;
+              } else {
+                // User exists but has no Kind 0 profile data
+                result[pubkey] = {'_noProfile': true};
+              }
             }
           }
         }

--- a/mobile/lib/services/user_profile_service.dart
+++ b/mobile/lib/services/user_profile_service.dart
@@ -310,6 +310,20 @@ class UserProfileService extends ChangeNotifier {
       if (_analyticsApiService != null && _funnelcakeAvailable) {
         final restProfile = await _analyticsApiService.getUserProfile(pubkey);
         if (restProfile != null) {
+          // Check for sentinel: FunnelCake knows this user but they have no
+          // Kind 0 profile. Short-circuit the relay/indexer fallback cascade.
+          if (restProfile['_noProfile'] == true) {
+            markProfileAsMissing(pubkey);
+            _pendingRequests.remove(pubkey);
+            Log.debug(
+              'FunnelCake confirmed no profile for $pubkey'
+              ' - skipping relay fallback',
+              name: 'UserProfileService',
+              category: LogCategory.system,
+            );
+            return null;
+          }
+
           // Create UserProfile from REST response
           final profile = UserProfile(
             pubkey: pubkey,

--- a/mobile/test/services/analytics_api_service_test.dart
+++ b/mobile/test/services/analytics_api_service_test.dart
@@ -671,6 +671,180 @@ void main() {
     });
   });
 
+  group('getUserProfile', () {
+    test('returns profile data when user has a Kind 0 profile', () async {
+      final mockClient = MockClient((request) async {
+        expect(request.url.path, '/api/users/abc123');
+        return http.Response(
+          jsonEncode({
+            'pubkey': 'abc123',
+            'profile': {
+              'name': 'alice',
+              'display_name': 'Alice',
+              'about': 'Hello world',
+              'picture': 'https://example.com/alice.jpg',
+              'banner': null,
+              'nip05': 'alice@example.com',
+              'lud16': null,
+            },
+          }),
+          200,
+        );
+      });
+
+      final service = AnalyticsApiService(
+        baseUrl: 'https://funnelcake.test',
+        httpClient: mockClient,
+      );
+
+      final result = await service.getUserProfile('abc123');
+
+      expect(result, isNotNull);
+      expect(result!['name'], equals('alice'));
+      expect(result['display_name'], equals('Alice'));
+      expect(result['_noProfile'], isNull);
+    });
+
+    test(
+      'returns _noProfile sentinel when user exists but has no profile data',
+      () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(
+            jsonEncode({
+              'pubkey': 'abc123',
+              'profile': {
+                'name': null,
+                'display_name': null,
+                'about': null,
+                'picture': null,
+                'banner': null,
+                'nip05': null,
+                'lud16': null,
+              },
+            }),
+            200,
+          );
+        });
+
+        final service = AnalyticsApiService(
+          baseUrl: 'https://funnelcake.test',
+          httpClient: mockClient,
+        );
+
+        final result = await service.getUserProfile('abc123');
+
+        expect(result, isNotNull);
+        expect(result!['_noProfile'], isTrue);
+        expect(result['pubkey'], equals('abc123'));
+      },
+    );
+
+    test(
+      'returns _noProfile sentinel when profile object has no keys',
+      () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(
+            jsonEncode({
+              'pubkey': 'abc123',
+              'profile': <String, dynamic>{},
+            }),
+            200,
+          );
+        });
+
+        final service = AnalyticsApiService(
+          baseUrl: 'https://funnelcake.test',
+          httpClient: mockClient,
+        );
+
+        final result = await service.getUserProfile('abc123');
+
+        expect(result, isNotNull);
+        expect(result!['_noProfile'], isTrue);
+      },
+    );
+
+    test('returns null when user is not found (404)', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response('Not Found', 404);
+      });
+
+      final service = AnalyticsApiService(
+        baseUrl: 'https://funnelcake.test',
+        httpClient: mockClient,
+      );
+
+      final result = await service.getUserProfile('nonexistent');
+      expect(result, isNull);
+    });
+
+    test('returns null when API is not available', () async {
+      final service = AnalyticsApiService(baseUrl: null);
+      final result = await service.getUserProfile('abc123');
+      expect(result, isNull);
+    });
+  });
+
+  group('getBulkProfiles', () {
+    test(
+      'returns _noProfile sentinel for users with all-null profile fields',
+      () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(
+            jsonEncode({
+              'users': [
+                {
+                  'pubkey': 'user_with_profile',
+                  'profile': {
+                    'name': 'alice',
+                    'display_name': 'Alice',
+                    'about': null,
+                    'picture': null,
+                  },
+                },
+                {
+                  'pubkey': 'user_without_profile',
+                  'profile': {
+                    'name': null,
+                    'display_name': null,
+                    'about': null,
+                    'picture': null,
+                  },
+                },
+              ],
+            }),
+            200,
+          );
+        });
+
+        final service = AnalyticsApiService(
+          baseUrl: 'https://funnelcake.test',
+          httpClient: mockClient,
+        );
+
+        final result = await service.getBulkProfiles([
+          'user_with_profile',
+          'user_without_profile',
+        ]);
+
+        expect(result.length, 2);
+
+        // Real profile
+        expect(result['user_with_profile']!['name'], equals('alice'));
+        expect(result['user_with_profile']!['_noProfile'], isNull);
+
+        // No-profile sentinel
+        expect(result['user_without_profile']!['_noProfile'], isTrue);
+      },
+    );
+
+    test('returns empty map when API not available', () async {
+      final service = AnalyticsApiService(baseUrl: null);
+      final result = await service.getBulkProfiles(['abc']);
+      expect(result, isEmpty);
+    });
+  });
+
   group('getRawEvent', () {
     test('returns raw event JSON on 200 response', () async {
       final rawEvent = {

--- a/mobile/test/services/user_profile_service_no_profile_test.dart
+++ b/mobile/test/services/user_profile_service_no_profile_test.dart
@@ -1,0 +1,264 @@
+// ABOUTME: Tests that FunnelCake all-null profile responses short-circuit
+// ABOUTME: the relay/indexer fallback cascade in UserProfileService
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/analytics_api_service.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/user_profile_service.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {
+  @override
+  bool get isInitialized => true;
+}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+class _MockAnalyticsApiService extends Mock implements AnalyticsApiService {}
+
+void main() {
+  late _MockNostrClient mockNostrClient;
+  late _MockSubscriptionManager mockSubscriptionManager;
+  late _MockAnalyticsApiService mockAnalyticsApi;
+
+  setUp(() {
+    mockNostrClient = _MockNostrClient();
+    mockSubscriptionManager = _MockSubscriptionManager();
+    mockAnalyticsApi = _MockAnalyticsApiService();
+
+    registerFallbackValue(<Filter>[]);
+    registerFallbackValue((Event e) {});
+
+    // Stub cancelSubscription so dispose() works
+    when(
+      () => mockSubscriptionManager.cancelSubscription(any()),
+    ).thenAnswer((_) async {});
+  });
+
+  group(UserProfileService, () {
+    group('fetchProfile with FunnelCake no-profile sentinel', () {
+      test(
+        'marks profile as missing when FunnelCake returns _noProfile sentinel',
+        () async {
+          const pubkey =
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+          when(
+            () => mockAnalyticsApi.getUserProfile(pubkey),
+          ).thenAnswer((_) async => {'_noProfile': true, 'pubkey': pubkey});
+
+          final service = UserProfileService(
+            mockNostrClient,
+            subscriptionManager: mockSubscriptionManager,
+            analyticsApiService: mockAnalyticsApi,
+            funnelcakeAvailable: true,
+            skipIndexerFallback: true,
+          );
+
+          await service.initialize();
+          final result = await service.fetchProfile(pubkey);
+
+          expect(result, isNull);
+          expect(service.shouldSkipProfileFetch(pubkey), isTrue);
+
+          // Verify no WebSocket subscription was created
+          verifyNever(
+            () => mockSubscriptionManager.createSubscription(
+              name: any(named: 'name'),
+              filters: any(named: 'filters'),
+              onEvent: any(named: 'onEvent'),
+              onError: any(named: 'onError'),
+              onComplete: any(named: 'onComplete'),
+              priority: any(named: 'priority'),
+            ),
+          );
+
+          service.dispose();
+        },
+      );
+
+      test(
+        'does not mark profile as missing when FunnelCake returns real data',
+        () async {
+          const pubkey =
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+          when(
+            () => mockAnalyticsApi.getUserProfile(pubkey),
+          ).thenAnswer(
+            (_) async => {
+              'pubkey': pubkey,
+              'name': 'alice',
+              'display_name': 'Alice',
+              'about': null,
+              'picture': 'https://example.com/alice.jpg',
+              'banner': null,
+              'nip05': null,
+              'lud16': null,
+            },
+          );
+
+          final service = UserProfileService(
+            mockNostrClient,
+            subscriptionManager: mockSubscriptionManager,
+            analyticsApiService: mockAnalyticsApi,
+            funnelcakeAvailable: true,
+            skipIndexerFallback: true,
+          );
+
+          await service.initialize();
+          final result = await service.fetchProfile(pubkey);
+
+          expect(result, isNotNull);
+          expect(result!.name, equals('alice'));
+          expect(service.shouldSkipProfileFetch(pubkey), isFalse);
+          expect(service.hasProfile(pubkey), isTrue);
+
+          service.dispose();
+        },
+      );
+
+      test(
+        'second fetchProfile call for missing profile returns null immediately',
+        () async {
+          const pubkey =
+              'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+          when(
+            () => mockAnalyticsApi.getUserProfile(pubkey),
+          ).thenAnswer((_) async => {'_noProfile': true, 'pubkey': pubkey});
+
+          final service = UserProfileService(
+            mockNostrClient,
+            subscriptionManager: mockSubscriptionManager,
+            analyticsApiService: mockAnalyticsApi,
+            funnelcakeAvailable: true,
+            skipIndexerFallback: true,
+          );
+
+          await service.initialize();
+
+          // First call: marks as missing
+          await service.fetchProfile(pubkey);
+          expect(service.shouldSkipProfileFetch(pubkey), isTrue);
+
+          // Reset the mock to track second call
+          reset(mockAnalyticsApi);
+
+          // Second call should be skipped entirely
+          // (shouldSkipProfileFetch is checked by callers like
+          // fetchMultipleProfiles, but fetchProfile itself returns null
+          // because the profile is not in cache)
+          expect(service.shouldSkipProfileFetch(pubkey), isTrue);
+
+          service.dispose();
+        },
+      );
+
+      test(
+        'falls through to WebSocket when FunnelCake returns null',
+        () async {
+          const pubkey =
+              'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+          when(
+            () => mockAnalyticsApi.getUserProfile(pubkey),
+          ).thenAnswer((_) async => null);
+
+          when(
+            () => mockSubscriptionManager.createSubscription(
+              name: any(named: 'name'),
+              filters: any(named: 'filters'),
+              onEvent: any(named: 'onEvent'),
+              onError: any(named: 'onError'),
+              onComplete: any(named: 'onComplete'),
+              priority: any(named: 'priority'),
+            ),
+          ).thenAnswer((_) async => 'sub-123');
+
+          final service = UserProfileService(
+            mockNostrClient,
+            subscriptionManager: mockSubscriptionManager,
+            analyticsApiService: mockAnalyticsApi,
+            funnelcakeAvailable: true,
+            skipIndexerFallback: true,
+          );
+
+          await service.initialize();
+
+          // Don't await - this returns a Completer future that
+          // won't complete without relay events
+          unawaited(service.fetchProfile(pubkey));
+
+          // Allow the batch debounce timer to fire
+          await Future<void>.delayed(const Duration(milliseconds: 200));
+
+          // Should NOT be marked as missing since FunnelCake returned null
+          // (user not in FunnelCake at all)
+          expect(service.shouldSkipProfileFetch(pubkey), isFalse);
+
+          service.dispose();
+        },
+      );
+    });
+
+    group('prefetchProfilesImmediately with no-profile sentinel', () {
+      test(
+        'marks no-profile users as missing from bulk API response',
+        () async {
+          const realPubkey =
+              'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+          const noProfPubkey =
+              'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+          when(
+            () => mockAnalyticsApi.getBulkProfiles([realPubkey, noProfPubkey]),
+          ).thenAnswer(
+            (_) async => {
+              realPubkey: {
+                'name': 'bob',
+                'display_name': 'Bob',
+                'about': null,
+                'picture': null,
+              },
+              noProfPubkey: {'_noProfile': true},
+            },
+          );
+
+          final service = UserProfileService(
+            mockNostrClient,
+            subscriptionManager: mockSubscriptionManager,
+            analyticsApiService: mockAnalyticsApi,
+            funnelcakeAvailable: true,
+            skipIndexerFallback: true,
+          );
+
+          await service.initialize();
+          await service.prefetchProfilesImmediately([
+            realPubkey,
+            noProfPubkey,
+          ]);
+
+          // Real profile should be cached
+          expect(service.hasProfile(realPubkey), isTrue);
+          expect(
+            service.getCachedProfile(realPubkey)?.name,
+            equals('bob'),
+          );
+
+          // No-profile user should be marked as missing
+          expect(service.shouldSkipProfileFetch(noProfPubkey), isTrue);
+          expect(service.hasProfile(noProfPubkey), isFalse);
+
+          service.dispose();
+        },
+      );
+    });
+  });
+}
+
+/// Silences unawaited futures lint for fire-and-forget futures in tests
+void unawaited(Future<void> future) {}


### PR DESCRIPTION
## Summary
- When FunnelCake REST API returns a 200 with all-null profile fields (user exists but never published Kind 0), return a `_noProfile: true` sentinel value instead of null
- `UserProfileService.fetchProfile()` detects this sentinel and calls `markProfileAsMissing()` to short-circuit the 20+ second relay batch fetch → indexer query → retry fallback cascade
- Fixes profile fetches for anonymous/new users taking 20+ seconds per missing profile

Closes #1946

## Test plan
- [x] 39 analytics_api_service tests pass
- [x] New `user_profile_service_no_profile_test.dart` tests verify sentinel detection
- [ ] Manual: View home feed with videos from users who have no Kind 0 profile → verify quick load (no 20s delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)