### PR TITLE
fix(profile): verify NIP-05 before copying subdomain URL

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -627,7 +627,12 @@ class _UniqueIdentifier extends ConsumerWidget {
               padding: const EdgeInsets.only(left: 8),
               child: GestureDetector(
                 onTap: () {
-                  final profileUrl = buildProfileUrl(nip05, npub);
+                  // Only use NIP-05 subdomain when verification passed
+                  // to avoid linking to wrong profile (see divine-web#195)
+                  final verifiedNip05 = hasNip05 && !verificationFailed
+                      ? nip05
+                      : null;
+                  final profileUrl = buildProfileUrl(verifiedNip05, npub);
                   ClipboardUtils.copy(
                     context,
                     profileUrl,


### PR DESCRIPTION
## Summary
- Copy button on profile header now checks NIP-05 verification status before 
  generating a subdomain URL
- When verification fails, falls back to npub-based URL instead of trusting 
  the self-declared nip05 field in kind 0 metadata

Mobile counterpart of divinevideo/divine-web#195 (same bug on web, already deployed)

## Test plan
- [x] Existing profile header widget tests pass (22/22)
- [x] Full test suite passes (5684 tests)
- [x] Analyzer clean