### PR TITLE
fix: resolve search crashes and loading state hangs (#1906)

### DIFF
--- a/mobile/lib/blocs/video_search/video_search_bloc.dart
+++ b/mobile/lib/blocs/video_search/video_search_bloc.dart
@@ -64,7 +64,10 @@ class VideoSearchBloc extends Bloc<VideoSearchEvent, VideoSearchState> {
       await emit.forEach<List<VideoEvent>>(
         _videosRepository.searchVideos(query: query),
         onData: (videos) => state.copyWith(
-          status: VideoSearchStatus.searching,
+          // Consider each stream emission a usable search result snapshot.
+          // This prevents indefinite loading UI when the first emission is empty
+          // and slower sources (e.g. relays) are still pending.
+          status: VideoSearchStatus.success,
           videos: videos,
         ),
       );

--- a/mobile/lib/screens/pure/search_screen_pure.dart
+++ b/mobile/lib/screens/pure/search_screen_pure.dart
@@ -63,7 +63,7 @@ class _SearchScreenPureState extends ConsumerState<SearchScreenPure>
   final TextEditingController _searchController = TextEditingController();
   final FocusNode _searchFocusNode = FocusNode();
   late TabController _tabController;
-  late UserSearchBloc _userSearchBloc;
+  UserSearchBloc? _userSearchBloc;
   late HashtagSearchBloc _hashtagSearchBloc;
   late VideoSearchBloc _videoSearchBloc;
 
@@ -71,9 +71,10 @@ class _SearchScreenPureState extends ConsumerState<SearchScreenPure>
   void initState() {
     super.initState();
     _tabController = TabController(length: 3, vsync: this);
-    _userSearchBloc = UserSearchBloc(
-      profileRepository: ref.read(profileRepositoryProvider)!,
-    );
+    final profileRepository = ref.read(profileRepositoryProvider);
+    if (profileRepository != null) {
+      _userSearchBloc = UserSearchBloc(profileRepository: profileRepository);
+    }
     _hashtagSearchBloc = HashtagSearchBloc(
       hashtagRepository: ref.read(hashtagRepositoryProvider),
     );
@@ -91,7 +92,7 @@ class _SearchScreenPureState extends ConsumerState<SearchScreenPure>
               ctx.searchTerm != null &&
               ctx.searchTerm!.isNotEmpty) {
             _searchController.text = ctx.searchTerm!;
-            _userSearchBloc.add(UserSearchQueryChanged(ctx.searchTerm!));
+            _userSearchBloc?.add(UserSearchQueryChanged(ctx.searchTerm!));
             _hashtagSearchBloc.add(HashtagSearchQueryChanged(ctx.searchTerm!));
             _videoSearchBloc.add(VideoSearchQueryChanged(ctx.searchTerm!));
             Log.info(
@@ -115,7 +116,7 @@ class _SearchScreenPureState extends ConsumerState<SearchScreenPure>
     _searchController.dispose();
     _searchFocusNode.dispose();
     _tabController.dispose();
-    _userSearchBloc.close();
+    _userSearchBloc?.close();
     _hashtagSearchBloc.close();
     _videoSearchBloc.close();
     super.dispose();
@@ -126,13 +127,24 @@ class _SearchScreenPureState extends ConsumerState<SearchScreenPure>
   void _onSearchChanged() {
     final query = _searchController.text.trim();
 
-    _userSearchBloc.add(UserSearchQueryChanged(query));
+    _userSearchBloc?.add(UserSearchQueryChanged(query));
     _hashtagSearchBloc.add(HashtagSearchQueryChanged(query));
     _videoSearchBloc.add(VideoSearchQueryChanged(query));
   }
 
   @override
   Widget build(BuildContext context) {
+    // ProfileRepository may be temporarily unavailable during startup.
+    // Initialize user search bloc lazily when provider becomes ready.
+    final profileRepository = ref.watch(profileRepositoryProvider);
+    if (_userSearchBloc == null && profileRepository != null) {
+      _userSearchBloc = UserSearchBloc(profileRepository: profileRepository);
+      final existingQuery = _searchController.text.trim();
+      if (existingQuery.isNotEmpty) {
+        _userSearchBloc!.add(UserSearchQueryChanged(existingQuery));
+      }
+    }
+
     // Derive feed mode from URL (single source of truth)
     final pageContext = ref.watch(pageContextProvider);
     final isInFeedMode =
@@ -157,7 +169,7 @@ class _SearchScreenPureState extends ConsumerState<SearchScreenPure>
       videoSearchBloc: _videoSearchBloc,
       onClear: () {
         _searchController.clear();
-        _userSearchBloc.add(const UserSearchCleared());
+        _userSearchBloc?.add(const UserSearchCleared());
         _hashtagSearchBloc.add(const HashtagSearchCleared());
         _videoSearchBloc.add(const VideoSearchCleared());
       },
@@ -167,14 +179,38 @@ class _SearchScreenPureState extends ConsumerState<SearchScreenPure>
       bloc: _videoSearchBloc,
       builder: (context, videoState) {
         final videoCount = videoState.videos.length;
-        return BlocBuilder<UserSearchBloc, UserSearchState>(
-          bloc: _userSearchBloc,
-          builder: (context, userSearchState) {
-            final userCount = userSearchState.results.length;
-            return BlocBuilder<HashtagSearchBloc, HashtagSearchState>(
-              bloc: _hashtagSearchBloc,
-              builder: (context, hashtagSearchState) {
-                final hashtagCount = hashtagSearchState.results.length;
+        return BlocBuilder<HashtagSearchBloc, HashtagSearchState>(
+          bloc: _hashtagSearchBloc,
+          builder: (context, hashtagSearchState) {
+            final hashtagCount = hashtagSearchState.results.length;
+            if (_userSearchBloc == null) {
+              return TabBar(
+                controller: _tabController,
+                isScrollable: true,
+                tabAlignment: TabAlignment.start,
+                padding: const EdgeInsets.only(left: 16),
+                indicatorColor: VineTheme.tabIndicatorGreen,
+                indicatorWeight: 4,
+                indicatorSize: TabBarIndicatorSize.tab,
+                dividerColor: Colors.transparent,
+                labelColor: VineTheme.whiteText,
+                unselectedLabelColor: VineTheme.tabIconInactive,
+                labelPadding: const EdgeInsets.symmetric(horizontal: 14),
+                labelStyle: VineTheme.tabTextStyle(),
+                unselectedLabelStyle: VineTheme.tabTextStyle(
+                  color: VineTheme.tabIconInactive,
+                ),
+                tabs: [
+                  Tab(text: 'Videos ($videoCount)'),
+                  const Tab(text: 'Users (0)'),
+                  Tab(text: 'Hashtags ($hashtagCount)'),
+                ],
+              );
+            }
+            return BlocBuilder<UserSearchBloc, UserSearchState>(
+              bloc: _userSearchBloc,
+              builder: (context, userSearchState) {
+                final userCount = userSearchState.results.length;
                 return TabBar(
                   controller: _tabController,
                   isScrollable: true,
@@ -206,10 +242,12 @@ class _SearchScreenPureState extends ConsumerState<SearchScreenPure>
 
     final tabContent = TabBarView(
       controller: _tabController,
-      children: const [
-        _VideosTab(),
-        UserSearchView(),
-        HashtagSearchView(),
+      children: [
+        const _VideosTab(),
+        _userSearchBloc == null
+            ? const _UsersTabLoadingPlaceholder()
+            : const UserSearchView(),
+        const HashtagSearchView(),
       ],
     );
 
@@ -263,11 +301,26 @@ class _SearchScreenPureState extends ConsumerState<SearchScreenPure>
 
     return MultiBlocProvider(
       providers: [
-        BlocProvider.value(value: _userSearchBloc),
+        if (_userSearchBloc != null)
+          BlocProvider.value(value: _userSearchBloc!),
         BlocProvider.value(value: _hashtagSearchBloc),
         BlocProvider.value(value: _videoSearchBloc),
       ],
       child: body,
+    );
+  }
+}
+
+class _UsersTabLoadingPlaceholder extends StatelessWidget {
+  const _UsersTabLoadingPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text(
+        'User search is initializing...',
+        style: TextStyle(color: VineTheme.secondaryText),
+      ),
     );
   }
 }

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -1412,6 +1412,12 @@ class VideoEventService extends ChangeNotifier {
             name: 'VideoEventService',
             category: LogCategory.video,
           );
+          // Reusing an active subscription means initial loading is complete
+          // for this request and UI should not remain in a spinner state.
+          if (paginationState != null) {
+            paginationState.isLoading = false;
+            notifyListeners();
+          }
           // Update active subscription mapping
           _activeSubscriptions[subscriptionType] = subscriptionId;
           return; // Reuse existing subscription
@@ -1558,6 +1564,8 @@ class VideoEventService extends ChangeNotifier {
           filters,
           onEose: () {
             eoseReceived = true;
+            // Initial load phase is complete once EOSE arrives, even with 0 events.
+            _paginationStates[subscriptionType]?.isLoading = false;
             feedLoadingTimeout
                 ?.cancel(); // Cancel timeout - EOSE received successfully
             final eoseDuration = DateTime.now().difference(
@@ -1628,6 +1636,9 @@ class VideoEventService extends ChangeNotifier {
                 isOnline: _connectionService.isOnline,
               );
             }
+
+            // Ensure listeners rebuild to show empty-state instead of spinner.
+            notifyListeners();
           },
         );
 
@@ -1689,6 +1700,8 @@ class VideoEventService extends ChangeNotifier {
             _handleNewVideoEvent(event, subscriptionType);
           },
           onError: (error) {
+            _paginationStates[subscriptionType]?.isLoading = false;
+            notifyListeners();
             Log.error(
               '❌ Subscription error for $subscriptionType after $eventCount events: $error',
               name: 'VideoEventService',
@@ -1762,6 +1775,8 @@ class VideoEventService extends ChangeNotifier {
         category: LogCategory.video,
       );
     } catch (e) {
+      _paginationStates[subscriptionType]?.isLoading = false;
+      notifyListeners();
       _error = e.toString();
       Log.error(
         'Failed to subscribe to video events: $e',

--- a/mobile/test/blocs/video_search/video_search_bloc_test.dart
+++ b/mobile/test/blocs/video_search/video_search_bloc_test.dart
@@ -90,7 +90,7 @@ void main() {
       );
 
       blocTest<VideoSearchBloc, VideoSearchState>(
-        'emits [searching, searching(videos), success] '
+        'emits [searching, success(videos)] '
         'when stream yields results',
         setUp: () {
           final video = createVideo(id: 'v1', title: 'Flutter Tutorial');
@@ -107,16 +107,13 @@ void main() {
               .having((s) => s.status, 'status', VideoSearchStatus.searching)
               .having((s) => s.query, 'query', 'flutter'),
           isA<VideoSearchState>()
-              .having((s) => s.status, 'status', VideoSearchStatus.searching)
-              .having((s) => s.videos, 'videos', hasLength(1)),
-          isA<VideoSearchState>()
               .having((s) => s.status, 'status', VideoSearchStatus.success)
               .having((s) => s.videos, 'videos', hasLength(1)),
         ],
       );
 
       blocTest<VideoSearchBloc, VideoSearchState>(
-        'emits progressive searching states then success '
+        'emits progressive success snapshots '
         'when stream yields multiple times',
         setUp: () {
           final localVideo = createVideo(id: 'local-1', title: 'Local');
@@ -142,11 +139,8 @@ void main() {
               .having((s) => s.status, 'status', VideoSearchStatus.searching)
               .having((s) => s.query, 'query', 'flutter'),
           isA<VideoSearchState>()
-              .having((s) => s.status, 'status', VideoSearchStatus.searching)
+              .having((s) => s.status, 'status', VideoSearchStatus.success)
               .having((s) => s.videos, 'videos', hasLength(1)),
-          isA<VideoSearchState>()
-              .having((s) => s.status, 'status', VideoSearchStatus.searching)
-              .having((s) => s.videos, 'videos', hasLength(2)),
           isA<VideoSearchState>()
               .having((s) => s.status, 'status', VideoSearchStatus.success)
               .having((s) => s.videos, 'videos', hasLength(2)),
@@ -154,8 +148,7 @@ void main() {
       );
 
       blocTest<VideoSearchBloc, VideoSearchState>(
-        'stays searching when local cache is empty '
-        'until API yields results and stream completes',
+        'shows success(empty) after local miss, then success(with data)',
         setUp: () {
           final apiVideo = createVideo(id: 'api-1', title: 'API Result');
 
@@ -176,12 +169,11 @@ void main() {
               .having((s) => s.status, 'status', VideoSearchStatus.searching)
               .having((s) => s.query, 'query', 'flutter')
               .having((s) => s.videos, 'videos', isEmpty),
-          // local cache yields [] — deduped by Equatable (same state)
-          // API yields results — still searching
+          // local cache yields [] as a usable result snapshot
           isA<VideoSearchState>()
-              .having((s) => s.status, 'status', VideoSearchStatus.searching)
-              .having((s) => s.videos, 'videos', hasLength(1)),
-          // stream done — now success
+              .having((s) => s.status, 'status', VideoSearchStatus.success)
+              .having((s) => s.videos, 'videos', isEmpty),
+          // API yields results
           isA<VideoSearchState>()
               .having((s) => s.status, 'status', VideoSearchStatus.success)
               .having((s) => s.videos, 'videos', hasLength(1)),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Hey @omartinma,  tagging you for review as requested. Could you take a look at this PR when you have a moment?

This PR fixes two regressions in search/feed behavior that caused either an error screen or endless loading states:

1. **Search screen crash on open**  
   In `SearchScreenPure`, unsafe initialization of `UserSearchBloc` via `profileRepositoryProvider!` was removed.  
   Initialization is now null-safe and lazy, so the screen does not crash when `ProfileRepository` is temporarily unavailable at startup.

2. **Endless loading when no results exist**  
   - In `VideoEventService`, per-subscription loading state for hashtag flows is now explicitly reset on `reuse`, `EOSE`, `onError`, and `catch` paths, with listener notifications.  
   - In `VideoSearchBloc`, progressive search stream emissions are treated as usable snapshots (`success`) so UI does not stay in `searching` forever when early emissions are empty.

3. **Updated search BLoC tests**  
   `video_search_bloc_test.dart` expectations were updated to match the corrected progressive state behavior.

**Related Issue:** Closes #1906 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore