### PR TITLE
perf(feed): batch-fetch creator profiles in VideoFeedBloc

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -13,6 +13,7 @@ import 'package:openvine/blocs/video_feed/home_feed_cache.dart';
 import 'package:openvine/repositories/follow_repository.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:profile_repository/profile_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -37,6 +38,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
     required VideosRepository videosRepository,
     required FollowRepository followRepository,
     required CuratedListRepository curatedListRepository,
+    ProfileRepository? profileRepository,
     String? userPubkey,
     SharedPreferences? sharedPreferences,
     bool serveCachedHomeFeed = true,
@@ -46,6 +48,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   }) : _videosRepository = videosRepository,
        _followRepository = followRepository,
        _curatedListRepository = curatedListRepository,
+       _profileRepository = profileRepository,
        _userPubkey = userPubkey,
        _sharedPreferences = sharedPreferences,
        _serveCachedHomeFeed = serveCachedHomeFeed,
@@ -68,6 +71,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
   final VideosRepository _videosRepository;
   final FollowRepository _followRepository;
   final CuratedListRepository _curatedListRepository;
+  final ProfileRepository? _profileRepository;
   final String? _userPubkey;
   final SharedPreferences? _sharedPreferences;
   final bool _serveCachedHomeFeed;
@@ -256,6 +260,9 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
           listOnlyVideoIds: mergedListOnly,
         ),
       );
+
+      // Batch-fetch profiles for new creators only.
+      await _fetchCreatorProfiles(validNewVideos, emit);
     } catch (e) {
       Log.error(
         'VideoFeedBloc: Failed to load more videos - $e',
@@ -439,6 +446,9 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
 
       _feedTracker?.markFeedDisplayed(mode.name, validVideos.length);
 
+      // Batch-fetch creator profiles to warm the Drift cache.
+      await _fetchCreatorProfiles(validVideos, emit);
+
       // Cache the raw response for next cold start (fire-and-forget).
       if ((mode == FeedMode.home || mode == FeedMode.forYou) &&
           _sharedPreferences != null &&
@@ -494,4 +504,44 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedState> {
               .getPopularVideos(until: until)
               .then((videos) => HomeFeedResult(videos: videos)),
       };
+
+  /// Batch-fetch creator profiles for the given videos.
+  ///
+  /// Only fetches profiles for pubkeys not already in
+  /// [state.creatorProfiles]. Does not block video display — called
+  /// after videos are already emitted.
+  Future<void> _fetchCreatorProfiles(
+    List<VideoEvent> videos,
+    Emitter<VideoFeedState> emit,
+  ) async {
+    if (_profileRepository == null || videos.isEmpty) return;
+
+    final newPubkeys = videos
+        .map((v) => v.pubkey)
+        .toSet()
+        .difference(state.creatorProfiles.keys.toSet())
+        .toList();
+
+    if (newPubkeys.isEmpty) return;
+
+    try {
+      final profiles = await _profileRepository.fetchBatchProfiles(
+        pubkeys: newPubkeys,
+      );
+
+      if (profiles.isNotEmpty) {
+        emit(
+          state.copyWith(
+            creatorProfiles: {...state.creatorProfiles, ...profiles},
+          ),
+        );
+      }
+    } catch (e) {
+      Log.error(
+        'VideoFeedBloc: Failed to batch-fetch creator profiles - $e',
+        name: 'VideoFeedBloc',
+        category: LogCategory.video,
+      );
+    }
+  }
 }

--- a/mobile/lib/blocs/video_feed/video_feed_state.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_state.dart
@@ -58,6 +58,7 @@ final class VideoFeedState extends Equatable {
     this.error,
     this.videoListSources = const {},
     this.listOnlyVideoIds = const {},
+    this.creatorProfiles = const {},
   });
 
   /// The current loading status.
@@ -90,6 +91,13 @@ final class VideoFeedState extends Equatable {
   /// list attribution for them (Phase 4).
   final Set<String> listOnlyVideoIds;
 
+  /// Creator profiles keyed by pubkey.
+  ///
+  /// Populated by batch-fetching profiles for video creators after
+  /// videos load. Warms the repository's Drift cache so individual
+  /// profile lookups are instant hits.
+  final Map<String, UserProfile> creatorProfiles;
+
   /// Whether data has been successfully loaded.
   bool get isLoaded => status == VideoFeedStatus.success;
 
@@ -110,6 +118,7 @@ final class VideoFeedState extends Equatable {
     bool clearError = false,
     Map<String, Set<String>>? videoListSources,
     Set<String>? listOnlyVideoIds,
+    Map<String, UserProfile>? creatorProfiles,
   }) {
     return VideoFeedState(
       status: status ?? this.status,
@@ -120,6 +129,7 @@ final class VideoFeedState extends Equatable {
       error: clearError ? null : (error ?? this.error),
       videoListSources: videoListSources ?? this.videoListSources,
       listOnlyVideoIds: listOnlyVideoIds ?? this.listOnlyVideoIds,
+      creatorProfiles: creatorProfiles ?? this.creatorProfiles,
     );
   }
 
@@ -133,5 +143,6 @@ final class VideoFeedState extends Equatable {
     error,
     videoListSources,
     listOnlyVideoIds,
+    creatorProfiles,
   ];
 }

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -90,6 +90,7 @@ class VideoFeedPage extends ConsumerWidget {
     final videosRepository = ref.watch(videosRepositoryProvider);
     final followRepository = ref.watch(followRepositoryProvider);
     final curatedListRepository = ref.watch(curatedListRepositoryProvider);
+    final profileRepository = ref.watch(profileRepositoryProvider);
     final authService = ref.watch(authServiceProvider);
     final sharedPreferences = ref.watch(sharedPreferencesProvider);
     final showDivineHostedOnly = ref
@@ -102,6 +103,7 @@ class VideoFeedPage extends ConsumerWidget {
         videosRepository: videosRepository,
         followRepository: followRepository,
         curatedListRepository: curatedListRepository,
+        profileRepository: profileRepository,
         userPubkey: authService.currentPublicKeyHex,
         sharedPreferences: sharedPreferences,
         serveCachedHomeFeed: !showDivineHostedOnly,
@@ -130,8 +132,6 @@ class VideoFeedView extends ConsumerStatefulWidget {
 
 class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     with WidgetsBindingObserver {
-  int? lastPrefetchIndex;
-
   /// Whether the home tab is currently active.
   ///
   /// Used to prevent overlay-close from resuming playback when the user
@@ -259,7 +259,6 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     }
     controllerMode = null;
     lastPooledVideos = null;
-    lastPrefetchIndex = null;
   }
 
   bool _samePooledVideos(List<VideoItem> previous, List<VideoItem> current) {
@@ -289,31 +288,6 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     }
 
     return true;
-  }
-
-  void prefetchProfiles(List<VideoEvent> videos, int index) {
-    if (index == lastPrefetchIndex) return;
-    lastPrefetchIndex = index;
-
-    final safeIndex = index.clamp(0, videos.length - 1);
-    final pubkeys = <String>[];
-
-    if (safeIndex > 0) {
-      pubkeys.add(videos[safeIndex - 1].pubkey);
-    }
-
-    if (safeIndex < videos.length - 1) {
-      pubkeys.add(videos[safeIndex + 1].pubkey);
-    }
-
-    if (pubkeys.isNotEmpty) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
-        ref
-            .read(profileRepositoryProvider)
-            ?.fetchBatchProfiles(pubkeys: pubkeys);
-      });
-    }
   }
 
   @override
