### PR TITLE
docs: update Claude rules based on PR review feedback

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -37,6 +37,35 @@ This compositional layer composes one or more data clients and applies "business
 - Should not import any Flutter dependencies
 - Should not be dependent on other repositories
 - This layer can be considered the "product" layer - the business/product owner determines the rules for how to combine data from one or more data providers
+- **Fallback and composition logic belongs here** — when data can come from multiple sources (e.g., try API first, fall back to local cache or relay), the repository decides the strategy. BLoCs and UI should never implement source-selection or fallback logic
+
+**Good — repository owns the fallback:**
+```dart
+class VideoRepository {
+  Future<List<Video>> getVideos(String query) async {
+    try {
+      return await _funnelcakeClient.search(query);
+    } catch (_) {
+      // Fallback to relay when API is unavailable
+      return _relayClient.queryVideos(query);
+    }
+  }
+}
+```
+
+**Bad — BLoC or UI picks the source:**
+```dart
+// In BLoC — WRONG, this is repository-level logic
+Future<void> _onSearch(SearchEvent event, Emitter emit) async {
+  try {
+    final results = await _funnelcakeClient.search(event.query);
+    emit(state.copyWith(results: results));
+  } catch (_) {
+    final results = await _relayClient.queryVideos(event.query);
+    emit(state.copyWith(results: results));
+  }
+}
+```
 
 ### Business Logic Layer (BLoC)
 
@@ -56,6 +85,34 @@ The presentation layer is the top layer in the stack. It is the UI layer of the 
 **Responsibility**: Building widgets and managing the widget's lifecycle. Requests updates from the business logic layer to provide it with a new state to update the widget with the correct data.
 
 **Key Rule**: No business logic should exist in this layer. The presentation layer should only interact with the business logic layer.
+
+> **Frequent review finding**: Logic such as filtering, sorting, data transformation, conditional fetching, or retry/fallback flows must NOT live in widgets. If the UI is doing more than reading state and dispatching events, extract that logic into a BLoC, Cubit, or repository.
+
+**Common violations:**
+```dart
+// WRONG — business logic in a widget
+class SearchScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final results = state.items
+        .where((i) => i.category == selectedCategory)  // filtering = logic
+        .toList()
+      ..sort((a, b) => b.date.compareTo(a.date));      // sorting = logic
+
+    return ListView(children: results.map(ResultTile.new).toList());
+  }
+}
+
+// WRONG — conditional fetching in a widget callback
+onPressed: () async {
+  final profile = await repository.getProfile(id);  // direct repo call
+  if (profile == null) {
+    await repository.fetchFromRelay(id);             // fallback logic
+  }
+}
+```
+
+**Correct**: Move all of the above into a BLoC/Cubit, expose the final result via state, and let the widget just render it.
 
 ## Project Organization
 

--- a/.claude/rules/code_style.md
+++ b/.claude/rules/code_style.md
@@ -66,6 +66,44 @@ void updateUser(User user) {
 
 ---
 
+## No Hardcoded Values
+
+Never hardcode relay URLs, port numbers, API endpoints, durations, or numeric thresholds directly in BLoCs, repositories, or widgets. Extract them into named constants grouped in a dedicated class or config object.
+
+**Bad:**
+```dart
+class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
+  Future<void> _onShare(...) async {
+    await _client.publish(
+      relays: ['wss://relay.example.com'],  // WRONG — hardcoded relay
+      retries: 3,                            // WRONG — magic number
+    );
+  }
+}
+```
+
+**Good:**
+```dart
+abstract class ShareConstants {
+  static const defaultRelays = ['wss://relay.example.com'];
+  static const maxRetries = 3;
+}
+
+// Or use environment config for environment-specific values
+class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
+  Future<void> _onShare(...) async {
+    await _client.publish(
+      relays: ShareConstants.defaultRelays,
+      retries: ShareConstants.maxRetries,
+    );
+  }
+}
+```
+
+Group related constants together so they are easy to find and update in one place.
+
+---
+
 ## Dart Best Practices
 
 ### Null Safety

--- a/.claude/rules/state_management.md
+++ b/.claude/rules/state_management.md
@@ -120,7 +120,9 @@ blocTest<MyBloc, MyState>(
 
 ## Error Handling in BLoC
 
-State should never contain error messages or exception objects. Errors are transient events, not stable UI data. Use BLoC's built-in `addError` to report them.
+> **Hard rule**: State must NEVER contain error messages, error strings, or exception objects. This is a frequent review finding — treat any `String? errorMessage` or `Exception?` field in state as a bug.
+
+Errors are transient events, not stable UI data. Use BLoC's built-in `addError` to report them, and use a status enum to drive UI reactions.
 
 ### Correct Pattern
 
@@ -162,6 +164,145 @@ emit(state.copyWith(
 1. **State semantics** — state represents displayable UI data, not transient error info.
 2. **Lifecycle** — `addError` integrates with BLoC's error stream, logging, and `blocTest`'s `errors` parameter.
 3. **Cleaner copyWith** — no `clearError` flags or manual error reset logic.
+4. **l10n readiness** — error messages in state bypass localization; status enums let the UI choose the correct translated string.
+
+---
+
+## No Mutable Instance Variables in BLoC
+
+All mutable data must live in the BLoC's state object, never as private fields on the BLoC class. Private fields bypass the state stream, making them invisible to the UI, untestable via `blocTest`, and prone to desyncing from the actual state.
+
+**Bad:**
+```dart
+class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
+  int _retryCount = 0;            // WRONG — hidden from state
+  bool _isInitialized = false;    // WRONG — not observable
+  List<String> _selectedIds = []; // WRONG — bypasses emit
+
+  Future<void> _onShare(...) async {
+    _retryCount++;
+    // UI has no idea _retryCount changed
+  }
+}
+```
+
+**Good:**
+```dart
+class ShareSheetState extends Equatable {
+  const ShareSheetState({
+    this.retryCount = 0,
+    this.isInitialized = false,
+    this.selectedIds = const [],
+  });
+
+  final int retryCount;
+  final bool isInitialized;
+  final List<String> selectedIds;
+  // ...
+}
+```
+
+**Exception**: Injected dependencies (repositories, clients) are fine as `final` fields — they are immutable configuration, not mutable state.
+
+---
+
+## Use BlocSelector for Granular Rebuilds
+
+When a widget only needs one or a few properties from state, use `BlocSelector` or `context.select` instead of `BlocBuilder` or `context.watch`. Watching the full state rebuilds the widget on every emit, even when the property it cares about hasn't changed.
+
+**Bad — rebuilds on every state change:**
+```dart
+class ConversationView extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // Rebuilds entire subtree on ANY state change
+    final state = context.watch<ConversationBloc, ConversationState>();
+    return Column(
+      children: [
+        ConversationAppBar(title: state.title),
+        MessageList(messages: state.messages),
+        SendButton(status: state.sendStatus),
+      ],
+    );
+  }
+}
+```
+
+**Good — each widget selects only what it needs:**
+```dart
+class ConversationView extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      children: [
+        _AppBar(),
+        _MessageList(),
+        _SendButton(),
+      ],
+    );
+  }
+}
+
+class _SendButton extends StatelessWidget {
+  const _SendButton();
+
+  @override
+  Widget build(BuildContext context) {
+    // Only rebuilds when sendStatus changes
+    final sendStatus = context.select(
+      (ConversationBloc bloc) => bloc.state.sendStatus,
+    );
+    return ElevatedButton(
+      onPressed: sendStatus == SendStatus.ready ? () {} : null,
+      child: const Text('Send'),
+    );
+  }
+}
+```
+
+**When to use which:**
+
+| Widget | Use |
+|--------|-----|
+| `BlocBuilder` | Widget depends on most/all of the state |
+| `BlocSelector` / `context.select` | Widget depends on one or a few properties |
+| `BlocListener` | Side effects (snackbars, navigation) |
+
+---
+
+## Computed Properties on State and Models
+
+When logic derives a display value from state fields, add it as a getter on the state or model class rather than computing it inline in the UI or BLoC. This keeps the UI thin, makes the logic testable, and avoids duplication when the same derivation is needed elsewhere.
+
+**Bad — logic scattered in UI:**
+```dart
+// In widget
+final displayName = state.profile.name.isNotEmpty
+    ? state.profile.name
+    : state.profile.npub.substring(0, 12);
+```
+
+**Good — getter on model or state:**
+```dart
+class UserProfile {
+  // ...
+  String get displayName =>
+      name.isNotEmpty ? name : npub.substring(0, 12);
+}
+
+// In widget — clean and reusable
+Text(state.profile.displayName);
+```
+
+**Good — derived validation on state:**
+```dart
+class CreateAccountState extends Equatable {
+  // ...
+  bool get isValid =>
+      name?.isNotEmpty == true &&
+      email?.isNotEmpty == true;
+}
+```
 
 ---
 


### PR DESCRIPTION
## Description

Add and strengthen Claude rules based on recurring PR review feedback patterns. Analyzed 30+ recent PRs for review comments, identified 7 recurring patterns, and updated 3 rules files: added new rules for BlocSelector usage, no mutable BLoC instance variables, computed properties on state/models, no hardcoded values, and repository-as-composition-layer; strengthened existing rules for no error strings in state and no business logic in UI with explicit callouts and violation examples.

**Related Issue:** N/A

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore