### PR TITLE
ci(mobile): add mergeability check

### DIFF
--- a/.github/workflows/mergeability_check.yml
+++ b/.github/workflows/mergeability_check.yml
@@ -11,6 +11,7 @@ on:
       - ready_for_review
 
 permissions:
+  pull-requests: read
   contents: read
 
 jobs:


### PR DESCRIPTION
## Summary
- add a dedicated `Mergeability Check` workflow for pull requests to `main`
- call the shared reusable workflow from `divinevideo/.github`
- pin the reusable workflow to commit `ab1136efcb2fdf0f4f0c9f201d1618d1175d3790`

## Notes
- this depends on the shared workflow PR in `divinevideo/.github`
- once this workflow exists on `main`, branch protection can safely require `mergeability / mergeability`

## Verification
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mergeability_check.yml'); puts 'yaml-ok'"
- gh pr view 2159 --repo divinevideo/divine-mobile --json statusCheckRollup,mergeable,mergeStateStatus