### PR TITLE
fix(camera): improve initialization handling and add watchdog for frame delivery

### DIFF
--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -596,24 +596,17 @@ class CameraController: NSObject {
                     
                     // Stop and restart the session to "kick" it
                     session.stopRunning()
-                    
+
                     // Brief pause before restarting
-                    Thread.sleep(forTimeInterval: 0.1)
-                    
-                    session.startRunning()
-                    print("DivineCamera: ✅ Session restarted by watchdog")
+                    self.sessionQueue.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                        guard let self = self, let session = self.captureSession else { return }
+                        session.startRunning()
+                        print("DivineCamera: ✅ Session restarted by watchdog")
+                    }
                 }
             } else {
                 print("DivineCamera: ✅ Watchdog: Frames are flowing normally")
             }
-        }
-        
-        // Additional check after 0.5s for debugging
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            if let connection = self?.videoOutput?.connection(with: .video) {
-                print("DivineCamera: After 0.5s - Video connection active: \(connection.isActive), enabled: \(connection.isEnabled)")
-            }
-            print("DivineCamera: After 0.5s - pixelBufferRef is nil: \(self?.pixelBufferRef == nil)")
         }
         
         // Register texture after session is running


### PR DESCRIPTION
## Description

- Fixes a black screen / frozen camera issue on some iOS devices where AVCaptureSession starts running but silently fails to deliver frames to Flutter's texture renderer
- Defers the initialization completion callback until the first real frame is received, ensuring the Flutter UI is only shown the camera preview when it is actually live
- Adds a watchdog timer (1 s) that detects a stuck session and performs a stop/restart to recover it automatically
- Adds a 2 s timeout fallback so initialization always completes, even if frames never arrive (e.g. camera denied mid-flow)
- Cleans up all pending timers and callbacks on dispose()/stopCamera() to prevent callbacks firing after teardown

### Root Cause
On certain iOS devices and OS versions, AVCaptureSession.startRunning() returns without error but the AVCaptureVideoDataOutputSampleBufferDelegate never fires. The previous code called the Flutter completion handler immediately after startRunning(), so Flutter displayed a black texture that never updated.

**Related Issue:** Closes #1955

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore