### PR TITLE
chore: update pro_image_editor version

### DIFF
--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -645,9 +645,7 @@ class VideoEditorRenderService {
       endTime: VideoEditorConstants.maxDuration,
       enableAudio: enableAudio,
       shouldOptimizeForNetworkUse: true,
-      customAudioPath: await _getAudioFilePath(
-        parameters?.customAudioTrack?.audio,
-      ),
+      customAudioPath: await parameters?.customAudioTrack?.audio.safeFilePath(),
       loopCustomAudio: false,
       originalAudioVolume: originalAudioVolume,
       customAudioVolume: customAudioVolume,
@@ -700,24 +698,5 @@ class VideoEditorRenderService {
         );
       }
     }
-  }
-
-  /// Returns a file path for the given [EditorAudio], writing bytes to a
-  /// temp file if necessary. Equivalent to `EditorAudio.safeFilePath()` which
-  /// was added in pro_image_editor 12.0.5.
-  static Future<String?> _getAudioFilePath(EditorAudio? audio) async {
-    if (audio == null) return null;
-    if (audio.file != null) return audio.file!.path;
-    if (audio.assetPath != null) return audio.assetPath;
-    if (audio.networkUrl != null) return audio.networkUrl;
-    if (audio.bytes != null) {
-      final tempDir = await getTemporaryDirectory();
-      final tempFile = File(
-        '${tempDir.path}/${DateTime.now().millisecondsSinceEpoch}.mp3',
-      );
-      await tempFile.writeAsBytes(audio.bytes!);
-      return tempFile.path;
-    }
-    return null;
   }
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1692,10 +1692,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: "2be8ab313b258a61f08c401849516216256ce94a2947051fd8ed50bf4f339def"
+      sha256: "314fb7b3493dfb301c9ff7f37cf6e8ae50042c6325597c5e848b85f25cc08727"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.4"
+    version: "12.0.6"
   pro_video_editor:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -168,7 +168,7 @@ dependencies:
   convert: ^3.1.2
   audio_session: ^0.2.2
   pro_video_editor: ^1.7.0
-  pro_image_editor: ">=12.0.0 <12.0.5"
+  pro_image_editor: ^12.0.6
   linked_scroll_controller: ^0.2.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
## Description

This PR reverts the changes that PR #2049 had to make because the pro_image_editor package was broken during the migration to the Swift Package Manager.

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore