### PR TITLE
fix(audio): correct sound index calculation in bundled sounds

### DIFF
--- a/mobile/lib/screens/sounds_screen.dart
+++ b/mobile/lib/screens/sounds_screen.dart
@@ -280,12 +280,11 @@ class _SoundsScreenState extends ConsumerState<SoundsScreen> {
     final bundledSounds =
         bundledSoundsAsync.whenOrNull(
           data: (service) {
-            final count = service.sounds.length;
             return service.sounds.indexed
                 .map(
                   (e) => AudioEvent.fromBundledSound(
                     e.$2,
-                    index: count - 1 - e.$1,
+                    index: e.$1,
                   ),
                 )
                 .toList();

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -149,12 +149,11 @@ class _AudioSelectionBottomSheetState
     final bundledSounds =
         bundledSoundsAsync.whenOrNull(
           data: (service) {
-            final count = service.sounds.length;
             return service.sounds.indexed
                 .map(
                   (e) => AudioEvent.fromBundledSound(
                     e.$2,
-                    index: count - 1 - e.$1,
+                    index: e.$1,
                   ),
                 )
                 .toList();


### PR DESCRIPTION
Closes #2387

 ## Description

Fix incorrect sort order of bundled sounds in the audio selection bottom sheet and sounds screen. The index was being reverse-calculated (`count - 1 - index`), which inverted the intended display order; this change uses the natural iteration index instead.


**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore