### PR TITLE
fix(delete): remove video from local cache after Edit Video dialog deletion

### DIFF
--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -1800,6 +1800,9 @@ class _EditVideoDialogState extends ConsumerState<_EditVideoDialog> {
       );
 
       if (result.success) {
+        final videoEventService = ref.read(videoEventServiceProvider);
+        videoEventService.removeVideoCompletely(widget.video.id);
+
         Log.info(
           'Video deleted successfully: ${widget.video.id}',
           name: 'EditVideoDialog',


### PR DESCRIPTION
## Description

One-line fix: call `videoEventService.removeVideoCompletely()` after successful deletion in `_EditVideoDialog._deleteVideo()`.

The Edit Video dialog published the kind 5 delete event to relays but never removed the video from the local feed cache. Users saw the video persist on their profile grid after deleting — it looked like "delete doesn't work" even though the relay received the deletion correctly.

The other two delete paths (`ShareVideoMenu` direct delete and `composable_video_grid`) already had this call — it was only missing from the Edit Video dialog path.

With this fix, the E2E test from #2210 (feat/e2e-delete-test) passes — the video disappears from the profile grid after deletion.

**Related Issue:** Fixes #2163

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)