### PR TITLE
fix(video): adjust bottom offset for safe area in video overlay actions

### DIFF
--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -1368,7 +1368,7 @@ class VideoOverlayActions extends ConsumerWidget {
               : 54.0) // Fallback for Dynamic Island iPhones
         : viewPaddingTop;
 
-    const bottomOffset = 14.0;
+    final bottomOffset = 14.0 + MediaQuery.viewPaddingOf(context).bottom;
 
     return Stack(
       children: [
@@ -1715,55 +1715,53 @@ class VideoOverlayActions extends ConsumerWidget {
         Positioned(
           bottom: bottomOffset - 6,
           right: 16,
-          child: SafeArea(
-            child: AnimatedOpacity(
-              opacity: isActive ? 1.0 : 0.0,
-              duration: const Duration(milliseconds: 200),
-              child: IgnorePointer(
-                ignoring: false, // Action buttons SHOULD receive taps
-                child: Column(
-                  children: [
-                    // Edit button (only show for owned videos when feature
-                    // is enabled)
-                    // Hide in fullscreen mode since it's shown in AppBar
-                    if (!isFullscreen && !isPreviewMode)
-                      _VideoEditButton(video: video),
+          child: AnimatedOpacity(
+            opacity: isActive ? 1.0 : 0.0,
+            duration: const Duration(milliseconds: 200),
+            child: IgnorePointer(
+              ignoring: false, // Action buttons SHOULD receive taps
+              child: Column(
+                children: [
+                  // Edit button (only show for owned videos when feature
+                  // is enabled)
+                  // Hide in fullscreen mode since it's shown in AppBar
+                  if (!isFullscreen && !isPreviewMode)
+                    _VideoEditButton(video: video),
 
-                    // CC (subtitles) button
-                    CcActionButton(video: video),
+                  // CC (subtitles) button
+                  CcActionButton(video: video),
 
-                    const SizedBox(height: 4),
+                  const SizedBox(height: 4),
 
-                    // Like button
-                    LikeActionButton(
-                      video: video,
-                      isPreviewMode: isPreviewMode,
-                    ),
+                  // Like button
+                  LikeActionButton(
+                    video: video,
+                    isPreviewMode: isPreviewMode,
+                  ),
 
-                    const SizedBox(height: 4),
+                  const SizedBox(height: 4),
 
-                    // Comment button with count
-                    _CommentActionButton(video: video, ref: ref),
+                  // Comment button with count
+                  _CommentActionButton(video: video, ref: ref),
 
-                    const SizedBox(height: 4),
+                  const SizedBox(height: 4),
 
-                    // Repost button
-                    RepostActionButton(
-                      video: video,
-                      isPreviewMode: isPreviewMode,
-                    ),
+                  // Repost button
+                  RepostActionButton(
+                    video: video,
+                    isPreviewMode: isPreviewMode,
+                  ),
 
-                    const SizedBox(height: 4),
+                  const SizedBox(height: 4),
 
-                    // Share button
-                    ShareActionButton(video: video),
+                  // Share button
+                  ShareActionButton(video: video),
 
-                    const SizedBox(height: 4),
+                  const SizedBox(height: 4),
 
-                    // More button (report, mute, block, etc.)
-                    MoreActionButton(video: video),
-                  ],
-                ),
+                  // More button (report, mute, block, etc.)
+                  MoreActionButton(video: video),
+                ],
               ),
             ),
           ),


### PR DESCRIPTION
## Description

Resolve the issue of content appearing behind the bottom bar on newer Android phones.

@meylis1998 I noticed that the social buttons in the home and explore feeds are ordered differently and have different spacing. I'm not sure if this is an intended design feature or an issue so i didn't touch it ;) 
Btw, if the design should be the same, maybe it would make sense to create a new widget that we could reuse :)

| Before | After |
| ----- | ----- |
|  <img width="879" height="1924" alt="Screenshot 2026-03-06 102605" src="https://github.com/user-attachments/assets/8c741714-bab0-4c31-88f0-a1716b3fa8cb" /> |  <img width="871" height="1916" alt="Screenshot 2026-03-06 102650" src="https://github.com/user-attachments/assets/8de92d25-8881-4627-bfb7-c000ca98385c" />  |

**Related Issue:** Closes #2009

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore