### PR TITLE
feat(funnelcake): adjust limit values in FunnelcakeApiClient

### DIFF
--- a/mobile/lib/providers/curation_providers.dart
+++ b/mobile/lib/providers/curation_providers.dart
@@ -277,7 +277,7 @@ class AnalyticsTrending extends _$AnalyticsTrending {
 
     try {
       final client = ref.read(funnelcakeApiClientProvider);
-      final stats = await client.getTrendingVideos(limit: 100);
+      final stats = await client.getTrendingVideos();
       final videos = stats.map((v) => v.toVideoEvent()).toList();
 
       // Check if provider is still mounted after async gap
@@ -410,7 +410,7 @@ class AnalyticsPopular extends _$AnalyticsPopular {
     try {
       final client = ref.read(funnelcakeApiClientProvider);
       // Popular uses the trending videos API
-      final stats = await client.getTrendingVideos(limit: 100);
+      final stats = await client.getTrendingVideos();
       final videos = stats.map((v) => v.toVideoEvent()).toList();
 
       // Update state with new popular videos

--- a/mobile/lib/providers/curation_providers.g.dart
+++ b/mobile/lib/providers/curation_providers.g.dart
@@ -333,7 +333,7 @@ final class AnalyticsTrendingProvider
   }
 }
 
-String _$analyticsTrendingHash() => r'91eae1566af8e7cfd2ef83a8c7d39996a5f1a4cf';
+String _$analyticsTrendingHash() => r'b99515b211faaff536c3bae0d0405ef69c39d065';
 
 /// Provider for analytics-based trending videos with cursor pagination
 
@@ -392,7 +392,7 @@ final class AnalyticsPopularProvider
   }
 }
 
-String _$analyticsPopularHash() => r'ed1bc63e7cbed5a2a84c006d45e327a1d5da0480';
+String _$analyticsPopularHash() => r'79772fd2bd481d73840647dcecb5c1684c2e37af';
 
 /// Provider for analytics-based popular videos
 

--- a/mobile/lib/providers/popular_now_feed_provider.dart
+++ b/mobile/lib/providers/popular_now_feed_provider.dart
@@ -95,7 +95,7 @@ class PopularNowFeed extends _$PopularNowFeed {
       );
 
       try {
-        final stats = await client.getRecentVideos(limit: 100);
+        final stats = await client.getRecentVideos();
         final apiVideos = stats.map((v) => v.toVideoEvent()).toList();
         if (apiVideos.isNotEmpty) {
           _usingRestApi = true;
@@ -150,7 +150,7 @@ class PopularNowFeed extends _$PopularNowFeed {
       subscribe: (service) async {
         await service.subscribeToVideoFeed(
           subscriptionType: SubscriptionType.popularNow,
-          limit: 100,
+          limit: AppConstants.paginationBatchSize,
           sortBy: VideoSortField.createdAt, // Newest videos first
         );
       },
@@ -232,10 +232,7 @@ class PopularNowFeed extends _$PopularNowFeed {
         );
 
         // Use cursor (before parameter) for pagination
-        final stats = await client.getRecentVideos(
-          limit: 100,
-          before: _nextCursor,
-        );
+        final stats = await client.getRecentVideos(before: _nextCursor);
         final apiVideos = stats.map((v) => v.toVideoEvent()).toList();
 
         if (!ref.mounted) return;
@@ -396,7 +393,7 @@ class PopularNowFeed extends _$PopularNowFeed {
     if (_usingRestApi) {
       try {
         final client = ref.read(funnelcakeApiClientProvider);
-        final stats = await client.getRecentVideos(limit: 100);
+        final stats = await client.getRecentVideos();
         final apiVideos = stats.map((v) => v.toVideoEvent()).toList();
 
         // Check if provider is still mounted after async gap
@@ -447,7 +444,7 @@ class PopularNowFeed extends _$PopularNowFeed {
     try {
       await videoEventService.subscribeToVideoFeed(
         subscriptionType: SubscriptionType.popularNow,
-        limit: 100,
+        limit: AppConstants.paginationBatchSize,
         sortBy: VideoSortField.createdAt,
         force: true,
       );

--- a/mobile/lib/providers/popular_now_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_now_feed_provider.g.dart
@@ -63,7 +63,7 @@ final class PopularNowFeedProvider
   PopularNowFeed create() => PopularNowFeed();
 }
 
-String _$popularNowFeedHash() => r'cc16abd4576e9e957043f592b1ade78c7ef10640';
+String _$popularNowFeedHash() => r'6afdf9c8a0d0ecfe87d2a8bc210c8e4e74dff8d9';
 
 /// PopularNow feed provider - shows newest videos (sorted by creation time)
 ///

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -95,10 +95,7 @@ class ProfileFeed extends _$ProfileFeed {
       );
 
       try {
-        final stats = await funnelcakeClient.getVideosByAuthor(
-          pubkey: userId,
-          limit: 100,
-        );
+        final stats = await funnelcakeClient.getVideosByAuthor(pubkey: userId);
         final apiVideos = stats.map((v) => v.toVideoEvent()).toList();
 
         if (apiVideos.isNotEmpty) {
@@ -152,7 +149,7 @@ class ProfileFeed extends _$ProfileFeed {
     if (!_usingRestApi) {
       // Subscribe to this user's videos (non-blocking: events stream in
       // progressively via VideoEventService)
-      await videoEventService.subscribeToUserVideos(userId, limit: 100);
+      await videoEventService.subscribeToUserVideos(userId);
 
       // Return immediately with whatever videos are available.
       // Progressive updates arrive via the video update/new video listeners
@@ -430,10 +427,7 @@ class ProfileFeed extends _$ProfileFeed {
   Future<void> _refreshFromRestApi() async {
     try {
       final client = ref.read(funnelcakeApiClientProvider);
-      final stats = await client.getVideosByAuthor(
-        pubkey: userId,
-        limit: 100,
-      );
+      final stats = await client.getVideosByAuthor(pubkey: userId);
       final apiVideos = stats.map((v) => v.toVideoEvent()).toList();
 
       if (!ref.mounted) return;
@@ -545,7 +539,6 @@ class ProfileFeed extends _$ProfileFeed {
 
         final stats = await client.getVideosByAuthor(
           pubkey: userId,
-          limit: 100,
           before: _nextCursor,
         );
         final apiVideos = stats.map((v) => v.toVideoEvent()).toList();
@@ -727,10 +720,7 @@ class ProfileFeed extends _$ProfileFeed {
     if (funnelcakeAvailable) {
       try {
         final client = ref.read(funnelcakeApiClientProvider);
-        final stats = await client.getVideosByAuthor(
-          pubkey: userId,
-          limit: 100,
-        );
+        final stats = await client.getVideosByAuthor(pubkey: userId);
         final apiVideos = stats.map((v) => v.toVideoEvent()).toList();
 
         if (!ref.mounted) return;
@@ -804,7 +794,7 @@ class ProfileFeed extends _$ProfileFeed {
     _nextCursor = null;
 
     final videoEventService = ref.read(videoEventServiceProvider);
-    await videoEventService.subscribeToUserVideos(userId, limit: 100);
+    await videoEventService.subscribeToUserVideos(userId);
 
     if (!ref.mounted) return;
 

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -89,7 +89,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'091dc04e112dcfaef881a9939997998bf7faf520';
+String _$profileFeedHash() => r'6d783dc5c7706b095f30031bca7369840e27ef49';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///

--- a/mobile/lib/providers/profile_feed_providers.dart
+++ b/mobile/lib/providers/profile_feed_providers.dart
@@ -35,7 +35,7 @@ final videosForProfileRouteProvider = Provider<AsyncValue<VideoFeedState>>((
 
   // Subscribe (service manages lifecycle internally; this is idempotent)
   final svc = ref.watch(videoEventServiceProvider);
-  svc.subscribeToUserVideos(hex, limit: 100);
+  svc.subscribeToUserVideos(hex);
   Log.info(
     'ProfileFeedProvider: subscribed to user=$hex',
     name: 'ProfileFeedProvider',

--- a/mobile/lib/screens/hashtag_feed_screen.dart
+++ b/mobile/lib/screens/hashtag_feed_screen.dart
@@ -69,12 +69,11 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
   /// Load videos from both Funnelcake REST API and WebSocket in parallel.
   /// Funnelcake is fast and provides complete video data - show immediately.
   /// WebSocket provides real-time updates and additional videos.
-  Future<void> _loadHashtagVideos({bool forceRefresh = false}) async {
+  Future<void> _loadHashtagVideos() async {
     if (!mounted) return;
 
     Log.info(
-      '🏷️ HashtagFeedScreen: Loading #${widget.hashtag}'
-      '${forceRefresh ? ' (force refresh)' : ''}',
+      '🏷️ HashtagFeedScreen: Loading #${widget.hashtag}',
       category: LogCategory.video,
     );
 
@@ -83,7 +82,7 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
     // Run both fetches in parallel for speed
     // Always try Funnelcake - it will fail fast if unavailable
     final futures = <Future<void>>[
-      _fetchFromFunnelcake(forceRefresh: forceRefresh),
+      _fetchFromFunnelcake(),
       _subscribeViaWebSocket(hashtagService),
     ];
 
@@ -96,7 +95,7 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
 
   /// Fetch videos from Funnelcake REST API and update state immediately.
   /// Fetches trending AND classic videos in parallel, then interleaves 50/50.
-  Future<void> _fetchFromFunnelcake({bool forceRefresh = false}) async {
+  Future<void> _fetchFromFunnelcake() async {
     try {
       final client = ref.read(funnelcakeApiClientProvider);
 
@@ -111,10 +110,7 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
 
       // Fetch trending AND classic videos in parallel
       final results = await Future.wait([
-        client.getVideosByHashtag(
-          hashtag: widget.hashtag,
-          limit: 100,
-        ),
+        client.getVideosByHashtag(hashtag: widget.hashtag),
         client.getClassicVideosByHashtag(hashtag: widget.hashtag),
       ]).timeout(const Duration(seconds: 5));
 
@@ -386,7 +382,7 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
                 (videoList, index) {
                   _navigateToFullscreenFeed(context, videoList, index);
                 },
-            onRefresh: () => _loadHashtagVideos(forceRefresh: true),
+            onRefresh: _loadHashtagVideos,
           );
         }
 
@@ -397,7 +393,7 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
           semanticsLabel: 'searching for more videos',
           color: VineTheme.onPrimary,
           backgroundColor: VineTheme.vineGreen,
-          onRefresh: () => _loadHashtagVideos(forceRefresh: true),
+          onRefresh: _loadHashtagVideos,
           child: ListView.builder(
             // Add 1 for loading indicator if still loading
             itemCount: videos.length + (isLoadingMore ? 1 : 0),

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -15,8 +15,14 @@ import 'package:models/models.dart';
 /// Funnelcake provides a ClickHouse-backed analytics API that offers
 /// faster queries than Nostr relays for video data and engagement metrics.
 ///
-/// This client handles HTTP requests only. Caching should be implemented
-/// by consumers of this client.
+/// **Stateless:** This client has no in-memory caching — every call hits
+/// the network. Callers that need request deduplication or stale-while-
+/// revalidate behavior should manage that at a higher layer.
+///
+/// **Errors:** Unlike the legacy analytics service (which often returned
+/// empty lists on HTTP failures), this client throws typed subclasses of
+/// `FunnelcakeException` (for example `FunnelcakeApiException`,
+/// `FunnelcakeTimeoutException`). Call sites should use `try`/`catch`.
 ///
 /// Example usage:
 /// ```dart
@@ -917,7 +923,9 @@ class FunnelcakeApiClient {
   /// - [FunnelcakeApiException] if the request fails.
   /// - [FunnelcakeTimeoutException] if the request times out.
   /// - [FunnelcakeException] for other errors.
-  Future<List<TrendingHashtag>> fetchTrendingHashtags({int limit = 20}) async {
+  Future<List<TrendingHashtag>> fetchTrendingHashtags({
+    int limit = 20,
+  }) async {
     if (!isAvailable) {
       throw const FunnelcakeNotConfiguredException();
     }

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -771,7 +771,6 @@ class VideosRepository {
         // Fetch videos by author from Funnelcake API
         final authorVideoStats = await _funnelcakeApiClient!.getVideosByAuthor(
           pubkey: pubkey,
-          limit: 100,
         );
 
         // Find videos matching our d-tags and convert to VideoEvent

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -3182,6 +3182,7 @@ void main() {
               () => mockFunnelcakeClient.getVideosByAuthor(
                 pubkey: any(named: 'pubkey'),
                 limit: any(named: 'limit'),
+                before: any(named: 'before'),
               ),
             );
           },
@@ -3218,6 +3219,7 @@ void main() {
               () => mockFunnelcakeClient.getVideosByAuthor(
                 pubkey: any(named: 'pubkey'),
                 limit: any(named: 'limit'),
+                before: any(named: 'before'),
               ),
             );
           },
@@ -3249,7 +3251,8 @@ void main() {
             when(
               () => mockFunnelcakeClient.getVideosByAuthor(
                 pubkey: 'pubkey1',
-                limit: 100,
+                limit: any(named: 'limit'),
+                before: any(named: 'before'),
               ),
             ).thenAnswer((_) async => [videoStats]);
 
@@ -3263,7 +3266,8 @@ void main() {
             verify(
               () => mockFunnelcakeClient.getVideosByAuthor(
                 pubkey: 'pubkey1',
-                limit: 100,
+                limit: any(named: 'limit', that: equals(50)),
+                before: any(named: 'before'),
               ),
             ).called(1);
           },
@@ -3302,7 +3306,8 @@ void main() {
             when(
               () => mockFunnelcakeClient.getVideosByAuthor(
                 pubkey: 'pubkey2',
-                limit: 100,
+                limit: any(named: 'limit'),
+                before: any(named: 'before'),
               ),
             ).thenAnswer((_) async => [videoStats]);
 
@@ -3355,14 +3360,16 @@ void main() {
           when(
             () => mockFunnelcakeClient.getVideosByAuthor(
               pubkey: 'pubkey1',
-              limit: 100,
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
             ),
           ).thenAnswer((_) async => [videoStats1]);
 
           when(
             () => mockFunnelcakeClient.getVideosByAuthor(
               pubkey: 'pubkey3',
-              limit: 100,
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
             ),
           ).thenAnswer((_) async => [videoStats3]);
 
@@ -3404,7 +3411,8 @@ void main() {
           when(
             () => mockFunnelcakeClient.getVideosByAuthor(
               pubkey: 'pubkey2',
-              limit: 100,
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
             ),
           ).thenThrow(const FunnelcakeException('Network error'));
 
@@ -3447,7 +3455,8 @@ void main() {
           when(
             () => mockFunnelcakeClient.getVideosByAuthor(
               pubkey: blockedPubkey,
-              limit: 100,
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
             ),
           ).thenAnswer((_) async => [videoStats]);
 
@@ -3483,7 +3492,8 @@ void main() {
           when(
             () => mockFunnelcakeClient.getVideosByAuthor(
               pubkey: 'pubkey1',
-              limit: 100,
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
             ),
           ).thenAnswer((_) async => [videoStats]);
 
@@ -3525,7 +3535,8 @@ void main() {
           when(
             () => mockFunnelcakeClient.getVideosByAuthor(
               pubkey: 'same-pubkey',
-              limit: 100,
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
             ),
           ).thenAnswer((_) async => [videoStats1, videoStats2]);
 
@@ -3540,7 +3551,8 @@ void main() {
           verify(
             () => mockFunnelcakeClient.getVideosByAuthor(
               pubkey: 'same-pubkey',
-              limit: 100,
+              limit: any(named: 'limit', that: equals(50)),
+              before: any(named: 'before'),
             ),
           ).called(1);
         });

--- a/mobile/test/providers/popular_now_feed_provider_test.dart
+++ b/mobile/test/providers/popular_now_feed_provider_test.dart
@@ -66,7 +66,7 @@ void main() {
         verify(
           () => mockService.subscribeToVideoFeed(
             subscriptionType: SubscriptionType.popularNow,
-            limit: 100,
+            limit: 50,
             sortBy: any(named: 'sortBy', that: isNotNull),
           ),
         ).called(greaterThanOrEqualTo(1));
@@ -231,7 +231,7 @@ void main() {
         verify(
           () => mockService.subscribeToVideoFeed(
             subscriptionType: SubscriptionType.popularNow,
-            limit: 100,
+            limit: 50,
             sortBy: any(named: 'sortBy', that: isNotNull),
             force: true, // Should force refresh
           ),

--- a/mobile/test/screens/explore_screen_pull_to_refresh_test.dart
+++ b/mobile/test/screens/explore_screen_pull_to_refresh_test.dart
@@ -65,7 +65,7 @@ void main() {
       verify(
         () => mockService.subscribeToVideoFeed(
           subscriptionType: SubscriptionType.popularNow,
-          limit: 100,
+          limit: 50,
           sortBy: any(that: isNotNull, named: 'sortBy'),
           force: true, // CRITICAL: Must force refresh to bypass caching
         ),
@@ -90,7 +90,7 @@ void main() {
         verify(
           () => mockService.subscribeToVideoFeed(
             subscriptionType: SubscriptionType.popularNow,
-            limit: 100,
+            limit: 50,
             sortBy: any(that: isNotNull, named: 'sortBy'),
             force: true, // CRITICAL: Must force refresh to bypass caching
           ),

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -46,7 +46,8 @@ void main() {
 
       when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
 
-      // Stub configuredRelays (needed by analyticsApiService provider)
+      // Stub configuredRelays (used when resolving Funnelcake base URL for
+      // funnelcakeApiClientProvider).
       when(() => mockNostrClient.configuredRelays).thenReturn(<String>[]);
       when(() => mockNostrClient.publicKey).thenReturn('');
       when(() => mockNostrClient.isInitialized).thenReturn(true);


### PR DESCRIPTION
Closes #2405


## Description
This is a follow-up PR for @realmeylisdev's review on https://github.com/divinevideo/divine-mobile/pull/2298.

(The limit dropped from 100 → 50 on every initial load (popular feed, profile feed, hashtag feed, trending))

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore