### PR TITLE
perf(logging): gate console output behind kDebugMode in UnifiedLogger (#1936)

### DIFF
--- a/mobile/lib/utils/unified_logger.dart
+++ b/mobile/lib/utils/unified_logger.dart
@@ -136,46 +136,41 @@ class UnifiedLogger {
     Object? error,
     StackTrace? stackTrace,
   }) {
-    // Check if this message should be printed to console
-    // Category/level filtering applies ONLY to console output (noise reduction)
-    final shouldPrintToConsole =
-        isLevelEnabled(level) &&
-        (category == null || isCategoryEnabled(category));
+    // Console output — entirely tree-shaken from release builds.
+    // Timestamp formatting, debugPrint, and developer.log only serve the
+    // developer console; nobody reads them in production.
+    if (kDebugMode) {
+      final shouldPrintToConsole =
+          isLevelEnabled(level) &&
+          (category == null || isCategoryEnabled(category));
 
-    // Create timestamp
-    final now = DateTime.now();
-    final timestamp =
-        '${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}:${now.second.toString().padLeft(2, '0')}.${now.millisecond.toString().padLeft(3, '0')}';
+      if (shouldPrintToConsole) {
+        final now = DateTime.now();
+        final timestamp =
+            '${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}:${now.second.toString().padLeft(2, '0')}.${now.millisecond.toString().padLeft(3, '0')}';
+        final categoryPrefix = category != null ? '[${category.name}] ' : '';
+        final timestampedMessage = '[$timestamp] $categoryPrefix$message';
 
-    // Format category prefix
-    final categoryPrefix = category != null ? '[${category.name}] ' : '';
+        debugPrint(timestampedMessage);
 
-    // Format message with timestamp and category
-    final timestampedMessage = '[$timestamp] $categoryPrefix$message';
-
-    // Output to console ONLY if category/level filters allow it
-    if (shouldPrintToConsole) {
-      // Always output to Flutter tool console via debugPrint
-      debugPrint(timestampedMessage);
-
-      // Also output to browser DevTools via developer.log (web only)
-      if (kIsWeb) {
-        developer.log(
-          timestampedMessage,
-          name: name ?? 'divine',
-          level: level.value,
-          error: error,
-          stackTrace: stackTrace,
-        );
+        if (kIsWeb) {
+          developer.log(
+            timestampedMessage,
+            name: name ?? 'divine',
+            level: level.value,
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
       }
     }
 
-    // CRITICAL: ALWAYS capture to file regardless of category/level filtering
+    // CRITICAL: ALWAYS capture to memory regardless of category/level filtering
     // Console filtering is for noise reduction during development
-    // File capture must be comprehensive for debugging remote user issues
+    // Memory capture must be comprehensive for debugging remote user issues
     try {
       final logEntry = LogEntry(
-        timestamp: now,
+        timestamp: DateTime.now(),
         level: level,
         message: message,
         category: category,
@@ -183,10 +178,8 @@ class UnifiedLogger {
         error: error?.toString(),
         stackTrace: stackTrace?.toString(),
       );
-      // Logging is now synchronous and non-blocking (in-memory only)
       LogCaptureService.instance.captureLog(logEntry);
     } catch (e) {
-      // Don't let log capture failures break logging
       if (kDebugMode) {
         debugPrint('Failed to capture log: $e');
       }


### PR DESCRIPTION
## Summary
- Wrap timestamp formatting, `debugPrint()`, and `developer.log()` inside a `kDebugMode` check in `UnifiedLogger._log()` so Dart tree-shakes the entire console-output block from release builds
- In production, `_log()` now only does `DateTime.now()`, `LogEntry` allocation, and ring buffer insert — eliminating 8 string operations and console I/O per call across 3,825+ call sites
- Log capture for the downloadable bug report feature is completely unaffected

## Context
Closes #1936

Testing confirmed that removing log calls makes the app noticeably smoother. The root cause is `_log()` running expensive synchronous work on every call in release builds:
- Timestamp string formatting (4× `padLeft`, 4× `toString`, string interpolation)
- `debugPrint()` — console I/O nobody reads in production
- `developer.log()` on web — same

Since `kDebugMode` is a compile-time constant, Dart's compiler tree-shakes the entire block from release builds — zero runtime overhead.

### Why not change `LogEntry` to store raw `Object?`/`StackTrace?`?
Investigation found this would:
1. Break `@immutable` + `const` constructor (can't cache lazy results)
2. Break equality semantics (`Object.==` uses identity, not value)
3. Break JSON round-trip (`fromJson` reads `String`, original stores `Exception`)
4. Ripple across 5 files / 12 access sites for negligible gain

The 95% win is eliminating the debug-only console work — a single-file change with zero API surface impact.

## Test plan
- [x] 5/5 `unified_logger_test.dart` pass (log capture path unchanged)
- [x] 10/10 `log_capture_service_test.dart` pass (ring buffer unaffected)
- [x] 11/11 `bug_report_service_test.dart` pass (export unaffected)
- [x] `flutter analyze` clean
- [x] Pre-commit hooks pass (format + analyze)
- [ ] Manual: export logs via bug report dialog to confirm content is correct