### PR TITLE
fix(video-player): prevent texture bleeding by managing active state visibility

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -697,6 +697,7 @@ class _PooledFullscreenItemContentState
       color: VineTheme.backgroundColor,
       child: PooledVideoPlayer(
         index: widget.index,
+        isActive: widget.isActive,
         thumbnailUrl: video.thumbnailUrl,
         enableTapToPause: widget.isActive,
         videoBuilder: (context, videoController, player) =>

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -677,6 +677,7 @@ class _PooledVideoFeedItemContent extends StatelessWidget {
       color: VineTheme.backgroundColor,
       child: PooledVideoPlayer(
         index: index,
+        isActive: isActive,
         thumbnailUrl: video.thumbnailUrl,
         enableTapToPause: isActive,
         videoBuilder: (context, videoController, player) => _FittedVideoPlayer(

--- a/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_player.dart
+++ b/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_player.dart
@@ -37,6 +37,7 @@ class PooledVideoPlayer extends StatelessWidget {
     required this.index,
     required this.videoBuilder,
     this.controller,
+    this.isActive = true,
     this.thumbnailUrl,
     this.loadingBuilder,
     this.errorBuilder,
@@ -48,6 +49,13 @@ class PooledVideoPlayer extends StatelessWidget {
 
   /// Optional explicit controller. Falls back to [VideoPoolProvider].
   final VideoFeedController? controller;
+
+  /// Whether this item is the currently active (visible) page.
+  ///
+  /// When `false` the native [Texture] is kept in the widget tree so that
+  /// preloading continues, but it is hidden via [Opacity] to prevent
+  /// media_kit texture bleeding during PageView scroll transitions.
+  final bool isActive;
 
   /// The index of this video in the feed.
   final int index;
@@ -115,10 +123,13 @@ class PooledVideoPlayer extends StatelessWidget {
               _DefaultLoadingState(thumbnailUrl: thumbnailUrl);
           final children = <Widget>[
             loadingPlaceholder,
-            _RevealVideoAfterFirstFrame(
-              videoController: videoController,
-              readyForFallback: loadState == LoadState.ready,
-              child: videoBuilder(context, videoController, player),
+            Opacity(
+              opacity: isActive ? 1 : 0,
+              child: _RevealVideoAfterFirstFrame(
+                videoController: videoController,
+                readyForFallback: loadState == LoadState.ready,
+                child: videoBuilder(context, videoController, player),
+              ),
             ),
             ?overlay,
           ];

--- a/mobile/packages/pooled_video_player/test/widgets/pooled_video_player_test.dart
+++ b/mobile/packages/pooled_video_player/test/widgets/pooled_video_player_test.dart
@@ -119,6 +119,7 @@ void main() {
       ErrorBuilder? errorBuilder,
       OverlayBuilder? overlayBuilder,
       bool enableTapToPause = false,
+      bool isActive = true,
       VoidCallback? onTap,
     }) {
       return MaterialApp(
@@ -127,6 +128,7 @@ void main() {
             feedController: controller ?? mockController,
             child: PooledVideoPlayer(
               index: index,
+              isActive: isActive,
               controller: controller ?? mockController,
               thumbnailUrl: thumbnailUrl,
               loadingBuilder: loadingBuilder,
@@ -671,6 +673,65 @@ void main() {
         // Widget at index 0 should now show video
         expect(find.byKey(const Key('video_widget')), findsOneWidget);
       });
+    });
+    group('isActive texture bleeding prevention', () {
+      setUp(() {
+        indexNotifiers[0] = ValueNotifier(
+          VideoIndexState(
+            loadState: LoadState.ready,
+            videoController: mockVideoController,
+            player: mockPlayer,
+          ),
+        );
+      });
+
+      testWidgets(
+        'hides video texture when isActive is false',
+        (tester) async {
+          await tester.pumpWidget(buildWidget(isActive: false));
+
+          final opacityFinder = find.ancestor(
+            of: find.byType(AnimatedOpacity),
+            matching: find.byType(Opacity),
+          );
+
+          expect(opacityFinder, findsOneWidget);
+          expect(
+            tester.widget<Opacity>(opacityFinder).opacity,
+            equals(0),
+          );
+        },
+      );
+
+      testWidgets(
+        'shows video texture when isActive is true',
+        (tester) async {
+          await tester.pumpWidget(buildWidget());
+
+          final opacityFinder = find.ancestor(
+            of: find.byType(AnimatedOpacity),
+            matching: find.byType(Opacity),
+          );
+
+          expect(opacityFinder, findsOneWidget);
+          expect(
+            tester.widget<Opacity>(opacityFinder).opacity,
+            equals(1),
+          );
+        },
+      );
+
+      testWidgets(
+        'video widget stays in tree when inactive',
+        (tester) async {
+          await tester.pumpWidget(buildWidget(isActive: false));
+
+          expect(
+            find.byKey(const Key('video_widget')),
+            findsOneWidget,
+          );
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
## Description

Fix video texture bleeding during PageView scroll transitions. When scrolling between videos in the feed, a frame from the next (inactive) video would briefly flash on the current video because media_kit's native `Texture` widgets were both being painted simultaneously. Added an `isActive` parameter to `PooledVideoPlayer` that wraps the video layer in `Opacity(opacity: 0)` when inactive — this prevents the texture from being composited while keeping it in the widget tree so preloading continues to work.

 

**Related Issue:** Closes #2286

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore