### PR TITLE
fix(search): avoid mutating unmodifiable relay address lists

### DIFF
--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -445,8 +445,8 @@ class RelayPool {
       throw ArgumentError("No filters given", "filters");
     }
 
-    handleAddrList(tempRelays);
-    handleAddrList(targetRelays);
+    tempRelays = handleAddrList(tempRelays);
+    targetRelays = handleAddrList(targetRelays);
 
     final Subscription subscription = Subscription(
       filters,
@@ -619,14 +619,9 @@ class RelayPool {
     return id;
   }
 
-  void handleAddrList(List<String>? addrList) {
-    if (addrList != null) {
-      var length = addrList.length;
-      for (var i = 0; i < length; i++) {
-        var relayAddr = addrList[i];
-        addrList[i] = RelayAddrUtil.handle(relayAddr);
-      }
-    }
+  List<String>? handleAddrList(List<String>? addrList) {
+    if (addrList == null) return null;
+    return addrList.map(RelayAddrUtil.handle).toList();
   }
 
   /// query should be a one time filter search.
@@ -649,8 +644,8 @@ class RelayPool {
       throw ArgumentError("No filters given", "filters");
     }
 
-    handleAddrList(tempRelays);
-    handleAddrList(targetRelays);
+    tempRelays = handleAddrList(tempRelays);
+    targetRelays = handleAddrList(targetRelays);
 
     Subscription subscription = Subscription(filters, onEvent, id: id);
     if (onComplete != null) {
@@ -972,7 +967,7 @@ class RelayPool {
       throw ArgumentError('No filters given', 'filters');
     }
 
-    handleAddrList(tempRelays);
+    tempRelays = handleAddrList(tempRelays);
 
     final subscriptionId = id ?? StringUtil.rndNameStr(16);
     final message = ['COUNT', subscriptionId, ...filters];


### PR DESCRIPTION
## Summary

Fixes crash when searching for users by name. `RelayPool.handleAddrList()` was mutating relay address lists in-place, which throws on unmodifiable lists (e.g. from `List.unmodifiable` or const literals passed as `tempRelays`/`targetRelays`).

Changed `handleAddrList` from void (in-place mutation) to returning a new list via `.map().toList()`. Updated all three call sites: `subscribe`, `query`, and `count`.

## Test plan

- [x] Search for a user by name — no crash, results from relay indexers appear
- [x] Relay address normalization preserved — `RelayAddrUtil.handle` is still applied to every address via `.map()`, same transformation as before