### PR TITLE
refactor(dm): clean up new message sheet after BLoC extraction

### DIFF
--- a/mobile/lib/blocs/user_search/user_search_bloc.dart
+++ b/mobile/lib/blocs/user_search/user_search_bloc.dart
@@ -9,23 +9,12 @@ import 'package:models/models.dart';
 import 'package:openvine/constants/search_constants.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:profile_repository/profile_repository.dart';
-import 'package:stream_transform/stream_transform.dart';
 
 part 'user_search_event.dart';
 part 'user_search_state.dart';
 
 /// Number of results per page
 const _pageSize = 50;
-
-/// Event transformer that debounces and restarts on new events
-EventTransformer<E> _debounceRestartable<E>() {
-  return (events, mapper) {
-    return restartable<E>().call(
-      events.debounce(searchDebounceDuration),
-      mapper,
-    );
-  };
-}
 
 /// BLoC for searching user profiles.
 class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
@@ -38,7 +27,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
        super(const UserSearchState()) {
     on<UserSearchQueryChanged>(
       _onQueryChanged,
-      transformer: _debounceRestartable(),
+      transformer: debounceRestartable(),
     );
     on<UserSearchCleared>(_onCleared);
     on<UserSearchLoadMore>(_onLoadMore, transformer: sequential());

--- a/mobile/lib/constants/search_constants.dart
+++ b/mobile/lib/constants/search_constants.dart
@@ -1,4 +1,8 @@
-// ABOUTME: Shared constants for search UX and performance behavior.
+// ABOUTME: Shared constants and utilities for search UX and performance.
+
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:stream_transform/stream_transform.dart';
 
 /// Debounce duration applied to search query updates.
 const searchDebounceDuration = Duration(milliseconds: 300);
@@ -8,3 +12,16 @@ const searchDebounceDuration = Duration(milliseconds: 300);
 /// Single-character queries tend to explode result sets and force broad local
 /// scans plus remote searches on every keystroke.
 const minSearchQueryLength = 2;
+
+/// Event transformer that debounces then restarts on new events.
+///
+/// Combines [searchDebounceDuration] debounce with a restartable (switchMap)
+/// strategy so only the latest query is processed.
+EventTransformer<E> debounceRestartable<E>() {
+  return (events, mapper) {
+    return restartable<E>().call(
+      events.debounce(searchDebounceDuration),
+      mapper,
+    );
+  };
+}

--- a/mobile/lib/screens/inbox/bloc/bloc.dart
+++ b/mobile/lib/screens/inbox/bloc/bloc.dart
@@ -1,0 +1,1 @@
+export 'new_message_search_bloc.dart';

--- a/mobile/lib/screens/inbox/bloc/new_message_search_bloc.dart
+++ b/mobile/lib/screens/inbox/bloc/new_message_search_bloc.dart
@@ -3,27 +3,15 @@
 
 import 'dart:developer' as developer;
 
-import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart';
 import 'package:openvine/constants/search_constants.dart';
 import 'package:openvine/repositories/follow_repository.dart';
 import 'package:profile_repository/profile_repository.dart';
-import 'package:stream_transform/stream_transform.dart';
 
 part 'new_message_search_event.dart';
 part 'new_message_search_state.dart';
-
-/// Event transformer that debounces and restarts on new events.
-EventTransformer<E> _debounceRestartable<E>() {
-  return (events, mapper) {
-    return restartable<E>().call(
-      events.debounce(searchDebounceDuration),
-      mapper,
-    );
-  };
-}
 
 /// BLoC for the new message sheet that loads followed contacts and searches
 /// for users to start a DM conversation.
@@ -38,7 +26,7 @@ class NewMessageSearchBloc
     on<NewMessageSearchStarted>(_onStarted);
     on<NewMessageSearchQueryChanged>(
       _onQueryChanged,
-      transformer: _debounceRestartable(),
+      transformer: debounceRestartable(),
     );
     on<NewMessageSearchCleared>(_onCleared);
   }

--- a/mobile/lib/screens/inbox/new_message_sheet.dart
+++ b/mobile/lib/screens/inbox/new_message_sheet.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart';
 import 'package:openvine/repositories/follow_repository.dart';
-import 'package:openvine/screens/inbox/bloc/new_message_search_bloc.dart';
+import 'package:openvine/screens/inbox/bloc/bloc.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:profile_repository/profile_repository.dart';
 
@@ -124,41 +124,28 @@ class _ResultsBody extends StatelessWidget {
           NewMessageSearchStatus.loadingContacts => const Center(
             child: CircularProgressIndicator(color: VineTheme.primary),
           ),
-          NewMessageSearchStatus.idle => _ContactsList(
-            contacts: state.contacts,
+          NewMessageSearchStatus.idle => _UserProfileList(
+            profiles: state.contacts,
+            emptyMessage: 'No contacts found.\nFollow people to see them here.',
           ),
           NewMessageSearchStatus.searching when state.results.isEmpty =>
             const Center(
               child: CircularProgressIndicator(color: VineTheme.primary),
             ),
-          NewMessageSearchStatus.searching => _UserResultsList(
-            results: state.results,
+          NewMessageSearchStatus.searching => _UserProfileList(
+            profiles: state.results,
           ),
           NewMessageSearchStatus.searchSuccess when state.results.isNotEmpty =>
-            _UserResultsList(results: state.results),
-          NewMessageSearchStatus.searchSuccess => Center(
-            child: Padding(
-              padding: const EdgeInsets.all(32),
-              child: Text(
-                'No users found',
-                style: VineTheme.bodyMediumFont(
-                  color: VineTheme.onSurfaceMuted,
-                ),
-              ),
-            ),
+            _UserProfileList(profiles: state.results),
+          NewMessageSearchStatus.searchSuccess => const _UserProfileList(
+            profiles: [],
+            emptyMessage: 'No users found',
           ),
           NewMessageSearchStatus.searchFailure when state.results.isNotEmpty =>
-            _UserResultsList(results: state.results),
-          NewMessageSearchStatus.searchFailure => Center(
-            child: Padding(
-              padding: const EdgeInsets.all(32),
-              child: Text(
-                'Search failed. Please try again.',
-                style: VineTheme.bodyMediumFont(
-                  color: VineTheme.onSurfaceMuted,
-                ),
-              ),
-            ),
+            _UserProfileList(profiles: state.results),
+          NewMessageSearchStatus.searchFailure => const _UserProfileList(
+            profiles: [],
+            emptyMessage: 'Search failed. Please try again.',
           ),
         };
       },
@@ -236,19 +223,23 @@ class _SearchField extends StatelessWidget {
   }
 }
 
-class _ContactsList extends StatelessWidget {
-  const _ContactsList({required this.contacts});
+class _UserProfileList extends StatelessWidget {
+  const _UserProfileList({
+    required this.profiles,
+    this.emptyMessage,
+  });
 
-  final List<UserProfile> contacts;
+  final List<UserProfile> profiles;
+  final String? emptyMessage;
 
   @override
   Widget build(BuildContext context) {
-    if (contacts.isEmpty) {
+    if (profiles.isEmpty && emptyMessage != null) {
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(32),
           child: Text(
-            'No contacts found.\nFollow people to see them here.',
+            emptyMessage!,
             style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted),
             textAlign: TextAlign.center,
           ),
@@ -257,7 +248,7 @@ class _ContactsList extends StatelessWidget {
     }
 
     return ListView.separated(
-      itemCount: contacts.length,
+      itemCount: profiles.length,
       separatorBuilder: (_, _) => const Divider(
         height: 1,
         thickness: 1,
@@ -265,33 +256,7 @@ class _ContactsList extends StatelessWidget {
         indent: 72,
       ),
       itemBuilder: (context, index) {
-        final profile = contacts[index];
-        return _UserTile(
-          profile: profile,
-          onTap: () => Navigator.of(context).pop(profile),
-        );
-      },
-    );
-  }
-}
-
-class _UserResultsList extends StatelessWidget {
-  const _UserResultsList({required this.results});
-
-  final List<UserProfile> results;
-
-  @override
-  Widget build(BuildContext context) {
-    return ListView.separated(
-      itemCount: results.length,
-      separatorBuilder: (_, _) => const Divider(
-        height: 1,
-        thickness: 1,
-        color: VineTheme.outlineMuted,
-        indent: 72,
-      ),
-      itemBuilder: (context, index) {
-        final profile = results[index];
+        final profile = profiles[index];
         return _UserTile(
           profile: profile,
           onTap: () => Navigator.of(context).pop(profile),


### PR DESCRIPTION
Closes #2415

## Summary

Follow-up to #2401 per [review feedback](https://github.com/divinevideo/divine-mobile/pull/2401#discussion_r2974106022).

- **Extract shared `debounceRestartable` transformer** — was duplicated between `UserSearchBloc` and `NewMessageSearchBloc`; now lives in `search_constants.dart`
- **Consolidate duplicate list widgets** — `_ContactsList` and `_UserResultsList` merged into a single `_UserProfileList` widget with an optional `emptyMessage`
- **Add barrel file** for `screens/inbox/bloc/`

## Test plan

- [x] All 13 `NewMessageSearchBloc` tests pass
- [x] All 36 `UserSearchBloc` tests pass
- [x] `flutter analyze` clean on all changed files