### PR TITLE
fix: unchecking use NIP-05 on profile edit page

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -299,6 +299,11 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         !isExternal || (event.externalNip05?.trim().isEmpty ?? true)
         ? null
         : event.externalNip05?.trim().toLowerCase();
+
+    // Explicitly clear NIP-05 when in divine mode with no username. Without
+    // this flag, saveProfileEvent would silently preserve the existing NIP-05
+    // from currentProfile.rawData even though the user opted out of both modes.
+    final clearNip05 = !isExternal && username == null;
     final picture = (event.picture?.trim().isEmpty ?? true)
         ? null
         : event.picture;
@@ -323,6 +328,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         about: about,
         username: username,
         nip05: externalNip05,
+        clearNip05: clearNip05,
         picture: picture,
         banner: banner,
         currentProfile: currentProfile,

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -131,7 +131,9 @@ class ProfileRepository {
   ///
   /// If both [nip05] and [username] are provided, [nip05] takes precedence.
   /// When neither is provided and a [currentProfile] is supplied, the existing
-  /// NIP-05 value is preserved from `currentProfile.rawData`.
+  /// NIP-05 value is preserved from `currentProfile.rawData`. Pass
+  /// [clearNip05] as `true` to explicitly remove the NIP-05 from the profile
+  /// (overriding any value in `currentProfile.rawData`).
   ///
   /// After successful publish, the profile is cached locally for immediate
   /// subsequent reads.
@@ -142,6 +144,7 @@ class ProfileRepository {
     String? about,
     String? username,
     String? nip05,
+    bool clearNip05 = false,
     String? picture,
     String? banner,
     UserProfile? currentProfile,
@@ -159,6 +162,13 @@ class ProfileRepository {
       'picture': ?picture,
       'banner': ?banner,
     };
+
+    // When the user explicitly removes their NIP-05 (no username, no external
+    // NIP-05), remove the key so the rawData spread does not preserve the old
+    // value.
+    if (clearNip05 && resolvedNip05 == null) {
+      profileContent.remove('nip05');
+    }
 
     final profileEvent = await _nostrClient.sendProfile(
       profileContent: profileContent,

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -388,6 +388,89 @@ void main() {
             ).called(1);
           },
         );
+
+        test(
+          'preserves existing nip05 from rawData when clearNip05 is false',
+          () async {
+            final currentProfile = await createCurrentProfile({
+              'display_name': 'Old Name',
+              'nip05': 'alice@example.com',
+            });
+
+            await profileRepository.saveProfileEvent(
+              displayName: 'New Name',
+              currentProfile: currentProfile,
+            );
+
+            verify(
+              () => mockNostrClient.sendProfile(
+                profileContent: {
+                  'display_name': 'New Name',
+                  'nip05': 'alice@example.com',
+                },
+              ),
+            ).called(1);
+          },
+        );
+
+        test(
+          'removes nip05 from rawData when clearNip05 is true',
+          () async {
+            final currentProfile = await createCurrentProfile({
+              'display_name': 'Old Name',
+              'nip05': 'alice@example.com',
+              'about': 'Bio',
+            });
+
+            await profileRepository.saveProfileEvent(
+              displayName: 'New Name',
+              clearNip05: true,
+              currentProfile: currentProfile,
+            );
+
+            verify(
+              () => mockNostrClient.sendProfile(
+                profileContent: {
+                  'display_name': 'New Name',
+                  'about': 'Bio',
+                },
+              ),
+            ).called(1);
+          },
+        );
+
+        test(
+          'clearNip05 is a no-op when a new nip05 is also provided',
+          () async {
+            final currentProfile = await createCurrentProfile({
+              'display_name': 'Old Name',
+              'nip05': 'old@example.com',
+            });
+
+            when(() => mockProfileEvent.content).thenReturn(
+              jsonEncode({
+                'display_name': 'New Name',
+                'nip05': 'new@example.com',
+              }),
+            );
+
+            await profileRepository.saveProfileEvent(
+              displayName: 'New Name',
+              nip05: 'new@example.com',
+              clearNip05: true,
+              currentProfile: currentProfile,
+            );
+
+            verify(
+              () => mockNostrClient.sendProfile(
+                profileContent: {
+                  'display_name': 'New Name',
+                  'nip05': 'new@example.com',
+                },
+              ),
+            ).called(1);
+          },
+        );
       });
     });
 

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -90,6 +90,7 @@ void main() {
                 displayName: testDisplayName,
                 about: testAbout,
                 picture: testPicture,
+                clearNip05: any(named: 'clearNip05'),
               ),
             ).thenAnswer((_) async => createTestProfile());
           },
@@ -120,6 +121,7 @@ void main() {
                 displayName: testDisplayName,
                 about: testAbout,
                 picture: testPicture,
+                clearNip05: any(named: 'clearNip05'),
               ),
             ).called(1);
             verifyNever(
@@ -144,6 +146,7 @@ void main() {
                 displayName: testDisplayName,
                 about: testAbout,
                 picture: testPicture,
+                clearNip05: any(named: 'clearNip05'),
                 currentProfile: existingProfile,
               ),
             ).thenAnswer((_) async => createTestProfile());
@@ -182,6 +185,7 @@ void main() {
                 displayName: testDisplayName,
                 about: testAbout,
                 picture: testPicture,
+                clearNip05: any(named: 'clearNip05'),
               ),
             ).thenAnswer((_) async => createTestProfile());
           },
@@ -213,6 +217,43 @@ void main() {
                 displayName: testDisplayName,
                 about: testAbout,
                 picture: testPicture,
+                clearNip05: any(named: 'clearNip05'),
+              ),
+            ).called(1);
+          },
+        );
+
+        blocTest<ProfileEditorBloc, ProfileEditorState>(
+          'passes clearNip05: true when no username in divine mode',
+          setUp: () {
+            when(
+              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+            ).thenAnswer((_) async => null);
+            when(
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: testAbout,
+                picture: testPicture,
+                clearNip05: true,
+              ),
+            ).thenAnswer((_) async => createTestProfile());
+          },
+          build: createBloc,
+          act: (bloc) => bloc.add(
+            const ProfileSaved(
+              pubkey: testPubkey,
+              displayName: testDisplayName,
+              about: testAbout,
+              picture: testPicture,
+            ),
+          ),
+          verify: (_) {
+            verify(
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: testAbout,
+                picture: testPicture,
+                clearNip05: true,
               ),
             ).called(1);
           },
@@ -376,6 +417,7 @@ void main() {
                 displayName: testDisplayName,
                 about: testAbout,
                 picture: testPicture,
+                clearNip05: any(named: 'clearNip05'),
               ),
             ).thenThrow(const ProfilePublishFailedException('Network error'));
           },


### PR DESCRIPTION
## Description

Fixes a bug where unchecking "Use your own NIP-05 address" in the profile editor and saving would not persist — the checkbox appeared checked again on re-open. The root cause was that `saveProfileEvent` used a null-conditional map entry for `nip05`, which omitted the key when null and allowed the `rawData` spread from the existing profile to silently re-populate the old value. A `clearNip05` flag is added to explicitly remove the key when the user opts out of NIP-05.

**Related Issue:** Closes #2036

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
