### PR TITLE
fix(video): reduce blur by adjusting filterQuality for video playback

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -691,11 +691,13 @@ class _FittedVideoPlayer extends StatelessWidget {
   Widget build(BuildContext context) {
     final boxFit = isPortrait ? BoxFit.cover : BoxFit.contain;
 
+    // Do not set filterQuality to high — on Android the bicubic
+    // interpolation causes visible blur on the Texture widget when
+    // the video resolution doesn't match the display size exactly.
     return Video(
       controller: videoController,
       fit: boxFit,
       alignment: alignment,
-      filterQuality: FilterQuality.high,
       controls: null,
     );
   }

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -728,11 +728,13 @@ class _FittedVideoPlayer extends StatelessWidget {
     // Portrait: fill screen (cover), Landscape: fit entirely (contain)
     final boxFit = isPortrait ? BoxFit.cover : BoxFit.contain;
 
+    // Do not set filterQuality to high — on Android the bicubic
+    // interpolation causes visible blur on the Texture widget when
+    // the video resolution doesn't match the display size exactly.
     return Video(
       controller: videoController,
       fit: boxFit,
       alignment: alignment,
-      filterQuality: FilterQuality.high,
       controls: null,
     );
   }


### PR DESCRIPTION
## Description

Remove explicit `FilterQuality.high` from the `Video` widget in both feed screens. On Android, the bicubic interpolation applied by `FilterQuality.high` on the `Texture` widget causes visible blur when the video resolution doesn't exactly match the display size — which is nearly always the case with `BoxFit.cover`. Reverts to the library default (`FilterQuality.low`).


| Before | After |
|------|------|
| <video src="https://github.com/user-attachments/assets/cbb69d27-37d8-4a56-b664-db418e994036" controls width="250"></video> | <video src="https://github.com/user-attachments/assets/6389a5c0-23c3-4a07-94ed-086d1dc31e7b" controls width="250"></video> |



**Related Issue:** Closes #2146


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore