### PR TITLE
fix(ci): disable macos signing in codemagic build

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -72,6 +72,11 @@ definitions:
     - &build_macos
       name: Build macOS app
       script: |
+        # This workflow packages a DMG for direct download. It does not provision
+        # a macOS signing identity/profile in Codemagic, so disable signing for
+        # the CI build and handle signing/notarization separately when needed.
+        export CODE_SIGNING_ALLOWED=NO
+        export CODE_SIGNING_REQUIRED=NO
         flutter build macos --release \
           --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
           --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \


### PR DESCRIPTION
## Summary
- disable macOS code signing during the Codemagic DMG build by exporting Xcode signing overrides in the workflow
- document in the workflow that signing and notarization remain separate from this CI artifact build

## Verification
- env CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO flutter build macos --release --dart-define=ZENDESK_APP_ID= --dart-define=ZENDESK_CLIENT_ID= --dart-define=ZENDESK_URL= --dart-define=DEFAULT_ENV=PRODUCTION --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT= --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN=
- hdiutil create -volname "Divine" -srcfolder build/macos/Build/Products/Release/Divine.app -ov -format UDZO build/macos/Build/Products/Release/Divine-macOS-test.dmg