@@ -438,9 +412,6 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                     videos: state.videos
                         .where((v) => v.videoUrl != null)
                         .toList(),
-                    onActiveVideoChanged: (video, index) {
-                      prefetchProfiles(state.videos, index);
-                    },
                     onNearEnd: (index) {
                       if (state.hasMore) {
                         context.read<VideoFeedBloc>().add(
@@ -508,7 +479,6 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                           name: 'VideoFeedPage',
                           category: LogCategory.video,
                         );
-                        prefetchProfiles(state.videos, sourceIndex);
                       }
                     },
                     onNearEnd: (index) {

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -14,6 +14,7 @@ import 'package:openvine/blocs/video_feed/home_feed_cache.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/repositories/follow_repository.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
+import 'package:profile_repository/profile_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -27,6 +28,8 @@ class _MockCuratedListRepository extends Mock
 class _MockFeedPerformanceTracker extends Mock
     implements FeedPerformanceTracker {}
 
+class _MockProfileRepository extends Mock implements ProfileRepository {}
+
 class _MockHomeFeedCache extends Mock implements HomeFeedCache {}
 
 class _FakeSharedPreferences extends Fake implements SharedPreferences {}
@@ -36,6 +39,7 @@ void main() {
     late _MockVideosRepository mockVideosRepository;
     late _MockFollowRepository mockFollowRepository;
     late _MockCuratedListRepository mockCuratedListRepository;
+    late _MockProfileRepository mockProfileRepository;
     late StreamController<List<String>> followingController;
     late StreamController<List<CuratedList>> curatedListsController;
 
@@ -43,6 +47,7 @@ void main() {
       mockVideosRepository = _MockVideosRepository();
       mockFollowRepository = _MockFollowRepository();
       mockCuratedListRepository = _MockCuratedListRepository();
+      mockProfileRepository = _MockProfileRepository();
       followingController = StreamController<List<String>>.broadcast();
       curatedListsController = StreamController<List<CuratedList>>.broadcast();
 
@@ -58,6 +63,12 @@ void main() {
       when(
         () => mockCuratedListRepository.getSubscribedListVideoRefs(),
       ).thenReturn({});
+
+      when(
+        () => mockProfileRepository.fetchBatchProfiles(
+          pubkeys: any(named: 'pubkeys'),
+        ),
+      ).thenAnswer((_) async => {});
     });
 
     tearDown(() {
@@ -312,10 +323,7 @@ void main() {
         expect: () => [
           const VideoFeedState(),
           // _loadVideos emits success with empty videos
-          const VideoFeedState(
-            status: VideoFeedStatus.success,
-            hasMore: false,
-          ),
+          const VideoFeedState(status: VideoFeedStatus.success, hasMore: false),
           // _onStarted detects empty follows → noFollowedUsers CTA
           const VideoFeedState(
             status: VideoFeedStatus.success,
@@ -416,9 +424,7 @@ void main() {
               limit: any(named: 'limit'),
               until: any(named: 'until'),
             ),
-          ).thenAnswer(
-            (_) async => HomeFeedResult(videos: videos),
-          );
+          ).thenAnswer((_) async => HomeFeedResult(videos: videos));
         },
         build: () => VideoFeedBloc(
           videosRepository: mockVideosRepository,
@@ -1714,20 +1720,12 @@ void main() {
           isA<VideoFeedState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'cached count', 2)
-              .having(
-                (s) => s.videos[0].id,
-                'first cached id',
-                'cached-0',
-              ),
+              .having((s) => s.videos[0].id, 'first cached id', 'cached-0'),
           // 3. Fresh videos replace cached
           isA<VideoFeedState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'fresh count', 3)
-              .having(
-                (s) => s.videos[0].id,
-                'first fresh id',
-                'fresh-0',
-              ),
+              .having((s) => s.videos[0].id, 'first fresh id', 'fresh-0'),
         ],
         verify: (_) {
           verify(() => mockCache.read(sharedPreferences)).called(1);
@@ -1826,10 +1824,8 @@ void main() {
         act: (bloc) => bloc.add(const VideoFeedStarted(mode: FeedMode.home)),
         verify: (_) {
           verify(
-            () => mockCache.write(
-              sharedPreferences,
-              '{"videos":[{"id":"v1"}]}',
-            ),
+            () =>
+                mockCache.write(sharedPreferences, '{"videos":[{"id":"v1"}]}'),
           ).called(1);
         },
       );
@@ -1947,6 +1943,241 @@ void main() {
         verify: (_) {
           // Cache read should only be called once (on first load)
           verify(() => mockCache.read(sharedPreferences)).called(1);
+        },
+      );
+    });
+
+    group('creator profile prefetching', () {
+      final pubkeyA = 'a' * 64;
+      final pubkeyB = 'b' * 64;
+      final pubkeyC = 'c' * 64;
+
+      VideoEvent videoWithPubkey(String id, String pubkey, {int? createdAt}) {
+        final timestamp =
+            createdAt ?? DateTime.now().millisecondsSinceEpoch ~/ 1000;
+        return VideoEvent(
+          id: id,
+          pubkey: pubkey,
+          createdAt: timestamp,
+          content: '',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(timestamp * 1000),
+          title: 'Test Video $id',
+          videoUrl: 'https://example.com/$id.mp4',
+          thumbnailUrl: 'https://example.com/$id.jpg',
+        );
+      }
+
+      UserProfile profileForPubkey(String pubkey) => UserProfile(
+        pubkey: pubkey,
+        eventId: 'event-$pubkey',
+        rawData: const {},
+        createdAt: DateTime(2024),
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedState>(
+        'fetches creator profiles when videos load',
+        setUp: () {
+          final baseTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          final videos = [
+            videoWithPubkey('v1', pubkeyA, createdAt: baseTime),
+            videoWithPubkey('v2', pubkeyB, createdAt: baseTime - 1),
+          ];
+
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+            ),
+          ).thenAnswer((_) async => HomeFeedResult(videos: videos));
+
+          when(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer(
+            (_) async => {
+              pubkeyA: profileForPubkey(pubkeyA),
+              pubkeyB: profileForPubkey(pubkeyB),
+            },
+          );
+        },
+        build: () => VideoFeedBloc(
+          videosRepository: mockVideosRepository,
+          followRepository: mockFollowRepository,
+          curatedListRepository: mockCuratedListRepository,
+          profileRepository: mockProfileRepository,
+        ),
+        act: (bloc) => bloc.add(const VideoFeedStarted(mode: FeedMode.home)),
+        verify: (_) {
+          verify(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).called(1);
+        },
+        expect: () => [
+          const VideoFeedState(),
+          // Videos loaded (no profiles yet)
+          isA<VideoFeedState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.videos, 'videos', hasLength(2))
+              .having((s) => s.creatorProfiles, 'profiles', isEmpty),
+          // Profiles fetched
+          isA<VideoFeedState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.creatorProfiles, 'profiles', hasLength(2)),
+        ],
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedState>(
+        'fetches only new profiles on pagination',
+        setUp: () {
+          final baseTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          final initialVideos = [
+            videoWithPubkey('v1', pubkeyA, createdAt: baseTime),
+          ];
+          final moreVideos = [
+            videoWithPubkey('v2', pubkeyB, createdAt: baseTime - 2),
+            videoWithPubkey('v3', pubkeyC, createdAt: baseTime - 3),
+          ];
+
+          var callCount = 0;
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+            ),
+          ).thenAnswer((_) async {
+            callCount++;
+            if (callCount == 1) {
+              return HomeFeedResult(videos: initialVideos);
+            }
+            return HomeFeedResult(videos: moreVideos);
+          });
+
+          when(
+            () => mockProfileRepository.fetchBatchProfiles(pubkeys: [pubkeyA]),
+          ).thenAnswer((_) async => {pubkeyA: profileForPubkey(pubkeyA)});
+
+          when(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys', that: isNot(equals([pubkeyA]))),
+            ),
+          ).thenAnswer(
+            (_) async => {
+              pubkeyB: profileForPubkey(pubkeyB),
+              pubkeyC: profileForPubkey(pubkeyC),
+            },
+          );
+        },
+        build: () => VideoFeedBloc(
+          videosRepository: mockVideosRepository,
+          followRepository: mockFollowRepository,
+          curatedListRepository: mockCuratedListRepository,
+          profileRepository: mockProfileRepository,
+        ),
+        act: (bloc) async {
+          bloc.add(const VideoFeedStarted(mode: FeedMode.home));
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          bloc.add(const VideoFeedLoadMoreRequested());
+        },
+        verify: (_) {
+          verify(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).called(2);
+        },
+        expect: () => [
+          // Loading
+          const VideoFeedState(),
+          // Initial videos loaded
+          isA<VideoFeedState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.videos, 'videos', hasLength(1)),
+          // Profiles for initial videos
+          isA<VideoFeedState>().having(
+            (s) => s.creatorProfiles,
+            'profiles after initial',
+            hasLength(1),
+          ),
+          // Pagination loading
+          isA<VideoFeedState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            isTrue,
+          ),
+          // Pagination complete
+          isA<VideoFeedState>()
+              .having((s) => s.videos, 'videos', hasLength(3))
+              .having((s) => s.isLoadingMore, 'isLoadingMore', isFalse),
+          // Profiles for new creators
+          isA<VideoFeedState>().having(
+            (s) => s.creatorProfiles,
+            'profiles after pagination',
+            hasLength(3),
+          ),
+        ],
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedState>(
+        'does not re-fetch existing profiles on pagination',
+        setUp: () {
+          final baseTime = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+          final initialVideos = [
+            videoWithPubkey('v1', pubkeyA, createdAt: baseTime),
+          ];
+          // Pagination returns a video from the same creator
+          final moreVideos = [
+            videoWithPubkey('v2', pubkeyA, createdAt: baseTime - 2),
+          ];
+
+          var callCount = 0;
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+            ),
+          ).thenAnswer((_) async {
+            callCount++;
+            if (callCount == 1) {
+              return HomeFeedResult(videos: initialVideos);
+            }
+            return HomeFeedResult(videos: moreVideos);
+          });
+
+          when(
+            () => mockProfileRepository.fetchBatchProfiles(pubkeys: [pubkeyA]),
+          ).thenAnswer((_) async => {pubkeyA: profileForPubkey(pubkeyA)});
+        },
+        build: () => VideoFeedBloc(
+          videosRepository: mockVideosRepository,
+          followRepository: mockFollowRepository,
+          curatedListRepository: mockCuratedListRepository,
+          profileRepository: mockProfileRepository,
+        ),
+        act: (bloc) async {
+          bloc.add(const VideoFeedStarted(mode: FeedMode.home));
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          bloc.add(const VideoFeedLoadMoreRequested());
+        },
+        verify: (_) {
+          // fetchBatchProfiles should only be called once (initial load).
+          // Pagination has no new pubkeys, so no second call.
+          verify(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).called(1);
         },
       );
     });


### PR DESCRIPTION
## Description

Batch-fetch creator profiles in `VideoFeedBloc` after videos load, replacing per-swipe profile prefetching in the UI. The BLoC now calls `ProfileRepository.fetchBatchProfiles()` for all unique creator pubkeys on initial load and for new creators on pagination, warming the Drift cache so individual profile lookups are instant hits.

**Related Issue:** Closes #1973

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore