### PR TITLE
refactor: Use VineTheme across the app

### DIFF
--- a/mobile/lib/blocs/video_editor/text_editor/video_editor_text_bloc.dart
+++ b/mobile/lib/blocs/video_editor/text_editor/video_editor_text_bloc.dart
@@ -1,3 +1,4 @@
+import 'package:divine_ui/divine_ui.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';

--- a/mobile/lib/blocs/video_editor/text_editor/video_editor_text_state.dart
+++ b/mobile/lib/blocs/video_editor/text_editor/video_editor_text_state.dart
@@ -6,7 +6,7 @@ class VideoEditorTextState extends Equatable {
     this.text = '',
     this.selectedFontIndex = 0,
     this.alignment = .center,
-    this.color = Colors.black,
+    this.color = VineTheme.backgroundColor,
     this.backgroundStyle = .backgroundAndColor,
     this.fontSize = 0.5,
     this.showFontSelector = false,

--- a/mobile/lib/constants/video_editor_constants.dart
+++ b/mobile/lib/constants/video_editor_constants.dart
@@ -1,3 +1,4 @@
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -102,7 +103,7 @@ class VideoEditorConstants {
   static const Color textEditorBackground = Color(0x9B000000);
 
   static const uiOverlayStyle = SystemUiOverlayStyle(
-    statusBarColor: Colors.transparent,
+    statusBarColor: VineTheme.transparent,
     statusBarIconBrightness: Brightness.light,
     systemNavigationBarIconBrightness: Brightness.light,
     statusBarBrightness: Brightness.dark,

--- a/mobile/lib/features/feature_flags/screens/feature_flag_screen.dart
+++ b/mobile/lib/features/feature_flags/screens/feature_flag_screen.dart
@@ -120,7 +120,7 @@ class FeatureFlagScreen extends ConsumerWidget {
           const SizedBox(height: 8),
           const Text(
             'If the app is crashing or behaving strangely, try clearing the cache.',
-            style: TextStyle(color: Colors.grey),
+            style: TextStyle(color: VineTheme.lightText),
           ),
           const SizedBox(height: 12),
           Row(
@@ -130,8 +130,8 @@ class FeatureFlagScreen extends ConsumerWidget {
                 icon: const Icon(Icons.cleaning_services),
                 label: const Text('Clear All Cache'),
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.orange,
-                  foregroundColor: Colors.white,
+                  backgroundColor: VineTheme.accentOrange,
+                  foregroundColor: VineTheme.whiteText,
                 ),
               ),
               const SizedBox(width: 12),
@@ -169,7 +169,9 @@ class FeatureFlagScreen extends ConsumerWidget {
               ),
               ElevatedButton(
                 onPressed: () => context.pop(true),
-                style: ElevatedButton.styleFrom(backgroundColor: Colors.orange),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: VineTheme.accentOrange,
+                ),
                 child: const Text('Clear Cache'),
               ),
             ],

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -193,7 +193,7 @@ class _SignInContentState extends ConsumerState<_SignInContent> {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(
               padding: EdgeInsets.zero,
-              backgroundColor: Colors.transparent,
+              backgroundColor: VineTheme.transparent,
               elevation: 0,
               behavior: SnackBarBehavior.floating,
               duration: Duration(seconds: 3),

--- a/mobile/lib/screens/auth/welcome_screen.dart
+++ b/mobile/lib/screens/auth/welcome_screen.dart
@@ -492,7 +492,7 @@ class _AccountTile extends StatelessWidget {
         decoration: BoxDecoration(
           color: isSelected
               ? VineTheme.vineGreen.withValues(alpha: 0.1)
-              : Colors.transparent,
+              : VineTheme.transparent,
           borderRadius: BorderRadius.circular(12),
         ),
         child: Row(

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -127,7 +127,7 @@ class CommentsScreen extends ConsumerWidget {
       context: context,
       isScrollControlled: true,
       useRootNavigator: true,
-      backgroundColor: Colors.transparent,
+      backgroundColor: VineTheme.transparent,
       elevation: 0,
       builder: (builderContext) {
         final keyboardHeight = MediaQuery.of(builderContext).viewInsets.bottom;

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -75,7 +75,7 @@ class _CommentItemState extends ConsumerState<CommentItem> {
         });
       },
       child: ColoredBox(
-        color: _isHeld ? VineTheme.containerLow : Colors.transparent,
+        color: _isHeld ? VineTheme.containerLow : VineTheme.transparent,
         child: IntrinsicHeight(
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/mobile/lib/screens/comments/widgets/comment_options_modal.dart
+++ b/mobile/lib/screens/comments/widgets/comment_options_modal.dart
@@ -313,7 +313,7 @@ class _ReasonRadioTile extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        color: Colors.transparent,
+        color: VineTheme.transparent,
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
         child: Row(
           children: [

--- a/mobile/lib/screens/comments/widgets/comments_empty_state.dart
+++ b/mobile/lib/screens/comments/widgets/comments_empty_state.dart
@@ -25,26 +25,30 @@ class CommentsEmptyState extends StatelessWidget {
             margin: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
-              color: Colors.orange.shade900.withValues(alpha: 0.3),
+              color: VineTheme.accentOrange.withValues(alpha: 0.3),
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
-                color: Colors.orange.shade700.withValues(alpha: 0.5),
+                color: VineTheme.accentOrange.withValues(alpha: 0.5),
               ),
             ),
-            child: Column(
+            child: const Column(
               children: [
-                Icon(Icons.history, color: Colors.orange.shade300, size: 32),
-                const SizedBox(height: 12),
+                Icon(
+                  Icons.history,
+                  color: VineTheme.contentWarningAmber,
+                  size: 32,
+                ),
+                SizedBox(height: 12),
                 Text(
                   'Classic Vine',
                   style: TextStyle(
-                    color: Colors.orange.shade300,
+                    color: VineTheme.contentWarningAmber,
                     fontSize: 16,
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                const SizedBox(height: 8),
-                const Text(
+                SizedBox(height: 8),
+                Text(
                   "We're still working on importing old comments "
                   "from the archive. They're not ready yet.",
                   textAlign: TextAlign.center,

--- a/mobile/lib/screens/content_filters_screen.dart
+++ b/mobile/lib/screens/content_filters_screen.dart
@@ -273,7 +273,7 @@ class _FilterSegmentedControl extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
         decoration: BoxDecoration(
-          color: selected ? VineTheme.vineGreen : Colors.transparent,
+          color: selected ? VineTheme.vineGreen : VineTheme.transparent,
           borderRadius: BorderRadius.circular(7),
         ),
         child: Text(

--- a/mobile/lib/screens/debug_video_test.dart
+++ b/mobile/lib/screens/debug_video_test.dart
@@ -55,7 +55,10 @@ class _DebugVideoTestScreenState extends ConsumerState<DebugVideoTestScreen> {
               testVideo != null
                   ? 'Video URL: ${testVideo.videoUrl}'
                   : 'No videos available in feed',
-              style: const TextStyle(color: Colors.white70, fontSize: 12),
+              style: const TextStyle(
+                color: VineTheme.onSurfaceVariant,
+                fontSize: 12,
+              ),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 20),
@@ -65,7 +68,7 @@ class _DebugVideoTestScreenState extends ConsumerState<DebugVideoTestScreen> {
               width: 300,
               height: 400,
               decoration: BoxDecoration(
-                color: Colors.black,
+                color: VineTheme.backgroundColor,
                 border: Border.all(color: VineTheme.vineGreen, width: 2),
               ),
               child: (_isPlaying && testVideo != null)
@@ -80,12 +83,12 @@ class _DebugVideoTestScreenState extends ConsumerState<DebugVideoTestScreen> {
                           Icon(
                             Icons.play_circle_outline,
                             size: 64,
-                            color: Colors.white54,
+                            color: VineTheme.onSurfaceMuted,
                           ),
                           SizedBox(height: 16),
                           Text(
                             'Tap Play to test video',
-                            style: TextStyle(color: Colors.white54),
+                            style: TextStyle(color: VineTheme.onSurfaceMuted),
                           ),
                         ],
                       ),
@@ -102,7 +105,7 @@ class _DebugVideoTestScreenState extends ConsumerState<DebugVideoTestScreen> {
               },
               style: ElevatedButton.styleFrom(
                 backgroundColor: VineTheme.vineGreen,
-                foregroundColor: Colors.white,
+                foregroundColor: VineTheme.whiteText,
               ),
               child: Text(_isPlaying ? 'Stop' : 'Play'),
             ),

--- a/mobile/lib/screens/explore_screen.dart
+++ b/mobile/lib/screens/explore_screen.dart
@@ -404,7 +404,7 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
             indicatorColor: VineTheme.tabIndicatorGreen,
             indicatorWeight: 4,
             indicatorSize: TabBarIndicatorSize.tab,
-            dividerColor: Colors.transparent,
+            dividerColor: VineTheme.transparent,
             labelColor: VineTheme.whiteText,
             unselectedLabelColor: VineTheme.tabIconInactive,
             labelPadding: const EdgeInsets.symmetric(horizontal: 14),

--- a/mobile/lib/screens/feed/feed_mode_switch.dart
+++ b/mobile/lib/screens/feed/feed_mode_switch.dart
@@ -37,7 +37,7 @@ class FeedModeSwitch extends StatelessWidget {
           gradient: LinearGradient(
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
-            colors: [VineTheme.innerShadowPressed, Colors.transparent],
+            colors: [VineTheme.innerShadowPressed, VineTheme.transparent],
           ),
         ),
         child: SafeArea(

--- a/mobile/lib/screens/fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/fullscreen_video_feed_screen.dart
@@ -359,7 +359,7 @@ class _FullscreenVideoFeedScreenState
           onBackPressed: context.pop,
           backButtonSemanticLabel: 'Close video player',
           backgroundMode: DiVineAppBarBackgroundMode.transparent,
-          surfaceTintColor: Colors.transparent,
+          surfaceTintColor: VineTheme.transparent,
           style: videoOverlayStyle,
         ),
         body: const Center(
@@ -380,7 +380,7 @@ class _FullscreenVideoFeedScreenState
         onBackPressed: context.pop,
         backButtonSemanticLabel: 'Close video player',
         backgroundMode: DiVineAppBarBackgroundMode.transparent,
-        surfaceTintColor: Colors.transparent,
+        surfaceTintColor: VineTheme.transparent,
         forceMaterialTransparency: true,
         systemOverlayStyle: SystemUiOverlayStyle.light,
         style: videoOverlayStyle,

--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -99,7 +99,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   }) {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        backgroundColor: Colors.transparent,
+        backgroundColor: VineTheme.transparent,
         elevation: 0,
         behavior: SnackBarBehavior.floating,
         content: DivineSnackbarContainer(label: label, error: error),
@@ -396,7 +396,7 @@ class _LibraryAppBar extends StatelessWidget implements PreferredSizeWidget {
         return DiVineAppBar(
           title: 'Library',
           backgroundColor: VineTheme.onPrimary,
-          surfaceTintColor: Colors.transparent,
+          surfaceTintColor: VineTheme.transparent,
           shape: const Border(
             bottom: BorderSide(color: VineTheme.outlineDisabled),
           ),

--- a/mobile/lib/screens/notifications_screen.dart
+++ b/mobile/lib/screens/notifications_screen.dart
@@ -75,7 +75,7 @@ class _NotificationsScreenState extends ConsumerState<NotificationsScreen>
             indicatorColor: VineTheme.tabIndicatorGreen,
             indicatorWeight: 4,
             indicatorSize: TabBarIndicatorSize.tab,
-            dividerColor: Colors.transparent,
+            dividerColor: VineTheme.transparent,
             labelColor: VineTheme.whiteText,
             unselectedLabelColor: VineTheme.tabIconInactive,
             labelStyle: VineTheme.tabTextStyle(),

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -1874,7 +1874,7 @@ class _ColorSwatch extends StatelessWidget {
           color: color ?? VineTheme.surfaceContainer,
           borderRadius: BorderRadius.circular(12),
           border: Border.all(
-            color: isSelected ? VineTheme.whiteText : Colors.transparent,
+            color: isSelected ? VineTheme.whiteText : VineTheme.transparent,
             width: 3,
           ),
         ),

--- a/mobile/lib/screens/pure/search_screen_pure.dart
+++ b/mobile/lib/screens/pure/search_screen_pure.dart
@@ -291,7 +291,7 @@ class _SearchScreenPureState extends ConsumerState<SearchScreenPure>
                     indicatorColor: VineTheme.tabIndicatorGreen,
                     indicatorWeight: 4,
                     indicatorSize: TabBarIndicatorSize.tab,
-                    dividerColor: Colors.transparent,
+                    dividerColor: VineTheme.transparent,
                     labelColor: VineTheme.whiteText,
                     unselectedLabelColor: VineTheme.tabIconInactive,
                     labelPadding: const EdgeInsets.symmetric(horizontal: 14),

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -313,7 +313,7 @@ class _RelaySettingsScreenState extends ConsumerState<RelaySettingsScreen> {
     final statusSummary = stats?.statusSummary ?? 'External relay';
 
     return Theme(
-      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+      data: Theme.of(context).copyWith(dividerColor: VineTheme.transparent),
       child: ExpansionTile(
         leading: Icon(
           isConnected ? Icons.cloud_done : Icons.cloud_off,

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -870,7 +870,7 @@ class _SoundVideoFeedOverlayState extends State<_SoundVideoFeedOverlay> {
                     end: Alignment.bottomCenter,
                     colors: [
                       VineTheme.backgroundColor.withValues(alpha: 0.7),
-                      Colors.transparent,
+                      VineTheme.transparent,
                     ],
                   ),
                 ),

--- a/mobile/lib/screens/user_list_people_screen.dart
+++ b/mobile/lib/screens/user_list_people_screen.dart
@@ -241,7 +241,7 @@ class _UserListPeopleScreenState extends ConsumerState<UserListPeopleScreen>
                       end: Alignment.bottomCenter,
                       colors: [
                         VineTheme.scrim70,
-                        Colors.transparent,
+                        VineTheme.transparent,
                       ],
                     ),
                   ),

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -169,7 +169,7 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              const Icon(Icons.error_outline, color: Colors.red, size: 64),
+              const Icon(Icons.error_outline, color: VineTheme.error, size: 64),
               const SizedBox(height: 16),
               Text(
                 _error!,

--- a/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
+++ b/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
@@ -199,13 +199,13 @@ class _VideoAudioEditorTimingScreenState
       ],
       child: AnnotatedRegion<SystemUiOverlayStyle>(
         value: const SystemUiOverlayStyle(
-          statusBarColor: Colors.transparent,
-          systemNavigationBarColor: Colors.transparent,
+          statusBarColor: VineTheme.transparent,
+          systemNavigationBarColor: VineTheme.transparent,
           statusBarIconBrightness: Brightness.light,
           statusBarBrightness: Brightness.dark,
         ),
         child: Scaffold(
-          backgroundColor: Colors.transparent,
+          backgroundColor: VineTheme.transparent,
           body: Stack(
             fit: StackFit.expand,
             children: [

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -192,7 +192,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen> {
       PageRouteBuilder<TextLayer>(
         opaque: false,
         barrierDismissible: true,
-        barrierColor: Colors.transparent,
+        barrierColor: VineTheme.transparent,
         pageBuilder: (_, _, _) => BlocProvider.value(
           value: textBloc,
           child: VideoTextEditorScreen(layer: layer),

--- a/mobile/lib/screens/video_metadata/video_metadata_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_screen.dart
@@ -82,11 +82,11 @@ class _VideoMetadataScreenState extends ConsumerState<VideoMetadataScreen> {
           children: [
             const Positioned.fill(child: _BackgroundGradient()),
             Scaffold(
-              backgroundColor: Colors.transparent,
+              backgroundColor: VineTheme.transparent,
               appBar: DiVineAppBar(
                 title: 'Post details',
                 backgroundMode: DiVineAppBarBackgroundMode.transparent,
-                surfaceTintColor: Colors.transparent,
+                surfaceTintColor: VineTheme.transparent,
                 showBackButton: true,
                 onBackPressed: context.pop,
                 backButtonHeroTag: VideoEditorConstants.heroBackButtonId,

--- a/mobile/lib/utils/pause_aware_modals.dart
+++ b/mobile/lib/utils/pause_aware_modals.dart
@@ -126,7 +126,7 @@ extension PauseAwareModals on BuildContext {
         builder: builder,
         isScrollControlled: true,
         useSafeArea: true,
-        backgroundColor: Colors.transparent,
+        backgroundColor: VineTheme.transparent,
       ).whenComplete(() {
         overlayNotifier.setBottomSheetOpen(false);
       });

--- a/mobile/lib/widgets/audio_waveform.dart
+++ b/mobile/lib/widgets/audio_waveform.dart
@@ -143,7 +143,7 @@ class _AudioWaveformState extends State<AudioWaveform>
   @override
   Widget build(BuildContext context) {
     final waveformColor = widget.color ?? VineTheme.vineGreen;
-    final bgColor = widget.backgroundColor ?? Colors.transparent;
+    final bgColor = widget.backgroundColor ?? VineTheme.transparent;
     // Total height: waveform + spacing + text
     final totalHeight = widget.height + _spacing + _textHeight;
 

--- a/mobile/lib/widgets/classic_vines_tab.dart
+++ b/mobile/lib/widgets/classic_vines_tab.dart
@@ -371,7 +371,7 @@ class _ClassicVideoItem extends StatelessWidget {
                   gradient: LinearGradient(
                     begin: Alignment.topCenter,
                     end: Alignment.bottomCenter,
-                    colors: [Colors.transparent, Color(0xCC000000)],
+                    colors: [VineTheme.transparent, VineTheme.scrim80],
                   ),
                 ),
                 child: UserName.fromPubKey(

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -547,7 +547,7 @@ class _VideoInfoSection extends StatelessWidget {
         gradient: LinearGradient(
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
-          colors: [Colors.transparent, VineTheme.scrim50],
+          colors: [VineTheme.transparent, VineTheme.scrim50],
         ),
       ),
       child: Column(

--- a/mobile/lib/widgets/content_warning.dart
+++ b/mobile/lib/widgets/content_warning.dart
@@ -180,7 +180,7 @@ class _ContentWarningState extends State<ContentWarning>
     width: double.infinity,
     padding: const EdgeInsets.all(24),
     decoration: BoxDecoration(
-      color: Colors.red.shade800,
+      color: VineTheme.errorContainer,
       borderRadius: BorderRadius.circular(12),
       border: Border.all(color: VineTheme.error, width: 2),
     ),
@@ -234,9 +234,9 @@ class _ContentWarningState extends State<ContentWarning>
       case ContentSeverity.warning:
         return VineTheme.warning;
       case ContentSeverity.hide:
-        return Colors.red.shade600;
+        return VineTheme.error;
       case ContentSeverity.block:
-        return Colors.red.shade800;
+        return VineTheme.errorContainer;
     }
   }
 
@@ -362,7 +362,10 @@ class _VideoContentWarningState extends State<VideoContentWarning> {
                   VineTheme.backgroundColor.withValues(alpha: 0.8),
                   BlendMode.srcOver,
                 )
-              : const ColorFilter.mode(Colors.transparent, BlendMode.multiply),
+              : const ColorFilter.mode(
+                  VineTheme.transparent,
+                  BlendMode.multiply,
+                ),
           child: widget.thumbnail,
         ),
 

--- a/mobile/lib/widgets/find_people_sheet.dart
+++ b/mobile/lib/widgets/find_people_sheet.dart
@@ -37,7 +37,7 @@ class FindPeopleSheet extends ConsumerStatefulWidget {
       context: context,
       isScrollControlled: true,
       useSafeArea: true,
-      backgroundColor: Colors.transparent,
+      backgroundColor: VineTheme.transparent,
       builder: (context) => FindPeopleSheet(contacts: contacts),
     );
   }

--- a/mobile/lib/widgets/global_error_widget.dart
+++ b/mobile/lib/widgets/global_error_widget.dart
@@ -66,7 +66,7 @@ class _MinimalFallbackError extends StatelessWidget {
           child: DecoratedBox(
             decoration: BoxDecoration(
               // vineGreen at 40% opacity - gentle, branded, not alarming
-              color: Color(0x6600B488),
+              color: Color(0x6627C58B),
               shape: BoxShape.circle,
             ),
           ),
@@ -262,7 +262,7 @@ class _TangledVinePainter extends CustomPainter {
     // Faded leaf paint for droopy leaves
     final fadedLeafPaint = Paint()
       ..color =
-          const Color(0x9900B488) // 60% vineGreen
+          const Color(0x9927C58B) // 60% vineGreen
       ..style = PaintingStyle.fill;
 
     // --- Vine stem from bottom, curving up ---
@@ -392,7 +392,7 @@ class _TangledVinePainter extends CustomPainter {
     // --- Small dots / tendrils ---
     final dotPaint = Paint()
       ..color =
-          const Color(0x6600B488) // 40% vineGreen
+          const Color(0x6627C58B) // 40% vineGreen
       ..style = PaintingStyle.fill;
 
     // Little curly tendril from the knot

--- a/mobile/lib/widgets/library/drafts_tab.dart
+++ b/mobile/lib/widgets/library/drafts_tab.dart
@@ -34,7 +34,7 @@ class DraftsTab extends ConsumerWidget {
         final isSuccess = state is DraftsLibraryDraftDeleted;
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            backgroundColor: Colors.transparent,
+            backgroundColor: VineTheme.transparent,
             elevation: 0,
             behavior: SnackBarBehavior.floating,
             content: DivineSnackbarContainer(

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -315,7 +315,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
                 indicatorColor: VineTheme.tabIndicatorGreen,
                 indicatorWeight: 4,
                 indicatorSize: TabBarIndicatorSize.tab,
-                dividerColor: Colors.transparent,
+                dividerColor: VineTheme.transparent,
                 tabs: [
                   Tab(
                     icon: Semantics(

--- a/mobile/lib/widgets/sound_tile.dart
+++ b/mobile/lib/widgets/sound_tile.dart
@@ -154,7 +154,7 @@ class SoundTile extends StatelessWidget {
           borderRadius: BorderRadius.circular(12),
         ),
         child: Material(
-          color: Colors.transparent,
+          color: VineTheme.transparent,
           child: InkWell(
             onTap: onTap,
             borderRadius: BorderRadius.circular(12),

--- a/mobile/lib/widgets/user_avatar.dart
+++ b/mobile/lib/widgets/user_avatar.dart
@@ -190,8 +190,8 @@ class UserAvatar extends StatelessWidget {
                 center: const Alignment(0.55, -0.9),
                 radius: 1.15,
                 colors: [
-                  Colors.white.withValues(alpha: 0.18),
-                  Colors.transparent,
+                  VineTheme.whiteText.withValues(alpha: 0.18),
+                  VineTheme.transparent,
                 ],
               ),
             ),
@@ -250,7 +250,7 @@ class UserAvatar extends StatelessWidget {
                     begin: Alignment.topCenter,
                     end: Alignment.bottomCenter,
                     colors: [
-                      Colors.transparent,
+                      VineTheme.transparent,
                       palette.shadow.withValues(alpha: 0.26),
                     ],
                   ),
@@ -283,10 +283,10 @@ class UserAvatar extends StatelessWidget {
   }
 
   static Color _lighten(Color color, double amount) =>
-      Color.lerp(color, Colors.white, amount) ?? color;
+      Color.lerp(color, VineTheme.whiteText, amount) ?? color;
 
   static Color _darken(Color color, double amount) =>
-      Color.lerp(color, Colors.black, amount) ?? color;
+      Color.lerp(color, VineTheme.backgroundColor, amount) ?? color;
 }
 
 class _AvatarPalette {

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -102,7 +102,7 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
 
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          backgroundColor: Colors.transparent,
+          backgroundColor: VineTheme.transparent,
           elevation: 0,
           behavior: SnackBarBehavior.floating,
           content: DivineSnackbarContainer(
@@ -122,7 +122,7 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
-            backgroundColor: Colors.transparent,
+            backgroundColor: VineTheme.transparent,
             elevation: 0,
             behavior: SnackBarBehavior.floating,
             content: DivineSnackbarContainer(

--- a/mobile/lib/widgets/video_clip_editor/gallery/video_editor_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip_editor/gallery/video_editor_clip_preview.dart
@@ -237,7 +237,7 @@ class _VideoClipPreviewState extends ConsumerState<VideoEditorClipPreview> {
                     : widget.isReordering
                     // Yellow when reordering
                     ? VineTheme.accentYellow
-                    : Colors.transparent, // Transparent otherwise
+                    : VineTheme.transparent, // Transparent otherwise
                 width: 6,
                 strokeAlign: BorderSide.strokeAlignOutside,
               ),

--- a/mobile/lib/widgets/video_clip_editor/video_clip_editor_bottom_bar.dart
+++ b/mobile/lib/widgets/video_clip_editor/video_clip_editor_bottom_bar.dart
@@ -21,7 +21,7 @@ class VideoClipEditorBottomBar extends ConsumerWidget {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         padding: EdgeInsets.zero,
-        backgroundColor: Colors.transparent,
+        backgroundColor: VineTheme.transparent,
         elevation: 0,
         behavior: .floating,
         duration: const Duration(seconds: 3),
@@ -103,7 +103,7 @@ class VideoClipEditorBottomBar extends ConsumerWidget {
                     spacing: 16,
                     children: [
                       VideoEditorIconButton(
-                        backgroundColor: Colors.transparent,
+                        backgroundColor: VineTheme.transparent,
                         icon: state.isPlaying ? .pause : .play,
                         onTap: notifier.togglePlayPause,
                         // TODO(l10n): Replace with context.l10n when localization is added.
@@ -111,7 +111,7 @@ class VideoClipEditorBottomBar extends ConsumerWidget {
                       ),
                       if (state.isEditing)
                         VideoEditorIconButton(
-                          backgroundColor: Colors.transparent,
+                          backgroundColor: VineTheme.transparent,
                           icon: .scissors,
                           onTap: () => _handleSplitClip(context, ref),
                           // TODO(l10n): Replace with context.l10n when localization is added.

--- a/mobile/lib/widgets/video_clip_editor/video_clip_editor_more_button.dart
+++ b/mobile/lib/widgets/video_clip_editor/video_clip_editor_more_button.dart
@@ -159,7 +159,7 @@ class _VideoEditorMoreButtonState
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         padding: EdgeInsets.zero,
-        backgroundColor: Colors.transparent,
+        backgroundColor: VineTheme.transparent,
         elevation: 0,
         behavior: .floating,
         duration: Duration(seconds: isError ? 3 : 2),
@@ -209,7 +209,7 @@ class _VideoEditorMoreButtonState
   @override
   Widget build(BuildContext context) {
     return VideoEditorIconButton(
-      backgroundColor: Colors.transparent,
+      backgroundColor: VineTheme.transparent,
       icon: .moreHoriz,
       onTap: _showMoreOptions,
       // TODO(l10n): Replace with context.l10n when localization is added.

--- a/mobile/lib/widgets/video_editor/audio_editor/video_editor_audio_chip.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/video_editor_audio_chip.dart
@@ -64,7 +64,7 @@ class VideoEditorAudioChip extends StatelessWidget {
       final timingResult = await Navigator.of(context).push<AudioTimingResult>(
         PageRouteBuilder(
           opaque: false,
-          barrierColor: Colors.transparent,
+          barrierColor: VineTheme.transparent,
           pageBuilder: (_, _, _) => VideoAudioEditorTimingScreen(
             sound: soundToEdit!,
           ),

--- a/mobile/lib/widgets/video_editor/draw_editor/video_editor_draw_bottom_bar.dart
+++ b/mobile/lib/widgets/video_editor/draw_editor/video_editor_draw_bottom_bar.dart
@@ -28,7 +28,7 @@ class VideoEditorDrawBottomBar extends StatelessWidget {
     final scope = VideoEditorScope.of(context);
     await showModalBottomSheet<void>(
       context: context,
-      backgroundColor: Colors.transparent,
+      backgroundColor: VineTheme.transparent,
       isScrollControlled: true,
       builder: (context) => VideoEditorColorPickerSheet(
         selectedColor: state.selectedColor,

--- a/mobile/lib/widgets/video_editor/sticker_editor/video_editor_sticker_sheet.dart
+++ b/mobile/lib/widgets/video_editor/sticker_editor/video_editor_sticker_sheet.dart
@@ -149,7 +149,7 @@ class _SearchBarState extends State<_SearchBar> {
       snap: true,
       automaticallyImplyLeading: false,
       backgroundColor: VineTheme.surfaceBackground,
-      surfaceTintColor: Colors.transparent,
+      surfaceTintColor: VineTheme.transparent,
       toolbarHeight: 64,
       flexibleSpace: Padding(
         padding: const .symmetric(horizontal: 16, vertical: 8),

--- a/mobile/lib/widgets/video_explore_tile.dart
+++ b/mobile/lib/widgets/video_explore_tile.dart
@@ -85,7 +85,7 @@ class VideoExploreTile extends ConsumerWidget {
                       end: Alignment.topCenter,
                       colors: [
                         VineTheme.backgroundColor.withValues(alpha: 0.8),
-                        Colors.transparent,
+                        VineTheme.transparent,
                       ],
                     ),
                   ),

--- a/mobile/lib/widgets/video_feed_item/actions/cc_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/cc_action_button.dart
@@ -32,7 +32,7 @@ class CcActionButton extends ConsumerWidget {
         padding: const EdgeInsets.all(8),
         constraints: const BoxConstraints.tightFor(width: 48, height: 48),
         style: IconButton.styleFrom(
-          highlightColor: Colors.transparent,
+          highlightColor: VineTheme.transparent,
           splashFactory: NoSplash.splashFactory,
         ),
         onPressed: () {

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -72,7 +72,7 @@ class ShareActionButton extends StatelessWidget {
             padding: const EdgeInsets.all(8),
             constraints: const BoxConstraints.tightFor(width: 48, height: 48),
             style: IconButton.styleFrom(
-              highlightColor: Colors.transparent,
+              highlightColor: VineTheme.transparent,
               splashFactory: NoSplash.splashFactory,
             ),
             onPressed: () {

--- a/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
@@ -70,7 +70,7 @@ class VideoActionButton extends StatelessWidget {
             padding: const EdgeInsets.all(8),
             constraints: const BoxConstraints.tightFor(width: 48, height: 48),
             style: IconButton.styleFrom(
-              highlightColor: Colors.transparent,
+              highlightColor: VineTheme.transparent,
               splashFactory: NoSplash.splashFactory,
             ),
             onPressed: isLoading ? null : onPressed,

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -1154,7 +1154,7 @@ class _VideoFeedItemState extends ConsumerState<VideoFeedItem> {
                                 right: 0,
                                 child: LinearProgressIndicator(
                                   minHeight: 12,
-                                  backgroundColor: Colors.transparent,
+                                  backgroundColor: VineTheme.transparent,
                                   valueColor: AlwaysStoppedAnimation<Color>(
                                     VineTheme.whiteText,
                                   ),
@@ -1974,7 +1974,7 @@ class _VideoEditButton extends ConsumerWidget {
             padding: const EdgeInsets.all(8),
             constraints: const BoxConstraints.tightFor(width: 48, height: 48),
             style: IconButton.styleFrom(
-              highlightColor: Colors.transparent,
+              highlightColor: VineTheme.transparent,
               splashFactory: NoSplash.splashFactory,
             ),
             onPressed: () {
@@ -2180,7 +2180,7 @@ class _CommentActionButton extends StatelessWidget {
             padding: const EdgeInsets.all(8),
             constraints: const BoxConstraints.tightFor(width: 48, height: 48),
             style: IconButton.styleFrom(
-              highlightColor: Colors.transparent,
+              highlightColor: VineTheme.transparent,
               splashFactory: NoSplash.splashFactory,
             ),
             onPressed: () {

--- a/mobile/lib/widgets/video_metadata/video_metadata_bottom_bar.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_bottom_bar.dart
@@ -51,7 +51,7 @@ class VideoMetadataBottomBar extends ConsumerWidget {
     scaffoldMessenger.showSnackBar(
       SnackBar(
         padding: EdgeInsets.zero,
-        backgroundColor: Colors.transparent,
+        backgroundColor: VineTheme.transparent,
         elevation: 0,
         behavior: SnackBarBehavior.floating,
         duration: const Duration(seconds: 5),

--- a/mobile/lib/widgets/video_metadata/video_metadata_preview_thumbnail.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_preview_thumbnail.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -19,7 +20,7 @@ class VideoMetadataPreviewThumbnail extends ConsumerWidget {
 
     if (clip.thumbnailPath == null) {
       return const Center(
-        child: Icon(Icons.broken_image, size: 32, color: Colors.grey),
+        child: Icon(Icons.broken_image, size: 32, color: VineTheme.lightText),
       );
     }
 

--- a/mobile/lib/widgets/video_metrics_overlay.dart
+++ b/mobile/lib/widgets/video_metrics_overlay.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Shows real-time performance data when videos load, bypassing console logging issues
 
 import 'dart:async';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/services/video_loading_metrics.dart';
@@ -91,7 +92,7 @@ class _VideoMetricsOverlayState extends State<VideoMetricsOverlay> {
                 child: IgnorePointer(
                   ignoring: false,
                   child: Material(
-                    color: Colors.black.withValues(alpha: 0.8),
+                    color: VineTheme.backgroundColor.withValues(alpha: 0.8),
                     borderRadius: BorderRadius.circular(8),
                     child: Container(
                       padding: const EdgeInsets.all(12),
@@ -103,14 +104,14 @@ class _VideoMetricsOverlayState extends State<VideoMetricsOverlay> {
                             children: [
                               const Icon(
                                 Icons.analytics,
-                                color: Colors.green,
+                                color: VineTheme.success,
                                 size: 16,
                               ),
                               const SizedBox(width: 8),
                               const Text(
                                 'Video Metrics Debug',
                                 style: TextStyle(
-                                  color: Colors.white,
+                                  color: VineTheme.whiteText,
                                   fontWeight: FontWeight.bold,
                                   fontSize: 14,
                                 ),
@@ -120,7 +121,7 @@ class _VideoMetricsOverlayState extends State<VideoMetricsOverlay> {
                                 onTap: _clearMetrics,
                                 child: const Icon(
                                   Icons.clear,
-                                  color: Colors.grey,
+                                  color: VineTheme.lightText,
                                   size: 16,
                                 ),
                               ),
@@ -133,7 +134,7 @@ class _VideoMetricsOverlayState extends State<VideoMetricsOverlay> {
                               child: Text(
                                 metric,
                                 style: const TextStyle(
-                                  color: Colors.greenAccent,
+                                  color: VineTheme.success,
                                   fontSize: 11,
                                   fontFamily: 'monospace',
                                 ),
@@ -169,7 +170,7 @@ class VideoMetricsDebugInfo extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.all(8),
         decoration: BoxDecoration(
-          color: Colors.purple.withValues(alpha: 0.8),
+          color: VineTheme.accentPurple.withValues(alpha: 0.8),
           borderRadius: BorderRadius.circular(8),
         ),
         child: Column(
@@ -179,17 +180,17 @@ class VideoMetricsDebugInfo extends StatelessWidget {
             const Text(
               '📊 Metrics Status',
               style: TextStyle(
-                color: Colors.white,
+                color: VineTheme.whiteText,
                 fontWeight: FontWeight.bold,
               ),
             ),
             Text(
               'Active Sessions: ${VideoLoadingMetrics.instance.activeSessions}',
-              style: const TextStyle(color: Colors.white, fontSize: 12),
+              style: const TextStyle(color: VineTheme.whiteText, fontSize: 12),
             ),
             Text(
               'Total Started: ${VideoLoadingMetrics.metricsCount}',
-              style: const TextStyle(color: Colors.white, fontSize: 12),
+              style: const TextStyle(color: VineTheme.whiteText, fontSize: 12),
             ),
           ],
         ),

--- a/mobile/lib/widgets/video_recorder/video_recorder_bottom_bar.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_bottom_bar.dart
@@ -24,7 +24,7 @@ class VideoRecorderBottomBar extends ConsumerWidget {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         padding: EdgeInsets.zero,
-        backgroundColor: Colors.transparent,
+        backgroundColor: VineTheme.transparent,
         elevation: 0,
         behavior: .floating,
         margin: const .fromLTRB(16, 0, 16, 68),

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -326,7 +326,7 @@ class _SafeNetworkImage extends StatelessWidget {
           return Container(
             width: width,
             height: height,
-            color: Colors.transparent,
+            color: VineTheme.transparent,
           );
         },
       );
@@ -341,7 +341,7 @@ class _SafeNetworkImage extends StatelessWidget {
       cacheManager: openVineImageCache,
       // Show transparent container so background surfaceContainer color shows through
       placeholder: (context, url) =>
-          Container(width: width, height: height, color: Colors.transparent),
+          Container(width: width, height: height, color: VineTheme.transparent),
       errorWidget: (context, url, error) {
         // 404s are expected - thumbnail may not exist yet. Handle silently.
         final errorStr = error.toString();
@@ -365,7 +365,7 @@ class _SafeNetworkImage extends StatelessWidget {
         return Container(
           width: width,
           height: height,
-          color: Colors.transparent,
+          color: VineTheme.transparent,
         );
       },
     );

--- a/mobile/lib/widgets/vine_drawer.dart
+++ b/mobile/lib/widgets/vine_drawer.dart
@@ -87,7 +87,7 @@ class _VineDrawerState extends ConsumerState<VineDrawer> {
     final statusBarHeight = MediaQuery.of(context).padding.top;
 
     return Drawer(
-      backgroundColor: Colors.transparent,
+      backgroundColor: VineTheme.transparent,
       child: Container(
         margin: EdgeInsets.only(top: statusBarHeight),
         decoration: const BoxDecoration(

--- a/mobile/packages/divine_camera/lib/src/widgets/camera_preview_widget.dart
+++ b/mobile/packages/divine_camera/lib/src/widgets/camera_preview_widget.dart
@@ -177,9 +177,9 @@ class _CameraPreviewWidgetState extends State<CameraPreviewWidget> {
     if (!_camera.isInitialized || textureToShow == null) {
       return widget.loadingWidget ??
           const ColoredBox(
-            color: Colors.black,
+            color: Color(0xFF000000),
             child: Center(
-              child: CircularProgressIndicator(color: Colors.white),
+              child: CircularProgressIndicator(color: Color(0xFFFFFFFF)),
             ),
           );
     }

--- a/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar.dart
+++ b/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar.dart
@@ -297,8 +297,8 @@ class DiVineAppBar extends StatelessWidget implements PreferredSizeWidget {
   Color? _getBackgroundColor() {
     return switch (backgroundMode) {
       DiVineAppBarBackgroundMode.solid => backgroundColor ?? VineTheme.navGreen,
-      DiVineAppBarBackgroundMode.transparent => Colors.transparent,
-      DiVineAppBarBackgroundMode.gradient => Colors.transparent,
+      DiVineAppBarBackgroundMode.transparent => VineTheme.transparent,
+      DiVineAppBarBackgroundMode.gradient => VineTheme.transparent,
     };
   }
 }

--- a/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar_gradient.dart
+++ b/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar_gradient.dart
@@ -52,7 +52,7 @@ class DiVineAppBarGradient extends Equatable {
   static DiVineAppBarGradient videoOverlay = DiVineAppBarGradient(
     colors: [
       VineTheme.backgroundColor.withValues(alpha: 0.7),
-      Colors.transparent,
+      VineTheme.transparent,
     ],
   );
 
@@ -62,7 +62,7 @@ class DiVineAppBarGradient extends Equatable {
   static DiVineAppBarGradient subtleOverlay = DiVineAppBarGradient(
     colors: [
       VineTheme.backgroundColor.withValues(alpha: 0.4),
-      Colors.transparent,
+      VineTheme.transparent,
     ],
   );
 

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
@@ -127,7 +127,7 @@ class VineBottomSheet extends StatelessWidget {
         context: context,
         isScrollControlled: true,
         useSafeArea: true,
-        backgroundColor: Colors.transparent,
+        backgroundColor: VineTheme.transparent,
         elevation: 0,
         builder: (_) => DraggableScrollableSheet(
           initialChildSize: initialChildSize,
@@ -153,7 +153,7 @@ class VineBottomSheet extends StatelessWidget {
         context: context,
         isScrollControlled: isScrollControlled ?? expanded,
         useSafeArea: true,
-        backgroundColor: Colors.transparent,
+        backgroundColor: VineTheme.transparent,
         elevation: 0,
         builder: (_) => VineBottomSheet(
           scrollable: false,

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_action_menu.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_action_menu.dart
@@ -102,9 +102,9 @@ class _VineBottomSheetListTile extends StatelessWidget {
 
     final color = isEnabled
         ? data.isDestructive
-              ? const Color(0xFFF44336)
-              : Colors.white
-        : const Color(0x40FFFFFF);
+              ? VineTheme.error
+              : VineTheme.whiteText
+        : VineTheme.onSurfaceDisabled;
 
     return ListTile(
       enabled: isEnabled,

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_selection_menu.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_selection_menu.dart
@@ -87,7 +87,7 @@ class _VineBottomSheetSelectionOption extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: isSelected ? VineTheme.surfaceContainer : Colors.transparent,
+      color: isSelected ? VineTheme.surfaceContainer : VineTheme.transparent,
       child: InkWell(
         onTap: onTap,
         child: Container(

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_tile_menu.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_tile_menu.dart
@@ -97,9 +97,9 @@ class _VineBottomSheetListTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final effectiveColor = data.onTap != null
         ? data.isDestructive
-              ? Colors.white
-              : const Color(0xFFF44336)
-        : Colors.white.withAlpha(64);
+              ? VineTheme.whiteText
+              : VineTheme.error
+        : VineTheme.onSurfaceDisabled;
 
     return ListTile(
       iconColor: effectiveColor,

--- a/mobile/packages/divine_ui/lib/src/button/divine_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_button.dart
@@ -186,7 +186,7 @@ class _DivineButtonContent extends StatelessWidget {
     DivineButtonType.tertiary => VineTheme.inverseSurface,
     DivineButtonType.ghost => VineTheme.scrim65,
     DivineButtonType.ghostSecondary => VineTheme.scrim15,
-    DivineButtonType.link => Colors.transparent,
+    DivineButtonType.link => VineTheme.transparent,
     DivineButtonType.error => VineTheme.error,
   };
 
@@ -286,7 +286,7 @@ class _DivineButtonContent extends StatelessWidget {
       duration: const Duration(milliseconds: 150),
       opacity: _isEnabled ? 1.0 : _disabledOpacity,
       child: Material(
-        color: Colors.transparent,
+        color: VineTheme.transparent,
         child: InkWell(
           onTap: onPressed,
           borderRadius: BorderRadius.circular(_borderRadius),

--- a/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
@@ -212,7 +212,7 @@ class _DivineIconButtonContent extends StatelessWidget {
         duration: const Duration(milliseconds: 150),
         opacity: _isEnabled ? 1.0 : _disabledOpacity,
         child: Material(
-          color: Colors.transparent,
+          color: VineTheme.transparent,
           child: InkWell(
             onTap: onPressed,
             borderRadius: BorderRadius.circular(_borderRadius),

--- a/mobile/packages/divine_ui/lib/src/divine_snackbar_container.dart
+++ b/mobile/packages/divine_ui/lib/src/divine_snackbar_container.dart
@@ -21,7 +21,7 @@ class DivineSnackbarContainer extends StatelessWidget {
     String? actionLabel,
     VoidCallback? onActionPressed,
   }) => SnackBar(
-    backgroundColor: Colors.transparent,
+    backgroundColor: VineTheme.transparent,
     elevation: 0,
     padding: EdgeInsets.zero,
     behavior: SnackBarBehavior.floating,

--- a/mobile/packages/divine_ui/lib/src/partial_circle_spinner.dart
+++ b/mobile/packages/divine_ui/lib/src/partial_circle_spinner.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 
 /// Custom circular progress spinner.
@@ -12,7 +13,7 @@ class PartialCircleSpinner extends StatefulWidget {
     required this.progress,
     this.size = 24,
     this.backgroundColor = const Color(0xFF737778),
-    this.progressColor = Colors.white,
+    this.progressColor = VineTheme.whiteText,
     super.key,
   });
 

--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -238,7 +238,7 @@ class VineTheme {
   // Classic Vine green color palette
 
   /// Primary brand green color.
-  static const Color vineGreen = Color(0xFF00B488);
+  static const Color vineGreen = Color(0xFF27C58B);
 
   /// On-primary color (text/icons on primary background).
   static const Color onPrimary = Color(0xFF00150D);
@@ -250,10 +250,10 @@ class VineTheme {
   static const Color vineGreenDark = Color(0xFF009A72);
 
   /// Dark green for primary accents on dark backgrounds.
-  static const Color primaryDarkGreen = Color(0xFF06281D);
+  static const Color primaryDarkGreen = Color(0xFF07241B);
 
   /// Lighter variant of the brand green.
-  static const Color vineGreenLight = Color(0xFF33C49F);
+  static const Color vineGreenLight = Color(0xFFD0FBCB);
 
   // Navigation colors
 
@@ -392,6 +392,9 @@ class VineTheme {
   /// Tertiary/light text color (medium gray).
   static const Color lightText = Color(0xFF888888);
 
+  /// Off-white surface color for light-on-dark text and backgrounds.
+  static const Color offWhite = Color(0xFFF9F7F6);
+
   /// White text color alias.
   static const Color whiteText = Colors.white;
 
@@ -477,6 +480,12 @@ class VineTheme {
 
   /// Accent purple color.
   static const Color accentPurple = Color(0xFF8568FF);
+
+  /// Fully transparent color sentinel.
+  static const Color transparent = Color(0x00000000);
+
+  /// Scrim at 80% opacity (black 80%).
+  static const Color scrim80 = Color(0xCC000000);
 
   /// The complete theme data for the app.
   static ThemeData get theme => ThemeData(

--- a/mobile/packages/divine_ui/test/src/divine_ui_test.dart
+++ b/mobile/packages/divine_ui/test/src/divine_ui_test.dart
@@ -12,9 +12,7 @@ void main() {
     });
     group('colors', () {
       test('has correct vineGreen color', () {
-        expect(VineTheme.vineGreen.r, closeTo(0, 0.01));
-        expect(VineTheme.vineGreen.g, closeTo(0.706, 0.01));
-        expect(VineTheme.vineGreen.b, closeTo(0.533, 0.01));
+        expect(VineTheme.vineGreen, const Color(0xFF27C58B));
       });
 
       test('has correct vineGreenDark color', () {
@@ -22,7 +20,7 @@ void main() {
       });
 
       test('has correct vineGreenLight color', () {
-        expect(VineTheme.vineGreenLight, const Color(0xFF33C49F));
+        expect(VineTheme.vineGreenLight, const Color(0xFFD0FBCB));
       });
 
       test('has correct backgroundColor', () {

--- a/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_player.dart
+++ b/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_player.dart
@@ -268,7 +268,7 @@ class _DefaultLoadingState extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ColoredBox(
-      color: Colors.black,
+      color: const Color(0xFF000000),
       child: Stack(
         fit: StackFit.expand,
         children: [
@@ -279,7 +279,9 @@ class _DefaultLoadingState extends StatelessWidget {
               errorBuilder: (context, error, stackTrace) =>
                   const SizedBox.shrink(),
             ),
-          const Center(child: CircularProgressIndicator(color: Colors.white)),
+          const Center(
+            child: CircularProgressIndicator(color: Color(0xFFFFFFFF)),
+          ),
         ],
       ),
     );
@@ -293,16 +295,16 @@ class _DefaultErrorState extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const ColoredBox(
-      color: Colors.black,
+      color: Color(0xFF000000),
       child: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.error_outline, color: Colors.white70, size: 48),
+            Icon(Icons.error_outline, color: Color(0xB3FFFFFF), size: 48),
             SizedBox(height: 16),
             Text(
               'Failed to load video',
-              style: TextStyle(color: Colors.white70, fontSize: 16),
+              style: TextStyle(color: Color(0xB3FFFFFF), fontSize: 16),
             ),
           ],
         ),

--- a/mobile/packages/pooled_video_player/lib/src/widgets/single_video_player.dart
+++ b/mobile/packages/pooled_video_player/lib/src/widgets/single_video_player.dart
@@ -216,9 +216,9 @@ class _DefaultLoadingState extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const ColoredBox(
-      color: Colors.black,
+      color: Color(0xFF000000),
       child: Center(
-        child: CircularProgressIndicator(color: Colors.white),
+        child: CircularProgressIndicator(color: Color(0xFFFFFFFF)),
       ),
     );
   }
@@ -232,24 +232,24 @@ class _DefaultErrorState extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ColoredBox(
-      color: Colors.black,
+      color: const Color(0xFF000000),
       child: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(Icons.error_outline, color: Colors.white70, size: 48),
+            const Icon(Icons.error_outline, color: Color(0xB3FFFFFF), size: 48),
             const SizedBox(height: 16),
             const Text(
               'Failed to load video',
-              style: TextStyle(color: Colors.white70, fontSize: 16),
+              style: TextStyle(color: Color(0xB3FFFFFF), fontSize: 16),
             ),
             const SizedBox(height: 16),
             TextButton.icon(
               onPressed: onRetry,
-              icon: const Icon(Icons.refresh, color: Colors.white),
+              icon: const Icon(Icons.refresh, color: Color(0xFFFFFFFF)),
               label: const Text(
                 'Tap to retry',
-                style: TextStyle(color: Colors.white),
+                style: TextStyle(color: Color(0xFFFFFFFF)),
               ),
             ),
           ],

--- a/mobile/test/widgets/list_attribution_chip_test.dart
+++ b/mobile/test/widgets/list_attribution_chip_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for ListAttributionChip widget - displays curated list attribution
 // ABOUTME: Verifies dark theme styling, list name display, and navigation on tap
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
@@ -122,8 +123,7 @@ void main() {
 
       final icon = tester.widget<Icon>(find.byIcon(Icons.playlist_play));
       expect(icon.size, equals(14));
-      // VineTheme.vineGreen is Color(0xFF00B488)
-      expect(icon.color, equals(const Color(0xFF00B488)));
+      expect(icon.color, equals(VineTheme.vineGreen));
     });
 
     testWidgets('text is vineGreen color and 12px size', (tester) async {
@@ -136,7 +136,7 @@ void main() {
 
       final text = tester.widget<Text>(find.text('Cool Videos'));
       expect(text.style?.fontSize, equals(12));
-      expect(text.style?.color, equals(const Color(0xFF00B488)));
+      expect(text.style?.color, equals(VineTheme.vineGreen));
     });
 
     testWidgets('uses Wrap widget with 4px spacing', (tester) async {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Eliminates all raw `Colors.*` usage across the app and packages, routing every color reference through `VineTheme` tokens. Also corrects four brand color values that were wrong in `VineTheme` — `vineGreen` (`#00B488` → `#27C58B`), `vineGreenLight` (`#33C49F` → `#D0FBCB`), `primaryDarkGreen` (`#06281D` → `#07241B`) — and adds two missing tokens: `VineTheme.transparent` and `VineTheme.offWhite` (`#F9F7F6`).

<!--- Describe your changes in detail -->

**Related Issue:** #1985 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore