### PR TITLE
perf: improve home feed loading speed with Funnelcake fast path

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -36,12 +36,14 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
     required VideosRepository videosRepository,
     required FollowRepository followRepository,
     required CuratedListRepository curatedListRepository,
+    String? userPubkey,
     SharedPreferences? sharedPreferences,
     Duration autoRefreshMinInterval = _defaultAutoRefreshMinInterval,
     FeedPerformanceTracker? feedTracker,
   }) : _videosRepository = videosRepository,
        _followRepository = followRepository,
        _curatedListRepository = curatedListRepository,
+       _userPubkey = userPubkey,
        _sharedPreferences = sharedPreferences,
        _autoRefreshMinInterval = autoRefreshMinInterval,
        _feedTracker = feedTracker,
@@ -61,6 +63,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   final VideosRepository _videosRepository;
   final FollowRepository _followRepository;
   final CuratedListRepository _curatedListRepository;
+  final String? _userPubkey;
   final SharedPreferences? _sharedPreferences;
   final Duration _autoRefreshMinInterval;
   final FeedPerformanceTracker? _feedTracker;
@@ -71,13 +74,18 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
 
   /// Handle feed started event.
   ///
-  /// After the initial load, subscribes to [FollowRepository.followingStream]
-  /// and [CuratedListRepository.subscribedListsStream] so the home feed
-  /// refreshes reactively when the user follows/unfollows someone or when
-  /// subscribed curated lists change.
+  /// Fires [_loadVideos] immediately without waiting for the follow list to
+  /// initialize. When `userPubkey` is available, the Funnelcake API is
+  /// attempted first (fast path).
   ///
-  /// The first emission of each BehaviorSubject stream is skipped to avoid
-  /// redundant refreshes on startup.
+  /// After the initial load, subscribes to [FollowRepository.followingStream]
+  /// (without skipping) so the BehaviorSubject replays the current follow
+  /// list. [_onFollowingListChanged] handles the "no follows" CTA and
+  /// silently refreshes the feed (no loading state) so the initial replay
+  /// is harmless and runtime changes are seamless.
+  ///
+  /// Also subscribes to [CuratedListRepository.subscribedListsStream]
+  /// (skipping the first replay) so curated list changes refresh the feed.
   ///
   /// Both subscriptions use `unawaited` on the first so neither blocks the
   /// other — `emit.onEach` never completes for BehaviorSubject streams.
@@ -100,16 +108,16 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
 
     _feedTracker?.startFeedLoad(mode.name);
 
-    await _followRepository.initialized;
-
     await _loadVideos(mode, emit);
 
-    // Subscribe to following list changes.
+    // Subscribe to following list changes (no skip — receive the
+    // BehaviorSubject replay so _onFollowingListChanged can handle
+    // initial follow-list arrival and "no follows" CTA).
     // unawaited because emit.onEach never completes for BehaviorSubjects,
     // which would block the curated list subscription below.
     unawaited(
       emit.onEach<List<String>>(
-        _followRepository.followingStream.skip(1),
+        _followRepository.followingStream,
         onData: (pubkeys) => add(VideoFeedFollowingListChanged(pubkeys)),
       ),
     );
@@ -277,8 +285,16 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
 
   /// Handle following list changes from [FollowRepository].
   ///
-  /// Only refreshes when the current mode is [FeedMode.home] and the
-  /// feed has already been loaded (avoids double-loading on startup).
+  /// Receives every emission from the BehaviorSubject (no skip), so the
+  /// first call after startup is the replayed current value. Performs a
+  /// silent refresh — keeps current videos visible and replaces when done.
+  ///
+  /// - **Empty list** → show `noFollowedUsers` CTA immediately.
+  /// - **Non-empty list** → silent refresh via [_loadVideos]. For the
+  ///   initial BehaviorSubject replay, Funnelcake content stays visible
+  ///   and the fetch returns same/similar videos (no visible change).
+  ///   For runtime follow/unfollow, old content stays visible briefly,
+  ///   then replaced with updated feed (no loading flash).
   Future<void> _onFollowingListChanged(
     VideoFeedFollowingListChanged event,
     Emitter<VideoFeedState> emit,
@@ -286,15 +302,22 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
     if (state.mode != FeedMode.home) return;
     if (state.status == VideoFeedStatus.loading) return;
 
-    emit(
-      state.copyWith(
-        status: VideoFeedStatus.loading,
-        videos: [],
-        hasMore: true,
-        clearError: true,
-      ),
-    );
+    // Empty follow list → show "follow someone" CTA.
+    if (event.followingPubkeys.isEmpty) {
+      emit(
+        state.copyWith(
+          status: VideoFeedStatus.success,
+          videos: [],
+          hasMore: false,
+          error: VideoFeedError.noFollowedUsers,
+          videoListSources: const {},
+          listOnlyVideoIds: const {},
+        ),
+      );
+      return;
+    }
 
+    // Silent refresh — keep current videos visible, replace when done.
     await _loadVideos(FeedMode.home, emit);
   }
 
@@ -322,6 +345,12 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   }
 
   /// Load videos for the specified mode.
+  ///
+  /// For the home feed, does NOT wait for the follow list to initialize.
+  /// Instead, the follow-list stream subscription (set up in [_onStarted])
+  /// drives recovery: when the follow list arrives via
+  /// [VideoFeedFollowingListChanged], the handler decides whether to show
+  /// the `noFollowedUsers` CTA or refresh the feed.
   Future<void> _loadVideos(FeedMode mode, Emitter<VideoFeedState> emit) async {
     try {
       final result = await _fetchVideosForMode(mode);
@@ -330,23 +359,6 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
       final validVideos = result.videos
           .where((v) => v.videoUrl != null)
           .toList();
-
-      // Check for empty home feed due to no followed users
-      if (mode == FeedMode.home &&
-          validVideos.isEmpty &&
-          _followRepository.followingPubkeys.isEmpty) {
-        emit(
-          state.copyWith(
-            status: VideoFeedStatus.success,
-            videos: [],
-            hasMore: false,
-            error: VideoFeedError.noFollowedUsers,
-            videoListSources: const {},
-            listOnlyVideoIds: const {},
-          ),
-        );
-        return;
-      }
 
       _lastRefreshedAt = DateTime.now();
 
@@ -405,6 +417,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
         return _videosRepository.getHomeFeedVideos(
           authors: authors,
           videoRefs: videoRefs,
+          userPubkey: _userPubkey,
           until: until,
         );
 

--- a/mobile/lib/repositories/follow_repository.dart
+++ b/mobile/lib/repositories/follow_repository.dart
@@ -108,13 +108,6 @@ class FollowRepository {
   Event? _currentUserContactListEvent;
   bool _isInitialized = false;
 
-  final Completer<void> _initCompleter = Completer<void>();
-
-  /// A future that completes when [initialize] has finished (successfully or
-  /// with an error). Await this before reading [followingPubkeys] to avoid a
-  /// race condition where the list appears empty.
-  Future<void> get initialized => _initCompleter.future;
-
   // Real-time sync subscription for cross-device synchronization
   StreamSubscription<Event>? _contactListSubscription;
   String? _contactListSubscriptionId;
@@ -148,9 +141,6 @@ class FollowRepository {
 
   /// Dispose resources (idempotent — safe to call multiple times).
   Future<void> dispose() async {
-    if (!_initCompleter.isCompleted) {
-      _initCompleter.complete();
-    }
     _contactListSubscription?.cancel();
     if (_contactListSubscriptionId != null) {
       await _nostrClient.unsubscribe(_contactListSubscriptionId!);
@@ -558,6 +548,14 @@ class FollowRepository {
 
       _isInitialized = true;
 
+      // Guarantee at least one post-seed emission for "no follows" users.
+      // When the user follows nobody, _emitFollowingList() never fires
+      // (list stays [] = same as seed). Force-emit so subscribers can
+      // distinguish "init not done" from "genuinely empty."
+      if (_followingPubkeys.isEmpty && !_followingSubject.isClosed) {
+        _followingSubject.add(const []);
+      }
+
       Log.info(
         'FollowRepository initialized: ${_followingPubkeys.length} following',
         name: 'FollowRepository',
@@ -569,10 +567,6 @@ class FollowRepository {
         name: 'FollowRepository',
         category: LogCategory.system,
       );
-    } finally {
-      if (!_initCompleter.isCompleted) {
-        _initCompleter.complete();
-      }
     }
   }
 

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -48,6 +48,7 @@ class VideoFeedPage extends ConsumerWidget {
     final videosRepository = ref.watch(videosRepositoryProvider);
     final followRepository = ref.watch(followRepositoryProvider);
     final curatedListRepository = ref.watch(curatedListRepositoryProvider);
+    final authService = ref.watch(authServiceProvider);
 
     // Show loading until NostrClient has keys
     if (followRepository == null) {
@@ -59,6 +60,7 @@ class VideoFeedPage extends ConsumerWidget {
         videosRepository: videosRepository,
         followRepository: followRepository,
         curatedListRepository: curatedListRepository,
+        userPubkey: authService.currentPublicKeyHex,
         feedTracker: FeedPerformanceTracker(),
       )..add(VideoFeedStarted(mode: initialMode)),
       child: const VideoFeedView(),

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -92,7 +92,9 @@ class VideosRepository {
   ///
   /// Returns a [HomeFeedResult] containing videos sorted by creation time
   /// (newest first) plus attribution metadata mapping videos to their
-  /// source curated lists. Returns empty result if [authors] is empty.
+  /// source curated lists. Returns empty result if both [authors] is empty
+  /// and [userPubkey] is null. When [userPubkey] is provided, the Funnelcake
+  /// API is attempted even with an empty [authors] list (fast-path startup).
   Future<HomeFeedResult> getHomeFeedVideos({
     required List<String> authors,
     Map<String, List<String>> videoRefs = const {},
@@ -100,7 +102,9 @@ class VideosRepository {
     int limit = _defaultLimit,
     int? until,
   }) async {
-    if (authors.isEmpty) return const HomeFeedResult(videos: []);
+    if (authors.isEmpty && userPubkey == null) {
+      return const HomeFeedResult(videos: []);
+    }
 
     // 1. Fetch following videos (Funnelcake API → Nostr relay waterfall)
     final followingVideos = await _fetchFollowingVideos(
@@ -147,7 +151,10 @@ class VideosRepository {
       }
     }
 
-    // Nostr fallback
+    // Nostr fallback — skip when authors list is empty (fast-path startup
+    // before follow list is ready).
+    if (authors.isEmpty) return [];
+
     final filter = Filter(
       kinds: [_videoKind],
       authors: authors,

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -715,12 +715,96 @@ void main() {
         });
       });
 
-      test('returns empty list when authors is empty', () async {
-        final result = await repository.getHomeFeedVideos(authors: []);
+      test(
+        'returns empty list when authors is empty '
+        'and userPubkey is null',
+        () async {
+          final result = await repository.getHomeFeedVideos(authors: []);
 
-        expect(result.videos, isEmpty);
-        verifyNever(() => mockNostrClient.queryEvents(any()));
-      });
+          expect(result.videos, isEmpty);
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+        },
+      );
+
+      test(
+        'hits Funnelcake API when authors is empty '
+        'but userPubkey is provided',
+        () async {
+          final mockFunnelcakeClient = MockFunnelcakeApiClient();
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getHomeFeed(
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer(
+            (_) async => HomeFeedResponse(
+              videos: [
+                _createVideoStats(
+                  id: 'event-1',
+                  pubkey: 'followed-user',
+                  dTag: 'dtag-1',
+                  videoUrl: 'https://example.com/video.mp4',
+                ),
+              ],
+              hasMore: true,
+              nextCursor: 1704067100,
+            ),
+          );
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repositoryWithApi.getHomeFeedVideos(
+            authors: [],
+            userPubkey: 'my-pubkey',
+          );
+
+          expect(result.videos, hasLength(1));
+          verify(
+            () => mockFunnelcakeClient.getHomeFeed(
+              pubkey: 'my-pubkey',
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).called(1);
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+        },
+      );
+
+      test(
+        'skips Nostr fallback when authors is empty '
+        'and Funnelcake returns empty',
+        () async {
+          final mockFunnelcakeClient = MockFunnelcakeApiClient();
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getHomeFeed(
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer(
+            (_) async => const HomeFeedResponse(videos: []),
+          );
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repositoryWithApi.getHomeFeedVideos(
+            authors: [],
+            userPubkey: 'my-pubkey',
+          );
+
+          expect(result.videos, isEmpty);
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+        },
+      );
 
       test('returns empty list when no events found', () async {
         when(() => mockNostrClient.queryEvents(any())).thenAnswer(

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -45,9 +45,6 @@ void main() {
         () => mockFollowRepository.followingStream,
       ).thenAnswer((_) => followingController.stream);
       when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
-      when(
-        () => mockFollowRepository.initialized,
-      ).thenAnswer((_) async {});
 
       when(
         () => mockCuratedListRepository.subscribedListsStream,
@@ -184,6 +181,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: authors,
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -234,6 +232,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: authors,
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -252,6 +251,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: ['author1', 'author2'],
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -288,22 +288,36 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedState>(
-        'emits [loading, success] with noFollowedUsers error when home feed empty due to no follows',
+        'emits noFollowedUsers when followingStream emits empty '
+        'list after startup',
         setUp: () {
           when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
           when(
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
           ).thenAnswer((_) async => const HomeFeedResult(videos: []));
         },
         build: createBloc,
-        act: (bloc) => bloc.add(const VideoFeedStarted(mode: FeedMode.home)),
+        act: (bloc) async {
+          bloc.add(const VideoFeedStarted(mode: FeedMode.home));
+          // Wait for _loadVideos to complete (emits success with empty)
+          await Future<void>.delayed(Duration.zero);
+          // followingStream replay of [] triggers _onFollowingListChanged
+          followingController.add([]);
+        },
         expect: () => [
           const VideoFeedState(),
+          // _loadVideos emits success with empty videos
+          const VideoFeedState(
+            status: VideoFeedStatus.success,
+            hasMore: false,
+          ),
+          // _onFollowingListChanged receives [] → noFollowedUsers CTA
           const VideoFeedState(
             status: VideoFeedStatus.success,
             hasMore: false,
@@ -320,6 +334,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -346,6 +361,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -370,6 +386,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -384,6 +401,47 @@ void main() {
               .having((s) => s.videos, 'videos', isEmpty)
               .having((s) => s.hasMore, 'hasMore', false),
         ],
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedState>(
+        'does not await initialized before calling repository',
+        setUp: () {
+          final videos = createTestVideos(pageSize);
+
+          when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+            ),
+          ).thenAnswer(
+            (_) async => HomeFeedResult(videos: videos),
+          );
+        },
+        build: () => VideoFeedBloc(
+          videosRepository: mockVideosRepository,
+          followRepository: mockFollowRepository,
+          curatedListRepository: mockCuratedListRepository,
+          userPubkey: 'user-pubkey',
+        ),
+        act: (bloc) => bloc.add(const VideoFeedStarted(mode: FeedMode.home)),
+        verify: (_) {
+          // Repository is called with empty authors (follow list
+          // not yet initialized) — the fast path relies on
+          // userPubkey to hit Funnelcake directly.
+          verify(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: [],
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: 'user-pubkey',
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+            ),
+          ).called(1);
+        },
       );
     });
 
@@ -452,6 +510,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -479,6 +538,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -543,6 +603,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -575,6 +636,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -613,6 +675,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -641,6 +704,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -667,6 +731,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -704,6 +769,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -739,6 +805,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -764,6 +831,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
             ),
           ).called(1);
@@ -780,6 +848,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -811,6 +880,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -882,6 +952,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -920,6 +991,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -963,6 +1035,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -985,7 +1058,7 @@ void main() {
 
     group('VideoFeedFollowingListChanged', () {
       blocTest<VideoFeedBloc, VideoFeedState>(
-        'refreshes home feed when following list changes',
+        'silently refreshes home feed on follow list change',
         setUp: () {
           final videos = createTestVideos(pageSize);
 
@@ -996,6 +1069,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -1009,7 +1083,7 @@ void main() {
         act: (bloc) =>
             bloc.add(const VideoFeedFollowingListChanged(['new-author'])),
         expect: () => [
-          const VideoFeedState(),
+          // No loading state — silent refresh replaces in-place
           isA<VideoFeedState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', pageSize)
@@ -1051,6 +1125,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -1065,7 +1140,7 @@ void main() {
         act: (bloc) =>
             bloc.add(const VideoFeedFollowingListChanged(['first-follow'])),
         expect: () => [
-          const VideoFeedState(),
+          // No loading state — silent refresh replaces in-place
           isA<VideoFeedState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', pageSize)
@@ -1074,7 +1149,8 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedState>(
-        'subscribes to followingStream via emit.onEach on startup',
+        'silently refreshes when follow list replays after Funnelcake '
+        'already loaded content',
         setUp: () {
           final videos = createTestVideos(pageSize);
 
@@ -1085,6 +1161,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -1093,21 +1170,126 @@ void main() {
         build: createBloc,
         act: (bloc) async {
           bloc.add(const VideoFeedStarted(mode: FeedMode.home));
-          // Wait for initial load to complete
+          // Wait for initial load to complete (Funnelcake loaded content)
           await Future<void>.delayed(Duration.zero);
-          // First stream emission is skipped (BehaviorSubject replay)
-          followingController.add([]);
-          await Future<void>.delayed(Duration.zero);
-          // Second emission triggers the handler
-          followingController.add(['new-author']);
+          // Stream replays follow list — silently refreshes (no loading)
+          followingController.add(['author']);
         },
         skip: 2, // Skip loading + success from VideoFeedStarted
+        // No state change — same videos re-fetched, Equatable deduplicates
+        expect: () => <VideoFeedState>[],
+        verify: (_) {
+          // Called twice: initial load + silent refresh from replay
+          verify(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+            ),
+          ).called(2);
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedState>(
+        'silently refreshes when follow list arrives and feed is empty '
+        '(Funnelcake failed)',
+        setUp: () {
+          final videos = createTestVideos(pageSize);
+          var callCount = 0;
+
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn(['author']);
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+            ),
+          ).thenAnswer((_) async {
+            callCount++;
+            if (callCount == 1) {
+              return const HomeFeedResult(videos: []);
+            }
+            return HomeFeedResult(videos: videos);
+          });
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const VideoFeedStarted(mode: FeedMode.home));
+          // Wait for initial load to complete (Funnelcake returned empty)
+          await Future<void>.delayed(Duration.zero);
+          // Stream replays follow list — feed empty, silently refreshes
+          followingController.add(['author']);
+        },
+        skip: 2, // Skip loading + success(empty) from VideoFeedStarted
         expect: () => [
-          const VideoFeedState(),
+          // No loading state — silent refresh replaces in-place
           isA<VideoFeedState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'videos count', pageSize),
         ],
+        verify: (_) {
+          // Called twice: initial (empty), then recovery
+          verify(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+            ),
+          ).called(2);
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedState>(
+        'silently refreshes on each follow list emission',
+        setUp: () {
+          final videos = createTestVideos(pageSize);
+
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn(['author']);
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+            ),
+          ).thenAnswer((_) async => HomeFeedResult(videos: videos));
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const VideoFeedStarted(mode: FeedMode.home));
+          await Future<void>.delayed(Duration.zero);
+          // Initial replay — silently refreshes (no loading)
+          followingController.add(['author']);
+          await Future<void>.delayed(Duration.zero);
+          // Runtime follow — silently refreshes again (no loading)
+          followingController.add(['author', 'new-author']);
+        },
+        skip: 2, // Skip loading + success from VideoFeedStarted
+        // No state changes — same videos returned, Equatable deduplicates
+        expect: () => <VideoFeedState>[],
+        verify: (_) {
+          // Called 3 times: initial + replay + runtime
+          verify(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+            ),
+          ).called(3);
+        },
       );
     });
 
@@ -1124,6 +1306,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -1176,6 +1359,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -1214,6 +1398,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -1260,6 +1445,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -1337,6 +1523,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -1358,6 +1545,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -1369,9 +1557,7 @@ void main() {
           verify(
             () => mockTracker.markFirstVideosReceived('home', 3),
           ).called(1);
-          verify(
-            () => mockTracker.markFeedDisplayed('home', 3),
-          ).called(1);
+          verify(() => mockTracker.markFeedDisplayed('home', 3)).called(1);
         },
       );
 
@@ -1383,6 +1569,7 @@ void main() {
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
               videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
@@ -1398,15 +1585,8 @@ void main() {
               errorMessage: any(named: 'errorMessage'),
             ),
           ).called(1);
-          verifyNever(
-            () => mockTracker.markFirstVideosReceived(
-              any(),
-              any(),
-            ),
-          );
-          verifyNever(
-            () => mockTracker.markFeedDisplayed(any(), any()),
-          );
+          verifyNever(() => mockTracker.markFirstVideosReceived(any(), any()));
+          verifyNever(() => mockTracker.markFeedDisplayed(any(), any()));
         },
       );
 
@@ -1428,9 +1608,7 @@ void main() {
           verify(
             () => mockTracker.markFirstVideosReceived('latest', 3),
           ).called(1);
-          verify(
-            () => mockTracker.markFeedDisplayed('latest', 3),
-          ).called(1);
+          verify(() => mockTracker.markFeedDisplayed('latest', 3)).called(1);
         },
       );
 
@@ -1452,9 +1630,7 @@ void main() {
           verify(
             () => mockTracker.markFirstVideosReceived('popular', 3),
           ).called(1);
-          verify(
-            () => mockTracker.markFeedDisplayed('popular', 3),
-          ).called(1);
+          verify(() => mockTracker.markFeedDisplayed('popular', 3)).called(1);
         },
       );
     });

--- a/mobile/test/repositories/follow_repository_test.dart
+++ b/mobile/test/repositories/follow_repository_test.dart
@@ -1188,39 +1188,74 @@ void main() {
       });
     });
 
-    group('initialized completer', () {
-      test('completes after successful initialize()', () async {
-        await repository.initialize();
+    group('followingStream force-emit on initialize', () {
+      test(
+        'emits on followingStream after initialize '
+        'when user has no follows',
+        () async {
+          // No cached follows, no PersonalEventCache, no relay data
+          SharedPreferences.setMockInitialValues({});
 
-        // initialized should complete immediately since initialize() finished
-        await expectLater(repository.initialized, completes);
-      });
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            personalEventCache: mockPersonalEventCache,
+            indexerRelayUrls: const [],
+          );
 
-      test('completes even when initialization fails', () async {
-        // Force SharedPreferences to throw during load
-        SharedPreferences.setMockInitialValues({
-          'following_list_$testCurrentUserPubkey': 'invalid json{{{',
-        });
+          final emissions = <List<String>>[];
+          final subscription = repository.followingStream.listen(
+            emissions.add,
+          );
 
-        repository = FollowRepository(
-          nostrClient: mockNostrClient,
-          personalEventCache: mockPersonalEventCache,
-          indexerRelayUrls: const [],
-        );
+          // Seed value is [] — capture it
+          await Future<void>.delayed(Duration.zero);
+          final preInitCount = emissions.length;
 
-        await repository.initialize();
+          await repository.initialize();
+          await Future<void>.delayed(Duration.zero);
 
-        // initialized should still complete despite the error
-        await expectLater(repository.initialized, completes);
-      });
+          // Force-emit should add one more [] emission
+          expect(emissions.length, greaterThan(preInitCount));
+          expect(emissions.last, isEmpty);
 
-      test('completes when dispose() called before initialize()', () async {
-        // dispose without ever calling initialize
-        await repository.dispose();
+          await subscription.cancel();
+        },
+      );
 
-        // initialized should complete because dispose completes the Completer
-        await expectLater(repository.initialized, completes);
-      });
+      test(
+        'does not double-emit after initialize '
+        'when user has follows',
+        () async {
+          SharedPreferences.setMockInitialValues({
+            'following_list_$testCurrentUserPubkey': '["$testTargetPubkey"]',
+          });
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            personalEventCache: mockPersonalEventCache,
+            indexerRelayUrls: const [],
+          );
+
+          final emissions = <List<String>>[];
+          final subscription = repository.followingStream.listen(
+            emissions.add,
+          );
+
+          await repository.initialize();
+          await Future<void>.delayed(Duration.zero);
+
+          // Should emit exactly once with the follow list (from
+          // _emitFollowingList during _loadFromLocalStorage), no
+          // extra force-emit because _followingPubkeys is non-empty.
+          final nonSeedEmissions = emissions
+              .where((e) => e.isNotEmpty)
+              .toList();
+          expect(nonSeedEmissions, hasLength(1));
+          expect(nonSeedEmissions.first, contains(testTargetPubkey));
+
+          await subscription.cancel();
+        },
+      );
     });
 
     group('getSocialCounts', () {


### PR DESCRIPTION
## Description

Speed up home feed startup by firing `_loadVideos` immediately via the Funnelcake API (using `userPubkey`) instead of waiting for the follow list to initialize. Follow list changes now perform a silent refresh (no loading state, no flash) — current videos stay visible while new content is fetched in the background. Also removes the `initialized` Completer from `FollowRepository` since the BLoC no longer awaits it.

**Related Issue:** Closes #1977 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore