### PR TITLE
fix(ci): add missing upsertBotComment in PR Issue Link workflow

### DIFF
--- a/.github/workflows/pr_issue_link.yml
+++ b/.github/workflows/pr_issue_link.yml
@@ -245,6 +245,18 @@ jobs:
               ].join('\n');
             }
 
+            async function upsertBotComment(body) {
+              const comments = await github.rest.issues.listComments({
+                ...repo, issue_number: pr.number, per_page: 30,
+              });
+              const existing = comments.data.find(c => c.body && c.body.includes(BOT_MARKER));
+              if (existing) {
+                await github.rest.issues.updateComment({ ...repo, comment_id: existing.id, body });
+              } else {
+                await github.rest.issues.createComment({ ...repo, issue_number: pr.number, body });
+              }
+            }
+
             async function addLabel(name) {
               try {
                 await github.rest.issues.getLabel({ ...repo, name });


### PR DESCRIPTION
Closes #2393

## Summary

- Adds the missing `upsertBotComment` function to the PR Issue Link workflow
- The function was called on line 82 but never defined, causing `ReferenceError` when Step 5 (suggest matching issues) was reached
- Creates or updates a bot comment on the PR using the `BOT_MARKER` identifier

## Test plan

- [ ] Open a PR without a `Closes #` reference where matching issues exist — workflow should post a suggestion comment instead of crashing