### PR TITLE
fix: display authoritative follower count instead of relay-capped list length

### DIFF
--- a/mobile/lib/screens/followers/my_followers_screen.dart
+++ b/mobile/lib/screens/followers/my_followers_screen.dart
@@ -58,9 +58,7 @@ class _MyFollowersView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.listen(blocklistVersionProvider, (_, _) {
-      context.read<MyFollowersBloc>().add(
-        const MyFollowersBlocklistChanged(),
-      );
+      context.read<MyFollowersBloc>().add(const MyFollowersBlocklistChanged());
     });
 
     final appBarTitle = displayName?.isNotEmpty == true
@@ -73,7 +71,7 @@ class _MyFollowersView extends ConsumerWidget {
         titleWidget: FollowerCountTitle<MyFollowersBloc, MyFollowersState>(
           title: appBarTitle,
           selector: (state) => state.status == MyFollowersStatus.success
-              ? state.followersPubkeys.length
+              ? state.followerCount
               : 0,
         ),
         showBackButton: true,

--- a/mobile/lib/screens/followers/others_followers_screen.dart
+++ b/mobile/lib/screens/followers/others_followers_screen.dart
@@ -82,7 +82,7 @@ class _OthersFollowersView extends ConsumerWidget {
             FollowerCountTitle<OthersFollowersBloc, OthersFollowersState>(
               title: appBarTitle,
               selector: (state) => state.status == OthersFollowersStatus.success
-                  ? state.followersPubkeys.length
+                  ? state.followerCount
                   : 0,
             ),
         showBackButton: true,

--- a/mobile/lib/widgets/profile/profile_followers_stat.dart
+++ b/mobile/lib/widgets/profile/profile_followers_stat.dart
@@ -59,9 +59,7 @@ class _MyFollowersStatView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     ref.listen(blocklistVersionProvider, (_, _) {
-      context.read<MyFollowersBloc>().add(
-        const MyFollowersBlocklistChanged(),
-      );
+      context.read<MyFollowersBloc>().add(const MyFollowersBlocklistChanged());
     });
 
     return BlocBuilder<MyFollowersBloc, MyFollowersState>(
@@ -71,7 +69,7 @@ class _MyFollowersStatView extends ConsumerWidget {
             state.status == MyFollowersStatus.loading;
 
         return ProfileStatColumn(
-          count: isLoading ? null : state.followersPubkeys.length,
+          count: isLoading ? null : state.followerCount,
           label: 'Followers',
           isLoading: isLoading,
           onTap: () => context.push(
@@ -102,27 +100,14 @@ class _OthersFollowersStatView extends ConsumerWidget {
       );
     });
 
-    final currentUserPubkey = ref.watch(nostrServiceProvider).publicKey;
-    final followRepository = ref.watch(followRepositoryProvider);
-    // Hide ourselves from the target's followers if we're not actually
-    // following them (e.g. follow severed by block→unblock flow).
-    final isFollowingTarget = followRepository.isFollowing(pubkey);
-
     return BlocBuilder<OthersFollowersBloc, OthersFollowersState>(
       builder: (context, state) {
         final isLoading =
             state.status == OthersFollowersStatus.initial ||
             state.status == OthersFollowersStatus.loading;
-        final filteredCount = isLoading
-            ? null
-            : state.followersPubkeys
-                  .where(
-                    (pk) => !(pk == currentUserPubkey && !isFollowingTarget),
-                  )
-                  .length;
 
         return ProfileStatColumn(
-          count: filteredCount,
+          count: isLoading ? null : state.followerCount,
           label: 'Followers',
           isLoading: isLoading,
           onTap: () => context.push(


### PR DESCRIPTION
## Description

Display the authoritative `followerCount` (which uses `max(list.length, countFromService)`) instead of `followersPubkeys.length` in the profile header and followers screen app bars. The BLoCs already computed the correct count via COUNT queries to indexer relays, but the UI was reading the pubkey list length which is capped by relay result limits — causing missmatch on the count.

Relates to #1835 
## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore