### PR TITLE
fix(reports): comply with NIP-56 tag structure for content reports

### DIFF
--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -5,6 +5,7 @@ import 'dart:convert';
 
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/content_moderation_service.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
@@ -243,7 +244,9 @@ class ContentReportingService {
     List<String>? relatedEventIds,
   }) async {
     // Use first related event or create a user-focused report
-    final eventId = relatedEventIds?.first ?? 'user_$userPubkey';
+    final eventId = (relatedEventIds != null && relatedEventIds.isNotEmpty)
+        ? relatedEventIds.first
+        : 'user_$userPubkey';
 
     return reportContent(
       eventId: eventId,
@@ -352,12 +355,12 @@ class ContentReportingService {
         return null;
       }
 
-      // Build NIP-56 compliant tags (kind 1984)
+      // NIP-56 requires the report type as the 3rd element of the e/p tags.
+      final nip56Type = _toNip56ReportType(reason);
       final tags = <List<String>>[
-        ['e', eventId], // Event being reported
-        ['p', authorPubkey], // Author of reported content
-        ['report', reason.name], // Report reason as per NIP-56
-        ['client', 'diVine'], // Reporting client
+        ['e', eventId, nip56Type],
+        ['p', authorPubkey, nip56Type],
+        ['client', 'diVine'],
       ];
 
       // Add hashtags as 't' tags
@@ -379,7 +382,7 @@ class ContentReportingService {
 
       // Create and sign event via AuthService
       final signedEvent = await _authService.createAndSignEvent(
-        kind: 1984, // NIP-56 reporting event kind
+        kind: EventKind.report,
         content: reportContent,
         tags: tags,
       );
@@ -418,6 +421,23 @@ class ContentReportingService {
       );
       return null;
     }
+  }
+
+  /// Maps app-level [ContentFilterReason] to one of the NIP-56 standard
+  /// report type strings: nudity, malware, profanity, illegal, spam,
+  /// impersonation, other.
+  String _toNip56ReportType(ContentFilterReason reason) {
+    return switch (reason) {
+      ContentFilterReason.spam => 'spam',
+      ContentFilterReason.harassment => 'profanity',
+      ContentFilterReason.violence => 'illegal',
+      ContentFilterReason.sexualContent => 'nudity',
+      ContentFilterReason.copyright => 'illegal',
+      ContentFilterReason.falseInformation => 'other',
+      ContentFilterReason.csam => 'illegal',
+      ContentFilterReason.aiGenerated => 'other',
+      ContentFilterReason.other => 'other',
+    };
   }
 
   /// Format report content for NIP-56 compliance (kind 1984)

--- a/mobile/packages/nostr_sdk/lib/event_kind.dart
+++ b/mobile/packages/nostr_sdk/lib/event_kind.dart
@@ -41,6 +41,10 @@ class EventKind {
 
   static const int giftWrap = 1059;
 
+  static const int report = 1984;
+
+  static const int label = 1985;
+
   static const int fileHeader = 1063;
 
   static const int storageSharedFile = 1064;

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -6,6 +6,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/content_moderation_service.dart';
 import 'package:openvine/services/content_reporting_service.dart';
@@ -410,6 +411,211 @@ void main() {
         );
       },
     );
+  });
+
+  group('NIP-56 tag compliance', () {
+    late _MockNostrClient mockNostrService;
+    late _MockAuthService mockAuthService;
+    late ContentReportingService service;
+    late String testPublicKey;
+
+    setUp(() async {
+      final testPrivateKey = generatePrivateKey();
+      testPublicKey = getPublicKey(testPrivateKey);
+
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+
+      mockNostrService = _MockNostrClient();
+      mockAuthService = _MockAuthService();
+
+      when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPublicKey);
+      when(() => mockNostrService.isInitialized).thenReturn(true);
+
+      service = ContentReportingService(
+        nostrService: mockNostrService,
+        authService: mockAuthService,
+        prefs: prefs,
+      );
+      await service.initialize();
+    });
+
+    test('uses EventKind.report (1984) as kind', () async {
+      final reportEvent = Event(
+        testPublicKey,
+        EventKind.report,
+        [],
+        'test',
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
+      reportEvent.id = 'test_id';
+      reportEvent.sig = 'test_sig';
+
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((_) async => reportEvent);
+
+      when(
+        () => mockNostrService.publishEvent(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) async => reportEvent);
+
+      await service.reportContent(
+        eventId: 'evt_1',
+        authorPubkey: 'author_1',
+        reason: ContentFilterReason.spam,
+        details: 'test',
+      );
+
+      verify(
+        () => mockAuthService.createAndSignEvent(
+          kind: EventKind.report,
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).called(1);
+    });
+
+    test('places NIP-56 report type as 3rd element of e and p tags', () async {
+      List<List<String>>? capturedTags;
+
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((invocation) async {
+        capturedTags = invocation.namedArguments[#tags] as List<List<String>>?;
+        final event = Event(
+          testPublicKey,
+          EventKind.report,
+          capturedTags ?? [],
+          'test',
+          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        );
+        event.id = 'test_id';
+        event.sig = 'test_sig';
+        return event;
+      });
+
+      when(
+        () => mockNostrService.publishEvent(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer(
+        (_) async => Event(
+          testPublicKey,
+          EventKind.report,
+          [],
+          '',
+          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        ),
+      );
+
+      await service.reportContent(
+        eventId: 'evt_spam',
+        authorPubkey: 'author_spam',
+        reason: ContentFilterReason.spam,
+        details: 'Spam content',
+      );
+
+      expect(capturedTags, isNotNull);
+
+      // Find e and p tags
+      final eTag = capturedTags!.firstWhere((t) => t[0] == 'e');
+      final pTag = capturedTags!.firstWhere((t) => t[0] == 'p');
+
+      // NIP-56: report type is the 3rd element
+      expect(eTag, hasLength(3));
+      expect(eTag[1], equals('evt_spam'));
+      expect(eTag[2], equals('spam'));
+
+      expect(pTag, hasLength(3));
+      expect(pTag[1], equals('author_spam'));
+      expect(pTag[2], equals('spam'));
+
+      // No separate ['report', ...] tag should exist
+      final reportTags = capturedTags!.where((t) => t[0] == 'report');
+      expect(reportTags, isEmpty);
+    });
+
+    test('maps ContentFilterReason to NIP-56 standard types', () async {
+      final expectedMappings = {
+        ContentFilterReason.spam: 'spam',
+        ContentFilterReason.harassment: 'profanity',
+        ContentFilterReason.violence: 'illegal',
+        ContentFilterReason.sexualContent: 'nudity',
+        ContentFilterReason.copyright: 'illegal',
+        ContentFilterReason.falseInformation: 'other',
+        ContentFilterReason.csam: 'illegal',
+        ContentFilterReason.aiGenerated: 'other',
+        ContentFilterReason.other: 'other',
+      };
+
+      for (final entry in expectedMappings.entries) {
+        List<List<String>>? capturedTags;
+
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedTags =
+              invocation.namedArguments[#tags] as List<List<String>>?;
+          final event = Event(
+            testPublicKey,
+            EventKind.report,
+            capturedTags ?? [],
+            'test',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          );
+          event.id = 'id_${entry.key.name}';
+          event.sig = 'sig';
+          return event;
+        });
+
+        when(
+          () => mockNostrService.publishEvent(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => Event(
+            testPublicKey,
+            EventKind.report,
+            [],
+            '',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          ),
+        );
+
+        await service.reportContent(
+          eventId: 'evt_${entry.key.name}',
+          authorPubkey: 'author_${entry.key.name}',
+          reason: entry.key,
+          details: 'Test ${entry.key.name}',
+        );
+
+        final eTag = capturedTags!.firstWhere((t) => t[0] == 'e');
+        expect(
+          eTag[2],
+          equals(entry.value),
+          reason:
+              '${entry.key.name} should map to NIP-56 type "${entry.value}"',
+        );
+      }
+    });
   });
 
   group('ContentReportingService Provider Integration', () {


### PR DESCRIPTION
## Summary
- Place the report type as the 3rd element of `e`/`p` tags per NIP-56 spec instead of a separate `report` tag
- Add mapping from `ContentFilterReason` to NIP-56 standard type strings (`spam`, `profanity`, `nudity`, `illegal`, `other`)
- Use `EventKind.report` constant instead of hardcoded `1984`

Closes #467

**Part of [#570 Direct Messaging (NIP-17)](https://github.com/divinevideo/divine-mobile/issues/570) — Phase 1 (independent, no DM dependencies)**

## Files changed (3)
| File | Change |
|------|--------|
| `packages/nostr_sdk/lib/event_kind.dart` | Add `report = 1984`, `label = 1985` constants |
| `lib/services/content_reporting_service.dart` | NIP-56 tag structure fix + `_toNip56ReportType()` |
| `test/services/content_reporting_service_test.dart` | NIP-56 compliance tests (3 new tests) |

## Test plan
- [x] `flutter test test/services/content_reporting_service_test.dart` — 14 tests pass
- [x] `flutter analyze` — no issues
- [ ] Verify report events on relay show correct NIP-56 tag format