### PR TITLE
fix: local_up task fails when e2e-seed container exits

### DIFF
--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -3,7 +3,14 @@ flutter = "3.41.2-stable"
 
 [tasks.local_up]
 description = "Start all local E2E services"
-run = "docker compose -f ../local_stack/docker-compose.yml up -d --wait"
+run = """
+docker compose -f ../local_stack/docker-compose.yml up -d
+docker compose -f ../local_stack/docker-compose.yml up -d --wait \
+  keycast keycast-postgres keycast-redis \
+  funnelcake-relay funnelcake-api funnelcake-redis funnelcake-clickhouse \
+  blossom
+docker compose -f ../local_stack/docker-compose.yml wait e2e-seed
+"""
 
 [tasks.local_down]
 description = "Stop all local E2E services"


### PR DESCRIPTION
## Summary

- `mise run local_up` failed because `docker compose up -d --wait` treats the `e2e-seed` container's exit as a failure, even though it exits successfully after seeding
- Split into three steps: start all containers, wait only on long-running services to become healthy, then `docker compose wait e2e-seed` to block until seeding completes
- Seed script is already idempotent (checks relay for existing data before seeding), so this is safe on both fresh and warm stacks

## Test plan

- [x] `mise run local_up` succeeds on a running stack (seed skips, exits instantly)
- [x] `mise run e2e_test` passes all auth journey tests after the fix