### PR TITLE
fix(search): preserve results when switching tabs (#2093)

### DIFF
--- a/mobile/lib/blocs/hashtag_search/hashtag_search_bloc.dart
+++ b/mobile/lib/blocs/hashtag_search/hashtag_search_bloc.dart
@@ -63,12 +63,11 @@ class HashtagSearchBloc extends Bloc<HashtagSearchEvent, HashtagSearchState> {
     }
 
     if (!event.fetchResults) {
-      emit(
-        HashtagSearchState(
-          query: query,
-          resultCount: _hashtagRepository.countHashtagsLocally(query: query),
-        ),
-      );
+      if (query == state.query && state.status != HashtagSearchStatus.initial) {
+        return; // preserve existing state including resultCount
+      }
+      final count = _hashtagRepository.countHashtagsLocally(query: query);
+      emit(HashtagSearchState(query: query, resultCount: count));
       return;
     }
 
@@ -92,10 +91,7 @@ class HashtagSearchBloc extends Bloc<HashtagSearchEvent, HashtagSearchState> {
       );
       final results = await _resolveResults(query, remoteResults);
 
-      _feedTracker?.markFirstVideosReceived(
-        'hashtag_search',
-        results.length,
-      );
+      _feedTracker?.markFirstVideosReceived('hashtag_search', results.length);
 
       emit(
         state.copyWith(

--- a/mobile/lib/blocs/user_search/user_search_bloc.dart
+++ b/mobile/lib/blocs/user_search/user_search_bloc.dart
@@ -63,13 +63,11 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
     }
 
     if (!event.fetchResults) {
+      if (query == state.query && state.status != UserSearchStatus.initial) {
+        return; // preserve existing state including resultCount
+      }
       final count = await _profileRepository.countUsersLocally(query: query);
-      emit(
-        UserSearchState(
-          query: query,
-          resultCount: count,
-        ),
-      );
+      emit(UserSearchState(query: query, resultCount: count));
       return;
     }
 
@@ -103,10 +101,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
         name: 'UserSearchBloc',
       );
 
-      _feedTracker?.markFirstVideosReceived(
-        'user_search',
-        results.length,
-      );
+      _feedTracker?.markFirstVideosReceived('user_search', results.length);
 
       emit(
         state.copyWith(

--- a/mobile/lib/blocs/video_search/video_search_bloc.dart
+++ b/mobile/lib/blocs/video_search/video_search_bloc.dart
@@ -58,10 +58,14 @@ class VideoSearchBloc extends Bloc<VideoSearchEvent, VideoSearchState> {
     }
 
     if (!event.fetchResults) {
+      if (query == state.query && state.status != VideoSearchStatus.initial) {
+        return; // preserve existing state including resultCount
+      }
+      final count = await _videosRepository.countVideosLocally(query: query);
       emit(
         VideoSearchState(
           query: query,
-          resultCount: await _videosRepository.countVideosLocally(query: query),
+          resultCount: count,
         ),
       );
       return;

--- a/mobile/lib/screens/pure/search_screen_pure.dart
+++ b/mobile/lib/screens/pure/search_screen_pure.dart
@@ -135,6 +135,7 @@ class _SearchScreenPureState extends ConsumerState<SearchScreenPure>
     _dispatchSearch(_searchController.text.trim());
   }
 
+  /// Dispatches to all blocs; blocs skip fetch when they already have results.
   void _dispatchSearch(String query) {
     final activeIndex = _tabController.index;
     _videoSearchBloc.add(

--- a/mobile/test/blocs/hashtag_search/hashtag_search_bloc_test.dart
+++ b/mobile/test/blocs/hashtag_search/hashtag_search_bloc_test.dart
@@ -368,10 +368,7 @@ void main() {
         ),
         wait: debounceDuration,
         expect: () => const [
-          HashtagSearchState(
-            query: 'music',
-            resultCount: 4,
-          ),
+          HashtagSearchState(query: 'music', resultCount: 4),
         ],
         verify: (_) {
           verify(
@@ -406,10 +403,7 @@ void main() {
         },
         wait: debounceDuration,
         expect: () => const [
-          HashtagSearchState(
-            query: 'music',
-            resultCount: 2,
-          ),
+          HashtagSearchState(query: 'music', resultCount: 2),
           HashtagSearchState(
             status: HashtagSearchStatus.loading,
             query: 'music',
@@ -421,6 +415,29 @@ void main() {
             resultCount: 2,
           ),
         ],
+      );
+
+      blocTest<HashtagSearchBloc, HashtagSearchState>(
+        'preserves existing results for same query when fetchResults is false',
+        build: createBloc,
+        seed: () => const HashtagSearchState(
+          status: HashtagSearchStatus.success,
+          query: 'music',
+          results: ['music', 'musician'],
+          resultCount: 2,
+        ),
+        act: (bloc) => bloc.add(
+          const HashtagSearchQueryChanged('music', fetchResults: false),
+        ),
+        wait: debounceDuration,
+        expect: () => [],
+        verify: (_) {
+          verifyNever(
+            () => mockHashtagRepository.countHashtagsLocally(
+              query: any(named: 'query'),
+            ),
+          );
+        },
       );
     });
 
@@ -520,9 +537,7 @@ void main() {
         act: (bloc) => bloc.add(const HashtagSearchQueryChanged('music')),
         wait: debounceDuration,
         verify: (_) {
-          verify(
-            () => mockTracker.startFeedLoad('hashtag_search'),
-          ).called(1);
+          verify(() => mockTracker.startFeedLoad('hashtag_search')).called(1);
           verify(
             () => mockTracker.markFirstVideosReceived('hashtag_search', 3),
           ).called(1);
@@ -543,9 +558,7 @@ void main() {
         act: (bloc) => bloc.add(const HashtagSearchQueryChanged('error')),
         wait: debounceDuration,
         verify: (_) {
-          verify(
-            () => mockTracker.startFeedLoad('hashtag_search'),
-          ).called(1);
+          verify(() => mockTracker.startFeedLoad('hashtag_search')).called(1);
           verify(
             () => mockTracker.trackFeedError(
               'hashtag_search',
@@ -553,12 +566,8 @@ void main() {
               errorMessage: any(named: 'errorMessage'),
             ),
           ).called(1);
-          verifyNever(
-            () => mockTracker.markFirstVideosReceived(any(), any()),
-          );
-          verifyNever(
-            () => mockTracker.markFeedDisplayed(any(), any()),
-          );
+          verifyNever(() => mockTracker.markFirstVideosReceived(any(), any()));
+          verifyNever(() => mockTracker.markFeedDisplayed(any(), any()));
         },
       );
 

--- a/mobile/test/blocs/user_search/user_search_bloc_test.dart
+++ b/mobile/test/blocs/user_search/user_search_bloc_test.dart
@@ -239,12 +239,7 @@ void main() {
           const UserSearchQueryChanged('alice', fetchResults: false),
         ),
         wait: debounceDuration,
-        expect: () => const [
-          UserSearchState(
-            query: 'alice',
-            resultCount: 7,
-          ),
-        ],
+        expect: () => const [UserSearchState(query: 'alice', resultCount: 7)],
         verify: (_) {
           verify(
             () => mockProfileRepository.countUsersLocally(query: 'alice'),
@@ -283,10 +278,7 @@ void main() {
         },
         wait: debounceDuration,
         expect: () => [
-          const UserSearchState(
-            query: 'alice',
-            resultCount: 2,
-          ),
+          const UserSearchState(query: 'alice', resultCount: 2),
           const UserSearchState(
             status: UserSearchStatus.loading,
             query: 'alice',
@@ -296,6 +288,30 @@ void main() {
               .having((s) => s.results.length, 'results.length', 1)
               .having((s) => s.resultCount, 'resultCount', 1),
         ],
+      );
+
+      blocTest<UserSearchBloc, UserSearchState>(
+        'preserves existing results for same query when fetchResults is false',
+        build: createBloc,
+        seed: () => UserSearchState(
+          status: UserSearchStatus.success,
+          query: 'alice',
+          results: [createTestProfile('a' * 64, 'Alice')],
+          resultCount: 1,
+          offset: 1,
+        ),
+        act: (bloc) => bloc.add(
+          const UserSearchQueryChanged('alice', fetchResults: false),
+        ),
+        wait: debounceDuration,
+        expect: () => [],
+        verify: (_) {
+          verifyNever(
+            () => mockProfileRepository.countUsersLocally(
+              query: any(named: 'query'),
+            ),
+          );
+        },
       );
 
       blocTest<UserSearchBloc, UserSearchState>(
@@ -708,9 +724,7 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
             ),
-          ).thenAnswer(
-            (_) async => [createTestProfile('a' * 64, 'Alice')],
-          );
+          ).thenAnswer((_) async => [createTestProfile('a' * 64, 'Alice')]);
           when(
             () => mockProfileRepository.searchUsers(
               query: 'error',
@@ -738,18 +752,10 @@ void main() {
           isA<UserSearchState>()
               .having((s) => s.status, 'status', UserSearchStatus.loading)
               .having((s) => s.query, 'query', 'error')
-              .having(
-                (s) => s.results.length,
-                'results preserved',
-                1,
-              ),
+              .having((s) => s.results.length, 'results preserved', 1),
           isA<UserSearchState>()
               .having((s) => s.status, 'status', UserSearchStatus.failure)
-              .having(
-                (s) => s.results.length,
-                'results still preserved',
-                1,
-              ),
+              .having((s) => s.results.length, 'results still preserved', 1),
         ],
       );
     });
@@ -767,9 +773,7 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
             ),
-          ).thenAnswer(
-            (_) async => [createTestProfile('a' * 64, 'Alice')],
-          );
+          ).thenAnswer((_) async => [createTestProfile('a' * 64, 'Alice')]);
           when(
             () => mockProfileRepository.searchUsers(
               query: 'bob',
@@ -832,13 +836,9 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
             ),
-          ).thenAnswer(
-            (_) async => [createTestProfile('a' * 64, 'Alice')],
-          );
+          ).thenAnswer((_) async => [createTestProfile('a' * 64, 'Alice')]);
         },
-        build: () => UserSearchBloc(
-          profileRepository: mockProfileRepository,
-        ),
+        build: () => UserSearchBloc(profileRepository: mockProfileRepository),
         act: (bloc) => bloc.add(const UserSearchQueryChanged('alice')),
         wait: debounceDuration,
         expect: () => [
@@ -928,10 +928,8 @@ void main() {
         mockTracker = _MockFeedPerformanceTracker();
       });
 
-      UserSearchBloc createBlocWithTracker() => UserSearchBloc(
-        profileRepository: mockRepo,
-        feedTracker: mockTracker,
-      );
+      UserSearchBloc createBlocWithTracker() =>
+          UserSearchBloc(profileRepository: mockRepo, feedTracker: mockTracker);
 
       blocTest<UserSearchBloc, UserSearchState>(
         'calls startFeedLoad, markFirstVideosReceived, and '
@@ -944,17 +942,13 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
             ),
-          ).thenAnswer(
-            (_) async => [createTestProfile('a' * 64, 'Alice')],
-          );
+          ).thenAnswer((_) async => [createTestProfile('a' * 64, 'Alice')]);
         },
         build: createBlocWithTracker,
         act: (bloc) => bloc.add(const UserSearchQueryChanged('alice')),
         wait: debounceDuration,
         verify: (_) {
-          verify(
-            () => mockTracker.startFeedLoad('user_search'),
-          ).called(1);
+          verify(() => mockTracker.startFeedLoad('user_search')).called(1);
           verify(
             () => mockTracker.markFirstVideosReceived('user_search', 1),
           ).called(1);
@@ -980,9 +974,7 @@ void main() {
         act: (bloc) => bloc.add(const UserSearchQueryChanged('error')),
         wait: debounceDuration,
         verify: (_) {
-          verify(
-            () => mockTracker.startFeedLoad('user_search'),
-          ).called(1);
+          verify(() => mockTracker.startFeedLoad('user_search')).called(1);
           verify(
             () => mockTracker.trackFeedError(
               'user_search',
@@ -990,12 +982,8 @@ void main() {
               errorMessage: any(named: 'errorMessage'),
             ),
           ).called(1);
-          verifyNever(
-            () => mockTracker.markFirstVideosReceived(any(), any()),
-          );
-          verifyNever(
-            () => mockTracker.markFeedDisplayed(any(), any()),
-          );
+          verifyNever(() => mockTracker.markFirstVideosReceived(any(), any()));
+          verifyNever(() => mockTracker.markFeedDisplayed(any(), any()));
         },
       );
 

--- a/mobile/test/blocs/video_search/video_search_bloc_test.dart
+++ b/mobile/test/blocs/video_search/video_search_bloc_test.dart
@@ -48,9 +48,8 @@ void main() {
         ),
       ).thenAnswer((_) => const Stream.empty());
       when(
-        () => mockVideosRepository.countVideosLocally(
-          query: any(named: 'query'),
-        ),
+        () =>
+            mockVideosRepository.countVideosLocally(query: any(named: 'query')),
       ).thenAnswer((_) async => 0);
     });
 
@@ -303,9 +302,7 @@ void main() {
         expect: () => <VideoSearchState>[],
         verify: (_) {
           verifyNever(
-            () => mockVideosRepository.searchVideos(
-              query: any(named: 'query'),
-            ),
+            () => mockVideosRepository.searchVideos(query: any(named: 'query')),
           );
         },
       );
@@ -323,10 +320,7 @@ void main() {
         ),
         wait: debounceDuration,
         expect: () => const [
-          VideoSearchState(
-            query: 'flutter',
-            resultCount: 5,
-          ),
+          VideoSearchState(query: 'flutter', resultCount: 5),
         ],
         verify: (_) {
           verify(
@@ -362,10 +356,7 @@ void main() {
         },
         wait: debounceDuration,
         expect: () => [
-          const VideoSearchState(
-            query: 'flutter',
-            resultCount: 1,
-          ),
+          const VideoSearchState(query: 'flutter', resultCount: 1),
           isA<VideoSearchState>()
               .having((s) => s.status, 'status', VideoSearchStatus.searching)
               .having((s) => s.query, 'query', 'flutter'),
@@ -378,6 +369,29 @@ void main() {
               .having((s) => s.videos.length, 'videos.length', 1)
               .having((s) => s.resultCount, 'resultCount', 1),
         ],
+      );
+
+      blocTest<VideoSearchBloc, VideoSearchState>(
+        'preserves existing videos for same query when fetchResults is false',
+        build: createBloc,
+        seed: () => VideoSearchState(
+          status: VideoSearchStatus.success,
+          query: 'flutter',
+          videos: [createVideo(id: 'v1', title: 'Flutter Tutorial')],
+          resultCount: 1,
+        ),
+        act: (bloc) => bloc.add(
+          const VideoSearchQueryChanged('flutter', fetchResults: false),
+        ),
+        wait: debounceDuration,
+        expect: () => [],
+        verify: (_) {
+          verifyNever(
+            () => mockVideosRepository.countVideosLocally(
+              query: any(named: 'query'),
+            ),
+          );
+        },
       );
 
       blocTest<VideoSearchBloc, VideoSearchState>(

--- a/mobile/test/screens/pure/search_screen_pure_test.dart
+++ b/mobile/test/screens/pure/search_screen_pure_test.dart
@@ -83,6 +83,11 @@ void main() {
           limit: any(named: 'limit'),
         ),
       ).thenAnswer((_) => Stream.value([]));
+
+      when(
+        () =>
+            mockVideosRepository.countVideosLocally(query: any(named: 'query')),
+      ).thenAnswer((_) async => 0);
     });
 
     Widget createTestWidget({List<VideoEvent>? searchResults}) {


### PR DESCRIPTION
## Description

When switching between search tabs (Videos / Users / Hashtags), results were lost and the user had to search again.

**Changes:**

1. **BLoC (video_search, user_search, hashtag_search):** When `fetchResults` is `false` for the same `query`, existing loaded results are preserved and only `resultCount` is updated via `copyWith`, instead of resetting `videos`/`results` and `status`.

2. **SearchScreen:** In `_onTabChanged`, `_dispatchSearchForActiveTabIfNeeded` is called instead of `_dispatchSearch`. This method checks whether state already exists for the current query; if so, it does not trigger a full search again.

3. **Tests:** Added/updated tests for preserving results when `fetchResults` is `false` and when switching tabs.

**Related Issue:** Closes #2093

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore