### PR TITLE
fix(video-player): prevent green frame on Android surface recreation

### DIFF
--- a/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_player.dart
+++ b/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_player.dart
@@ -184,19 +184,40 @@ class _RevealVideoAfterFirstFrameState
   int _generation = 0;
   Timer? _firstFrameTimeout;
 
+  /// Tracks the last known texture ID to detect Android surface recreation.
+  ///
+  /// On Android, when the app backgrounds/foregrounds or the GPU context is
+  /// lost, `SurfaceProducer` destroys and recreates the surface. The new
+  /// surface has uninitialized content (green in YUV color space). Since
+  /// `waitUntilFirstFrameRendered` is a one-shot `Completer`, it stays
+  /// completed after the initial load and never re-fires on surface
+  /// recreation. This means `_hasRenderedFirstFrame` stays `true` and the
+  /// green frame is visible.
+  ///
+  /// By tracking texture ID changes we can detect surface recreation and
+  /// temporarily re-hide the video until a new frame is rendered.
+  int? _lastTextureId;
+
+  /// Whether we're waiting for the first frame after a surface recreation.
+  bool _surfaceRecreating = false;
+  Timer? _surfaceRecoveryTimer;
+
   @override
   void initState() {
     super.initState();
     _subscribeToFirstFrame();
     _syncFallbackTimer();
+    _listenToTextureId();
   }
 
   @override
   void didUpdateWidget(covariant _RevealVideoAfterFirstFrame oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (!identical(oldWidget.videoController, widget.videoController)) {
+      _stopListeningToTextureId(oldWidget.videoController);
       _resetRevealState();
       _subscribeToFirstFrame();
+      _listenToTextureId();
     }
     if (oldWidget.readyForFallback != widget.readyForFallback) {
       _syncFallbackTimer();
@@ -205,8 +226,56 @@ class _RevealVideoAfterFirstFrameState
 
   void _resetRevealState() {
     _firstFrameTimeout?.cancel();
+    _surfaceRecoveryTimer?.cancel();
     _hasRenderedFirstFrame = false;
     _revealedByTimeout = false;
+    _surfaceRecreating = false;
+    _lastTextureId = null;
+  }
+
+  void _listenToTextureId() {
+    _lastTextureId = widget.videoController.id.value;
+    widget.videoController.id.addListener(_onTextureIdChanged);
+  }
+
+  void _stopListeningToTextureId(VideoController controller) {
+    controller.id.removeListener(_onTextureIdChanged);
+    _surfaceRecoveryTimer?.cancel();
+  }
+
+  void _onTextureIdChanged() {
+    final newId = widget.videoController.id.value;
+    if (_lastTextureId != null &&
+        newId != null &&
+        newId != _lastTextureId &&
+        _hasRenderedFirstFrame) {
+      // Surface was recreated — hide texture until a new frame renders.
+      // The `rect` notifier fires once mpv renders to the new surface,
+      // but since dimensions may not change we use a timer as fallback.
+      setState(() => _surfaceRecreating = true);
+      _surfaceRecoveryTimer?.cancel();
+
+      void reveal() {
+        if (!mounted) return;
+        setState(() => _surfaceRecreating = false);
+      }
+
+      // Listen for the next rect update as a "frame rendered" signal.
+      void onRect() {
+        _surfaceRecoveryTimer?.cancel();
+        widget.videoController.rect.removeListener(onRect);
+        reveal();
+      }
+
+      widget.videoController.rect.addListener(onRect);
+
+      // Fallback: reveal after 500ms even if no rect update arrives.
+      _surfaceRecoveryTimer = Timer(const Duration(milliseconds: 500), () {
+        widget.videoController.rect.removeListener(onRect);
+        reveal();
+      });
+    }
+    _lastTextureId = newId;
   }
 
   void _subscribeToFirstFrame() {
@@ -251,6 +320,7 @@ class _RevealVideoAfterFirstFrameState
 
   @override
   void dispose() {
+    _stopListeningToTextureId(widget.videoController);
     _firstFrameTimeout?.cancel();
     super.dispose();
   }
@@ -258,8 +328,9 @@ class _RevealVideoAfterFirstFrameState
   @override
   Widget build(BuildContext context) {
     final shouldReveal =
-        _hasRenderedFirstFrame ||
-        (widget.readyForFallback && _revealedByTimeout);
+        !_surfaceRecreating &&
+        (_hasRenderedFirstFrame ||
+            (widget.readyForFallback && _revealedByTimeout));
 
     return AnimatedOpacity(
       duration: const Duration(milliseconds: 120),

--- a/mobile/packages/pooled_video_player/test/widgets/pooled_video_player_test.dart
+++ b/mobile/packages/pooled_video_player/test/widgets/pooled_video_player_test.dart
@@ -99,12 +99,20 @@ void main() {
     late Map<int, ValueNotifier<VideoIndexState>> indexNotifiers;
     late _MockVideoController mockVideoController;
     late _MockPlayer mockPlayer;
+    late ValueNotifier<int?> textureIdNotifier;
+    late ValueNotifier<Rect?> textureRectNotifier;
 
     setUp(() {
       final result = _createMockVideoFeedControllerWithNotifier();
       mockController = result.controller;
       indexNotifiers = result.notifiers;
       mockVideoController = _MockVideoController();
+      textureIdNotifier = ValueNotifier<int?>(1);
+      textureRectNotifier = ValueNotifier<Rect?>(
+        const Rect.fromLTWH(0, 0, 1920, 1080),
+      );
+      when(() => mockVideoController.id).thenReturn(textureIdNotifier);
+      when(() => mockVideoController.rect).thenReturn(textureRectNotifier);
       when(
         () => mockVideoController.waitUntilFirstFrameRendered,
       ).thenAnswer((_) => Future<void>.value());
@@ -462,9 +470,7 @@ void main() {
       });
 
       testWidgets('reveals video after timeout when ready and first frame '
-          'stalls', (
-        tester,
-      ) async {
+          'stalls', (tester) async {
         final firstFrameCompleter = Completer<void>();
         when(
           () => mockVideoController.waitUntilFirstFrameRendered,
@@ -685,53 +691,166 @@ void main() {
         );
       });
 
+      testWidgets('hides video texture when isActive is false', (tester) async {
+        await tester.pumpWidget(buildWidget(isActive: false));
+
+        final opacityFinder = find.ancestor(
+          of: find.byType(AnimatedOpacity),
+          matching: find.byType(Opacity),
+        );
+
+        expect(opacityFinder, findsOneWidget);
+        expect(tester.widget<Opacity>(opacityFinder).opacity, equals(0));
+      });
+
+      testWidgets('shows video texture when isActive is true', (tester) async {
+        await tester.pumpWidget(buildWidget());
+
+        final opacityFinder = find.ancestor(
+          of: find.byType(AnimatedOpacity),
+          matching: find.byType(Opacity),
+        );
+
+        expect(opacityFinder, findsOneWidget);
+        expect(tester.widget<Opacity>(opacityFinder).opacity, equals(1));
+      });
+
+      testWidgets('video widget stays in tree when inactive', (tester) async {
+        await tester.pumpWidget(buildWidget(isActive: false));
+
+        expect(find.byKey(const Key('video_widget')), findsOneWidget);
+      });
+    });
+
+    group('surface recreation green frame prevention', () {
+      setUp(() {
+        indexNotifiers[0] = ValueNotifier(
+          VideoIndexState(
+            loadState: LoadState.ready,
+            videoController: mockVideoController,
+            player: mockPlayer,
+          ),
+        );
+      });
+
+      testWidgets('hides video when texture ID changes after first frame', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 120));
+
+        final opacityFinder = find.ancestor(
+          of: find.byKey(const Key('video_widget')),
+          matching: find.byType(AnimatedOpacity),
+        );
+
+        // Video should be visible after first frame
+        expect(
+          tester.widget<AnimatedOpacity>(opacityFinder).opacity,
+          equals(1),
+        );
+
+        // Simulate surface recreation: texture ID changes
+        textureIdNotifier.value = 2;
+        await tester.pump();
+
+        // Video should be hidden during surface recreation
+        expect(
+          tester.widget<AnimatedOpacity>(opacityFinder).opacity,
+          equals(0),
+        );
+      });
+
       testWidgets(
-        'hides video texture when isActive is false',
-        (tester) async {
-          await tester.pumpWidget(buildWidget(isActive: false));
-
-          final opacityFinder = find.ancestor(
-            of: find.byType(AnimatedOpacity),
-            matching: find.byType(Opacity),
-          );
-
-          expect(opacityFinder, findsOneWidget);
-          expect(
-            tester.widget<Opacity>(opacityFinder).opacity,
-            equals(0),
-          );
-        },
-      );
-
-      testWidgets(
-        'shows video texture when isActive is true',
+        'reveals video after rect update following surface recreation',
         (tester) async {
           await tester.pumpWidget(buildWidget());
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 120));
 
           final opacityFinder = find.ancestor(
-            of: find.byType(AnimatedOpacity),
-            matching: find.byType(Opacity),
+            of: find.byKey(const Key('video_widget')),
+            matching: find.byType(AnimatedOpacity),
           );
 
-          expect(opacityFinder, findsOneWidget);
+          // Simulate surface recreation
+          textureIdNotifier.value = 2;
+          await tester.pump();
           expect(
-            tester.widget<Opacity>(opacityFinder).opacity,
+            tester.widget<AnimatedOpacity>(opacityFinder).opacity,
+            equals(0),
+          );
+
+          // Simulate new frame rendered: rect notifier fires with new value
+          textureRectNotifier.value = const Rect.fromLTWH(0, 0, 1280, 720);
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 120));
+
+          // Video should be visible again
+          expect(
+            tester.widget<AnimatedOpacity>(opacityFinder).opacity,
             equals(1),
           );
         },
       );
 
-      testWidgets(
-        'video widget stays in tree when inactive',
-        (tester) async {
-          await tester.pumpWidget(buildWidget(isActive: false));
+      testWidgets('reveals video after timeout if no rect update arrives', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 120));
 
-          expect(
-            find.byKey(const Key('video_widget')),
-            findsOneWidget,
-          );
-        },
-      );
+        final opacityFinder = find.ancestor(
+          of: find.byKey(const Key('video_widget')),
+          matching: find.byType(AnimatedOpacity),
+        );
+
+        // Simulate surface recreation
+        textureIdNotifier.value = 2;
+        await tester.pump();
+        expect(
+          tester.widget<AnimatedOpacity>(opacityFinder).opacity,
+          equals(0),
+        );
+
+        // Wait for fallback timeout (500ms)
+        await tester.pump(const Duration(milliseconds: 500));
+        await tester.pump(const Duration(milliseconds: 120));
+
+        // Video should be visible via timeout fallback
+        expect(
+          tester.widget<AnimatedOpacity>(opacityFinder).opacity,
+          equals(1),
+        );
+      });
+
+      testWidgets('does not hide video when initial texture ID is set', (
+        tester,
+      ) async {
+        // Start with null texture ID
+        textureIdNotifier.value = null;
+
+        await tester.pumpWidget(buildWidget());
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 120));
+
+        final opacityFinder = find.ancestor(
+          of: find.byKey(const Key('video_widget')),
+          matching: find.byType(AnimatedOpacity),
+        );
+
+        // First texture ID assignment should NOT trigger hiding
+        textureIdNotifier.value = 1;
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 120));
+
+        expect(
+          tester.widget<AnimatedOpacity>(opacityFinder).opacity,
+          equals(1),
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

On Android, when the app backgrounds/foregrounds or the GPU context is lost, `SurfaceProducer` destroys and recreates the video surface. The new surface has uninitialized content (green in YUV color space). Since media_kit's `waitUntilFirstFrameRendered` is a one-shot `Completer` that never re-fires on surface recreation, the reveal overlay was already removed and the green frame was visible. This fix detects surface recreation by tracking `VideoController.id` changes and temporarily re-hides the texture until a valid frame is rendered.

This is a well-documented class of issues with Android video surfaces:
- [ExoPlayer #2321: Surface turns green upon return from background](https://github.com/google/ExoPlayer/issues/2321)
- [ExoPlayer #1084: Best practice for SurfaceView recreation](https://github.com/google/ExoPlayer/issues/1084)
- [Flutter #145077: SurfaceTexture + Texture widget + Impeller may cause problems](https://github.com/flutter/flutter/issues/145077)
- [Flutter #139702: Migrate rendering plugins to SurfaceProducer](https://github.com/flutter/flutter/issues/139702)

**Related Issue:** N/A (reported via Discord)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore