### PR TITLE
feat: restore per-video content warning flow

### DIFF
--- a/mobile/lib/models/divine_video_draft.dart
+++ b/mobile/lib/models/divine_video_draft.dart
@@ -7,6 +7,7 @@ import 'package:models/models.dart' show AspectRatio;
 import 'package:models/models.dart' show InspiredByInfo;
 import 'package:models/models.dart' show NativeProofData;
 import 'package:openvine/models/audio_event.dart';
+import 'package:openvine/models/content_label.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/utils/path_resolver.dart';
 import 'package:openvine/utils/unified_logger.dart';
@@ -37,6 +38,7 @@ class DivineVideoDraft {
     this.inspiredByVideo,
     this.inspiredByNpub,
     this.selectedSound,
+    this.contentWarning,
   });
 
   factory DivineVideoDraft.create({
@@ -56,6 +58,7 @@ class DivineVideoDraft {
     InspiredByInfo? inspiredByVideo,
     String? inspiredByNpub,
     AudioEvent? selectedSound,
+    String? contentWarning,
   }) {
     final now = DateTime.now();
     return DivineVideoDraft(
@@ -79,6 +82,7 @@ class DivineVideoDraft {
       inspiredByVideo: inspiredByVideo,
       inspiredByNpub: inspiredByNpub,
       selectedSound: selectedSound,
+      contentWarning: contentWarning,
     );
   }
 
@@ -172,6 +176,7 @@ class DivineVideoDraft {
       selectedSound: json['selectedSound'] != null
           ? AudioEvent.fromJson(json['selectedSound'] as Map<String, dynamic>)
           : null,
+      contentWarning: json['contentWarning'] as String?,
     );
   }
 
@@ -228,6 +233,9 @@ class DivineVideoDraft {
   /// Persisted to drafts so the sound selection survives app restarts.
   final AudioEvent? selectedSound;
 
+  /// Comma-separated NIP-32 content warning labels for this video.
+  final String? contentWarning;
+
   /// Check if this draft has ProofMode data
   bool get hasProofMode => proofManifestJson != null;
 
@@ -275,6 +283,7 @@ class DivineVideoDraft {
     String? inspiredByNpub,
     AudioEvent? selectedSound,
     bool clearSelectedSound = false,
+    Object? contentWarning = _sentinel,
     bool skipUpdateLastModified = false,
   }) => DivineVideoDraft(
     id: id ?? this.id,
@@ -307,7 +316,12 @@ class DivineVideoDraft {
     selectedSound: clearSelectedSound
         ? null
         : (selectedSound ?? this.selectedSound),
+    contentWarning: contentWarning == _sentinel
+        ? this.contentWarning
+        : contentWarning as String?,
   );
+
+  static const _sentinel = Object();
 
   Map<String, dynamic> toJson() => {
     'id': id,
@@ -334,7 +348,10 @@ class DivineVideoDraft {
     if (inspiredByVideo != null) 'inspiredByVideo': inspiredByVideo!.toJson(),
     if (inspiredByNpub != null) 'inspiredByNpub': inspiredByNpub,
     if (selectedSound != null) 'selectedSound': selectedSound!.toJson(),
+    if (contentWarning != null) 'contentWarning': contentWarning,
   };
+
+  Set<ContentLabel> get contentWarnings => ContentLabel.fromCsv(contentWarning);
 
   String get displayDuration {
     final duration = DateTime.now().difference(createdAt);

--- a/mobile/lib/models/video_editor/video_editor_provider_state.dart
+++ b/mobile/lib/models/video_editor/video_editor_provider_state.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:models/models.dart' show InspiredByInfo;
 import 'package:openvine/models/audio_event.dart';
+import 'package:openvine/models/content_label.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_metadata/video_metadata_expiration.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
@@ -43,6 +44,7 @@ class VideoEditorProviderState {
     this.inspiredByVideo,
     this.inspiredByNpub,
     this.selectedSound,
+    this.contentWarnings = const {},
     this.proofManifestJson,
     GlobalKey? deleteButtonKey,
   }) : deleteButtonKey = deleteButtonKey ?? GlobalKey();
@@ -131,6 +133,9 @@ class VideoEditorProviderState {
   /// This is persisted in drafts and used for audio playback during editing.
   final AudioEvent? selectedSound;
 
+  /// NIP-32 content warning labels for sensitive content self-labeling.
+  final Set<ContentLabel> contentWarnings;
+
   /// ProofMode attestation manifest JSON for the final rendered clip.
   final String? proofManifestJson;
 
@@ -188,6 +193,7 @@ class VideoEditorProviderState {
     bool clearInspiredByNpub = false,
     AudioEvent? selectedSound,
     bool clearSelectedSound = false,
+    Set<ContentLabel>? contentWarnings,
   }) {
     return VideoEditorProviderState(
       currentClipIndex: currentClipIndex ?? this.currentClipIndex,
@@ -225,6 +231,7 @@ class VideoEditorProviderState {
       selectedSound: clearSelectedSound
           ? null
           : (selectedSound ?? this.selectedSound),
+      contentWarnings: contentWarnings ?? this.contentWarnings,
       proofManifestJson: clearProofManifestJson || clearFinalRenderedClip
           ? null
           : proofManifestJson ?? this.proofManifestJson,

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' show InspiredByInfo;
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/audio_event.dart';
+import 'package:openvine/models/content_label.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
@@ -98,9 +99,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       cancelRenderVideo();
     }
 
-    state = state.copyWith(
-      clearFinalRenderedClip: true,
-    );
+    state = state.copyWith(clearFinalRenderedClip: true);
 
     // Delete the old rendered file from disk to free up space
     final db = ref.read(databaseProvider);
@@ -140,6 +139,18 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         name: 'VideoEditorNotifier',
         category: .video,
       );
+      final accountLabelService = ref.read(accountLabelServiceProvider);
+      await accountLabelService.initialized;
+      final accountLabels = accountLabelService.defaultVideoLabels;
+      if (accountLabels.isNotEmpty) {
+        state = state.copyWith(contentWarnings: accountLabels);
+        Log.info(
+          '⚠️ Auto-selected content warnings from account labels: '
+          '${accountLabels.map((label) => label.value).join(", ")}',
+          name: 'VideoEditorNotifier',
+          category: LogCategory.video,
+        );
+      }
     }
     this.draftId = draftId ?? 'Draft_${DateTime.now().microsecondsSinceEpoch}';
   }
@@ -552,6 +563,12 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     triggerAutosave();
   }
 
+  /// Set NIP-32 content warning labels for the current video.
+  void setContentWarnings(Set<ContentLabel> labels) {
+    state = state.copyWith(contentWarnings: Set<ContentLabel>.of(labels));
+    triggerAutosave();
+  }
+
   // === COLLABORATORS & INSPIRED BY ===
 
   /// Maximum number of collaborators allowed per video.
@@ -676,6 +693,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       inspiredByVideo: inspiredByVideo,
       inspiredByNpub: state.inspiredByNpub,
       selectedSound: selectedSound,
+      contentWarning: ContentLabel.toCsv(state.contentWarnings),
       finalRenderedClip: isAutosave ? state.finalRenderedClip : null,
       proofManifestJson: state.proofManifestJson,
     );
@@ -925,6 +943,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       inspiredByVideo: draft.inspiredByVideo,
       inspiredByNpub: draft.inspiredByNpub,
       selectedSound: draft.selectedSound,
+      contentWarnings: draft.contentWarnings,
       finalRenderedClip: validFinalRenderedClip,
       clearFinalRenderedClip: validFinalRenderedClip == null,
     );

--- a/mobile/lib/screens/video_metadata/video_metadata_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_screen.dart
@@ -13,6 +13,7 @@ import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_bottom_bar.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_clip_preview.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_collaborators_input.dart';
+import 'package:openvine/widgets/video_metadata/video_metadata_content_warning_selector.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_expiration_selector.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_inspired_by_input.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_tags_input.dart';
@@ -234,6 +235,8 @@ class _FormData extends ConsumerWidget {
         const SizedBox(height: 16),
         const _MetadataLimitWarning(),
         const _SectionCard(child: VideoMetadataExpirationSelector()),
+        const SizedBox(height: 12),
+        const _SectionCard(child: VideoMetadataContentWarningSelector()),
         const SizedBox(height: 12),
         const _SectionCard(child: VideoMetadataCollaboratorsInput()),
         const SizedBox(height: 12),

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -253,6 +253,7 @@ class VideoEventPublisher {
     String? selectedAudioEventId,
     String? selectedAudioRelay,
     String? language,
+    String? contentWarning,
   }) async {
     // Create a temporary upload with updated metadata
     final updatedUpload = upload.copyWith(
@@ -272,6 +273,7 @@ class VideoEventPublisher {
       selectedAudioEventId: selectedAudioEventId,
       selectedAudioRelay: selectedAudioRelay,
       language: language,
+      contentWarning: contentWarning,
     );
   }
 
@@ -287,6 +289,7 @@ class VideoEventPublisher {
     String? selectedAudioEventId,
     String? selectedAudioRelay,
     String? language,
+    String? contentWarning,
   }) async {
     if (upload.videoId == null || upload.cdnUrl == null) {
       Log.error(
@@ -570,6 +573,16 @@ class VideoEventPublisher {
       if (language != null && language.isNotEmpty) {
         tags.add(['L', 'ISO-639-1']);
         tags.add(['l', language, 'ISO-639-1']);
+      }
+
+      // Add NIP-32 content-warning self-labeling tags (NIP-36).
+      if (contentWarning != null && contentWarning.isNotEmpty) {
+        final warnings = contentWarning.split(',').map((value) => value.trim());
+        tags.add(['content-warning', warnings.first]);
+        tags.add(['L', 'content-warning']);
+        for (final warning in warnings) {
+          tags.add(['l', warning, 'content-warning']);
+        }
       }
 
       // Add client tag

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -146,6 +146,7 @@ class VideoPublishService {
         selectedAudioEventId: draft.selectedSound?.id,
         selectedAudioRelay: draft.selectedSound?.sourceVideoRelay,
         language: languagePreferenceService?.contentLanguage,
+        contentWarning: draft.contentWarning,
       );
 
       if (!published) {

--- a/mobile/lib/widgets/video_metadata/video_metadata_content_warning_selector.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_content_warning_selector.dart
@@ -1,0 +1,273 @@
+// ABOUTME: Widget for selecting NIP-32 content warning labels on videos
+// ABOUTME: Multi-select bottom sheet with checkboxes for all ContentLabel values
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:openvine/models/content_label.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
+
+/// Widget for selecting content warning labels on a video.
+///
+/// Displays the currently selected content warnings and opens
+/// a multi-select bottom sheet with all available options when tapped.
+class VideoMetadataContentWarningSelector extends ConsumerWidget {
+  /// Creates a video content warning selector.
+  const VideoMetadataContentWarningSelector({super.key});
+
+  /// Opens the multi-select bottom sheet for content warnings.
+  Future<void> _selectContentWarnings(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    FocusManager.instance.primaryFocus?.unfocus();
+
+    final current = ref.read(
+      videoEditorProvider.select((state) => state.contentWarnings),
+    );
+
+    final result = await _ContentWarningMultiSelect.show(
+      context: context,
+      selected: current,
+    );
+
+    if (result != null && context.mounted) {
+      ref.read(videoEditorProvider.notifier).setContentWarnings(result);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final warnings = ref.watch(
+      videoEditorProvider.select((state) => state.contentWarnings),
+    );
+
+    final isSet = warnings.isNotEmpty;
+    final displayText = isSet
+        ? warnings.map((label) => label.displayName).join(', ')
+        : 'None';
+    final iconColor = isSet
+        ? const Color(0xFFFFB84D)
+        : VineTheme.tabIndicatorGreen;
+
+    return Semantics(
+      button: true,
+      label: 'Select content warnings',
+      child: InkWell(
+        onTap: () => _selectContentWarnings(context, ref),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            spacing: 8,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Content Warning',
+                style: GoogleFonts.inter(
+                  color: const Color(0xBFFFFFFF),
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  height: 1.45,
+                  letterSpacing: 0.5,
+                ),
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Flexible(
+                    child: Text(
+                      displayText,
+                      style: VineTheme.titleFont(
+                        fontSize: 17,
+                        color: const Color(0xF2FFFFFF),
+                        letterSpacing: 0.15,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  Container(
+                    width: 30,
+                    height: 30,
+                    decoration: BoxDecoration(
+                      color: const Color(0x8C032017),
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(color: VineTheme.outlineVariant),
+                    ),
+                    child: Center(
+                      child: SizedBox(
+                        height: 18,
+                        width: 18,
+                        child: isSet
+                            ? Icon(
+                                Icons.warning_amber_rounded,
+                                size: 18,
+                                color: iconColor,
+                              )
+                            : SvgPicture.asset(
+                                'assets/icon/caret_right.svg',
+                                colorFilter: ColorFilter.mode(
+                                  iconColor,
+                                  BlendMode.srcIn,
+                                ),
+                              ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Multi-select bottom sheet for choosing content warning labels.
+class _ContentWarningMultiSelect extends StatefulWidget {
+  const _ContentWarningMultiSelect({required this.selected});
+
+  final Set<ContentLabel> selected;
+
+  /// Show the multi-select bottom sheet and return selected labels.
+  ///
+  /// Returns `null` if dismissed without saving.
+  static Future<Set<ContentLabel>?> show({
+    required BuildContext context,
+    required Set<ContentLabel> selected,
+  }) {
+    return showModalBottomSheet<Set<ContentLabel>>(
+      context: context,
+      backgroundColor: VineTheme.cardBackground,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      isScrollControlled: true,
+      builder: (_) => _ContentWarningMultiSelect(selected: selected),
+    );
+  }
+
+  @override
+  State<_ContentWarningMultiSelect> createState() =>
+      _ContentWarningMultiSelectState();
+}
+
+class _ContentWarningMultiSelectState
+    extends State<_ContentWarningMultiSelect> {
+  late Set<ContentLabel> _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = Set.of(widget.selected);
+  }
+
+  void _toggle(ContentLabel label) {
+    setState(() {
+      if (_selected.contains(label)) {
+        _selected.remove(label);
+      } else {
+        _selected.add(label);
+      }
+    });
+  }
+
+  void _clearAll() {
+    setState(_selected.clear);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DraggableScrollableSheet(
+      initialChildSize: 0.7,
+      maxChildSize: 0.9,
+      minChildSize: 0.4,
+      expand: false,
+      builder: (context, scrollController) {
+        return Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 12, bottom: 4),
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: VineTheme.onSurfaceMuted,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    'Content Warnings',
+                    style: VineTheme.titleFont(fontSize: 18),
+                  ),
+                  if (_selected.isNotEmpty)
+                    TextButton(
+                      onPressed: _clearAll,
+                      child: const Text(
+                        'Clear All',
+                        style: TextStyle(color: VineTheme.vineGreen),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16),
+              child: Text(
+                'Select all that apply to your content',
+                style: TextStyle(color: VineTheme.secondaryText, fontSize: 13),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Expanded(
+              child: ListView.builder(
+                controller: scrollController,
+                itemCount: ContentLabel.values.length,
+                itemBuilder: (context, index) {
+                  final label = ContentLabel.values[index];
+                  final isChecked = _selected.contains(label);
+                  return CheckboxListTile(
+                    value: isChecked,
+                    onChanged: (_) => _toggle(label),
+                    title: Text(
+                      label.displayName,
+                      style: const TextStyle(
+                        color: VineTheme.whiteText,
+                        fontSize: 15,
+                      ),
+                    ),
+                    activeColor: VineTheme.vineGreen,
+                    checkColor: VineTheme.whiteText,
+                    controlAffinity: ListTileControlAffinity.leading,
+                  );
+                },
+              ),
+            ),
+            SafeArea(
+              top: false,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: () => Navigator.of(context).pop(_selected),
+                    child: const Text('Done'),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/mobile/test/models/vine_draft_collab_ib_test.dart
+++ b/mobile/test/models/vine_draft_collab_ib_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' show AspectRatio, InspiredByInfo;
+import 'package:openvine/models/content_label.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -80,6 +81,25 @@ void main() {
         );
 
         expect(draft.inspiredByNpub, equals('npub1testvalue123'));
+      });
+
+      test('accepts content warnings', () {
+        final draft = DivineVideoDraft.create(
+          clips: [_testClip()],
+          title: 'Test',
+          description: '',
+          hashtags: const {},
+          selectedApproach: 'native',
+          contentWarning: ContentLabel.toCsv({
+            ContentLabel.nudity,
+            ContentLabel.violence,
+          }),
+        );
+
+        expect(
+          draft.contentWarnings,
+          equals({ContentLabel.nudity, ContentLabel.violence}),
+        );
       });
     });
 
@@ -179,6 +199,20 @@ void main() {
         final json = draft.toJson();
         expect(json.containsKey('inspiredByNpub'), isFalse);
       });
+
+      test('includes contentWarning when set', () {
+        final draft = DivineVideoDraft.create(
+          clips: [_testClip()],
+          title: 'Test',
+          description: '',
+          hashtags: const {},
+          selectedApproach: 'native',
+          contentWarning: 'nudity,violence',
+        );
+
+        final json = draft.toJson();
+        expect(json['contentWarning'], equals('nudity,violence'));
+      });
     });
 
     group('fromJson round-trip', () {
@@ -252,6 +286,26 @@ void main() {
         expect(restored.inspiredByNpub, equals('npub1testvalue'));
       });
 
+      test('preserves contentWarning through serialization', () {
+        final original = DivineVideoDraft.create(
+          clips: [_testClip()],
+          title: 'Warning Video',
+          description: 'Sensitive content',
+          hashtags: const {},
+          selectedApproach: 'native',
+          contentWarning: 'nudity,violence',
+        );
+
+        final json = original.toJson();
+        final restored = DivineVideoDraft.fromJson(json, '/path/to');
+
+        expect(restored.contentWarning, equals('nudity,violence'));
+        expect(
+          restored.contentWarnings,
+          equals({ContentLabel.nudity, ContentLabel.violence}),
+        );
+      });
+
       test('preserves all collab+IB fields together', () {
         const ib = InspiredByInfo(addressableId: '34236:pubkey:dtag');
 
@@ -320,6 +374,23 @@ void main() {
         expect(updated.title, equals('Updated Title'));
         expect(updated.collaboratorPubkeys, hasLength(1));
         expect(updated.inspiredByNpub, equals('npub1keep'));
+      });
+
+      test('preserves contentWarning when not updated', () {
+        final draft = DivineVideoDraft.create(
+          clips: [_testClip()],
+          title: 'Original',
+          description: '',
+          hashtags: const {},
+          selectedApproach: 'native',
+          contentWarning: 'nudity',
+        );
+
+        final updated = draft.copyWith(title: 'Updated Title');
+
+        expect(updated.title, equals('Updated Title'));
+        expect(updated.contentWarning, equals('nudity'));
+        expect(updated.contentWarnings, equals({ContentLabel.nudity}));
       });
 
       test('can update collaboratorPubkeys', () {

--- a/mobile/test/services/video_event_publisher_language_tag_test.dart
+++ b/mobile/test/services/video_event_publisher_language_tag_test.dart
@@ -215,4 +215,70 @@ void main() {
       );
     });
   });
+
+  group('NIP-32 content warning tagging', () {
+    test('adds content-warning tags when labels are provided', () async {
+      stubSignAndPublish();
+
+      await publisher.publishDirectUpload(
+        createTestUpload(),
+        contentWarning: 'nudity,violence',
+      );
+
+      expect(capturedTags, isNotNull);
+      expect(
+        _containsTag(capturedTags!, ['content-warning', 'nudity']),
+        isTrue,
+      );
+      expect(_containsTag(capturedTags!, ['L', 'content-warning']), isTrue);
+      expect(
+        _containsTag(capturedTags!, ['l', 'nudity', 'content-warning']),
+        isTrue,
+      );
+      expect(
+        _containsTag(capturedTags!, ['l', 'violence', 'content-warning']),
+        isTrue,
+      );
+    });
+
+    test('publishVideoEvent passes contentWarning through', () async {
+      stubSignAndPublish();
+
+      await publisher.publishVideoEvent(
+        upload: createTestUpload(),
+        contentWarning: 'drugs',
+      );
+
+      expect(capturedTags, isNotNull);
+      expect(_containsTag(capturedTags!, ['content-warning', 'drugs']), isTrue);
+      expect(
+        _containsTag(capturedTags!, ['l', 'drugs', 'content-warning']),
+        isTrue,
+      );
+    });
+
+    test('does not add content-warning tags when labels are empty', () async {
+      stubSignAndPublish();
+
+      await publisher.publishDirectUpload(
+        createTestUpload(),
+        contentWarning: '',
+      );
+
+      expect(capturedTags, isNotNull);
+      expect(
+        capturedTags!.any(
+          (tag) => tag.isNotEmpty && tag.first == 'content-warning',
+        ),
+        isFalse,
+      );
+      expect(
+        capturedTags!.any(
+          (tag) =>
+              tag.length >= 3 && tag[0] == 'l' && tag[2] == 'content-warning',
+        ),
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- restore the content warning selector to the video metadata flow
- persist per-video content warning labels through editor state and saved drafts, including account-label defaults for new videos
- publish NIP-32 content-warning tags with video events and cover the recovered path with targeted tests

## Testing
- flutter test test/models/vine_draft_collab_ib_test.dart
- flutter test test/services/video_event_publisher_language_tag_test.dart
- flutter analyze