### PR TITLE
fix(feed): top-align square Vine videos in feed

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -18,6 +18,7 @@ import 'package:openvine/router/app_router.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/view_event_publisher.dart';
+import 'package:openvine/utils/video_presentation.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/pooled_video_metrics_tracker.dart';
 import 'package:openvine/widgets/share_video_menu.dart';
@@ -561,6 +562,7 @@ class _PooledFullscreenItemContentState
   Widget build(BuildContext context) {
     final video = widget.video;
     final isPortrait = video.dimensions != null && video.isPortrait;
+    final alignment = videoAlignmentForDimensions(video.width, video.height);
 
     return ColoredBox(
       color: VineTheme.backgroundColor,
@@ -579,11 +581,13 @@ class _PooledFullscreenItemContentState
               child: _FittedVideoPlayer(
                 videoController: videoController,
                 isPortrait: isPortrait,
+                alignment: alignment,
               ),
             ),
         loadingBuilder: (context) => _VideoLoadingPlaceholder(
           thumbnailUrl: video.thumbnailUrl,
           isPortrait: isPortrait,
+          alignment: alignment,
         ),
         overlayBuilder: (context, videoController, player) {
           if (video.shouldShowWarning && !_contentWarningRevealed) {
@@ -632,10 +636,12 @@ class _FittedVideoPlayer extends StatelessWidget {
   const _FittedVideoPlayer({
     required this.videoController,
     this.isPortrait = true,
+    this.alignment = Alignment.center,
   });
 
   final VideoController videoController;
   final bool isPortrait;
+  final Alignment alignment;
 
   @override
   Widget build(BuildContext context) {
@@ -644,6 +650,7 @@ class _FittedVideoPlayer extends StatelessWidget {
     return Video(
       controller: videoController,
       fit: boxFit,
+      alignment: alignment,
       filterQuality: FilterQuality.high,
       controls: null,
     );
@@ -651,10 +658,15 @@ class _FittedVideoPlayer extends StatelessWidget {
 }
 
 class _VideoLoadingPlaceholder extends StatelessWidget {
-  const _VideoLoadingPlaceholder({this.thumbnailUrl, this.isPortrait = true});
+  const _VideoLoadingPlaceholder({
+    this.thumbnailUrl,
+    this.isPortrait = true,
+    this.alignment = Alignment.center,
+  });
 
   final String? thumbnailUrl;
   final bool isPortrait;
+  final Alignment alignment;
 
   @override
   Widget build(BuildContext context) {
@@ -669,6 +681,7 @@ class _VideoLoadingPlaceholder extends StatelessWidget {
           Image.network(
             url,
             fit: boxFit,
+            alignment: alignment,
             errorBuilder: (_, _, _) =>
                 const ColoredBox(color: VineTheme.backgroundColor),
           )

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -17,6 +17,7 @@ import 'package:openvine/screens/feed/feed_video_overlay.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:openvine/services/startup_performance_service.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/utils/video_presentation.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
 import 'package:pooled_video_player/pooled_video_player.dart';
@@ -594,6 +595,7 @@ class _PooledVideoFeedItemContent extends StatelessWidget {
     // All videos without dimensions are treated as portrait as its default
     // usecase (e.g. Reels-style vertical videos).
     final isPortrait = !(video.dimensions != null) || video.isPortrait;
+    final alignment = videoAlignmentForDimensions(video.width, video.height);
 
     return ColoredBox(
       color: VineTheme.backgroundColor,
@@ -604,6 +606,7 @@ class _PooledVideoFeedItemContent extends StatelessWidget {
         videoBuilder: (context, videoController, player) => _FittedVideoPlayer(
           videoController: videoController,
           isPortrait: isPortrait,
+          alignment: alignment,
         ),
         loadingBuilder: (context) => _VideoLoadingPlaceholder(
           thumbnailUrl: video.thumbnailUrl,
@@ -611,6 +614,7 @@ class _PooledVideoFeedItemContent extends StatelessWidget {
           videoId: video.id,
           feedMode: contextTitle,
           index: index,
+          alignment: alignment,
         ),
         overlayBuilder: (context, videoController, player) => FeedVideoOverlay(
           video: video,
@@ -628,10 +632,12 @@ class _FittedVideoPlayer extends StatelessWidget {
   const _FittedVideoPlayer({
     required this.videoController,
     this.isPortrait = true,
+    this.alignment = Alignment.center,
   });
 
   final VideoController videoController;
   final bool isPortrait;
+  final Alignment alignment;
 
   @override
   Widget build(BuildContext context) {
@@ -641,6 +647,7 @@ class _FittedVideoPlayer extends StatelessWidget {
     return Video(
       controller: videoController,
       fit: boxFit,
+      alignment: alignment,
       filterQuality: FilterQuality.high,
       controls: null,
     );
@@ -654,6 +661,7 @@ class _VideoLoadingPlaceholder extends StatefulWidget {
     this.feedMode,
     this.thumbnailUrl,
     this.isPortrait = true,
+    this.alignment = Alignment.center,
   });
 
   final String videoId;
@@ -661,6 +669,7 @@ class _VideoLoadingPlaceholder extends StatefulWidget {
   final String? feedMode;
   final String? thumbnailUrl;
   final bool isPortrait;
+  final Alignment alignment;
 
   @override
   State<_VideoLoadingPlaceholder> createState() =>
@@ -734,6 +743,7 @@ class _VideoLoadingPlaceholderState extends State<_VideoLoadingPlaceholder> {
         child: Image.network(
           widget.thumbnailUrl!,
           fit: boxFit,
+          alignment: widget.alignment,
           frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
             if (wasSynchronouslyLoaded || frame != null) {
               _logLoadedIfNeeded();

--- a/mobile/lib/utils/video_presentation.dart
+++ b/mobile/lib/utils/video_presentation.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+const double _squareAspectRatioTolerance = 0.1;
+
+/// Returns true when the dimensions are close enough to 1:1 to treat as square.
+bool isSquareVideoDimensions(
+  num? width,
+  num? height, {
+  double tolerance = _squareAspectRatioTolerance,
+}) {
+  if (width == null || height == null) return false;
+  if (width <= 0 || height <= 0) return false;
+
+  final aspectRatio = width / height;
+  return aspectRatio >= 1 - tolerance && aspectRatio <= 1 + tolerance;
+}
+
+/// Square clips should sit at the top of the stage instead of being centered.
+Alignment videoAlignmentForDimensions(num? width, num? height) {
+  return isSquareVideoDimensions(width, height)
+      ? Alignment.topCenter
+      : Alignment.center;
+}

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -41,6 +41,7 @@ import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/utils/video_presentation.dart';
 import 'package:openvine/widgets/badge_explanation_modal.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/clickable_hashtag_text.dart';
@@ -1023,6 +1024,10 @@ class _VideoFeedItemState extends ConsumerState<VideoFeedItem> {
                     //   to stay centered without cropping
                     final isPortraitVideo = videoHeight > videoWidth;
                     final useCoverFit = isPortraitVideo;
+                    final alignment = videoAlignmentForDimensions(
+                      videoWidth,
+                      videoHeight,
+                    );
 
                     // UNIFIED structure - use Offstage instead of conditional
                     // widgets to maintain stable widget tree during scroll
@@ -1036,6 +1041,7 @@ class _VideoFeedItemState extends ConsumerState<VideoFeedItem> {
                             Offstage(
                               offstage: !value.isInitialized,
                               child: FittedBox(
+                                alignment: alignment,
                                 fit: useCoverFit
                                     ? BoxFit.cover
                                     : BoxFit.contain,
@@ -1734,10 +1740,7 @@ class VideoOverlayActions extends ConsumerWidget {
                   const SizedBox(height: 4),
 
                   // Like button
-                  LikeActionButton(
-                    video: video,
-                    isPreviewMode: isPreviewMode,
-                  ),
+                  LikeActionButton(video: video, isPreviewMode: isPreviewMode),
 
                   const SizedBox(height: 4),
 

--- a/mobile/test/widgets/video_alignment_test.dart
+++ b/mobile/test/widgets/video_alignment_test.dart
@@ -1,20 +1,23 @@
-// ABOUTME: Test for video alignment behavior with square videos
-// ABOUTME: Verifies that square videos are top-aligned instead of centered
-
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/video_presentation.dart';
 
 void main() {
-  group('Video alignment tests', () {
-    testWidgets('square videos should be top-aligned', (tester) async {
-      // This test verifies the implementation of square video alignment
-      // Square videos (aspect ratio between 0.9 and 1.1) should use Alignment.topCenter
-      // Non-square videos should use Alignment.center
+  group('videoAlignmentForDimensions', () {
+    test('square videos are top-aligned', () {
+      expect(videoAlignmentForDimensions(480, 480), Alignment.topCenter);
+    });
 
-      // The actual implementation is in video_feed_item.dart:
-      // - Lines 417-418: Check if video is square
-      // - Lines 423 and 457: Use appropriate alignment based on aspect ratio
+    test('portrait videos stay centered', () {
+      expect(videoAlignmentForDimensions(607, 1080), Alignment.center);
+    });
 
-      expect(true, isTrue);
+    test('landscape videos stay centered', () {
+      expect(videoAlignmentForDimensions(1920, 1080), Alignment.center);
+    });
+
+    test('near-square videos still count as square', () {
+      expect(isSquareVideoDimensions(500, 480), isTrue);
     });
   });
 }


### PR DESCRIPTION
Classic 1:1 Vine clips were being rendered with `contain` and centered inside the tall feed viewport, which made them look letterboxed in recent builds.

This change keeps square videos uncropped, but top-aligns them across the pooled home feed, fullscreen feed, and legacy `VideoFeedItem` path so they present like classic Vine again.

Validation:
- flutter test test/screens/feed/video_feed_page_test.dart
- flutter test --no-pub test/widgets/video_alignment_test.dart
- flutter test --no-pub test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
- flutter analyze --no-pub lib/utils/video_presentation.dart lib/screens/feed/video_feed_page.dart lib/screens/feed/pooled_fullscreen_video_feed_screen.dart lib/widgets/video_feed_item/video_feed_item.dart