### PR TITLE
fix: Restore last-used account on app restart

### DIFF
--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -135,11 +135,14 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           location.startsWith(ResetPasswordScreen.path) ||
           location.startsWith(EmailVerificationScreen.path);
 
-      // Unauthenticated users on non-auth routes → redirect to welcome
-      if (!isAuthRoute && authState == AuthState.unauthenticated) {
+      // Non-authenticated users on protected routes → welcome.
+      // awaitingTosAcceptance has no dedicated screen, so treat it like unauthenticated.
+      if (!isAuthRoute &&
+          (authState == AuthState.unauthenticated ||
+              authState == AuthState.awaitingTosAcceptance)) {
         _hasNavigated = false;
         Log.info(
-          'Router redirect: unauthenticated on $location — '
+          'Router redirect: ${authState.name} on $location — '
           'redirecting to ${WelcomeScreen.path}',
           name: 'AppRouter',
           category: LogCategory.auth,

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -28,6 +28,9 @@ import 'package:url_launcher/url_launcher.dart';
 // Key for persisted authentication source
 const _kAuthSourceKey = 'authentication_source';
 
+// Key for the last-used account npub (used to restore the correct identity on restart)
+const _kLastUsedNpubKey = 'last_used_npub';
+
 // Keys for bunker connection persistence
 const _kBunkerInfoKey = 'bunker_info';
 
@@ -433,62 +436,14 @@ class AuthService implements BackgroundAwareService {
           return;
 
         case AuthenticationSource.importedKeys:
-          // Only restore if secure keys exist
-          Log.info(
-            'initialize: restoring imported keys...',
-            name: 'AuthService',
-            category: LogCategory.auth,
+          await _restoreLastUsedAccountOrFallback(
+            AuthenticationSource.importedKeys,
           );
-          try {
-            final hasKeys = await _keyStorage.hasKeys();
-            if (hasKeys) {
-              final keyContainer = await _keyStorage.getKeyContainer();
-              if (keyContainer != null) {
-                Log.info(
-                  'initialize: imported keys found — '
-                  'pubkey=${keyContainer.publicKeyHex}',
-                  name: 'AuthService',
-                  category: LogCategory.auth,
-                );
-                await _setupUserSession(
-                  keyContainer,
-                  AuthenticationSource.importedKeys,
-                );
-                return;
-              }
-              Log.error(
-                'Imported keys: hasKeys() true but getKeyContainer() '
-                'returned null — possible storage corruption',
-                name: 'AuthService',
-                category: LogCategory.auth,
-              );
-              _reportStorageError(
-                StateError(
-                  'hasKeys() true but getKeyContainer() returned null',
-                ),
-                StackTrace.current,
-                'importedKeys storage inconsistency',
-              );
-            }
-          } catch (e, stack) {
-            Log.error(
-              'Secure storage error loading imported keys: $e. '
-              'User will need to re-import their key.',
-              name: 'AuthService',
-              category: LogCategory.auth,
-            );
-            _reportStorageError(e, stack, 'importedKeys load');
-            _lastError =
-                "Couldn't load your saved identity from this device. "
-                'Sign in with your existing account, or continue '
-                'to create a new one.';
-          }
-          _setAuthState(AuthState.unauthenticated);
-          return;
 
         case AuthenticationSource.automatic:
-          // Default behavior: check for keys and auto-create if needed
-          await _checkExistingAuth();
+          await _restoreLastUsedAccountOrFallback(
+            AuthenticationSource.automatic,
+          );
 
         case AuthenticationSource.bunker:
           // Try to restore bunker connection from secure storage
@@ -2385,6 +2340,7 @@ class AuthService implements BackgroundAwareService {
       // returns.
       if (deleteKeys) {
         await prefs.remove(_kAuthSourceKey);
+        await prefs.remove(_kLastUsedNpubKey);
       }
       await prefs.remove('age_verified_16_plus');
       await prefs.remove('terms_accepted_at');
@@ -2717,6 +2673,61 @@ class AuthService implements BackgroundAwareService {
     }
   }
 
+  /// Restores the last-used account's per-identity key, falling back to
+  /// [_checkExistingAuth] when the pref is absent or the key is missing.
+  Future<void> _restoreLastUsedAccountOrFallback(
+    AuthenticationSource source,
+  ) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final lastNpub = prefs.getString(_kLastUsedNpubKey);
+
+      if (lastNpub != null && lastNpub.isNotEmpty) {
+        Log.info(
+          '_restoreLastUsedAccountOrFallback: '
+          'found last-used npub, loading identity key...',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        final container = await _keyStorage.getIdentityKeyContainer(lastNpub);
+        if (container != null) {
+          Log.info(
+            '_restoreLastUsedAccountOrFallback: '
+            'identity key found — pubkey=${container.publicKeyHex}',
+            name: 'AuthService',
+            category: LogCategory.auth,
+          );
+          await _setupUserSession(container, source);
+          return;
+        }
+        Log.warning(
+          '_restoreLastUsedAccountOrFallback: '
+          'identity key absent for last-used npub — falling back',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+      } else {
+        Log.info(
+          '_restoreLastUsedAccountOrFallback: '
+          'no last-used npub stored — falling back to _checkExistingAuth',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+      }
+    } catch (e, stack) {
+      Log.warning(
+        '_restoreLastUsedAccountOrFallback: error reading last-used npub: $e '
+        '— falling back to _checkExistingAuth',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+      _reportStorageError(e, stack, '_restoreLastUsedAccountOrFallback');
+    }
+
+    // Fall back to the original behaviour (load primary key, or create new).
+    await _checkExistingAuth();
+  }
+
   /// Check for existing authentication
   Future<void> _checkExistingAuth() async {
     // If storage already failed once, the user saw the error and chose to
@@ -2967,6 +2978,8 @@ class AuthService implements BackgroundAwareService {
       );
 
       await prefs.setString(_kAuthSourceKey, source.code);
+
+      await prefs.setString(_kLastUsedNpubKey, keyContainer.npub);
 
       // Pre-fetch following list from REST API BEFORE setting auth state.
       // The router redirect fires synchronously on auth state change and reads

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -1157,4 +1157,148 @@ void main() {
       expect(restored['access_token'], equals('my_token'));
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // _restoreLastUsedAccountOrFallback (via initialize)
+  // ---------------------------------------------------------------------------
+
+  group('initialize: restores last-used account (not primary key)', () {
+    late SecureKeyContainer accountBContainer;
+
+    setUp(() {
+      accountBContainer = SecureKeyContainer.fromNsec(
+        'nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsmhltgl',
+      );
+    });
+
+    test(
+      'restores per-identity key when last_used_npub is present',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+          'last_used_npub': accountBContainer.npub,
+          kKnownAccountsKey: '[]',
+        });
+
+        when(
+          () => mockKeyStorage.getKeyContainer(),
+        ).thenAnswer((_) async => testKeyContainer);
+        when(
+          () => mockKeyStorage.getIdentityKeyContainer(
+            accountBContainer.npub,
+            biometricPrompt: any(named: 'biometricPrompt'),
+          ),
+        ).thenAnswer((_) async => accountBContainer);
+
+        await _ignoringDiscoveryErrors(authService.initialize);
+
+        expect(authService.authState, equals(AuthState.authenticated));
+        expect(
+          authService.currentPublicKeyHex,
+          equals(accountBContainer.publicKeyHex),
+        );
+        verifyNever(() => mockKeyStorage.getKeyContainer());
+      },
+    );
+
+    test(
+      'falls back to _checkExistingAuth when last_used_npub is absent',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+          kKnownAccountsKey: '[]',
+        });
+
+        when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => true);
+        when(
+          () => mockKeyStorage.getKeyContainer(),
+        ).thenAnswer((_) async => testKeyContainer);
+
+        await _ignoringDiscoveryErrors(authService.initialize);
+
+        expect(authService.authState, equals(AuthState.authenticated));
+        expect(
+          authService.currentPublicKeyHex,
+          equals(testKeyContainer.publicKeyHex),
+        );
+      },
+    );
+
+    test(
+      'falls back to _checkExistingAuth when identity key container is absent',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+          'last_used_npub': accountBContainer.npub,
+          kKnownAccountsKey: '[]',
+        });
+
+        when(
+          () => mockKeyStorage.getIdentityKeyContainer(
+            accountBContainer.npub,
+            biometricPrompt: any(named: 'biometricPrompt'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => true);
+        when(
+          () => mockKeyStorage.getKeyContainer(),
+        ).thenAnswer((_) async => testKeyContainer);
+
+        await _ignoringDiscoveryErrors(authService.initialize);
+
+        expect(authService.authState, equals(AuthState.authenticated));
+        expect(
+          authService.currentPublicKeyHex,
+          equals(testKeyContainer.publicKeyHex),
+        );
+      },
+    );
+
+    test(
+      'destructive sign-out clears last_used_npub',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+          'last_used_npub': testKeyContainer.npub,
+          kKnownAccountsKey: '[]',
+        });
+
+        await _ignoringDiscoveryErrors(authService.createNewIdentity);
+        await authService.signOut(deleteKeys: true);
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getString('last_used_npub'), isNull);
+      },
+    );
+
+    test(
+      'non-destructive sign-out preserves last_used_npub',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+          'last_used_npub': testKeyContainer.npub,
+          kKnownAccountsKey: '[]',
+        });
+
+        await _ignoringDiscoveryErrors(authService.createNewIdentity);
+        await authService.signOut();
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getString('last_used_npub'), isNotNull);
+      },
+    );
+
+    test(
+      '_setupUserSession persists last_used_npub',
+      () async {
+        await _ignoringDiscoveryErrors(authService.createNewIdentity);
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getString('last_used_npub'),
+          equals(testKeyContainer.npub),
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
On app restart, `initialize()` always loaded the primary key slot (`nostr_primary_key`) rather than the per-identity key of the account the user was last signed into, causing the wrong account to be restored. This fix persists the last-used npub in SharedPreferences on every sign-in and reads that per-identity key on restart — the same path `signInForAccount` already uses. A secondary fix ensures `awaitingTosAcceptance` (set when session restore throws) redirects to the welcome screen instead of leaving the user stuck on a blank screen.

Fixes #1917

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore