### PR TITLE
fix(dm): clear DM database on account switch to prevent data leakage

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -958,7 +958,18 @@ Future<void> _setZendeskIdentity(
 @riverpod
 UserDataCleanupService userDataCleanupService(Ref ref) {
   final prefs = ref.watch(sharedPreferencesProvider);
-  return UserDataCleanupService(prefs);
+  final db = ref.watch(databaseProvider);
+  final service = UserDataCleanupService(prefs);
+
+  // Wire database cleanup callback so signOut() clears DM and notification data
+  service.onDatabaseCleanup = () async {
+    await db.directMessagesDao.clearAll();
+    await db.conversationsDao.clearAll();
+    await db.notificationsDao.clearAll();
+    await NotificationServiceEnhanced.instance.clearAllData();
+  };
+
+  return service;
 }
 
 /// Subscription manager for centralized subscription management

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -2419,7 +2419,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'bad5e2e3ae1a38a6de7e77d75e321628c36a3ba2';
+    r'808d26e12d8cc5c18793a22f4e888bf3c9840abe';
 
 /// Subscription manager for centralized subscription management
 

--- a/mobile/lib/repositories/dm_repository.dart
+++ b/mobile/lib/repositories/dm_repository.dart
@@ -91,21 +91,54 @@ class DmRepository {
   /// Called by the provider when the user's keys become available.
   /// Read methods work before this; send/subscribe require it.
   ///
-  /// Safe to call multiple times — subsequent calls are no-ops when the
-  /// repository is already initialized.
+  /// Safe to call multiple times — subsequent calls for the same user are
+  /// no-ops. If called with a different user, resets and re-initializes.
   void initialize({
     required String userPubkey,
     required NostrSigner signer,
     required NIP17MessageService messageService,
     RumorDecryptor? rumorDecryptor,
   }) {
-    if (isInitialized) return;
+    if (isInitialized && _userPubkey == userPubkey) return;
+
+    // If switching users, stop the old subscription first.
+    if (isInitialized && _userPubkey != userPubkey) {
+      Log.info(
+        'DmRepository: switching user from $_userPubkey to $userPubkey',
+        category: LogCategory.system,
+      );
+      _resetState();
+    }
 
     _userPubkey = userPubkey;
     _signer = signer;
     _messageService = messageService;
     if (rumorDecryptor != null) _rumorDecryptor = rumorDecryptor;
     startListening();
+  }
+
+  /// Reset internal state so the repository can be re-initialized for a
+  /// different user. Stops the relay subscription and clears credentials.
+  ///
+  /// Synchronous so [initialize] can call it inline. Subscription cancel
+  /// is fire-and-forget — the old subscription filtered by the old pubkey
+  /// so any late arrivals are harmless (dedup rejects them).
+  void _resetState() {
+    _disposed = true;
+    _pollTimer?.cancel();
+    _pollTimer = null;
+    unawaited(_giftWrapSubscription?.cancel());
+    _giftWrapSubscription = null;
+    try {
+      unawaited(_nostrClient.unsubscribe('dm_inbox'));
+    } on Object {
+      // Ignore if subscription doesn't exist
+    }
+    _userPubkey = '';
+    _signer = null;
+    _messageService = null;
+    _disposed = false;
+    _pollInProgress = false;
   }
 
   /// Delay before attempting to re-subscribe after stream closure.
@@ -319,6 +352,7 @@ class DmRepository {
         dimensions: fileMetadata?.dimensions,
         blurhash: fileMetadata?.blurhash,
         thumbnailUrl: fileMetadata?.thumbnailUrl,
+        ownerPubkey: _userPubkey,
       );
 
       // Update or create the conversation
@@ -348,6 +382,7 @@ class DmRepository {
         isRead: isSentByMe,
         currentUserHasSent:
             isSentByMe || (existing?.currentUserHasSent ?? false),
+        ownerPubkey: _userPubkey,
       );
 
       Log.debug(
@@ -411,6 +446,7 @@ class DmRepository {
           createdAt: now,
           giftWrapId: result.messageEventId!,
           replyToId: replyToId,
+          ownerPubkey: _userPubkey,
         );
 
         final existingSend = await _conversationsDao.getConversation(
@@ -425,6 +461,7 @@ class DmRepository {
           lastMessageTimestamp: now,
           lastMessageSenderPubkey: _userPubkey,
           currentUserHasSent: true,
+          ownerPubkey: _userPubkey,
         );
 
         Log.debug(
@@ -506,6 +543,7 @@ class DmRepository {
         createdAt: now,
         giftWrapId: firstSuccess.messageEventId!,
         replyToId: replyToId,
+        ownerPubkey: _userPubkey,
       );
 
       final existingGroup = await _conversationsDao.getConversation(
@@ -520,6 +558,7 @@ class DmRepository {
         lastMessageTimestamp: now,
         lastMessageSenderPubkey: _userPubkey,
         currentUserHasSent: true,
+        ownerPubkey: _userPubkey,
       );
     }
 
@@ -599,6 +638,7 @@ class DmRepository {
         dimensions: fileMetadata.dimensions,
         blurhash: fileMetadata.blurhash,
         thumbnailUrl: fileMetadata.thumbnailUrl,
+        ownerPubkey: _userPubkey,
       );
 
       final existingFile = await _conversationsDao.getConversation(
@@ -613,6 +653,7 @@ class DmRepository {
         lastMessageTimestamp: now,
         lastMessageSenderPubkey: _userPubkey,
         currentUserHasSent: true,
+        ownerPubkey: _userPubkey,
       );
     }
 
@@ -628,8 +669,9 @@ class DmRepository {
   /// When [limit] is provided, only the top [limit] conversations are
   /// watched. Omit for all conversations.
   Stream<List<DmConversation>> watchConversations({int? limit}) {
+    final pubkey = _userPubkey.isEmpty ? null : _userPubkey;
     return _conversationsDao
-        .watchAllConversations(limit: limit)
+        .watchAllConversations(limit: limit, ownerPubkey: pubkey)
         .map(
           (rows) => rows.map(_conversationFromRow).toList(),
         );
@@ -645,7 +687,10 @@ class DmRepository {
 
   /// Get all conversations.
   Future<List<DmConversation>> getConversations() async {
-    final rows = await _conversationsDao.getAllConversations();
+    final pubkey = _userPubkey.isEmpty ? null : _userPubkey;
+    final rows = await _conversationsDao.getAllConversations(
+      ownerPubkey: pubkey,
+    );
     return rows.map(_conversationFromRow).toList();
   }
 
@@ -654,8 +699,9 @@ class DmRepository {
   /// Supports pagination via [limit]. These conversations are never
   /// message requests.
   Stream<List<DmConversation>> watchAcceptedConversations({int? limit}) {
+    final pubkey = _userPubkey.isEmpty ? null : _userPubkey;
     return _conversationsDao
-        .watchAcceptedConversations(limit: limit)
+        .watchAcceptedConversations(limit: limit, ownerPubkey: pubkey)
         .map((rows) => rows.map(_conversationFromRow).toList());
   }
 
@@ -665,9 +711,12 @@ class DmRepository {
   /// follow state) is applied by [classifyPotentialRequests]. Returned
   /// without pagination since the list is typically small and needed in full.
   Stream<List<DmConversation>> watchPotentialRequests() {
-    return _conversationsDao.watchPotentialRequestConversations().map(
-      (rows) => rows.map(_conversationFromRow).toList(),
-    );
+    final pubkey = _userPubkey.isEmpty ? null : _userPubkey;
+    return _conversationsDao
+        .watchPotentialRequestConversations(ownerPubkey: pubkey)
+        .map(
+          (rows) => rows.map(_conversationFromRow).toList(),
+        );
   }
 
   /// Classifies potential request conversations by follow state.
@@ -721,11 +770,16 @@ class DmRepository {
   }
 
   /// Watch unread conversation count (all conversations).
-  Stream<int> watchUnreadCount() => _conversationsDao.watchUnreadCount();
+  Stream<int> watchUnreadCount() {
+    final pubkey = _userPubkey.isEmpty ? null : _userPubkey;
+    return _conversationsDao.watchUnreadCount(ownerPubkey: pubkey);
+  }
 
   /// Watch unread count for accepted conversations only (excludes requests).
-  Stream<int> watchUnreadAcceptedCount() =>
-      _conversationsDao.watchUnreadAcceptedCount();
+  Stream<int> watchUnreadAcceptedCount() {
+    final pubkey = _userPubkey.isEmpty ? null : _userPubkey;
+    return _conversationsDao.watchUnreadAcceptedCount(ownerPubkey: pubkey);
+  }
 
   /// Mark a conversation as read.
   Future<void> markConversationAsRead(String conversationId) {
@@ -773,7 +827,11 @@ class DmRepository {
 
   /// Count the total number of messages in a conversation.
   Future<int> countMessagesInConversation(String conversationId) {
-    return _directMessagesDao.countMessages(conversationId);
+    final pubkey = _userPubkey.isEmpty ? null : _userPubkey;
+    return _directMessagesDao.countMessages(
+      conversationId,
+      ownerPubkey: pubkey,
+    );
   }
 
   // -------------------------------------------------------------------------
@@ -782,8 +840,12 @@ class DmRepository {
 
   /// Watch messages in a conversation (reactive stream).
   Stream<List<DmMessage>> watchMessages(String conversationId) {
+    final pubkey = _userPubkey.isEmpty ? null : _userPubkey;
     return _directMessagesDao
-        .watchMessagesForConversation(conversationId)
+        .watchMessagesForConversation(
+          conversationId,
+          ownerPubkey: pubkey,
+        )
         .map((rows) => rows.map(_messageFromRow).toList());
   }
 
@@ -792,9 +854,11 @@ class DmRepository {
     String conversationId, {
     int? limit,
   }) async {
+    final pubkey = _userPubkey.isEmpty ? null : _userPubkey;
     final rows = await _directMessagesDao.getMessagesForConversation(
       conversationId,
       limit: limit,
+      ownerPubkey: pubkey,
     );
     return rows.map(_messageFromRow).toList();
   }

--- a/mobile/lib/services/notification_service_enhanced.dart
+++ b/mobile/lib/services/notification_service_enhanced.dart
@@ -68,6 +68,23 @@ class NotificationServiceEnhanced {
   /// Check if notification permissions are granted
   bool get hasPermissions => _permissionsGranted;
 
+  /// Clear all notification data from memory and Hive storage.
+  ///
+  /// Called on account switch to prevent data leakage between users.
+  Future<void> clearAllData() async {
+    _notifications.clear();
+    _unreadCount = 0;
+    try {
+      await _notificationBox?.clear();
+    } catch (e) {
+      Log.error(
+        'Failed to clear notification box: $e',
+        name: 'NotificationServiceEnhanced',
+        category: LogCategory.system,
+      );
+    }
+  }
+
   /// Initialize notification service
   Future<void> initialize({
     required NostrClient nostrService,

--- a/mobile/lib/services/user_data_cleanup_service.dart
+++ b/mobile/lib/services/user_data_cleanup_service.dart
@@ -15,6 +15,11 @@ class UserDataCleanupService {
 
   final SharedPreferences _prefs;
 
+  /// Optional callback invoked during cleanup to clear user-specific
+  /// database tables (DMs, conversations, notifications, etc.).
+  /// Set by the provider layer which has access to DAOs.
+  Future<void> Function()? onDatabaseCleanup;
+
   /// Keys that store user-specific data and should be cleared on identity change.
   /// Device/app settings like relay URLs, analytics preferences are NOT included.
   static const List<String> userSpecificKeys = [
@@ -128,6 +133,24 @@ class UserDataCleanupService {
         await _prefs.remove(key);
         clearedCount++;
         clearedKeys.add(key);
+      }
+    }
+
+    // Clear user-specific database tables (DMs, conversations, notifications)
+    if (onDatabaseCleanup != null) {
+      try {
+        await onDatabaseCleanup!();
+        Log.info(
+          'Database cleanup complete',
+          name: 'UserDataCleanupService',
+          category: LogCategory.auth,
+        );
+      } catch (e) {
+        Log.error(
+          'Database cleanup failed: $e',
+          name: 'UserDataCleanupService',
+          category: LogCategory.auth,
+        );
       }
     }
 

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -379,6 +379,22 @@ class AppDatabase extends _$AppDatabase {
       'INTEGER NOT NULL DEFAULT 0',
     );
 
+    // Add owner_pubkey columns for multi-account DM isolation
+    await _addColumnIfMissing('direct_messages', 'owner_pubkey', 'TEXT');
+    await _addColumnIfMissing('conversations', 'owner_pubkey', 'TEXT');
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_dm_owner_pubkey
+      ON direct_messages (owner_pubkey)
+    ''');
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_dm_owner_conversation
+      ON direct_messages (owner_pubkey, conversation_id, created_at DESC)
+    ''');
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_conversation_owner_pubkey
+      ON conversations (owner_pubkey)
+    ''');
+
     // Populate new columns from existing JSON data blobs
     await _backfillFilePathColumns();
   }

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -8304,6 +8304,17 @@ class $DirectMessagesTable extends DirectMessages
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _ownerPubkeyMeta = const VerificationMeta(
+    'ownerPubkey',
+  );
+  @override
+  late final GeneratedColumn<String> ownerPubkey = GeneratedColumn<String>(
+    'owner_pubkey',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -8325,6 +8336,7 @@ class $DirectMessagesTable extends DirectMessages
     dimensions,
     blurhash,
     thumbnailUrl,
+    ownerPubkey,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -8488,6 +8500,15 @@ class $DirectMessagesTable extends DirectMessages
         ),
       );
     }
+    if (data.containsKey('owner_pubkey')) {
+      context.handle(
+        _ownerPubkeyMeta,
+        ownerPubkey.isAcceptableOrUnknown(
+          data['owner_pubkey']!,
+          _ownerPubkeyMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -8573,6 +8594,10 @@ class $DirectMessagesTable extends DirectMessages
         DriftSqlType.string,
         data['${effectivePrefix}thumbnail_url'],
       ),
+      ownerPubkey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}owner_pubkey'],
+      ),
     );
   }
 
@@ -8642,6 +8667,10 @@ class DirectMessageRow extends DataClass
 
   /// URL of an encrypted thumbnail (same key/nonce).
   final String? thumbnailUrl;
+
+  /// Hex public key of the account that received/sent this message.
+  /// NULL for legacy messages created before multi-account support.
+  final String? ownerPubkey;
   const DirectMessageRow({
     required this.id,
     required this.conversationId,
@@ -8662,6 +8691,7 @@ class DirectMessageRow extends DataClass
     this.dimensions,
     this.blurhash,
     this.thumbnailUrl,
+    this.ownerPubkey,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -8708,6 +8738,9 @@ class DirectMessageRow extends DataClass
     }
     if (!nullToAbsent || thumbnailUrl != null) {
       map['thumbnail_url'] = Variable<String>(thumbnailUrl);
+    }
+    if (!nullToAbsent || ownerPubkey != null) {
+      map['owner_pubkey'] = Variable<String>(ownerPubkey);
     }
     return map;
   }
@@ -8757,6 +8790,9 @@ class DirectMessageRow extends DataClass
       thumbnailUrl: thumbnailUrl == null && nullToAbsent
           ? const Value.absent()
           : Value(thumbnailUrl),
+      ownerPubkey: ownerPubkey == null && nullToAbsent
+          ? const Value.absent()
+          : Value(ownerPubkey),
     );
   }
 
@@ -8787,6 +8823,7 @@ class DirectMessageRow extends DataClass
       dimensions: serializer.fromJson<String?>(json['dimensions']),
       blurhash: serializer.fromJson<String?>(json['blurhash']),
       thumbnailUrl: serializer.fromJson<String?>(json['thumbnailUrl']),
+      ownerPubkey: serializer.fromJson<String?>(json['ownerPubkey']),
     );
   }
   @override
@@ -8812,6 +8849,7 @@ class DirectMessageRow extends DataClass
       'dimensions': serializer.toJson<String?>(dimensions),
       'blurhash': serializer.toJson<String?>(blurhash),
       'thumbnailUrl': serializer.toJson<String?>(thumbnailUrl),
+      'ownerPubkey': serializer.toJson<String?>(ownerPubkey),
     };
   }
 
@@ -8835,6 +8873,7 @@ class DirectMessageRow extends DataClass
     Value<String?> dimensions = const Value.absent(),
     Value<String?> blurhash = const Value.absent(),
     Value<String?> thumbnailUrl = const Value.absent(),
+    Value<String?> ownerPubkey = const Value.absent(),
   }) => DirectMessageRow(
     id: id ?? this.id,
     conversationId: conversationId ?? this.conversationId,
@@ -8863,6 +8902,7 @@ class DirectMessageRow extends DataClass
     dimensions: dimensions.present ? dimensions.value : this.dimensions,
     blurhash: blurhash.present ? blurhash.value : this.blurhash,
     thumbnailUrl: thumbnailUrl.present ? thumbnailUrl.value : this.thumbnailUrl,
+    ownerPubkey: ownerPubkey.present ? ownerPubkey.value : this.ownerPubkey,
   );
   DirectMessageRow copyWithCompanion(DirectMessagesCompanion data) {
     return DirectMessageRow(
@@ -8905,6 +8945,9 @@ class DirectMessageRow extends DataClass
       thumbnailUrl: data.thumbnailUrl.present
           ? data.thumbnailUrl.value
           : this.thumbnailUrl,
+      ownerPubkey: data.ownerPubkey.present
+          ? data.ownerPubkey.value
+          : this.ownerPubkey,
     );
   }
 
@@ -8929,7 +8972,8 @@ class DirectMessageRow extends DataClass
           ..write('fileSize: $fileSize, ')
           ..write('dimensions: $dimensions, ')
           ..write('blurhash: $blurhash, ')
-          ..write('thumbnailUrl: $thumbnailUrl')
+          ..write('thumbnailUrl: $thumbnailUrl, ')
+          ..write('ownerPubkey: $ownerPubkey')
           ..write(')'))
         .toString();
   }
@@ -8955,6 +8999,7 @@ class DirectMessageRow extends DataClass
     dimensions,
     blurhash,
     thumbnailUrl,
+    ownerPubkey,
   );
   @override
   bool operator ==(Object other) =>
@@ -8978,7 +9023,8 @@ class DirectMessageRow extends DataClass
           other.fileSize == this.fileSize &&
           other.dimensions == this.dimensions &&
           other.blurhash == this.blurhash &&
-          other.thumbnailUrl == this.thumbnailUrl);
+          other.thumbnailUrl == this.thumbnailUrl &&
+          other.ownerPubkey == this.ownerPubkey);
 }
 
 class DirectMessagesCompanion extends UpdateCompanion<DirectMessageRow> {
@@ -9001,6 +9047,7 @@ class DirectMessagesCompanion extends UpdateCompanion<DirectMessageRow> {
   final Value<String?> dimensions;
   final Value<String?> blurhash;
   final Value<String?> thumbnailUrl;
+  final Value<String?> ownerPubkey;
   final Value<int> rowid;
   const DirectMessagesCompanion({
     this.id = const Value.absent(),
@@ -9022,6 +9069,7 @@ class DirectMessagesCompanion extends UpdateCompanion<DirectMessageRow> {
     this.dimensions = const Value.absent(),
     this.blurhash = const Value.absent(),
     this.thumbnailUrl = const Value.absent(),
+    this.ownerPubkey = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   DirectMessagesCompanion.insert({
@@ -9044,6 +9092,7 @@ class DirectMessagesCompanion extends UpdateCompanion<DirectMessageRow> {
     this.dimensions = const Value.absent(),
     this.blurhash = const Value.absent(),
     this.thumbnailUrl = const Value.absent(),
+    this.ownerPubkey = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : id = Value(id),
        conversationId = Value(conversationId),
@@ -9071,6 +9120,7 @@ class DirectMessagesCompanion extends UpdateCompanion<DirectMessageRow> {
     Expression<String>? dimensions,
     Expression<String>? blurhash,
     Expression<String>? thumbnailUrl,
+    Expression<String>? ownerPubkey,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -9094,6 +9144,7 @@ class DirectMessagesCompanion extends UpdateCompanion<DirectMessageRow> {
       if (dimensions != null) 'dimensions': dimensions,
       if (blurhash != null) 'blurhash': blurhash,
       if (thumbnailUrl != null) 'thumbnail_url': thumbnailUrl,
+      if (ownerPubkey != null) 'owner_pubkey': ownerPubkey,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -9118,6 +9169,7 @@ class DirectMessagesCompanion extends UpdateCompanion<DirectMessageRow> {
     Value<String?>? dimensions,
     Value<String?>? blurhash,
     Value<String?>? thumbnailUrl,
+    Value<String?>? ownerPubkey,
     Value<int>? rowid,
   }) {
     return DirectMessagesCompanion(
@@ -9140,6 +9192,7 @@ class DirectMessagesCompanion extends UpdateCompanion<DirectMessageRow> {
       dimensions: dimensions ?? this.dimensions,
       blurhash: blurhash ?? this.blurhash,
       thumbnailUrl: thumbnailUrl ?? this.thumbnailUrl,
+      ownerPubkey: ownerPubkey ?? this.ownerPubkey,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -9204,6 +9257,9 @@ class DirectMessagesCompanion extends UpdateCompanion<DirectMessageRow> {
     if (thumbnailUrl.present) {
       map['thumbnail_url'] = Variable<String>(thumbnailUrl.value);
     }
+    if (ownerPubkey.present) {
+      map['owner_pubkey'] = Variable<String>(ownerPubkey.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -9232,6 +9288,7 @@ class DirectMessagesCompanion extends UpdateCompanion<DirectMessageRow> {
           ..write('dimensions: $dimensions, ')
           ..write('blurhash: $blurhash, ')
           ..write('thumbnailUrl: $thumbnailUrl, ')
+          ..write('ownerPubkey: $ownerPubkey, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -9360,6 +9417,17 @@ class $ConversationsTable extends Conversations
     type: DriftSqlType.int,
     requiredDuringInsert: true,
   );
+  static const VerificationMeta _ownerPubkeyMeta = const VerificationMeta(
+    'ownerPubkey',
+  );
+  @override
+  late final GeneratedColumn<String> ownerPubkey = GeneratedColumn<String>(
+    'owner_pubkey',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   @override
   List<GeneratedColumn> get $columns => [
     id,
@@ -9372,6 +9440,7 @@ class $ConversationsTable extends Conversations
     isRead,
     currentUserHasSent,
     createdAt,
+    ownerPubkey,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -9463,6 +9532,15 @@ class $ConversationsTable extends Conversations
     } else if (isInserting) {
       context.missing(_createdAtMeta);
     }
+    if (data.containsKey('owner_pubkey')) {
+      context.handle(
+        _ownerPubkeyMeta,
+        ownerPubkey.isAcceptableOrUnknown(
+          data['owner_pubkey']!,
+          _ownerPubkeyMeta,
+        ),
+      );
+    }
     return context;
   }
 
@@ -9512,6 +9590,10 @@ class $ConversationsTable extends Conversations
         DriftSqlType.int,
         data['${effectivePrefix}created_at'],
       )!,
+      ownerPubkey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}owner_pubkey'],
+      ),
     );
   }
 
@@ -9552,6 +9634,10 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
 
   /// Unix timestamp when the conversation was first created.
   final int createdAt;
+
+  /// Hex public key of the account that owns this conversation view.
+  /// NULL for legacy conversations created before multi-account support.
+  final String? ownerPubkey;
   const ConversationRow({
     required this.id,
     required this.participantPubkeys,
@@ -9563,6 +9649,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     required this.isRead,
     required this.currentUserHasSent,
     required this.createdAt,
+    this.ownerPubkey,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -9587,6 +9674,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     map['is_read'] = Variable<bool>(isRead);
     map['current_user_has_sent'] = Variable<bool>(currentUserHasSent);
     map['created_at'] = Variable<int>(createdAt);
+    if (!nullToAbsent || ownerPubkey != null) {
+      map['owner_pubkey'] = Variable<String>(ownerPubkey);
+    }
     return map;
   }
 
@@ -9610,6 +9700,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
       isRead: Value(isRead),
       currentUserHasSent: Value(currentUserHasSent),
       createdAt: Value(createdAt),
+      ownerPubkey: ownerPubkey == null && nullToAbsent
+          ? const Value.absent()
+          : Value(ownerPubkey),
     );
   }
 
@@ -9637,6 +9730,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
       isRead: serializer.fromJson<bool>(json['isRead']),
       currentUserHasSent: serializer.fromJson<bool>(json['currentUserHasSent']),
       createdAt: serializer.fromJson<int>(json['createdAt']),
+      ownerPubkey: serializer.fromJson<String?>(json['ownerPubkey']),
     );
   }
   @override
@@ -9655,6 +9749,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
       'isRead': serializer.toJson<bool>(isRead),
       'currentUserHasSent': serializer.toJson<bool>(currentUserHasSent),
       'createdAt': serializer.toJson<int>(createdAt),
+      'ownerPubkey': serializer.toJson<String?>(ownerPubkey),
     };
   }
 
@@ -9669,6 +9764,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     bool? isRead,
     bool? currentUserHasSent,
     int? createdAt,
+    Value<String?> ownerPubkey = const Value.absent(),
   }) => ConversationRow(
     id: id ?? this.id,
     participantPubkeys: participantPubkeys ?? this.participantPubkeys,
@@ -9686,6 +9782,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     isRead: isRead ?? this.isRead,
     currentUserHasSent: currentUserHasSent ?? this.currentUserHasSent,
     createdAt: createdAt ?? this.createdAt,
+    ownerPubkey: ownerPubkey.present ? ownerPubkey.value : this.ownerPubkey,
   );
   ConversationRow copyWithCompanion(ConversationsCompanion data) {
     return ConversationRow(
@@ -9709,6 +9806,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
           ? data.currentUserHasSent.value
           : this.currentUserHasSent,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      ownerPubkey: data.ownerPubkey.present
+          ? data.ownerPubkey.value
+          : this.ownerPubkey,
     );
   }
 
@@ -9724,7 +9824,8 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
           ..write('subject: $subject, ')
           ..write('isRead: $isRead, ')
           ..write('currentUserHasSent: $currentUserHasSent, ')
-          ..write('createdAt: $createdAt')
+          ..write('createdAt: $createdAt, ')
+          ..write('ownerPubkey: $ownerPubkey')
           ..write(')'))
         .toString();
   }
@@ -9741,6 +9842,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     isRead,
     currentUserHasSent,
     createdAt,
+    ownerPubkey,
   );
   @override
   bool operator ==(Object other) =>
@@ -9755,7 +9857,8 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
           other.subject == this.subject &&
           other.isRead == this.isRead &&
           other.currentUserHasSent == this.currentUserHasSent &&
-          other.createdAt == this.createdAt);
+          other.createdAt == this.createdAt &&
+          other.ownerPubkey == this.ownerPubkey);
 }
 
 class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
@@ -9769,6 +9872,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
   final Value<bool> isRead;
   final Value<bool> currentUserHasSent;
   final Value<int> createdAt;
+  final Value<String?> ownerPubkey;
   final Value<int> rowid;
   const ConversationsCompanion({
     this.id = const Value.absent(),
@@ -9781,6 +9885,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
     this.isRead = const Value.absent(),
     this.currentUserHasSent = const Value.absent(),
     this.createdAt = const Value.absent(),
+    this.ownerPubkey = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   ConversationsCompanion.insert({
@@ -9794,6 +9899,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
     this.isRead = const Value.absent(),
     this.currentUserHasSent = const Value.absent(),
     required int createdAt,
+    this.ownerPubkey = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : id = Value(id),
        participantPubkeys = Value(participantPubkeys),
@@ -9809,6 +9915,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
     Expression<bool>? isRead,
     Expression<bool>? currentUserHasSent,
     Expression<int>? createdAt,
+    Expression<String>? ownerPubkey,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -9826,6 +9933,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
       if (currentUserHasSent != null)
         'current_user_has_sent': currentUserHasSent,
       if (createdAt != null) 'created_at': createdAt,
+      if (ownerPubkey != null) 'owner_pubkey': ownerPubkey,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -9841,6 +9949,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
     Value<bool>? isRead,
     Value<bool>? currentUserHasSent,
     Value<int>? createdAt,
+    Value<String?>? ownerPubkey,
     Value<int>? rowid,
   }) {
     return ConversationsCompanion(
@@ -9855,6 +9964,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
       isRead: isRead ?? this.isRead,
       currentUserHasSent: currentUserHasSent ?? this.currentUserHasSent,
       createdAt: createdAt ?? this.createdAt,
+      ownerPubkey: ownerPubkey ?? this.ownerPubkey,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -9894,6 +10004,9 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
     if (createdAt.present) {
       map['created_at'] = Variable<int>(createdAt.value);
     }
+    if (ownerPubkey.present) {
+      map['owner_pubkey'] = Variable<String>(ownerPubkey.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -9913,6 +10026,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
           ..write('isRead: $isRead, ')
           ..write('currentUserHasSent: $currentUserHasSent, ')
           ..write('createdAt: $createdAt, ')
+          ..write('ownerPubkey: $ownerPubkey, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -13918,6 +14032,7 @@ typedef $$DirectMessagesTableCreateCompanionBuilder =
       Value<String?> dimensions,
       Value<String?> blurhash,
       Value<String?> thumbnailUrl,
+      Value<String?> ownerPubkey,
       Value<int> rowid,
     });
 typedef $$DirectMessagesTableUpdateCompanionBuilder =
@@ -13941,6 +14056,7 @@ typedef $$DirectMessagesTableUpdateCompanionBuilder =
       Value<String?> dimensions,
       Value<String?> blurhash,
       Value<String?> thumbnailUrl,
+      Value<String?> ownerPubkey,
       Value<int> rowid,
     });
 
@@ -14045,6 +14161,11 @@ class $$DirectMessagesTableFilterComposer
 
   ColumnFilters<String> get thumbnailUrl => $composableBuilder(
     column: $table.thumbnailUrl,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
     builder: (column) => ColumnFilters(column),
   );
 }
@@ -14152,6 +14273,11 @@ class $$DirectMessagesTableOrderingComposer
     column: $table.thumbnailUrl,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$DirectMessagesTableAnnotationComposer
@@ -14239,6 +14365,11 @@ class $$DirectMessagesTableAnnotationComposer
     column: $table.thumbnailUrl,
     builder: (column) => column,
   );
+
+  GeneratedColumn<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
+    builder: (column) => column,
+  );
 }
 
 class $$DirectMessagesTableTableManager
@@ -14297,6 +14428,7 @@ class $$DirectMessagesTableTableManager
                 Value<String?> dimensions = const Value.absent(),
                 Value<String?> blurhash = const Value.absent(),
                 Value<String?> thumbnailUrl = const Value.absent(),
+                Value<String?> ownerPubkey = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => DirectMessagesCompanion(
                 id: id,
@@ -14318,6 +14450,7 @@ class $$DirectMessagesTableTableManager
                 dimensions: dimensions,
                 blurhash: blurhash,
                 thumbnailUrl: thumbnailUrl,
+                ownerPubkey: ownerPubkey,
                 rowid: rowid,
               ),
           createCompanionCallback:
@@ -14341,6 +14474,7 @@ class $$DirectMessagesTableTableManager
                 Value<String?> dimensions = const Value.absent(),
                 Value<String?> blurhash = const Value.absent(),
                 Value<String?> thumbnailUrl = const Value.absent(),
+                Value<String?> ownerPubkey = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => DirectMessagesCompanion.insert(
                 id: id,
@@ -14362,6 +14496,7 @@ class $$DirectMessagesTableTableManager
                 dimensions: dimensions,
                 blurhash: blurhash,
                 thumbnailUrl: thumbnailUrl,
+                ownerPubkey: ownerPubkey,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0
@@ -14401,6 +14536,7 @@ typedef $$ConversationsTableCreateCompanionBuilder =
       Value<bool> isRead,
       Value<bool> currentUserHasSent,
       required int createdAt,
+      Value<String?> ownerPubkey,
       Value<int> rowid,
     });
 typedef $$ConversationsTableUpdateCompanionBuilder =
@@ -14415,6 +14551,7 @@ typedef $$ConversationsTableUpdateCompanionBuilder =
       Value<bool> isRead,
       Value<bool> currentUserHasSent,
       Value<int> createdAt,
+      Value<String?> ownerPubkey,
       Value<int> rowid,
     });
 
@@ -14474,6 +14611,11 @@ class $$ConversationsTableFilterComposer
 
   ColumnFilters<int> get createdAt => $composableBuilder(
     column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
     builder: (column) => ColumnFilters(column),
   );
 }
@@ -14536,6 +14678,11 @@ class $$ConversationsTableOrderingComposer
     column: $table.createdAt,
     builder: (column) => ColumnOrderings(column),
   );
+
+  ColumnOrderings<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
+    builder: (column) => ColumnOrderings(column),
+  );
 }
 
 class $$ConversationsTableAnnotationComposer
@@ -14586,6 +14733,11 @@ class $$ConversationsTableAnnotationComposer
 
   GeneratedColumn<int> get createdAt =>
       $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
+    builder: (column) => column,
+  );
 }
 
 class $$ConversationsTableTableManager
@@ -14629,6 +14781,7 @@ class $$ConversationsTableTableManager
                 Value<bool> isRead = const Value.absent(),
                 Value<bool> currentUserHasSent = const Value.absent(),
                 Value<int> createdAt = const Value.absent(),
+                Value<String?> ownerPubkey = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ConversationsCompanion(
                 id: id,
@@ -14641,6 +14794,7 @@ class $$ConversationsTableTableManager
                 isRead: isRead,
                 currentUserHasSent: currentUserHasSent,
                 createdAt: createdAt,
+                ownerPubkey: ownerPubkey,
                 rowid: rowid,
               ),
           createCompanionCallback:
@@ -14655,6 +14809,7 @@ class $$ConversationsTableTableManager
                 Value<bool> isRead = const Value.absent(),
                 Value<bool> currentUserHasSent = const Value.absent(),
                 required int createdAt,
+                Value<String?> ownerPubkey = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ConversationsCompanion.insert(
                 id: id,
@@ -14667,6 +14822,7 @@ class $$ConversationsTableTableManager
                 isRead: isRead,
                 currentUserHasSent: currentUserHasSent,
                 createdAt: createdAt,
+                ownerPubkey: ownerPubkey,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0

--- a/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Data Access Object for conversation metadata persistence.
 // ABOUTME: Provides CRUD, reactive watch streams, and unread counts
 // ABOUTME: for the messages tab conversation list.
+// ABOUTME: All queries are scoped by ownerPubkey for multi-account isolation.
 
 import 'package:db_client/db_client.dart';
 import 'package:drift/drift.dart';
@@ -11,6 +12,16 @@ part 'conversations_dao.g.dart';
 class ConversationsDao extends DatabaseAccessor<AppDatabase>
     with _$ConversationsDaoMixin {
   ConversationsDao(super.attachedDatabase);
+
+  /// Build a filter expression that returns rows owned by [ownerPubkey]
+  /// **or** legacy rows with no owner (NULL).
+  Expression<bool> _ownedOrLegacy(
+    GeneratedColumn<String> column,
+    String? ownerPubkey,
+  ) {
+    if (ownerPubkey == null) return const Constant(true);
+    return column.equals(ownerPubkey) | column.isNull();
+  }
 
   /// Upsert a conversation (create or update last-message metadata).
   ///
@@ -28,6 +39,7 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
     String? subject,
     bool isRead = true,
     bool currentUserHasSent = false,
+    String? ownerPubkey,
   }) {
     return into(conversations).insertOnConflictUpdate(
       ConversationsCompanion.insert(
@@ -41,6 +53,7 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
         subject: Value(subject),
         isRead: Value(isRead),
         currentUserHasSent: Value(currentUserHasSent),
+        ownerPubkey: Value(ownerPubkey),
       ),
     );
   }
@@ -49,8 +62,10 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
   Future<List<ConversationRow>> getAllConversations({
     int? limit,
     int? offset,
+    String? ownerPubkey,
   }) {
     final query = select(conversations)
+      ..where((t) => _ownedOrLegacy(t.ownerPubkey, ownerPubkey))
       ..orderBy([
         (t) => OrderingTerm(
           expression: t.lastMessageTimestamp,
@@ -65,8 +80,10 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
   Stream<List<ConversationRow>> watchAllConversations({
     int? limit,
     int? offset,
+    String? ownerPubkey,
   }) {
     final query = select(conversations)
+      ..where((t) => _ownedOrLegacy(t.ownerPubkey, ownerPubkey))
       ..orderBy([
         (t) => OrderingTerm(
           expression: t.lastMessageTimestamp,
@@ -84,9 +101,14 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
   Stream<List<ConversationRow>> watchAcceptedConversations({
     int? limit,
     int? offset,
+    String? ownerPubkey,
   }) {
     final query = select(conversations)
-      ..where((t) => t.currentUserHasSent.equals(true))
+      ..where(
+        (t) =>
+            t.currentUserHasSent.equals(true) &
+            _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
+      )
       ..orderBy([
         (t) => OrderingTerm(
           expression: t.lastMessageTimestamp,
@@ -103,9 +125,15 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
   /// on follow state, which is applied in the BLoC layer). Returned
   /// without pagination since the count is typically small and needed
   /// in full for accurate badge counts.
-  Stream<List<ConversationRow>> watchPotentialRequestConversations() {
+  Stream<List<ConversationRow>> watchPotentialRequestConversations({
+    String? ownerPubkey,
+  }) {
     final query = select(conversations)
-      ..where((t) => t.currentUserHasSent.equals(false))
+      ..where(
+        (t) =>
+            t.currentUserHasSent.equals(false) &
+            _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
+      )
       ..orderBy([
         (t) => OrderingTerm(
           expression: t.lastMessageTimestamp,
@@ -116,9 +144,12 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
   }
 
   /// Watch count of potential request conversations.
-  Stream<int> watchPotentialRequestCount() {
+  Stream<int> watchPotentialRequestCount({String? ownerPubkey}) {
     final query = selectOnly(conversations)
-      ..where(conversations.currentUserHasSent.equals(false))
+      ..where(
+        conversations.currentUserHasSent.equals(false) &
+            _ownedOrLegacy(conversations.ownerPubkey, ownerPubkey),
+      )
       ..addColumns([conversations.id.count()]);
     return query.watchSingle().map(
       (row) => row.read(conversations.id.count()) ?? 0,
@@ -153,18 +184,24 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
   }
 
   /// Get unread conversation count.
-  Future<int> getUnreadCount() async {
+  Future<int> getUnreadCount({String? ownerPubkey}) async {
     final query = selectOnly(conversations)
-      ..where(conversations.isRead.equals(false))
+      ..where(
+        conversations.isRead.equals(false) &
+            _ownedOrLegacy(conversations.ownerPubkey, ownerPubkey),
+      )
       ..addColumns([conversations.id.count()]);
     final result = await query.getSingle();
     return result.read(conversations.id.count()) ?? 0;
   }
 
   /// Watch unread conversation count (all conversations).
-  Stream<int> watchUnreadCount() {
+  Stream<int> watchUnreadCount({String? ownerPubkey}) {
     final query = selectOnly(conversations)
-      ..where(conversations.isRead.equals(false))
+      ..where(
+        conversations.isRead.equals(false) &
+            _ownedOrLegacy(conversations.ownerPubkey, ownerPubkey),
+      )
       ..addColumns([conversations.id.count()]);
     return query.watchSingle().map(
       (row) => row.read(conversations.id.count()) ?? 0,
@@ -176,11 +213,12 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
   /// Excludes conversations where the user has never sent a message
   /// (potential requests), so the badge on the nav bar reflects only
   /// the "Messages" tab unreads.
-  Stream<int> watchUnreadAcceptedCount() {
+  Stream<int> watchUnreadAcceptedCount({String? ownerPubkey}) {
     final query = selectOnly(conversations)
       ..where(
         conversations.isRead.equals(false) &
-            conversations.currentUserHasSent.equals(true),
+            conversations.currentUserHasSent.equals(true) &
+            _ownedOrLegacy(conversations.ownerPubkey, ownerPubkey),
       )
       ..addColumns([conversations.id.count()]);
     return query.watchSingle().map(
@@ -210,6 +248,13 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
   /// Run a callback inside a database transaction.
   Future<T> runInTransaction<T>(Future<T> Function() action) {
     return attachedDatabase.transaction(action);
+  }
+
+  /// Delete all conversations for a specific user.
+  Future<int> clearAllForUser(String ownerPubkey) {
+    return (delete(
+      conversations,
+    )..where((t) => t.ownerPubkey.equals(ownerPubkey))).go();
   }
 
   /// Delete all conversations.

--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Data Access Object for NIP-17 direct message persistence.
 // ABOUTME: Provides CRUD operations for decrypted DM storage and
 // ABOUTME: conversation-scoped queries with reactive streams.
+// ABOUTME: All queries are scoped by ownerPubkey for multi-account isolation.
 
 import 'package:db_client/db_client.dart';
 import 'package:drift/drift.dart';
@@ -11,6 +12,16 @@ part 'direct_messages_dao.g.dart';
 class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
     with _$DirectMessagesDaoMixin {
   DirectMessagesDao(super.attachedDatabase);
+
+  /// Build a filter expression that returns rows owned by [ownerPubkey]
+  /// **or** legacy rows with no owner (NULL).
+  Expression<bool> _ownedOrLegacy(
+    GeneratedColumn<String> column,
+    String? ownerPubkey,
+  ) {
+    if (ownerPubkey == null) return const Constant(true);
+    return column.equals(ownerPubkey) | column.isNull();
+  }
 
   /// Insert a decrypted DM, ignoring duplicates by gift_wrap_id.
   ///
@@ -41,6 +52,7 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
     String? dimensions,
     String? blurhash,
     String? thumbnailUrl,
+    String? ownerPubkey,
   }) {
     return into(directMessages).insertOnConflictUpdate(
       DirectMessagesCompanion.insert(
@@ -63,6 +75,7 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
         dimensions: Value(dimensions),
         blurhash: Value(blurhash),
         thumbnailUrl: Value(thumbnailUrl),
+        ownerPubkey: Value(ownerPubkey),
       ),
     );
   }
@@ -72,9 +85,14 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
     String conversationId, {
     int? limit,
     int? offset,
+    String? ownerPubkey,
   }) {
     final query = select(directMessages)
-      ..where((t) => t.conversationId.equals(conversationId))
+      ..where(
+        (t) =>
+            t.conversationId.equals(conversationId) &
+            _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
+      )
       ..orderBy([
         (t) => OrderingTerm(
           expression: t.createdAt,
@@ -89,9 +107,14 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
   Stream<List<DirectMessageRow>> watchMessagesForConversation(
     String conversationId, {
     int? limit,
+    String? ownerPubkey,
   }) {
     final query = select(directMessages)
-      ..where((t) => t.conversationId.equals(conversationId))
+      ..where(
+        (t) =>
+            t.conversationId.equals(conversationId) &
+            _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
+      )
       ..orderBy([
         (t) => OrderingTerm(
           expression: t.createdAt,
@@ -136,12 +159,25 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
   }
 
   /// Count messages in a conversation.
-  Future<int> countMessages(String conversationId) async {
+  Future<int> countMessages(
+    String conversationId, {
+    String? ownerPubkey,
+  }) async {
     final query = selectOnly(directMessages)
-      ..where(directMessages.conversationId.equals(conversationId))
+      ..where(
+        directMessages.conversationId.equals(conversationId) &
+            _ownedOrLegacy(directMessages.ownerPubkey, ownerPubkey),
+      )
       ..addColumns([directMessages.id.count()]);
     final result = await query.getSingle();
     return result.read(directMessages.id.count()) ?? 0;
+  }
+
+  /// Delete all DMs for a specific user.
+  Future<int> clearAllForUser(String ownerPubkey) {
+    return (delete(
+      directMessages,
+    )..where((t) => t.ownerPubkey.equals(ownerPubkey))).go();
   }
 
   /// Delete all DMs.

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -723,6 +723,10 @@ class DirectMessages extends Table {
   /// URL of an encrypted thumbnail (same key/nonce).
   TextColumn get thumbnailUrl => text().nullable().named('thumbnail_url')();
 
+  /// Hex public key of the account that received/sent this message.
+  /// NULL for legacy messages created before multi-account support.
+  TextColumn get ownerPubkey => text().nullable().named('owner_pubkey')();
+
   @override
   Set<Column> get primaryKey => {id};
 
@@ -746,6 +750,16 @@ class DirectMessages extends Table {
       'idx_dm_sender',
       'CREATE INDEX IF NOT EXISTS idx_dm_sender '
           'ON direct_messages (sender_pubkey)',
+    ),
+    Index(
+      'idx_dm_owner_pubkey',
+      'CREATE INDEX IF NOT EXISTS idx_dm_owner_pubkey '
+          'ON direct_messages (owner_pubkey)',
+    ),
+    Index(
+      'idx_dm_owner_conversation',
+      'CREATE INDEX IF NOT EXISTS idx_dm_owner_conversation '
+          'ON direct_messages (owner_pubkey, conversation_id, created_at DESC)',
     ),
   ];
 }
@@ -797,6 +811,10 @@ class Conversations extends Table {
   /// Unix timestamp when the conversation was first created.
   IntColumn get createdAt => integer().named('created_at')();
 
+  /// Hex public key of the account that owns this conversation view.
+  /// NULL for legacy conversations created before multi-account support.
+  TextColumn get ownerPubkey => text().nullable().named('owner_pubkey')();
+
   @override
   Set<Column> get primaryKey => {id};
 
@@ -810,6 +828,11 @@ class Conversations extends Table {
       'idx_conversation_is_read',
       'CREATE INDEX IF NOT EXISTS idx_conversation_is_read '
           'ON conversations (is_read)',
+    ),
+    Index(
+      'idx_conversation_owner_pubkey',
+      'CREATE INDEX IF NOT EXISTS idx_conversation_owner_pubkey '
+          'ON conversations (owner_pubkey)',
     ),
   ];
 }

--- a/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
@@ -448,5 +448,115 @@ void main() {
         expect(deleted, equals(0));
       });
     });
+
+    group('ownerPubkey scoping', () {
+      const userA = 'pubkey_user_a';
+      const userB = 'pubkey_user_b';
+
+      test(
+        'queries scoped by ownerPubkey only return that user conversations',
+        () async {
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["pubkey_a","pubkey_b"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageTimestamp: 1700000100,
+            ownerPubkey: userA,
+          );
+          await dao.upsertConversation(
+            id: 'conv_2',
+            participantPubkeys: '["pubkey_c","pubkey_d"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageTimestamp: 1700000200,
+            ownerPubkey: userB,
+          );
+
+          final userAConvs = await dao.getAllConversations(ownerPubkey: userA);
+          final userBConvs = await dao.getAllConversations(ownerPubkey: userB);
+
+          expect(userAConvs, hasLength(1));
+          expect(userAConvs.first.id, equals('conv_1'));
+          expect(userBConvs, hasLength(1));
+          expect(userBConvs.first.id, equals('conv_2'));
+        },
+      );
+
+      test(
+        'legacy conversations (NULL ownerPubkey) are visible to scoped queries',
+        () async {
+          await dao.upsertConversation(
+            id: 'conv_legacy',
+            participantPubkeys: '["pubkey_a","pubkey_b"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageTimestamp: 1700000100,
+          );
+          await dao.upsertConversation(
+            id: 'conv_a1',
+            participantPubkeys: '["pubkey_c","pubkey_d"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageTimestamp: 1700000200,
+            ownerPubkey: userA,
+          );
+
+          final userAConvs = await dao.getAllConversations(ownerPubkey: userA);
+          expect(userAConvs, hasLength(2));
+        },
+      );
+
+      test('clearAllForUser only deletes that user conversations', () async {
+        await dao.upsertConversation(
+          id: 'conv_a1',
+          participantPubkeys: '["pubkey_a","pubkey_b"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageTimestamp: 1700000100,
+          ownerPubkey: userA,
+        );
+        await dao.upsertConversation(
+          id: 'conv_b1',
+          participantPubkeys: '["pubkey_c","pubkey_d"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageTimestamp: 1700000200,
+          ownerPubkey: userB,
+        );
+
+        final deleted = await dao.clearAllForUser(userA);
+
+        expect(deleted, equals(1));
+        final remaining = await dao.getAllConversations(ownerPubkey: userB);
+        expect(remaining, hasLength(1));
+        expect(remaining.first.id, equals('conv_b1'));
+      });
+
+      test('unread count respects ownerPubkey', () async {
+        await dao.upsertConversation(
+          id: 'conv_a1',
+          participantPubkeys: '["pubkey_a","pubkey_b"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          isRead: false,
+          ownerPubkey: userA,
+        );
+        await dao.upsertConversation(
+          id: 'conv_b1',
+          participantPubkeys: '["pubkey_c","pubkey_d"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          isRead: false,
+          ownerPubkey: userB,
+        );
+
+        final countA = await dao.getUnreadCount(ownerPubkey: userA);
+        final countB = await dao.getUnreadCount(ownerPubkey: userB);
+
+        expect(countA, equals(1));
+        expect(countB, equals(1));
+      });
+    });
   });
 }

--- a/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
@@ -465,5 +465,142 @@ void main() {
         expect(deleted, equals(0));
       });
     });
+
+    group('ownerPubkey scoping', () {
+      const userA = 'pubkey_user_a';
+      const userB = 'pubkey_user_b';
+
+      test(
+        'queries scoped by ownerPubkey only return that user messages',
+        () async {
+          await dao.insertMessage(
+            id: 'msg_a1',
+            conversationId: conversationId1,
+            senderPubkey: 'pubkey_alice',
+            content: 'For user A',
+            createdAt: 1700000001,
+            giftWrapId: 'gw_a1',
+            ownerPubkey: userA,
+          );
+          await dao.insertMessage(
+            id: 'msg_b1',
+            conversationId: conversationId1,
+            senderPubkey: 'pubkey_alice',
+            content: 'For user B',
+            createdAt: 1700000002,
+            giftWrapId: 'gw_b1',
+            ownerPubkey: userB,
+          );
+
+          final userAMessages = await dao.getMessagesForConversation(
+            conversationId1,
+            ownerPubkey: userA,
+          );
+          final userBMessages = await dao.getMessagesForConversation(
+            conversationId1,
+            ownerPubkey: userB,
+          );
+
+          expect(userAMessages, hasLength(1));
+          expect(userAMessages.first.content, equals('For user A'));
+          expect(userBMessages, hasLength(1));
+          expect(userBMessages.first.content, equals('For user B'));
+        },
+      );
+
+      test(
+        'legacy messages (NULL ownerPubkey) are visible to scoped queries',
+        () async {
+          await dao.insertMessage(
+            id: 'msg_legacy',
+            conversationId: conversationId1,
+            senderPubkey: 'pubkey_alice',
+            content: 'Legacy message',
+            createdAt: 1700000001,
+            giftWrapId: 'gw_legacy',
+          );
+          await dao.insertMessage(
+            id: 'msg_a1',
+            conversationId: conversationId1,
+            senderPubkey: 'pubkey_alice',
+            content: 'User A message',
+            createdAt: 1700000002,
+            giftWrapId: 'gw_a1',
+            ownerPubkey: userA,
+          );
+
+          final userAMessages = await dao.getMessagesForConversation(
+            conversationId1,
+            ownerPubkey: userA,
+          );
+
+          expect(userAMessages, hasLength(2));
+        },
+      );
+
+      test('clearAllForUser only deletes that user messages', () async {
+        await dao.insertMessage(
+          id: 'msg_a1',
+          conversationId: conversationId1,
+          senderPubkey: 'pubkey_alice',
+          content: 'User A msg',
+          createdAt: 1700000001,
+          giftWrapId: 'gw_a1',
+          ownerPubkey: userA,
+        );
+        await dao.insertMessage(
+          id: 'msg_b1',
+          conversationId: conversationId1,
+          senderPubkey: 'pubkey_alice',
+          content: 'User B msg',
+          createdAt: 1700000002,
+          giftWrapId: 'gw_b1',
+          ownerPubkey: userB,
+        );
+
+        final deleted = await dao.clearAllForUser(userA);
+
+        expect(deleted, equals(1));
+        final remaining = await dao.getMessagesForConversation(
+          conversationId1,
+          ownerPubkey: userB,
+        );
+        expect(remaining, hasLength(1));
+        expect(remaining.first.content, equals('User B msg'));
+      });
+
+      test('countMessages respects ownerPubkey', () async {
+        await dao.insertMessage(
+          id: 'msg_a1',
+          conversationId: conversationId1,
+          senderPubkey: 'pubkey_alice',
+          content: 'A',
+          createdAt: 1700000001,
+          giftWrapId: 'gw_a1',
+          ownerPubkey: userA,
+        );
+        await dao.insertMessage(
+          id: 'msg_b1',
+          conversationId: conversationId1,
+          senderPubkey: 'pubkey_alice',
+          content: 'B',
+          createdAt: 1700000002,
+          giftWrapId: 'gw_b1',
+          ownerPubkey: userB,
+        );
+
+        final countA = await dao.countMessages(
+          conversationId1,
+          ownerPubkey: userA,
+        );
+        final countB = await dao.countMessages(
+          conversationId1,
+          ownerPubkey: userB,
+        );
+
+        expect(countA, equals(1));
+        expect(countB, equals(1));
+      });
+    });
   });
 }

--- a/mobile/test/repositories/dm_repository_test.dart
+++ b/mobile/test/repositories/dm_repository_test.dart
@@ -234,6 +234,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -248,6 +249,7 @@ void main() {
             subject: any(named: 'subject'),
             isRead: any(named: 'isRead'),
             currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -283,6 +285,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).called(1);
 
@@ -297,6 +300,7 @@ void main() {
             lastMessageSenderPubkey: _validPubkeyA,
             isRead: any(named: 'isRead'),
             currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).called(1);
       });
@@ -343,6 +347,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         );
       });
@@ -472,6 +477,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -486,6 +492,7 @@ void main() {
             subject: any(named: 'subject'),
             isRead: any(named: 'isRead'),
             currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -540,6 +547,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).called(1);
 
@@ -554,6 +562,7 @@ void main() {
             lastMessageSenderPubkey: _validPubkeyB,
             isRead: false,
             currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).called(1);
 
@@ -606,6 +615,7 @@ void main() {
             subject: any(named: 'subject'),
             isRead: any(named: 'isRead'),
             currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).called(1);
 
@@ -659,6 +669,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         );
 
@@ -712,6 +723,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         );
 
@@ -767,6 +779,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         );
 
@@ -822,6 +835,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         );
 
@@ -882,6 +896,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).called(1);
 
@@ -933,6 +948,7 @@ void main() {
             subject: any(named: 'subject'),
             isRead: any(named: 'isRead'),
             currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).called(1);
 
@@ -1008,6 +1024,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).called(2);
 
@@ -1045,6 +1062,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).thenThrow(Exception('DB write failed'));
 
@@ -1154,7 +1172,9 @@ void main() {
         final convId = DmRepository.computeConversationId(participants);
 
         when(
-          () => mockConversationsDao.watchAllConversations(),
+          () => mockConversationsDao.watchAllConversations(
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
         ).thenAnswer(
           (_) => Stream.value([
             ConversationRow(
@@ -1237,7 +1257,10 @@ void main() {
         );
 
         when(
-          () => mockDirectMessagesDao.watchMessagesForConversation(convId),
+          () => mockDirectMessagesDao.watchMessagesForConversation(
+            convId,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
         ).thenAnswer(
           (_) => Stream.value([
             DirectMessageRow(
@@ -1433,7 +1456,10 @@ void main() {
             'aabb00112233445566778899aabbccddeeff0011223344556677889900aabb00';
 
         when(
-          () => mockDirectMessagesDao.countMessages(convId),
+          () => mockDirectMessagesDao.countMessages(
+            convId,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
         ).thenAnswer((_) async => 5);
 
         final repository = createRepository();
@@ -1441,7 +1467,10 @@ void main() {
 
         expect(count, equals(5));
         verify(
-          () => mockDirectMessagesDao.countMessages(convId),
+          () => mockDirectMessagesDao.countMessages(
+            convId,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
         ).called(1);
       });
     });
@@ -1469,6 +1498,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -1483,6 +1513,7 @@ void main() {
             subject: any(named: 'subject'),
             isRead: any(named: 'isRead'),
             currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -1578,6 +1609,7 @@ void main() {
               subject: any(named: 'subject'),
               isRead: false,
               currentUserHasSent: true,
+              ownerPubkey: any(named: 'ownerPubkey'),
             ),
           ).called(1);
 
@@ -1614,6 +1646,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -1628,6 +1661,7 @@ void main() {
             subject: any(named: 'subject'),
             isRead: any(named: 'isRead'),
             currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -1714,6 +1748,7 @@ void main() {
             fileHash: fileHash,
             fileSize: 1024,
             dimensions: '1920x1080',
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).called(1);
 
@@ -1728,6 +1763,7 @@ void main() {
             lastMessageSenderPubkey: _validPubkeyB,
             isRead: false,
             currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).called(1);
 
@@ -1795,6 +1831,7 @@ void main() {
             createdAt: 1700000000,
             giftWrapId: _giftWrapEventId,
             messageKind: EventKind.fileMessage,
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).called(1);
 
@@ -1818,7 +1855,10 @@ void main() {
         const decryptionNonce = 'eeeeeeeeeeeeeeeeeeeeeeee';
 
         when(
-          () => mockDirectMessagesDao.watchMessagesForConversation(convId),
+          () => mockDirectMessagesDao.watchMessagesForConversation(
+            convId,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
         ).thenAnswer(
           (_) => Stream.value([
             DirectMessageRow(
@@ -1951,6 +1991,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -1965,6 +2006,7 @@ void main() {
             subject: any(named: 'subject'),
             isRead: any(named: 'isRead'),
             currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -2008,6 +2050,7 @@ void main() {
             decryptionNonce: decryptionNonce,
             fileHash: fileHash,
             fileSize: 2048,
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).called(1);
 
@@ -2024,6 +2067,7 @@ void main() {
             subject: any(named: 'subject'),
             isRead: any(named: 'isRead'),
             currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).called(1);
       });
@@ -2071,6 +2115,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         );
       });
@@ -2106,6 +2151,7 @@ void main() {
             dimensions: any(named: 'dimensions'),
             blurhash: any(named: 'blurhash'),
             thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -2120,6 +2166,7 @@ void main() {
             subject: any(named: 'subject'),
             isRead: any(named: 'isRead'),
             currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -2188,6 +2235,7 @@ void main() {
               dimensions: any(named: 'dimensions'),
               blurhash: any(named: 'blurhash'),
               thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
             ),
           ).called(1);
         },
@@ -2264,6 +2312,7 @@ void main() {
               dimensions: any(named: 'dimensions'),
               blurhash: any(named: 'blurhash'),
               thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
             ),
           ).called(1);
 
@@ -2281,6 +2330,7 @@ void main() {
               subject: any(named: 'subject'),
               isRead: false,
               currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
             ),
           ).called(1);
 


### PR DESCRIPTION
## Summary

Closes #2284

- Add `ownerPubkey` column to `DirectMessages` and `Conversations` tables for per-user data isolation
- Clear all DM, conversation, and notification data on `signOut()` to prevent User A's private messages from appearing when User B logs in
- Fix `DmRepository.initialize()` to support user switching (was blocked by `if (isInitialized) return` guard)

## Changes

### Data Layer (db_client)
- **tables.dart**: Add nullable `owner_pubkey` column + indexes to `DirectMessages` and `Conversations`
- **app_database.dart**: Lazy migration via `_addColumnIfMissing()` — no schema version bump
- **direct_messages_dao.dart**: Add `_ownedOrLegacy` filter, scope all queries by `ownerPubkey`, add `clearAllForUser()`
- **conversations_dao.dart**: Same pattern — scope all queries, counts, and watch streams by `ownerPubkey`

### Repository Layer
- **dm_repository.dart**: Pass `ownerPubkey` to all 8 DAO insert/upsert calls and all 8 query calls. Add `_resetState()` for clean subscription teardown on account switch. Fix `initialize()` re-init guard to allow switching users.

### Auth/Cleanup Layer
- **user_data_cleanup_service.dart**: Add `onDatabaseCleanup` callback, invoked during `clearUserSpecificData()`
- **notification_service_enhanced.dart**: Add `clearAllData()` to wipe Hive notification box on switch
- **app_providers.dart**: Wire cleanup callback to clear DM tables + Hive notifications on signOut

### Tests
- 8 new `ownerPubkey` isolation tests (scoping, legacy NULL compat, `clearAllForUser`, unread counts)
- Updated all 34 mock verify/when stubs in `dm_repository_test.dart`

## Design decisions

- **Nullable `ownerPubkey`**: Legacy rows (pre-migration) have NULL, matched via `_ownedOrLegacy()` helper — same pattern as Drafts/Clips
- **`clearAll()` on signOut**: Primary defense against data leakage. `ownerPubkey` scoping is defense-in-depth for query-time isolation
- **Conversations PK stays `{id}`**: A composite `{id, ownerPubkey}` PK would require a table rebuild migration. Current approach is safe because `clearAll()` runs before any new user signs in

## Test plan

- [x] All 56 DM repository tests pass
- [x] All 80 DAO tests pass (including 8 new scoping tests)
- [x] All 88 DM BLoC tests pass
- [x] Zero analyzer errors
- [ ] Manual: Log in as User A, send/receive DMs, trigger notifications
- [ ] Manual: Log out, log in as User B — verify User A's data is not visible
- [ ] Manual: Log back in as User A — verify DMs re-fetch from relay