### PR TITLE
chore(ci): add integration_test to format and analyze checks

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -41,10 +41,10 @@ jobs:
           fi
 
       - name: ✨ Check formatting
-        run: dart format --output=none --set-exit-if-changed lib test
+        run: dart format --output=none --set-exit-if-changed lib test integration_test
 
       - name: 🕵️ Analyze code
-        run: flutter analyze lib test
+        run: flutter analyze lib test integration_test
 
       - name: 🚀 Run tests
         run: flutter test

--- a/mobile/integration_test/auth/user_journey_test.dart
+++ b/mobile/integration_test/auth/user_journey_test.dart
@@ -207,7 +207,6 @@ void main() {
         final foundEditor = await waitForWidget(
           tester,
           nextButton,
-          maxSeconds: 15,
         );
         expect(
           foundEditor,
@@ -223,7 +222,6 @@ void main() {
         final foundPost = await waitForWidget(
           tester,
           find.bySemanticsIdentifier('post_button'),
-          maxSeconds: 15,
         );
         expect(foundPost, isTrue, reason: 'Metadata screen should appear');
 
@@ -304,7 +302,6 @@ void main() {
         final foundTile = await waitForWidget(
           tester,
           videoTile,
-          maxSeconds: 15,
         );
         expect(
           foundTile,
@@ -373,7 +370,6 @@ void main() {
         final foundSnackbar = await waitForText(
           tester,
           'Video deletion requested',
-          maxSeconds: 15,
         );
         expect(
           foundSnackbar,
@@ -389,7 +385,7 @@ void main() {
         // fullscreen player. Navigate back to profile.
         // Use system back or tap back button to leave fullscreen player.
         await tester.pageBack();
-        await pumpUntilSettled(tester, maxSeconds: 5);
+        await pumpUntilSettled(tester);
 
         // Navigate: profile → home → explore → profile to force refresh
         await tapBottomNavTab(tester, 'home_tab');


### PR DESCRIPTION
## Description

Add `integration_test/` to the CI format and analyze checks, which were previously only running against `lib` and `test`. Also fix 5 `avoid_redundant_argument_values` analyzer warnings in `user_journey_test.dart` that were hidden by this gap.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [x] Chore