### PR TITLE
fix: correct original Vine badge classification

### DIFF
--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -72,7 +72,7 @@ extension VideoEventAppExtensions on VideoEvent {
   /// - AND does NOT have ProofMode verification (those show ProofMode badge)
   /// - AND is NOT a vintage recovered vine (those show V Original badge)
   bool get shouldShowNotDivineBadge {
-    return !isFromDivineServer && !hasProofMode && !isOriginalVine;
+    return !isFromDivineServer && !hasProofMode && !isVintageRecoveredVine;
   }
 
   // ---------------------------------------------------------------------------

--- a/mobile/lib/utils/proofmode_helpers.dart
+++ b/mobile/lib/utils/proofmode_helpers.dart
@@ -27,6 +27,6 @@ extension ProofModeHelpers on VideoEvent {
   /// Should show original Vine badge
   /// Only show for vintage vines WITHOUT ProofMode (those show ProofMode badge instead)
   bool get shouldShowVineBadge {
-    return isOriginalVine && !hasProofMode;
+    return isVintageRecoveredVine && !hasProofMode;
   }
 }

--- a/mobile/lib/widgets/badge_explanation_modal.dart
+++ b/mobile/lib/widgets/badge_explanation_modal.dart
@@ -15,7 +15,7 @@ class BadgeExplanationModal extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isVineArchive = video.isOriginalVine;
+    final isVineArchive = video.isVintageRecoveredVine;
 
     return AlertDialog(
       backgroundColor: VineTheme.cardBackground,

--- a/mobile/test/extensions/video_event_divine_server_test.dart
+++ b/mobile/test/extensions/video_event_divine_server_test.dart
@@ -54,9 +54,7 @@ void main() {
     });
 
     test('returns true for bare divine.video domain', () {
-      final video = _createVideoWithUrl(
-        'https://divine.video/video.mp4',
-      );
+      final video = _createVideoWithUrl('https://divine.video/video.mp4');
       expect(video.isFromDivineServer, isTrue);
     });
 
@@ -68,9 +66,7 @@ void main() {
     });
 
     test('returns false for other video hosts', () {
-      final video = _createVideoWithUrl(
-        'https://nostr.build/video/abc123.mp4',
-      );
+      final video = _createVideoWithUrl('https://nostr.build/video/abc123.mp4');
       expect(video.isFromDivineServer, isFalse);
     });
   });
@@ -104,7 +100,7 @@ void main() {
             'aaaa1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab',
         'pubkey':
             'bbbb1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab',
-        'created_at': 1234567890,
+        'created_at': 1473050841,
         'kind': 34236,
         'content': '',
         'tags': [

--- a/mobile/test/utils/proofmode_helpers_test.dart
+++ b/mobile/test/utils/proofmode_helpers_test.dart
@@ -163,9 +163,9 @@ void main() {
       final video = VideoEvent(
         id: 'vine1',
         pubkey: 'pubkey1',
-        createdAt: DateTime.now().millisecondsSinceEpoch,
+        createdAt: 1473050841,
         content: 'classic vine',
-        timestamp: DateTime.now(),
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1473050841 * 1000),
         originalLoops: 1000000,
       );
 
@@ -204,9 +204,9 @@ void main() {
       final video = VideoEvent(
         id: 'vine4',
         pubkey: 'pubkey4',
-        createdAt: DateTime.now().millisecondsSinceEpoch,
+        createdAt: 1473050841,
         content: 'vine with one loop',
-        timestamp: DateTime.now(),
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1473050841 * 1000),
         originalLoops: 1,
       );
 
@@ -243,6 +243,7 @@ void main() {
 
       expect(video.isOriginalVine, isTrue);
       expect(video.isVintageRecoveredVine, isFalse);
+      expect(video.shouldShowVineBadge, isFalse);
     });
   });
 
@@ -251,9 +252,9 @@ void main() {
       final video = VideoEvent(
         id: 'combo1',
         pubkey: 'pubkey1',
-        createdAt: DateTime.now().millisecondsSinceEpoch,
+        createdAt: 1473050841,
         content: 'verified original vine',
-        timestamp: DateTime.now(),
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1473050841 * 1000),
         rawTags: const {'verification': 'verified_mobile'},
         originalLoops: 500000,
       );
@@ -285,14 +286,30 @@ void main() {
       final video = VideoEvent(
         id: 'combo3',
         pubkey: 'pubkey3',
-        createdAt: DateTime.now().millisecondsSinceEpoch,
+        createdAt: 1473050841,
         content: 'classic unverified vine',
-        timestamp: DateTime.now(),
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1473050841 * 1000),
         originalLoops: 1000000,
       );
 
       expect(video.shouldShowProofModeBadge, isFalse);
       expect(video.shouldShowVineBadge, isTrue);
+    });
+
+    test('shows no Vine badge for recent looped videos', () {
+      final video = VideoEvent(
+        id: 'combo5',
+        pubkey: 'pubkey5',
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        content: 'recent looped divine video',
+        timestamp: DateTime.now(),
+        originalLoops: 1000000,
+      );
+
+      expect(video.isOriginalVine, isTrue);
+      expect(video.isVintageRecoveredVine, isFalse);
+      expect(video.shouldShowProofModeBadge, isFalse);
+      expect(video.shouldShowVineBadge, isFalse);
     });
 
     test('shows no badges for unverified new videos', () {

--- a/mobile/test/widgets/original_content_badge_test.dart
+++ b/mobile/test/widgets/original_content_badge_test.dart
@@ -105,7 +105,7 @@ void main() {
         final event = Event.fromJson({
           'id': 'vintage1234567890abcdef',
           'pubkey': 'pubkey1234567890abcdef',
-          'created_at': 1234567890,
+          'created_at': 1473050841,
           'kind': 34236,
           'content': 'Vintage vine',
           'tags': [


### PR DESCRIPTION
## Summary
- only show the Vine archive badge for vintage recovered Vines
- keep recent looped videos eligible for non-Vine badging instead of labeling them as archive content
- align the badge explanation modal and focused tests with the vintage-only rule

## Testing
- flutter test test/utils/proofmode_helpers_test.dart test/extensions/video_event_divine_server_test.dart test/widgets/original_content_badge_test.dart