### PR TITLE
ci: add git hooks check and align analyze with CI

### DIFF
--- a/.claude/hooks/check-git-hooks.sh
+++ b/.claude/hooks/check-git-hooks.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Block git commit/push if git hooks aren't installed (CI checks won't be caught locally)
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[ -z "$COMMAND" ] && exit 0
+
+# Only care about git commit/push commands
+FIRST_CMD=$(echo "$COMMAND" | head -1 | sed 's/\s*&&.*//' | sed 's/\s*|.*//' | sed 's/\s*;.*//')
+echo "$FIRST_CMD" | grep -qE '^\s*git\s+(commit|push)\b' || exit 0
+
+REPO_ROOT=$(git -C "$CLAUDE_PROJECT_DIR" rev-parse --show-toplevel 2>/dev/null) || exit 0
+GIT_COMMON_DIR=$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null) || exit 0
+[[ "$GIT_COMMON_DIR" != /* ]] && GIT_COMMON_DIR="$(cd "$GIT_COMMON_DIR" && pwd)"
+
+if [ ! -f "$GIT_COMMON_DIR/hooks/pre-commit" ] || [ ! -f "$GIT_COMMON_DIR/hooks/pre-push" ]; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "Git hooks not installed — CI checks won'\''t be caught locally. Run: cd mobile && mise run setup_hooks"
+    }
+  }'
+fi

--- a/.claude/hooks/pre-commit-build-runner.sh
+++ b/.claude/hooks/pre-commit-build-runner.sh
@@ -7,6 +7,13 @@
 
 set -e
 
+# Filter: only run on git commit commands
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[ -z "$COMMAND" ] && exit 0
+FIRST_CMD=$(echo "$COMMAND" | head -1 | sed 's/\s*&&.*//' | sed 's/\s*|.*//' | sed 's/\s*;.*//')
+echo "$FIRST_CMD" | grep -qE '^\s*git\s+commit\b' || exit 0
+
 # Get staged Dart files (excluding generated files)
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.dart$' | grep -v '\.g\.dart$' | grep -v '\.freezed\.dart$' || true)
 

--- a/.claude/rules/git_hooks.md
+++ b/.claude/rules/git_hooks.md
@@ -8,16 +8,17 @@ The repo has pre-commit and pre-push hooks that mirror CI checks locally. They l
 cd mobile && mise run setup_hooks
 ```
 
-If a developer reports CI failures on format, analyze, or codegen that they didn't catch locally, check whether hooks are installed (`ls .git/hooks/pre-commit .git/hooks/pre-push`) and suggest `mise run setup_hooks` if missing.
+When a developer reports CI failures on format, analyze, or codegen that they didn't catch locally, FIRST check whether hooks are installed (`ls .git/hooks/pre-commit .git/hooks/pre-push`) before analyzing the failure itself. If hooks are missing, that is likely the root cause — suggest `mise run setup_hooks`. Do not skip this check.
 
 ## What the hooks check
 
 **Pre-commit** (staged `.dart` files only):
 - `dart format --output=none --set-exit-if-changed`
-- `flutter analyze`
+- `flutter analyze lib test integration_test`
 - build_runner codegen verification (if codegen inputs changed)
 
 **Pre-push**:
 - Merge conflict check against `origin/main`
+- `flutter analyze lib test integration_test`
 - build_runner codegen verification
 - Runs tests for changed files

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,18 @@
         ]
       },
       {
-        "matcher": "Bash(git commit:*)",
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-git-hooks.sh",
+            "timeout": 3000,
+            "statusMessage": "Checking git hooks..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -22,6 +22,7 @@ run = "docker compose -f ../local_stack/docker-compose.yml logs -f"
 
 [tasks.local_build]
 description = "Build APK with LOCAL environment"
+depends = ["setup_hooks"]
 run = "flutter build apk --debug --dart-define=DEFAULT_ENV=LOCAL"
 
 [tasks.local_install]
@@ -61,5 +62,5 @@ run = "bash ../scripts/install-hooks.sh"
 
 [tasks.e2e_test]
 description = "Run E2E tests with log profiling (starts Docker stack, captures merged timeline)"
-depends = ["local_up"]
+depends = ["setup_hooks", "local_up"]
 run = "bash ../local_stack/profile.sh {{ arg(i=0, name='test_path', default='integration_test/auth/') }}"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -7,7 +7,7 @@ set -e
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
 if [[ "$GIT_COMMON_DIR" != /* ]]; then
-  GIT_COMMON_DIR="$REPO_ROOT/$GIT_COMMON_DIR"
+  GIT_COMMON_DIR="$(cd "$GIT_COMMON_DIR" && pwd)"
 fi
 HOOKS_DIR="$GIT_COMMON_DIR/hooks"
 
@@ -83,7 +83,7 @@ echo "Format OK"
 
 # Run flutter analyze (medium speed)
 echo "[2/3] Running analyzer..."
-if ! mise exec -- flutter analyze 2>/dev/null; then
+if ! mise exec -- flutter analyze lib test integration_test 2>/dev/null; then
     echo ""
     echo "Analysis failed!"
     echo "Fix the issues above before committing"
@@ -215,6 +215,17 @@ if [ "$TOTAL_CHANGED" -gt 10 ]; then
 fi
 echo ""
 
+# Run flutter analyze (mirrors CI)
+echo "Running analyzer..."
+if ! mise exec -- flutter analyze lib test integration_test 2>/dev/null; then
+    echo ""
+    echo "Analysis failed!"
+    echo "Fix the issues above before pushing."
+    exit 1
+fi
+echo "Analysis OK"
+echo ""
+
 # Mirror CI's generated-file check for codegen inputs
 CODEGEN_INPUTS=$(printf '%s\n' "$CHANGED_FILES" | list_codegen_inputs)
 if [ -n "$CODEGEN_INPUTS" ]; then
@@ -279,8 +290,9 @@ for file in $CHANGED_FILES; do
     fi
 done
 
-# Remove duplicates and mobile/ prefix for flutter test
-TEST_FILES=$(echo "$TEST_FILES" | tr ' ' '\n' | sort -u | sed 's|^mobile/||' | grep -v '^$' || true)
+# Remove duplicates, strip mobile/ prefix, and exclude integration tests
+# (integration tests require an emulator and can't mix with unit tests)
+TEST_FILES=$(echo "$TEST_FILES" | tr ' ' '\n' | sort -u | sed 's|^mobile/||' | grep -v '^$' | grep -v '^integration_test/' || true)
 
 if [ -z "$TEST_FILES" ]; then
     echo "No corresponding test files found for changed files"


### PR DESCRIPTION
## Description

Align the pre-commit hook's `flutter analyze` invocation with CI (explicitly pass `lib test integration_test`), add a Claude Code PreToolUse hook that blocks commits when git hooks aren't installed, fix a path resolution bug in `install-hooks.sh` for subdirectory execution, and auto-install hooks via mise for `e2e_test` and `local_build`.

**Related Issue:** Follow-up to #2301

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [x] Build configuration change
- [ ] Documentation
- [ ] Chore