### PR TITLE
feat(c2pa): add CAWG training-mining assertion to protect content from AI

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -30,6 +30,7 @@ import 'package:openvine/repositories/follow_repository.dart';
 import 'package:openvine/services/account_deletion_service.dart';
 import 'package:openvine/services/account_label_service.dart';
 import 'package:openvine/services/age_verification_service.dart';
+import 'package:openvine/services/ai_training_preference_service.dart';
 import 'package:openvine/services/analytics_api_service.dart';
 import 'package:openvine/services/analytics_service.dart';
 import 'package:openvine/services/api_service.dart';
@@ -488,6 +489,16 @@ AudioSharingPreferenceService audioSharingPreferenceService(Ref ref) {
   return service;
 }
 
+/// AI training opt-out preference service. Controls whether the
+/// CAWG training-mining assertion is embedded in C2PA manifests.
+/// keepAlive ensures setting persists across widget rebuilds.
+@Riverpod(keepAlive: true)
+AiTrainingPreferenceService aiTrainingPreferenceService(Ref ref) {
+  final service = AiTrainingPreferenceService();
+  service.initialize(); // Initialize asynchronously
+  return service;
+}
+
 /// Audio device preference service for managing the preferred input device
 /// for recording on macOS. keepAlive ensures preference persists.
 @Riverpod(keepAlive: true)
@@ -817,21 +828,18 @@ bool isNostrReady(Ref ref) {
     // hasKeys transitions because it's the same object reference.
     // Poll with a periodic timer until hasKeys becomes true.
     const pollInterval = Duration(milliseconds: 50);
-    final timer = Timer.periodic(
-      pollInterval,
-      (timer) {
-        if (nostrClient.hasKeys) {
-          timer.cancel();
-          Log.info(
-            'isNostrReady: NostrClient.hasKeys became true after '
-            '${timer.tick * pollInterval.inMilliseconds}ms, invalidating',
-            name: 'isNostrReadyProvider',
-            category: LogCategory.system,
-          );
-          ref.invalidateSelf();
-        }
-      },
-    );
+    final timer = Timer.periodic(pollInterval, (timer) {
+      if (nostrClient.hasKeys) {
+        timer.cancel();
+        Log.info(
+          'isNostrReady: NostrClient.hasKeys became true after '
+          '${timer.tick * pollInterval.inMilliseconds}ms, invalidating',
+          name: 'isNostrReadyProvider',
+          category: LogCategory.system,
+        );
+        ref.invalidateSelf();
+      }
+    });
     ref.onDispose(timer.cancel);
   }
 

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -943,6 +943,66 @@ final class AudioSharingPreferenceServiceProvider
 String _$audioSharingPreferenceServiceHash() =>
     r'6d09af615c19937bc2842079c368161b513dd323';
 
+/// AI training opt-out preference service. Controls whether the
+/// CAWG training-mining assertion is embedded in C2PA manifests.
+/// keepAlive ensures setting persists across widget rebuilds.
+
+@ProviderFor(aiTrainingPreferenceService)
+const aiTrainingPreferenceServiceProvider =
+    AiTrainingPreferenceServiceProvider._();
+
+/// AI training opt-out preference service. Controls whether the
+/// CAWG training-mining assertion is embedded in C2PA manifests.
+/// keepAlive ensures setting persists across widget rebuilds.
+
+final class AiTrainingPreferenceServiceProvider
+    extends
+        $FunctionalProvider<
+          AiTrainingPreferenceService,
+          AiTrainingPreferenceService,
+          AiTrainingPreferenceService
+        >
+    with $Provider<AiTrainingPreferenceService> {
+  /// AI training opt-out preference service. Controls whether the
+  /// CAWG training-mining assertion is embedded in C2PA manifests.
+  /// keepAlive ensures setting persists across widget rebuilds.
+  const AiTrainingPreferenceServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'aiTrainingPreferenceServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$aiTrainingPreferenceServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<AiTrainingPreferenceService> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  AiTrainingPreferenceService create(Ref ref) {
+    return aiTrainingPreferenceService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AiTrainingPreferenceService value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AiTrainingPreferenceService>(value),
+    );
+  }
+}
+
+String _$aiTrainingPreferenceServiceHash() =>
+    r'9b679889e93d0f25cc130290244017d293d5a1ae';
+
 /// Audio device preference service for managing the preferred input device
 /// for recording on macOS. keepAlive ensures preference persists.
 

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -63,9 +63,8 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// Get clips from clip manager.
   List<DivineVideoClip> get _clips => ref.read(clipManagerProvider).clips;
 
-  DraftStorageService get _draftService => ref.read(
-    draftStorageServiceProvider,
-  );
+  DraftStorageService get _draftService =>
+      ref.read(draftStorageServiceProvider);
 
   bool get isAutosavedDraft => draftId == VideoEditorConstants.autoSaveId;
 
@@ -591,10 +590,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     if (state.collaboratorPubkeys.contains(pubkey)) return;
     if (state.pendingCollaboratorPubkeys.contains(pubkey)) return;
     state = state.copyWith(
-      pendingCollaboratorPubkeys: {
-        ...state.pendingCollaboratorPubkeys,
-        pubkey,
-      },
+      pendingCollaboratorPubkeys: {...state.pendingCollaboratorPubkeys, pubkey},
     );
   }
 
@@ -1059,6 +1055,9 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     final result = await VideoEditorRenderService.renderVideoToClip(
       clips: _clips,
       enableAudio: !state.isMuted,
+      aiTrainingOptOut: ref
+          .read(aiTrainingPreferenceServiceProvider)
+          .isOptOutEnabled,
       parameters: renderParameters,
     );
 

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -34,9 +34,8 @@ final videoPublishProvider =
 
 /// Manages video publish screen state including playback and position.
 class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
-  DraftStorageService get _draftService => ref.read(
-    draftStorageServiceProvider,
-  );
+  DraftStorageService get _draftService =>
+      ref.read(draftStorageServiceProvider);
 
   @override
   VideoPublishProviderState build() {
@@ -100,9 +99,10 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
   Future<void> resumePendingPublishes(BuildContext context) async {
     final List<DivineVideoDraft> pendingDrafts;
     try {
-      pendingDrafts = await _draftService.getDraftsByPublishStatuses(
-        const {PublishStatus.publishing, PublishStatus.failed},
-      );
+      pendingDrafts = await _draftService.getDraftsByPublishStatuses(const {
+        PublishStatus.publishing,
+        PublishStatus.failed,
+      });
     } catch (e) {
       Log.error(
         '❌ Failed to load drafts for pending publish resume: $e',
@@ -250,6 +250,9 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
           final result = await VideoEditorRenderService.renderVideoToClip(
             clips: draft.clips,
             parameters: parameters,
+            aiTrainingOptOut: ref
+                .read(aiTrainingPreferenceServiceProvider)
+                .isOptOutEnabled,
           );
 
           if (result == null) {
@@ -278,7 +281,13 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         );
 
         final filePath = await finalRenderedClip.video.safeFilePath();
-        final result = await NativeProofModeService.proofFile(File(filePath));
+        final aiTrainingOptOut = ref
+            .read(aiTrainingPreferenceServiceProvider)
+            .isOptOutEnabled;
+        final result = await NativeProofModeService.proofFile(
+          File(filePath),
+          aiTrainingOptOut: aiTrainingOptOut,
+        );
         proofManifestJson = result != null ? jsonEncode(result) : null;
 
         if (proofManifestJson != null) {

--- a/mobile/lib/screens/settings_screen.dart
+++ b/mobile/lib/screens/settings_screen.dart
@@ -149,6 +149,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 onTap: () => context.push(SafetySettingsScreen.path),
               ),
               _buildAudioSharingToggle(),
+              _buildAiTrainingOptOutToggle(),
               _buildLanguageSetting(),
               // Audio device selector (macOS only - shows when multiple mics)
               if (!kIsWeb && defaultTargetPlatform == TargetPlatform.macOS)
@@ -311,6 +312,34 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       ),
       activeThumbColor: VineTheme.vineGreen,
       secondary: const Icon(Icons.music_note, color: VineTheme.vineGreen),
+    );
+  }
+
+  Widget _buildAiTrainingOptOutToggle() {
+    final aiTrainingService = ref.watch(aiTrainingPreferenceServiceProvider);
+    final isEnabled = aiTrainingService.isOptOutEnabled;
+
+    return SwitchListTile(
+      value: isEnabled,
+      onChanged: (value) async {
+        await aiTrainingService.setOptOutEnabled(value);
+        setState(() {});
+      },
+      title: const Text(
+        'Protect content from AI training',
+        style: TextStyle(
+          color: VineTheme.whiteText,
+          fontSize: 16,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      subtitle: const Text(
+        'Embeds a machine-readable flag telling AI systems not to '
+        'use your videos for training or data mining',
+        style: TextStyle(color: VineTheme.lightText, fontSize: 14),
+      ),
+      activeThumbColor: VineTheme.vineGreen,
+      secondary: const Icon(Icons.shield, color: VineTheme.vineGreen),
     );
   }
 

--- a/mobile/lib/services/ai_training_preference_service.dart
+++ b/mobile/lib/services/ai_training_preference_service.dart
@@ -1,0 +1,62 @@
+// ABOUTME: Service for managing the AI training opt-out preference
+// ABOUTME: Controls whether CAWG training-mining assertion is embedded in C2PA manifests
+
+import 'package:openvine/utils/unified_logger.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Service for managing the user's preference for opting out of AI training
+/// and data mining. When enabled, a `cawg.training-mining` assertion is
+/// embedded in C2PA manifests marking all training/mining uses as "notAllowed".
+///
+/// Based on the CAWG Training and Data Mining specification v1.1:
+/// https://cawg.io/training-and-data-mining/1.1/
+class AiTrainingPreferenceService {
+  /// SharedPreferences key for the AI training opt-out preference
+  static const String prefsKey = 'ai_training_opt_out_enabled';
+
+  bool _isOptOutEnabled = true;
+
+  /// Whether the user has opted out of AI training and data mining.
+  /// Defaults to true (opted out) to protect creators by default.
+  bool get isOptOutEnabled => _isOptOutEnabled;
+
+  /// Initialize the service by loading the saved preference
+  Future<void> initialize() async {
+    await _loadPreference();
+  }
+
+  Future<void> _loadPreference() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      // Default to true - protect creators by default
+      _isOptOutEnabled = prefs.getBool(prefsKey) ?? true;
+    } catch (e) {
+      Log.error(
+        'Error loading AI training preference: $e',
+        name: 'AiTrainingPreferenceService',
+        category: LogCategory.system,
+      );
+    }
+  }
+
+  /// Set the AI training opt-out preference
+  Future<void> setOptOutEnabled(bool enabled) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(prefsKey, enabled);
+      _isOptOutEnabled = enabled;
+
+      Log.debug(
+        'AI training opt-out preference set to: $enabled',
+        name: 'AiTrainingPreferenceService',
+        category: LogCategory.system,
+      );
+    } catch (e) {
+      Log.error(
+        'Error saving AI training preference: $e',
+        name: 'AiTrainingPreferenceService',
+        category: LogCategory.system,
+      );
+    }
+  }
+}

--- a/mobile/lib/services/c2pa_signing_service.dart
+++ b/mobile/lib/services/c2pa_signing_service.dart
@@ -40,11 +40,15 @@ class C2paSigningService {
   /// Signs a video file with C2PA content credentials.
   ///
   /// [videoPath] - Path to the video file to sign
-  /// [claimGenerator] - Identifier for the app/tool creating the claim
+  /// [aiTrainingOptOut] - When true, includes a CAWG training-mining assertion
+  ///   marking all AI training and data mining uses as "notAllowed"
   ///
   /// Returns the path to the signed video file, or the original path if
   /// signing fails (signing is best-effort, not blocking).
-  Future<C2paSigningResult> signVideo({required String videoPath}) async {
+  Future<C2paSigningResult> signVideo({
+    required String videoPath,
+    bool aiTrainingOptOut = true,
+  }) async {
     try {
       Log.info(
         'Starting C2PA signing for video: $videoPath',
@@ -77,6 +81,7 @@ class C2paSigningService {
         claimGenerator,
         filename,
         DigitalSourceType.digitalCapture.url,
+        aiTrainingOptOut: aiTrainingOptOut,
       );
       Log.info('prepared C2PA manifest json: $manifestJsonSource');
 
@@ -164,15 +169,41 @@ class C2paSigningService {
     return _c2pa.isHardwareSigningAvailable();
   }
 
+  /// Exposes [_buildManifestJson] for testing.
+  @visibleForTesting
+  String buildManifestJsonPublic(
+    String claimGenerator,
+    String title,
+    String digitalSourceUrl, {
+    bool aiTrainingOptOut = true,
+  }) => _buildManifestJson(
+    claimGenerator,
+    title,
+    digitalSourceUrl,
+    aiTrainingOptOut: aiTrainingOptOut,
+  );
+
   /// Builds the manifest JSON for a freshly captured video.
+  ///
+  /// When [aiTrainingOptOut] is true, includes a `cawg.training-mining`
+  /// assertion per the CAWG Training and Data Mining spec v1.1, marking
+  /// all AI training, inference, generative training, and data mining
+  /// uses as "notAllowed".
   String _buildManifestJson(
     String claimGenerator,
     String title,
-    String digitalSourceUrl,
-  ) {
-    // Using digitalCapture source type for in-app recorded content
-    // DigitalSourceType.digitalCapture.url provides the IPTC URL
-    //final digitalSourceUrl = DigitalSourceType.digitalCapture.url;
+    String digitalSourceUrl, {
+    bool aiTrainingOptOut = true,
+  }) {
+    final trainingMiningAssertion = aiTrainingOptOut
+        ? ','
+              ' {"label": "cawg.training-mining",'
+              ' "data": {"entries": {'
+              ' "cawg.ai_training": {"use": "notAllowed"},'
+              ' "cawg.ai_inference": {"use": "notAllowed"},'
+              ' "cawg.ai_generative_training": {"use": "notAllowed"},'
+              ' "cawg.data_mining": {"use": "notAllowed"}}}}'
+        : '';
 
     return '''
 {
@@ -199,7 +230,7 @@ class C2paSigningService {
           }
         ]
       }
-    }
+    }$trainingMiningAssertion
   ]
 }
 ''';

--- a/mobile/lib/services/native_proofmode_service.dart
+++ b/mobile/lib/services/native_proofmode_service.dart
@@ -24,7 +24,10 @@ class NativeProofModeService {
   /// Returns [NativeProofData] if proof generation succeeds, null otherwise.
   /// Handles platform availability checks and graceful fallback if ProofMode
   /// is not supported.
-  static Future<NativeProofData?> proofFile(File videoFile) async {
+  static Future<NativeProofData?> proofFile(
+    File videoFile, {
+    bool aiTrainingOptOut = true,
+  }) async {
     try {
       // Check if native ProofMode/C2PA is available on this platform
       final isAvailable = await NativeProofModeService.isAvailable();
@@ -100,6 +103,7 @@ class NativeProofModeService {
       );
       final c2paResult = await c2paSigningService.signVideo(
         videoPath: videoFile.path,
+        aiTrainingOptOut: aiTrainingOptOut,
       );
 
       if (c2paResult.success) {

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -190,6 +190,7 @@ class VideoEditorRenderService {
   renderVideoToClip({
     required List<DivineVideoClip> clips,
     bool enableAudio = true,
+    bool aiTrainingOptOut = true,
     CompleteParameters? parameters,
   }) async {
     if (clips.isEmpty) return null;
@@ -224,6 +225,7 @@ class VideoEditorRenderService {
     );
     final proofData = await NativeProofModeService.proofFile(
       File(outputPath),
+      aiTrainingOptOut: aiTrainingOptOut,
     );
     final String? proofManifestJson = proofData != null
         ? jsonEncode(proofData)

--- a/mobile/test/services/ai_training_preference_test.dart
+++ b/mobile/test/services/ai_training_preference_test.dart
@@ -1,0 +1,51 @@
+// ABOUTME: Tests for AiTrainingPreferenceService
+// ABOUTME: Tests preference persistence and default opt-out for AI training
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/ai_training_preference_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group(AiTrainingPreferenceService, () {
+    late AiTrainingPreferenceService service;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      service = AiTrainingPreferenceService();
+      await service.initialize();
+    });
+
+    test('default preference is true (opted out)', () {
+      expect(service.isOptOutEnabled, isTrue);
+    });
+
+    test('can disable opt-out', () async {
+      await service.setOptOutEnabled(false);
+      expect(service.isOptOutEnabled, isFalse);
+    });
+
+    test('can re-enable opt-out', () async {
+      await service.setOptOutEnabled(false);
+      expect(service.isOptOutEnabled, isFalse);
+
+      await service.setOptOutEnabled(true);
+      expect(service.isOptOutEnabled, isTrue);
+    });
+
+    test('preference persists after reinitialization', () async {
+      await service.setOptOutEnabled(false);
+
+      final newService = AiTrainingPreferenceService();
+      await newService.initialize();
+
+      expect(newService.isOptOutEnabled, isFalse);
+    });
+
+    test('preference key is correct', () {
+      expect(
+        AiTrainingPreferenceService.prefsKey,
+        equals('ai_training_opt_out_enabled'),
+      );
+    });
+  });
+}

--- a/mobile/test/services/c2pa_training_mining_assertion_test.dart
+++ b/mobile/test/services/c2pa_training_mining_assertion_test.dart
@@ -1,0 +1,96 @@
+// ABOUTME: Tests for CAWG training-mining assertion in C2PA manifests
+// ABOUTME: Verifies the cawg.training-mining assertion is correctly embedded
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/c2pa_signing_service.dart';
+
+void main() {
+  group('C2PA training-mining assertion', () {
+    late C2paSigningService service;
+
+    setUp(() {
+      service = C2paSigningService();
+    });
+
+    test(
+      'includes cawg.training-mining assertion when opt-out is enabled',
+      () {
+        final manifest = service.buildManifestJsonPublic(
+          'DiVine/1.0',
+          'test.mp4',
+          'https://example.com/digitalCapture',
+        );
+
+        final json = jsonDecode(manifest) as Map<String, dynamic>;
+        final assertions = json['assertions'] as List<dynamic>;
+
+        expect(assertions, hasLength(2));
+
+        final trainingAssertion = assertions[1] as Map<String, dynamic>;
+        expect(trainingAssertion['label'], equals('cawg.training-mining'));
+
+        final data = trainingAssertion['data'] as Map<String, dynamic>;
+        final entries = data['entries'] as Map<String, dynamic>;
+
+        expect(entries, hasLength(4));
+
+        for (final key in [
+          'cawg.ai_training',
+          'cawg.ai_inference',
+          'cawg.ai_generative_training',
+          'cawg.data_mining',
+        ]) {
+          final entry = entries[key] as Map<String, dynamic>;
+          expect(
+            entry['use'],
+            equals('notAllowed'),
+            reason: '$key should be notAllowed',
+          );
+        }
+      },
+    );
+
+    test(
+      'excludes cawg.training-mining assertion when opt-out is disabled',
+      () {
+        final manifest = service.buildManifestJsonPublic(
+          'DiVine/1.0',
+          'test.mp4',
+          'https://example.com/digitalCapture',
+          aiTrainingOptOut: false,
+        );
+
+        final json = jsonDecode(manifest) as Map<String, dynamic>;
+        final assertions = json['assertions'] as List<dynamic>;
+
+        expect(assertions, hasLength(1));
+        expect(
+          (assertions[0] as Map<String, dynamic>)['label'],
+          equals('c2pa.actions.v2'),
+        );
+      },
+    );
+
+    test(
+      'always includes c2pa.actions.v2 assertion regardless of opt-out',
+      () {
+        for (final optOut in [true, false]) {
+          final manifest = service.buildManifestJsonPublic(
+            'DiVine/1.0',
+            'test.mp4',
+            'https://example.com/digitalCapture',
+            aiTrainingOptOut: optOut,
+          );
+
+          final json = jsonDecode(manifest) as Map<String, dynamic>;
+          final assertions = json['assertions'] as List<dynamic>;
+          final actionsAssertion = assertions[0] as Map<String, dynamic>;
+
+          expect(actionsAssertion['label'], equals('c2pa.actions.v2'));
+        }
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Embeds a `cawg.training-mining` assertion in C2PA manifests per the [CAWG Training and Data Mining spec v1.1](https://cawg.io/training-and-data-mining/1.1/), marking all four categories (`ai_training`, `ai_inference`, `ai_generative_training`, `data_mining`) as `"notAllowed"` by default
- Adds a user-facing toggle in **Settings > Preferences** ("Protect content from AI training") so creators can opt in to allowing AI use if they choose
- Threads the preference through all video signing paths (publish provider, editor provider, render service)

## Test plan
- [x] `AiTrainingPreferenceService` unit tests (5 tests) — default value, toggle, persistence
- [x] `C2PA training-mining assertion` unit tests (3 tests) — assertion present when opted out, absent when allowed, actions assertion always present
- [ ] Manual: verify toggle appears in Settings under Preferences
- [ ] Manual: publish a video with opt-out enabled, verify C2PA manifest contains `cawg.training-mining` assertion
- [ ] Manual: publish a video with opt-out disabled, verify assertion is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)