### PR TITLE
fix: update c2pa-flutter to 0.0.3 to fix OOM errors during signing

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -261,11 +261,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "0.0.2"
-      resolved-ref: f484b983b6bf3661495642f76448efdffdc15399
+      ref: "0.0.3"
+      resolved-ref: "847d0c0183c9c09946ce321c107decd3fd9f56b2"
       url: "https://github.com/guardianproject/c2pa-flutter.git"
     source: git
-    version: "0.0.2"
+    version: "0.0.3"
   cached_network_image:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -85,7 +85,7 @@ dependencies:
   c2pa_flutter:
     git:
       url: https://github.com/guardianproject/c2pa-flutter.git
-      ref: 0.0.2
+      ref: 0.0.3
   divine_camera:
     path: packages/divine_camera
   camera_macos_plus: ^0.0.4


### PR DESCRIPTION

## Description

c2pa signing was causing out of memory errors due to loading video into memory instead of using a stream

tip o' the hat to dcadenas
info here: https://github.com/guardianproject/c2pa-flutter/issues/4

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ x ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore