### PR TITLE
ci: auto-create tracking issue for PRs without linked issues

### DIFF
--- a/.github/workflows/pr_issue_link.yml
+++ b/.github/workflows/pr_issue_link.yml
@@ -1,0 +1,279 @@
+name: PR Issue Link
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  ensure-issue:
+    name: ensure-linked-issue
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - name: Ensure PR has a linked tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const repo = context.repo;
+            const LABEL = 'needs-issue';
+            const BOT_MARKER = '<!-- pr-issue-link-bot -->';
+
+            await run();
+
+            // ═══════════════════════════════════════════════
+            // Main flow
+            // ═══════════════════════════════════════════════
+
+            async function run() {
+              // Step 1: "Closes #none" — dev dismissed suggestions, auto-create
+              const nonePattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#none/i;
+              if (nonePattern.test(body)) {
+                console.log(`PR #${pr.number} has "Closes #none" — creating issue.`);
+                const cleanBody = body.replace(nonePattern, '').trim();
+                await github.rest.pulls.update({ ...repo, pull_number: pr.number, body: cleanBody });
+                await autoCreateIssue(cleanBody);
+                return;
+              }
+
+              // Step 2: Already linked via closing keywords in body?
+              const closingPattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+              const bodyMatches = [...body.matchAll(closingPattern)];
+              if (bodyMatches.length > 0) {
+                console.log(`PR #${pr.number} linked to: ${bodyMatches.map(m => '#' + m[1]).join(', ')}`);
+                await cleanup();
+                return;
+              }
+
+              // Step 3: Already linked via GitHub sidebar?
+              const sidebarLinked = await getSidebarLinkedIssues();
+              if (sidebarLinked.length > 0) {
+                console.log(`PR #${pr.number} sidebar-linked to: ${sidebarLinked.map(n => '#' + n).join(', ')}`);
+                await cleanup();
+                return;
+              }
+
+              // Step 4: Branch name contains an issue number?
+              const branchIssue = await resolveIssueFromBranch();
+              if (branchIssue) {
+                console.log(`Branch "${pr.head.ref}" → auto-linking to #${branchIssue}.`);
+                const closeLine = `Closes #${branchIssue}`;
+                const newBody = body.length > 0 ? `${closeLine}\n\n${body}` : closeLine;
+                await github.rest.pulls.update({ ...repo, pull_number: pr.number, body: newBody });
+                await cleanup();
+                return;
+              }
+
+              // Step 5: Search open issues for potential matches
+              const candidates = await findMatchingIssues();
+              if (candidates.length > 0) {
+                console.log(`Found ${candidates.length} candidate issue(s) — asking dev to pick.`);
+                await addLabel(LABEL);
+                await upsertBotComment(buildSuggestionComment(candidates));
+                return;
+              }
+
+              // Step 6: No matches anywhere — auto-create a tracking issue
+              console.log(`No matching issues for PR #${pr.number} — creating one.`);
+              await autoCreateIssue(body);
+            }
+
+            // ═══════════════════════════════════════════════
+            // Issue detection helpers
+            // ═══════════════════════════════════════════════
+
+            async function getSidebarLinkedIssues() {
+              const query = `query($owner:String!, $repo:String!, $number:Int!) {
+                repository(owner:$owner, name:$repo) {
+                  pullRequest(number:$number) {
+                    closingIssuesReferences(first:5) {
+                      nodes { number }
+                    }
+                  }
+                }
+              }`;
+              const result = await github.graphql(query, {
+                owner: repo.owner, repo: repo.repo, number: pr.number,
+              });
+              return result.repository.pullRequest.closingIssuesReferences.nodes.map(n => n.number);
+            }
+
+            async function resolveIssueFromBranch() {
+              const match = pr.head.ref.match(/(?:^|[\/\-_])(\d{3,})/);
+              if (!match) return null;
+              const num = parseInt(match[1], 10);
+              try {
+                const issue = await github.rest.issues.get({ ...repo, issue_number: num });
+                if (!issue.data.pull_request && issue.data.state === 'open') return num;
+              } catch { /* doesn't exist */ }
+              return null;
+            }
+
+            // ═══════════════════════════════════════════════
+            // Issue search — find plausible existing issues
+            // ═══════════════════════════════════════════════
+
+            async function findMatchingIssues() {
+              const stopWords = new Set([
+                'that', 'this', 'with', 'from', 'into', 'when', 'after',
+                'before', 'about', 'between', 'through', 'during', 'each',
+                'also', 'been', 'have', 'will', 'would', 'could', 'should',
+                'being', 'their', 'there', 'where', 'which', 'while',
+                'does', 'done', 'make', 'made', 'only', 'very', 'some',
+                'just', 'than', 'then', 'them', 'they', 'what', 'your',
+                'more', 'other', 'were', 'like', 'over', 'such', 'allow',
+                'users', 'added', 'adding', 'update', 'updated',
+              ]);
+
+              // Strip conventional commit prefix: "feat(scope): description" → "description"
+              const rawTitle = pr.title
+                .replace(/^(\w+)(?:\(.*?\))?:\s*/, '')
+                .replace(/[^\w\s]/g, ' ');
+
+              const keywords = rawTitle
+                .toLowerCase()
+                .split(/\s+/)
+                .filter(w => w.length >= 4 && !stopWords.has(w));
+
+              // Also include scope as a keyword (e.g., "auth" from "fix(auth):")
+              const scopeMatch = pr.title.match(/^\w+\(([^)]+)\):/);
+              if (scopeMatch) {
+                const scope = scopeMatch[1].toLowerCase();
+                if (scope.length >= 3 && !keywords.includes(scope)) {
+                  keywords.unshift(scope);
+                }
+              }
+
+              if (keywords.length === 0) return [];
+
+              // Search with up to 3 keywords for relevance
+              const searchTerms = keywords.slice(0, 3).join(' ');
+              const q = `repo:${repo.owner}/${repo.repo} is:issue is:open ${searchTerms}`;
+              console.log(`Issue search query: "${q}"`);
+
+              try {
+                const result = await github.rest.search.issuesAndPullRequests({
+                  q, per_page: 5, sort: 'updated', order: 'desc',
+                });
+                return result.data.items.filter(item => {
+                  if (item.pull_request) return false;
+                  // Skip issues auto-created by this workflow
+                  if (item.body && item.body.includes('Auto-created from PR #')) return false;
+                  return true;
+                }).slice(0, 5);
+              } catch (e) {
+                console.log(`Issue search failed: ${e.message}`);
+                return [];
+              }
+            }
+
+            // ═══════════════════════════════════════════════
+            // Issue creation
+            // ═══════════════════════════════════════════════
+
+            async function autoCreateIssue(currentBody) {
+              const prType = pr.title.match(/^(\w+)(?:\(.*?\))?:/)?.[1] || 'task';
+              const typeLabels = {
+                feat: 'enhancement', fix: 'bug', refactor: 'enhancement',
+                docs: 'documentation', perf: 'enhancement', chore: 'chore',
+                test: 'enhancement',
+              };
+              const labels = [];
+              const labelName = typeLabels[prType];
+              if (labelName) {
+                try {
+                  await github.rest.issues.getLabel({ ...repo, name: labelName });
+                  labels.push(labelName);
+                } catch { /* label doesn't exist */ }
+              }
+
+              const issueBody = [
+                `Auto-created from PR #${pr.number}.`,
+                '',
+                `**PR:** ${pr.html_url}`,
+                `**Branch:** \`${pr.head.ref}\``,
+              ].join('\n');
+
+              const created = await github.rest.issues.create({
+                ...repo, title: pr.title, body: issueBody, labels,
+              });
+              console.log(`Created issue #${created.data.number}`);
+
+              const closeLine = `Closes #${created.data.number}`;
+              const newBody = currentBody.length > 0
+                ? `${closeLine}\n\n${currentBody}`
+                : closeLine;
+
+              await github.rest.pulls.update({
+                ...repo, pull_number: pr.number, body: newBody,
+              });
+              await cleanup();
+              console.log(`Linked PR #${pr.number} → #${created.data.number}`);
+            }
+
+            // ═══════════════════════════════════════════════
+            // Comment and label management
+            // ═══════════════════════════════════════════════
+
+            function buildSuggestionComment(candidates) {
+              const issueList = candidates
+                .map(c => `- [ ] **#${c.number}** — ${c.title}`)
+                .join('\n');
+
+              return [
+                BOT_MARKER,
+                '### 🔗 Link this PR to an issue',
+                '',
+                'This PR doesn\'t reference a tracking issue yet. These open issues look related:',
+                '',
+                issueList,
+                '',
+                '**To link:** edit the PR description and add `Closes #<number>`.',
+                'If none of these match, add `Closes #none` and a new tracking issue will be created automatically.',
+                '',
+                '*This comment and the `needs-issue` label will be removed once an issue is linked.*',
+              ].join('\n');
+            }
+
+            async function addLabel(name) {
+              try {
+                await github.rest.issues.getLabel({ ...repo, name });
+              } catch {
+                await github.rest.issues.createLabel({
+                  ...repo, name, color: 'e4e669',
+                  description: 'PR needs a linked tracking issue',
+                });
+              }
+              try {
+                await github.rest.issues.addLabels({
+                  ...repo, issue_number: pr.number, labels: [name],
+                });
+              } catch { /* already has label */ }
+            }
+
+            async function cleanup() {
+              try {
+                await github.rest.issues.removeLabel({
+                  ...repo, issue_number: pr.number, name: LABEL,
+                });
+              } catch { /* label not present */ }
+
+              const comments = await github.rest.issues.listComments({
+                ...repo, issue_number: pr.number, per_page: 30,
+              });
+              const botComment = comments.data.find(c => c.body && c.body.includes(BOT_MARKER));
+              if (botComment) {
+                await github.rest.issues.deleteComment({ ...repo, comment_id: botComment.id });
+                console.log('Cleaned up bot comment.');
+              }
+            }


### PR DESCRIPTION
Closes #2361

## Summary

- Adds a GitHub Actions workflow that ensures every PR has a linked tracking issue
- Smart matching finds existing open issues before creating new ones
- Adds a small amount of friction (comment + `needs-issue` label) when matches exist, so devs learn to link issues upfront
- Zero friction when no matches exist — auto-creates and links silently
- Self-cleaning: comment and label are removed once an issue is linked

## Flow

```
PR opened/edited
  │
  ├─ "" in body? → Auto-create issue (escape hatch)
  │
  ├─ "Closes/Fixes/Resolves #N" in body? → Done ✅
  │
  ├─ Sidebar-linked issues? → Done ✅
  │
  ├─ Branch name has issue number (e.g. fix/2233-foo)?
  │   → Auto-link that issue → Done ✅
  │
  ├─ Search open issues by PR title keywords
  │   ├─ Matches found → Comment with suggestions + "needs-issue" label
  │   │                   Dev edits PR body → label/comment auto-removed
  │   │
  │   └─ No matches → Auto-create issue → Done ✅
```

## Details

- Extracts keywords from PR title (strips conventional commit prefix + stop words)
- Uses scope from title as a keyword (e.g., "auth" from `fix(auth):`)
- Searches up to 3 keywords against open issues, returns top 5 matches
- Filters out bot-created stub issues from results
- `Closes #none` lets devs dismiss suggestions and trigger auto-create
- Skips Dependabot PRs
- `needs-issue` label auto-created (yellow) if it doesn't exist

## Why

We found multiple open PRs with no associated issues (#2351, #2343, #2354). The PR template has a `Closes #` placeholder but nothing enforces it. This workflow ensures every PR has traceability while surfacing existing issues that might already describe the work.

## Test plan

- [ ] Open PR without issue reference, with matching open issues → verify suggestion comment appears with `needs-issue` label
- [ ] Edit PR body to add `Closes #N` → verify label and comment are removed
- [ ] Open PR without issue reference, no matching issues → verify issue auto-created and body updated
- [ ] Open PR with `Closes #none` → verify auto-create bypasses suggestions
- [ ] Open PR on branch `fix/2233-foo` → verify auto-links to #2233
- [ ] Open PR with `Closes #123` already in body → verify no action taken
- [ ] Verify Dependabot PRs are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)