### PR TITLE
feat: add figma-designer skill for design-to-code workflow

### DIFF
--- a/.claude/skills/figma-designer/SKILL.md
+++ b/.claude/skills/figma-designer/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: figma-designer
 description: |
-  Analyze Figma designs and translate them into Flutter implementation guidance.
-  Wraps any design question with project-specific context about existing UI
-  components, theming, and conventions. Invoke with /figma-designer.
-author: Daniel Cadenas
+  Analyze Figma designs and translate them into Flutter code using existing
+  divine_ui components and VineTheme. Use when implementing UI from Figma
+  mockups or when checking if a component already exists before building new.
+  Invoke with /figma-designer.
+author: Claude Code
 version: 1.0.0
 user_invocable: true
+invocation_hint: /figma-designer
+arguments: |
+  Required: Figma URL or description of the design to implement
+  Example: /figma-designer https://www.figma.com/design/xxx
+  Example: /figma-designer implement the new profile header
 ---
 
 # Figma Designer
@@ -27,4 +33,9 @@ Before you implement the UI, check for existing UI components in the
 2. If Figma MCP tools are available, use them to inspect the design
 3. Check the `divine_ui` package for existing components that match the design
 4. Reference `VineTheme` for all colors, text styles, and spacing
-5. Provide implementation guidance or code that reuses existing components
+5. If an existing component matches, reuse it. If no match exists:
+   - For reusable components: create a new widget in `divine_ui`
+   - For feature-specific widgets: create a private widget in the feature folder
+   - Ask the user if scope is unclear
+6. For new screens, follow the Page/View pattern from the ui_theming rule
+7. Provide implementation guidance or code that reuses existing components


### PR DESCRIPTION
## Summary
- Adds a new `figma-designer` skill that wraps Figma design questions with project-specific context
- Ensures UI implementations reuse existing `divine_ui` components and `VineTheme` before creating new ones
- Follows Page/View pattern for new screens

## Test plan
- [ ] Verify `/figma-designer` invocation works in Claude Code
- [ ] Confirm skill correctly references divine_ui components and VineTheme