### PR TITLE
fix(video-editor): prevent app crashes when drawing extensively

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1739,10 +1739,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: "314fb7b3493dfb301c9ff7f37cf6e8ae50042c6325597c5e848b85f25cc08727"
+      sha256: cb34a3f2964c8a18835bf918279d6b70e36db71f68e6f7a7a225c13e41779f09
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.6"
+    version: "12.0.8"
   pro_video_editor:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -169,7 +169,7 @@ dependencies:
   convert: ^3.1.2
   audio_session: ^0.2.2
   pro_video_editor: ^1.7.0
-  pro_image_editor: ^12.0.6
+  pro_image_editor: ^12.0.8
   linked_scroll_controller: ^0.2.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
 ## Description

Bump `pro_image_editor` from 12.0.6 to 12.0.8 to fix a crash when using the draw tool in the editor.


**Related Issue:** Closes #2339

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore