### PR TITLE
fix(divine_ui): auto-grow multiline text fields

### DIFF
--- a/mobile/packages/divine_ui/lib/src/text_field/divine_text_field.dart
+++ b/mobile/packages/divine_ui/lib/src/text_field/divine_text_field.dart
@@ -134,6 +134,11 @@ class _DivineTextFieldState extends State<DivineTextField> {
 
   bool get _hasText => _controller.text.isNotEmpty;
   bool get _isFloating => _hasFocus || _hasText;
+  bool get _isMultiline {
+    final minLines = widget.minLines ?? 1;
+    final maxLines = widget.maxLines ?? 1;
+    return !widget.obscureText && (minLines > 1 || maxLines > 1);
+  }
 
   @override
   void initState() {
@@ -201,7 +206,10 @@ class _DivineTextFieldState extends State<DivineTextField> {
     final hasLabel = label != null && label.isNotEmpty;
 
     return Container(
-      height: _totalHeight,
+      height: _isMultiline ? null : _totalHeight,
+      constraints: _isMultiline
+          ? const BoxConstraints(minHeight: _totalHeight)
+          : null,
       decoration: BoxDecoration(
         color: VineTheme.surfaceContainer,
         borderRadius: BorderRadius.circular(24),
@@ -221,6 +229,7 @@ class _DivineTextFieldState extends State<DivineTextField> {
                   label: label,
                   hasLabel: hasLabel,
                   isFloating: _isFloating,
+                  isMultiline: _isMultiline,
                   child: _DivineTextFieldInput(
                     controller: _controller,
                     focusNode: _focusNode,
@@ -264,12 +273,14 @@ class _DivineTextFieldContent extends StatelessWidget {
     required this.label,
     required this.hasLabel,
     required this.isFloating,
+    required this.isMultiline,
     required this.child,
   });
 
   final String? label;
   final bool hasLabel;
   final bool isFloating;
+  final bool isMultiline;
   final Widget child;
 
   static const double _verticalPadding = 16;
@@ -296,6 +307,43 @@ class _DivineTextFieldContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final inputTop = hasLabel
+        ? (isFloating ? _inputTopFloating : _inputTopCentered)
+        : _verticalPadding;
+
+    if (isMultiline) {
+      return Stack(
+        clipBehavior: Clip.none,
+        children: [
+          if (hasLabel)
+            AnimatedPositioned(
+              duration: _animationDuration,
+              curve: Curves.easeOut,
+              top: isFloating ? _labelTopFloating : _labelTopCentered,
+              left: 0,
+              right: 0,
+              child: AnimatedDefaultTextStyle(
+                duration: _animationDuration,
+                curve: Curves.easeOut,
+                style: isFloating
+                    ? VineTheme.labelSmallFont(color: VineTheme.primary)
+                    : VineTheme.bodyLargeFont(color: VineTheme.onSurfaceMuted),
+                child: Text(label!),
+              ),
+            ),
+          AnimatedPadding(
+            duration: _animationDuration,
+            curve: Curves.easeOut,
+            padding: EdgeInsets.only(top: inputTop, bottom: _verticalPadding),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: _inputLineHeight),
+              child: child,
+            ),
+          ),
+        ],
+      );
+    }
+
     return Stack(
       clipBehavior: Clip.none,
       children: [
@@ -310,19 +358,15 @@ class _DivineTextFieldContent extends StatelessWidget {
               duration: _animationDuration,
               curve: Curves.easeOut,
               style: isFloating
-                  ? VineTheme.labelSmallFont(
-                      color: VineTheme.primary,
-                    )
-                  : VineTheme.bodyLargeFont(
-                      color: VineTheme.onSurfaceMuted,
-                    ),
+                  ? VineTheme.labelSmallFont(color: VineTheme.primary)
+                  : VineTheme.bodyLargeFont(color: VineTheme.onSurfaceMuted),
               child: Text(label!),
             ),
           ),
         AnimatedPositioned(
           duration: _animationDuration,
           curve: Curves.easeOut,
-          top: isFloating ? _inputTopFloating : _inputTopCentered,
+          top: inputTop,
           left: 0,
           right: 0,
           height: _inputLineHeight,

--- a/mobile/packages/divine_ui/test/src/text_field/divine_text_field_test.dart
+++ b/mobile/packages/divine_ui/test/src/text_field/divine_text_field_test.dart
@@ -13,6 +13,8 @@ void main() {
       bool enabled = true,
       TextInputType? keyboardType,
       TextInputAction? textInputAction,
+      int? minLines,
+      int? maxLines,
       ValueChanged<String>? onChanged,
       ValueChanged<String>? onSubmitted,
       VoidCallback? onTap,
@@ -29,6 +31,8 @@ void main() {
             enabled: enabled,
             keyboardType: keyboardType,
             textInputAction: textInputAction,
+            minLines: minLines,
+            maxLines: maxLines,
             onChanged: onChanged,
             onSubmitted: onSubmitted,
             onTap: onTap,
@@ -120,6 +124,30 @@ void main() {
         await tester.pump();
 
         expect(find.text('Test Label'), findsOneWidget);
+      });
+
+      testWidgets('grows vertically for multiline input', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            keyboardType: TextInputType.multiline,
+            textInputAction: TextInputAction.newline,
+            minLines: 1,
+            maxLines: 10,
+          ),
+        );
+
+        final initialHeight = tester.getSize(find.byType(DivineTextField));
+
+        await tester.enterText(
+          find.byType(TextField),
+          'Line 1\nLine 2\nLine 3',
+        );
+        await tester.pumpAndSettle();
+
+        final expandedHeight = tester.getSize(find.byType(DivineTextField));
+        expect(expandedHeight.height, greaterThan(initialHeight.height));
       });
     });
 


### PR DESCRIPTION
## Summary
- allow DivineTextField to expand vertically when configured for multiline input
- keep the existing fixed-height layout for single-line fields
- add a regression test proving multiline input increases field height

## Testing
- flutter test --no-pub test/src/text_field/divine_text_field_test.dart in mobile/packages/divine_ui
- flutter test --no-pub test/screens/video_metadata_screen_test.dart in mobile

## Context
- no direct open issue found for this specific bug
- open PR #1623 also touches the metadata flow, but this fix is isolated to the shared text field used by the description input
