### PR TITLE
fix(feed): prevent pooled feed index RangeError during rapid updates

### DIFF
--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -287,6 +287,9 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
 
             // Wrap videos for pool compatibility
             final pooledVideos = state.videos.toVideoItems;
+            final eventsById = {
+              for (final event in state.videos) event.id: event,
+            };
 
             // Note: RefreshIndicator removed - it conflicts with PageView
             // scrolling and adds memory overhead. Use the refresh button
@@ -298,7 +301,12 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                   videos: pooledVideos,
                   controller: controller,
                   itemBuilder: (context, video, index, {required isActive}) {
-                    final originalEvent = state.videos[index];
+                    final originalEvent = eventsById[video.id];
+                    if (originalEvent == null) {
+                      return const ColoredBox(
+                        color: VineTheme.backgroundColor,
+                      );
+                    }
                     final listSources =
                         state.listOnlyVideoIds.contains(originalEvent.id)
                         ? state.videoListSources[originalEvent.id]
@@ -313,7 +321,12 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                   },
                   onActiveVideoChanged: (video, index) {
                     FeedPerformanceTracker().startVideoSwipeTracking(video.id);
-                    prefetchProfiles(state.videos, index);
+                    final sourceIndex = state.videos.indexWhere(
+                      (event) => event.id == video.id,
+                    );
+                    if (sourceIndex != -1) {
+                      prefetchProfiles(state.videos, sourceIndex);
+                    }
                   },
                   onNearEnd: (index) {
                     // PooledVideoFeed fires this when the user is within


### PR DESCRIPTION
## Summary
- fixes a `RangeError (length)` crash in `VideoFeedPage` when `PooledVideoFeed` index and `state.videos` drift during rapid feed updates/swipes
- resolves feed item rendering by `video.id` instead of direct `state.videos[index]` access
- aligns profile prefetch lookup to the active video's source index via id matching

## Root cause
`PooledVideoFeed` can build with controller-managed indices that temporarily differ from the Bloc state's raw list length/order (dedupe/addition timing). The old code indexed `state.videos[index]` directly, causing out-of-range access.

## Validation
- `flutter analyze lib/screens/feed/video_feed_page.dart`
- `flutter test test/screens/feed/video_feed_page_test.dart`
