### PR TITLE
fix: back button after viewing hashtag video returns to hashtag grid

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1036,6 +1036,9 @@ class _DivineAppState extends ConsumerState<DivineApp> {
       // If so, navigate back to parent route
       switch (ctx.type) {
         case RouteType.hashtag:
+          // Hashtag is a standalone screen — pop back
+          router.pop();
+          return true; // Handled
         case RouteType.search:
           // Go back to explore
           router.go(ExploreScreen.path);
@@ -1173,15 +1176,13 @@ class _DivineAppState extends ConsumerState<DivineApp> {
     Widget wrapped = MultiRepositoryProvider(
       providers: [
         RepositoryProvider(
-          create: (_) => InviteApiService(
-            authService: ref.read(nip98AuthServiceProvider),
-          ),
+          create: (_) =>
+              InviteApiService(authService: ref.read(nip98AuthServiceProvider)),
           dispose: (service) => service.dispose(),
         ),
         BlocProvider(
-          create: (_) => DmUnreadCountCubit(
-            dmRepository: ref.read(dmRepositoryProvider),
-          ),
+          create: (_) =>
+              DmUnreadCountCubit(dmRepository: ref.read(dmRepositoryProvider)),
         ),
       ],
       child: MultiBlocProvider(

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -30,6 +30,7 @@ import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/fullscreen_video_feed_screen.dart';
+import 'package:openvine/screens/hashtag_feed_screen.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/inbox/inbox_page.dart';
@@ -397,25 +398,25 @@ final goRouterProvider = Provider<GoRouter>((ref) {
               ),
             ),
           ),
-
-          // HASHTAG route - grid mode (no index)
-          GoRoute(
-            path: HashtagScreenRouter.path,
-            name: HashtagScreenRouter.routeName,
-            pageBuilder: (ctx, st) => NoTransitionPage(
-              key: st.pageKey,
-              child: Navigator(
-                key: NavigatorKeys.hashtagGrid,
-                onGenerateRoute: (r) => MaterialPageRoute(
-                  builder: (_) => const HashtagScreenRouter(),
-                  settings: const RouteSettings(
-                    name: HashtagScreenRouter.routeName,
-                  ),
-                ),
-              ),
-            ),
-          ),
         ],
+      ),
+
+      // HASHTAG route - standalone screen (no bottom nav)
+      GoRoute(
+        path: HashtagScreenRouter.path,
+        name: HashtagScreenRouter.routeName,
+        parentNavigatorKey: NavigatorKeys.root,
+        builder: (ctx, st) {
+          final tag = st.pathParameters['tag'];
+          if (tag == null || tag.isEmpty) {
+            return const Scaffold(
+              appBar: DiVineAppBar(title: 'Error'),
+              body: Center(child: Text('Invalid hashtag')),
+            );
+          }
+          final decoded = Uri.decodeComponent(tag);
+          return HashtagFeedScreen(hashtag: decoded);
+        },
       ),
 
       // DM conversation detail (pushed from inbox, no bottom nav)
@@ -809,9 +810,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           final extra = st.extra as Map<String, dynamic>?;
           final fromLibrary = extra?['fromLibrary'] as bool? ?? false;
 
-          return VideoEditorScreen(
-            fromLibrary: fromLibrary,
-          );
+          return VideoEditorScreen(fromLibrary: fromLibrary);
         },
       ),
       GoRoute(
@@ -923,8 +922,6 @@ int tabIndexFromLocation(String loc) {
       return 0;
     case 'explore':
       return 1;
-    case 'hashtag':
-      return 1; // Hashtag keeps explore tab active
     case 'notifications':
     case 'inbox':
       return 2; // Inbox replaces notifications in the same tab position
@@ -962,6 +959,7 @@ int tabIndexFromLocation(String loc) {
     case 'list':
     case 'discover-lists':
     case 'creator-analytics':
+    case 'hashtag':
       return -1; // Non-tab routes - no bottom nav (outside shell)
     default:
       return 0; // fallback to home

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -74,9 +74,6 @@ class _AppShellState extends ConsumerState<AppShell> {
         return 'Notifications';
       case RouteType.inbox:
         return 'Inbox';
-      case RouteType.hashtag:
-        final raw = ctx?.hashtag ?? '';
-        return raw.isEmpty ? '#—' : '#$raw';
       case RouteType.profile:
         final npub = ctx?.npub ?? '';
         if (npub == 'me') {
@@ -115,8 +112,7 @@ class _AppShellState extends ConsumerState<AppShell> {
   int? _tabIndexFromRouteType(RouteType type) {
     return switch (type) {
       RouteType.home => 0,
-      // Hashtag is part of explore tab
-      RouteType.explore || RouteType.hashtag => 1,
+      RouteType.explore => 1,
       RouteType.notifications || RouteType.inbox => 2,
       RouteType.profile => 3,
       // Not a main tab route
@@ -190,8 +186,7 @@ class _AppShellState extends ConsumerState<AppShell> {
     final routeType = ctx?.type;
 
     // Check if title should be tappable (Explore-related routes)
-    final isTappable =
-        routeType == RouteType.explore || routeType == RouteType.hashtag;
+    final isTappable = routeType == RouteType.explore;
 
     final titleWidget = Text(
       title,
@@ -305,8 +300,7 @@ class _AppShellState extends ConsumerState<AppShell> {
     );
     final showBackButton = pageCtxAsync.maybeWhen(
       data: (ctx) {
-        final isSubRoute =
-            ctx.type == RouteType.hashtag || ctx.type == RouteType.search;
+        final isSubRoute = ctx.type == RouteType.search;
         final isExploreVideo =
             ctx.type == RouteType.explore && ctx.videoIndex != null;
         // Notifications base state is index 0, not null
@@ -370,7 +364,6 @@ class _AppShellState extends ConsumerState<AppShell> {
                       // Check if we're in a sub-route (hashtag, search, etc.)
                       // If so, navigate back to parent route
                       switch (ctx.type) {
-                        case RouteType.hashtag:
                         case RouteType.search:
                           // Go back to explore
                           return context.go(ExploreScreen.path);

--- a/mobile/lib/router/navigator_keys.dart
+++ b/mobile/lib/router/navigator_keys.dart
@@ -44,11 +44,6 @@ class NavigatorKeys {
     debugLabel: 'search-feed',
   );
 
-  /// Hashtag navigator key for grid mode (no video index).
-  static final hashtagGrid = GlobalKey<NavigatorState>(
-    debugLabel: 'hashtag-grid',
-  );
-
   /// Inbox tab navigator key (Messages + Notifications).
   static final inbox = GlobalKey<NavigatorState>(debugLabel: 'inbox');
 

--- a/mobile/lib/screens/hashtag_feed_screen.dart
+++ b/mobile/lib/screens/hashtag_feed_screen.dart
@@ -16,7 +16,6 @@ import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
-import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:rxdart/rxdart.dart';
 
 class HashtagFeedScreen extends ConsumerStatefulWidget {
@@ -372,85 +371,15 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
           );
         }
 
-        // Use grid view when embedded (in explore), full-screen list when standalone
-        if (widget.embedded) {
-          return ComposableVideoGrid(
-            videos: videos,
-            useMasonryLayout: true,
-            onVideoTap:
-                widget.onVideoTap ??
-                (videoList, index) {
-                  _navigateToFullscreenFeed(context, videoList, index);
-                },
-            onRefresh: _loadHashtagVideos,
-          );
-        }
-
-        // Standalone mode: full-screen scrollable list
-        final isLoadingMore = isLoadingHashtag;
-
-        return RefreshIndicator(
-          semanticsLabel: 'searching for more videos',
-          color: VineTheme.onPrimary,
-          backgroundColor: VineTheme.vineGreen,
+        return ComposableVideoGrid(
+          videos: videos,
+          useMasonryLayout: true,
+          onVideoTap:
+              widget.onVideoTap ??
+              (videoList, index) {
+                _navigateToFullscreenFeed(context, videoList, index);
+              },
           onRefresh: _loadHashtagVideos,
-          child: ListView.builder(
-            // Add 1 for loading indicator if still loading
-            itemCount: videos.length + (isLoadingMore ? 1 : 0),
-            itemBuilder: (context, index) {
-              // Show loading indicator as last item
-              if (index == videos.length) {
-                return Container(
-                  height: MediaQuery.of(context).size.height,
-                  alignment: Alignment.center,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const CircularProgressIndicator(
-                        color: VineTheme.vineGreen,
-                      ),
-                      const SizedBox(height: 24),
-                      Text(
-                        'Getting more videos about #${widget.hashtag}...',
-                        style: const TextStyle(
-                          color: VineTheme.primaryText,
-                          fontSize: 18,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      const Text(
-                        'Please wait while we fetch from relays',
-                        style: TextStyle(
-                          color: VineTheme.secondaryText,
-                          fontSize: 14,
-                        ),
-                      ),
-                    ],
-                  ),
-                );
-              }
-
-              final video = videos[index];
-              return GestureDetector(
-                onTap: () {
-                  _navigateToFullscreenFeed(context, videos, index);
-                },
-                child: SizedBox(
-                  height: MediaQuery.of(context).size.height,
-                  width: double.infinity,
-                  child: VideoFeedItem(
-                    video: video,
-                    index: index,
-                    contextTitle: '#${widget.hashtag}',
-                    forceShowOverlay: true,
-                    trafficSource: ViewTrafficSource.search,
-                    sourceDetail: widget.hashtag,
-                  ),
-                ),
-              );
-            },
-          ),
         );
       },
     );
@@ -466,7 +395,6 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
         title: '#${widget.hashtag}',
         showBackButton: true,
         onBackPressed: context.pop,
-        backgroundColor: VineTheme.vineGreen,
       ),
       body: body,
     );

--- a/mobile/lib/widgets/clickable_hashtag_text.dart
+++ b/mobile/lib/widgets/clickable_hashtag_text.dart
@@ -204,8 +204,8 @@ class ClickableHashtagText extends ConsumerWidget {
     // Notify parent about video state change if callback provided
     onVideoStateChange?.call();
 
-    // Navigate to hashtag grid view (no index = grid mode)
-    context.go(HashtagScreenRouter.pathForTag(hashtag));
+    // Navigate to standalone hashtag screen (outside shell, no bottom nav)
+    context.push(HashtagScreenRouter.pathForTag(hashtag));
   }
 
   void _navigateToProfile(BuildContext context, String hexPubkey) {

--- a/mobile/lib/widgets/hashtag_search_view.dart
+++ b/mobile/lib/widgets/hashtag_search_view.dart
@@ -128,7 +128,7 @@ class _HashtagResultTile extends StatelessWidget {
             'HashtagSearchView: Tapped hashtag: $hashtag',
             category: LogCategory.video,
           );
-          context.go(HashtagScreenRouter.pathForTag(hashtag));
+          context.push(HashtagScreenRouter.pathForTag(hashtag));
         },
       ),
     );
@@ -173,10 +173,7 @@ class _HashtagSearchErrorState extends StatelessWidget {
         children: [
           Icon(Icons.error_outline, size: 64, color: VineTheme.error),
           SizedBox(height: 16),
-          Text(
-            'Search failed',
-            style: TextStyle(color: VineTheme.lightText),
-          ),
+          Text('Search failed', style: TextStyle(color: VineTheme.lightText)),
         ],
       ),
     );

--- a/mobile/lib/widgets/trending_hashtags_section.dart
+++ b/mobile/lib/widgets/trending_hashtags_section.dart
@@ -88,7 +88,7 @@ class _HashtagChipList extends StatelessWidget {
             if (onHashtagTap != null) {
               onHashtagTap!(hashtag);
             } else {
-              context.go(HashtagScreenRouter.pathForTag(hashtag));
+              context.push(HashtagScreenRouter.pathForTag(hashtag));
             }
           },
         );


### PR DESCRIPTION
## Description

Move the hashtag feed route outside the ShellRoute so it renders as a standalone screen without the bottom navigation bar. The standalone screen now shows the video grid (same as embedded mode) instead of a full-screen video list, and tapping a video opens the fullscreen feed via push navigation.

**Related Issue:** Closes #1752

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore