### PR TITLE
fix(android): prevent Zendesk AppCompat crash in support screens

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -131,6 +131,12 @@
 
 
         </activity>
+        <activity
+            android:name="zendesk.support.request.RequestActivity"
+            android:theme="@style/ZendeskTheme" />
+        <activity
+            android:name="zendesk.support.requestlist.RequestListActivity"
+            android:theme="@style/ZendeskTheme" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/mobile/android/app/src/main/res/values-night-v31/styles.xml
+++ b/mobile/android/app/src/main/res/values-night-v31/styles.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <!-- Keep the Android 12+ splash theme AppCompat-based so Zendesk activities
+         inheriting the app theme still satisfy Material ThemeEnforcement. -->
+    <style name="LaunchTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowBackground">@drawable/launch_background</item>
         <item name="android:windowSplashScreenBackground">@color/splash_background</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/launch_image</item>
         <item name="android:windowSplashScreenIconBackgroundColor">@color/splash_background</item>
     </style>
-    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <style name="NormalTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/mobile/android/app/src/main/res/values-v31/styles.xml
+++ b/mobile/android/app/src/main/res/values-v31/styles.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <!-- Keep the Android 12+ splash theme AppCompat-based so Zendesk activities
+         inheriting the app theme still satisfy Material ThemeEnforcement. -->
+    <style name="LaunchTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowBackground">@drawable/launch_background</item>
         <item name="android:windowSplashScreenBackground">@color/splash_background</item>
         <item name="android:windowSplashScreenAnimatedIcon">@drawable/launch_image</item>
         <item name="android:windowSplashScreenIconBackgroundColor">@color/splash_background</item>
     </style>
-    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="NormalTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/mobile/android/app/src/main/res/values/styles.xml
+++ b/mobile/android/app/src/main/res/values/styles.xml
@@ -17,4 +17,8 @@
     <style name="NormalTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
+
+    <!-- Keep Zendesk activities on an explicit AppCompat theme even if app-wide
+         theme resources change again in future splash-screen work. -->
+    <style name="ZendeskTheme" parent="Theme.AppCompat.DayNight.NoActionBar" />
 </resources>


### PR DESCRIPTION
## Description

This fixes the Android Zendesk support crash on Android 12/13 by restoring AppCompat inheritance in the API 31+ splash theme resources and by explicitly applying an AppCompat-based `ZendeskTheme` to Zendesk's support activities.

The underlying regression was that `values-v31/styles.xml` and `values-night-v31/styles.xml` had switched `LaunchTheme` and `NormalTheme` back to platform `Theme.*.NoTitleBar` parents, so Zendesk's `RequestActivity` / `RequestListActivity` could inherit a non-AppCompat theme and crash inside Material `ThemeEnforcement` when inflating `AppBarLayout`.

**Related Issue:** Crashlytics ID `21e57f5d97197022e918604aff863495`

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Testing

- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' PATH="$JAVA_HOME/bin:$PATH" java -classpath gradle/wrapper/gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain app:processDebugMainManifest app:mergeDebugResources -x compileFlutterBuildDebug`
- `flutter analyze lib test`
- `flutter test test/services/profile_update_test.dart --reporter expanded`
- `flutter test`
  - This full suite is not clean locally in the repo baseline. It progressed past 3,600 tests but surfaced unrelated failures outside the Android files changed in this PR.
