### PR TITLE
fix: reserve space for action button counts to prevent layout jump

### DIFF
--- a/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
@@ -49,7 +49,7 @@ class VideoActionButton extends StatelessWidget {
   /// Color applied to the SVG icon. Defaults to white.
   final Color iconColor;
 
-  /// Count to display beneath the icon. Hidden when 0.
+  /// Count to display beneath the icon. Shows empty space when 0.
   final int count;
 
   /// When true, shows a loading spinner instead of the icon.
@@ -103,18 +103,17 @@ class VideoActionButton extends StatelessWidget {
                   ),
           ),
         ),
-        if (count > 0)
-          Padding(
-            padding: const EdgeInsets.only(bottom: 8),
-            child: SizedBox(
-              width: 48,
-              child: Text(
-                StringUtils.formatCompactNumber(count),
-                style: VineTheme.labelSmallFont(color: VineTheme.onSurface),
-                textAlign: TextAlign.center,
-              ),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: SizedBox(
+            width: 48,
+            child: Text(
+              count > 0 ? StringUtils.formatCompactNumber(count) : '',
+              style: VineTheme.labelSmallFont(color: VineTheme.onSurface),
+              textAlign: TextAlign.center,
             ),
           ),
+        ),
       ],
     );
   }


### PR DESCRIPTION
## Description

Reserve space for the count label in `VideoActionButton` so the overlay action column doesn't jump when interaction counts load asynchronously from the relay. The count text area is now always rendered with empty text when count is 0, instead of being conditionally hidden.

**Related Issue:** Closes #2173

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore