### PR TITLE
chore(release): remove the Zapstore arm64 APK match filter

### DIFF
--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,6 +1,5 @@
 repository: https://github.com/divinevideo/divine-mobile
 release_source: https://github.com/divinevideo/divine-mobile/releases/tag/1.0.6
-match: .*arm64.*\.apk$
 name: Divine
 description: |
   Divine is a new 6-second looping video app, inspired by Vine, with a


### PR DESCRIPTION
## Summary
- remove the explicit `arm64` APK match filter from `zapstore.yaml`

## Validation
- ruby -e "require 'yaml'; YAML.load_file('zapstore.yaml'); puts 'ok'"