### PR TITLE
fix(zendesk): add Crashlytics reporting to ticket creation error paths

### DIFF
--- a/mobile/lib/services/zendesk_support_service.dart
+++ b/mobile/lib/services/zendesk_support_service.dart
@@ -1,11 +1,13 @@
 // ABOUTME: Flutter wrapper for Zendesk Support (native SDK + REST API fallback)
 // ABOUTME: Provides ticket creation via native iOS/Android SDKs or REST API for desktop
 
+import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:openvine/config/zendesk_config.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/nip98_auth_service.dart';
 import 'package:openvine/utils/unified_logger.dart';
 
@@ -14,6 +16,9 @@ class ZendeskSupportService {
   static const MethodChannel _channel = MethodChannel(
     'com.openvine/zendesk_support',
   );
+
+  static final CrashReportingService _crashlytics =
+      CrashReportingService.instance;
 
   static bool _initialized = false;
 
@@ -440,6 +445,14 @@ class ZendeskSupportService {
           'Failed to create Zendesk ticket: $subject',
           category: LogCategory.system,
         );
+        _crashlytics.log('Zendesk SDK returned false for ticket: $subject');
+        unawaited(
+          _crashlytics.recordError(
+            Exception('Zendesk SDK returned false'),
+            StackTrace.current,
+            reason: 'zendesk_sdk_returned_false',
+          ),
+        );
         return false;
       }
     } on MissingPluginException {
@@ -512,10 +525,18 @@ class ZendeskSupportService {
         requesterEmail: _userEmail,
         tags: tags,
       );
-    } catch (e) {
+    } catch (e, stackTrace) {
       Log.error(
         'Unexpected error creating Zendesk ticket: $e',
         category: LogCategory.system,
+      );
+      _crashlytics.log('Zendesk createTicket failed: $subject');
+      unawaited(
+        _crashlytics.recordError(
+          e,
+          stackTrace,
+          reason: 'zendesk_ticket_unexpected_error',
+        ),
       );
       return false;
     }
@@ -609,6 +630,16 @@ class ZendeskSupportService {
           'Zendesk API error: ${response.statusCode} - ${response.body}',
           category: LogCategory.system,
         );
+        _crashlytics.log(
+          'Zendesk REST API error ${response.statusCode}: $subject',
+        );
+        unawaited(
+          _crashlytics.recordError(
+            Exception('Zendesk REST API HTTP error'),
+            StackTrace.current,
+            reason: 'zendesk_rest_api_http_error',
+          ),
+        );
         return false;
       }
     } catch (e, stackTrace) {
@@ -617,6 +648,14 @@ class ZendeskSupportService {
         category: LogCategory.system,
         error: e,
         stackTrace: stackTrace,
+      );
+      _crashlytics.log('Zendesk REST API exception for ticket: $subject');
+      unawaited(
+        _crashlytics.recordError(
+          e,
+          stackTrace,
+          reason: 'zendesk_rest_api_exception',
+        ),
       );
       return false;
     }
@@ -828,6 +867,16 @@ class ZendeskSupportService {
           'Zendesk API error: ${response.statusCode} - ${response.body}',
           category: LogCategory.system,
         );
+        _crashlytics.log(
+          'Zendesk form API error ${response.statusCode}: $label',
+        );
+        unawaited(
+          _crashlytics.recordError(
+            Exception('Zendesk form API HTTP error'),
+            StackTrace.current,
+            reason: 'zendesk_form_api_http_error',
+          ),
+        );
         return false;
       }
     } catch (e, stackTrace) {
@@ -836,6 +885,14 @@ class ZendeskSupportService {
         category: LogCategory.system,
         error: e,
         stackTrace: stackTrace,
+      );
+      _crashlytics.log('Zendesk form API exception for: $label');
+      unawaited(
+        _crashlytics.recordError(
+          e,
+          stackTrace,
+          reason: 'zendesk_form_api_exception',
+        ),
       );
       return false;
     }


### PR DESCRIPTION
Closes #2420

## Summary

- Add Crashlytics error reporting to Zendesk ticket creation failure paths in `zendesk_support_service.dart`

## Context

Cherry-picked from `fix/loop-enforcement-non-divine-videos` where it was committed by mistake — unrelated to the loop enforcement work on that branch.

## Test plan

- [ ] Zendesk ticket creation failure triggers Crashlytics event
- [ ] Normal ticket creation unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)