### PR TITLE
fix(share): restore download actions and more menu

### DIFF
--- a/mobile/lib/widgets/video_feed_item/actions/more_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/more_action_button.dart
@@ -1,16 +1,30 @@
 // ABOUTME: Three-dots more action button for video feed overlay.
-// ABOUTME: Opens unified share sheet with more actions (report, copy, etc.).
+// ABOUTME: Opens bottom sheet with Report, Mute, Block, View JSON, Copy Event ID.
+
+import 'dart:convert';
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
-import 'package:models/models.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:models/models.dart' hide LogCategory;
+import 'package:nostr_sdk/nip19/nip19_tlv.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/unified_logger.dart';
-import 'package:openvine/widgets/video_feed_item/actions/share_action_button.dart';
+import 'package:openvine/widgets/report_content_dialog.dart';
+import 'package:openvine/widgets/user_avatar.dart';
+import 'package:openvine/widgets/user_name.dart';
 
 /// Three-dots more action button for the video overlay.
 ///
-/// Opens the unified share sheet which contains moderation and developer
-/// actions: Report, Copy Link, Share via, Event JSON, Event ID.
+/// Opens a bottom sheet with moderation and developer actions:
+/// Report, Mute, Block, View Nostr event JSON, Copy Nostr event ID.
 class MoreActionButton extends StatelessWidget {
   const MoreActionButton({required this.video, super.key});
 
@@ -18,35 +32,528 @@ class MoreActionButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Semantics(
-      identifier: 'more_button',
-      container: true,
-      explicitChildNodes: true,
-      button: true,
-      label: 'More options',
-      child: GestureDetector(
-        onTap: () {
-          Log.info(
-            'More button tapped for ${video.id}',
-            name: 'MoreActionButton',
-            category: LogCategory.ui,
-          );
-          ShareActionButton.showShareSheet(context, video);
-        },
-        child: Container(
-          width: 40,
-          height: 40,
-          padding: const EdgeInsets.all(8),
-          decoration: BoxDecoration(
-            color: VineTheme.scrim30,
-            borderRadius: BorderRadius.circular(16),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Semantics(
+          identifier: 'more_button',
+          container: true,
+          explicitChildNodes: true,
+          button: true,
+          label: 'More options',
+          child: GestureDetector(
+            onTap: () {
+              Log.info(
+                'More button tapped for ${video.id}',
+                name: 'MoreActionButton',
+                category: LogCategory.ui,
+              );
+              context.showVideoPausingVineBottomSheet<void>(
+                builder: (context) => _VideoMoreMenu(video: video),
+              );
+            },
+            child: Container(
+              width: 40,
+              height: 40,
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: VineTheme.scrim30,
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: const DivineIcon(
+                icon: DivineIconName.dotsThree,
+                color: VineTheme.whiteText,
+              ),
+            ),
           ),
-          child: const DivineIcon(
-            icon: DivineIconName.dotsThree,
-            color: VineTheme.whiteText,
-          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _VideoMoreMenu extends ConsumerWidget {
+  const _VideoMoreMenu({required this.video});
+
+  final VideoEvent video;
+
+  void _safePop(BuildContext ctx) {
+    if (ctx.canPop()) {
+      ctx.pop();
+    } else {
+      Navigator.of(ctx).maybePop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Material(
+      color: VineTheme.surfaceBackground,
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      child: SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _MoreMenuHeader(video: video),
+            const Divider(color: VineTheme.cardBackground, height: 1),
+            _MoreMenuItems(
+              video: video,
+              onReport: () => _handleReport(context),
+              onMute: () => _handleMute(context, ref),
+              onBlock: () => _handleBlock(context, ref),
+              onViewSource: () => _handleViewSource(context),
+              onCopyEventId: () => _handleCopyEventId(context),
+            ),
+          ],
         ),
       ),
     );
+  }
+
+  void _handleReport(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      builder: (context) => ReportContentDialog(video: video),
+    );
+  }
+
+  Future<void> _handleMute(BuildContext context, WidgetRef ref) async {
+    try {
+      final muteService = await ref.read(muteServiceProvider.future);
+      await muteService.muteUser(video.pubkey);
+
+      if (context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('User muted')));
+        _safePop(context);
+      }
+    } catch (e) {
+      Log.error(
+        'Failed to mute user: $e',
+        name: 'VideoMoreMenu',
+        category: LogCategory.ui,
+      );
+      if (context.mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(const SnackBar(content: Text('Failed to mute user')));
+        _safePop(context);
+      }
+    }
+  }
+
+  void _handleBlock(BuildContext context, WidgetRef ref) {
+    final blocklistService = ref.read(contentBlocklistServiceProvider);
+    final nostrClient = ref.read(nostrServiceProvider);
+
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: VineTheme.cardBackground,
+        title: const Text(
+          'Block User?',
+          style: TextStyle(color: VineTheme.whiteText),
+        ),
+        content: const Text(
+          "You won't see their content in feeds. "
+          "They won't be notified.",
+          style: TextStyle(color: VineTheme.secondaryText),
+        ),
+        actions: [
+          TextButton(
+            onPressed: dialogContext.pop,
+            child: const Text(
+              'Cancel',
+              style: TextStyle(color: VineTheme.secondaryText),
+            ),
+          ),
+          TextButton(
+            onPressed: () {
+              try {
+                blocklistService.blockUser(
+                  video.pubkey,
+                  ourPubkey: nostrClient.publicKey,
+                );
+                dialogContext.pop();
+                if (context.mounted) {
+                  ScaffoldMessenger.of(
+                    context,
+                  ).showSnackBar(const SnackBar(content: Text('User blocked')));
+                  _safePop(context);
+                }
+              } catch (e) {
+                Log.error(
+                  'Failed to block user: $e',
+                  name: 'VideoMoreMenu',
+                  category: LogCategory.ui,
+                );
+                if (dialogContext.mounted) dialogContext.pop();
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Failed to block user')),
+                  );
+                }
+              }
+            },
+            style: TextButton.styleFrom(foregroundColor: VineTheme.error),
+            child: const Text('Block'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _handleViewSource(BuildContext context) {
+    showDialog<void>(
+      context: context,
+      builder: (context) => _ViewSourceDialog(video: video),
+    );
+  }
+
+  Future<void> _handleCopyEventId(BuildContext context) async {
+    try {
+      final nevent = NIP19Tlv.encodeNevent(
+        Nevent(
+          id: video.id,
+          author: video.pubkey,
+          relays: ['wss://relay.divine.video'],
+        ),
+      );
+      await Clipboard.setData(ClipboardData(text: nevent));
+
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Event ID copied to clipboard'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+        _safePop(context);
+      }
+    } catch (e) {
+      Log.error(
+        'Failed to copy event ID: $e',
+        name: 'VideoMoreMenu',
+        category: LogCategory.ui,
+      );
+    }
+  }
+}
+
+class _MoreMenuHeader extends ConsumerWidget {
+  const _MoreMenuHeader({required this.video});
+
+  static const double _avatarSize = 40;
+
+  final VideoEvent video;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profileAsync = ref.watch(userProfileReactiveProvider(video.pubkey));
+
+    final videoTitle = video.title?.isNotEmpty == true
+        ? video.title!
+        : video.content;
+
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        spacing: 12,
+        children: [
+          profileAsync.when(
+            data: (profile) => UserAvatar(
+              imageUrl: profile?.picture,
+              name: profile?.displayName,
+              size: _avatarSize,
+            ),
+            loading: () => const UserAvatar(size: _avatarSize),
+            error: (_, _) => const UserAvatar(size: _avatarSize),
+          ),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (videoTitle.isNotEmpty)
+                  Text(
+                    videoTitle,
+                    style: const TextStyle(
+                      color: VineTheme.whiteText,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                UserName.fromPubKey(
+                  video.pubkey,
+                  style: const TextStyle(
+                    color: VineTheme.secondaryText,
+                    fontSize: 14,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MoreMenuItems extends ConsumerWidget {
+  const _MoreMenuItems({
+    required this.video,
+    required this.onReport,
+    required this.onMute,
+    required this.onBlock,
+    required this.onViewSource,
+    required this.onCopyEventId,
+  });
+
+  final VideoEvent video;
+  final VoidCallback onReport;
+  final VoidCallback onMute;
+  final VoidCallback onBlock;
+  final VoidCallback onViewSource;
+  final VoidCallback onCopyEventId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profileAsync = ref.watch(userProfileReactiveProvider(video.pubkey));
+    final displayName =
+        profileAsync.whenOrNull(data: (profile) => profile?.bestDisplayName) ??
+        '';
+    final showDebugTools = ref.watch(
+      isFeatureEnabledProvider(FeatureFlag.debugTools),
+    );
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _MoreMenuItem(
+          icon: const DivineIcon(
+            icon: DivineIconName.flag,
+            color: VineTheme.error,
+          ),
+          label: 'Report content',
+          labelColor: VineTheme.error,
+          onTap: onReport,
+        ),
+        _MoreMenuItem(
+          icon: const DivineIcon(
+            icon: DivineIconName.eyeSlash,
+            color: VineTheme.error,
+          ),
+          label: displayName.isNotEmpty ? 'Mute $displayName' : 'Mute user',
+          labelColor: VineTheme.error,
+          onTap: onMute,
+        ),
+        _MoreMenuItem(
+          icon: const DivineIcon(
+            icon: DivineIconName.prohibit,
+            color: VineTheme.error,
+          ),
+          label: displayName.isNotEmpty ? 'Block $displayName' : 'Block user',
+          labelColor: VineTheme.error,
+          onTap: onBlock,
+        ),
+        if (showDebugTools) ...[
+          const Divider(color: VineTheme.cardBackground, height: 1),
+          _MoreMenuItem(
+            icon: const DivineIcon(
+              icon: DivineIconName.bracketsAngle,
+              color: VineTheme.whiteText,
+            ),
+            label: 'View Nostr event JSON',
+            labelColor: VineTheme.whiteText,
+            onTap: onViewSource,
+          ),
+          _MoreMenuItem(
+            icon: const DivineIcon(
+              icon: DivineIconName.copySimple,
+              color: VineTheme.whiteText,
+            ),
+            label: 'Copy Nostr event ID',
+            labelColor: VineTheme.whiteText,
+            onTap: onCopyEventId,
+          ),
+        ],
+        const SizedBox(height: 8),
+      ],
+    );
+  }
+}
+
+class _MoreMenuItem extends StatelessWidget {
+  const _MoreMenuItem({
+    required this.icon,
+    required this.label,
+    required this.labelColor,
+    required this.onTap,
+  });
+
+  final Widget icon;
+  final String label;
+  final Color labelColor;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
+        child: Row(
+          spacing: 16,
+          children: [
+            icon,
+            Text(
+              label,
+              style: TextStyle(
+                color: labelColor,
+                fontSize: 16,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Dialog for viewing raw Nostr event JSON.
+class _ViewSourceDialog extends StatelessWidget {
+  const _ViewSourceDialog({required this.video});
+  final VideoEvent video;
+
+  static const Color _warningColor = VineTheme.accentOrange;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: VineTheme.cardBackground,
+      title: const Row(
+        spacing: 12,
+        children: [
+          DivineIcon(
+            icon: DivineIconName.bracketsAngle,
+            color: VineTheme.vineGreen,
+          ),
+          Text('Event Source', style: TextStyle(color: VineTheme.whiteText)),
+        ],
+      ),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: 12,
+          children: [
+            Row(
+              spacing: 4,
+              children: [
+                const Text(
+                  'Event ID: ',
+                  style: TextStyle(
+                    color: VineTheme.secondaryText,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                Expanded(
+                  child: Text(
+                    video.id,
+                    style: const TextStyle(
+                      color: VineTheme.whiteText,
+                      fontSize: 12,
+                      fontFamily: 'monospace',
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.copy, size: 16),
+                  color: VineTheme.vineGreen,
+                  onPressed: () {
+                    Clipboard.setData(ClipboardData(text: video.id));
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Event ID copied'),
+                        duration: Duration(seconds: 1),
+                      ),
+                    );
+                  },
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                ),
+              ],
+            ),
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: _warningColor.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(4),
+                border: Border.all(color: _warningColor.withValues(alpha: 0.3)),
+              ),
+              child: const Text(
+                'Parsed event data, not raw Nostr source',
+                style: TextStyle(
+                  color: _warningColor,
+                  fontSize: 11,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+            ),
+            Flexible(
+              child: Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: VineTheme.backgroundColor,
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: VineTheme.lightText),
+                ),
+                child: SingleChildScrollView(
+                  child: SelectableText(
+                    _getEventJson(),
+                    style: const TextStyle(
+                      color: VineTheme.whiteText,
+                      fontSize: 12,
+                      fontFamily: 'monospace',
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () async {
+            final json = _getEventJson();
+            await Clipboard.setData(ClipboardData(text: json));
+            if (context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('JSON copied to clipboard'),
+                  duration: Duration(seconds: 2),
+                ),
+              );
+            }
+          },
+          child: const Text('Copy JSON'),
+        ),
+        TextButton(onPressed: context.pop, child: const Text('Close')),
+      ],
+    );
+  }
+
+  String _getEventJson() {
+    return const JsonEncoder.withIndent('  ').convert(video.toJson());
   }
 }

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -21,9 +21,11 @@ import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/add_to_list_dialog.dart';
 import 'package:openvine/widgets/find_people_sheet.dart';
 import 'package:openvine/widgets/report_content_dialog.dart';
+import 'package:openvine/widgets/save_original_progress_sheet.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
+import 'package:openvine/widgets/watermark_download_progress_sheet.dart';
 import 'package:share_plus/share_plus.dart';
 
 part 'share_sheet_header.dart';
@@ -37,8 +39,8 @@ part 'share_sheet_more_actions.dart';
 /// - Video context/preview header
 /// - "Share with" horizontal contact row with "Find people" search
 /// - Optional message input when a recipient is selected
-/// - "More actions" horizontal row (Save, Add to List, Copy, Share via,
-///   Report, Mute, Block, Event JSON, Event ID)
+/// - "More actions" horizontal row (Save, download, Add to List, Copy,
+///   Share via, Report, debug tools)
 class ShareActionButton extends StatelessWidget {
   const ShareActionButton({required this.video, super.key});
 
@@ -46,9 +48,8 @@ class ShareActionButton extends StatelessWidget {
 
   /// Opens the unified share sheet for the given [video].
   ///
-  /// This is exposed as a static method so that other widgets (e.g.
-  /// [MoreActionButton]) can open the same share sheet without duplicating
-  /// the bottom-sheet wiring.
+  /// This is exposed as a static method so share entry points can reuse the
+  /// same bottom-sheet wiring without duplicating setup logic.
   static void showShareSheet(BuildContext context, VideoEvent video) {
     context.showVideoPausingVineBottomSheet<void>(
       builder: (context) => _UnifiedShareSheet(video: video),
@@ -157,6 +158,8 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
 
   @override
   Widget build(BuildContext context) {
+    final isOwnContent = _isUserOwnContent();
+
     return BlocProvider.value(
       value: _bloc,
       child: BlocListener<ShareSheetBloc, ShareSheetState>(
@@ -166,9 +169,12 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
         child: _UnifiedShareSheetView(
           video: widget.video,
           messageController: _messageController,
+          isOwnContent: isOwnContent,
           onFindPeople: _handleFindPeople,
           onAddToList: _handleAddToList,
           onReport: _handleReport,
+          onSaveOriginal: isOwnContent ? _handleSaveOriginal : null,
+          onSaveWithWatermark: _handleSaveWithWatermark,
         ),
       ),
     );
@@ -238,6 +244,54 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
       builder: (context) => ReportContentDialog(video: widget.video),
     );
   }
+
+  bool _isUserOwnContent() {
+    try {
+      final authService = ref.read(authServiceProvider);
+      if (!authService.isAuthenticated) return false;
+
+      final userPubkey = authService.currentPublicKeyHex;
+      if (userPubkey == null) return false;
+
+      return widget.video.pubkey == userPubkey;
+    } catch (e) {
+      Log.error(
+        'Error checking content ownership: $e',
+        name: 'ShareActionButton',
+        category: LogCategory.ui,
+      );
+      return false;
+    }
+  }
+
+  Future<void> _handleSaveOriginal() async {
+    _safePop(context);
+    if (!context.mounted) return;
+
+    await showSaveOriginalSheet(
+      context: context,
+      ref: ref,
+      video: widget.video,
+    );
+  }
+
+  Future<void> _handleSaveWithWatermark() async {
+    _safePop(context);
+
+    final profileService = ref.read(userProfileServiceProvider);
+    final profile = profileService.getCachedProfile(widget.video.pubkey);
+    final username =
+        profile?.bestDisplayName ?? widget.video.authorName ?? 'Divine';
+
+    if (!context.mounted) return;
+
+    await showWatermarkDownloadSheet(
+      context: context,
+      ref: ref,
+      video: widget.video,
+      username: username,
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -248,16 +302,22 @@ class _UnifiedShareSheetView extends StatelessWidget {
   const _UnifiedShareSheetView({
     required this.video,
     required this.messageController,
+    required this.isOwnContent,
     required this.onFindPeople,
     required this.onAddToList,
     required this.onReport,
+    required this.onSaveWithWatermark,
+    this.onSaveOriginal,
   });
 
   final VideoEvent video;
   final TextEditingController messageController;
+  final bool isOwnContent;
   final VoidCallback onFindPeople;
   final VoidCallback onAddToList;
   final VoidCallback onReport;
+  final Future<void> Function()? onSaveOriginal;
+  final Future<void> Function() onSaveWithWatermark;
 
   @override
   Widget build(BuildContext context) {
@@ -301,7 +361,10 @@ class _UnifiedShareSheetView extends StatelessWidget {
                     const Divider(color: VineTheme.cardBackground, height: 1),
                     _MoreActionsSection(
                       video: video,
+                      isOwnContent: isOwnContent,
                       onSave: () => bloc.add(const ShareSheetSaveRequested()),
+                      onSaveOriginal: onSaveOriginal,
+                      onSaveWithWatermark: onSaveWithWatermark,
                       onAddToList: onAddToList,
                       onCopyLink: () =>
                           bloc.add(const ShareSheetCopyLinkRequested()),

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
@@ -7,17 +7,23 @@ part of 'share_action_button.dart';
 class _MoreActionsSection extends ConsumerWidget {
   const _MoreActionsSection({
     required this.video,
+    required this.isOwnContent,
     required this.onSave,
+    required this.onSaveWithWatermark,
     required this.onAddToList,
     required this.onCopyLink,
     required this.onShareVia,
     required this.onReport,
     required this.onCopyEventJson,
     required this.onCopyEventId,
+    this.onSaveOriginal,
   });
 
   final VideoEvent video;
+  final bool isOwnContent;
   final VoidCallback onSave;
+  final Future<void> Function()? onSaveOriginal;
+  final Future<void> Function() onSaveWithWatermark;
   final VoidCallback onAddToList;
   final VoidCallback onCopyLink;
   final VoidCallback onShareVia;
@@ -39,6 +45,17 @@ class _MoreActionsSection extends ConsumerWidget {
         icon: DivineIconName.bookmarkSimple,
         label: 'Save',
         onTap: onSave,
+      ),
+      if (onSaveOriginal != null)
+        _ActionData(
+          icon: DivineIconName.downloadSimple,
+          label: 'Save to Gallery',
+          onTap: () => onSaveOriginal!.call(),
+        ),
+      _ActionData(
+        icon: DivineIconName.downloadSimple,
+        label: isOwnContent ? 'Save with Watermark' : 'Save Video',
+        onTap: onSaveWithWatermark,
       ),
       if (showCuratedLists)
         _ActionData(

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -123,6 +123,7 @@ MockNostrClient createMockNostrService() {
 
   // Stub common properties
   when(() => mockNostr.isInitialized).thenReturn(true);
+  when(() => mockNostr.hasKeys).thenReturn(false);
   when(() => mockNostr.connectedRelayCount).thenReturn(1);
   when(() => mockNostr.configuredRelays).thenReturn(<String>[]);
 

--- a/mobile/test/widgets/video_feed_item/actions/more_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/more_action_button_test.dart
@@ -1,13 +1,27 @@
-// ABOUTME: Tests for MoreActionButton widget
-// ABOUTME: Verifies the button renders correctly with proper semantics
+// ABOUTME: Tests for MoreActionButton widget and _VideoMoreMenu
+// ABOUTME: Verifies moderation actions (report, mute, block) and debug tools
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/content_blocklist_service.dart';
+import 'package:openvine/services/mute_service.dart';
+import 'package:openvine/widgets/report_content_dialog.dart';
 import 'package:openvine/widgets/video_feed_item/actions/more_action_button.dart';
 
 import '../../../helpers/test_provider_overrides.dart';
+
+class _MockContentBlocklistService extends Mock
+    implements ContentBlocklistService {}
+
+class _MockMuteService extends Mock implements MuteService {}
 
 void main() {
   late VideoEvent testVideo;
@@ -55,5 +69,314 @@ void main() {
       final semanticsFinder = find.bySemanticsLabel('More options');
       expect(semanticsFinder, findsOneWidget);
     });
+
+    testWidgets('opens moderation menu instead of share sheet', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildMenuWidget(testVideo: testVideo));
+      await tester.tap(find.byType(MoreActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Report content'), findsOneWidget);
+      expect(find.text('Share with'), findsNothing);
+    });
   });
+
+  group('VideoMoreMenu', () {
+    late _MockContentBlocklistService mockBlocklistService;
+    late _MockMuteService mockMuteService;
+    late MockNostrClient mockNostrClient;
+
+    setUp(() {
+      mockBlocklistService = _MockContentBlocklistService();
+      mockMuteService = _MockMuteService();
+      mockNostrClient = createMockNostrService();
+      when(() => mockNostrClient.publicKey).thenReturn('test_pubkey_hex');
+    });
+
+    testWidgets('renders moderation menu items', (tester) async {
+      await tester.pumpWidget(
+        buildMenuWidget(
+          testVideo: testVideo,
+          mockBlocklistService: mockBlocklistService,
+          mockMuteService: mockMuteService,
+          mockNostrClient: mockNostrClient,
+        ),
+      );
+
+      await tester.tap(find.byType(MoreActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Report content'), findsOneWidget);
+      expect(find.textContaining('Mute'), findsOneWidget);
+      expect(find.textContaining('Block'), findsOneWidget);
+    });
+
+    testWidgets('hides debug tools when feature flag is disabled', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildMenuWidget(
+          testVideo: testVideo,
+          mockBlocklistService: mockBlocklistService,
+          mockMuteService: mockMuteService,
+          mockNostrClient: mockNostrClient,
+        ),
+      );
+      await tester.tap(find.byType(MoreActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('View Nostr event JSON'), findsNothing);
+      expect(find.text('Copy Nostr event ID'), findsNothing);
+    });
+
+    testWidgets('shows debug tools when feature flag is enabled', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildMenuWidget(
+          testVideo: testVideo,
+          debugToolsEnabled: true,
+          mockBlocklistService: mockBlocklistService,
+          mockMuteService: mockMuteService,
+          mockNostrClient: mockNostrClient,
+        ),
+      );
+      await tester.tap(find.byType(MoreActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('View Nostr event JSON'), findsOneWidget);
+      expect(find.text('Copy Nostr event ID'), findsOneWidget);
+    });
+
+    testWidgets('tapping Report opens $ReportContentDialog', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1200));
+
+      await tester.pumpWidget(
+        buildMenuWidget(
+          testVideo: testVideo,
+          mockBlocklistService: mockBlocklistService,
+          mockMuteService: mockMuteService,
+          mockNostrClient: mockNostrClient,
+        ),
+      );
+      await tester.tap(find.byType(MoreActionButton));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Report content'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Report Content'), findsOneWidget);
+      expect(find.text('Why are you reporting this content?'), findsOneWidget);
+    });
+
+    testWidgets('tapping Mute shows success snackbar on success', (
+      tester,
+    ) async {
+      when(
+        () => mockMuteService.muteUser(
+          any(),
+          reason: any(named: 'reason'),
+          duration: any(named: 'duration'),
+        ),
+      ).thenAnswer((_) async => true);
+
+      await tester.pumpWidget(
+        buildMenuWidget(
+          testVideo: testVideo,
+          mockBlocklistService: mockBlocklistService,
+          mockMuteService: mockMuteService,
+          mockNostrClient: mockNostrClient,
+        ),
+      );
+      await tester.tap(find.byType(MoreActionButton));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.textContaining('Mute'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('User muted'), findsOneWidget);
+    });
+
+    testWidgets('tapping Mute shows error snackbar on failure', (tester) async {
+      when(
+        () => mockMuteService.muteUser(
+          any(),
+          reason: any(named: 'reason'),
+          duration: any(named: 'duration'),
+        ),
+      ).thenThrow(Exception('Network error'));
+
+      await tester.pumpWidget(
+        buildMenuWidget(
+          testVideo: testVideo,
+          mockBlocklistService: mockBlocklistService,
+          mockMuteService: mockMuteService,
+          mockNostrClient: mockNostrClient,
+        ),
+      );
+      await tester.tap(find.byType(MoreActionButton));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.textContaining('Mute'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Failed to mute user'), findsOneWidget);
+    });
+
+    testWidgets('tapping Block shows confirmation dialog', (tester) async {
+      await tester.pumpWidget(
+        buildMenuWidget(
+          testVideo: testVideo,
+          mockBlocklistService: mockBlocklistService,
+          mockMuteService: mockMuteService,
+          mockNostrClient: mockNostrClient,
+        ),
+      );
+      await tester.tap(find.byType(MoreActionButton));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.textContaining('Block'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Block User?'), findsOneWidget);
+      expect(
+        find.text(
+          "You won't see their content in feeds. "
+          "They won't be notified.",
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Cancel'), findsOneWidget);
+      expect(find.text('Block'), findsOneWidget);
+    });
+
+    testWidgets('confirming Block calls blockUser and shows snackbar', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildMenuWidget(
+          testVideo: testVideo,
+          mockBlocklistService: mockBlocklistService,
+          mockMuteService: mockMuteService,
+          mockNostrClient: mockNostrClient,
+        ),
+      );
+      await tester.tap(find.byType(MoreActionButton));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.textContaining('Block'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(TextButton, 'Block'));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockBlocklistService.blockUser(
+          testVideo.pubkey,
+          ourPubkey: any(named: 'ourPubkey'),
+        ),
+      ).called(1);
+
+      expect(find.text('User blocked'), findsOneWidget);
+    });
+
+    testWidgets('cancelling Block dismisses dialog without blocking', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildMenuWidget(
+          testVideo: testVideo,
+          mockBlocklistService: mockBlocklistService,
+          mockMuteService: mockMuteService,
+          mockNostrClient: mockNostrClient,
+        ),
+      );
+      await tester.tap(find.byType(MoreActionButton));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.textContaining('Block'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      verifyNever(
+        () => mockBlocklistService.blockUser(
+          any(),
+          ourPubkey: any(named: 'ourPubkey'),
+        ),
+      );
+    });
+
+    testWidgets('tapping Copy Nostr event ID copies to clipboard', (
+      tester,
+    ) async {
+      String? clipboardContent;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (MethodCall methodCall) async {
+          if (methodCall.method == 'Clipboard.setData') {
+            final args = methodCall.arguments as Map<String, dynamic>;
+            clipboardContent = args['text'] as String?;
+          }
+          return null;
+        },
+      );
+
+      await tester.pumpWidget(
+        buildMenuWidget(
+          testVideo: testVideo,
+          debugToolsEnabled: true,
+          mockBlocklistService: mockBlocklistService,
+          mockMuteService: mockMuteService,
+          mockNostrClient: mockNostrClient,
+        ),
+      );
+      await tester.tap(find.byType(MoreActionButton));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Copy Nostr event ID'));
+      await tester.pumpAndSettle();
+
+      expect(clipboardContent, isNotNull);
+      expect(clipboardContent, startsWith('nevent1'));
+      expect(find.text('Event ID copied to clipboard'), findsOneWidget);
+    });
+  });
+}
+
+Widget buildMenuWidget({
+  required VideoEvent testVideo,
+  bool debugToolsEnabled = false,
+  ContentBlocklistService? mockBlocklistService,
+  MuteService? mockMuteService,
+  MockNostrClient? mockNostrClient,
+}) {
+  final router = GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) =>
+            Scaffold(body: MoreActionButton(video: testVideo)),
+      ),
+    ],
+  );
+
+  return testProviderScope(
+    mockUserProfileService: createMockUserProfileService(),
+    mockNostrService: mockNostrClient ?? createMockNostrService(),
+    additionalOverrides: [
+      if (mockBlocklistService != null)
+        contentBlocklistServiceProvider.overrideWith(
+          (ref) => mockBlocklistService,
+        ),
+      if (mockMuteService != null)
+        muteServiceProvider.overrideWith((ref) async => mockMuteService),
+      isFeatureEnabledProvider(
+        FeatureFlag.debugTools,
+      ).overrideWithValue(debugToolsEnabled),
+    ],
+    child: MaterialApp.router(routerConfig: router),
+  );
 }

--- a/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
@@ -1,11 +1,14 @@
 // ABOUTME: Tests for ShareActionButton widget
 // ABOUTME: Verifies share icon renders, share sheet opens with correct sections,
-// ABOUTME: and standard action items display in the unified share sheet.
+// ABOUTME: and ownership-specific download actions display correctly.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/repositories/follow_repository.dart';
 import 'package:openvine/widgets/video_feed_item/actions/share_action_button.dart';
 
 import '../../../helpers/test_provider_overrides.dart';
@@ -14,6 +17,8 @@ void main() {
   group(ShareActionButton, () {
     const ownPubkey =
         'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+    const otherPubkey =
+        '1111111111111111111111111111111111111111111111111111111111111111';
 
     late VideoEvent testVideo;
 
@@ -65,26 +70,49 @@ void main() {
         ),
       );
 
-      // Find Semantics widget with share button label
-      final semanticsFinder = find.bySemanticsLabel('Share video');
-      expect(semanticsFinder, findsOneWidget);
+      expect(find.bySemanticsLabel('Share video'), findsOneWidget);
     });
 
     group('share menu', () {
+      Widget buildShareButton({
+        MockAuthService? mockAuth,
+        MockUserProfileService? mockProfile,
+      }) {
+        final mockNostr = createMockNostrService();
+
+        return testMaterialApp(
+          home: Scaffold(body: ShareActionButton(video: testVideo)),
+          mockAuthService: mockAuth,
+          mockUserProfileService: mockProfile,
+          mockNostrService: mockNostr,
+          additionalOverrides: [
+            followRepositoryProvider.overrideWith(
+              (ref) => FollowRepository(
+                nostrClient: mockNostr,
+                indexerRelayUrls: [],
+              ),
+            ),
+          ],
+        );
+      }
+
+      MockAuthService createAuthenticatedMock(String pubkey) {
+        final mockAuth = createMockAuthService();
+        when(() => mockAuth.isAuthenticated).thenReturn(true);
+        when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkey);
+        return mockAuth;
+      }
+
       testWidgets('shows Share with section', (tester) async {
         final mockAuth = createMockAuthService();
         final mockProfile = createMockUserProfileService();
 
         await tester.pumpWidget(
-          testMaterialApp(
-            home: Scaffold(body: ShareActionButton(video: testVideo)),
-            mockAuthService: mockAuth,
-            mockUserProfileService: mockProfile,
-          ),
+          buildShareButton(mockAuth: mockAuth, mockProfile: mockProfile),
         );
 
         await tester.tap(find.byType(IconButton));
-        await tester.pumpAndSettle();
+        await tester.pump();
 
         expect(find.text('Share with'), findsOneWidget);
       });
@@ -94,15 +122,11 @@ void main() {
         final mockProfile = createMockUserProfileService();
 
         await tester.pumpWidget(
-          testMaterialApp(
-            home: Scaffold(body: ShareActionButton(video: testVideo)),
-            mockAuthService: mockAuth,
-            mockUserProfileService: mockProfile,
-          ),
+          buildShareButton(mockAuth: mockAuth, mockProfile: mockProfile),
         );
 
         await tester.tap(find.byType(IconButton));
-        await tester.pumpAndSettle();
+        await tester.pump();
 
         expect(find.text('Find\npeople'), findsOneWidget);
       });
@@ -112,17 +136,61 @@ void main() {
         final mockProfile = createMockUserProfileService();
 
         await tester.pumpWidget(
-          testMaterialApp(
-            home: Scaffold(body: ShareActionButton(video: testVideo)),
-            mockAuthService: mockAuth,
-            mockUserProfileService: mockProfile,
-          ),
+          buildShareButton(mockAuth: mockAuth, mockProfile: mockProfile),
         );
 
         await tester.tap(find.byType(IconButton));
-        await tester.pumpAndSettle();
+        await tester.pump();
 
         expect(find.text('More actions'), findsOneWidget);
+      });
+
+      testWidgets('shows save options for own content', (tester) async {
+        final mockAuth = createAuthenticatedMock(ownPubkey);
+        final mockProfile = createMockUserProfileService();
+
+        await tester.pumpWidget(
+          buildShareButton(mockAuth: mockAuth, mockProfile: mockProfile),
+        );
+
+        await tester.tap(find.byType(IconButton));
+        await tester.pump();
+
+        expect(find.text('Save to Gallery'), findsOneWidget);
+        expect(find.text('Save with Watermark'), findsOneWidget);
+        expect(find.text('Save Video'), findsNothing);
+      });
+
+      testWidgets('shows Save Video for other user content', (tester) async {
+        final mockAuth = createAuthenticatedMock(otherPubkey);
+        final mockProfile = createMockUserProfileService();
+
+        await tester.pumpWidget(
+          buildShareButton(mockAuth: mockAuth, mockProfile: mockProfile),
+        );
+
+        await tester.tap(find.byType(IconButton));
+        await tester.pump();
+
+        expect(find.text('Save to Gallery'), findsNothing);
+        expect(find.text('Save with Watermark'), findsNothing);
+        expect(find.text('Save Video'), findsOneWidget);
+      });
+
+      testWidgets('shows Save Video when not authenticated', (tester) async {
+        final mockAuth = createMockAuthService();
+        final mockProfile = createMockUserProfileService();
+
+        await tester.pumpWidget(
+          buildShareButton(mockAuth: mockAuth, mockProfile: mockProfile),
+        );
+
+        await tester.tap(find.byType(IconButton));
+        await tester.pump();
+
+        expect(find.text('Save to Gallery'), findsNothing);
+        expect(find.text('Save with Watermark'), findsNothing);
+        expect(find.text('Save Video'), findsOneWidget);
       });
 
       testWidgets('shows standard action items', (tester) async {
@@ -130,15 +198,11 @@ void main() {
         final mockProfile = createMockUserProfileService();
 
         await tester.pumpWidget(
-          testMaterialApp(
-            home: Scaffold(body: ShareActionButton(video: testVideo)),
-            mockAuthService: mockAuth,
-            mockUserProfileService: mockProfile,
-          ),
+          buildShareButton(mockAuth: mockAuth, mockProfile: mockProfile),
         );
 
         await tester.tap(find.byType(IconButton));
-        await tester.pumpAndSettle();
+        await tester.pump();
 
         expect(find.text('Save'), findsOneWidget);
         expect(find.text('Copy'), findsOneWidget);


### PR DESCRIPTION
## Summary
- restore `Save to Gallery` and `Save with Watermark` for your own videos, and `Save Video` for other users' videos
- make the `...` button open its moderation/dev menu again instead of duplicating the share sheet
- add regression coverage for the restored share-sheet and more-menu behavior, plus the missing Nostr test stub

## Testing
- `flutter test test/widgets/video_feed_item/actions/share_action_button_test.dart`
- `flutter test test/widgets/video_feed_item/actions/more_action_button_test.dart`
- `flutter analyze lib/widgets/video_feed_item/actions/share_action_button.dart lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart lib/widgets/video_feed_item/actions/more_action_button.dart test/widgets/video_feed_item/actions/share_action_button_test.dart test/widgets/video_feed_item/actions/more_action_button_test.dart test/helpers/test_provider_overrides.dart`