### PR TITLE
fix(playback): unify center play pause control

### DIFF
--- a/docs/superpowers/plans/2026-03-12-play-pause-control.md
+++ b/docs/superpowers/plans/2026-03-12-play-pause-control.md
@@ -1,0 +1,70 @@
+# Play/Pause Control Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the Figma-matched center play/pause control everywhere short-form playback appears and fix the pooled paused-state overlay bug without changing the underlying player architecture.
+
+**Architecture:** Extract one reusable centered playback-control widget in the app layer and use it from both the pooled overlay path and the legacy `VideoFeedItem` path. Fix the pooled stale-state bug by persisting "played before" state per `Player` instance so widget remounts do not erase paused-state visibility.
+
+**Tech Stack:** Flutter, Dart, `flutter_svg`, `media_kit`, `video_player`, Flutter widget tests
+
+---
+
+## Chunk 1: Shared Control And Pooled Overlay
+
+### Task 1: Add failing pooled-overlay tests
+
+**Files:**
+- Create: `mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart`
+- Modify: `mobile/test/screens/feed/feed_video_overlay_test.dart`
+
+- [ ] **Step 1: Write the failing tests**
+
+- [ ] **Step 2: Run the targeted tests and verify the pooled remount case fails for the current implementation**
+
+Run: `flutter test test/widgets/video_feed_item/paused_video_play_overlay_test.dart test/screens/feed/feed_video_overlay_test.dart`
+
+- [ ] **Step 3: Implement the minimal pooled-overlay fix**
+
+**Files:**
+- Modify: `mobile/lib/widgets/video_feed_item/paused_video_play_overlay.dart`
+- Create: `mobile/lib/widgets/video_feed_item/center_playback_control.dart`
+
+- [ ] **Step 4: Re-run the targeted pooled tests until green**
+
+Run: `flutter test test/widgets/video_feed_item/paused_video_play_overlay_test.dart test/screens/feed/feed_video_overlay_test.dart`
+
+## Chunk 2: Legacy Surface Reuse
+
+### Task 2: Replace inline legacy controls with the shared widget
+
+**Files:**
+- Modify: `mobile/lib/widgets/video_feed_item/video_feed_item.dart`
+- Test: `mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart`
+
+- [ ] **Step 1: Write or extend a test that verifies the shared control remains accessible in play and pause states where practical**
+
+- [ ] **Step 2: Replace the legacy inline play/pause button containers with the shared control**
+
+- [ ] **Step 3: Re-run the smallest relevant tests**
+
+Run: `flutter test test/widgets/video_feed_item/paused_video_play_overlay_test.dart test/screens/feed/feed_video_overlay_test.dart`
+
+## Chunk 3: Follow-Up Tracking And Verification
+
+### Task 3: File the architecture follow-up and verify the final diff
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-03-12-play-pause-control-design.md`
+
+- [ ] **Step 1: Create a GitHub issue describing migration from legacy `VideoFeedItem` playback to pooled playback**
+
+- [ ] **Step 2: Run final targeted verification**
+
+Run: `flutter test test/widgets/video_feed_item/paused_video_play_overlay_test.dart test/screens/feed/feed_video_overlay_test.dart`
+
+- [ ] **Step 3: Run one additional relevant regression test if legacy playback code changes materially**
+
+Run: `flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart`
+
+- [ ] **Step 4: Review `git diff` and ensure only play/pause-control and issue-tracking changes remain**

--- a/docs/superpowers/specs/2026-03-12-play-pause-control-design.md
+++ b/docs/superpowers/specs/2026-03-12-play-pause-control-design.md
@@ -1,0 +1,44 @@
+# Play/Pause Control Design
+
+**Date:** 2026-03-12
+
+**Goal**
+
+Implement the Figma center play/pause control everywhere short-form video playback appears, remove duplicate control styling, and fix the pooled-player bug where playback can stop without the play affordance reappearing.
+
+**Current State**
+
+- Pooled feed surfaces use `PausedVideoPlayOverlay` for the centered paused state.
+- Legacy `VideoFeedItem` surfaces render their own centered play and fading pause controls inline.
+- The pooled overlay keeps "has playback started" as widget-local state, so rebuilding the overlay while the player is paused can permanently suppress the play affordance for that player instance.
+
+**Design**
+
+1. Introduce a shared centered playback control widget for the Figma design.
+   - Render the same `64x64` scrim button for both play and pause states.
+   - Use the existing `assets/icon/content-controls/play.svg` and `pause.svg` assets.
+   - Keep semantics labels explicit for accessibility and tests.
+
+2. Reuse that shared widget in both playback paths.
+   - `PausedVideoPlayOverlay` will render the shared control in the play state.
+   - `VideoFeedItem` will render the shared control for its centered play state and for the fading pause animation.
+
+3. Fix the pooled paused-state bug at the shared overlay boundary.
+   - Track "this player has played before" per `Player` instance rather than per overlay widget instance.
+   - Preserve the existing first-frame guard so the play affordance does not appear before the video is visually ready.
+   - Continue hiding the play affordance while buffering or actively playing.
+
+**Testing**
+
+- Add a widget test that remounts `PausedVideoPlayOverlay` with the same paused `Player` after playback was previously observed, and verify the play affordance still appears.
+- Add a widget test that validates the shared control styling/semantics in both play and pause modes where practical.
+- Update feed-overlay coverage to ensure pooled surfaces still hide the play affordance before first frame and while actively playing.
+
+**Non-Goals**
+
+- Unifying the legacy `VideoFeedItem` backend and the pooled `media_kit` backend in this change.
+- Broad playback architecture changes outside the center-control behavior.
+
+**Follow-Up**
+
+- File a separate issue to migrate remaining legacy `VideoFeedItem` surfaces onto the pooled playback stack so the app no longer maintains two playback implementations.

--- a/mobile/lib/widgets/video_feed_item/center_playback_control.dart
+++ b/mobile/lib/widgets/video_feed_item/center_playback_control.dart
@@ -1,0 +1,87 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+enum CenterPlaybackControlState {
+  play,
+  pause,
+}
+
+/// Shared Figma-matched center control used for transient play/pause states.
+class CenterPlaybackControl extends StatelessWidget {
+  const CenterPlaybackControl({
+    required this.state,
+    this.semanticsLabel,
+    super.key,
+  });
+
+  final CenterPlaybackControlState state;
+  final String? semanticsLabel;
+
+  static const _buttonShadowColor = Color(0x1A000000);
+
+  @override
+  Widget build(BuildContext context) {
+    final iconAsset = switch (state) {
+      CenterPlaybackControlState.play =>
+        'assets/icon/content-controls/play.svg',
+      CenterPlaybackControlState.pause =>
+        'assets/icon/content-controls/pause.svg',
+    };
+
+    Widget icon = SvgPicture.asset(
+      iconAsset,
+      width: 32,
+      height: 32,
+      colorFilter: const ColorFilter.mode(
+        VineTheme.whiteText,
+        BlendMode.srcIn,
+      ),
+    );
+
+    if (semanticsLabel != null) {
+      icon = Semantics(
+        identifier: 'play_button',
+        container: true,
+        explicitChildNodes: true,
+        label: semanticsLabel,
+        child: Center(child: icon),
+      );
+    } else {
+      icon = Center(child: icon);
+    }
+
+    return Center(
+      child: Container(
+        width: 64,
+        height: 64,
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: VineTheme.scrim65,
+          borderRadius: BorderRadius.circular(24),
+        ),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            boxShadow: const [
+              BoxShadow(
+                color: _buttonShadowColor,
+                offset: Offset(1, 1),
+                blurRadius: 1,
+              ),
+              BoxShadow(
+                color: _buttonShadowColor,
+                offset: Offset(0.4, 0.4),
+                blurRadius: 0.6,
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(8),
+            child: icon,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/video_feed_item/paused_video_play_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/paused_video_play_overlay.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
 
-import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:media_kit/media_kit.dart';
+import 'package:openvine/widgets/video_feed_item/center_playback_control.dart';
 
 /// Large centered play affordance shown when a pooled video is paused.
 class PausedVideoPlayOverlay extends StatefulWidget {
@@ -23,6 +22,10 @@ class PausedVideoPlayOverlay extends StatefulWidget {
 }
 
 class _PausedVideoPlayOverlayState extends State<PausedVideoPlayOverlay> {
+  static final Expando<bool> _playerPlaybackSeen = Expando<bool>(
+    'playerPlaybackSeen',
+  );
+
   StreamSubscription<bool>? _playingSubscription;
   bool _hasStartedPlayback = false;
 
@@ -42,8 +45,16 @@ class _PausedVideoPlayOverlayState extends State<PausedVideoPlayOverlay> {
   }
 
   void _subscribeToPlayback() {
-    _hasStartedPlayback = widget.player.state.playing;
+    final playerIsPlaying = widget.player.state.playing;
+    _hasStartedPlayback =
+        playerIsPlaying || (_playerPlaybackSeen[widget.player] ?? false);
+    if (playerIsPlaying) {
+      _playerPlaybackSeen[widget.player] = true;
+    }
     _playingSubscription = widget.player.stream.playing.listen((isPlaying) {
+      if (isPlaying) {
+        _playerPlaybackSeen[widget.player] = true;
+      }
       if (isPlaying && !_hasStartedPlayback && mounted) {
         setState(() {
           _hasStartedPlayback = true;
@@ -107,8 +118,10 @@ class _PausedVideoPlayOverlayState extends State<PausedVideoPlayOverlay> {
                       );
                     },
                     child: shouldShow
-                        ? const _PausedPlayAffordance(
+                        ? const CenterPlaybackControl(
                             key: ValueKey('paused-play'),
+                            state: CenterPlaybackControlState.play,
+                            semanticsLabel: 'Play video',
                           )
                         : const SizedBox.shrink(
                             key: ValueKey('paused-hidden'),
@@ -120,41 +133,6 @@ class _PausedVideoPlayOverlayState extends State<PausedVideoPlayOverlay> {
           },
         );
       },
-    );
-  }
-}
-
-class _PausedPlayAffordance extends StatelessWidget {
-  const _PausedPlayAffordance({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Center(
-      child: Container(
-        width: 64,
-        height: 64,
-        decoration: BoxDecoration(
-          color: VineTheme.scrim65,
-          borderRadius: BorderRadius.circular(24),
-        ),
-        child: Semantics(
-          identifier: 'play_button',
-          container: true,
-          explicitChildNodes: true,
-          label: 'Play video',
-          child: Center(
-            child: SvgPicture.asset(
-              'assets/icon/content-controls/play.svg',
-              width: 32,
-              height: 32,
-              colorFilter: const ColorFilter.mode(
-                VineTheme.whiteText,
-                BlendMode.srcIn,
-              ),
-            ),
-          ),
-        ),
-      ),
     );
   }
 }

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -50,6 +50,7 @@ import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/video_feed_item/actions/actions.dart';
 import 'package:openvine/widgets/video_feed_item/audio_attribution_row.dart';
+import 'package:openvine/widgets/video_feed_item/center_playback_control.dart';
 import 'package:openvine/widgets/video_feed_item/collaborator_avatar_row.dart';
 import 'package:openvine/widgets/video_feed_item/inspired_by_attribution_row.dart';
 import 'package:openvine/widgets/video_feed_item/list_attribution_chip.dart';
@@ -1164,34 +1165,9 @@ class _VideoFeedItemState extends ConsumerState<VideoFeedItem> {
                             if (isActive &&
                                 value.isInitialized &&
                                 !value.isPlaying)
-                              Center(
-                                child: Container(
-                                  width: 64,
-                                  height: 64,
-                                  decoration: BoxDecoration(
-                                    color: VineTheme.backgroundColor.withValues(
-                                      alpha: 0.65,
-                                    ),
-                                    borderRadius: BorderRadius.circular(24),
-                                  ),
-                                  child: Semantics(
-                                    identifier: 'play_button',
-                                    container: true,
-                                    explicitChildNodes: true,
-                                    label: 'Play video',
-                                    child: Center(
-                                      child: SvgPicture.asset(
-                                        'assets/icon/content-controls/play.svg',
-                                        width: 32,
-                                        height: 32,
-                                        colorFilter: const ColorFilter.mode(
-                                          VineTheme.whiteText,
-                                          BlendMode.srcIn,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                ),
+                              const CenterPlaybackControl(
+                                state: CenterPlaybackControlState.play,
+                                semanticsLabel: 'Play video',
                               ),
                             // Fading pause button when resuming playback
                             if (_showFadingPauseButton &&
@@ -1202,24 +1178,8 @@ class _VideoFeedItemState extends ConsumerState<VideoFeedItem> {
                                 child: AnimatedOpacity(
                                   opacity: _pauseButtonOpacity,
                                   duration: const Duration(milliseconds: 500),
-                                  child: Container(
-                                    width: 64,
-                                    height: 64,
-                                    decoration: BoxDecoration(
-                                      color: VineTheme.scrim65,
-                                      borderRadius: BorderRadius.circular(24),
-                                    ),
-                                    child: Center(
-                                      child: SvgPicture.asset(
-                                        'assets/icon/content-controls/pause.svg',
-                                        width: 32,
-                                        height: 32,
-                                        colorFilter: const ColorFilter.mode(
-                                          VineTheme.whiteText,
-                                          BlendMode.srcIn,
-                                        ),
-                                      ),
-                                    ),
+                                  child: const CenterPlaybackControl(
+                                    state: CenterPlaybackControlState.pause,
                                   ),
                                 ),
                               ),

--- a/mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/paused_video_play_overlay_test.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/widgets/video_feed_item/paused_video_play_overlay.dart';
+
+class _MockPlayer extends Mock implements Player {}
+
+class _MockPlayerState extends Mock implements PlayerState {}
+
+class _MockPlayerStream extends Mock implements PlayerStream {}
+
+void main() {
+  group('PausedVideoPlayOverlay', () {
+    late Player mockPlayer;
+    late PlayerState mockPlayerState;
+    late PlayerStream mockPlayerStream;
+    late StreamController<bool> playingController;
+    late StreamController<bool> bufferingController;
+
+    setUp(() {
+      mockPlayer = _MockPlayer();
+      mockPlayerState = _MockPlayerState();
+      mockPlayerStream = _MockPlayerStream();
+      playingController = StreamController<bool>.broadcast();
+      bufferingController = StreamController<bool>.broadcast();
+
+      when(() => mockPlayer.state).thenReturn(mockPlayerState);
+      when(() => mockPlayer.stream).thenReturn(mockPlayerStream);
+      when(() => mockPlayerState.playing).thenReturn(false);
+      when(() => mockPlayerState.buffering).thenReturn(false);
+      when(
+        () => mockPlayerStream.playing,
+      ).thenAnswer((_) => playingController.stream);
+      when(
+        () => mockPlayerStream.buffering,
+      ).thenAnswer((_) => bufferingController.stream);
+    });
+
+    tearDown(() async {
+      await playingController.close();
+      await bufferingController.close();
+    });
+
+    Widget buildSubject({Key? key}) {
+      return MaterialApp(
+        home: Scaffold(
+          body: PausedVideoPlayOverlay(
+            key: key,
+            player: mockPlayer,
+            firstFrameFuture: Future<void>.value(),
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+      'keeps the play affordance visible when remounted with the same paused player after playback was observed',
+      (tester) async {
+        await tester.pumpWidget(buildSubject(key: const ValueKey('first')));
+        await tester.pump();
+
+        playingController.add(true);
+        await tester.pump();
+        playingController.add(false);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 220));
+
+        expect(find.bySemanticsLabel('Play video'), findsOneWidget);
+
+        await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+        await tester.pump();
+
+        await tester.pumpWidget(buildSubject(key: const ValueKey('second')));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 220));
+
+        expect(find.bySemanticsLabel('Play video'), findsOneWidget);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared Figma-matched center playback control for short-form video surfaces
- reuse that control in both pooled and legacy playback overlays
- fix pooled paused-state remounts so the play affordance survives widget rebuilds for the same player

## Verification
- `flutter test test/widgets/video_feed_item/paused_video_play_overlay_test.dart`
- `flutter test test/screens/feed/feed_video_overlay_test.dart`
- `flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart`
- `flutter analyze lib/widgets/video_feed_item/paused_video_play_overlay.dart lib/widgets/video_feed_item/video_feed_item.dart lib/widgets/video_feed_item/center_playback_control.dart`

## Follow-up
- refs #2182
