### PR TITLE
fix: detect hashtags when # is inserted before existing word

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -458,9 +458,9 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// Validates and enforces the 64KB size limit. Rejects updates that exceed
   /// the limit and sets metadataLimitReached flag.
   ///
-  /// Automatically extracts completed hashtags from title and description.
-  /// A hashtag is considered complete when followed by a space or at the end
-  /// of the string (e.g., "#hot " or "text #hot").
+  /// Automatically extracts hashtags from title and description.
+  /// A hashtag is detected when followed by a non-alphanumeric character
+  /// or at end of string (e.g., "#hot ", "#hot", "text #hot.").
   void updateMetadata({String? title, String? description, Set<String>? tags}) {
     Log.debug(
       '📝 Updated video metadata',
@@ -488,10 +488,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
           .toSet();
     } else {
       // Text changed - compare old and new hashtags to only update changed ones
-      final hashtagPattern = RegExp(r'#([a-zA-Z0-9]+)\s');
+      final hashtagPattern = RegExp('#([a-zA-Z0-9]+)(?![a-zA-Z0-9])');
 
       // Extract hashtags from OLD text
-      final oldText = '${state.title} ${state.description} ';
+      final oldText = '${state.title} ${state.description}';
       final oldHashtags = hashtagPattern
           .allMatches(oldText)
           .map((m) => m.group(1))
@@ -500,7 +500,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
           .toSet();
 
       // Extract hashtags from NEW text
-      final newText = '$rawTitle $rawDescription ';
+      final newText = '$rawTitle $rawDescription';
       final newHashtags = hashtagPattern
           .allMatches(newText)
           .map((m) => m.group(1))

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -531,6 +531,66 @@ void main() {
       });
     });
 
+    group('updateMetadata hashtag extraction', () {
+      test('extracts hashtag when # is typed before existing word', () {
+        final notifier = container.read(videoEditorProvider.notifier);
+
+        // First type "hello"
+        notifier.updateMetadata(description: 'hello');
+        expect(container.read(videoEditorProvider).tags, isEmpty);
+
+        // Then insert # before "hello" to make "#hello"
+        notifier.updateMetadata(description: '#hello');
+        expect(container.read(videoEditorProvider).tags, contains('hello'));
+      });
+
+      test('extracts hashtag at end of description', () {
+        final notifier = container.read(videoEditorProvider.notifier);
+
+        notifier.updateMetadata(description: 'check out #flutter');
+        expect(container.read(videoEditorProvider).tags, contains('flutter'));
+      });
+
+      test('extracts hashtag in middle of description', () {
+        final notifier = container.read(videoEditorProvider.notifier);
+
+        notifier.updateMetadata(description: 'check #dart today');
+        expect(container.read(videoEditorProvider).tags, contains('dart'));
+      });
+
+      test('removes tag when # is deleted from description', () {
+        final notifier = container.read(videoEditorProvider.notifier);
+
+        notifier.updateMetadata(description: 'hello #world');
+        expect(container.read(videoEditorProvider).tags, contains('world'));
+
+        notifier.updateMetadata(description: 'hello world');
+        expect(
+          container.read(videoEditorProvider).tags,
+          isNot(contains('world')),
+        );
+      });
+
+      test('preserves manually added tags when description changes', () {
+        final notifier = container.read(videoEditorProvider.notifier);
+
+        // Manually add a tag
+        notifier.updateMetadata(tags: {'manual'});
+        expect(container.read(videoEditorProvider).tags, contains('manual'));
+
+        // Change description - manual tag should persist
+        notifier.updateMetadata(description: 'some text');
+        expect(container.read(videoEditorProvider).tags, contains('manual'));
+      });
+
+      test('extracts hashtag from title field', () {
+        final notifier = container.read(videoEditorProvider.notifier);
+
+        notifier.updateMetadata(title: 'My #video title');
+        expect(container.read(videoEditorProvider).tags, contains('video'));
+      });
+    });
+
     group('setDraftId', () {
       test('should set the draft ID', () {
         const id = 'test-draft-id';


### PR DESCRIPTION
## Summary
- Fix hashtag detection regex that required a trailing space (`\s`) after the hashtag word, causing failures when `#` was inserted before an existing word (e.g., typing "hello" then inserting `#` to make "#hello")
- Replace with negative lookahead `(?![a-zA-Z0-9])` that matches hashtags at end-of-string, before punctuation, or before whitespace
- Remove fragile artificial trailing-space hack from `oldText`/`newText` construction

## Test plan
- [x] Add test: hashtag extracted when `#` typed before existing word (the reported bug)
- [x] Add test: hashtag at end of description
- [x] Add test: hashtag in middle of description
- [x] Add test: tag removed when `#` deleted from description
- [x] Add test: manually added tags preserved when description changes
- [x] Add test: hashtag extracted from title field
- [x] All 40 provider tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)