### PR TITLE
fix(feed): reset page position on mode switch to restore overlay

### DIFF
--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -306,6 +306,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
           BlocListener<VideoFeedBloc, VideoFeedState>(
             listenWhen: (previous, current) => previous.mode != current.mode,
             listener: (_, state) {
+              _pagePosition.value = 0;
               _resetVideoController();
               handleVideoController(state);
             },


### PR DESCRIPTION
## Description

When switching feed modes (e.g., Popular to New), the first video's overlay (profile info, like button, etc.) was invisible until the user scrolled. This was caused by `_pagePosition` retaining the previous feed's scroll offset, so the overlay opacity for index 0 computed as fully transparent. Resetting `_pagePosition` to `0` on mode change fixes the stale value.

**Related Issue:** Part of #970

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore