### PR TITLE
fix(dependencies): update pro_image_editor to version 12.0.10

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1739,10 +1739,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: af6eae5d3b5f3b854d3e06c3b90e85c60ffce54efcacab69cb75afc1235afb27
+      sha256: e9bc9e699133d83078cd4ba7f23aaa549e5616e8b208910d5ea3f161d99ca1ee
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.9"
+    version: "12.0.10"
   pro_video_editor:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -173,7 +173,7 @@ dependencies:
   convert: ^3.1.2
   audio_session: ^0.2.2
   pro_video_editor: ^1.7.0
-  pro_image_editor: ^12.0.9
+  pro_image_editor: ^12.0.10
   linked_scroll_controller: ^0.2.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
Closes #2413

## Description

ProImageEditor was not compatible with CocoaPods and only worked with SPM. This makes it backwards compatible.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore