### PR TITLE
fix(android): prevent crash when app closes during background work

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -129,6 +129,10 @@ dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
     implementation("androidx.multidex:multidex:2.0.1")
 
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("io.mockk:mockk:1.13.13")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+
     // BouncyCastle jdk18on for CertificateSigningService (replaces excluded jdk15to18 versions)
     implementation("org.bouncycastle:bcpkix-jdk18on:1.78.1")
     implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")

--- a/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
@@ -30,6 +30,8 @@ import com.zendesk.service.ZendeskCallback
 import com.zendesk.service.ErrorResponse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
 import org.witness.proofmode.notarization.NotarizationProvider
@@ -50,6 +52,9 @@ class MainActivity : FlutterActivity() {
     private val ZENDESK_CHANNEL = "com.openvine/zendesk_support"
     private val PROOFMODE_TAG = "OpenVineProofMode"
     private val ZENDESK_TAG = "OpenVineZendesk"
+
+    // Lifecycle-aware scope: cancelled in onDestroy to prevent post-detach crashes
+    private val activityScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     // NIP-55 Android Signer plugin
     private var nostrSignerPlugin: NostrSignerPlugin? = null
@@ -179,17 +184,20 @@ class MainActivity : FlutterActivity() {
 
     override fun onDestroy() {
         isActivityDestroyed = true
-        super.onDestroy()
+        activityScope.cancel()
+        navigationChannel = null
+        nostrSignerPlugin = null
         // Unregister callback when activity is destroyed
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && backCallback != null) {
             onBackInvokedDispatcher.unregisterOnBackInvokedCallback(backCallback!!)
         }
+        super.onDestroy()
     }
     private fun initC2PA () {
         var keyAlias = "c2pa_signing_divine";
         var fileCert = File(context.filesDir.parent + "/app_flutter","$keyAlias.cert")
 
-        CoroutineScope(Dispatchers.IO).launch {
+        activityScope.launch {
             try {
                 C2PAIdentityManager(this@MainActivity).createHardwareSigner(
                     keyAlias,
@@ -241,6 +249,10 @@ class MainActivity : FlutterActivity() {
                             val proofHash = ProofMode.generateProof(context, mediaUri)
 
                             mainHandler.post {
+                                if (isActivityDestroyed || isFinishing) {
+                                    Log.w(PROOFMODE_TAG, "Dropped proof result: activity destroyed")
+                                    return@post
+                                }
                                 if (proofHash.isNullOrEmpty()) {
                                     Log.e(PROOFMODE_TAG, "ProofMode did not generate hash")
                                     result.error("PROOF_HASH_MISSING", "ProofMode did not generate video hash", null)
@@ -252,6 +264,10 @@ class MainActivity : FlutterActivity() {
                         } catch (e: Exception) {
                             Log.e(PROOFMODE_TAG, "Failed to generate proof", e)
                             mainHandler.post {
+                                if (isActivityDestroyed || isFinishing) {
+                                    Log.w(PROOFMODE_TAG, "Dropped proof error: activity destroyed")
+                                    return@post
+                                }
                                 result.error("PROOF_GENERATION_FAILED", e.message, null)
                             }
                         }
@@ -464,11 +480,19 @@ class MainActivity : FlutterActivity() {
 
                         provider.createRequest(createRequest, object : ZendeskCallback<Request>() {
                             override fun onSuccess(request: Request?) {
+                                if (isActivityDestroyed || isFinishing) {
+                                    Log.w(ZENDESK_TAG, "Dropped ticket result: activity destroyed")
+                                    return
+                                }
                                 Log.d(ZENDESK_TAG, "Ticket created successfully - ID: ${request?.id}")
                                 result.success(true)
                             }
 
                             override fun onError(error: ErrorResponse?) {
+                                if (isActivityDestroyed || isFinishing) {
+                                    Log.w(ZENDESK_TAG, "Dropped ticket error: activity destroyed")
+                                    return
+                                }
                                 Log.e(ZENDESK_TAG, "Failed to create ticket: ${error?.reason}")
                                 result.success(false)
                             }

--- a/mobile/android/app/src/test/kotlin/co/openvine/app/FlutterJNILifecycleGuardTest.kt
+++ b/mobile/android/app/src/test/kotlin/co/openvine/app/FlutterJNILifecycleGuardTest.kt
@@ -1,0 +1,172 @@
+package co.openvine.app
+
+import android.os.Handler
+import android.os.Looper
+import io.flutter.plugin.common.MethodChannel
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests that MethodChannel result callbacks are guarded against
+ * activity destruction, preventing FlutterJNI detach crashes.
+ *
+ * The crash (java.lang.RuntimeException: Cannot execute operation because
+ * FlutterJNI is not attached to native) occurs when async callbacks
+ * (ProofMode background thread, Zendesk network callback) try to send
+ * results through a platform channel after the Flutter engine is destroyed.
+ *
+ * These tests verify that the lifecycle guard pattern works:
+ * callbacks must check isActivityDestroyed/isFinishing before calling
+ * result.success() or result.error().
+ */
+class FlutterJNILifecycleGuardTest {
+
+    /**
+     * Simulates the lifecycle guard pattern used in MainActivity.
+     * Extracted here so we can test the logic without needing a real Activity.
+     */
+    class LifecycleGuardedCallback(
+        private val isActivityDestroyed: () -> Boolean,
+        private val isFinishing: () -> Boolean,
+    ) {
+        fun postResult(result: MethodChannel.Result, value: Any?) {
+            if (isActivityDestroyed() || isFinishing()) {
+                return
+            }
+            result.success(value)
+        }
+
+        fun postError(
+            result: MethodChannel.Result,
+            code: String,
+            message: String?,
+            details: Any?,
+        ) {
+            if (isActivityDestroyed() || isFinishing()) {
+                return
+            }
+            result.error(code, message, details)
+        }
+    }
+
+    private lateinit var result: MethodChannel.Result
+
+    @Before
+    fun setUp() {
+        result = mockk(relaxed = true)
+    }
+
+    @Test
+    fun `result success is delivered when activity is alive`() {
+        val guard = LifecycleGuardedCallback(
+            isActivityDestroyed = { false },
+            isFinishing = { false },
+        )
+
+        guard.postResult(result, "proof_hash_123")
+
+        verify(exactly = 1) { result.success("proof_hash_123") }
+    }
+
+    @Test
+    fun `result success is dropped when activity is destroyed`() {
+        val guard = LifecycleGuardedCallback(
+            isActivityDestroyed = { true },
+            isFinishing = { false },
+        )
+
+        guard.postResult(result, "proof_hash_123")
+
+        verify(exactly = 0) { result.success(any()) }
+    }
+
+    @Test
+    fun `result success is dropped when activity is finishing`() {
+        val guard = LifecycleGuardedCallback(
+            isActivityDestroyed = { false },
+            isFinishing = { true },
+        )
+
+        guard.postResult(result, "proof_hash_123")
+
+        verify(exactly = 0) { result.success(any()) }
+    }
+
+    @Test
+    fun `result error is delivered when activity is alive`() {
+        val guard = LifecycleGuardedCallback(
+            isActivityDestroyed = { false },
+            isFinishing = { false },
+        )
+
+        guard.postError(result, "PROOF_GENERATION_FAILED", "timeout", null)
+
+        verify(exactly = 1) {
+            result.error("PROOF_GENERATION_FAILED", "timeout", null)
+        }
+    }
+
+    @Test
+    fun `result error is dropped when activity is destroyed`() {
+        val guard = LifecycleGuardedCallback(
+            isActivityDestroyed = { true },
+            isFinishing = { false },
+        )
+
+        guard.postError(result, "PROOF_GENERATION_FAILED", "timeout", null)
+
+        verify(exactly = 0) { result.error(any(), any(), any()) }
+    }
+
+    @Test
+    fun `result error is dropped when activity is finishing`() {
+        val guard = LifecycleGuardedCallback(
+            isActivityDestroyed = { false },
+            isFinishing = { true },
+        )
+
+        guard.postError(result, "PROOF_GENERATION_FAILED", "timeout", null)
+
+        verify(exactly = 0) { result.error(any(), any(), any()) }
+    }
+
+    @Test
+    fun `result is dropped when both destroyed and finishing`() {
+        val guard = LifecycleGuardedCallback(
+            isActivityDestroyed = { true },
+            isFinishing = { true },
+        )
+
+        guard.postResult(result, "proof_hash_123")
+        guard.postError(result, "ERROR", "msg", null)
+
+        verify(exactly = 0) { result.success(any()) }
+        verify(exactly = 0) { result.error(any(), any(), any()) }
+    }
+
+    @Test
+    fun `guard transitions from alive to destroyed mid-sequence`() {
+        var destroyed = false
+        val guard = LifecycleGuardedCallback(
+            isActivityDestroyed = { destroyed },
+            isFinishing = { false },
+        )
+
+        // First call succeeds (activity alive)
+        guard.postResult(result, "first")
+        verify(exactly = 1) { result.success("first") }
+
+        // Activity destroyed between calls
+        destroyed = true
+
+        // Second call is dropped
+        guard.postResult(result, "second")
+        verify(exactly = 0) { result.success("second") }
+    }
+}


### PR DESCRIPTION
## Summary
When a user closed the app while a video proof was being generated or a support ticket was being submitted, the app would crash. The background work would finish and try to report back, but the app was already gone.

This was the #1 Android crash — 23 events across 14 users.

## What changes for users
Users can safely close the app at any time without triggering a crash. Background work that's still running is either cancelled or its result is silently dropped.

## Note
This fix covers the Java/Kotlin platform channel layer. A separate native/Rust JNI fix is also needed — panic unwinds on the native side can skip thread cleanup, and pre-decoded URIs from Java can trigger panics that expose the detach issue. See follow-up for the native layer.

## Test plan
- [ ] Android app builds clean (verified locally)
- [ ] Kotlin unit tests for lifecycle guard logic (8 tests)
- [ ] Monitor Crashlytics after release — `FlutterJNI is not attached to native` should drop to zero