### PR TITLE
fix(video): remove _resolveCachePaths that caused iOS cache URI crash

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -47,9 +47,9 @@ const _maxConcurrentCacheDownloads = 1;
 /// loading indicators, seek commands).
 ///
 /// **Playback hooks integration:**
-/// - Videos are cache-resolved when received (cached file paths replace URLs)
 /// - Background caching triggered via [FullscreenFeedVideoCacheStarted]
 /// - Loop enforcement via [FullscreenFeedPositionUpdated] → [SeekCommand]
+/// - Cache resolution happens at the player level (individual_video_providers)
 class FullscreenFeedBloc
     extends Bloc<FullscreenFeedEvent, FullscreenFeedState> {
   FullscreenFeedBloc({
@@ -94,8 +94,8 @@ class FullscreenFeedBloc
   /// - Emits states for each data event
   /// - Cancels the subscription when the bloc is closed
   ///
-  /// Videos are cache-resolved when received - if a video's file is cached,
-  /// the videoUrl is replaced with the cached file path for instant playback.
+  /// Cache resolution is handled at the player level by
+  /// individualVideoControllerProvider, not here.
   Future<void> _onStarted(
     FullscreenFeedStarted event,
     Emitter<FullscreenFeedState> emit,
@@ -109,17 +109,14 @@ class FullscreenFeedBloc
           category: LogCategory.video,
         );
 
-        // Resolve cache paths for videos
-        final resolvedVideos = _resolveCachePaths(videos);
-
         // Clamp current index to valid range
-        final clampedIndex = resolvedVideos.isEmpty
+        final clampedIndex = videos.isEmpty
             ? 0
-            : state.currentIndex.clamp(0, resolvedVideos.length - 1);
+            : state.currentIndex.clamp(0, videos.length - 1);
 
         return state.copyWith(
           status: FullscreenFeedStatus.ready,
-          videos: resolvedVideos,
+          videos: videos,
           currentIndex: clampedIndex,
           isLoadingMore: false,
         );
@@ -134,25 +131,6 @@ class FullscreenFeedBloc
         return state;
       },
     );
-  }
-
-  /// Resolves cache paths for a list of videos.
-  ///
-  /// For each video, checks if a cached file exists and replaces the videoUrl
-  /// with the cached file path for instant playback.
-  List<VideoEvent> _resolveCachePaths(List<VideoEvent> videos) {
-    return videos.map((video) {
-      final cachedFile = _mediaCache.getCachedFileSync(video.id);
-      if (cachedFile != null) {
-        Log.debug(
-          'FullscreenFeedBloc: Cache hit for video ${video.id}',
-          name: 'FullscreenFeedBloc',
-          category: LogCategory.video,
-        );
-        return video.copyWith(videoUrl: cachedFile.path);
-      }
-      return video;
-    }).toList();
   }
 
   /// Handle load more request - trigger the source's pagination.
@@ -215,6 +193,17 @@ class FullscreenFeedBloc
     if (videoUrl == null || videoUrl.isEmpty) {
       Log.warning(
         'FullscreenFeedBloc: Video ${video.id} has no URL, cannot cache',
+        name: 'FullscreenFeedBloc',
+        category: LogCategory.video,
+      );
+      return;
+    }
+
+    // Guard: only cache HTTP URLs (never local file paths)
+    if (!videoUrl.startsWith('http://') && !videoUrl.startsWith('https://')) {
+      Log.warning(
+        'FullscreenFeedBloc: Video ${video.id} has non-HTTP URL, '
+        'skipping cache: $videoUrl',
         name: 'FullscreenFeedBloc',
         category: LogCategory.video,
       );

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -466,7 +466,7 @@ void main() {
 
     group('cache resolution', () {
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
-        'resolves cached file paths when videos arrive',
+        'does not replace videoUrl with cache path when videos arrive',
         setUp: () {
           final mockFile = MockFile();
           when(() => mockFile.path).thenReturn('/cached/video1.mp4');
@@ -486,8 +486,8 @@ void main() {
               .having((s) => s.status, 'status', FullscreenFeedStatus.ready)
               .having(
                 (s) => s.videos.first.videoUrl,
-                'resolved video URL',
-                '/cached/video1.mp4',
+                'videoUrl preserved as HTTP',
+                'https://example.com/video_video1.mp4',
               ),
         ],
       );
@@ -507,6 +507,36 @@ void main() {
             'original video URL',
             'https://example.com/video_video1.mp4',
           ),
+        ],
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'preserves HTTP videoUrl when cache hit occurs '
+        '(never replaces with local file path)',
+        setUp: () {
+          final mockFile = MockFile();
+          when(() => mockFile.path).thenReturn(
+            '/data/user/0/co.openvine.app/cache/openvine_video_cache/video1.mp4',
+          );
+          when(
+            () => mockMediaCache.getCachedFileSync('video1'),
+          ).thenReturn(mockFile);
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([createTestVideo('video1')]);
+        },
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          isA<FullscreenFeedState>()
+              .having((s) => s.status, 'status', FullscreenFeedStatus.ready)
+              .having(
+                (s) => s.videos.first.videoUrl,
+                'videoUrl must remain HTTP',
+                startsWith('https://'),
+              ),
         ],
       );
     });
@@ -579,6 +609,77 @@ void main() {
         act: (bloc) =>
             bloc.add(const FullscreenFeedVideoCacheStarted(index: 5)),
         wait: const Duration(milliseconds: 50),
+        verify: (_) {
+          verifyNever(
+            () => mockMediaCache.downloadFile(
+              any(),
+              key: any(named: 'key'),
+              authHeaders: any(named: 'authHeaders'),
+            ),
+          );
+        },
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'background caching uses HTTP URL '
+        '(never passes local file path to downloadFile)',
+        setUp: () {
+          when(
+            () => mockMediaCache.downloadFile(
+              any(),
+              key: any(named: 'key'),
+              authHeaders: any(named: 'authHeaders'),
+            ),
+          ).thenAnswer((_) async => MockFileInfo());
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([createTestVideo('video1')]);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          bloc.add(const FullscreenFeedVideoCacheStarted(index: 0));
+        },
+        wait: const Duration(milliseconds: 200),
+        verify: (_) {
+          // downloadFile must receive an HTTP URL, not a local file path
+          verify(
+            () => mockMediaCache.downloadFile(
+              'https://example.com/video_video1.mp4',
+              key: 'video1',
+            ),
+          ).called(1);
+          // Must never be called with a file path
+          verifyNever(
+            () => mockMediaCache.downloadFile(
+              any(that: startsWith('/')),
+              key: any(named: 'key'),
+              authHeaders: any(named: 'authHeaders'),
+            ),
+          );
+        },
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'skips caching when videoUrl is a local file path',
+        build: createBloc,
+        seed: () => FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [
+            VideoEvent(
+              id: 'video1',
+              pubkey: '0' * 64,
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+              content: '',
+              timestamp: DateTime.now(),
+              title: 'Test',
+              videoUrl: '/data/user/0/cache/video1.mp4',
+            ),
+          ],
+        ),
+        act: (bloc) =>
+            bloc.add(const FullscreenFeedVideoCacheStarted(index: 0)),
+        wait: const Duration(milliseconds: 100),
         verify: (_) {
           verifyNever(
             () => mockMediaCache.downloadFile(


### PR DESCRIPTION
Fixes an iOS crash (161 events, 11 users) where background video caching crashed because a local file path was used instead of an internet URL.

**User impact after fix:** Videos in fullscreen feed load more reliably. No more silent failures from the caching system trying to "download" a file that's already on the phone.

**What was broken:** The fullscreen feed overwrote video URLs with local cache paths. When background caching later tried to download those videos, it crashed — the HTTP client can't fetch a file path.

**What changed:**
- Removed the URL overwriting (redundant — the video player checks cache on its own)
- Added a guard to skip caching attempts on non-HTTP URLs

**Note:** 8 existing corrupted events were found on relay.divine.video (5 Android, 3 iOS, 4 users, Jan 31 – Mar 4) where local file paths leaked into published Nostr event metadata. This fix prevents new corruptions but does not repair existing ones. See #2033 for repair discussion.

**Tests:** 3 new, 1 updated, 1076 total bloc tests pass. Analyze and format clean.