### PR TITLE
fix: use local asset for README hero image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Divine
 
-<img src="https://devine.video/og.png" alt="Divine logo and screenshot"/>
+<img src="mobile/assets/icon/divine-web-thumbnail.png" alt="Divine logo and screenshot"/>
 
 ### Divine is a decentralized, short-form video sharing mobile application built on the Nostr protocol, inspired by the simplicity and creativity of Vine.
 


### PR DESCRIPTION
## Summary
- Replace broken external URL (`devine.video/og.png`) with the local asset `mobile/assets/icon/divine-web-thumbnail.png` for the README hero image

## Test plan
- [x] Verify image renders correctly on GitHub README

🤖 Generated with [Claude Code](https://claude.com/claude-code)