### PR TITLE
fix(notifications): harden generic fallback copy

### DIFF
--- a/mobile/lib/services/notification_model_converter.dart
+++ b/mobile/lib/services/notification_model_converter.dart
@@ -3,6 +3,7 @@
 
 import 'package:models/models.dart';
 import 'package:openvine/services/relay_notification_api_service.dart';
+import 'package:openvine/utils/unified_logger.dart';
 
 /// Convert a [RelayNotification] from the Divine Relay API to a
 /// [NotificationModel] suitable for display in the app.
@@ -13,8 +14,13 @@ NotificationModel notificationModelFromRelayApi(
   String? targetVideoUrl,
   String? targetVideoThumbnail,
 }) {
-  final type = _mapNotificationType(relay.notificationType);
-  final message = _generateMessage(type, actorName, relay.content);
+  final type = _mapNotificationType(relay.notificationType, relay.sourceKind);
+  final message = _generateMessage(
+    type,
+    actorName,
+    relay.content,
+    hasTargetEvent: relay.referencedEventId != null,
+  );
 
   return NotificationModel(
     id: relay.id,
@@ -28,31 +34,66 @@ NotificationModel notificationModelFromRelayApi(
     targetEventId: relay.referencedEventId,
     targetVideoUrl: targetVideoUrl,
     targetVideoThumbnail: targetVideoThumbnail,
-    metadata: {
-      'sourceEventId': relay.sourceEventId,
-      'sourceKind': relay.sourceKind,
-      if (relay.content != null) 'content': relay.content,
-    },
+    metadata: _buildMetadata(relay, type),
   );
 }
 
 /// Map relay notification type string to [NotificationType] enum
-NotificationType _mapNotificationType(String relayType) {
-  switch (relayType.toLowerCase()) {
+NotificationType _mapNotificationType(String relayType, int sourceKind) {
+  switch (relayType.trim().toLowerCase()) {
     case 'reaction':
+    case 'like':
+    case 'liked':
+    case 'zap':
+    case 'zapped':
       return NotificationType.like;
     case 'reply':
+    case 'comment':
+    case 'commented':
       return NotificationType.comment;
     case 'repost':
+    case 'reposted':
       return NotificationType.repost;
     case 'follow':
+    case 'followed':
       return NotificationType.follow;
     case 'mention':
+    case 'mentioned':
       return NotificationType.mention;
-    case 'zap':
-      return NotificationType.like; // Treat zaps as likes for now
     default:
+      final fallbackType = _mapNotificationTypeFromSourceKind(sourceKind);
+      if (fallbackType != null) {
+        Log.warning(
+          'Unknown relay notification type "$relayType"; '
+          'using source_kind=$sourceKind fallback to $fallbackType',
+          name: 'NotificationModelConverter',
+          category: LogCategory.system,
+        );
+        return fallbackType;
+      }
+      Log.warning(
+        'Unknown relay notification type "$relayType"; '
+        'falling back to system (source_kind=$sourceKind)',
+        name: 'NotificationModelConverter',
+        category: LogCategory.system,
+      );
       return NotificationType.system;
+  }
+}
+
+NotificationType? _mapNotificationTypeFromSourceKind(int sourceKind) {
+  switch (sourceKind) {
+    case 3:
+      return NotificationType.follow;
+    case 6:
+    case 16:
+      return NotificationType.repost;
+    case 7:
+      return NotificationType.like;
+    case 1111:
+      return NotificationType.comment;
+    default:
+      return null;
   }
 }
 
@@ -60,8 +101,9 @@ NotificationType _mapNotificationType(String relayType) {
 String _generateMessage(
   NotificationType type,
   String? actorName,
-  String? content,
-) {
+  String? content, {
+  required bool hasTargetEvent,
+}) {
   final name = actorName ?? 'Someone';
   switch (type) {
     case NotificationType.like:
@@ -82,6 +124,84 @@ String _generateMessage(
     case NotificationType.repost:
       return '$name reposted your video';
     case NotificationType.system:
-      return content ?? 'System notification';
+      return _generateSystemMessage(
+        actorName: actorName,
+        content: content,
+        hasTargetEvent: hasTargetEvent,
+      );
   }
 }
+
+Map<String, dynamic> _buildMetadata(
+  RelayNotification relay,
+  NotificationType type,
+) {
+  final metadata = <String, dynamic>{
+    'sourceEventId': relay.sourceEventId,
+    'sourceKind': relay.sourceKind,
+    'relayNotificationType': relay.notificationType,
+  };
+
+  final trimmedContent = relay.content?.trim();
+  if (trimmedContent == null || trimmedContent.isEmpty) {
+    return metadata;
+  }
+
+  metadata['content'] = relay.content;
+  switch (type) {
+    case NotificationType.comment:
+      metadata['comment'] = trimmedContent;
+    case NotificationType.mention:
+      metadata['text'] = trimmedContent;
+    case NotificationType.like:
+    case NotificationType.follow:
+    case NotificationType.repost:
+    case NotificationType.system:
+      break;
+  }
+
+  return metadata;
+}
+
+String _generateSystemMessage({
+  required String? actorName,
+  required String? content,
+  required bool hasTargetEvent,
+}) {
+  final trimmedContent = content?.trim();
+  if (_isMeaningfulSystemContent(trimmedContent, actorName: actorName)) {
+    return trimmedContent!;
+  }
+
+  if (actorName != null) {
+    if (hasTargetEvent) {
+      return '$actorName interacted with your video';
+    }
+    return '$actorName sent you an update';
+  }
+
+  return 'You have a new update';
+}
+
+bool _isMeaningfulSystemContent(String? content, {required String? actorName}) {
+  if (content == null || content.isEmpty) return false;
+
+  final normalizedContent = _normalizeWhitespace(content);
+  if (<String>{
+    'notification',
+    'system notification',
+    'new notification',
+  }.contains(normalizedContent)) {
+    return false;
+  }
+
+  if (actorName != null &&
+      normalizedContent == '${_normalizeWhitespace(actorName)} notification') {
+    return false;
+  }
+
+  return true;
+}
+
+String _normalizeWhitespace(String value) =>
+    value.trim().toLowerCase().replaceAll(RegExp(r'\s+'), ' ');

--- a/mobile/lib/widgets/notification_list_item.dart
+++ b/mobile/lib/widgets/notification_list_item.dart
@@ -41,7 +41,7 @@ class NotificationListItem extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     // Main message
-                    _buildMessage(context),
+                    _buildMessage(),
                     const SizedBox(height: 4),
 
                     // Additional content (comment text, etc.)
@@ -169,26 +169,25 @@ class NotificationListItem extends StatelessWidget {
     ),
   );
 
-  Widget _buildMessage(BuildContext context) {
+  Widget _buildMessage() {
     const textStyle = TextStyle(
       fontSize: 14,
       color: VineTheme.whiteText,
     );
 
-    if (notification.actorName != null) {
+    final actorName = notification.actorName;
+    if (_messageStartsWithActorName(actorName)) {
       // Build rich text with bold actor name
       return RichText(
         text: TextSpan(
           style: textStyle,
           children: [
             TextSpan(
-              text: notification.actorName,
+              text: actorName,
               style: const TextStyle(fontWeight: FontWeight.bold),
             ),
             TextSpan(
-              text: notification.message.substring(
-                notification.message.indexOf(' '),
-              ),
+              text: notification.message.substring(actorName!.length),
             ),
           ],
         ),
@@ -196,6 +195,12 @@ class NotificationListItem extends StatelessWidget {
     }
 
     return Text(notification.message, style: textStyle);
+  }
+
+  bool _messageStartsWithActorName(String? actorName) {
+    if (actorName == null) return false;
+    return notification.message == actorName ||
+        notification.message.startsWith('$actorName ');
   }
 
   bool _hasAdditionalContent() {

--- a/mobile/test/services/notification_model_converter_test.dart
+++ b/mobile/test/services/notification_model_converter_test.dart
@@ -1,0 +1,118 @@
+// ABOUTME: Tests for relay notification conversion into app-facing models
+// ABOUTME: Covers fallback type mapping, user-facing copy, and metadata
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/services/notification_model_converter.dart';
+import 'package:openvine/services/relay_notification_api_service.dart';
+
+void main() {
+  group('notificationModelFromRelayApi', () {
+    RelayNotification makeRelayNotification({
+      String notificationType = 'reaction',
+      int sourceKind = 7,
+      String? referencedEventId = 'video-event-1',
+      String? content,
+    }) {
+      return RelayNotification(
+        id: 'notif-1',
+        sourcePubkey:
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        sourceEventId:
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        sourceKind: sourceKind,
+        referencedEventId: referencedEventId,
+        notificationType: notificationType,
+        createdAt: DateTime.utc(2026, 3, 9, 10),
+        read: false,
+        content: content,
+      );
+    }
+
+    test('maps unknown relay type to like using source kind fallback', () {
+      final relay = makeRelayNotification(
+        notificationType: 'notification',
+      );
+
+      final model = notificationModelFromRelayApi(relay, actorName: 'Alice');
+
+      expect(model.type, NotificationType.like);
+      expect(model.message, 'Alice liked your video');
+      expect(model.metadata?['relayNotificationType'], 'notification');
+    });
+
+    test(
+      'maps unknown relay type to comment and preserves comment metadata',
+      () {
+        final relay = makeRelayNotification(
+          notificationType: 'notification',
+          sourceKind: 1111,
+          content: 'Great video!',
+        );
+
+        final model = notificationModelFromRelayApi(relay, actorName: 'Alice');
+
+        expect(model.type, NotificationType.comment);
+        expect(model.message, 'Alice commented: Great video!');
+        expect(model.metadata?['comment'], 'Great video!');
+        expect(model.metadata?['content'], 'Great video!');
+      },
+    );
+
+    test('maps common relay aliases to their app notification types', () {
+      final cases = <String, NotificationType>{
+        'like': NotificationType.like,
+        'comment': NotificationType.comment,
+        'reposted': NotificationType.repost,
+        'followed': NotificationType.follow,
+        'mentioned': NotificationType.mention,
+        'zapped': NotificationType.like,
+      };
+
+      for (final entry in cases.entries) {
+        final relay = makeRelayNotification(
+          notificationType: entry.key,
+          sourceKind: 9999,
+        );
+
+        final model = notificationModelFromRelayApi(relay, actorName: 'Alice');
+
+        expect(model.type, entry.value, reason: 'failed for ${entry.key}');
+      }
+    });
+
+    test('avoids surfacing raw generic notification copy to users', () {
+      final relay = makeRelayNotification(
+        notificationType: 'notification',
+        sourceKind: 9999,
+        content: 'Scary Guy notification',
+      );
+
+      final model = notificationModelFromRelayApi(
+        relay,
+        actorName: 'Scary Guy',
+      );
+
+      expect(model.type, NotificationType.system);
+      expect(model.message, 'Scary Guy interacted with your video');
+      expect(model.message.toLowerCase(), isNot(contains('notification')));
+    });
+
+    test(
+      'uses a neutral update fallback for unknown system activity without actor',
+      () {
+        final relay = makeRelayNotification(
+          notificationType: 'notification',
+          sourceKind: 9999,
+          referencedEventId: null,
+          content: 'notification',
+        );
+
+        final model = notificationModelFromRelayApi(relay);
+
+        expect(model.type, NotificationType.system);
+        expect(model.message, 'You have a new update');
+      },
+    );
+  });
+}

--- a/mobile/test/widgets/notification_list_item_test.dart
+++ b/mobile/test/widgets/notification_list_item_test.dart
@@ -266,6 +266,23 @@ void main() {
         expect(foundBoldActor, isTrue);
       });
 
+      testWidgets('handles multi-word actor names without duplicating text', (
+        WidgetTester tester,
+      ) async {
+        final notification = makeNotification(
+          actorName: 'Scary Guy',
+          message: 'Scary Guy liked your video',
+        );
+
+        await tester.pumpWidget(buildTestWidget(notification: notification));
+
+        expect(_richTextContains(tester, 'Scary Guy liked your video'), isTrue);
+        expect(
+          _richTextContains(tester, 'Scary Guy Guy liked your video'),
+          isFalse,
+        );
+      });
+
       testWidgets('renders plain text when actor name is null', (
         WidgetTester tester,
       ) async {
@@ -324,6 +341,26 @@ void main() {
         expect(find.text('📱'), findsOneWidget);
         expect(find.text('System notification'), findsOneWidget);
       });
+
+      testWidgets(
+        'renders plain text when message does not start with actor name',
+        (
+          WidgetTester tester,
+        ) async {
+          final notification = NotificationModel(
+            id: 'sys-2',
+            type: NotificationType.system,
+            actorPubkey: testPubkey,
+            actorName: 'Scary Guy',
+            message: 'You have a new update',
+            timestamp: DateTime.now(),
+          );
+
+          await tester.pumpWidget(buildTestWidget(notification: notification));
+
+          expect(find.text('You have a new update'), findsOneWidget);
+        },
+      );
     });
 
     group('timestamp', () {


### PR DESCRIPTION
## Description

Fixes the generic notification fallback path described in #2053 and hardens notification rendering against malformed or drifted relay payloads.

Changes in this PR:
- map common relay notification aliases and fall back from unknown `notification_type` values using `source_kind`
- log unknown relay types with `source_kind` so backend-contract drift is visible in app logs
- avoid surfacing raw generic copy like `<name> notification` to users when we still cannot resolve a specific type
- preserve converted comment and mention text in metadata for notification UI
- fix `NotificationListItem` actor-name rendering so multi-word names are not duplicated and non-prefixed messages render as plain text
- add converter-focused tests and widget coverage for the fallback and rendering edge cases

**Related Issue:** Closes #2053

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Verification

- `flutter test test/services/notification_model_converter_test.dart`
- `flutter test test/widgets/notification_list_item_test.dart`
- `flutter test test/services/notification_model_converter_test.dart test/widgets/notification_list_item_test.dart test/screens/notifications_screen_test.dart test/providers/relay_notifications_provider_test.dart`
- `flutter analyze lib/services/notification_model_converter.dart lib/widgets/notification_list_item.dart test/services/notification_model_converter_test.dart test/widgets/notification_list_item_test.dart`
