### PR TITLE
fix(moderation): point moderation status lookups at moderation API

### DIFF
--- a/mobile/lib/services/video_moderation_status_service.dart
+++ b/mobile/lib/services/video_moderation_status_service.dart
@@ -156,8 +156,7 @@ class VideoModerationStatusService {
        _endpointBases =
            endpointBases ??
            const [
-             'https://divine-moderation-service.protestnet.workers.dev',
-             'https://moderation.admin.divine.video',
+             'https://moderation-api.divine.video',
            ].map(Uri.parse).toList(),
        _cacheTtl = cacheTtl ?? const Duration(minutes: 10);
 

--- a/mobile/test/services/video_moderation_status_service_test.dart
+++ b/mobile/test/services/video_moderation_status_service_test.dart
@@ -99,6 +99,35 @@ void main() {
   });
 
   group('VideoModerationStatusService.fetchStatus', () {
+    test('uses moderation-api host by default', () async {
+      const hash =
+          'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+
+      late Uri requestedUri;
+      final client = MockClient((request) async {
+        requestedUri = request.url;
+        return http.Response(
+          jsonEncode({
+            'moderated': true,
+            'blocked': false,
+            'age_restricted': false,
+            'needs_review': false,
+            'action': 'SAFE',
+            'categories': ['safe'],
+            'scores': {'safe': 0.99},
+          }),
+          200,
+        );
+      });
+
+      final service = VideoModerationStatusService(httpClient: client);
+      final status = await service.fetchStatus(hash);
+
+      expect(status, isNotNull);
+      expect(requestedUri.host, 'moderation-api.divine.video');
+      expect(requestedUri.path, '/check-result/$hash');
+    });
+
     test('falls back across endpoints and caches result', () async {
       const hash =
           'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd';


### PR DESCRIPTION
## Summary
- switch the default moderation status endpoint to `https://moderation-api.divine.video`
- remove the dead `workers.dev` and admin-host fallbacks from the mobile client
- add a test that locks the default host selection

## Verification
- `flutter test test/services/video_moderation_status_service_test.dart`
