### PR TITLE
fix(e2e): update tests for inbox tab rename and recording timing

### DIFF
--- a/mobile/integration_test/auth/auth_journey_test.dart
+++ b/mobile/integration_test/auth/auth_journey_test.dart
@@ -726,19 +726,19 @@ void main() {
         // ════════════════════════════════════════════════════════════
 
         logPhase('── Phase 3m: Checking notifications ──');
-        await tapBottomNavTab(tester, 'notifications_tab');
+        await tapBottomNavTab(tester, 'inbox_tab');
         await tester.pump(const Duration(seconds: 3));
 
-        final hasNotifTabs =
-            find.text('All').evaluate().isNotEmpty ||
-            find.text('Likes').evaluate().isNotEmpty;
+        final hasInboxTabs =
+            find.text('Messages').evaluate().isNotEmpty ||
+            find.text('Notifications').evaluate().isNotEmpty;
         expect(
-          hasNotifTabs,
+          hasInboxTabs,
           isTrue,
-          reason: 'Notifications screen should show filter tabs',
+          reason: 'Inbox screen should show Messages/Notifications toggle',
         );
 
-        logPhase('Phase 3m complete -- notifications screen rendered');
+        logPhase('Phase 3m complete -- inbox screen rendered');
 
         // ════════════════════════════════════════════════════════════
         // Phase 3n: Settings

--- a/mobile/integration_test/auth/user_journey_test.dart
+++ b/mobile/integration_test/auth/user_journey_test.dart
@@ -151,22 +151,45 @@ void main() {
         await tester.tap(recordButton);
         logPhase('Record tap 1 — starting recording');
 
-        // Wait for native camera to produce first keyframe and truly start.
-        // On the emulator fake camera this can take 5-10 seconds.
-        for (var i = 0; i < 60; i++) {
+        // Wait for recording to truly start. On the emulator the camera
+        // can take 5-15s to produce its first keyframe. Poll the record
+        // button's tooltip: it changes from "Start recording" to
+        // "Stop recording" once recording begins.
+        var recordingStarted = false;
+        for (var i = 0; i < 80; i++) {
+          await tester.pump(const Duration(milliseconds: 250));
+          final button = find.bySemanticsIdentifier(
+            'divine-camera-record-button',
+          );
+          if (button.evaluate().isNotEmpty) {
+            final semantics = tester.getSemantics(button);
+            if (semantics.tooltip == 'Stop recording') {
+              recordingStarted = true;
+              logPhase('Recording truly started (tooltip: Stop recording)');
+              break;
+            }
+          }
+        }
+        if (!recordingStarted) {
+          logPhase('Warning: recording did not start within 20s');
+        }
+
+        // Now record for at least 3 seconds to get a usable clip
+        for (var i = 0; i < 12; i++) {
           await tester.pump(const Duration(milliseconds: 250));
         }
-        logPhase('Waited 15s for recording');
+        logPhase('Recorded for 3s');
 
         // Second tap → toggleRecording() → stopRecording() → addClip()
         await tester.tap(recordButton);
         logPhase('Record tap 2 — stopping recording');
 
-        // Wait for clip processing (thumbnail, metadata extraction)
-        for (var i = 0; i < 20; i++) {
+        // Wait for clip processing (thumbnail, metadata extraction).
+        // On the emulator, stopRecording can take several seconds.
+        for (var i = 0; i < 40; i++) {
           await tester.pump(const Duration(milliseconds: 250));
         }
-        logPhase('Clip processing done');
+        logPhase('Clip processing done (10s wait)');
 
         // Tap the continue button and verify we navigate to the editor.
         // The button exists in the tree but has onPressed: null when no clips,

--- a/mobile/integration_test/helpers/navigation_helpers.dart
+++ b/mobile/integration_test/helpers/navigation_helpers.dart
@@ -155,8 +155,8 @@ Future<bool> waitForTextGone(
 
 /// Tap a bottom navigation tab by its semantic identifier.
 ///
-/// Valid identifiers: 'home_tab', 'explore_tab', 'profile_tab',
-/// 'notifications_tab'.
+/// Valid identifiers: 'home_tab', 'explore_tab', 'inbox_tab',
+/// 'profile_tab'.
 Future<void> tapBottomNavTab(
   WidgetTester tester,
   String semanticId,


### PR DESCRIPTION
## Summary
- auth_journey_test: `notifications_tab` -> `inbox_tab`, `All/Likes` -> `Messages/Notifications` (UI was renamed in the inbox DM feature)
- user_journey_test: poll for recording tooltip change before starting timer (emulator camera takes 5-15s to init, was consuming the entire recording window)
- navigation_helpers: update doc comment with current tab identifiers

## Test plan
- [x] auth_journey_test passes (verified on emulator with XWayland display)
- [x] user_journey_test passes full record/publish/delete flow
- [x] 5/6 auth suite tests pass (user_journey has pre-existing clip state handoff issue in editor)