### PR TITLE
fix: Home video audio resumes when navigating back from Search

### DIFF
--- a/mobile/lib/screens/feed/feed_mode_switch.dart
+++ b/mobile/lib/screens/feed/feed_mode_switch.dart
@@ -5,9 +5,9 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/screens/pure/search_screen_pure.dart';
+import 'package:openvine/utils/pause_aware_modals.dart';
 
 /// Feed mode picker overlay that displays the current feed mode
 /// and allows users to switch between modes via a bottom sheet.
@@ -96,7 +96,8 @@ class FeedModeSwitch extends StatelessWidget {
                       ),
                     ),
                     _SearchButton(
-                      onTap: () => context.push(SearchScreenPure.path),
+                      onTap: () =>
+                          context.pushWithVideoPause(SearchScreenPure.path),
                     ),
                   ],
                 );


### PR DESCRIPTION
## Description

Fix home feed video audio resuming in the background when navigating Search → Profile → Video → Back. The search screen was pushed with plain `context.push()`, so GoRouter's transient shell-route emission during pops bypassed the overlay visibility guard and briefly reactivated home video playback. Switching to `pushWithVideoPause()` keeps the overlay flag set for the entire navigation chain.

**Related Issue:** Closes #2206

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore