### PR TITLE
Fix classic vine archive notice showing on recent worktree vines

### DIFF
--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -247,7 +247,7 @@ class _CommentsScreenBody extends StatelessWidget {
       },
       child: SizedBox(
         child: CommentsList(
-          isOriginalVine: videoEvent.isOriginalVine,
+          showClassicVineNotice: videoEvent.isVintageRecoveredVine,
           scrollController: sheetScrollController,
         ),
       ),

--- a/mobile/lib/screens/comments/widgets/comments_list.dart
+++ b/mobile/lib/screens/comments/widgets/comments_list.dart
@@ -9,12 +9,12 @@ import 'package:openvine/screens/comments/widgets/widgets.dart';
 
 class CommentsList extends StatefulWidget {
   const CommentsList({
-    required this.isOriginalVine,
+    required this.showClassicVineNotice,
     required this.scrollController,
     super.key,
   });
 
-  final bool isOriginalVine;
+  final bool showClassicVineNotice;
   final ScrollController scrollController;
 
   @override
@@ -58,7 +58,9 @@ class _CommentsListState extends State<CommentsList> {
         final threaded = state.threadedComments;
 
         if (threaded.isEmpty) {
-          return CommentsEmptyState(isClassicVine: widget.isOriginalVine);
+          return CommentsEmptyState(
+            isClassicVine: widget.showClassicVineNotice,
+          );
         }
 
         return ListView.builder(

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -842,6 +842,19 @@ class VideoEvent {
     return originalLoops != null && originalLoops! > 0;
   }
 
+  /// Vintage recovered Vine: original Vine metrics plus a pre-shutdown date.
+  ///
+  /// New Divine videos can also carry loop stats, so loop count alone is not
+  /// sufficient when the UI needs to know whether this is genuinely old archive
+  /// content.
+  bool get isVintageRecoveredVine {
+    if (!isOriginalVine) return false;
+
+    final effectiveCreatedAt = int.tryParse(publishedAt ?? '') ?? createdAt;
+    return effectiveCreatedAt > 0 &&
+        effectiveCreatedAt < _vineShutdownAtUtcSeconds;
+  }
+
   /// Check if this is original content (not a repost)
   bool get isOriginalContent {
     return !isRepost;
@@ -917,6 +930,8 @@ class VideoEvent {
 
     return score;
   }
+
+  static const int _vineShutdownAtUtcSeconds = 1484611200;
 
   /// Parse imeta tag which contains space-separated key-value pairs
   /// NIP-71 format: ["imeta", "key1 value1", "key2 value2", ...]

--- a/mobile/test/screens/comments/comments_list_test.dart
+++ b/mobile/test/screens/comments/comments_list_test.dart
@@ -56,7 +56,7 @@ void main() {
 
     Widget buildTestWidget({
       required CommentsState commentsState,
-      bool isOriginalVine = false,
+      bool showClassicVineNotice = false,
       ScrollController? scrollController,
     }) {
       final sc = scrollController ?? ScrollController();
@@ -73,7 +73,7 @@ void main() {
             body: BlocProvider<CommentsBloc>.value(
               value: mockCommentsBloc,
               child: CommentsList(
-                isOriginalVine: isOriginalVine,
+                showClassicVineNotice: showClassicVineNotice,
                 scrollController: sc,
               ),
             ),
@@ -123,7 +123,7 @@ void main() {
       expect(find.byType(CommentsEmptyState), findsOneWidget);
     });
 
-    testWidgets('shows Classic Vine notice when isOriginalVine', (
+    testWidgets('shows Classic Vine notice when requested', (
       tester,
     ) async {
       const state = CommentsState(
@@ -133,7 +133,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        buildTestWidget(commentsState: state, isOriginalVine: true),
+        buildTestWidget(commentsState: state, showClassicVineNotice: true),
       );
       await tester.pump();
 

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -381,6 +381,65 @@ void main() {
         expect(find.text('No comments yet'), findsOneWidget);
         expect(find.text('Get the party started!'), findsOneWidget);
       });
+
+      testWidgets(
+        'does not show archive notice for recent videos with loop stats',
+        (tester) async {
+          const state = CommentsState(
+            rootEventId: testVideoEventId,
+            rootAuthorPubkey: testVideoAuthorPubkey,
+            status: CommentsStatus.success,
+          );
+
+          final recentVideoWithLoops = VideoEvent(
+            id: testVideoEventId,
+            pubkey: testVideoAuthorPubkey,
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            content: 'recent video',
+            timestamp: DateTime.now(),
+            originalLoops: 13565,
+          );
+
+          await tester.pumpWidget(
+            buildTestWidget(
+              commentsState: state,
+              videoEvent: recentVideoWithLoops,
+            ),
+          );
+          await tester.pump();
+
+          expect(find.text('Classic Vine'), findsNothing);
+        },
+      );
+
+      testWidgets('shows archive notice for vintage recovered vines', (
+        tester,
+      ) async {
+        const state = CommentsState(
+          rootEventId: testVideoEventId,
+          rootAuthorPubkey: testVideoAuthorPubkey,
+          status: CommentsStatus.success,
+        );
+
+        final vintageRecoveredVine = VideoEvent(
+          id: testVideoEventId,
+          pubkey: testVideoAuthorPubkey,
+          createdAt: 1473050841,
+          content: 'classic vine',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1473050841 * 1000),
+          originalLoops: 3169386,
+        );
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            commentsState: state,
+            videoEvent: vintageRecoveredVine,
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Classic Vine'), findsOneWidget);
+      });
     });
 
     group('error handling', () {
@@ -432,7 +491,7 @@ class _CommentsScreenTestContent extends StatelessWidget {
           const Divider(color: Colors.white24, height: 1),
           Expanded(
             child: CommentsList(
-              isOriginalVine: videoEvent.isOriginalVine,
+              showClassicVineNotice: videoEvent.isVintageRecoveredVine,
               scrollController: sheetScrollController,
             ),
           ),

--- a/mobile/test/utils/proofmode_helpers_test.dart
+++ b/mobile/test/utils/proofmode_helpers_test.dart
@@ -213,6 +213,37 @@ void main() {
       expect(video.isOriginalVine, isTrue);
       expect(video.shouldShowVineBadge, isTrue);
     });
+
+    test(
+      'detects vintage recovered vine when looped video predates shutdown',
+      () {
+        final video = VideoEvent(
+          id: 'vine5',
+          pubkey: 'pubkey5',
+          createdAt: 1473050841,
+          content: 'archived vine',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(1473050841 * 1000),
+          originalLoops: 3169386,
+        );
+
+        expect(video.isOriginalVine, isTrue);
+        expect(video.isVintageRecoveredVine, isTrue);
+      },
+    );
+
+    test('does not detect recent looped video as vintage recovered vine', () {
+      final video = VideoEvent(
+        id: 'vine6',
+        pubkey: 'pubkey6',
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        content: 'new video with loops',
+        timestamp: DateTime.now(),
+        originalLoops: 13565,
+      );
+
+      expect(video.isOriginalVine, isTrue);
+      expect(video.isVintageRecoveredVine, isFalse);
+    });
   });
 
   group('Combined Badge Display Logic', () {


### PR DESCRIPTION
## Description

This fixes the comments empty-state bug where recent worktree vines could show the Classic Vine archive notice just because they had loop stats.

The change adds a stricter `isVintageRecoveredVine` check that requires both original Vine metrics and a pre-shutdown timestamp, and uses that narrower predicate only for the comments archive notice path.

It also renames the `CommentsList` input from `isOriginalVine` to `showClassicVineNotice` so the UI contract matches the actual behavior.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Testing

- [x] `flutter test test/screens/comments/comments_list_test.dart test/screens/comments/comments_screen_test.dart test/utils/proofmode_helpers_test.dart`
- [x] `flutter analyze lib/screens/comments/comments_screen.dart lib/screens/comments/widgets/comments_list.dart test/screens/comments/comments_list_test.dart test/screens/comments/comments_screen_test.dart test/utils/proofmode_helpers_test.dart packages/models/lib/src/video_event.dart`

## Notes

- Recent videos with loop stats no longer show the archive-comments notice.
- Vintage recovered vines still show the notice.
- Scope is limited to the comments notice path; broader original-vine badge behavior was not changed in this PR.
