### PR TITLE
refactor: add VineCachedImage wrapper for consistent cache manager usage

### DIFF
--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -1,16 +1,15 @@
 // ABOUTME: Safety Settings screen - navigation hub for moderation and user safety
 // ABOUTME: Provides age verification gate and navigation to sub-screens
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
-import 'package:openvine/services/image_cache_manager.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/npub_hex.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 class SafetySettingsScreen extends ConsumerStatefulWidget {
   /// Route name for this screen.
@@ -409,12 +408,10 @@ class _BlockedUserTile extends ConsumerWidget {
         child: ClipRRect(
           borderRadius: BorderRadius.circular(11),
           child: profile?.picture != null && profile!.picture!.isNotEmpty
-              ? CachedNetworkImage(
+              ? VineCachedImage(
                   imageUrl: profile.picture!,
                   width: 38,
                   height: 38,
-                  fit: BoxFit.cover,
-                  cacheManager: openVineImageCache,
                   placeholder: (context, url) => Image.asset(
                     'assets/icon/acid_avatar.png',
                     width: 38,

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -1,7 +1,6 @@
 // ABOUTME: Detail screen for viewing a sound and videos using that sound.
 // ABOUTME: Displays sound info, preview/use buttons, and grid of related videos.
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -16,6 +15,7 @@ import 'package:openvine/services/screen_analytics_service.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:sound_service/sound_service.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -855,9 +855,8 @@ class _VideoThumbnail extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (thumbnailUrl != null && thumbnailUrl!.isNotEmpty) {
-      return CachedNetworkImage(
+      return VineCachedImage(
         imageUrl: thumbnailUrl!,
-        fit: BoxFit.cover,
         placeholder: (context, url) => const _ThumbnailPlaceholder(),
         errorWidget: (context, url, error) => const _ThumbnailPlaceholder(),
       );

--- a/mobile/lib/widgets/notification_list_item.dart
+++ b/mobile/lib/widgets/notification_list_item.dart
@@ -1,13 +1,12 @@
 // ABOUTME: Widget for displaying individual notification items in the notifications list
 // ABOUTME: Shows actor avatar, notification message, timestamp, and action buttons
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:models/models.dart';
-import 'package:openvine/services/image_cache_manager.dart';
 import 'package:openvine/theme/app_theme.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 class NotificationListItem extends StatelessWidget {
   const NotificationListItem({
@@ -98,12 +97,10 @@ class NotificationListItem extends StatelessWidget {
         // Avatar
         ClipOval(
           child: notification.actorPictureUrl != null
-              ? CachedNetworkImage(
+              ? VineCachedImage(
                   imageUrl: notification.actorPictureUrl!,
                   width: 48,
                   height: 48,
-                  fit: BoxFit.cover,
-                  cacheManager: openVineImageCache,
                   placeholder: (context, url) => Container(
                     width: 48,
                     height: 48,
@@ -245,12 +242,10 @@ class NotificationListItem extends StatelessWidget {
     padding: const EdgeInsets.only(left: 8),
     child: ClipRRect(
       borderRadius: BorderRadius.circular(8),
-      child: CachedNetworkImage(
+      child: VineCachedImage(
         imageUrl: notification.targetVideoThumbnail!,
         width: 64,
         height: 64,
-        fit: BoxFit.cover,
-        cacheManager: openVineImageCache,
         placeholder: (context, url) => Container(
           width: 64,
           height: 64,

--- a/mobile/lib/widgets/profile/profile_collabs_grid.dart
+++ b/mobile/lib/widgets/profile/profile_collabs_grid.dart
@@ -2,7 +2,6 @@
 // ABOUTME: Shows 3-column grid with thumbnails for videos where user
 // ABOUTME: is tagged as a collaborator
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -13,6 +12,7 @@ import 'package:openvine/mixins/grid_prefetch_mixin.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Grid widget displaying user's collab videos.
 ///
@@ -244,9 +244,8 @@ class _CollabThumbnail extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (thumbnailUrl != null && thumbnailUrl!.isNotEmpty) {
-      return CachedNetworkImage(
+      return VineCachedImage(
         imageUrl: thumbnailUrl!,
-        fit: BoxFit.cover,
         placeholder: (context, url) => const _CollabThumbnailPlaceholder(),
         errorWidget: (context, url, error) =>
             const _CollabThumbnailPlaceholder(),

--- a/mobile/lib/widgets/profile/profile_comments_grid.dart
+++ b/mobile/lib/widgets/profile/profile_comments_grid.dart
@@ -2,7 +2,6 @@
 // ABOUTME: Shows video replies as a 3-column thumbnail grid at top,
 // ABOUTME: followed by text comments as a list below.
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -10,6 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/profile_comments/profile_comments_bloc.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Grid widget displaying a user's comments (video replies + text).
 ///
@@ -241,9 +241,8 @@ class _VideoReplyThumbnail extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (thumbnailUrl != null && thumbnailUrl!.isNotEmpty) {
-      return CachedNetworkImage(
+      return VineCachedImage(
         imageUrl: thumbnailUrl!,
-        fit: BoxFit.cover,
         placeholder: (context, url) => const _ThumbnailPlaceholder(),
         errorWidget: (context, url, error) => const _ThumbnailPlaceholder(),
       );

--- a/mobile/lib/widgets/profile/profile_liked_grid.dart
+++ b/mobile/lib/widgets/profile/profile_liked_grid.dart
@@ -1,7 +1,6 @@
 // ABOUTME: Grid widget displaying user's liked videos on profile page
 // ABOUTME: Shows 3-column grid with thumbnails and heart badge indicator
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -11,6 +10,7 @@ import 'package:openvine/blocs/profile_liked_videos/profile_liked_videos_bloc.da
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Grid widget displaying user's liked videos
 ///
@@ -228,9 +228,8 @@ class _LikedThumbnail extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (thumbnailUrl != null && thumbnailUrl!.isNotEmpty) {
-      return CachedNetworkImage(
+      return VineCachedImage(
         imageUrl: thumbnailUrl!,
-        fit: BoxFit.cover,
         placeholder: (context, url) => const _LikedThumbnailPlaceholder(),
         errorWidget: (context, url, error) =>
             const _LikedThumbnailPlaceholder(),

--- a/mobile/lib/widgets/profile/profile_reposts_grid.dart
+++ b/mobile/lib/widgets/profile/profile_reposts_grid.dart
@@ -1,7 +1,6 @@
 // ABOUTME: Grid widget displaying user's reposted videos on profile page
 // ABOUTME: Shows 3-column grid with thumbnails and repost badge indicator
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -11,6 +10,7 @@ import 'package:openvine/blocs/profile_reposted_videos/profile_reposted_videos_b
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Grid widget displaying user's reposted videos
 ///
@@ -223,9 +223,8 @@ class _RepostThumbnail extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (thumbnailUrl != null && thumbnailUrl!.isNotEmpty) {
-      return CachedNetworkImage(
+      return VineCachedImage(
         imageUrl: thumbnailUrl!,
-        fit: BoxFit.cover,
         placeholder: (context, url) => const _RepostThumbnailPlaceholder(),
         errorWidget: (context, url, error) =>
             const _RepostThumbnailPlaceholder(),

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -4,7 +4,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -18,6 +17,7 @@ import 'package:openvine/providers/profile_feed_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:rxdart/rxdart.dart';
 
 /// Internal class that represents a video entry in the grid
@@ -353,9 +353,8 @@ class _VideoThumbnail extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (thumbnailUrl != null && thumbnailUrl!.isNotEmpty) {
-      return CachedNetworkImage(
+      return VineCachedImage(
         imageUrl: thumbnailUrl!,
-        fit: BoxFit.cover,
         placeholder: (context, url) => const _ThumbnailPlaceholder(),
         errorWidget: (context, url, error) => const _ThumbnailPlaceholder(),
       );

--- a/mobile/lib/widgets/user_avatar.dart
+++ b/mobile/lib/widgets/user_avatar.dart
@@ -3,11 +3,10 @@
 
 import 'dart:math' as math;
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
-import 'package:openvine/services/image_cache_manager.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 enum UserAvatarPlaceholderTone {
   auto,
@@ -135,10 +134,8 @@ class UserAvatar extends StatelessWidget {
     }
 
     if (imageUrl != null && imageUrl!.isNotEmpty) {
-      return CachedNetworkImage(
+      return VineCachedImage(
         imageUrl: imageUrl!,
-        fit: BoxFit.cover,
-        cacheManager: openVineImageCache,
         placeholder: (context, url) => _buildPlaceholder(),
         errorWidget: (context, url, error) {
           if (error.toString().contains('Invalid image data') ||

--- a/mobile/lib/widgets/video_editor/sticker_editor/video_editor_sticker.dart
+++ b/mobile/lib/widgets/video_editor/sticker_editor/video_editor_sticker.dart
@@ -1,10 +1,10 @@
 // ABOUTME: Sticker display widget supporting both asset and network images.
 // ABOUTME: Includes memory-efficient caching based on displayed size.
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:models/models.dart' show StickerData;
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// A sticker widget that displays an image from either an asset or URL.
 ///
@@ -77,9 +77,9 @@ class _RawImage extends StatelessWidget {
             cacheHeight: cacheHeight,
             errorBuilder: (context, error, stackTrace) => const _ErrorImage(),
           )
-        : CachedNetworkImage(
+        : VineCachedImage(
             imageUrl: sticker.networkUrl!,
-            fit: .contain,
+            fit: BoxFit.contain,
             memCacheWidth: cacheWidth,
             memCacheHeight: cacheHeight,
             placeholder: (context, url) =>

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -1,15 +1,14 @@
 // ABOUTME: Smart video thumbnail widget that displays thumbnails or blurhash placeholders
 // ABOUTME: Uses existing thumbnail URLs from video events and falls back to blurhash when missing
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:models/models.dart' hide AspectRatio, LogCategory;
 import 'package:openvine/extensions/video_event_extensions.dart';
-import 'package:openvine/services/image_cache_manager.dart';
 import 'package:openvine/services/thumbnail_api_service.dart'
     show ThumbnailSize;
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Smart thumbnail widget that displays thumbnails with blurhash fallback
 class VideoThumbnailWidget extends StatefulWidget {
@@ -332,13 +331,12 @@ class _SafeNetworkImage extends StatelessWidget {
       );
     }
 
-    return CachedNetworkImage(
+    return VineCachedImage(
       imageUrl: url,
       width: width,
       height: height,
       fit: fit,
       alignment: Alignment.topCenter,
-      cacheManager: openVineImageCache,
       // Show transparent container so background surfaceContainer color shows through
       placeholder: (context, url) =>
           Container(width: width, height: height, color: VineTheme.transparent),

--- a/mobile/lib/widgets/vine_cached_image.dart
+++ b/mobile/lib/widgets/vine_cached_image.dart
@@ -1,0 +1,46 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/widgets.dart';
+import 'package:openvine/services/image_cache_manager.dart';
+
+/// A wrapper around [CachedNetworkImage] that always uses
+/// [openVineImageCache] as the cache manager.
+class VineCachedImage extends StatelessWidget {
+  const VineCachedImage({
+    required this.imageUrl,
+    super.key,
+    this.width,
+    this.height,
+    this.fit = BoxFit.cover,
+    this.alignment = Alignment.center,
+    this.placeholder,
+    this.errorWidget,
+    this.memCacheWidth,
+    this.memCacheHeight,
+  });
+
+  final String imageUrl;
+  final double? width;
+  final double? height;
+  final BoxFit fit;
+  final Alignment alignment;
+  final PlaceholderWidgetBuilder? placeholder;
+  final LoadingErrorWidgetBuilder? errorWidget;
+  final int? memCacheWidth;
+  final int? memCacheHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    return CachedNetworkImage(
+      imageUrl: imageUrl,
+      width: width,
+      height: height,
+      fit: fit,
+      alignment: alignment,
+      cacheManager: openVineImageCache,
+      placeholder: placeholder,
+      errorWidget: errorWidget,
+      memCacheWidth: memCacheWidth,
+      memCacheHeight: memCacheHeight,
+    );
+  }
+}

--- a/mobile/test/widgets/vine_cached_image_test.dart
+++ b/mobile/test/widgets/vine_cached_image_test.dart
@@ -1,0 +1,130 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/image_cache_manager.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
+
+void main() {
+  group(VineCachedImage, () {
+    const testUrl = 'https://example.com/image.jpg';
+
+    testWidgets('renders $CachedNetworkImage with correct imageUrl', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: VineCachedImage(imageUrl: testUrl),
+        ),
+      );
+
+      expect(find.byType(CachedNetworkImage), findsOneWidget);
+
+      final cached = tester.widget<CachedNetworkImage>(
+        find.byType(CachedNetworkImage),
+      );
+      expect(cached.imageUrl, equals(testUrl));
+    });
+
+    testWidgets('uses openVineImageCache as cacheManager', (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: VineCachedImage(imageUrl: testUrl),
+        ),
+      );
+
+      final cached = tester.widget<CachedNetworkImage>(
+        find.byType(CachedNetworkImage),
+      );
+      expect(cached.cacheManager, equals(openVineImageCache));
+    });
+
+    testWidgets('defaults fit to BoxFit.cover', (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: VineCachedImage(imageUrl: testUrl),
+        ),
+      );
+
+      final cached = tester.widget<CachedNetworkImage>(
+        find.byType(CachedNetworkImage),
+      );
+      expect(cached.fit, equals(BoxFit.cover));
+    });
+
+    testWidgets('defaults alignment to Alignment.center', (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: VineCachedImage(imageUrl: testUrl),
+        ),
+      );
+
+      final cached = tester.widget<CachedNetworkImage>(
+        find.byType(CachedNetworkImage),
+      );
+      expect(cached.alignment, equals(Alignment.center));
+    });
+
+    testWidgets('passes width and height through', (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: VineCachedImage(
+            imageUrl: testUrl,
+            width: 100,
+            height: 200,
+          ),
+        ),
+      );
+
+      final cached = tester.widget<CachedNetworkImage>(
+        find.byType(CachedNetworkImage),
+      );
+      expect(cached.width, equals(100));
+      expect(cached.height, equals(200));
+    });
+
+    testWidgets('passes fit and alignment through', (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: VineCachedImage(
+            imageUrl: testUrl,
+            fit: BoxFit.contain,
+            alignment: Alignment.topCenter,
+          ),
+        ),
+      );
+
+      final cached = tester.widget<CachedNetworkImage>(
+        find.byType(CachedNetworkImage),
+      );
+      expect(cached.fit, equals(BoxFit.contain));
+      expect(cached.alignment, equals(Alignment.topCenter));
+    });
+
+    testWidgets('passes memCacheWidth and memCacheHeight through', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: VineCachedImage(
+            imageUrl: testUrl,
+            memCacheWidth: 256,
+            memCacheHeight: 512,
+          ),
+        ),
+      );
+
+      final cached = tester.widget<CachedNetworkImage>(
+        find.byType(CachedNetworkImage),
+      );
+      expect(cached.memCacheWidth, equals(256));
+      expect(cached.memCacheHeight, equals(512));
+    });
+  });
+}


### PR DESCRIPTION
## Description

Introduces a `VineCachedImage` wrapper widget that always injects `openVineImageCache`, replacing all 12 direct `CachedNetworkImage` usages across 11 files. This eliminates the risk of forgetting to pass the app's cache manager at individual call sites.

**Related Issue:** Closes #2078

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore