### PR TITLE
fix: adjust padding in various screens to account for bottom view insets

### DIFF
--- a/mobile/lib/screens/auth/create_account_screen.dart
+++ b/mobile/lib/screens/auth/create_account_screen.dart
@@ -226,7 +226,12 @@ class _SkipConfirmationSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
-      padding: const EdgeInsets.fromLTRB(24, 24, 24, 32),
+      padding: .fromLTRB(
+        24,
+        24,
+        24,
+        32 + MediaQuery.viewPaddingOf(context).bottom,
+      ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/mobile/lib/screens/key_management_screen.dart
+++ b/mobile/lib/screens/key_management_screen.dart
@@ -50,7 +50,12 @@ class _KeyManagementScreenState extends ConsumerState<KeyManagementScreen> {
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 600),
           child: ListView(
-            padding: const EdgeInsets.all(16),
+            padding: .fromLTRB(
+              16,
+              16,
+              16,
+              16 + MediaQuery.viewPaddingOf(context).bottom,
+            ),
             children: [
               // What are Nostr keys explanation
               _buildExplanationCard(),

--- a/mobile/lib/screens/notification_settings_screen.dart
+++ b/mobile/lib/screens/notification_settings_screen.dart
@@ -73,7 +73,12 @@ class _NotificationSettingsScreenState
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 600),
         child: ListView(
-          padding: const EdgeInsets.all(16),
+          padding: .fromLTRB(
+            16,
+            16,
+            16,
+            16 + MediaQuery.viewPaddingOf(context).bottom,
+          ),
           children: [
             // Notification Types Section
             _buildSectionHeader('Notification Types'),

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -903,13 +903,16 @@ class _ProfileSetupScreenViewState
                                 ),
                               ),
                               const SizedBox(height: 8),
-                              _ProfileColorPicker(
-                                selectedColor: _selectedProfileColor,
-                                onColorChanged: (color) {
-                                  setState(() {
-                                    _selectedProfileColor = color;
-                                  });
-                                },
+                              Padding(
+                                padding: const .symmetric(horizontal: 16),
+                                child: _ProfileColorPicker(
+                                  selectedColor: _selectedProfileColor,
+                                  onColorChanged: (color) {
+                                    setState(() {
+                                      _selectedProfileColor = color;
+                                    });
+                                  },
+                                ),
                               ),
                             ],
                           ),

--- a/mobile/lib/screens/relay_diagnostic_screen.dart
+++ b/mobile/lib/screens/relay_diagnostic_screen.dart
@@ -571,7 +571,12 @@ class _RelayDiagnosticScreenState extends ConsumerState<RelayDiagnosticScreen> {
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 600),
           child: ListView(
-            padding: const EdgeInsets.all(16),
+            padding: .fromLTRB(
+              16,
+              16,
+              16,
+              16 + MediaQuery.viewPaddingOf(context).bottom,
+            ),
             children: [
               // Last refresh time
               if (_lastRefresh != null)


### PR DESCRIPTION
## Description

Fixes missing bottom safe area padding in multiple settings and setup screens, preventing UI elements from being obscured by system navigation bars on devices with gesture navigation or home indicators.

Note that we don't wrap it in a SafeArea instant we add it to the scroll widget. This allows us to maintain the modern look on newer Android devices by making the scrolling visible behind the system navigation bar.


| Example | Example |
| ------- | ----- |
|   ![page](https://github.com/user-attachments/assets/e83ef51e-2407-469d-8459-7816597ee4e5)       |     ![sheet](https://github.com/user-attachments/assets/76a4b115-10f2-4cb0-8284-d8387c3bc040)    |

**Related Issue:** Closes #2091

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore