### PR TITLE
feat: support nip-49 to allow creating account from a ncryptsec1 string

### DIFF
--- a/mobile/lib/screens/key_import_screen.dart
+++ b/mobile/lib/screens/key_import_screen.dart
@@ -30,8 +30,11 @@ class KeyImportScreen extends ConsumerStatefulWidget {
 
 class _KeyImportScreenState extends ConsumerState<KeyImportScreen> {
   final _keyController = TextEditingController();
+  final _passwordController = TextEditingController();
   bool _isImporting = false;
+  bool _isEncryptedKey = false;
   String? _keyError;
+  String? _passwordError;
 
   /// Cached reference to auth service, since ref is invalid after unmount.
   late final AuthService _authService;
@@ -45,6 +48,7 @@ class _KeyImportScreenState extends ConsumerState<KeyImportScreen> {
   @override
   void dispose() {
     _keyController.dispose();
+    _passwordController.dispose();
 
     // Clear any authentication errors when leaving this screen.
     // Uses cached reference because Riverpod ref is invalid after unmount.
@@ -110,12 +114,32 @@ class _KeyImportScreenState extends ConsumerState<KeyImportScreen> {
                       enabled: !_isImporting,
                       autocorrect: false,
                       errorText: _keyError,
-                      onChanged: (_) {
-                        if (_keyError != null) {
-                          setState(() => _keyError = null);
-                        }
+                      onChanged: (value) {
+                        final encrypted = Nip49.isEncryptedKey(value.trim());
+                        setState(() {
+                          _keyError = null;
+                          _isEncryptedKey = encrypted;
+                          if (!encrypted) _passwordError = null;
+                        });
                       },
                     ),
+
+                    if (_isEncryptedKey) ...[
+                      const SizedBox(height: 16),
+                      DivineAuthTextField(
+                        controller: _passwordController,
+                        label: 'Password',
+                        enabled: !_isImporting,
+                        autocorrect: false,
+                        obscureText: true,
+                        errorText: _passwordError,
+                        onChanged: (_) {
+                          if (_passwordError != null) {
+                            setState(() => _passwordError = null);
+                          }
+                        },
+                      ),
+                    ],
 
                     const SizedBox(height: 24),
 
@@ -177,9 +201,14 @@ class _KeyImportScreenState extends ConsumerState<KeyImportScreen> {
       return null;
     }
 
+    // ncryptsec1: encrypted private key (NIP-49) — password validated separately
+    if (Nip49.isEncryptedKey(trimmed)) {
+      return null;
+    }
+
     // Check if it looks like a valid key format
     if (!trimmed.startsWith('nsec') && trimmed.length != 64) {
-      return 'Invalid format. Use nsec..., hex, or bunker://...';
+      return 'Invalid format. Use nsec..., hex, ncryptsec1..., or bunker://...';
     }
 
     if (trimmed.startsWith('nsec') && trimmed.length != 63) {
@@ -189,11 +218,28 @@ class _KeyImportScreenState extends ConsumerState<KeyImportScreen> {
     return null;
   }
 
+  String? _validatePassword(String value) {
+    if (value.isEmpty) {
+      return 'Please enter the password for this encrypted key';
+    }
+    return null;
+  }
+
   Future<void> _importKey() async {
-    final error = _validateKey(_keyController.text);
-    if (error != null) {
-      setState(() => _keyError = error);
+    final keyError = _validateKey(_keyController.text);
+    if (keyError != null) {
+      setState(() => _keyError = keyError);
       return;
+    }
+
+    final keyText = _keyController.text.trim();
+
+    if (Nip49.isEncryptedKey(keyText)) {
+      final passwordError = _validatePassword(_passwordController.text);
+      if (passwordError != null) {
+        setState(() => _passwordError = passwordError);
+        return;
+      }
     }
 
     setState(() {
@@ -202,12 +248,17 @@ class _KeyImportScreenState extends ConsumerState<KeyImportScreen> {
 
     try {
       final authService = ref.read(authServiceProvider);
-      final keyText = _keyController.text.trim();
       final AuthResult result;
 
       if (NostrRemoteSignerInfo.isBunkerUrl(keyText)) {
         // Handle bunker URL (NIP-46 remote signing)
         result = await authService.connectWithBunker(keyText);
+      } else if (Nip49.isEncryptedKey(keyText)) {
+        // Handle NIP-49 password-encrypted key
+        result = await authService.importFromNcryptsec(
+          keyText,
+          _passwordController.text,
+        );
       } else if (keyText.startsWith('nsec')) {
         result = await authService.importFromNsec(keyText);
       } else {
@@ -215,8 +266,9 @@ class _KeyImportScreenState extends ConsumerState<KeyImportScreen> {
       }
 
       if (result.success && mounted) {
-        // Clear the text field for security
+        // Clear the text fields for security
         _keyController.clear();
+        _passwordController.clear();
 
         // Start fetching the user's profile from relays in background
         // This ensures profile data is available when user navigates

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -1686,6 +1686,32 @@ class AuthService implements BackgroundAwareService {
     }
   }
 
+  /// Import identity from an ncryptsec1 encrypted private key (NIP-49).
+  ///
+  /// Decrypts [ncryptsec] with [password] using scrypt + XChaCha20-Poly1305,
+  /// then imports the recovered private key via [importFromHex].
+  ///
+  /// Returns [AuthResult.failure] with message 'Incorrect password' if the
+  /// password is wrong or the ciphertext is corrupted.
+  Future<AuthResult> importFromNcryptsec(
+    String ncryptsec,
+    String password,
+  ) async {
+    Log.debug(
+      'Importing identity from ncryptsec1 (NIP-49)',
+      name: 'AuthService',
+      category: LogCategory.auth,
+    );
+
+    try {
+      final privateKeyHex = await Nip49.decode(ncryptsec, password);
+      return importFromHex(privateKeyHex);
+    } on Nip49Exception {
+      _setAuthState(AuthState.unauthenticated);
+      return AuthResult.failure('Incorrect password');
+    }
+  }
+
   /// Import identity from hex private key
   Future<AuthResult> importFromHex(
     String privateKeyHex, {

--- a/mobile/packages/nostr_sdk/lib/nip19/hrps.dart
+++ b/mobile/packages/nostr_sdk/lib/nip19/hrps.dart
@@ -10,4 +10,5 @@ class Hrps {
   static const String nevent = "nevent";
   static const String nrelay = "nrelay";
   static const String naddr = "naddr";
+  static const String encryptedPrivateKey = "ncryptsec";
 }

--- a/mobile/packages/nostr_sdk/lib/nip49/nip49.dart
+++ b/mobile/packages/nostr_sdk/lib/nip49/nip49.dart
@@ -1,0 +1,219 @@
+// ABOUTME: NIP-49 private key encryption/decryption using scrypt + XChaCha20-Poly1305
+// ABOUTME: Encodes/decodes ncryptsec1 bech32 strings for password-protected key storage
+
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:bech32/bech32.dart';
+import 'package:cryptography/cryptography.dart' as cryptography;
+import 'package:hex/hex.dart';
+import 'package:pointycastle/export.dart';
+
+import '../nip19/hrps.dart';
+import '../nip19/nip19.dart';
+
+/// Exception thrown when NIP-49 encryption or decryption fails.
+class Nip49Exception implements Exception {
+  Nip49Exception(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'Nip49Exception: $message';
+}
+
+/// NIP-49: Private Key Encryption
+///
+/// Encrypts and decrypts Nostr private keys using a password, scrypt KDF,
+/// and XChaCha20-Poly1305 AEAD cipher.
+///
+/// The output format is an `ncryptsec1` bech32-encoded string. The 91-byte
+/// payload is structured as:
+/// ```
+/// [0]      VERSION (0x02)
+/// [1]      LOG_N (scrypt cost parameter)
+/// [2..17]  SALT (16 bytes)
+/// [18..41] NONCE (24 bytes, XChaCha20)
+/// [42]     KEY_SECURITY_BYTE (associated data)
+/// [43..90] CIPHERTEXT (32 bytes encrypted key + 16 bytes Poly1305 MAC)
+/// ```
+///
+/// See: https://github.com/nostr-protocol/nips/blob/master/49.md
+class Nip49 {
+  static const int _version = 0x02;
+  static const int _saltLength = 16;
+  static const int _nonceLength = 24;
+  static const int _keyLength = 32;
+  static const int _payloadLength = 91; // 1+1+16+24+1+32+16
+  // Allow bech32 strings up to 200 chars (ncryptsec1 is ~163 chars,
+  // exceeding the standard 90-char bech32 limit).
+  static const int _maxBech32Length = 200;
+
+  /// Returns true if [s] is an `ncryptsec1`-encoded encrypted private key.
+  static bool isEncryptedKey(String s) =>
+      s.startsWith('${Hrps.encryptedPrivateKey}1');
+
+  /// Decrypts an `ncryptsec1` string using [password].
+  ///
+  /// Returns the decrypted private key as a 64-character hex string.
+  ///
+  /// Note: The NIP-49 spec requires passwords to be NFKC unicode-normalized.
+  /// This implementation uses the password as-is. Pure ASCII passwords are
+  /// unaffected; non-ASCII passwords may not interoperate with clients that
+  /// apply normalization.
+  ///
+  /// Throws [Nip49Exception] if the password is incorrect or the input is
+  /// malformed.
+  static Future<String> decode(String ncryptsec, String password) async {
+    final payload = _bech32Decode(ncryptsec);
+
+    if (payload.length != _payloadLength) {
+      throw Nip49Exception(
+        'Invalid payload length: expected $_payloadLength, got ${payload.length}',
+      );
+    }
+
+    if (payload[0] != _version) {
+      throw Nip49Exception('Unsupported version: ${payload[0]}');
+    }
+
+    final logN = payload[1];
+    final salt = Uint8List.fromList(payload.sublist(2, 18));
+    final nonce = payload.sublist(18, 42);
+    final keySecurityByte = payload[42];
+    final ciphertextBytes = payload.sublist(43, 75);
+    final mac = payload.sublist(75, 91);
+
+    final symmetricKey = _deriveKey(
+      password: utf8.encode(password),
+      salt: salt,
+      logN: logN,
+    );
+
+    final algorithm = cryptography.Xchacha20.poly1305Aead();
+    final secretBox = cryptography.SecretBox(
+      ciphertextBytes,
+      nonce: nonce,
+      mac: cryptography.Mac(mac),
+    );
+
+    final List<int> privateKeyBytes;
+    try {
+      privateKeyBytes = await algorithm.decrypt(
+        secretBox,
+        secretKey: cryptography.SecretKey(symmetricKey),
+        aad: [keySecurityByte],
+      );
+    } on cryptography.SecretBoxAuthenticationError {
+      throw Nip49Exception(
+        'Decryption failed: incorrect password or corrupted data',
+      );
+    } catch (e) {
+      throw Nip49Exception('Decryption failed: $e');
+    }
+
+    if (privateKeyBytes.length != _keyLength) {
+      throw Nip49Exception(
+        'Decrypted key has unexpected length: ${privateKeyBytes.length}',
+      );
+    }
+
+    return HEX.encode(privateKeyBytes);
+  }
+
+  /// Encrypts [privateKeyHex] with [password] and returns an `ncryptsec1` string.
+  ///
+  /// [logN] controls the scrypt cost (default 16 = 64 MiB, ~100 ms on fast
+  /// hardware). Higher values increase security at the cost of time and memory.
+  ///
+  /// [keySecurityByte] indicates how the key was handled:
+  /// - `0x00`: known to have been handled insecurely
+  /// - `0x01`: not known to have been handled insecurely
+  /// - `0x02`: client does not track this (default)
+  ///
+  /// Note: The NIP-49 spec requires passwords to be NFKC unicode-normalized.
+  static Future<String> encode(
+    String privateKeyHex,
+    String password, {
+    int logN = 16,
+    int keySecurityByte = 0x02,
+  }) async {
+    final List<int> decodedBytes;
+    try {
+      decodedBytes = HEX.decode(privateKeyHex);
+    } on FormatException {
+      throw Nip49Exception(
+        'Private key must be a valid 64-character hex string',
+      );
+    }
+    if (decodedBytes.length != _keyLength) {
+      throw Nip49Exception('Private key must be 32 bytes (64 hex chars)');
+    }
+    final privateKeyBytes = Uint8List.fromList(decodedBytes);
+
+    final random = Random.secure();
+    final salt = Uint8List.fromList(
+      List.generate(_saltLength, (_) => random.nextInt(256)),
+    );
+    final nonce = List.generate(_nonceLength, (_) => random.nextInt(256));
+
+    final symmetricKey = _deriveKey(
+      password: utf8.encode(password),
+      salt: salt,
+      logN: logN,
+    );
+
+    final algorithm = cryptography.Xchacha20.poly1305Aead();
+    final secretBox = await algorithm.encrypt(
+      privateKeyBytes,
+      secretKey: cryptography.SecretKey(symmetricKey),
+      nonce: nonce,
+      aad: [keySecurityByte],
+    );
+
+    final payload = Uint8List(_payloadLength)
+      ..[0] = _version
+      ..[1] = logN
+      ..setRange(2, 18, salt)
+      ..setRange(18, 42, secretBox.nonce)
+      ..[42] = keySecurityByte
+      ..setRange(43, 75, secretBox.cipherText)
+      ..setRange(75, 91, secretBox.mac.bytes);
+
+    final bech32Data = Nip19.convertBits(payload, 8, 5, true);
+    final encoder = Bech32Encoder();
+    return encoder.convert(
+      Bech32(Hrps.encryptedPrivateKey, bech32Data),
+      _maxBech32Length,
+    );
+  }
+
+  static List<int> _bech32Decode(String ncryptsec) {
+    try {
+      final decoder = Bech32Decoder();
+      final result = decoder.convert(ncryptsec, _maxBech32Length);
+      if (result.hrp != Hrps.encryptedPrivateKey) {
+        throw Nip49Exception(
+          'Expected hrp "${Hrps.encryptedPrivateKey}", got "${result.hrp}"',
+        );
+      }
+      return Nip19.convertBits(result.data, 5, 8, false);
+    } on Nip49Exception {
+      rethrow;
+    } catch (e) {
+      throw Nip49Exception('Invalid bech32 encoding: $e');
+    }
+  }
+
+  static Uint8List _deriveKey({
+    required List<int> password,
+    required Uint8List salt,
+    required int logN,
+  }) {
+    final n = 1 << logN;
+    final params = ScryptParameters(n, 8, 1, _keyLength, salt);
+    final scrypt = Scrypt()..init(params);
+    return scrypt.process(Uint8List.fromList(password));
+  }
+}

--- a/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
@@ -20,6 +20,7 @@ export 'nip05/nip05_validor.dart';
 export 'nip07/nip07_signer.dart';
 export 'nip19/hrps.dart';
 export 'nip19/nip19.dart';
+export 'nip49/nip49.dart';
 export 'nip23/long_form_info.dart';
 export 'nip29/group_identifier.dart';
 export 'nip29/nip29.dart';

--- a/mobile/packages/nostr_sdk/test/unit/nip49_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nip49_test.dart
@@ -1,0 +1,120 @@
+// ABOUTME: Tests for NIP-49 ncryptsec1 private key encryption/decryption
+// ABOUTME: Validates against the official NIP-49 test vector and error cases
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+void main() {
+  // Official NIP-49 test vector
+  // https://github.com/nostr-protocol/nips/blob/master/49.md#decryption
+  const testVector =
+      'ncryptsec1qgg9947rlpvqu76pj5ecreduf9jxhselq2nae2kghhvd5g7dgjtcxfqtd67p9m0w57lspw8gsq6yphnm8623nsl8xn9j4jdzz84zm3frztj3z7s35vpzmqf6ksu8r89qk5z2zxfmu5gv8th8wclt0h4p';
+  const testPassword = 'nostr';
+  const testPrivateKeyHex =
+      '3501454135014541350145413501453fefb02227e449e57cf4d3a3ce05378683';
+
+  group(Nip49, () {
+    group('isEncryptedKey', () {
+      test('returns true for ncryptsec1 strings', () {
+        expect(Nip49.isEncryptedKey(testVector), isTrue);
+        expect(Nip49.isEncryptedKey('ncryptsec1abc'), isTrue);
+      });
+
+      test('returns false for nsec strings', () {
+        expect(
+          Nip49.isEncryptedKey(
+            'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k3lvr'
+            'paxge38re5qf6vm6j',
+          ),
+          isFalse,
+        );
+      });
+
+      test('returns false for hex private keys', () {
+        expect(Nip49.isEncryptedKey(testPrivateKeyHex), isFalse);
+      });
+
+      test('returns false for bunker URLs', () {
+        expect(
+          Nip49.isEncryptedKey('bunker://pubkey?relay=wss://r.com'),
+          isFalse,
+        );
+      });
+
+      test('returns false for empty string', () {
+        expect(Nip49.isEncryptedKey(''), isFalse);
+      });
+    });
+
+    group('decode', () {
+      test('decrypts official NIP-49 test vector', () async {
+        final result = await Nip49.decode(testVector, testPassword);
+        expect(result, equals(testPrivateKeyHex));
+      });
+
+      test('throws Nip49Exception on wrong password', () async {
+        await expectLater(
+          () => Nip49.decode(testVector, 'wrongpassword'),
+          throwsA(isA<Nip49Exception>()),
+        );
+      });
+
+      test('throws Nip49Exception on non-ncryptsec1 input', () async {
+        await expectLater(
+          () => Nip49.decode('nsec1notencrypted', testPassword),
+          throwsA(isA<Nip49Exception>()),
+        );
+      });
+
+      test('throws Nip49Exception on malformed bech32', () async {
+        await expectLater(
+          () => Nip49.decode('ncryptsec1invalidbech32!!!', testPassword),
+          throwsA(isA<Nip49Exception>()),
+        );
+      });
+    });
+
+    group('encode + decode round-trip', () {
+      test('round-trip preserves private key with logN 16', () async {
+        final encrypted = await Nip49.encode(
+          testPrivateKeyHex,
+          testPassword,
+          logN: 16,
+        );
+
+        expect(Nip49.isEncryptedKey(encrypted), isTrue);
+        expect(encrypted, startsWith('ncryptsec1'));
+
+        final decrypted = await Nip49.decode(encrypted, testPassword);
+        expect(decrypted, equals(testPrivateKeyHex));
+      });
+
+      test(
+        'encode produces different output each time (random nonce)',
+        () async {
+          final encrypted1 = await Nip49.encode(
+            testPrivateKeyHex,
+            testPassword,
+            logN: 16,
+          );
+          final encrypted2 = await Nip49.encode(
+            testPrivateKeyHex,
+            testPassword,
+            logN: 16,
+          );
+          expect(encrypted1, isNot(equals(encrypted2)));
+        },
+      );
+
+      test(
+        'encode throws Nip49Exception for invalid private key length',
+        () async {
+          await expectLater(
+            () => Nip49.encode('tooshort', testPassword),
+            throwsA(isA<Nip49Exception>()),
+          );
+        },
+      );
+    });
+  });
+}

--- a/mobile/test/screens/key_import_screen_test.dart
+++ b/mobile/test/screens/key_import_screen_test.dart
@@ -1,0 +1,207 @@
+// ABOUTME: Tests for KeyImportScreen including NIP-49 ncryptsec1 support
+// ABOUTME: Verifies password field visibility, validation, and import delegation
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/screens/key_import_screen.dart';
+import 'package:openvine/services/auth_service.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+void main() {
+  late _MockAuthService mockAuthService;
+
+  // A real ncryptsec1 string from the NIP-49 spec
+  const ncryptsecKey =
+      'ncryptsec1qgg9947rlpvqu76pj5ecreduf9jxhselq2nae2kghhvd5g7dgjtcxfqtd67p9m0w57lspw8gsq6yphnm8623nsl8xn9j4jdzz84zm3frztj3z7s35vpzmqf6ksu8r89qk5z2zxfmu5gv8th8wclt0h4p';
+  const nsecKey =
+      'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k3lvr'
+      'paxge38re5qf6vm6j';
+
+  setUp(() {
+    mockAuthService = _MockAuthService();
+    registerFallbackValue(AuthState.unauthenticated);
+  });
+
+  Widget createTestWidget() {
+    return ProviderScope(
+      overrides: [
+        ...getStandardTestOverrides(mockAuthService: mockAuthService),
+      ],
+      child: MaterialApp.router(
+        theme: VineTheme.theme,
+        routerConfig: GoRouter(
+          initialLocation: KeyImportScreen.path,
+          routes: [
+            GoRoute(path: '/', builder: (_, _) => const Scaffold()),
+            GoRoute(
+              path: KeyImportScreen.path,
+              builder: (_, _) => const KeyImportScreen(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  group(KeyImportScreen, () {
+    group('renders', () {
+      testWidgets('renders $KeyImportScreen', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byType(KeyImportScreen), findsOneWidget);
+      });
+
+      testWidgets('password field is not visible initially', (tester) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(
+          find.widgetWithText(DivineAuthTextField, 'Password'),
+          findsNothing,
+        );
+      });
+    });
+
+    group('ncryptsec1 detection', () {
+      testWidgets('password field appears when ncryptsec1 is entered', (
+        tester,
+      ) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.widgetWithText(DivineAuthTextField, 'Private key or bunker URL'),
+          ncryptsecKey,
+        );
+        await tester.pump();
+
+        expect(
+          find.widgetWithText(DivineAuthTextField, 'Password'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('password field disappears when key changes to nsec', (
+        tester,
+      ) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        // First type an ncryptsec1 key
+        await tester.enterText(
+          find.widgetWithText(DivineAuthTextField, 'Private key or bunker URL'),
+          ncryptsecKey,
+        );
+        await tester.pump();
+
+        expect(
+          find.widgetWithText(DivineAuthTextField, 'Password'),
+          findsOneWidget,
+        );
+
+        // Switch to a regular nsec
+        await tester.enterText(
+          find.widgetWithText(DivineAuthTextField, 'Private key or bunker URL'),
+          nsecKey,
+        );
+        await tester.pump();
+
+        expect(
+          find.widgetWithText(DivineAuthTextField, 'Password'),
+          findsNothing,
+        );
+      });
+    });
+
+    group('validation', () {
+      testWidgets(
+        'shows password error when ncryptsec1 submitted without password',
+        (tester) async {
+          await tester.pumpWidget(createTestWidget());
+          await tester.pumpAndSettle();
+
+          await tester.enterText(
+            find.widgetWithText(
+              DivineAuthTextField,
+              'Private key or bunker URL',
+            ),
+            ncryptsecKey,
+          );
+          await tester.pump();
+
+          await tester.tap(find.text('Import Nostr key'));
+          await tester.pump();
+
+          expect(
+            find.text('Please enter the password for this encrypted key'),
+            findsOneWidget,
+          );
+        },
+      );
+    });
+
+    group('import', () {
+      testWidgets('calls importFromNcryptsec with key and password', (
+        tester,
+      ) async {
+        when(
+          () => mockAuthService.importFromNcryptsec(any(), any()),
+        ).thenAnswer((_) async => AuthResult.failure('Incorrect password'));
+        when(() => mockAuthService.clearError()).thenReturn(null);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.widgetWithText(DivineAuthTextField, 'Private key or bunker URL'),
+          ncryptsecKey,
+        );
+        await tester.pump();
+
+        await tester.enterText(
+          find.widgetWithText(DivineAuthTextField, 'Password'),
+          'mypassword',
+        );
+        await tester.pump();
+
+        await tester.tap(find.text('Import Nostr key'));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockAuthService.importFromNcryptsec(ncryptsecKey, 'mypassword'),
+        ).called(1);
+      });
+
+      testWidgets('does not call importFromNcryptsec for regular nsec', (
+        tester,
+      ) async {
+        when(
+          () => mockAuthService.importFromNsec(any()),
+        ).thenAnswer((_) async => AuthResult.failure('Invalid nsec'));
+        when(() => mockAuthService.clearError()).thenReturn(null);
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.widgetWithText(DivineAuthTextField, 'Private key or bunker URL'),
+          nsecKey,
+        );
+        await tester.pump();
+
+        await tester.tap(find.text('Import Nostr key'));
+        await tester.pumpAndSettle();
+
+        verifyNever(() => mockAuthService.importFromNcryptsec(any(), any()));
+      });
+    });
+  });
+}

--- a/wingspan/brainstorms/2026-03-07-nip49-ncryptsec1-import-brainstorm-doc.md
+++ b/wingspan/brainstorms/2026-03-07-nip49-ncryptsec1-import-brainstorm-doc.md
@@ -1,0 +1,44 @@
+---
+date: 2026-03-07
+topic: nip49-ncryptsec1-import
+---
+
+# NIP-49 ncryptsec1 Import Support
+
+## What We're Building
+
+Add support for importing a password-encrypted Nostr private key (`ncryptsec1`) in the `KeyImportScreen`. When a user pastes an `ncryptsec1` string, the screen expands inline to show a password field. On submit, the key is decrypted using the NIP-49 algorithm (scrypt + AES-256-GCM) and the recovered private key is imported through the existing `nsec` path.
+
+This is general-purpose support — `ncryptsec1` is the standard portable encrypted key format across the Nostr ecosystem and Divine should accept it wherever `nsec` is accepted.
+
+## Why This Approach
+
+Three placement options were considered for the NIP-49 decryption logic:
+1. **In `nostr_sdk`** alongside the existing `Nip19` class — chosen because all Nostr protocol encoding/decoding already lives there, and it avoids scattering protocol logic across packages.
+2. In `nostr_key_manager` co-located with `SecureKeyStorage` — reasonable but mixes storage concerns with protocol decoding.
+3. Via a pub.dev package — adds a dependency with uncertain maintenance.
+
+For the UX, an inline password field (expanding `KeyImportScreen` when `ncryptsec1` is detected) was chosen over a modal/bottom sheet because it keeps the import flow on one screen, consistent with the existing text-field-first pattern.
+
+## Key Decisions
+
+- **Decryption in `nostr_sdk`**: Add `Nip49` class to `packages/nostr_sdk/lib/nip49/` with `decode(ncryptsec, password) → nsecHex` and `encode(nsecHex, password) → ncryptsec` (encode is useful for future backup export).
+- **Inline UX in `KeyImportScreen`**: Detect `ncryptsec1` prefix on text change; conditionally show a password field below the key field. No new screen or route needed.
+- **Auth pipeline**: Add `AuthService.importFromNcryptsec(ncryptsec, password)` that decrypts via `Nip49.decode()` then delegates to the existing `importFromNsec()` path. No changes needed in `SecureKeyStorage`.
+- **Crypto dependencies**: NIP-49 requires scrypt (KDF) and AES-256-GCM. Dart's `pointycastle` package (already used in the project via `nostr_sdk`) provides both. No new packages needed.
+- **Key security byte**: NIP-49 encodes a `key_security_byte` (0=unknown, 1=weak/cloned, 2=medium/hardware). We read it but do not surface it in the UI for now — it can be logged or stored as metadata in a follow-up.
+- **Error handling**: Wrong password produces an AES-GCM auth tag failure. Show an inline error "Incorrect password" rather than a generic failure.
+
+## Layers Touched
+
+| Layer | Change |
+|-------|--------|
+| `nostr_sdk` (data) | New `Nip49` class: bech32 decode, scrypt KDF, AES-256-GCM decrypt/encrypt |
+| `AuthService` (service) | New `importFromNcryptsec(ncryptsec, password)` method |
+| `KeyImportScreen` (UI) | Detect `ncryptsec1` prefix, show password field inline, wire to new auth method |
+
+## Open Questions
+
+- Should we surface the `key_security_byte` anywhere in the UI (e.g. a warning if the key is marked as "weak/cloned")?
+- Should we also add `ncryptsec1` **export** (backup) as part of this issue, or defer to a separate issue?
+- Are there existing test fixtures (known ncryptsec1 vectors) from the NIP-49 spec we can use for unit tests?

--- a/wingspan/plans/2026-03-07-nip49-ncryptsec1-import.md
+++ b/wingspan/plans/2026-03-07-nip49-ncryptsec1-import.md
@@ -1,0 +1,153 @@
+# Plan: NIP-49 ncryptsec1 Import Support
+
+**Type**: Feature
+**Complexity**: Medium
+**Brainstorm doc**: `wingspan/brainstorms/2026-03-07-nip49-ncryptsec1-import-brainstorm-doc.md`
+
+---
+
+## Issue Summary
+
+Add support for importing a password-encrypted Nostr private key (`ncryptsec1`, NIP-49) in the `KeyImportScreen`. When the user pastes an `ncryptsec1` string, a password field appears inline. On submit, the app decrypts via scrypt + XChaCha20-Poly1305, then imports the recovered private key through the existing `nsec` path.
+
+> **Note**: NIP-49 uses **XChaCha20-Poly1305** (not AES-256-GCM). The nonce is 24 bytes.
+
+---
+
+## Architecture Design
+
+- **New packages needed**: None — `pointycastle` (scrypt) and `cryptography` (XChaCha20-Poly1305) are already `nostr_sdk` dependencies
+- **Layers affected**: `nostr_sdk` package (data), `AuthService` (service), `KeyImportScreen` (UI)
+- **Data flow**: UI captures `(ncryptsec, password)` → `AuthService.importFromNcryptsec()` → `Nip49.decode()` in `nostr_sdk` → hex private key → existing `AuthService.importFromHex()` path
+- **Nostr spec**: NIP-49 payload is 91 bytes: `VERSION(1) + LOG_N(1) + SALT(16) + NONCE(24) + KEY_SECURITY_BYTE(1) + CIPHERTEXT(48)`, bech32-encoded with HRP `ncryptsec`
+
+---
+
+## Affected Files
+
+| File | Action | Description |
+|------|--------|-------------|
+| `mobile/packages/nostr_sdk/lib/nip19/hrps.dart` | Modify | Add `ncryptsec` HRP constant |
+| `mobile/packages/nostr_sdk/lib/nip49/nip49.dart` | Create | `Nip49` class with `decode()`, `encode()`, and `isEncryptedKey()` |
+| `mobile/packages/nostr_sdk/lib/nostr_sdk.dart` | Modify | Export `nip49/nip49.dart` |
+| `mobile/lib/services/auth_service.dart` | Modify | Add `importFromNcryptsec(ncryptsec, password)` |
+| `mobile/lib/screens/key_import_screen.dart` | Modify | Detect `ncryptsec1`, show inline password field |
+| `mobile/packages/nostr_sdk/test/unit/nip49_test.dart` | Create | Decrypt spec test vector, error cases |
+| `mobile/test/screens/key_import_screen_test.dart` | Create | Password field visibility, import flow |
+
+---
+
+## Implementation Steps
+
+### Step 1: [nostr_sdk] Add `ncryptsec` HRP constant
+
+- File: `mobile/packages/nostr_sdk/lib/nip19/hrps.dart`
+- Add: `static const String encryptedPrivateKey = 'ncryptsec';`
+- Why: Centralises all HRP constants; used in `Nip49` for bech32 decode
+
+### Step 2: [nostr_sdk] Create `Nip49` class
+
+- File: `mobile/packages/nostr_sdk/lib/nip49/nip49.dart`
+
+Methods:
+
+**`static bool isEncryptedKey(String s)`**
+- Returns `s.startsWith('ncryptsec1')`
+
+**`static Future<String> decode(String ncryptsec, String password)`**
+- Bech32-decode the string (91-byte payload)
+- Parse: `version[0]`, `logN[1]`, `salt[2..17]`, `nonce[18..41]`, `keySecurityByte[42]`, `ciphertext[43..90]`
+- Derive 32-byte symmetric key: `scrypt(password_utf8, salt, N=2^logN, r=8, p=1)` using `pointycastle`
+- Decrypt: `XChaCha20-Poly1305(ciphertext, nonce, key, aad=[keySecurityByte])` using `cryptography`
+- Return `HEX.encode(plaintext)` — the 32-byte raw private key as hex
+- Throw `Nip49Exception` on wrong password (Poly1305 auth failure) or bad format
+- Add comment: NFKC unicode normalization is required by spec for non-ASCII passwords but not yet implemented
+
+**`static Future<String> encode(String privateKeyHex, String password, {int logN = 16})`**
+- Inverse of decode (useful for future backup/export feature)
+
+NIP-49 payload structure (91 bytes total):
+```
+[0]      VERSION_NUMBER = 0x02
+[1]      LOG_N
+[2..17]  SALT (16 bytes)
+[18..41] NONCE (24 bytes)
+[42]     KEY_SECURITY_BYTE (ASSOCIATED_DATA)
+[43..90] CIPHERTEXT (32 bytes plaintext + 16 bytes Poly1305 tag = 48 bytes)
+```
+
+### Step 3: [nostr_sdk] Export `Nip49`
+
+- File: `mobile/packages/nostr_sdk/lib/nostr_sdk.dart`
+- Add: `export 'nip49/nip49.dart';`
+
+### Step 4: [AuthService] Add `importFromNcryptsec`
+
+- File: `mobile/lib/services/auth_service.dart`
+- Add after `importFromNsec` (around line 1636):
+
+```dart
+/// Import identity from an ncryptsec1 encrypted private key (NIP-49).
+///
+/// Decrypts [ncryptsec] with [password] using scrypt + XChaCha20-Poly1305,
+/// then imports the recovered private key via [importFromHex].
+///
+/// Throws:
+/// - [Nip49Exception] if the password is incorrect or the format is invalid.
+Future<AuthResult> importFromNcryptsec(String ncryptsec, String password)
+```
+
+- Calls `Nip49.decode(ncryptsec, password)` to get hex private key
+- Delegates to existing `importFromHex(hexKey)`
+- Catches `Nip49Exception` and returns `AuthResult.failure('Incorrect password')`
+
+### Step 5: [UI] Update `KeyImportScreen`
+
+- File: `mobile/lib/screens/key_import_screen.dart`
+- Add state variables: `final _passwordController = TextEditingController()` and `bool _isEncryptedKey = false`
+- Key field `onChanged`: add `setState(() => _isEncryptedKey = Nip49.isEncryptedKey(value.trim()))`
+- In `build`: when `_isEncryptedKey` is true, show a `DivineAuthTextField` (obscured) for the password below the key field
+- Update `_validateKey`:
+  - Accept `ncryptsec1` prefix as a valid key format
+  - When `_isEncryptedKey`, validate that password is non-empty
+  - Remove the rejection of strings that don't start with `nsec` or aren't 64 chars (add `ncryptsec1` as a third valid format)
+- Update `_importKey`: add branch `else if (Nip49.isEncryptedKey(keyText))` → `authService.importFromNcryptsec(keyText, _passwordController.text)`
+- In `dispose`: add `_passwordController.dispose()`
+- In the success handler: add `_passwordController.clear()`
+
+---
+
+## Testing Strategy
+
+### `mobile/packages/nostr_sdk/test/unit/nip49_test.dart`
+
+Use the official NIP-49 test vector:
+- Input: `ncryptsec1qgg9947rlpvqu76pj5ecreduf9jxhselq2nae2kghhvd5g7dgjtcxfqtd67p9m0w57lspw8gsq6yphnm8623nsl8xn9j4jdzz84zm3frztj3z7s35vpzmqf6ksu8r89qk5z2zxfmu5gv8th8wclt0h4p`
+- Password: `nostr`, log_n: 16
+- Expected hex: `3501454135014541350145413501453fefb02227e449e57cf4d3a3ce05378683`
+
+Test cases:
+- `decode()` with correct password returns expected hex (spec test vector)
+- `decode()` with wrong password throws `Nip49Exception`
+- `decode()` with non-ncryptsec1 string throws
+- `isEncryptedKey()` returns true for `ncryptsec1...`
+- `isEncryptedKey()` returns false for `nsec1...`, hex, `bunker://`
+- Round-trip: `encode()` then `decode()` returns original private key
+
+### `mobile/test/screens/key_import_screen_test.dart`
+
+Test cases:
+- Password field is not visible on initial render
+- Password field appears when `ncryptsec1...` is entered in key field
+- Password field disappears when key field is changed to `nsec1...`
+- Tapping import with ncryptsec1 + password calls `authService.importFromNcryptsec`
+- Error shown when import returns failure (wrong password)
+
+---
+
+## Risks and Considerations
+
+- **scrypt performance**: log_n=18 requires ~256 MiB and can take seconds. The `cryptography_flutter` package offloads to a platform thread. The existing `_isImporting` spinner already covers the loading state.
+- **Bech32 length**: `ncryptsec1` strings are ~163 characters. Verify that `bech32` ^0.2.2 doesn't enforce the 90-char RFC limit — the existing NIP-19 `nprofile`/`nevent` usage (which exceed 90 chars) suggests it does not.
+- **NFKC unicode normalization**: The spec requires passwords to be NFKC-normalized. Dart has no built-in support. For pure ASCII passwords this is a no-op; document the limitation.
+- **Key security byte**: NIP-49 encodes whether the key was handled insecurely. We read it but don't surface it in the UI — future improvement.


### PR DESCRIPTION
```markdown
## Description

Adds NIP-49 support so users can import a password-encrypted `ncryptsec1` private key directly from the key import screen. A password field appears automatically when an `ncryptsec1` string is detected, and the key is decrypted using scrypt + XChaCha20-Poly1305 before being imported normally.

**Related Issue:** N/A

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
```
