### PR TITLE
fix(brand): capitalize app display name to "Divine" on iOS and Android

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -79,7 +79,7 @@
         tools:node="remove" />
 
     <application
-        android:label="divine"
+        android:label="Divine"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:theme="@style/NormalTheme"

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>divine</string>
+	<string>Divine</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>divine</string>
+	<string>Divine</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
## Summary
- Updates iOS `CFBundleDisplayName` and `CFBundleName` from "divine" to "Divine"
- Updates Android `android:label` from "divine" to "Divine"
- This is the name users see on their home screen and in app switchers

URL schemes (`divine://`) and internal identifiers are intentionally left lowercase — they are protocol identifiers, not user-facing branding.

## Test plan
- [ ] iOS: Build and verify app name shows as "Divine" on home screen
- [ ] Android: Build and verify app name shows as "Divine" on home screen / app drawer
- [ ] Deep links (`divine://`) still work on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)