### PR TITLE
fix: text input overflows background in video editor with large system font size

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1739,10 +1739,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: cb34a3f2964c8a18835bf918279d6b70e36db71f68e6f7a7a225c13e41779f09
+      sha256: af6eae5d3b5f3b854d3e06c3b90e85c60ffce54efcacab69cb75afc1235afb27
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.8"
+    version: "12.0.9"
   pro_video_editor:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -173,7 +173,7 @@ dependencies:
   convert: ^3.1.2
   audio_session: ^0.2.2
   pro_video_editor: ^1.7.0
-  pro_image_editor: ^12.0.8
+  pro_image_editor: ^12.0.9
   linked_scroll_controller: ^0.2.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
## Description

Resolve issue that the text input in the video editor overflows its background when the device font size is set to maximum.

**Related Issue:** Closes #2380

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore