### PR TITLE
fix: secure account flow fails for anonymous users (#2092)

### DIFF
--- a/mobile/integration_test/auth/secure_account_test.dart
+++ b/mobile/integration_test/auth/secure_account_test.dart
@@ -1,0 +1,213 @@
+// ABOUTME: E2E test for the Secure Account flow (anonymous → registered)
+// ABOUTME: Verifies that an anonymous user can add email/password via the
+// ABOUTME: Secure Account screen. Exercises the exportNsec() → headlessRegister
+// ABOUTME: pipeline that has zero E2E coverage. Covers issue #2092.
+// ABOUTME: Requires: local Docker stack (mise run local_up)
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/main.dart' as app;
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/widgets/divine_primary_button.dart';
+import 'package:patrol/patrol.dart';
+
+import '../helpers/db_helpers.dart';
+import '../helpers/http_helpers.dart';
+import '../helpers/navigation_helpers.dart';
+import '../helpers/test_setup.dart';
+
+void main() {
+  group('Secure Account Flow', () {
+    final testEmail =
+        'secure-${DateTime.now().millisecondsSinceEpoch}@test.divine.video';
+    const testPassword = 'TestPass123!';
+
+    patrolTest(
+      'anonymous user can secure account with email and password',
+      ($) async {
+        final tester = $.tester;
+
+        // ── Setup ──
+        final originalOnError = suppressSetStateErrors();
+        final originalErrorBuilder = saveErrorWidgetBuilder();
+
+        launchAppGuarded(app.main);
+        await tester.pumpAndSettle(const Duration(seconds: 3));
+
+        // ════════════════════════════════════════════════════════════
+        // Phase 1: Create anonymous account (skip registration)
+        // ════════════════════════════════════════════════════════════
+
+        await navigateToCreateAccount(tester);
+
+        // Tap "Use Divine with no backup" to show confirmation sheet
+        final skipButton = find.text('Use Divine with no backup');
+        expect(skipButton, findsOneWidget);
+        await tester.tap(skipButton);
+        await tester.pumpAndSettle(const Duration(seconds: 1));
+
+        // Confirm with "Use this device only"
+        final confirmSkip = find.text('Use this device only');
+        expect(confirmSkip, findsOneWidget);
+        await tester.tap(confirmSkip);
+        await pumpUntilSettled(tester, maxSeconds: 10);
+
+        // Verify we're authenticated as anonymous
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(MaterialApp)),
+        );
+        final authService = container.read(authServiceProvider);
+
+        expect(authService.isAuthenticated, isTrue);
+        expect(
+          authService.isAnonymous,
+          isTrue,
+          reason: 'User should be anonymous after skipping registration',
+        );
+
+        logPhase('Phase 1 complete: anonymous account created');
+
+        // ════════════════════════════════════════════════════════════
+        // Phase 2: Navigate to profile and find Secure Account banner
+        // ════════════════════════════════════════════════════════════
+
+        await tapBottomNavTab(tester, 'profile_tab');
+        await pumpUntilSettled(tester);
+
+        final foundBanner = await waitForText(
+          tester,
+          'Secure Your Account',
+        );
+        expect(
+          foundBanner,
+          isTrue,
+          reason: 'Profile should show "Secure Your Account" banner',
+        );
+
+        // Tap "Register" button on the banner
+        final registerButton = find.widgetWithText(
+          ElevatedButton,
+          'Register',
+        );
+        expect(registerButton, findsOneWidget);
+        await tester.tap(registerButton);
+        await pumpUntilSettled(tester);
+
+        logPhase('Phase 2 complete: navigated to Secure Account screen');
+
+        // ════════════════════════════════════════════════════════════
+        // Phase 3: Fill and submit the secure account form
+        // ════════════════════════════════════════════════════════════
+
+        // Verify we're on the Secure Account screen
+        final foundTitle = await waitForText(tester, 'Secure account');
+        expect(
+          foundTitle,
+          isTrue,
+          reason: 'Should be on the Secure Account screen',
+        );
+
+        // Fill email and password
+        final textFields = find.byType(DivineAuthTextField);
+        expect(
+          textFields,
+          findsNWidgets(2),
+          reason: 'Secure account screen should show email and password fields',
+        );
+
+        await tester.enterText(textFields.at(0), testEmail);
+        await tester.pumpAndSettle();
+        await tester.enterText(textFields.at(1), testPassword);
+        await tester.pumpAndSettle();
+
+        // Dismiss keyboard
+        await tester.tapAt(const Offset(10, 100));
+        await tester.pumpAndSettle();
+
+        // Tap "Secure account" button
+        final submitButton = find.widgetWithText(
+          DivinePrimaryButton,
+          'Secure account',
+        );
+        expect(submitButton, findsOneWidget);
+        await tester.tap(submitButton);
+        await pumpUntilSettled(tester, maxSeconds: 10);
+
+        // ── Assert: no key access error (the #2092 bug) ──
+        final hasKeyError = find
+            .text('Unable to access your keys. Please try again.')
+            .evaluate()
+            .isNotEmpty;
+        expect(
+          hasKeyError,
+          isFalse,
+          reason:
+              'exportNsec() should not fail — this is the #2092 bug if it does',
+        );
+
+        logPhase('Phase 3 complete: form submitted, no key access error');
+
+        // ════════════════════════════════════════════════════════════
+        // Phase 4: Verify email via keycast API
+        // ════════════════════════════════════════════════════════════
+
+        // The secure account screen starts polling via
+        // EmailVerificationCubit. We verify the email by calling
+        // keycast's verify-email endpoint directly. The cubit's next
+        // poll cycle (every 3s) will detect verification and complete
+        // the OAuth exchange + sign-in automatically.
+        final verifyToken = await getVerificationToken(testEmail);
+        expect(verifyToken, isNotEmpty);
+
+        await callVerifyEmail(verifyToken);
+
+        // Wait for the polling cubit to detect verification, exchange
+        // tokens, and sign in. This can take up to ~10s (poll interval
+        // + exchange + sign-in).
+        var secured = false;
+        for (var i = 0; i < 30; i++) {
+          await tester.pump(const Duration(seconds: 1));
+          if (!authService.isAnonymous && authService.isAuthenticated) {
+            secured = true;
+            break;
+          }
+        }
+
+        logPhase(
+          'Phase 4 complete: email verified via API '
+          '(secured=$secured)',
+        );
+
+        // ════════════════════════════════════════════════════════════
+        // Phase 5: Assert account is now secured
+        // ════════════════════════════════════════════════════════════
+
+        expect(
+          authService.isAuthenticated,
+          isTrue,
+          reason: 'User should still be authenticated',
+        );
+        expect(
+          authService.isAnonymous,
+          isFalse,
+          reason: 'User should no longer be anonymous after securing account',
+        );
+        expect(
+          authService.isRegistered,
+          isTrue,
+          reason: 'User should be registered (divineOAuth) after securing',
+        );
+
+        logPhase('Phase 5 complete: account secured successfully');
+
+        // ── Cleanup ──
+        drainAsyncErrors(tester);
+        restoreErrorHandler(originalOnError);
+        restoreErrorWidgetBuilder(originalErrorBuilder);
+      },
+      timeout: const Timeout(Duration(minutes: 5)),
+    );
+  });
+}

--- a/mobile/lib/blocs/email_verification/email_verification_cubit.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_cubit.dart
@@ -169,10 +169,12 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
       return;
     }
 
-    // Guard: stop polling if user is already authenticated on this auth service.
-    if (_authService.isAuthenticated) {
+    // Guard: stop polling if user completed OAuth sign-in on this auth service.
+    // Use isRegistered (not isAuthenticated) because anonymous users are
+    // authenticated but still need polling to complete the secure-account flow.
+    if (_authService.isRegistered) {
       Log.info(
-        'Auth already authenticated, stopping orphaned poll '
+        'Auth already registered, stopping orphaned poll '
         '(cubit=$hashCode)',
         name: 'EmailVerificationCubit',
         category: LogCategory.auth,

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -2618,6 +2618,16 @@ class AuthService implements BackgroundAwareService {
         name: 'AuthService',
         category: LogCategory.auth,
       );
+
+      // Use the in-memory key container when available to avoid re-reading
+      // from platform storage. iOS keychain can fail transiently, causing
+      // "Unable to access your keys" errors even though the key is in RAM.
+      // Falls back to storage read if the container isn't loaded yet.
+      final container = _currentKeyContainer;
+      if (container != null && container.hasPrivateKey) {
+        return container.withNsec((nsec) => nsec);
+      }
+
       return await _keyStorage.exportNsec(biometricPrompt: biometricPrompt);
     } catch (e) {
       Log.error(

--- a/mobile/packages/nostr_key_manager/lib/src/secure_key_container.dart
+++ b/mobile/packages/nostr_key_manager/lib/src/secure_key_container.dart
@@ -167,6 +167,12 @@ class SecureKeyContainer {
     }
   }
 
+  /// Whether this container holds a private key.
+  ///
+  /// Returns `false` for public-key-only containers (e.g. OAuth flow where
+  /// keys are managed server-side).
+  bool get hasPrivateKey => _privateKeyBytes.isNotEmpty;
+
   /// Temporarily expose the nsec for backup operations
   ///
   /// CRITICAL: Use with extreme caution. Only for backup/export scenarios.


### PR DESCRIPTION
## Summary
Regression: anonymous users can't secure their account with email/password.
No test coverage for this flow — Maestro only checks the banner is visible,
widget tests mock the auth service entirely.

This PR builds on `feat/e2e-infrastructure` (#1928), which can test real
auth flows against a local backend. Merging #1928 unblocks these fixes on
main and strengthens regression coverage — @rabble [feedback](https://github.com/divinevideo/divine-mobile/pull/1928#issuecomment-4026729913)
has been addressed, waiting on your go-ahead so we can merge both.

## What was wrong

1. **Verification polling stopped immediately** — A guard to stop orphaned
   polls checks if the user is "already logged in." But anonymous users are
   already authenticated, so the poll quits on first tick. The account stays
   anonymous forever.

2. **Unnecessary key re-read from device storage (iOS)** — `exportNsec()`
   re-reads the key from iOS keychain even though it's already in memory.
   If the read fails for any reason (transient error, locked state, missing
   entry), the user sees "Unable to access your keys." Using the in-memory
   copy eliminates this failure point entirely.

## Changes
- Poll guard: `isAuthenticated` → `isRegistered`
- `exportNsec()`: use in-memory key, fall back to storage
- Add `hasPrivateKey` getter to `SecureKeyContainer`
- Add Patrol E2E test for the full anonymous → secure account flow

## Test plan
- [x] New E2E test passes (failed before fix)
- [x] All 6 auth E2E tests pass
- [x] Analyzer clean

Closes #2092