### PR TITLE
fix(feed): restore 6.3s pooled fullscreen loop limit

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -20,9 +20,8 @@ part 'fullscreen_feed_state.dart';
 
 /// Maximum playback duration before looping back to start.
 ///
-/// TODO(product): Confirm with product - original Vine was 6.0s exactly.
-/// Current app uses 6.3s without clear documentation.
-const maxPlaybackDuration = Duration(seconds: 6);
+/// Keep aligned with provider-based playback loop enforcement (6.3s).
+const maxPlaybackDuration = Duration(milliseconds: 6300);
 
 /// Maximum number of concurrent background cache downloads.
 ///

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -771,6 +771,10 @@ void main() {
     });
 
     group('FullscreenFeedPositionUpdated', () {
+      test('uses a 6.3s loop limit', () {
+        expect(maxPlaybackDuration, const Duration(milliseconds: 6300));
+      });
+
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'emits SeekCommand when position exceeds max duration',
         build: createBloc,


### PR DESCRIPTION
## Summary
- restore pooled fullscreen feed loop-enforcement threshold to 6.3s (6300ms)
- keep this aligned with provider-based playback loop behavior
- add regression test to lock the fullscreen bloc limit at 6.3s

## Root cause
The fullscreen feed bloc had `maxPlaybackDuration` set to `Duration(seconds: 6)` while the rest of the app enforces 6.3s. This mismatch regressed pooled playback loop timing.

## Verification
- `flutter test test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart`
