### PR TITLE
chore: update zapstore release source to 1.0.7

### DIFF
--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,5 +1,5 @@
 repository: https://github.com/divinevideo/divine-mobile
-release_source: https://github.com/divinevideo/divine-mobile/releases/tag/1.0.6
+release_source: https://github.com/divinevideo/divine-mobile/releases/tag/1.0.7
 name: Divine
 description: |
   Divine is a new 6-second looping video app, inspired by Vine, with a


### PR DESCRIPTION
Closes #2374

## Summary
- Update `zapstore.yaml` release_source tag from 1.0.6 to 1.0.7

## Test plan
- [ ] Verify zapstore picks up the new release after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)