### PR TITLE
feat(share): add download actions to the share sheet

### DIFF
--- a/mobile/lib/screens/feed/feed_video_overlay.dart
+++ b/mobile/lib/screens/feed/feed_video_overlay.dart
@@ -21,13 +21,6 @@ import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/badge_explanation_modal.dart';
 import 'package:openvine/widgets/clickable_hashtag_text.dart';
 import 'package:openvine/widgets/proofmode_badge_row.dart';
-import 'package:openvine/widgets/video_feed_item/actions/cc_action_button.dart';
-import 'package:openvine/widgets/video_feed_item/actions/comment_action_button.dart';
-import 'package:openvine/widgets/video_feed_item/actions/like_action_button.dart';
-import 'package:openvine/widgets/video_feed_item/actions/more_action_button.dart';
-import 'package:openvine/widgets/video_feed_item/actions/repost_action_button.dart';
-import 'package:openvine/widgets/video_feed_item/actions/share_action_button.dart';
-import 'package:openvine/widgets/video_feed_item/actions/video_edit_button.dart';
 import 'package:openvine/widgets/video_feed_item/audio_attribution_row.dart';
 import 'package:openvine/widgets/video_feed_item/collaborator_avatar_row.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
@@ -369,30 +362,7 @@ class _ActionButtons extends StatelessWidget {
   final VideoEvent video;
 
   @override
-  Widget build(BuildContext context) {
-    const gap = 24.0;
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        // Edit button self-hides via SizedBox.shrink() when not
-        // applicable, so it sits outside the uniform spacing to
-        // avoid a phantom gap.
-        VideoEditButton(video: video),
-        Column(
-          spacing: gap,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            LikeActionButton(video: video),
-            CommentActionButton(video: video),
-            CcActionButton(video: video),
-            RepostActionButton(video: video),
-            ShareActionButton(video: video),
-            MoreActionButton(video: video),
-          ],
-        ),
-      ],
-    );
-  }
+  Widget build(BuildContext context) => VideoOverlayActionColumn(video: video);
 }
 
 /// NIP-05 verification badge.

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -18,12 +18,15 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/utils/watermark_text_resolver.dart';
 import 'package:openvine/widgets/add_to_list_dialog.dart';
 import 'package:openvine/widgets/find_people_sheet.dart';
 import 'package:openvine/widgets/report_content_dialog.dart';
+import 'package:openvine/widgets/save_original_progress_sheet.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
+import 'package:openvine/widgets/watermark_download_progress_sheet.dart';
 import 'package:share_plus/share_plus.dart';
 
 part 'share_sheet_header.dart';
@@ -37,8 +40,8 @@ part 'share_sheet_more_actions.dart';
 /// - Video context/preview header
 /// - "Share with" horizontal contact row with "Find people" search
 /// - Optional message input when a recipient is selected
-/// - "More actions" horizontal row (Save, Add to List, Copy, Share via,
-///   Report, Mute, Block, Event JSON, Event ID)
+/// - "More actions" horizontal row (Save, download, Add to List, Copy,
+///   Share via, Report, debug tools)
 class ShareActionButton extends StatelessWidget {
   const ShareActionButton({required this.video, super.key});
 
@@ -46,9 +49,8 @@ class ShareActionButton extends StatelessWidget {
 
   /// Opens the unified share sheet for the given [video].
   ///
-  /// This is exposed as a static method so that other widgets (e.g.
-  /// [MoreActionButton]) can open the same share sheet without duplicating
-  /// the bottom-sheet wiring.
+  /// This is exposed as a static method so share entry points can reuse the
+  /// same bottom-sheet wiring without duplicating setup logic.
   static void showShareSheet(BuildContext context, VideoEvent video) {
     context.showVideoPausingVineBottomSheet<void>(
       builder: (context) => _UnifiedShareSheet(video: video),
@@ -157,6 +159,8 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
 
   @override
   Widget build(BuildContext context) {
+    final isOwnContent = _isUserOwnContent();
+
     return BlocProvider.value(
       value: _bloc,
       child: BlocListener<ShareSheetBloc, ShareSheetState>(
@@ -166,9 +170,12 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
         child: _UnifiedShareSheetView(
           video: widget.video,
           messageController: _messageController,
+          isOwnContent: isOwnContent,
           onFindPeople: _handleFindPeople,
           onAddToList: _handleAddToList,
           onReport: _handleReport,
+          onSaveOriginal: isOwnContent ? _handleSaveOriginal : null,
+          onSaveWithWatermark: _handleSaveWithWatermark,
         ),
       ),
     );
@@ -222,21 +229,78 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
   }
 
   void _handleAddToList() {
-    _safePop(context);
-
-    if (!context.mounted) return;
-    showDialog<void>(
-      context: context,
-      builder: (context) => SelectListDialog(video: widget.video),
-    );
+    _presentAfterDismiss<void>((hostContext) {
+      return showDialog<void>(
+        context: hostContext,
+        builder: (context) => SelectListDialog(video: widget.video),
+      );
+    });
   }
 
   void _handleReport() {
-    _safePop(context);
-    showDialog<void>(
-      context: context,
-      builder: (context) => ReportContentDialog(video: widget.video),
+    _presentAfterDismiss<void>((hostContext) {
+      return showDialog<void>(
+        context: hostContext,
+        builder: (context) => ReportContentDialog(video: widget.video),
+      );
+    });
+  }
+
+  bool _isUserOwnContent() {
+    try {
+      final authService = ref.read(authServiceProvider);
+      if (!authService.isAuthenticated) return false;
+
+      final userPubkey = authService.currentPublicKeyHex;
+      if (userPubkey == null) return false;
+
+      return widget.video.pubkey == userPubkey;
+    } catch (e) {
+      Log.error(
+        'Error checking content ownership: $e',
+        name: 'ShareActionButton',
+        category: LogCategory.ui,
+      );
+      return false;
+    }
+  }
+
+  Future<void> _handleSaveOriginal() async {
+    await _presentAfterDismiss<void>((hostContext) {
+      return showSaveOriginalSheet(
+        context: hostContext,
+        ref: ref,
+        video: widget.video,
+      );
+    });
+  }
+
+  Future<void> _handleSaveWithWatermark() async {
+    final profileService = ref.read(userProfileServiceProvider);
+    final profile = profileService.getCachedProfile(widget.video.pubkey);
+    final watermarkText = resolveWatermarkText(
+      profile: profile,
+      fallbackAuthorName: widget.video.authorName,
     );
+
+    await _presentAfterDismiss<void>((hostContext) {
+      return showWatermarkDownloadSheet(
+        context: hostContext,
+        ref: ref,
+        video: widget.video,
+        watermarkText: watermarkText,
+      );
+    });
+  }
+
+  Future<T?> _presentAfterDismiss<T>(
+    Future<T?> Function(BuildContext hostContext) presenter,
+  ) async {
+    final hostContext = Navigator.of(context, rootNavigator: true).context;
+    _safePop(context);
+    await Future<void>.delayed(Duration.zero);
+    if (!mounted || !hostContext.mounted) return null;
+    return presenter(hostContext);
   }
 }
 
@@ -248,16 +312,22 @@ class _UnifiedShareSheetView extends StatelessWidget {
   const _UnifiedShareSheetView({
     required this.video,
     required this.messageController,
+    required this.isOwnContent,
     required this.onFindPeople,
     required this.onAddToList,
     required this.onReport,
+    required this.onSaveWithWatermark,
+    this.onSaveOriginal,
   });
 
   final VideoEvent video;
   final TextEditingController messageController;
+  final bool isOwnContent;
   final VoidCallback onFindPeople;
   final VoidCallback onAddToList;
   final VoidCallback onReport;
+  final Future<void> Function()? onSaveOriginal;
+  final Future<void> Function() onSaveWithWatermark;
 
   @override
   Widget build(BuildContext context) {
@@ -301,7 +371,10 @@ class _UnifiedShareSheetView extends StatelessWidget {
                     const Divider(color: VineTheme.cardBackground, height: 1),
                     _MoreActionsSection(
                       video: video,
+                      isOwnContent: isOwnContent,
                       onSave: () => bloc.add(const ShareSheetSaveRequested()),
+                      onSaveOriginal: onSaveOriginal,
+                      onSaveWithWatermark: onSaveWithWatermark,
                       onAddToList: onAddToList,
                       onCopyLink: () =>
                           bloc.add(const ShareSheetCopyLinkRequested()),

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
@@ -7,17 +7,23 @@ part of 'share_action_button.dart';
 class _MoreActionsSection extends ConsumerWidget {
   const _MoreActionsSection({
     required this.video,
+    required this.isOwnContent,
     required this.onSave,
+    required this.onSaveWithWatermark,
     required this.onAddToList,
     required this.onCopyLink,
     required this.onShareVia,
     required this.onReport,
     required this.onCopyEventJson,
     required this.onCopyEventId,
+    this.onSaveOriginal,
   });
 
   final VideoEvent video;
+  final bool isOwnContent;
   final VoidCallback onSave;
+  final Future<void> Function()? onSaveOriginal;
+  final Future<void> Function() onSaveWithWatermark;
   final VoidCallback onAddToList;
   final VoidCallback onCopyLink;
   final VoidCallback onShareVia;
@@ -39,6 +45,17 @@ class _MoreActionsSection extends ConsumerWidget {
         icon: DivineIconName.bookmarkSimple,
         label: 'Save',
         onTap: onSave,
+      ),
+      if (onSaveOriginal != null)
+        _ActionData(
+          icon: DivineIconName.downloadSimple,
+          label: 'Save to Gallery',
+          onTap: () => onSaveOriginal!.call(),
+        ),
+      _ActionData(
+        icon: DivineIconName.downloadSimple,
+        label: isOwnContent ? 'Save with Watermark' : 'Save Video',
+        onTap: onSaveWithWatermark,
       ),
       if (showCuratedLists)
         _ActionData(

--- a/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
@@ -5,7 +5,9 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/widgets/video_feed_item/actions/share_action_button.dart';
 
 import '../../../helpers/test_provider_overrides.dart';
@@ -141,9 +143,36 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('Save'), findsOneWidget);
+        expect(find.text('Save Video'), findsOneWidget);
         expect(find.text('Copy'), findsOneWidget);
         expect(find.text('Share via'), findsOneWidget);
         expect(find.text('Report'), findsOneWidget);
+      });
+
+      testWidgets('shows own-video download actions for owned content', (
+        tester,
+      ) async {
+        final mockAuth = createMockAuthService();
+        final mockProfile = createMockUserProfileService();
+        when(() => mockAuth.isAuthenticated).thenReturn(true);
+        when(() => mockAuth.currentPublicKeyHex).thenReturn(ownPubkey);
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            home: Scaffold(body: ShareActionButton(video: testVideo)),
+            additionalOverrides: [
+              followRepositoryProvider.overrideWithValue(null),
+            ],
+            mockAuthService: mockAuth,
+            mockUserProfileService: mockProfile,
+          ),
+        );
+
+        await tester.tap(find.byType(IconButton));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Save to Gallery'), findsOneWidget);
+        expect(find.text('Save with Watermark'), findsOneWidget);
       });
     });
   });


### PR DESCRIPTION
## Summary
- add explicit save/download actions to the unified share sheet, including separate owned-video and watermark flows
- route the feed overlay action column through the shared video overlay action widget instead of duplicating button composition
- cover the owned-content action labels in the share action widget test

## Testing
- flutter analyze lib/screens/feed/feed_video_overlay.dart lib/widgets/video_feed_item/actions/share_action_button.dart lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart test/widgets/video_feed_item/actions/share_action_button_test.dart
- flutter test test/widgets/video_feed_item/actions/share_action_button_test.dart