### PR TITLE
refactor(models): add UserProfile.fromFunnelcake() factory constructor

### DIFF
--- a/mobile/packages/models/lib/src/user_profile.dart
+++ b/mobile/packages/models/lib/src/user_profile.dart
@@ -87,6 +87,32 @@ class UserProfile {
     eventId: json['event_id'] as String,
   );
 
+  /// Creates a [UserProfile] from a Funnelcake REST API response.
+  ///
+  /// Both single-profile and batch endpoints return the same shape, so this
+  /// factory works for either. Use [eventIdPrefix] to distinguish the source
+  /// (defaults to `'rest'`; batch callers pass `'rest-bulk'`).
+  factory UserProfile.fromFunnelcake(
+    String pubkey,
+    Map<String, dynamic> data, {
+    String? eventIdPrefix,
+  }) {
+    return UserProfile(
+      pubkey: pubkey,
+      name: data['name'] as String?,
+      displayName: data['display_name'] as String?,
+      about: data['about'] as String?,
+      picture: data['picture'] as String?,
+      banner: data['banner'] as String?,
+      website: data['website'] as String?,
+      nip05: data['nip05'] as String?,
+      lud16: data['lud16'] as String?,
+      rawData: data,
+      createdAt: DateTime.now(),
+      eventId: '${eventIdPrefix ?? 'rest'}-$pubkey',
+    );
+  }
+
   /// Create profile from Drift database row
   factory UserProfile.fromDrift(dynamic row) {
     // Parse rawData from JSON string if present

--- a/mobile/packages/models/test/src/user_profile_test.dart
+++ b/mobile/packages/models/test/src/user_profile_test.dart
@@ -174,6 +174,85 @@ void main() {
       });
     });
 
+    group('fromFunnelcake', () {
+      test('parses complete Funnelcake response', () {
+        final data = <String, dynamic>{
+          'name': 'testname',
+          'display_name': 'Test User',
+          'about': 'Test bio',
+          'picture': 'https://example.com/avatar.png',
+          'banner': 'https://example.com/banner.png',
+          'website': 'https://example.com',
+          'nip05': 'test@example.com',
+          'lud16': 'test@wallet.com',
+        };
+
+        final profile = UserProfile.fromFunnelcake(testPubkey, data);
+
+        expect(profile.pubkey, equals(testPubkey));
+        expect(profile.name, equals('testname'));
+        expect(profile.displayName, equals('Test User'));
+        expect(profile.about, equals('Test bio'));
+        expect(profile.picture, equals('https://example.com/avatar.png'));
+        expect(profile.banner, equals('https://example.com/banner.png'));
+        expect(profile.website, equals('https://example.com'));
+        expect(profile.nip05, equals('test@example.com'));
+        expect(profile.lud16, equals('test@wallet.com'));
+        expect(profile.rawData, equals(data));
+        expect(profile.eventId, equals('rest-$testPubkey'));
+        expect(profile.createdAt, isA<DateTime>());
+      });
+
+      test('handles partial data with null fields', () {
+        final data = <String, dynamic>{
+          'name': 'testname',
+        };
+
+        final profile = UserProfile.fromFunnelcake(testPubkey, data);
+
+        expect(profile.pubkey, equals(testPubkey));
+        expect(profile.name, equals('testname'));
+        expect(profile.displayName, isNull);
+        expect(profile.about, isNull);
+        expect(profile.picture, isNull);
+        expect(profile.banner, isNull);
+        expect(profile.website, isNull);
+        expect(profile.nip05, isNull);
+        expect(profile.lud16, isNull);
+      });
+
+      test('uses default eventIdPrefix when not provided', () {
+        final profile = UserProfile.fromFunnelcake(
+          testPubkey,
+          const <String, dynamic>{},
+        );
+
+        expect(profile.eventId, equals('rest-$testPubkey'));
+      });
+
+      test('uses custom eventIdPrefix', () {
+        final profile = UserProfile.fromFunnelcake(
+          testPubkey,
+          const <String, dynamic>{},
+          eventIdPrefix: 'rest-bulk',
+        );
+
+        expect(profile.eventId, equals('rest-bulk-$testPubkey'));
+      });
+
+      test('preserves rawData from response', () {
+        final data = <String, dynamic>{
+          'name': 'test',
+          'follower_count': 42,
+          'video_count': 10,
+        };
+
+        final profile = UserProfile.fromFunnelcake(testPubkey, data);
+
+        expect(profile.rawData, equals(data));
+      });
+    });
+
     group('fromJson', () {
       test('parses JSON correctly', () {
         final json = {

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -231,19 +231,7 @@ class ProfileRepository {
       try {
         final data = await _funnelcakeApiClient!.getUserProfile(pubkey);
         if (data != null && data['_noProfile'] != true) {
-          final profile = UserProfile(
-            pubkey: pubkey,
-            name: data['name'] as String?,
-            displayName: data['display_name'] as String?,
-            about: data['about'] as String?,
-            picture: data['picture'] as String?,
-            banner: data['banner'] as String?,
-            nip05: data['nip05'] as String?,
-            lud16: data['lud16'] as String?,
-            rawData: data,
-            createdAt: DateTime.now(),
-            eventId: 'rest-$pubkey',
-          );
+          final profile = UserProfile.fromFunnelcake(pubkey, data);
           developer.log(
             'Fetched from REST API and caching: '
             '${profile.bestDisplayName}',
@@ -762,18 +750,10 @@ class ProfileRepository {
             continue;
           }
 
-          final profile = UserProfile(
-            pubkey: pubkey,
-            name: data['name'] as String?,
-            displayName: data['display_name'] as String?,
-            about: data['about'] as String?,
-            picture: data['picture'] as String?,
-            banner: data['banner'] as String?,
-            nip05: data['nip05'] as String?,
-            lud16: data['lud16'] as String?,
-            rawData: data,
-            createdAt: DateTime.now(),
-            eventId: 'rest-bulk-$pubkey',
+          final profile = UserProfile.fromFunnelcake(
+            pubkey,
+            data,
+            eventIdPrefix: 'rest-bulk',
           );
           results[pubkey] = profile;
           toCache.add(profile);


### PR DESCRIPTION
Closes #2285

## Summary

- **Add `UserProfile.fromFunnelcake()` factory** in `user_profile.dart` — centralizes the Funnelcake REST API → `UserProfile` mapping with an optional `eventIdPrefix` parameter
- **Replace two duplicate mapping sites** in `profile_repository.dart` (`_doFetchFreshProfile` and `fetchBatchProfiles`)
- **Fix missing `website` field** — both call sites silently dropped the `website` field returned by the Funnelcake API

## Test plan

- [x] Unit test `fromFunnelcake()` with complete data
- [x] Unit test with partial/null fields
- [x] Unit test default `eventIdPrefix` (`'rest'`)
- [x] Unit test custom `eventIdPrefix` (`'rest-bulk'`)
- [x] Unit test `rawData` preservation
- [x] All 80 models tests pass
- [x] All 131 profile_repository tests pass
- [x] `dart analyze` clean on both packages