### PR TITLE
fix: Complete Your Profile shown even for users with display name

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -117,7 +117,10 @@ class ProfileHeaderWidget extends ConsumerWidget {
               children: [
                 // Setup profile banner for new users with default names
                 // (only on own profile)
-                if (isOwnProfile && !hasCustomName && onSetupProfile != null)
+                if (isOwnProfile &&
+                    !profileAsync.isLoading &&
+                    !hasCustomName &&
+                    onSetupProfile != null)
                   _SetupProfileBanner(onSetup: onSetupProfile!),
 
                 // Session expired banner for divineOAuth users (only on own

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for ProfileHeaderWidget
 // ABOUTME: Verifies profile header displays avatar, stats, name, bio, and npub correctly
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -145,6 +147,7 @@ void main() {
       required AsyncValue<ProfileStats> profileStatsAsync,
       int videoCount = 10,
       UserProfile? profile,
+      bool profileIsLoading = false,
       VoidCallback? onSetupProfile,
       bool isAnonymous = false,
       String? displayNameHint,
@@ -159,9 +162,11 @@ void main() {
             mockNostrService: mockNostrClient,
             mockUserProfileService: mockUserProfileService,
           ),
-          fetchUserProfileProvider(
-            userIdHex,
-          ).overrideWith((ref) async => profile),
+          fetchUserProfileProvider(userIdHex).overrideWith(
+            profileIsLoading
+                ? (ref) => Completer<UserProfile?>().future
+                : (ref) async => profile,
+          ),
           followRepositoryProvider.overrideWithValue(mockFollowRepository),
           authServiceProvider.overrideWithValue(authService),
           currentAuthStateProvider.overrideWith(
@@ -295,6 +300,25 @@ void main() {
 
       expect(setupCalled, isTrue);
     });
+
+    testWidgets(
+      'hides setup banner while profile is still loading',
+      (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profileStatsAsync: AsyncValue.data(createTestStats()),
+            profileIsLoading: true,
+            onSetupProfile: () {},
+          ),
+        );
+        // Do not pumpAndSettle — provider never resolves
+        await tester.pump();
+
+        expect(find.text('Complete Your Profile'), findsNothing);
+      },
+    );
 
     testWidgets('hides setup banner when profile has custom name', (
       tester,


### PR DESCRIPTION
## Description

The "Complete Your Profile" banner was incorrectly appearing on the My Profile screen for users who had already set a display name. Because `fetchUserProfileProvider` is auto-disposed, it re-creates and enters a loading state on every navigation to the profile screen — during which `profileAsync.value` is `null`, causing `hasCustomName` to evaluate as `false` and the banner to persist until the relay responds.

**Related Issue:** Closes #2026

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore