### PR TITLE
fix(video): serve classic Vine originals from raw blob

### DIFF
--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -249,13 +249,15 @@ extension VideoEventAppExtensions on VideoEvent {
   /// Get the optimal video URL for initial playback.
   ///
   /// **Strategy**:
-  /// - Divine videos default to progressive MP4 720p (faststart, moov at front)
-  ///   for fastest startup with short videos (1 request, no manifest overhead).
+  /// - Classic Vine originals use the raw blob directly (/{hash}) because the
+  ///   source is already 480p or lower — transcoded variants are upscales at
+  ///   best and may not exist, causing needless 404s.
+  /// - Other Divine videos default to progressive MP4 720p (faststart, moov at
+  ///   front) for fastest startup with short videos (1 request, no manifest
+  ///   overhead).
   /// - Developer options can override to HLS or other formats for A/B testing.
   /// - If MP4 fails (e.g. not yet transcoded after upload), [getFallbackUrl]
   ///   provides an HLS fallback via the quality variant error handler.
-  /// - The raw blob (/{hash}) is 7-21 Mbps and exists only for archival/
-  ///   protocol purposes.
   ///
   /// Non-Divine videos always use original (no transcoded variants exist).
   String? getOptimalVideoUrlForPlatform() {
@@ -264,6 +266,10 @@ extension VideoEventAppExtensions on VideoEvent {
 
     final hash = _extractVideoHash(videoUrl);
     if (hash == null) return videoUrl;
+
+    // Classic Vine originals are 480p or lower — serve the raw blob directly.
+    // Transcoded 720p variants are pointless upscales and may not exist.
+    if (isOriginalVine) return '$_divineMediaBase/$hash';
 
     // Developer format override takes priority
     final override = videoFormatPreference.format;


### PR DESCRIPTION
Closes #2439

## Summary
- Classic Vine originals are 480p or lower — requesting `/{hash}/720p.mp4` is a pointless upscale at best, and a 404 when the transcode doesn't exist
- This caused "Failed to load video" errors for classic vines where transcoded variants were missing
- Now serves the raw Blossom blob (`/{hash}`) directly for `isOriginalVine` videos, which always exists as the original upload
- The pooled player's existing fallback chain still provides HLS as a secondary option

## Test plan
- [ ] Open Explore > Classics tab, tap into fullscreen feed
- [ ] Swipe through multiple classic vines — previously-broken ones should now play
- [ ] Verify new Divine videos (non-classic) still use 720p.mp4 as before
- [ ] Check aspect ratio displays correctly for square (480x480) classic vines

🤖 Generated with [Claude Code](https://claude.com/claude-code)