### PR TITLE
fix(theme): add text selection theme customization for improved UX

### DIFF
--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -510,6 +510,11 @@ class VineTheme {
         fontWeight: FontWeight.w400,
       ),
     ),
+    textSelectionTheme: TextSelectionThemeData(
+      cursorColor: primary,
+      selectionColor: primary.withAlpha(80),
+      selectionHandleColor: primary,
+    ),
     elevatedButtonTheme: ElevatedButtonThemeData(
       style: ElevatedButton.styleFrom(
         backgroundColor: vineGreen,


### PR DESCRIPTION
## Description

This PR corrects the text selection theme so that it follows the primary app color instead of the material default color.
Note that we added the theme but it appears that another PR accidentally removed it.

| Before | After |
| ------- | ------ |
|    ![Before](https://github.com/user-attachments/assets/0afee48c-fe70-4ff9-9d56-4c8c9231aa07)       |     ![After](https://github.com/user-attachments/assets/426ed40e-a392-477e-a2f8-1efec1697df8)      |


**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore