### PR TITLE
fix(ui): remove left padding from app bar title when no leading widget

### DIFF
--- a/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar.dart
+++ b/mobile/packages/divine_ui/lib/src/app_bar/divine_app_bar.dart
@@ -238,31 +238,35 @@ class DiVineAppBar extends StatelessWidget implements PreferredSizeWidget {
     };
     final effectiveStyle = modeDefaultStyle.merge(style);
 
+    final hasLeading = showBackButton || showMenuButton || leadingIcon != null;
+
     final appBarContent = AppBar(
       backgroundColor: _getBackgroundColor(),
       surfaceTintColor: surfaceTintColor,
       elevation: 0,
       scrolledUnderElevation: 0,
       toolbarHeight: effectiveStyle.height,
-      leadingWidth: effectiveStyle.leadingWidth,
-      titleSpacing: 0,
+      leadingWidth: hasLeading ? effectiveStyle.leadingWidth : 0,
+      titleSpacing: hasLeading ? 0 : effectiveStyle.horizontalPadding,
       centerTitle: false,
       automaticallyImplyLeading: false,
       forceMaterialTransparency: forceMaterialTransparency,
       systemOverlayStyle: systemOverlayStyle,
       shape: shape,
       bottom: bottom,
-      leading: DiVineAppBarLeading(
-        showBackButton: showBackButton,
-        onBackPressed: onBackPressed,
-        backButtonSemanticLabel: backButtonSemanticLabel,
-        backButtonHeroTag: backButtonHeroTag,
-        showMenuButton: showMenuButton,
-        onMenuPressed: onMenuPressed,
-        leadingIcon: leadingIcon,
-        onLeadingPressed: onLeadingPressed,
-        style: effectiveStyle,
-      ),
+      leading: hasLeading
+          ? DiVineAppBarLeading(
+              showBackButton: showBackButton,
+              onBackPressed: onBackPressed,
+              backButtonSemanticLabel: backButtonSemanticLabel,
+              backButtonHeroTag: backButtonHeroTag,
+              showMenuButton: showMenuButton,
+              onMenuPressed: onMenuPressed,
+              leadingIcon: leadingIcon,
+              onLeadingPressed: onLeadingPressed,
+              style: effectiveStyle,
+            )
+          : null,
       title: DiVineAppBarTitle(
         title: title,
         titleWidget: titleWidget,

--- a/mobile/packages/divine_ui/test/src/app_bar/divine_app_bar_test.dart
+++ b/mobile/packages/divine_ui/test/src/app_bar/divine_app_bar_test.dart
@@ -416,15 +416,39 @@ void main() {
         expect(appBar.toolbarHeight, 72);
       });
 
-      testWidgets('has correct leadingWidth', (tester) async {
+      testWidgets('has zero leadingWidth when no leading widget', (
+        tester,
+      ) async {
         await tester.pumpWidget(buildTestWidget(title: 'Test'));
+
+        final appBar = tester.widget<AppBar>(find.byType(AppBar));
+        expect(appBar.leadingWidth, 0);
+      });
+
+      testWidgets('has correct leadingWidth when back button shown', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(title: 'Test', showBackButton: true),
+        );
 
         final appBar = tester.widget<AppBar>(find.byType(AppBar));
         expect(appBar.leadingWidth, 80);
       });
 
-      testWidgets('has zero titleSpacing', (tester) async {
+      testWidgets('uses horizontalPadding as titleSpacing without leading', (
+        tester,
+      ) async {
         await tester.pumpWidget(buildTestWidget(title: 'Test'));
+
+        final appBar = tester.widget<AppBar>(find.byType(AppBar));
+        expect(appBar.titleSpacing, 16);
+      });
+
+      testWidgets('has zero titleSpacing with leading', (tester) async {
+        await tester.pumpWidget(
+          buildTestWidget(title: 'Test', showBackButton: true),
+        );
 
         final appBar = tester.widget<AppBar>(find.byType(AppBar));
         expect(appBar.titleSpacing, 0);
@@ -472,6 +496,7 @@ void main() {
         await tester.pumpWidget(
           buildTestWidget(
             title: 'Test',
+            showBackButton: true,
             style: const DiVineAppBarStyle(
               height: 64,
               leadingWidth: 72,


### PR DESCRIPTION
Closes #2410

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Skip the leading widget and its reserved width when no back/menu/custom icon is configured, so the title sits flush-left with standard horizontal padding.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore