### PR TITLE
docs: add brand guidelines reference docs

### DIFF
--- a/brand-guidelines/AGENT_QUICK_REFERENCE.md
+++ b/brand-guidelines/AGENT_QUICK_REFERENCE.md
@@ -1,0 +1,108 @@
+# diVine Brand Quick Reference for AI Agents
+
+Use this as a fast lookup when writing copy, designing UI, or making product decisions.
+
+---
+
+## One-Line Summary
+
+diVine is a decentralized short-form video app reviving Vine's 6-second format, built on Nostr, championing human creativity over AI slop.
+
+## Purpose
+
+**Creative power belongs in human hands.**
+
+## Value Proposition
+
+**Your playground for human creativity and connection -- in all its weird, wonderful, technicolor glory.**
+
+## Brand Archetype
+
+**The Playful Rebel** -- uses joy, humor, and play as vehicles for rebellion against big tech's grip on creativity.
+
+---
+
+## Voice Cheat Sheet
+
+### Three Principles
+
+1. **Candid Simplicity**: No jargon, straight to the point, transparent. Lead with benefits, not features.
+2. **Collective Optimism**: Positive, community-focused, inviting. Not toxic positivity. Use "we" and "our."
+3. **A Shot of Punk**: Energetic, scrappy, slightly subversive. Never corporate or polished.
+
+### Do
+
+- Use casual, direct language
+- Show personality in microcopy
+- Celebrate community and creators
+- Be honest about what we can and can't do
+- Use vivid, energetic language
+
+### Don't
+
+- Use corporate speak (leverage, synergy, ecosystem)
+- Sound like a Silicon Valley pitch deck
+- Over-promise or hype
+- Use passive voice
+- Call AI-generated content "creative"
+- Sound sterile or polished
+
+---
+
+## Key Messages
+
+- **No AI slop**: Human-made content only. We detect and remove machine-generated content.
+- **User ownership**: Your content, your data, your feed. Built on Nostr where you own everything.
+- **Joy scrolling**: Trade doom scrolling for delight. Quick bursts of real human creativity.
+- **Community-built**: Open source, decentralized, built with and for the community.
+- **Vine nostalgia**: 100,000+ archived Vines brought back to life. The golden days of the internet, reimagined.
+
+---
+
+## Color Quick Reference
+
+| Role | Color | HEX |
+|------|-------|-----|
+| Brand Green (primary) | Green | `#27C58B` |
+| Dark background | Dark Green | `#07241B` |
+| Light accent | Light Green | `#D0FBCB` |
+| Light background | Off White | `#F9F7F6` |
+
+Secondary accent colors: Yellow `#FFF140`, Lime `#D2FF40`, Pink `#FF7FAF`, Orange `#FF7640`, Violet `#A3A9FF`, Purple `#8568FF`, Blue `#34BBF1`
+
+---
+
+## Typography
+
+- **Headlines**: Bricolage Grotesque (Bold / Extra Bold)
+- **Body / UI**: Inter (Regular / Medium / Semi Bold / Bold)
+- **Icons**: Phosphor Icons (phosphoricons.com)
+
+---
+
+## Community Shorthand
+
+| Audience | Mindset Name | Core Need |
+|----------|-------------|-----------|
+| Users | Joy Scrollers | Lightness, control, human moments |
+| Creators | Self-Directed Creatives | Freedom, ownership, no algorithm games |
+| Brands/Builders | Principled Challengers | Values-driven, experimental, participatory |
+
+---
+
+## Taglines / Phrases to Use
+
+- "Life in Loops"
+- "Live, Love, Loop"
+- "Your playground for human creativity"
+- "No slop. All human."
+- "Joy scrolling > doom scrolling"
+- "Own what you make. Choose what you see."
+
+## Phrases to Avoid
+
+- "Leveraging blockchain/protocol technology"
+- "Next-generation social platform"
+- "Disrupting the social media landscape"
+- "Empowering users through innovation"
+- Anything that sounds like a VC pitch deck

--- a/brand-guidelines/BRAND_DNA.md
+++ b/brand-guidelines/BRAND_DNA.md
@@ -1,0 +1,119 @@
+# diVine Brand DNA
+
+## Purpose
+
+**Creative power belongs in human hands.**
+
+It's not just about creativity, but about the power that creativity gives you -- power that has been co-opted by corporations and algorithms. This is a rebellious, declarative statement of how and where power should be distributed.
+
+- Human hands that make real things
+- Human hands that hold diVine in their phones
+- Human hands that join together
+
+We are building a movement to brighten the world.
+
+---
+
+## Brand Manifesto
+
+People remember Vine as the golden days of the Internet. Back when you could laugh with millions of people at the same stupid, six-second burst of brilliance. Before all-powerful algorithms decided what we see.
+
+Then social media grew darker. It got hateful and heavier. It learned how to divide, compare, and isolate us. To hold our attention in pursuit of profit. To make us never feel as good as someone else in a tiny square. And big tech grew more powerful. It hurtled us into the slopocalypse. Algorithms became black boxes beholden to the interests of corporations, rather than the communities that power them.
+
+At diVine, we say: fuck that.
+
+We want you to own what you make. Choose what you see. Trade doom scrolling for joy scrolling. Trade keyboard wars for a playground of human creativity. Crack the algorithm open and make it work for you. Bring your weird unfiltered self. Chances are you'll find someone just like you. Together, we'll put the power of creativity back in human hands.
+
+---
+
+## Value Proposition
+
+**Your playground for human creativity and connection -- in all its weird, wonderful, technicolor glory.**
+
+- Open, cooperative, and built with users and creators in mind
+- A safe place for experimentation and play -- seeing, sharing, and creating
+- A commitment to no AI slop, a place for real humans
+- A place to not only express, but also to find others like you
+- The full, expansive spectrum of how humans want to create
+- Calls back to the nostalgia and epoch of an exciting time in internet history
+
+### What diVine Offers
+
+- No-slop, all-human creativity
+- Agency over your feed and followers
+- Your content and data stay yours
+- Space to play and experiment
+- Access to 100,000+ archived Vine videos from the original era
+
+---
+
+## Brand Archetype: The Playful Rebel
+
+diVine sits at the intersection of the **Jester** and the **Rebel**.
+
+### Why Jester
+- We know that play and laughter are essential to the world
+- We channel joy into better products
+- We tell the truth, wrapped in comedy
+
+### Why Rebel
+- A band of thoughtful rascals who saw a better way and chose to build it
+- Challenges who holds power online, and puts ownership back to the people
+- Building a movement in community
+
+### The Playful Rebel at Its Best
+- Breaks rules to make better things for its community (not just for the sake of it)
+- Uses joy, play, and humor as the vehicle for its rebellion
+- Connects people with a vision and invites them to take part
+- Embraces the misfits in a space where weirdness feels welcome
+
+### Key Words
+Expressive, Bold, Raw, Community-First, Principled
+
+### References / Inspiration
+- Solar Punk aesthetic
+- Keith Haring
+- Ben & Jerry's (pre-Unilever)
+- JR (street artist)
+
+---
+
+## Community Mindsets
+
+### Users: "Joy Scrollers"
+
+- **Drawn to human moments**: Pulled toward content that feels unpolished and genuine -- small spontaneous flashes of real people being themselves
+- **Looking for lightness**: They want quick bursts of delight and provocation that cut through the weight of their feed and day
+- **Seeking calm and control**: Tired of scrolling through AI-slop, chaos, and ads; they want a feed shaped by their curiosity, not tugged around by an algorithm
+- **Nostalgic for the old internet**: Miss the low-stakes, un-self-conscious energy of early online culture, when things were weird, quick, and funny (even if they weren't there)
+
+### Creators: "Self-Directed Creatives"
+
+*If you've got an imagination, you're a creative.*
+
+- **Moves early, learns fast**: Curious by default, drawn to things that are still forming, and like being the first to test and figure things out
+- **Creative at their core**: See the world at strange angles -- spotting moments, patterns, and jokes most people miss, and turning them into unexpected content
+- **Craving freedom**: Space to follow impulses and be silly and experimental, instead of tailoring to an algorithm's fickle taste
+- **Worn down by the system**: Tired of feeds that flatten originality, tools that add friction, and business models that take the lion's share while demanding constant output
+- **Thinking like owners, not posters**: Want to own their identity, audience, and business, the way musicians own their masters or writers self-publish
+
+### Brands & Builders: "Principled Challengers"
+
+*This mindset encompasses the back-end builders who contribute to the code and project.*
+
+- **Already breaking the mould**: Doing things differently in their category, and open to rethinking how partnerships should work
+- **Putting action behind values**: Believes in transparency, giving power back to customers, and helping build a better future -- and takes action on it
+- **Comfortable experimenting early**: Eager to test new platforms before they're polished or proven
+- **Culturally switched on**: Relevant now, or actively working to stay close to what's next
+- **Partnership as participation**: Wants to show up in community with creators, users, and diVine
+
+---
+
+## The Brand DNA Summary
+
+| Dimension | Element | Description |
+|-----------|---------|-------------|
+| **Why** (Purpose) | Creative power belongs in human hands | Make decisions, motivate employees, shape reputation |
+| **Who** (Community) | Joy Scrollers, Self-Directed Creatives, Principled Challengers | Understand our users and what they need |
+| **What** (Value Prop) | Your playground for human creativity and connection | Deliver experiences that answer community needs |
+| **How** (Archetype) | The Playful Rebel | Show up visually and verbally in a way that's true to us |

--- a/brand-guidelines/README.md
+++ b/brand-guidelines/README.md
@@ -1,0 +1,28 @@
+# diVine Brand Guidelines
+
+Brand guidelines for diVine, translated from the official brand PDFs (January 2026).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| [BRAND_DNA.md](BRAND_DNA.md) | Purpose, manifesto, value proposition, archetype, community mindsets |
+| [TONE_OF_VOICE.md](TONE_OF_VOICE.md) | Three voice principles with before/after examples, practical copy guidance |
+| [VISUAL_IDENTITY.md](VISUAL_IDENTITY.md) | Logo, colors, typography, icons, illustrations, do's and don'ts |
+| [AGENT_QUICK_REFERENCE.md](AGENT_QUICK_REFERENCE.md) | Fast lookup for AI agents -- voice cheat sheet, key messages, color/type reference |
+
+## How to Use
+
+**For AI agents**: Add `AGENT_QUICK_REFERENCE.md` to your context or CLAUDE.md rules. It contains everything needed for writing copy and making product decisions.
+
+**For designers**: `VISUAL_IDENTITY.md` has all color values, typography specs, and icon guidelines.
+
+**For anyone writing copy**: `TONE_OF_VOICE.md` has the three principles with concrete before/after examples.
+
+**For strategy/positioning**: `BRAND_DNA.md` covers the full brand framework -- purpose, audiences, value prop, and archetype.
+
+## Source
+
+Translated from:
+- `Divine-Brand_Guidelines_2026.pdf` (visual identity, 53 pages)
+- `divine-brand.pdf` (brand DNA & tone of voice, 41 pages)

--- a/brand-guidelines/TONE_OF_VOICE.md
+++ b/brand-guidelines/TONE_OF_VOICE.md
@@ -1,0 +1,104 @@
+# diVine Tone of Voice
+
+We have three tone of voice principles that shape how we sound. They ensure consistency across everything we say, wherever we say it.
+
+---
+
+## Principle 1: Candid Simplicity
+
+**We are as open and transparent as our protocol. We explain things clearly, but never drone on about what our audience doesn't need to know.**
+
+### How We Do It
+
+**Balance pragmatism with punch.** Steer clear of hyper-rational language, but don't go so far as to create a PR nightmare. Say it straight and without scandal. Be honest about what we can and can't control.
+
+**Ask: why should they care?** Filter through the lens of why our audience should be excited or interested. Lead with benefits (not features), and frame any technical language based on what matters to them.
+
+### Before & After
+
+| Instead of | Try |
+|------------|-----|
+| "diVine will do its utmost to detect and flag suspected GenAI content and prevent it from being posted. diVine is building systems designed to detect and flag suspected AI-generated videos. We will provide tools for users to flag suspected AI content for us to further evaluate." | "We stand against AI-slop. Our systems are designed to catch and remove machine-generated content, and we also ask our users to flag anything suspicious. We might not catch it all, but we're committed to making diVine as human-only as possible." |
+| "diVine is a new open-source social video app built on the Nostr protocol, reviving the iconic six-second video format that made Vine so popular." | "diVine is bringing back the six-second videos that shaped Internet culture. All on a new protocol where creators own what they make, and users have more say over their feeds." |
+
+---
+
+## Principle 2: Collective Optimism
+
+**Positive, but not the toxic kind. More like: we know there's joy to find, a better future to build, and a community to do it with and for.**
+
+### How We Do It
+
+**Speak as a collective.** Talk the way we work: in community with our creators and users. Our language invites them into a movement we're creating together -- never a top-down "we know better than you."
+
+**Wrap darkness in joy.** It's important to talk about the enemy we're fighting, but make sure we round it out with levity, play, and our vision for the future.
+
+### Before & After
+
+| Instead of | Try |
+|------------|-----|
+| "diVine is designed to bring a focus back on real human creativity in an era increasingly flooded with AI slop." | "As activists who've always questioned the concentration of social media power in the hands of a few corporations, we're building with and for people who believe in keeping creativity human. Join us in protecting the brightest corner of the Internet." |
+| "We are encouraging an ecosystem of algorithms for users to choose from. The problem on other social platforms has been the monoculture of ad-focused algorithms designed merely to drive eyeballs which have in turn promoted much of the type of content we don't want to see, and also forced creators to game the algorithm." | "We believe you should have agency over your feed and followers, so we're building a set of 'choose your experience' algorithms. Whether you want to see something silly or serious, or you want to post something quick or polished, or everything in between -- it's up to you." |
+
+---
+
+## Principle 3: A Shot of Punk
+
+**We're scrappy and subversive, but only enough to make our point. We're not like the polished big tech guys, and you feel it in our energy and conviction.**
+
+### How We Do It
+
+**Creatively resist, in the right moments.** We're mobilizing change through millions of mini trojan horses, but we're not trying to scare people away. If it's a headline? More rebel. A brand partnership proposal? More playful.
+
+**Make our passion electric.** Amp the energy and show our product love (sometimes with an iconic Vine quote). Use vivid language that makes it hard not to get excited about what we're building.
+
+### Before & After
+
+| Instead of | Try |
+|------------|-----|
+| "Vine Revisited - A Return to the Halcyon Days of the Internet" | "Our diVine right to AI-free, human-made creativity" |
+| "diVine includes access to more than 100,000 archived Vine videos and lets people create their own six-second looping videos. We are aiming to provide an experience that is free of AI-generated content." | "We've brought back to life 100,000 Vines from the original archives. At diVine, we want everyone to show up as they are to our human-made, no-slop playground." |
+
+---
+
+## Practical Application for Product & Code
+
+### In-App Copy
+
+- **Use casual, direct language**: "Share your thing" not "Upload your content"
+- **Show personality in microcopy**: Error messages, empty states, tooltips should have character
+- **Use "we" and "our"**: Reinforce community ("We're building this together")
+- **Celebrate creators**: Highlight people, not metrics
+- **Be honest**: About what diVine is and isn't
+
+### Avoid
+
+- Corporate speak ("leverage", "synergy", "ecosystem")
+- Silicon Valley pitch deck language
+- Over-promising or hyping features
+- Passive voice when active is clearer
+- Unnecessary disclaimers or legalese in user-facing copy
+- Calling AI-generated content "creative" -- this is a human creativity space
+- Sounding polished or sterile -- a little rough around the edges is on brand
+
+### Tone Dial by Context
+
+| Context | Rebel | Playful |
+|---------|:-----:|:-------:|
+| Headlines & marketing | High | Medium |
+| Social media posts | Medium | High |
+| In-app UI copy | Low | High |
+| Error messages | Low | Medium |
+| Brand partnerships | Medium | Medium |
+| Press / PR | Medium | Low |
+| Developer docs | Low | Low |
+| Legal / compliance | None | None |
+
+### Example Microcopy
+
+| Scenario | Corporate | diVine |
+|----------|-----------|--------|
+| Empty feed | "No content available" | "Nothing here yet. Go find your people." |
+| Upload success | "Your video has been uploaded successfully" | "Your loop is live. Let's go." |
+| No search results | "No results found for your query" | "Nada. Try something different?" |
+| Following empty | "You are not following anyone" | "You're flying solo. Time to find your crew." |

--- a/brand-guidelines/VISUAL_IDENTITY.md
+++ b/brand-guidelines/VISUAL_IDENTITY.md
@@ -1,0 +1,164 @@
+# diVine Visual Identity
+
+## Logotype
+
+The diVine logotype is the most recognizable aspect of the brand. It is built on a consistent geometric system that ensures visual balance and clarity.
+
+### Versions
+- **Primary**: Green and Dark Green
+- **On images**: Dark Green or White versions are permitted, provided strong contrast is maintained
+- The "V" in diVine is always capitalized in the logotype
+
+### Safe Space
+Always leave at least the x-height of the typography as free space around the logo on all sides.
+
+### Placement
+The logo is intentionally positioned at the bottom of applications to create a calm, grounded brand signature without competing with content.
+
+### Don'ts
+- Don't alter the colors of the logotype
+- Don't stretch, squeeze, or rotate the logotype
+- Don't outline the logotype
+- Don't add effects or shadows
+- Don't use the V-shape from the logo by itself
+- Don't use imagery or patterns inside the logotype
+
+---
+
+## Avatars
+
+The avatars are 3D interpretations of a video icon with wings and a floating halo. They serve as a subtle nod to the brand's heritage.
+
+- **Original**: Standard version with background
+- **Inverted**: Inverted version with background
+- Both available as isolated (no background) variants
+- Used as the brand's primary profile image across social and digital environments
+
+---
+
+## App Icon
+
+The app icon is based on the avatar to create a unique and ownable presence. Its bold 3D character makes the app instantly recognizable in crowded app environments.
+
+---
+
+## Watermark
+
+Downloaded videos include a subtle watermark:
+- **Position**: Left-aligned, randomly positioned vertically
+- **Content**: diVine logo + creator @username
+- **Username text**: 50px
+- **Left margin**: 64px
+- **Logo width**: 160px
+- **Video width reference**: 1920px
+
+---
+
+## Color Palette
+
+### Primary Colors (Core Brand Foundation)
+
+| Color | HEX | RGB |
+|-------|-----|-----|
+| **Green** | `#27C58B` | 39, 197, 139 |
+| **Dark Green** | `#07241B` | 7, 36, 27 |
+| **Light Green** | `#D0FBCB` | 208, 251, 203 |
+| **Off White** | `#F9F7F6` | 249, 247, 246 |
+
+### Secondary Colors (Energy & Variation)
+
+| Color | Main | Light | Dark |
+|-------|------|-------|------|
+| **Yellow** | `#FFF140` | `#FFFABB` | `#363313` |
+| **Lime** | `#D2FF40` | `#F1FFC8` | `#272F0E` |
+| **Pink** | `#FF7FAF` | `#FFDEEA` | `#3E0C1F` |
+| **Orange** | `#FF7640` | `#FFD8C9` | `#471F10` |
+| **Violet** | `#A3A9FF` | `#E1E3FF` | `#2D214D` |
+| **Purple** | `#8568FF` | `#DDD4FF` | `#231557` |
+| **Blue** | `#34BBF1` | `#CCEEFE` | `#0A223C` |
+
+### Color Balance
+- Primary colors form the visual foundation
+- Secondary colors add energy and variation **on top** of the primary system
+- Secondary colors should NOT be used for large areas
+- Don't use colors outside the brand palette
+- Don't create or use gradients
+- Don't apply color to imagery
+- Don't use combinations that create poor contrast
+
+---
+
+## Typography
+
+### Primary: Bricolage Grotesque
+- **Role**: Headlines and display text
+- **Weights**: Bold, Extra Bold
+- **Character**: Bold, chunky forms give headlines a strong, confident presence while remaining clear and legible
+
+### Secondary: Inter
+- **Role**: Body text, UI, functional text
+- **Weights**: Regular, Medium, Semi Bold, Bold
+- **Character**: Designed for on-screen readability, provides a clean, reliable foundation
+
+### Hierarchy Example
+- Headlines: Bricolage Grotesque, Extra Bold, 96pt
+- Subheadings: Inter, Semi Bold
+- Buttons / CTAs: Inter, Bold
+- Body text: Inter, Regular
+- Form labels: Inter, Medium
+
+### Typography Don'ts
+- Don't use all caps for headlines or paragraphs
+- Don't use typefaces other than Bricolage Grotesque and Inter
+- Don't make letter spacing too tight or too wide
+- Don't use loose line height
+- Never right-align text
+
+---
+
+## Icons
+
+### System: Phosphor Icons
+- Source: [phosphoricons.com](https://phosphoricons.com)
+- Style: Soft, rounded shapes that align with the logo and typography
+- Creates a cohesive and friendly interface language
+
+### Icon Rules
+- Maintain consistent proportions, style, and stroke width
+- Follow a baseline grid for consistency
+- Don't use a different icon style than specified
+- Don't use illustrations over iconography
+- Don't combine icons to build new ones
+- Don't rotate or distort icons
+- Don't use too-thin icons with low contrast
+- Don't use icons larger than 48px
+
+---
+
+## Illustrations
+
+### Two Styles
+1. **3D Icons**: Bold, dimensional objects
+2. **Cutout Imagery**: Photo-based cutouts with playful energy
+
+Both add playfulness and expression. They can be used independently depending on context and tone.
+
+### Illustration Don'ts
+- Don't use flat vector illustrations
+- Don't use illustrations with poor quality
+- Don't use overly complex illustrations -- focus on one thing
+- Don't use poorly isolated images
+- Don't use objects that could be offensive
+- Don't create illustration clusters -- use them separately
+
+---
+
+## Application Examples
+
+The visual identity extends to:
+- Merchandise (t-shirts, caps, etc.)
+- Stickers
+- Billboard advertising
+- Digital ads (mixed formats)
+- Website / landing pages
+- App Store presence


### PR DESCRIPTION
## Summary
- add the translated diVine brand guideline markdown set under `brand-guidelines/`
- include the full brand DNA, tone of voice, visual identity, and an agent quick reference
- document the source PDFs and intended audiences in the brand-guidelines README

## Validation
- docs-only change; no code checks required