### PR TITLE
fix(upload): resolve issue that uploads fail when added collaborators

### DIFF
--- a/mobile/lib/models/divine_video_draft.dart
+++ b/mobile/lib/models/divine_video_draft.dart
@@ -344,7 +344,7 @@ class DivineVideoDraft {
     if (finalRenderedClip != null)
       'finalRenderedClip': finalRenderedClip!.toJson(),
     if (collaboratorPubkeys.isNotEmpty)
-      'collaboratorPubkeys': collaboratorPubkeys,
+      'collaboratorPubkeys': collaboratorPubkeys.toList(),
     if (inspiredByVideo != null) 'inspiredByVideo': inspiredByVideo!.toJson(),
     if (inspiredByNpub != null) 'inspiredByNpub': inspiredByNpub,
     if (selectedSound != null) 'selectedSound': selectedSound!.toJson(),

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -709,6 +709,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   DivineVideoDraft getActiveDraft({
     bool isAutosave = false,
     bool enforceSeparatedClips = false,
+    String? draftId,
   }) {
     // Read selected sound from local state
     final selectedSound = state.selectedSound;
@@ -724,7 +725,9 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     }
 
     return DivineVideoDraft.create(
-      id: isAutosave ? VideoEditorConstants.autoSaveId : draftId,
+      id:
+          draftId ??
+          (isAutosave ? VideoEditorConstants.autoSaveId : this.draftId),
       clips:
           state.finalRenderedClip == null || isAutosave || enforceSeparatedClips
           ? _clips
@@ -853,10 +856,14 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   ///
   /// Persists clips and metadata to local storage for later editing.
   /// Returns `true` on success, `false` on failure.
-  Future<bool> saveAsDraft() async {
+  Future<bool> saveAsDraft({bool enforceCreateNewDraft = false}) async {
     if (state.isSavingDraft) return false;
 
     state = state.copyWith(isSavingDraft: true);
+
+    final draftId = enforceCreateNewDraft
+        ? 'draft_${DateTime.now().microsecondsSinceEpoch}'
+        : this.draftId;
 
     Log.info(
       '💾 Saving draft: $draftId',
@@ -866,7 +873,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
 
     try {
       await _draftService.saveDraft(
-        getActiveDraft(enforceSeparatedClips: true),
+        getActiveDraft(enforceSeparatedClips: true, draftId: draftId),
       );
 
       // Remove the autosaved draft

--- a/mobile/lib/widgets/video_metadata/video_metadata_bottom_bar.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_bottom_bar.dart
@@ -78,7 +78,7 @@ class VideoMetadataBottomBar extends ConsumerWidget {
       // Save the draft to the library.
       final draftSuccess = await ref
           .read(videoEditorProvider.notifier)
-          .saveAsDraft();
+          .saveAsDraft(enforceCreateNewDraft: true);
       if (!draftSuccess) {
         throw StateError('Failed to save draft');
       }

--- a/mobile/test/models/vine_draft_collab_ib_test.dart
+++ b/mobile/test/models/vine_draft_collab_ib_test.dart
@@ -126,6 +126,23 @@ void main() {
         );
       });
 
+      test('collaboratorPubkeys serializes as List, not Set', () {
+        final draft = DivineVideoDraft.create(
+          clips: [_testClip()],
+          title: 'Test',
+          description: '',
+          hashtags: const {},
+          selectedApproach: 'native',
+          collaboratorPubkeys: {
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          },
+        );
+
+        final json = draft.toJson();
+        expect(json['collaboratorPubkeys'], isA<List>());
+      });
+
       test('omits collaboratorPubkeys when empty', () {
         final draft = DivineVideoDraft.create(
           clips: [_testClip()],

--- a/mobile/test/widgets/video_metadata/video_metadata_bottom_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_bottom_bar_test.dart
@@ -696,7 +696,7 @@ class _MockVideoEditorNotifier extends VideoEditorNotifier {
   }
 
   @override
-  Future<bool> saveAsDraft() async {
+  Future<bool> saveAsDraft({bool enforceCreateNewDraft = false}) async {
     onSaveAsDraft?.call();
     return saveAsDraftResult;
   }


### PR DESCRIPTION
## Description

Fix two bugs that caused uploads to fail when collaborators were added: `collaboratorPubkeys` was serialized as a `Set` (not valid JSON) instead of a `List`, and the "save as draft" step before upload reused the existing draft ID instead of creating a fresh one, causing ID conflicts.


**Related Issue:** Closes #2244

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore