### PR TITLE
perf: in-memory cache my followers data for instant profile loads

### DIFF
--- a/mobile/lib/blocs/my_followers/my_followers_bloc.dart
+++ b/mobile/lib/blocs/my_followers/my_followers_bloc.dart
@@ -1,8 +1,6 @@
 // ABOUTME: BLoC for displaying current user's followers list
 // ABOUTME: Fetches Kind 3 events that mention current user in 'p' tags
 
-import 'dart:math';
-
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/repositories/follow_repository.dart';
@@ -44,36 +42,34 @@ class MyFollowersBloc extends Bloc<MyFollowersEvent, MyFollowersState> {
       )
       .toList();
 
-  /// Handle request to load current user's followers list
+  /// Handle request to load current user's followers list.
+  ///
+  /// Listens to [FollowRepository.watchMyFollowers] which progressively
+  /// yields cached data (instant) then fresh data from relays.
   Future<void> _onLoadRequested(
     MyFollowersListLoadRequested event,
     Emitter<MyFollowersState> emit,
   ) async {
-    emit(
-      state.copyWith(status: MyFollowersStatus.loading, followersPubkeys: []),
-    );
-
-    try {
-      // Fetch the follower list and accurate count in parallel.
-      // The list is limited by relay result caps, so the count
-      // (from COUNT queries) is more accurate for display.
-      final results = await Future.wait([
-        _followRepository.getMyFollowers(),
-        _followRepository.getMyFollowerCount(),
-      ]);
-      final followers = results[0] as List<String>;
-      final countFromService = results[1] as int;
-      final followerCount = max(followers.length, countFromService);
-
-      _rawFollowersPubkeys = followers;
-      final filtered = _filterPubkeys(followers);
-
+    if (state.status != MyFollowersStatus.success) {
       emit(
         state.copyWith(
-          status: MyFollowersStatus.success,
-          followersPubkeys: filtered,
-          followerCount: followerCount,
+          status: MyFollowersStatus.loading,
+          followersPubkeys: [],
         ),
+      );
+    }
+
+    try {
+      await emit.forEach<({List<String> pubkeys, int count})>(
+        _followRepository.watchMyFollowers(),
+        onData: (result) {
+          _rawFollowersPubkeys = result.pubkeys;
+          return state.copyWith(
+            status: MyFollowersStatus.success,
+            followersPubkeys: _filterPubkeys(result.pubkeys),
+            followerCount: result.count,
+          );
+        },
       );
     } catch (e) {
       Log.error(
@@ -81,7 +77,9 @@ class MyFollowersBloc extends Bloc<MyFollowersEvent, MyFollowersState> {
         name: 'MyFollowersBloc',
         category: LogCategory.system,
       );
-      emit(state.copyWith(status: MyFollowersStatus.failure));
+      if (state.status != MyFollowersStatus.success) {
+        emit(state.copyWith(status: MyFollowersStatus.failure));
+      }
     }
   }
 

--- a/mobile/lib/repositories/follow_repository.dart
+++ b/mobile/lib/repositories/follow_repository.dart
@@ -10,6 +10,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:models/models.dart';
@@ -103,10 +104,15 @@ class FollowRepository {
   final _followingSubject = BehaviorSubject<List<String>>.seeded(const []);
   Stream<List<String>> get followingStream => _followingSubject.stream;
 
-  // In-memory cache
+  // In-memory cache — following
   List<String> _followingPubkeys = [];
   Event? _currentUserContactListEvent;
   bool _isInitialized = false;
+
+  // In-memory cache — my followers (populated after first fetch)
+  List<String> _cachedMyFollowersPubkeys = [];
+  int _cachedMyFollowerCount = 0;
+  bool _hasMyFollowersCache = false;
 
   // Real-time sync subscription for cross-device synchronization
   StreamSubscription<Event>? _contactListSubscription;
@@ -161,7 +167,10 @@ class FollowRepository {
   ///
   /// Returns a list of unique pubkeys of users who follow the current user.
   Future<List<String>> getMyFollowers() async {
-    return _fetchFollowers(_nostrClient.publicKey);
+    final result = await _fetchFollowers(_nostrClient.publicKey);
+    _cachedMyFollowersPubkeys = result;
+    _hasMyFollowersCache = true;
+    return result;
   }
 
   /// Get the list of followers for another user.
@@ -180,7 +189,42 @@ class FollowRepository {
   /// which uses COUNT queries to indexer relays for accurate results.
   /// Returns 0 if no callback is configured.
   Future<int> getMyFollowerCount() async {
-    return getFollowerCount(_nostrClient.publicKey);
+    final count = await getFollowerCount(_nostrClient.publicKey);
+    _cachedMyFollowerCount = count;
+    return count;
+  }
+
+  /// Progressively streams the current user's followers.
+  ///
+  /// Yields cached data immediately when available (from a previous fetch),
+  /// then fetches fresh data from all sources and yields the updated result.
+  /// Each emission contains the full follower list and an accurate count.
+  ///
+  /// Follows the same progressive-yield pattern as
+  /// `VideosRepository.searchVideos`.
+  Stream<({List<String> pubkeys, int count})> watchMyFollowers() async* {
+    // Phase 1: Yield cached data immediately (if available)
+    if (_hasMyFollowersCache) {
+      yield (
+        pubkeys: List<String>.unmodifiable(_cachedMyFollowersPubkeys),
+        count: _cachedMyFollowerCount,
+      );
+    }
+
+    // Phase 2: Fetch fresh data from all sources in parallel
+    final results = await Future.wait([
+      getMyFollowers(),
+      getMyFollowerCount(),
+    ]);
+    final pubkeys = results[0] as List<String>;
+    final countFromService = results[1] as int;
+    final count = max(pubkeys.length, countFromService);
+
+    // Cache is updated by getMyFollowers/getMyFollowerCount; store the
+    // merged count so the next watchMyFollowers call yields it.
+    _cachedMyFollowerCount = count;
+
+    yield (pubkeys: pubkeys, count: count);
   }
 
   /// Get an accurate follower count for any user.

--- a/mobile/test/blocs/my_followers/my_followers_bloc_test.dart
+++ b/mobile/test/blocs/my_followers/my_followers_bloc_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for MyFollowersBloc - current user's followers list
-// ABOUTME: Tests loading from repository and follow-back operations
+// ABOUTME: Tests loading from repository stream and blocklist filtering
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -14,7 +14,7 @@ class _MockContentBlocklistService extends Mock
     implements ContentBlocklistService {}
 
 void main() {
-  group('MyFollowersBloc', () {
+  group(MyFollowersBloc, () {
     late _MockFollowRepository mockFollowRepository;
     late _MockContentBlocklistService mockBlocklistService;
 
@@ -50,14 +50,19 @@ void main() {
 
     group('MyFollowersListLoadRequested', () {
       blocTest<MyFollowersBloc, MyFollowersState>(
-        'emits [loading, success] with followers from repository',
+        'emits [loading, success] when no cache exists',
         setUp: () {
-          when(() => mockFollowRepository.getMyFollowers()).thenAnswer(
-            (_) async => [validPubkey('follower1'), validPubkey('follower2')],
+          when(() => mockFollowRepository.watchMyFollowers()).thenAnswer(
+            (_) => Stream.value(
+              (
+                pubkeys: [
+                  validPubkey('follower1'),
+                  validPubkey('follower2'),
+                ],
+                count: 2,
+              ),
+            ),
           );
-          when(
-            () => mockFollowRepository.getMyFollowerCount(),
-          ).thenAnswer((_) async => 2);
         },
         build: createBloc,
         act: (bloc) => bloc.add(const MyFollowersListLoadRequested()),
@@ -75,14 +80,49 @@ void main() {
       );
 
       blocTest<MyFollowersBloc, MyFollowersState>(
+        'emits [loading, cached, fresh] when cache yields then fresh data',
+        setUp: () {
+          when(() => mockFollowRepository.watchMyFollowers()).thenAnswer(
+            (_) => Stream.fromIterable([
+              (pubkeys: [validPubkey('old')], count: 1),
+              (
+                pubkeys: [
+                  validPubkey('follower1'),
+                  validPubkey('follower2'),
+                ],
+                count: 2,
+              ),
+            ]),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const MyFollowersListLoadRequested()),
+        expect: () => [
+          const MyFollowersState(status: MyFollowersStatus.loading),
+          MyFollowersState(
+            status: MyFollowersStatus.success,
+            followersPubkeys: [validPubkey('old')],
+            followerCount: 1,
+          ),
+          MyFollowersState(
+            status: MyFollowersStatus.success,
+            followersPubkeys: [
+              validPubkey('follower1'),
+              validPubkey('follower2'),
+            ],
+            followerCount: 2,
+          ),
+        ],
+      );
+
+      blocTest<MyFollowersBloc, MyFollowersState>(
         'uses higher count from service when list is incomplete',
         setUp: () {
-          when(
-            () => mockFollowRepository.getMyFollowers(),
-          ).thenAnswer((_) async => [validPubkey('follower1')]);
-          when(
-            () => mockFollowRepository.getMyFollowerCount(),
-          ).thenAnswer((_) async => 500);
+          when(() => mockFollowRepository.watchMyFollowers()).thenAnswer(
+            (_) => Stream.value(
+              (pubkeys: [validPubkey('follower1')], count: 500),
+            ),
+          );
         },
         build: createBloc,
         act: (bloc) => bloc.add(const MyFollowersListLoadRequested()),
@@ -99,12 +139,9 @@ void main() {
       blocTest<MyFollowersBloc, MyFollowersState>(
         'emits [loading, success] with empty list when no followers',
         setUp: () {
-          when(
-            () => mockFollowRepository.getMyFollowers(),
-          ).thenAnswer((_) async => []);
-          when(
-            () => mockFollowRepository.getMyFollowerCount(),
-          ).thenAnswer((_) async => 0);
+          when(() => mockFollowRepository.watchMyFollowers()).thenAnswer(
+            (_) => Stream.value((pubkeys: <String>[], count: 0)),
+          );
         },
         build: createBloc,
         act: (bloc) => bloc.add(const MyFollowersListLoadRequested()),
@@ -115,14 +152,11 @@ void main() {
       );
 
       blocTest<MyFollowersBloc, MyFollowersState>(
-        'emits [loading, failure] when repository throws',
+        'emits [loading, failure] when stream throws and no data',
         setUp: () {
-          when(
-            () => mockFollowRepository.getMyFollowers(),
-          ).thenThrow(Exception('Network error'));
-          when(
-            () => mockFollowRepository.getMyFollowerCount(),
-          ).thenAnswer((_) async => 0);
+          when(() => mockFollowRepository.watchMyFollowers()).thenAnswer(
+            (_) => Stream.error(Exception('Network error')),
+          );
         },
         build: createBloc,
         act: (bloc) => bloc.add(const MyFollowersListLoadRequested()),
@@ -131,10 +165,97 @@ void main() {
           const MyFollowersState(status: MyFollowersStatus.failure),
         ],
       );
+
+      blocTest<MyFollowersBloc, MyFollowersState>(
+        'keeps cached data when stream errors after first yield',
+        setUp: () {
+          when(() => mockFollowRepository.watchMyFollowers()).thenAnswer(
+            (_) async* {
+              yield (pubkeys: [validPubkey('cached')], count: 1);
+              throw Exception('Network error');
+            },
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const MyFollowersListLoadRequested()),
+        expect: () => [
+          const MyFollowersState(status: MyFollowersStatus.loading),
+          MyFollowersState(
+            status: MyFollowersStatus.success,
+            followersPubkeys: [validPubkey('cached')],
+            followerCount: 1,
+          ),
+        ],
+      );
+
+      blocTest<MyFollowersBloc, MyFollowersState>(
+        'filters blocked users from stream results',
+        setUp: () {
+          final blocked = validPubkey('blocked');
+          when(() => mockBlocklistService.isBlocked(blocked)).thenReturn(true);
+
+          when(() => mockFollowRepository.watchMyFollowers()).thenAnswer(
+            (_) => Stream.value(
+              (pubkeys: [blocked, validPubkey('ok')], count: 2),
+            ),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const MyFollowersListLoadRequested()),
+        expect: () => [
+          const MyFollowersState(status: MyFollowersStatus.loading),
+          MyFollowersState(
+            status: MyFollowersStatus.success,
+            followersPubkeys: [validPubkey('ok')],
+            followerCount: 2,
+          ),
+        ],
+      );
+    });
+
+    group('MyFollowersBlocklistChanged', () {
+      blocTest<MyFollowersBloc, MyFollowersState>(
+        're-filters followers when blocklist changes',
+        setUp: () {
+          when(() => mockFollowRepository.watchMyFollowers()).thenAnswer(
+            (_) => Stream.value(
+              (
+                pubkeys: [validPubkey('a'), validPubkey('b')],
+                count: 2,
+              ),
+            ),
+          );
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const MyFollowersListLoadRequested());
+          await Future<void>.delayed(Duration.zero);
+          // Now block user 'a'
+          when(
+            () => mockBlocklistService.isBlocked(validPubkey('a')),
+          ).thenReturn(true);
+          bloc.add(const MyFollowersBlocklistChanged());
+        },
+        skip: 2, // skip loading + initial success
+        expect: () => [
+          MyFollowersState(
+            status: MyFollowersStatus.success,
+            followersPubkeys: [validPubkey('b')],
+            followerCount: 2,
+          ),
+        ],
+      );
+
+      blocTest<MyFollowersBloc, MyFollowersState>(
+        'does nothing when not in success state',
+        build: createBloc,
+        act: (bloc) => bloc.add(const MyFollowersBlocklistChanged()),
+        expect: () => <MyFollowersState>[],
+      );
     });
   });
 
-  group('MyFollowersState', () {
+  group(MyFollowersState, () {
     test('supports value equality', () {
       const state1 = MyFollowersState(
         status: MyFollowersStatus.success,

--- a/mobile/test/repositories/follow_repository_test.dart
+++ b/mobile/test/repositories/follow_repository_test.dart
@@ -862,6 +862,87 @@ void main() {
       });
     });
 
+    group('watchMyFollowers', () {
+      const follower1 =
+          'e5f6789012345678901234567890abcdef1234567890123456789012abcd1234';
+      const follower2 =
+          'f6789012345678901234567890abcdef1234567890123456789012abcde12345';
+
+      test('yields only fresh data on first call (no cache)', () async {
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+          (_) async => [
+            Event(
+              follower1,
+              3,
+              [
+                ['p', testCurrentUserPubkey],
+              ],
+              '',
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            ),
+          ],
+        );
+
+        final emissions = await repository.watchMyFollowers().toList();
+
+        expect(emissions, hasLength(1));
+        expect(emissions.first.pubkeys, contains(follower1));
+      });
+
+      test('yields cached data then fresh data on second call', () async {
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+          (_) async => [
+            Event(
+              follower1,
+              3,
+              [
+                ['p', testCurrentUserPubkey],
+              ],
+              '',
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            ),
+          ],
+        );
+
+        // First call — populates cache
+        await repository.watchMyFollowers().toList();
+
+        // Second call — should now yield cache first, then fresh
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+          (_) async => [
+            Event(
+              follower1,
+              3,
+              [
+                ['p', testCurrentUserPubkey],
+              ],
+              '',
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            ),
+            Event(
+              follower2,
+              3,
+              [
+                ['p', testCurrentUserPubkey],
+              ],
+              '',
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            ),
+          ],
+        );
+
+        final emissions = await repository.watchMyFollowers().toList();
+
+        expect(emissions, hasLength(2));
+        // First emission: cached data from first call
+        expect(emissions[0].pubkeys, contains(follower1));
+        expect(emissions[0].pubkeys, isNot(contains(follower2)));
+        // Second emission: fresh data
+        expect(emissions[1].pubkeys, contains(follower1));
+        expect(emissions[1].pubkeys, contains(follower2));
+      });
+    });
+
     group('real-time sync', () {
       late StreamController<Event> realTimeStreamController;
 
@@ -1189,73 +1270,61 @@ void main() {
     });
 
     group('followingStream force-emit on initialize', () {
-      test(
-        'emits on followingStream after initialize '
-        'when user has no follows',
-        () async {
-          // No cached follows, no PersonalEventCache, no relay data
-          SharedPreferences.setMockInitialValues({});
+      test('emits on followingStream after initialize '
+          'when user has no follows', () async {
+        // No cached follows, no PersonalEventCache, no relay data
+        SharedPreferences.setMockInitialValues({});
 
-          repository = FollowRepository(
-            nostrClient: mockNostrClient,
-            personalEventCache: mockPersonalEventCache,
-            indexerRelayUrls: const [],
-          );
+        repository = FollowRepository(
+          nostrClient: mockNostrClient,
+          personalEventCache: mockPersonalEventCache,
+          indexerRelayUrls: const [],
+        );
 
-          final emissions = <List<String>>[];
-          final subscription = repository.followingStream.listen(
-            emissions.add,
-          );
+        final emissions = <List<String>>[];
+        final subscription = repository.followingStream.listen(emissions.add);
 
-          // Seed value is [] — capture it
-          await Future<void>.delayed(Duration.zero);
-          final preInitCount = emissions.length;
+        // Seed value is [] — capture it
+        await Future<void>.delayed(Duration.zero);
+        final preInitCount = emissions.length;
 
-          await repository.initialize();
-          await Future<void>.delayed(Duration.zero);
+        await repository.initialize();
+        await Future<void>.delayed(Duration.zero);
 
-          // Force-emit should add one more [] emission
-          expect(emissions.length, greaterThan(preInitCount));
-          expect(emissions.last, isEmpty);
+        // Force-emit should add one more [] emission
+        expect(emissions.length, greaterThan(preInitCount));
+        expect(emissions.last, isEmpty);
 
-          await subscription.cancel();
-        },
-      );
+        await subscription.cancel();
+      });
 
-      test(
-        'does not double-emit after initialize '
-        'when user has follows',
-        () async {
-          SharedPreferences.setMockInitialValues({
-            'following_list_$testCurrentUserPubkey': '["$testTargetPubkey"]',
-          });
+      test('does not double-emit after initialize '
+          'when user has follows', () async {
+        SharedPreferences.setMockInitialValues({
+          'following_list_$testCurrentUserPubkey': '["$testTargetPubkey"]',
+        });
 
-          repository = FollowRepository(
-            nostrClient: mockNostrClient,
-            personalEventCache: mockPersonalEventCache,
-            indexerRelayUrls: const [],
-          );
+        repository = FollowRepository(
+          nostrClient: mockNostrClient,
+          personalEventCache: mockPersonalEventCache,
+          indexerRelayUrls: const [],
+        );
 
-          final emissions = <List<String>>[];
-          final subscription = repository.followingStream.listen(
-            emissions.add,
-          );
+        final emissions = <List<String>>[];
+        final subscription = repository.followingStream.listen(emissions.add);
 
-          await repository.initialize();
-          await Future<void>.delayed(Duration.zero);
+        await repository.initialize();
+        await Future<void>.delayed(Duration.zero);
 
-          // Should emit exactly once with the follow list (from
-          // _emitFollowingList during _loadFromLocalStorage), no
-          // extra force-emit because _followingPubkeys is non-empty.
-          final nonSeedEmissions = emissions
-              .where((e) => e.isNotEmpty)
-              .toList();
-          expect(nonSeedEmissions, hasLength(1));
-          expect(nonSeedEmissions.first, contains(testTargetPubkey));
+        // Should emit exactly once with the follow list (from
+        // _emitFollowingList during _loadFromLocalStorage), no
+        // extra force-emit because _followingPubkeys is non-empty.
+        final nonSeedEmissions = emissions.where((e) => e.isNotEmpty).toList();
+        expect(nonSeedEmissions, hasLength(1));
+        expect(nonSeedEmissions.first, contains(testTargetPubkey));
 
-          await subscription.cancel();
-        },
-      );
+        await subscription.cancel();
+      });
     });
 
     group('getSocialCounts', () {


### PR DESCRIPTION
## Description

Add in-memory caching and progressive streaming to `FollowRepository` for the current user's followers data. `MyFollowersBloc` now consumes a `watchMyFollowers()` stream that yields cached results instantly on repeat profile views, then refreshes from relays in the background — eliminating the 5+ second loading delay on every visit.

**Related Issue:** #974 

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore