### PR TITLE
fix: show loading spinner instead of empty flash on search

### DIFF
--- a/mobile/lib/screens/pure/search_screen_pure.dart
+++ b/mobile/lib/screens/pure/search_screen_pure.dart
@@ -529,10 +529,10 @@ class _SearchFeedModeContent extends ConsumerWidget {
         pageContext.whenOrNull(data: (ctx) => ctx.videoIndex ?? 0) ?? 0;
 
     if (videos.isEmpty || startIndex >= videos.length) {
-      return const Center(
-        child: Text(
-          'No videos available',
-          style: TextStyle(color: VineTheme.whiteText),
+      return const ColoredBox(
+        color: VineTheme.backgroundColor,
+        child: Center(
+          child: CircularProgressIndicator(color: VineTheme.vineGreen),
         ),
       );
     }

--- a/mobile/test/screens/pure/search_screen_pure_test.dart
+++ b/mobile/test/screens/pure/search_screen_pure_test.dart
@@ -150,18 +150,18 @@ void main() {
         );
       }
 
-      testWidgets('shows "No videos available" when videoIndex is set but '
+      testWidgets('shows loading indicator when videoIndex is set but '
           'no videos', (tester) async {
         await tester.pumpWidget(createFeedModeWidget(videoIndex: 0));
-        await tester.pumpAndSettle();
+        await tester.pump();
 
-        expect(find.text('No videos available'), findsOneWidget);
-        expect(find.text('Videos (0)'), findsNothing);
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.text('No videos available'), findsNothing);
       });
 
       testWidgets('hides tabs when in feed mode', (tester) async {
         await tester.pumpWidget(createFeedModeWidget(videoIndex: 0));
-        await tester.pumpAndSettle();
+        await tester.pump();
 
         expect(find.byType(TabBar), findsNothing);
         expect(find.byType(TextField), findsNothing);


### PR DESCRIPTION
## Summary
- Replace "No videos available" text with a loading spinner in the search video feed view
- The empty text was flashing for one frame when navigating from search results to a video, because the provider briefly returns null before emitting data
- Update test to expect `CircularProgressIndicator` instead of the old text

Closes #1754

## Test plan
- [x] 8/8 search screen and search provider tests pass
- [x] `dart analyze` clean
- [x] Only affects the brief transition state — no change to actual empty search results behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)