### PR TITLE
refactor: Migrate creator consumers to Funnelcake

### DIFF
--- a/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
+++ b/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
@@ -3,8 +3,8 @@
 
 import 'dart:math' as math;
 
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:models/models.dart';
-import 'package:openvine/services/analytics_api_service.dart';
 
 /// Provenance source for analytics values.
 enum AnalyticsDataSource { authorVideos, bulkVideoStats, videoViewsEndpoint }
@@ -45,55 +45,6 @@ class CreatorAnalyticsSnapshot {
   final CreatorAnalyticsDiagnostics diagnostics;
 }
 
-/// Minimal API contract required by the repository.
-abstract class CreatorAnalyticsApi {
-  bool get isAvailable;
-
-  Future<List<VideoEvent>> getVideosByAuthor({
-    required String pubkey,
-    int limit,
-    int? before,
-  });
-
-  Future<Map<String, BulkVideoStatsEntry>> getBulkVideoStats(
-    List<String> eventIds,
-  );
-
-  Future<int?> getVideoViews(String eventId);
-
-  Future<SocialCounts?> getSocialCounts(String pubkey);
-}
-
-/// Adapter for existing AnalyticsApiService.
-class AnalyticsApiCreatorAdapter implements CreatorAnalyticsApi {
-  AnalyticsApiCreatorAdapter(this._service);
-
-  final AnalyticsApiService _service;
-
-  @override
-  bool get isAvailable => _service.isAvailable;
-
-  @override
-  Future<List<VideoEvent>> getVideosByAuthor({
-    required String pubkey,
-    int limit = 50,
-    int? before,
-  }) =>
-      _service.getVideosByAuthor(pubkey: pubkey, limit: limit, before: before);
-
-  @override
-  Future<Map<String, BulkVideoStatsEntry>> getBulkVideoStats(
-    List<String> eventIds,
-  ) => _service.getBulkVideoStats(eventIds);
-
-  @override
-  Future<int?> getVideoViews(String eventId) => _service.getVideoViews(eventId);
-
-  @override
-  Future<SocialCounts?> getSocialCounts(String pubkey) =>
-      _service.getSocialCounts(pubkey);
-}
-
 /// Repository used by creator analytics screens.
 abstract class CreatorAnalyticsRepository {
   Future<CreatorAnalyticsSnapshot> fetchCreatorAnalytics(String pubkey);
@@ -102,22 +53,22 @@ abstract class CreatorAnalyticsRepository {
 /// Funnelcake-backed implementation with layered fallbacks.
 class FunnelcakeCreatorAnalyticsRepository
     implements CreatorAnalyticsRepository {
-  FunnelcakeCreatorAnalyticsRepository(this._api);
+  FunnelcakeCreatorAnalyticsRepository(this._client);
 
-  final CreatorAnalyticsApi _api;
+  final FunnelcakeApiClient _client;
 
   @override
   Future<CreatorAnalyticsSnapshot> fetchCreatorAnalytics(String pubkey) async {
-    if (!_api.isAvailable) {
-      throw StateError('Funnelcake analytics is not available right now.');
+    if (!_client.isAvailable) {
+      throw const FunnelcakeNotConfiguredException();
     }
     if (pubkey.isEmpty) {
-      throw StateError('Missing pubkey for creator analytics.');
+      throw const FunnelcakeException('Pubkey cannot be empty');
     }
 
     final sourcesUsed = <AnalyticsDataSource>{};
 
-    final socialFuture = _api.getSocialCounts(pubkey);
+    final socialFuture = _client.getSocialCounts(pubkey);
     final videos = await _fetchAuthorVideos(pubkey);
     if (videos.isNotEmpty) {
       sourcesUsed.add(AnalyticsDataSource.authorVideos);
@@ -164,13 +115,14 @@ class FunnelcakeCreatorAnalyticsRepository
     int? before;
 
     for (var page = 0; page < maxPages; page++) {
-      final batch = await _api.getVideosByAuthor(
+      final batchStats = await _client.getVideosByAuthor(
         pubkey: pubkey,
         limit: pageSize,
         before: before,
       );
 
-      if (batch.isEmpty) break;
+      if (batchStats.isEmpty) break;
+      final batch = batchStats.map((stats) => stats.toVideoEvent()).toList();
       collected.addAll(batch);
 
       if (batch.length < pageSize) break;
@@ -202,8 +154,8 @@ class FunnelcakeCreatorAnalyticsRepository
     final statsById = <String, BulkVideoStatsEntry>{};
 
     for (final chunk in chunks) {
-      final chunkStats = await _api.getBulkVideoStats(chunk);
-      statsById.addAll(chunkStats);
+      final chunkResponse = await _client.getBulkVideoStats(chunk);
+      statsById.addAll(chunkResponse.stats);
     }
 
     if (statsById.isEmpty) {
@@ -259,13 +211,10 @@ class FunnelcakeCreatorAnalyticsRepository
 
     for (final chunk in chunks) {
       final counts = await Future.wait(
-        chunk.map((video) => _api.getVideoViews(video.id)),
+        chunk.map((video) => _client.getVideoViews(video.id)),
       );
       for (var i = 0; i < chunk.length; i++) {
-        final count = counts[i];
-        if (count != null) {
-          fetchedViews[chunk[i].id] = count;
-        }
+        fetchedViews[chunk[i].id] = counts[i];
       }
     }
 

--- a/mobile/lib/providers/creator_analytics_providers.dart
+++ b/mobile/lib/providers/creator_analytics_providers.dart
@@ -18,10 +18,8 @@ final creatorAnalyticsRepositoryProvider = Provider<CreatorAnalyticsRepository>(
       return _FixtureCreatorAnalyticsRepository();
     }
 
-    final service = ref.watch(analyticsApiServiceProvider);
-    return FunnelcakeCreatorAnalyticsRepository(
-      AnalyticsApiCreatorAdapter(service),
-    );
+    final funnelcakeClient = ref.watch(funnelcakeApiClientProvider);
+    return FunnelcakeCreatorAnalyticsRepository(funnelcakeClient);
   },
 );
 

--- a/mobile/test/features/creator_analytics/creator_analytics_repository_test.dart
+++ b/mobile/test/features/creator_analytics/creator_analytics_repository_test.dart
@@ -1,46 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/features/creator_analytics/creator_analytics_repository.dart';
 
-class _FakeCreatorAnalyticsApi implements CreatorAnalyticsApi {
-  _FakeCreatorAnalyticsApi({
-    required this.videos,
-    required this.bulkStats,
-    required this.viewsById,
-  });
-
-  final List<VideoEvent> videos;
-  final Map<String, BulkVideoStatsEntry> bulkStats;
-  final Map<String, int?> viewsById;
-
-  @override
-  bool get isAvailable => true;
-
-  @override
-  Future<Map<String, BulkVideoStatsEntry>> getBulkVideoStats(
-    List<String> eventIds,
-  ) async {
-    return {
-      for (final id in eventIds)
-        if (bulkStats.containsKey(id)) id: bulkStats[id]!,
-    };
-  }
-
-  @override
-  Future<SocialCounts?> getSocialCounts(String pubkey) async => null;
-
-  @override
-  Future<int?> getVideoViews(String eventId) async => viewsById[eventId];
-
-  @override
-  Future<List<VideoEvent>> getVideosByAuthor({
-    required String pubkey,
-    int limit = 50,
-    int? before,
-  }) async {
-    return videos;
-  }
-}
+class MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
 
 VideoEvent _video({
   required String id,
@@ -62,7 +26,36 @@ VideoEvent _video({
   );
 }
 
+VideoStats _videoStats({
+  required String id,
+  required String pubkey,
+  int? loops,
+  int? views,
+}) {
+  return VideoStats(
+    id: id,
+    pubkey: pubkey,
+    createdAt: DateTime.fromMillisecondsSinceEpoch(1739350000 * 1000),
+    kind: 34236,
+    dTag: id,
+    title: id,
+    thumbnail: 'thumb',
+    videoUrl: 'videoUrl',
+    reactions: 2,
+    comments: 1,
+    reposts: 0,
+    engagementScore: 0,
+    loops: loops,
+    views: views,
+  );
+}
+
 void main() {
+  setUpAll(() {
+    registerFallbackValue('');
+    registerFallbackValue(<String>[]);
+  });
+
   group('extractViewLikeCount', () {
     test('prefers explicit views tag', () {
       final event = _video(id: 'v1', rawTags: const {'views': '55'}, loops: 9);
@@ -82,20 +75,43 @@ void main() {
 
   group('FunnelcakeCreatorAnalyticsRepository', () {
     test('hydrates views from bulk stats when available', () async {
-      final api = _FakeCreatorAnalyticsApi(
-        videos: [_video(id: 'a')],
-        bulkStats: {
-          'a': const BulkVideoStatsEntry(
-            eventId: 'a',
-            reactions: 4,
-            comments: 2,
-            reposts: 1,
-            loops: 12,
-            views: 15,
-          ),
-        },
-        viewsById: const {},
+      const pubkey = 'pubkey';
+      final api = MockFunnelcakeApiClient();
+
+      when(() => api.isAvailable).thenReturn(true);
+      when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+      when(() => api.getVideoViews(any())).thenAnswer((_) async => 0);
+      when(() => api.getBulkVideoStats(any())).thenAnswer((invocation) async {
+        final ids = invocation.positionalArguments[0] as List<String>;
+        if (ids.length == 1 && ids.first == 'a') {
+          return const BulkVideoStatsResponse(
+            stats: {
+              'a': BulkVideoStatsEntry(
+                eventId: 'a',
+                reactions: 4,
+                comments: 2,
+                reposts: 1,
+                loops: 12,
+                views: 15,
+              ),
+            },
+          );
+        }
+        return const BulkVideoStatsResponse(stats: {});
+      });
+
+      when(
+        () => api.getVideosByAuthor(
+          pubkey: pubkey,
+          limit: 100,
+          before: any(named: 'before'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          _videoStats(id: 'a', pubkey: pubkey),
+        ],
       );
+
       final repo = FunnelcakeCreatorAnalyticsRepository(api);
       final snapshot = await repo.fetchCreatorAnalytics('pubkey');
 
@@ -103,17 +119,39 @@ void main() {
       expect(snapshot.diagnostics.videosHydratedByBulkStats, 1);
       expect(snapshot.diagnostics.videosHydratedByViewsEndpoint, 0);
       expect(snapshot.diagnostics.videosWithAnyViews, 1);
+      expect(snapshot.diagnostics.videosMissingViews, 0);
       expect(snapshot.videos.first.rawTags['views'], '15');
     });
 
     test(
       'hydrates views from /views endpoint when bulk stats missing',
       () async {
-        final api = _FakeCreatorAnalyticsApi(
-          videos: [_video(id: 'b')],
-          bulkStats: const {},
-          viewsById: const {'b': 21},
+        const pubkey = 'pubkey';
+        final api = MockFunnelcakeApiClient();
+
+        when(() => api.isAvailable).thenReturn(true);
+        when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+
+        when(() => api.getBulkVideoStats(any())).thenAnswer(
+          (_) async => const BulkVideoStatsResponse(stats: {}),
         );
+        when(() => api.getVideoViews(any())).thenAnswer((invocation) async {
+          final eventId = invocation.positionalArguments[0] as String;
+          return eventId == 'b' ? 21 : 0;
+        });
+
+        when(
+          () => api.getVideosByAuthor(
+            pubkey: pubkey,
+            limit: 100,
+            before: any(named: 'before'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            _videoStats(id: 'b', pubkey: pubkey),
+          ],
+        );
+
         final repo = FunnelcakeCreatorAnalyticsRepository(api);
         final snapshot = await repo.fetchCreatorAnalytics('pubkey');
 
@@ -121,25 +159,49 @@ void main() {
         expect(snapshot.diagnostics.videosHydratedByBulkStats, 0);
         expect(snapshot.diagnostics.videosHydratedByViewsEndpoint, 1);
         expect(snapshot.diagnostics.videosWithAnyViews, 1);
+        expect(snapshot.diagnostics.videosMissingViews, 0);
         expect(snapshot.videos.first.rawTags['views'], '21');
       },
     );
 
     test(
-      'keeps missing-view diagnostics when no view source is available',
+      'hydrates views from /views endpoint when endpoint returns 0',
       () async {
-        final api = _FakeCreatorAnalyticsApi(
-          videos: [_video(id: 'c')],
-          bulkStats: const {},
-          viewsById: const {'c': null},
+        const pubkey = 'pubkey';
+        final api = MockFunnelcakeApiClient();
+
+        when(() => api.isAvailable).thenReturn(true);
+        when(() => api.getSocialCounts(pubkey)).thenAnswer((_) async => null);
+
+        when(() => api.getBulkVideoStats(any())).thenAnswer(
+          (_) async => const BulkVideoStatsResponse(stats: {}),
         );
+        when(() => api.getVideoViews(any())).thenAnswer((invocation) async {
+          final eventId = invocation.positionalArguments[0] as String;
+          return eventId == 'c' ? 0 : 0;
+        });
+
+        when(
+          () => api.getVideosByAuthor(
+            pubkey: pubkey,
+            limit: 100,
+            before: any(named: 'before'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            _videoStats(id: 'c', pubkey: pubkey),
+          ],
+        );
+
         final repo = FunnelcakeCreatorAnalyticsRepository(api);
         final snapshot = await repo.fetchCreatorAnalytics('pubkey');
 
         expect(snapshot.diagnostics.totalVideos, 1);
-        expect(snapshot.diagnostics.videosWithAnyViews, 0);
-        expect(snapshot.diagnostics.videosMissingViews, 1);
-        expect(snapshot.diagnostics.hasAnyViewData, isFalse);
+        expect(snapshot.diagnostics.videosHydratedByBulkStats, 0);
+        expect(snapshot.diagnostics.videosHydratedByViewsEndpoint, 1);
+        expect(snapshot.diagnostics.videosWithAnyViews, 1);
+        expect(snapshot.diagnostics.videosMissingViews, 0);
+        expect(snapshot.videos.first.rawTags['views'], '0');
       },
     );
   });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Migrate creator analytics off the legacy AnalyticsApiService as part of the Funnelcake API consolidation (Phase 5). FunnelcakeCreatorAnalyticsRepository now injects FunnelcakeApiClient directly and calls it using typed client methods for getVideosByAuthor, getBulkVideoStats, getVideoViews, and getSocialCounts, mapping VideoStats -> VideoEvent and preserving existing UI-facing repository behavior (so creator_analytics_screen.dart required no functional changes). The Riverpod wiring now constructs the repository from funnelcakeApiClientProvider, and unit tests were updated to mock FunnelcakeApiClient instead of the old analytics adapter.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #1693 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore