### PR TITLE
perf(startup): reduce Funnelcake probe timeout to 3 seconds

### DIFF
--- a/mobile/lib/providers/curation_providers.dart
+++ b/mobile/lib/providers/curation_providers.dart
@@ -79,7 +79,11 @@ class FunnelcakeAvailable extends _$FunnelcakeAvailable {
       );
       // Use recent endpoint with limit=1 as lightweight probe
       // (trending endpoint may 500 on staging due to scoring query issues)
-      await analyticsService.getRecentVideos(limit: 1);
+      // Use a short 3s timeout so the probe doesn't block startup
+      await analyticsService.getRecentVideos(
+        limit: 1,
+        timeout: const Duration(seconds: 3),
+      );
       Log.info(
         '✅ Funnelcake: API available',
         name: 'FunnelcakeAvailable',

--- a/mobile/lib/providers/curation_providers.g.dart
+++ b/mobile/lib/providers/curation_providers.g.dart
@@ -161,7 +161,7 @@ final class FunnelcakeAvailableProvider
 }
 
 String _$funnelcakeAvailableHash() =>
-    r'de0cbcdee459c443ca81fa108287ba87362d1d16';
+    r'e65c2299450c146a4694943df9a9b1ce28faf30d';
 
 /// Single source of truth for Funnelcake REST API availability.
 ///

--- a/mobile/lib/services/analytics_api_service.dart
+++ b/mobile/lib/services/analytics_api_service.dart
@@ -297,6 +297,7 @@ class AnalyticsApiService {
     int limit = 50,
     int? before,
     bool forceRefresh = false,
+    Duration? timeout,
   }) async {
     if (!isAvailable) return [];
 
@@ -336,7 +337,7 @@ class AnalyticsApiService {
               'User-Agent': 'OpenVine-Mobile/1.0',
             },
           )
-          .timeout(const Duration(seconds: 15));
+          .timeout(timeout ?? const Duration(seconds: 15));
 
       if (response.statusCode == 200) {
         final List<dynamic> data = jsonDecode(response.body);

--- a/mobile/test/services/analytics_api_service_test.dart
+++ b/mobile/test/services/analytics_api_service_test.dart
@@ -671,6 +671,119 @@ void main() {
     });
   });
 
+  group('getRecentVideos', () {
+    test('returns videos from API', () async {
+      final mockResponse = jsonEncode([
+        {
+          'id': 'recent1',
+          'pubkey': 'pub1',
+          'created_at': 1767316187,
+          'kind': 34236,
+          'd_tag': 'dtag1',
+          'title': 'Recent Video',
+          'thumbnail': 'https://example.com/thumb.jpg',
+          'video_url': 'https://example.com/video.mp4',
+          'reactions': 5,
+          'comments': 1,
+          'reposts': 0,
+          'engagement_score': 7,
+        },
+      ]);
+
+      final mockClient = MockClient((request) async {
+        expect(request.url.path, '/api/videos');
+        expect(request.url.queryParameters['sort'], 'recent');
+        expect(request.url.queryParameters['limit'], '10');
+        return http.Response(mockResponse, 200);
+      });
+
+      final service = AnalyticsApiService(
+        baseUrl: 'https://funnelcake.test',
+        httpClient: mockClient,
+      );
+
+      final videos = await service.getRecentVideos(limit: 10);
+
+      expect(videos.length, 1);
+      expect(videos.first.id, 'recent1');
+      expect(videos.first.title, 'Recent Video');
+    });
+
+    test('returns empty list when not available', () async {
+      final service = AnalyticsApiService(baseUrl: null);
+      final videos = await service.getRecentVideos();
+      expect(videos, isEmpty);
+    });
+
+    test('uses custom timeout when provided', () async {
+      final mockClient = MockClient((request) async {
+        // Simulate a slow response that exceeds the custom timeout
+        await Future<void>.delayed(const Duration(seconds: 4));
+        return http.Response('[]', 200);
+      });
+
+      final service = AnalyticsApiService(
+        baseUrl: 'https://funnelcake.test',
+        httpClient: mockClient,
+      );
+
+      // With a 1-second timeout, the 4-second delay should cause a timeout
+      final videos = await service.getRecentVideos(
+        limit: 1,
+        timeout: const Duration(seconds: 1),
+      );
+
+      // Should return empty list due to timeout (caught internally)
+      expect(videos, isEmpty);
+    });
+
+    test('uses default 15s timeout when no timeout specified', () async {
+      final mockResponse = jsonEncode([
+        {
+          'id': 'vid1',
+          'pubkey': 'pub1',
+          'created_at': 1767316187,
+          'kind': 34236,
+          'd_tag': '',
+          'title': 'Video',
+          'thumbnail': '',
+          'video_url': 'https://example.com/video.mp4',
+          'reactions': 0,
+          'comments': 0,
+          'reposts': 0,
+          'engagement_score': 0,
+        },
+      ]);
+
+      final mockClient = MockClient((request) async {
+        return http.Response(mockResponse, 200);
+      });
+
+      final service = AnalyticsApiService(
+        baseUrl: 'https://funnelcake.test',
+        httpClient: mockClient,
+      );
+
+      // Should work fine with default timeout
+      final videos = await service.getRecentVideos(limit: 1);
+      expect(videos.length, 1);
+    });
+
+    test('handles API error response', () async {
+      final mockClient = MockClient((request) async {
+        return http.Response('Internal Server Error', 500);
+      });
+
+      final service = AnalyticsApiService(
+        baseUrl: 'https://funnelcake.test',
+        httpClient: mockClient,
+      );
+
+      final videos = await service.getRecentVideos();
+      expect(videos, isEmpty);
+    });
+  });
+
   group('getUserProfile', () {
     test('returns profile data when user has a Kind 0 profile', () async {
       final mockClient = MockClient((request) async {


### PR DESCRIPTION
## Summary
- Add an optional `timeout` parameter to `AnalyticsApiService.getRecentVideos()` (defaults to 15s for backward compatibility)
- Use a 3-second timeout for the Funnelcake availability probe in `FunnelcakeAvailable.build()` so startup isn't blocked by slow/unreachable servers
- Add tests covering the new timeout parameter (custom timeout, default timeout, error handling)

## Test plan
- [x] Existing `analytics_api_service_test.dart` tests continue to pass (39/39)
- [x] New tests verify custom timeout triggers graceful fallback
- [x] New tests verify default timeout still works when no override provided
- [x] `dart analyze` passes with no issues
- [x] Pre-commit hooks pass (format + analysis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)