### PR TITLE
fix(android): dispatch Zendesk ticket callback to main thread

### DIFF
--- a/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
@@ -499,23 +499,28 @@ class MainActivity : FlutterActivity() {
                             createRequest.customFields = customFields
                         }
 
+                        val mainHandler = Handler(Looper.getMainLooper())
                         provider.createRequest(createRequest, object : ZendeskCallback<Request>() {
                             override fun onSuccess(request: Request?) {
-                                if (isActivityDestroyed || isFinishing) {
-                                    Log.w(ZENDESK_TAG, "Dropped ticket result: activity destroyed")
-                                    return
+                                mainHandler.post {
+                                    if (isActivityDestroyed || isFinishing) {
+                                        Log.w(ZENDESK_TAG, "Dropped ticket result: activity destroyed")
+                                        return@post
+                                    }
+                                    Log.d(ZENDESK_TAG, "Ticket created successfully - ID: ${request?.id}")
+                                    result.success(true)
                                 }
-                                Log.d(ZENDESK_TAG, "Ticket created successfully - ID: ${request?.id}")
-                                result.success(true)
                             }
 
                             override fun onError(error: ErrorResponse?) {
-                                if (isActivityDestroyed || isFinishing) {
-                                    Log.w(ZENDESK_TAG, "Dropped ticket error: activity destroyed")
-                                    return
+                                mainHandler.post {
+                                    if (isActivityDestroyed || isFinishing) {
+                                        Log.w(ZENDESK_TAG, "Dropped ticket error: activity destroyed")
+                                        return@post
+                                    }
+                                    Log.e(ZENDESK_TAG, "Failed to create ticket: ${error?.reason}")
+                                    result.success(false)
                                 }
-                                Log.e(ZENDESK_TAG, "Failed to create ticket: ${error?.reason}")
-                                result.success(false)
                             }
                         })
                     } catch (e: Exception) {


### PR DESCRIPTION
Closes #1679

## Summary

- Wrap `ZendeskCallback.onSuccess` and `onError` in `Handler(Looper.getMainLooper()).post { }` so `result.success()` is delivered on the main thread
- Matches the existing proofmode handler pattern in the same file (line 220)
- Mirrors the iOS implementation which uses `DispatchQueue.main.async`

## Root cause

The Zendesk SDK's `createRequest` callback fires on a background thread. Flutter's platform channel contract requires `MethodChannel.Result` to be called on the main thread. On Android, `result.success(true)` was called directly from the callback, causing the result to silently fail. iOS worked because it wraps in `DispatchQueue.main.async`.

## Change

One file, 5 net new lines. `return` → `return@post` for the activity-destroyed guards since they're now inside a lambda.

## Test plan

- [ ] On Android: submit a content report → verify Zendesk ticket is created in dashboard
- [ ] On Android: submit report while backgrounding app → verify no crash (activity-destroyed guard)
- [ ] On iOS: submit a content report → verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)