### PR TITLE
fix(video-editor): resolve incorrect clipping from square videos

### DIFF
--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_player.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_player.dart
@@ -31,35 +31,34 @@ class VideoEditorPlayer extends StatelessWidget {
         ? renderSize.aspectRatio
         : targetAspectRatio.value;
 
-    return Center(
-      child: ClipPath(
-        clipper: _RoundedRectClipper(
-          bodySize: bodySize,
-          enableFullScreen: useFullSize,
-          borderRadius: targetAspectRatio == .square ? 0 : 32,
-        ),
-        child: AspectRatio(
-          aspectRatio: aspectRatio,
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              // Video layer
-              if (isPlayerReady)
-                FittedBox(
-                  child: SizedBox(
-                    width: controller!.value.size.width,
-                    height: controller!.value.size.height,
-                    child: VideoPlayer(controller!),
-                  ),
+    return ClipPath(
+      clipper: _RoundedRectClipper(
+        bodySize: bodySize,
+        enableFullScreen: useFullSize,
+        targetAspectRatio: targetAspectRatio.value,
+        borderRadius: targetAspectRatio == .square ? 0 : 32,
+      ),
+      child: AspectRatio(
+        aspectRatio: aspectRatio,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            // Video layer
+            if (isPlayerReady)
+              FittedBox(
+                child: SizedBox(
+                  width: controller!.value.size.width,
+                  height: controller!.value.size.height,
+                  child: VideoPlayer(controller!),
                 ),
-
-              // Thumbnail layer with fade out
-              VideoEditorThumbnail(
-                isInitialized: isPlayerReady,
-                contentSize: renderSize,
               ),
-            ],
-          ),
+
+            // Thumbnail layer with fade out
+            VideoEditorThumbnail(
+              isInitialized: isPlayerReady,
+              contentSize: renderSize,
+            ),
+          ],
         ),
       ),
     );
@@ -70,31 +69,23 @@ class _RoundedRectClipper extends CustomClipper<Path> {
   const _RoundedRectClipper({
     required this.bodySize,
     required this.enableFullScreen,
+    required this.targetAspectRatio,
     required this.borderRadius,
   });
 
   final Size bodySize;
   final bool enableFullScreen;
+  final double targetAspectRatio;
   final double borderRadius;
 
   @override
   Path getClip(Size size) {
-    final Size clipSize;
-
-    if (enableFullScreen) {
-      // BoxFit.cover: the visible area is bodySize, scaled to widget coordinates.
-      // Calculate the scale that FittedBox.cover applies to make size cover bodySize.
-      final scale = max(
-        bodySize.width / size.width,
-        bodySize.height / size.height,
-      );
-      // The visible region in widget coordinates
-      clipSize = bodySize / scale;
-    } else {
-      // BoxFit.contain: the AspectRatio widget already has correct proportions,
-      // just use its full size
-      clipSize = size;
-    }
+    final clipSize = computeClipSize(
+      widgetSize: size,
+      bodySize: bodySize,
+      enableFullScreen: enableFullScreen,
+      targetAspectRatio: targetAspectRatio,
+    );
 
     // Convert 32px screen radius to widget coordinates
     final radius = Radius.circular(
@@ -119,5 +110,30 @@ class _RoundedRectClipper extends CustomClipper<Path> {
   @override
   bool shouldReclip(_RoundedRectClipper oldClipper) =>
       bodySize != oldClipper.bodySize ||
-      enableFullScreen != oldClipper.enableFullScreen;
+      enableFullScreen != oldClipper.enableFullScreen ||
+      targetAspectRatio != oldClipper.targetAspectRatio ||
+      borderRadius != oldClipper.borderRadius;
+}
+
+/// Computes the clipped region for the video player.
+///
+/// Exposed for testing only.
+@visibleForTesting
+Size computeClipSize({
+  required Size widgetSize,
+  required Size bodySize,
+  required bool enableFullScreen,
+  required double targetAspectRatio,
+}) {
+  if (enableFullScreen) {
+    final scale = max(
+      bodySize.width / widgetSize.width,
+      bodySize.height / widgetSize.height,
+    );
+    return bodySize / scale;
+  }
+  if (widgetSize.aspectRatio > targetAspectRatio) {
+    return Size(widgetSize.height * targetAspectRatio, widgetSize.height);
+  }
+  return Size(widgetSize.width, widgetSize.width / targetAspectRatio);
 }

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_player_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_player_test.dart
@@ -1,0 +1,118 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/video_editor/main_editor/video_editor_player.dart';
+
+void main() {
+  group(computeClipSize, () {
+    group('square (1:1) target', () {
+      test('clips tall widget to square using width as shortest side', () {
+        // 9:16 video rendered at 219×390
+        final result = computeClipSize(
+          widgetSize: const Size(219, 390),
+          bodySize: const Size(400, 800),
+          enableFullScreen: false,
+          targetAspectRatio: 1,
+        );
+
+        expect(result.width, equals(219));
+        expect(result.height, equals(219));
+      });
+
+      test('clips wide widget to square using height as shortest side', () {
+        // 16:9 video rendered at 640×360
+        final result = computeClipSize(
+          widgetSize: const Size(640, 360),
+          bodySize: const Size(400, 800),
+          enableFullScreen: false,
+          targetAspectRatio: 1,
+        );
+
+        expect(result.width, equals(360));
+        expect(result.height, equals(360));
+      });
+
+      test('returns same size when widget is already square', () {
+        final result = computeClipSize(
+          widgetSize: const Size(300, 300),
+          bodySize: const Size(400, 800),
+          enableFullScreen: false,
+          targetAspectRatio: 1,
+        );
+
+        expect(result.width, equals(300));
+        expect(result.height, equals(300));
+      });
+    });
+
+    group('vertical (9:16) target', () {
+      test('clips to 9:16 when widget matches aspect ratio', () {
+        final result = computeClipSize(
+          widgetSize: const Size(225, 400),
+          bodySize: const Size(400, 800),
+          enableFullScreen: false,
+          targetAspectRatio: 9 / 16,
+        );
+
+        expect(result.width, closeTo(225, 0.01));
+        expect(result.height, equals(400));
+      });
+
+      test('constrains width for wider-than-target widget', () {
+        // Widget is wider than 9:16
+        final result = computeClipSize(
+          widgetSize: const Size(400, 400),
+          bodySize: const Size(400, 800),
+          enableFullScreen: false,
+          targetAspectRatio: 9 / 16,
+        );
+
+        expect(result.width, closeTo(400 * 9 / 16, 0.01));
+        expect(result.height, equals(400));
+      });
+    });
+
+    group('fullscreen mode', () {
+      test('scales bodySize into widget coordinates', () {
+        final result = computeClipSize(
+          widgetSize: const Size(219, 390),
+          bodySize: const Size(400, 800),
+          enableFullScreen: true,
+          targetAspectRatio: 9 / 16,
+        );
+
+        // scale = max(400/219, 800/390) = max(1.826, 2.051) = 2.051
+        // clipSize = 400/2.051, 800/2.051 = ~195, ~390
+        expect(result.width, closeTo(195, 1));
+        expect(result.height, closeTo(390, 1));
+      });
+    });
+
+    group('clip is centered', () {
+      test('square clip from tall widget is centered vertically', () {
+        const widgetSize = Size(200, 400);
+        final clipSize = computeClipSize(
+          widgetSize: widgetSize,
+          bodySize: const Size(400, 800),
+          enableFullScreen: false,
+          targetAspectRatio: 1,
+        );
+
+        // Verify shortest side is used
+        expect(clipSize.width, equals(200));
+        expect(clipSize.height, equals(200));
+
+        // Rect.fromCenter would place this at (0, 100) → (200, 300)
+        final rect = Rect.fromCenter(
+          center: Offset(widgetSize.width / 2, widgetSize.height / 2),
+          width: clipSize.width,
+          height: clipSize.height,
+        );
+        expect(rect.left, equals(0));
+        expect(rect.top, equals(100));
+        expect(rect.right, equals(200));
+        expect(rect.bottom, equals(300));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

Fix incorrect clipping of 1:1 (square) aspect ratio videos in the video editor player. The `_RoundedRectClipper` previously used the widget's full size as the clip region, which meant tall (9:16) videos were not cropped to a square — they appeared letterboxed. The clipper now computes the clip size based on the target aspect ratio, constraining to the shortest fitting dimension. Also adds `shouldReclip` checks for `targetAspectRatio` and `borderRadius`, and extracts the clip computation into a `@visibleForTesting` helper with unit tests.

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore