### PR TITLE
feat(gallery): implement gallery permission bottom sheet for improved error handling

### DIFF
--- a/mobile/lib/widgets/gallery_permission_sheet.dart
+++ b/mobile/lib/widgets/gallery_permission_sheet.dart
@@ -18,6 +18,9 @@ enum GalleryPermissionChoice {
   /// User tapped "Open Settings" and may have granted permission.
   openedSettings,
 
+  /// User granted permission via the OS dialog.
+  granted,
+
   /// User tapped "Don't Ask Again" — skip gallery saves from now on.
   dismissedForever,
 
@@ -41,6 +44,16 @@ Future<GalleryPermissionChoice> showGalleryPermissionSheet(
   required PermissionsService permissionsService,
 }) async {
   final destination = GallerySaveService.destinationName;
+  final status = await permissionsService.checkGalleryStatus();
+
+  // Permission may have been granted since the save attempt.
+  if (status == PermissionStatus.granted) {
+    return GalleryPermissionChoice.granted;
+  } else if (!context.mounted) {
+    return GalleryPermissionChoice.skipped;
+  }
+
+  final requiresSettings = status == PermissionStatus.requiresSettings;
 
   final result = await VineBottomSheet.show<GalleryPermissionChoice>(
     context: context,
@@ -48,14 +61,27 @@ Future<GalleryPermissionChoice> showGalleryPermissionSheet(
     children: [
       _GalleryPermissionSheetContent(
         destination: destination,
-        onOpenSettings: () async {
-          await permissionsService.openAppSettings();
-          if (context.mounted) {
-            Navigator.of(
-              context,
-            ).pop(GalleryPermissionChoice.openedSettings);
-          }
-        },
+        requiresSettings: requiresSettings,
+        onPrimaryAction: requiresSettings
+            ? () async {
+                await permissionsService.openAppSettings();
+                if (context.mounted) {
+                  Navigator.of(
+                    context,
+                  ).pop(GalleryPermissionChoice.openedSettings);
+                }
+              }
+            : () async {
+                final requested = await permissionsService
+                    .requestGalleryPermission();
+                if (context.mounted) {
+                  Navigator.of(context).pop(
+                    requested == PermissionStatus.granted
+                        ? GalleryPermissionChoice.granted
+                        : GalleryPermissionChoice.skipped,
+                  );
+                }
+              },
         onDismissForever: () async {
           final prefs = await SharedPreferences.getInstance();
           await prefs.setBool(_kGalleryPermissionDismissedKey, true);
@@ -78,13 +104,15 @@ Future<GalleryPermissionChoice> showGalleryPermissionSheet(
 class _GalleryPermissionSheetContent extends StatelessWidget {
   const _GalleryPermissionSheetContent({
     required this.destination,
-    required this.onOpenSettings,
+    required this.requiresSettings,
+    required this.onPrimaryAction,
     required this.onDismissForever,
     required this.onSkip,
   });
 
   final String destination;
-  final VoidCallback onOpenSettings;
+  final bool requiresSettings;
+  final VoidCallback onPrimaryAction;
   final VoidCallback onDismissForever;
   final VoidCallback onSkip;
 
@@ -113,8 +141,11 @@ class _GalleryPermissionSheetContent extends StatelessWidget {
           Text(
             // TODO(l10n): Replace with context.l10n when localization
             // is added.
-            'To save a copy of your videos, allow '
-            '$destination access in Settings.',
+            requiresSettings
+                ? 'To save a copy of your videos, allow '
+                      '$destination access in Settings.'
+                : 'Divine needs $destination access to '
+                      'save a copy of your videos.',
             style: VineTheme.bodyLargeFont(
               color: VineTheme.onSurfaceVariant,
             ),
@@ -125,8 +156,8 @@ class _GalleryPermissionSheetContent extends StatelessWidget {
           DivinePrimaryButton(
             // TODO(l10n): Replace with context.l10n when localization
             // is added.
-            label: 'Open Settings',
-            onPressed: onOpenSettings,
+            label: requiresSettings ? 'Open Settings' : 'Allow Access',
+            onPressed: onPrimaryAction,
           ),
 
           const SizedBox(height: 16),

--- a/mobile/lib/widgets/video_metadata/video_metadata_bottom_bar.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_bottom_bar.dart
@@ -53,8 +53,9 @@ class VideoMetadataBottomBar extends ConsumerWidget {
       permissionsService: permissionsService,
     );
 
-    if (choice == GalleryPermissionChoice.openedSettings) {
-      // Retry once — the user may have just granted access in Settings.
+    if (choice == GalleryPermissionChoice.openedSettings ||
+        choice == GalleryPermissionChoice.granted) {
+      // Retry once — the user may have just granted access.
       await gallerySaveService.saveVideoToGallery(
         finalRenderedClip.video,
       );

--- a/mobile/test/widgets/gallery_permission_sheet_test.dart
+++ b/mobile/test/widgets/gallery_permission_sheet_test.dart
@@ -1,5 +1,7 @@
 // ABOUTME: Widget tests for the gallery permission bottom sheet.
-// ABOUTME: Verifies Open Settings, Not Now, and Don't Ask Again actions.
+// ABOUTME: Verifies Open Settings, Allow Access, Not Now, and
+// ABOUTME: Don't Ask Again actions for both canRequest and
+// ABOUTME: requiresSettings permission states.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -22,6 +24,12 @@ void main() {
     when(
       () => mockPermissionsService.openAppSettings(),
     ).thenAnswer((_) async => true);
+    when(
+      () => mockPermissionsService.checkGalleryStatus(),
+    ).thenAnswer((_) async => PermissionStatus.requiresSettings);
+    when(
+      () => mockPermissionsService.requestGalleryPermission(),
+    ).thenAnswer((_) async => PermissionStatus.granted);
   });
 
   Widget buildSubject() {
@@ -173,6 +181,123 @@ void main() {
         },
       );
     });
+
+    group('when permission can be requested', () {
+      setUp(() {
+        when(
+          () => mockPermissionsService.checkGalleryStatus(),
+        ).thenAnswer((_) async => PermissionStatus.canRequest);
+      });
+
+      group('renders', () {
+        testWidgets('Allow Access primary button', (tester) async {
+          await tester.pumpWidget(buildSubject());
+          await tester.tap(find.text('Open Sheet'));
+          await tester.pumpAndSettle();
+
+          expect(find.byType(DivinePrimaryButton), findsOneWidget);
+          expect(find.text('Allow Access'), findsOneWidget);
+          expect(find.text('Open Settings'), findsNothing);
+        });
+
+        testWidgets('request description text', (tester) async {
+          await tester.pumpWidget(buildSubject());
+          await tester.tap(find.text('Open Sheet'));
+          await tester.pumpAndSettle();
+
+          expect(
+            find.textContaining(
+              'Divine needs Gallery access to save a copy of your videos',
+            ),
+            findsOneWidget,
+          );
+        });
+      });
+
+      group('interactions', () {
+        testWidgets(
+          'tapping Allow Access calls requestGalleryPermission '
+          'and returns $GalleryPermissionChoice.granted when granted',
+          (tester) async {
+            await tester.pumpWidget(buildSubject());
+            await tester.tap(find.text('Open Sheet'));
+            await tester.pumpAndSettle();
+
+            await tester.tap(find.text('Allow Access'));
+            await tester.pumpAndSettle();
+
+            // Sheet dismissed
+            expect(find.text('Gallery Access Needed'), findsNothing);
+
+            verify(
+              () => mockPermissionsService.requestGalleryPermission(),
+            ).called(1);
+            verifyNever(() => mockPermissionsService.openAppSettings());
+            expect(find.text('result:granted'), findsOneWidget);
+          },
+        );
+
+        testWidgets(
+          'tapping Allow Access returns '
+          '$GalleryPermissionChoice.skipped when denied',
+          (tester) async {
+            when(
+              () => mockPermissionsService.requestGalleryPermission(),
+            ).thenAnswer(
+              (_) async => PermissionStatus.requiresSettings,
+            );
+
+            await tester.pumpWidget(buildSubject());
+            await tester.tap(find.text('Open Sheet'));
+            await tester.pumpAndSettle();
+
+            await tester.tap(find.text('Allow Access'));
+            await tester.pumpAndSettle();
+
+            expect(find.text('Gallery Access Needed'), findsNothing);
+
+            verify(
+              () => mockPermissionsService.requestGalleryPermission(),
+            ).called(1);
+            expect(find.text('result:skipped'), findsOneWidget);
+          },
+        );
+
+        testWidgets(
+          'tapping Not Now returns $GalleryPermissionChoice.skipped',
+          (tester) async {
+            await tester.pumpWidget(buildSubject());
+            await tester.tap(find.text('Open Sheet'));
+            await tester.pumpAndSettle();
+
+            await tester.tap(find.text('Not Now'));
+            await tester.pumpAndSettle();
+
+            expect(find.text('Gallery Access Needed'), findsNothing);
+            expect(find.text('result:skipped'), findsOneWidget);
+          },
+        );
+      });
+    });
+
+    testWidgets(
+      'returns $GalleryPermissionChoice.granted without showing sheet '
+      'when permission is already granted',
+      (tester) async {
+        when(
+          () => mockPermissionsService.checkGalleryStatus(),
+        ).thenAnswer((_) async => PermissionStatus.granted);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.tap(find.text('Open Sheet'));
+        await tester.pumpAndSettle();
+
+        // Sheet should not appear
+        expect(find.text('Gallery Access Needed'), findsNothing);
+        // Result should be granted
+        expect(find.text('result:granted'), findsOneWidget);
+      },
+    );
   });
 
   group('isGalleryPermissionDismissedForever', () {

--- a/mobile/test/widgets/video_metadata/video_metadata_bottom_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_bottom_bar_test.dart
@@ -75,8 +75,7 @@ void main() {
           child: MaterialApp(home: Scaffold(body: VideoMetadataBottomBar())),
         ),
       );
-      // TODO(@hm21): Once the Drafts library exists, uncomment below
-      // expect(find.text('Save draft'), findsOneWidget);
+      expect(find.text('Save for Later'), findsOneWidget);
       expect(find.text('Post'), findsOneWidget);
     });
 
@@ -187,6 +186,9 @@ void main() {
         when(
           () => mockGallerySaveService.saveVideoToGallery(any()),
         ).thenAnswer((_) async => const GallerySavePermissionDenied());
+        when(
+          () => mockPermissionsService.checkGalleryStatus(),
+        ).thenAnswer((_) async => PermissionStatus.requiresSettings);
 
         final mockNotifier = _MockVideoEditorNotifier(
           VideoEditorProviderState(
@@ -280,6 +282,9 @@ void main() {
       when(
         () => mockGallerySaveService.saveVideoToGallery(any()),
       ).thenAnswer((_) async => const GallerySavePermissionDenied());
+      when(
+        () => mockPermissionsService.checkGalleryStatus(),
+      ).thenAnswer((_) async => PermissionStatus.requiresSettings);
 
       final mockNotifier = _MockVideoEditorNotifier(
         VideoEditorProviderState(


### PR DESCRIPTION
## Description

Previously, the logic always showed an error snackbar when posting a video or saving it to drafts if the user had not granted gallery permission. This confused users because it made them think something was broken with the upload.


This PR replaces now the passive snackbar shown on gallery permission denial with an actionable bottom sheet (`GalleryPermissionSheet`) that lets users open system settings, skip once, or opt out permanently. The snackbar logic in `VideoMetadataBottomBar` is simplified to only reflect draft save status, since gallery errors are now handled interactively.
 


<img src="https://github.com/user-attachments/assets/032b8ce1-5dc4-44e8-9ec0-ed29f7592278" width="350px" />

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore