### PR TITLE
chore(divine_ui): remove leftover time_formatter dependency

### DIFF
--- a/mobile/packages/divine_ui/lib/divine_ui.dart
+++ b/mobile/packages/divine_ui/lib/divine_ui.dart
@@ -1,5 +1,3 @@
-export 'package:time_formatter/time_formatter.dart';
-
 export 'src/app_bar/app_bar.dart';
 export 'src/bottom_sheet/bottom_sheet.dart';
 export 'src/button/button.dart';

--- a/mobile/packages/divine_ui/pubspec.yaml
+++ b/mobile/packages/divine_ui/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
   flutter_svg: ^2.0.10+1
   google_fonts: ^6.3.2
   intl: ^0.19.0
-  time_formatter:
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Remove `time_formatter` dependency from `divine_ui/pubspec.yaml`
- Remove re-export from `divine_ui/lib/divine_ui.dart`

`time_formatter` was extracted into its own standalone package in #2118 but the dependency and barrel re-export in `divine_ui` were not cleaned up.

Addresses review comments from @hm21 on #2118.