### PR TITLE
fix(profile): use single isOwnProfile flag for followers stat

### DIFF
--- a/mobile/lib/widgets/profile/profile_followers_stat.dart
+++ b/mobile/lib/widgets/profile/profile_followers_stat.dart
@@ -17,6 +17,7 @@ class ProfileFollowersStat extends ConsumerWidget {
   const ProfileFollowersStat({
     required this.pubkey,
     required this.displayName,
+    required this.isOwnProfile,
     super.key,
   });
 
@@ -26,14 +27,15 @@ class ProfileFollowersStat extends ConsumerWidget {
   /// The display name of the user for the followers screen title.
   final String? displayName;
 
+  /// Whether this is the current user's own profile.
+  final bool isOwnProfile;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final followRepository = ref.watch(followRepositoryProvider);
-    final nostrClient = ref.watch(nostrServiceProvider);
     final blocklistService = ref.watch(contentBlocklistServiceProvider);
-    final isCurrentUser = pubkey == nostrClient.publicKey;
 
-    if (isCurrentUser) {
+    if (isOwnProfile) {
       return BlocProvider(
         create: (_) => MyFollowersBloc(
           followRepository: followRepository,
@@ -59,9 +61,7 @@ class _MyFollowersStatView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.listen(blocklistVersionProvider, (_, _) {
-      context.read<MyFollowersBloc>().add(
-        const MyFollowersBlocklistChanged(),
-      );
+      context.read<MyFollowersBloc>().add(const MyFollowersBlocklistChanged());
     });
 
     return BlocBuilder<MyFollowersBloc, MyFollowersState>(

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -162,6 +162,7 @@ class ProfileHeaderWidget extends ConsumerWidget {
                             child: ProfileFollowersStat(
                               pubkey: userIdHex,
                               displayName: displayName,
+                              isOwnProfile: isOwnProfile,
                             ),
                           ),
                           Flexible(

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -14,6 +14,7 @@ import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/blocs/email_verification/email_verification_cubit.dart';
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
+import 'package:openvine/blocs/others_followers/others_followers_bloc.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/repositories/follow_repository.dart';
@@ -26,6 +27,10 @@ import '../../helpers/test_provider_overrides.dart';
 
 class _MockMyProfileBloc extends MockBloc<MyProfileEvent, MyProfileState>
     implements MyProfileBloc {}
+
+class _MockOthersFollowersBloc
+    extends MockBloc<OthersFollowersEvent, OthersFollowersState>
+    implements OthersFollowersBloc {}
 
 // Mock for KeycastOAuth used by EmailVerificationCubit
 class MockKeycastOAuth extends Mock implements KeycastOAuth {}
@@ -49,6 +54,9 @@ class MockFollowRepository extends Mock implements FollowRepository {
 
   @override
   Future<List<String>> getFollowers(String pubkey) async => [];
+
+  @override
+  bool isFollowing(String pubkey) => false;
 }
 
 class MockNostrClient extends Mock implements NostrClient {
@@ -169,6 +177,15 @@ void main() {
         }
         header = BlocProvider<MyProfileBloc>.value(
           value: mockMyProfileBloc,
+          child: header,
+        );
+      } else {
+        final mockOthersFollowersBloc = _MockOthersFollowersBloc();
+        when(
+          () => mockOthersFollowersBloc.state,
+        ).thenReturn(const OthersFollowersState());
+        header = BlocProvider<OthersFollowersBloc>.value(
+          value: mockOthersFollowersBloc,
           child: header,
         );
       }


### PR DESCRIPTION
## Description

Fix "Oops" error on own profile's followers count caused by two independent "is own profile?" checks (`authService.currentPublicKeyHex` vs `nostrServiceProvider.publicKey`) disagreeing during startup. Replaces the independent check in `ProfileFollowersStat` with an `isOwnProfile` flag passed from the parent `ProfileHeaderWidget`, ensuring a single source of truth.

**Related Issue:** Closes #1695

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore