### PR TITLE
fix(gallery): recheck permission after save prompt

### DIFF
--- a/docs/superpowers/plans/2026-03-12-gallery-save-permission-recheck.md
+++ b/docs/superpowers/plans/2026-03-12-gallery-save-permission-recheck.md
@@ -1,0 +1,64 @@
+# Gallery Save Permission Recheck Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent gallery save/export from returning permission denied when the OS permission prompt was accepted but the plugin returns a stale non-granted result.
+
+**Architecture:** Keep the fix inside `GallerySaveService` by re-checking gallery permission status after a non-granted request result. Add one regression test that exercises the save path with a real temp file so the permission code runs.
+
+**Tech Stack:** Flutter, `flutter_test`, `mocktail`, `permissions_service`, `gal`
+
+---
+
+## Chunk 1: Regression Test And Minimal Fix
+
+### Task 1: Add the failing regression test
+
+**Files:**
+- Modify: `mobile/test/services/gallery_save_service_test.dart`
+- Test: `mobile/test/services/gallery_save_service_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that configures:
+
+- `checkGalleryStatus()` to return `canRequest`, then `granted`
+- `requestGalleryPermission()` to return `canRequest`
+- a real temp file path for `EditorVideo.file(...)`
+
+Assert that the result is not `GallerySavePermissionDenied()`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile && flutter test test/services/gallery_save_service_test.dart`
+Expected: FAIL because `_checkPermission()` trusts the stale request result and returns denial before saving.
+
+### Task 2: Implement the minimal permission re-check
+
+**Files:**
+- Modify: `mobile/lib/services/gallery_save_service.dart`
+- Test: `mobile/test/services/gallery_save_service_test.dart`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `_checkPermission()`, after `requestGalleryPermission()` returns a non-granted status, immediately call `checkGalleryStatus()` again and allow the save flow to continue if the follow-up status is `granted`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mobile && flutter test test/services/gallery_save_service_test.dart`
+Expected: PASS
+
+- [ ] **Step 5: Run focused verification**
+
+Run: `cd mobile && flutter test test/services/gallery_save_service_test.dart`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-03-12-gallery-save-permission-recheck-design.md \
+        docs/superpowers/plans/2026-03-12-gallery-save-permission-recheck.md \
+        mobile/lib/services/gallery_save_service.dart \
+        mobile/test/services/gallery_save_service_test.dart
+git commit -m "fix(gallery): recheck permission after save grant prompt"
+```

--- a/docs/superpowers/specs/2026-03-12-gallery-save-permission-recheck-design.md
+++ b/docs/superpowers/specs/2026-03-12-gallery-save-permission-recheck-design.md
@@ -1,0 +1,49 @@
+# Gallery Save Permission Recheck Design
+
+## Goal
+
+Fix the gallery save/export flow so it does not report permission denied when the OS permission prompt was just accepted but the immediate request result is stale.
+
+## Problem
+
+`GallerySaveService._checkPermission()` currently:
+
+1. Checks gallery status.
+2. If status is `canRequest`, calls `requestGalleryPermission()`.
+3. Trusts the direct return value from `requestGalleryPermission()`.
+
+On iOS, the permission plugin can briefly report a non-granted result immediately after the user accepts the prompt. That makes the save flow incorrectly return `GallerySavePermissionDenied()` even though a follow-up status check would report `granted`.
+
+## Scope
+
+This change is limited to the save/export permission path in `mobile/lib/services/gallery_save_service.dart`.
+
+It does not change:
+
+- camera entry permission gating
+- permission model types
+- settings UX
+- gallery save result types
+
+## Design
+
+Keep the existing save flow and permission abstraction. Change `_checkPermission()` so that when the initial status is `canRequest`, the service:
+
+1. calls `requestGalleryPermission()`
+2. if that direct result is `granted`, proceed as today
+3. otherwise immediately calls `checkGalleryStatus()` again
+4. proceeds if the follow-up status is `granted`
+5. only returns `GallerySavePermissionDenied()` if the follow-up status is still non-granted
+
+This keeps the logic local to the save flow, avoids retrying the entire save operation, and minimizes surface area.
+
+## Testing
+
+Add a regression test in `mobile/test/services/gallery_save_service_test.dart` that proves:
+
+- the initial status is `canRequest`
+- the request result is still non-granted
+- the follow-up status check returns `granted`
+- the service no longer returns `GallerySavePermissionDenied()`
+
+Use a real temp file so the permission logic is exercised instead of failing early on a missing path.

--- a/mobile/lib/services/gallery_save_service.dart
+++ b/mobile/lib/services/gallery_save_service.dart
@@ -165,6 +165,11 @@ class GallerySaveService {
       if (status == PermissionStatus.canRequest) {
         final requested = await _permissionsService.requestGalleryPermission();
         if (requested == PermissionStatus.granted) return null;
+
+        // Some platforms can briefly report a stale non-granted request result
+        // immediately after the user accepts the OS prompt.
+        final refreshedStatus = await _permissionsService.checkGalleryStatus();
+        if (refreshedStatus == PermissionStatus.granted) return null;
       }
 
       // Permanently denied or still not granted

--- a/mobile/test/services/gallery_save_service_test.dart
+++ b/mobile/test/services/gallery_save_service_test.dart
@@ -119,6 +119,42 @@ void main() {
     });
 
     test(
+      're-checks gallery status after a stale non-granted request result',
+      () async {
+        var statusChecks = 0;
+        when(() => mockPermissionsService.checkGalleryStatus()).thenAnswer((
+          _,
+        ) async {
+          statusChecks += 1;
+          return statusChecks == 1
+              ? PermissionStatus.canRequest
+              : PermissionStatus.granted;
+        });
+        when(
+          () => mockPermissionsService.requestGalleryPermission(),
+        ).thenAnswer((_) async => PermissionStatus.canRequest);
+
+        final tempDir = Directory.systemTemp.createTempSync('gallery_test_');
+        final tempFile = File('${tempDir.path}/test_video.mp4');
+        tempFile.writeAsBytesSync([0, 1, 2, 3]);
+
+        try {
+          final result = await service.saveVideoToGallery(
+            EditorVideo.file(tempFile.path),
+          );
+
+          expect(result, isNot(isA<GallerySavePermissionDenied>()));
+          verify(() => mockPermissionsService.checkGalleryStatus()).called(2);
+          verify(
+            () => mockPermissionsService.requestGalleryPermission(),
+          ).called(1);
+        } finally {
+          tempDir.deleteSync(recursive: true);
+        }
+      },
+    );
+
+    test(
       'skips permission check on MissingPluginException (desktop)',
       () async {
         // Simulate desktop platform where permission_handler is unavailable


### PR DESCRIPTION
## Summary
- re-check gallery permission status after a non-granted save prompt result before returning denial
- add a regression test for the stale post-grant permission case in gallery save/export
- document the design and implementation plan for this focused bugfix

## Test Plan
- [x] cd mobile && flutter test --no-pub test/services/gallery_save_service_test.dart
- [x] pre-commit analyzer (`Analyzing mobile... No issues found!`)
- [x] pre-push targeted test hook for `test/services/gallery_save_service_test.dart`
