### PR TITLE
fix(feed): prevent playback resume when overlay is open during false home report

### DIFF
--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -325,6 +325,17 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
       final isHome = routeType == RouteType.home;
       if (isHome == _isOnHomeTab) return;
       _isOnHomeTab = isHome;
+
+      // Don't resume when GoRouter falsely reports "home" while a pushed
+      // overlay (e.g. video recorder) is still open. This happens because
+      // GoRouter's routeInformationProvider can emit the shell-route
+      // location when popping between pushed routes (recorder → editor →
+      // pop back to recorder). The overlay listener handles resume when
+      // the overlay actually closes.
+      if (isHome && ref.read(overlayVisibilityProvider).hasVisibleOverlay) {
+        return;
+      }
+
       controller?.setActive(active: isHome);
     });
 

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -361,5 +361,74 @@ void main() {
         );
       },
     );
+
+    testWidgets(
+      'does not resume when router reports home while page overlay is open',
+      (tester) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        final element = tester.element(find.byType(VideoFeedView));
+        final container = ProviderScope.containerOf(element);
+
+        // Start on home
+        locationController.add('/home/0');
+        await tester.pump();
+
+        // Simulate pushing to video recorder (overlay opens, location
+        // changes to /video-recorder)
+        container.read(overlayVisibilityProvider.notifier).setPageOpen(true);
+        locationController.add('/video-recorder');
+        await tester.pump();
+
+        clearInteractions(videoFeedController);
+
+        // GoRouter falsely reports home while recorder is still open
+        // (happens when popping from editor back to recorder)
+        locationController.add('/home/0');
+        await tester.pump();
+
+        // setActive(active: true) must NOT be called — the overlay is
+        // still open, so the overlay listener handles resume later.
+        verifyNever(
+          () => videoFeedController.setActive(active: true),
+        );
+      },
+    );
+
+    testWidgets(
+      'resumes playback when overlay closes after false home report',
+      (tester) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        final element = tester.element(find.byType(VideoFeedView));
+        final container = ProviderScope.containerOf(element);
+
+        // Start on home
+        locationController.add('/home/0');
+        await tester.pump();
+
+        // Open page overlay (e.g. video recorder)
+        container.read(overlayVisibilityProvider.notifier).setPageOpen(true);
+        locationController.add('/video-recorder');
+        await tester.pump();
+
+        // GoRouter falsely reports home
+        locationController.add('/home/0');
+        await tester.pump();
+
+        clearInteractions(videoFeedController);
+
+        // Recorder actually closes — overlay cleared
+        container.read(overlayVisibilityProvider.notifier).setPageOpen(false);
+        await tester.pump();
+
+        // Now the overlay listener should resume playback
+        verify(
+          () => videoFeedController.setActive(active: true),
+        ).called(1);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description

Prevent home feed video playback from resuming while a pushed overlay (e.g. video recorder) is still open. GoRouter's route listener can falsely report the home location when popping between pushed routes (recorder → editor → pop back), causing feed audio to bleed into the recording flow. The fix adds a guard that checks `overlayVisibilityProvider` before calling `setActive`, deferring resume to the existing overlay-close listener.


**Related Issue:** Closes #2137

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore