### PR TITLE
fix(profile): adjust padding for video grid to account for safe area

### DIFF
--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -172,7 +172,12 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
     return CustomScrollView(
       slivers: [
         SliverPadding(
-          padding: const EdgeInsets.all(4),
+          padding: .fromLTRB(
+            4,
+            4,
+            4,
+            4 + MediaQuery.viewPaddingOf(context).bottom,
+          ),
           sliver: SliverGrid(
             gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisCount: 3,


### PR DESCRIPTION
## Description

This PR fixes a minor issue in the profile screen. On newer Android devices, videos would always be behind the system navigation bar, even when the user had scrolled all the way down. This PR change ensures that videos are fully visible when scrolling down. Note that we don't use SafeArea, so the scroll is still visible behind the system navigation bar.

| Before | After |
| ------- | ------ |
|     ![Before](https://github.com/user-attachments/assets/644c916a-68dc-4ffd-adcf-437c5a4a12ba)       |     ![After](https://github.com/user-attachments/assets/687a9bcc-53f1-4a0f-99a0-2f3d522a8e0f)      |

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore