### PR TITLE
fix: use locale-aware date formatting in notifications

### DIFF
--- a/mobile/lib/screens/notifications_screen.dart
+++ b/mobile/lib/screens/notifications_screen.dart
@@ -5,6 +5,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -395,7 +396,7 @@ class _NotificationTabContentState
       ];
       return weekdays[date.weekday - 1];
     } else {
-      return '${date.day}/${date.month}/${date.year}';
+      return DateFormat.yMd().format(date);
     }
   }
 

--- a/mobile/packages/models/lib/src/notification_model.dart
+++ b/mobile/packages/models/lib/src/notification_model.dart
@@ -3,6 +3,7 @@
 // ABOUTME: notifications.
 
 import 'package:equatable/equatable.dart';
+import 'package:intl/intl.dart';
 
 enum NotificationType { like, comment, follow, mention, repost, system }
 
@@ -125,7 +126,7 @@ class NotificationModel extends Equatable {
     } else if (difference.inDays < 7) {
       return '${difference.inDays}d ago';
     } else {
-      return '${timestamp.day}/${timestamp.month}/${timestamp.year}';
+      return DateFormat.yMd().format(timestamp);
     }
   }
 

--- a/mobile/packages/models/pubspec.yaml
+++ b/mobile/packages/models/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   equatable: ^2.0.7
+  intl: ^0.19.0
   json_annotation: ^4.9.0
   logging: ^1.2.0
   meta: ^1.17.0


### PR DESCRIPTION
## Summary
- Replace hardcoded `d/M/y` date formats with `DateFormat.yMd()` from the `intl` package in both notification timestamp locations
- Add `intl` as a dependency to the `models` package
- Dates now render correctly for the user's device locale (e.g., `3/9/2026` for US, `09/03/2026` for UK, `9.3.2026` for Germany)

Closes #1555

## Test plan
- [x] 338 model + notification tests pass
- [x] `dart analyze` clean on both changed files
- [x] Only affects dates older than 7 days (recent timestamps use relative format like "3h ago")

🤖 Generated with [Claude Code](https://claude.com/claude-code)