### PR TITLE
fix(auth): reset EmailVerificationCubit state when screen reopens

### DIFF
--- a/mobile/lib/blocs/email_verification/email_verification_cubit.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_cubit.dart
@@ -120,6 +120,17 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
     }
   }
 
+  /// Reset to initial state unconditionally.
+  ///
+  /// Called when a new verification screen opens to clear stale state from
+  /// a previous verification (e.g., User A verified, now User B's deep link
+  /// arrives). Without this, the builder would render success UI from the
+  /// previous verification instead of the new verification flow.
+  void reset() {
+    _cleanup();
+    emit(const EmailVerificationState());
+  }
+
   void _onTimeout() {
     Log.warning(
       'Email verification polling timed out after '

--- a/mobile/lib/screens/auth/email_verification_screen.dart
+++ b/mobile/lib/screens/auth/email_verification_screen.dart
@@ -74,6 +74,10 @@ class _EmailVerificationScreenState
     super.initState();
     _cubit = context.read<EmailVerificationCubit>();
 
+    // Clear any stale state from a previous verification (e.g., User A
+    // verified successfully, now User B's deep link opens this screen).
+    _cubit.reset();
+
     // Use post-frame callback to access context safely
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _initializeVerification();

--- a/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
+++ b/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
@@ -118,6 +118,51 @@ void main() {
       );
     });
 
+    group('reset', () {
+      blocTest<EmailVerificationCubit, EmailVerificationState>(
+        'resets from success state to initial',
+        build: buildCubit,
+        seed: () => const EmailVerificationState(
+          status: EmailVerificationStatus.success,
+        ),
+        act: (cubit) => cubit.reset(),
+        expect: () => [const EmailVerificationState()],
+        verify: (cubit) {
+          expect(cubit.state.status, EmailVerificationStatus.initial);
+        },
+      );
+
+      blocTest<EmailVerificationCubit, EmailVerificationState>(
+        'resets from polling state to initial',
+        build: buildCubit,
+        seed: () => const EmailVerificationState(
+          status: EmailVerificationStatus.polling,
+          pendingEmail: testEmail,
+        ),
+        act: (cubit) => cubit.reset(),
+        expect: () => [const EmailVerificationState()],
+        verify: (cubit) {
+          expect(cubit.state.status, EmailVerificationStatus.initial);
+          expect(cubit.state.pendingEmail, isNull);
+        },
+      );
+
+      blocTest<EmailVerificationCubit, EmailVerificationState>(
+        'resets from failure state to initial',
+        build: buildCubit,
+        seed: () => const EmailVerificationState(
+          status: EmailVerificationStatus.failure,
+          error: 'some error',
+        ),
+        act: (cubit) => cubit.reset(),
+        expect: () => [const EmailVerificationState()],
+        verify: (cubit) {
+          expect(cubit.state.status, EmailVerificationStatus.initial);
+          expect(cubit.state.error, isNull);
+        },
+      );
+    });
+
     group('zombie cubit detection', () {
       const testCode = 'auth-code-from-server';
 


### PR DESCRIPTION
## Summary

Fixes stale cubit state in cross-user email verification flow.

**Bug:** `EmailVerificationCubit` is provided at the app level (`main.dart`), so it persists across screen visits. After User A verifies their email, the cubit stays in `success` state. When User B's verification deep link opens the screen, the `BlocConsumer` builder renders the stale success UI ("Welcome to Divine!") instead of showing the verification flow.

**Fix:** Add `reset()` method to the cubit and call it in `initState` when the screen opens. This unconditionally clears any stale state before starting the new verification flow. The existing `stopPolling()` intentionally preserves success state (to avoid UI flash during navigation), so a separate method is needed.

**Note:** The server-side verification still works correctly — this is a UX-only bug where the user sees the wrong screen briefly before being redirected.

## Changes

| File | Change |
|------|--------|
| `email_verification_cubit.dart` | Add `reset()` method that clears state unconditionally |
| `email_verification_screen.dart` | Call `_cubit.reset()` in `initState` before starting verification |
| `email_verification_cubit_test.dart` | 3 new tests for `reset()` from success/polling/failure states |

## Test plan

- [x] 19 unit tests pass (3 new for `reset()`)
- [x] Existing `stopPolling` behavior preserved (still skips reset on success)
- [x] Zombie cubit detection still works