### PR TITLE
fix(app): improve explore thumbnails and initial loading

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -26,6 +26,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/deep_link_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/popular_now_feed_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
@@ -721,6 +722,27 @@ class _DivineAppState extends ConsumerState<DivineApp> {
   /// Initialize non-critical background services.
   /// Critical services are already initialized before runApp in _initializeCoreServices.
   void _initializeBackgroundServices() {
+    Future.microtask(() {
+      unawaited(
+        ref
+            .read(popularNowFeedProvider.future)
+            .then((state) {
+              Log.info(
+                '[INIT] Warmed New feed with ${state.videos.length} videos',
+                name: 'Main',
+                category: LogCategory.system,
+              );
+            })
+            .catchError((Object error, StackTrace stackTrace) {
+              Log.warning(
+                '[INIT] New feed warmup failed (non-critical): $error',
+                name: 'Main',
+                category: LogCategory.system,
+              );
+            }),
+      );
+    });
+
     // Initialize mutual mute list sync in background
     Future.microtask(() async {
       try {

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -730,6 +730,7 @@ ClipLibraryService clipLibraryService(Ref ref) {
 @Riverpod(keepAlive: true)
 AuthService authService(Ref ref) {
   final keyStorage = ref.watch(secureKeyStorageProvider);
+  final nostrKeyManager = ref.watch(nostrKeyManagerProvider);
   final userDataCleanupService = ref.watch(userDataCleanupServiceProvider);
   final oauthClient = ref.watch(oauthClientProvider);
   final flutterSecureStorage = ref.watch(flutterSecureStorageProvider);
@@ -745,6 +746,7 @@ AuthService authService(Ref ref) {
   return AuthService(
     userDataCleanupService: userDataCleanupService,
     keyStorage: keyStorage,
+    nostrKeyManager: nostrKeyManager,
     oauthClient: oauthClient,
     flutterSecureStorage: flutterSecureStorage,
     oauthConfig: oauthConfig,

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -2186,7 +2186,7 @@ final class AuthServiceProvider
   }
 }
 
-String _$authServiceHash() => r'21c98cd95333c3197814e2d50cdf496c9e3194d6';
+String _$authServiceHash() => r'4bb86052429096d3a396412f9e64f695e882f92e';
 
 /// Provider that returns current auth state and rebuilds when it changes.
 /// Widgets should watch this instead of authService.authState directly

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -10,7 +10,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart'
-    show SecureKeyContainer, SecureKeyStorage;
+    show NostrKeyManager, SecureKeyContainer, SecureKeyStorage;
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/services/background_activity_manager.dart';
@@ -145,6 +145,7 @@ class AuthService implements BackgroundAwareService {
   AuthService({
     required UserDataCleanupService userDataCleanupService,
     SecureKeyStorage? keyStorage,
+    NostrKeyManager? nostrKeyManager,
     KeycastOAuth? oauthClient,
     FlutterSecureStorage? flutterSecureStorage,
     OAuthConfig? oauthConfig,
@@ -153,6 +154,7 @@ class AuthService implements BackgroundAwareService {
     String? profileCheckIndexerUrl,
     List<String>? indexerRelays,
   }) : _keyStorage = keyStorage ?? SecureKeyStorage(),
+       _nostrKeyManager = nostrKeyManager,
        _userDataCleanupService = userDataCleanupService,
        _oauthClient = oauthClient,
        _flutterSecureStorage = flutterSecureStorage,
@@ -166,6 +168,7 @@ class AuthService implements BackgroundAwareService {
            oauthConfig ??
            const OAuthConfig(serverUrl: '', clientId: '', redirectUri: '');
   final SecureKeyStorage _keyStorage;
+  final NostrKeyManager? _nostrKeyManager;
   final UserDataCleanupService _userDataCleanupService;
   final KeycastOAuth? _oauthClient;
   final FlutterSecureStorage? _flutterSecureStorage;
@@ -2764,6 +2767,20 @@ class AuthService implements BackgroundAwareService {
           name: 'AuthService',
           category: LogCategory.auth,
         );
+        final cachedPrimaryIdentity = _restoreFromLoadedPrimaryIdentity(
+          lastNpub,
+        );
+        if (cachedPrimaryIdentity != null) {
+          Log.info(
+            '_restoreLastUsedAccountOrFallback: '
+            'reused already-loaded primary identity — '
+            'pubkey=${cachedPrimaryIdentity.publicKeyHex}',
+            name: 'AuthService',
+            category: LogCategory.auth,
+          );
+          await _setupUserSession(cachedPrimaryIdentity, source);
+          return;
+        }
         final container = await _keyStorage.getIdentityKeyContainer(lastNpub);
         if (container != null) {
           Log.info(
@@ -2801,6 +2818,33 @@ class AuthService implements BackgroundAwareService {
 
     // Fall back to the original behaviour (load primary key, or create new).
     await _checkExistingAuth();
+  }
+
+  SecureKeyContainer? _restoreFromLoadedPrimaryIdentity(String lastNpub) {
+    final keyManager = _nostrKeyManager;
+    final publicKeyHex = keyManager?.publicKey;
+    final privateKeyHex = keyManager?.privateKey;
+
+    if (publicKeyHex == null || privateKeyHex == null) {
+      return null;
+    }
+
+    final primaryNpub = NostrKeyUtils.encodePubKey(publicKeyHex);
+    if (primaryNpub != lastNpub) {
+      return null;
+    }
+
+    try {
+      return SecureKeyContainer.fromPrivateKeyHex(privateKeyHex);
+    } catch (e) {
+      Log.warning(
+        '_restoreFromLoadedPrimaryIdentity: failed to reuse loaded identity: '
+        '$e',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+      return null;
+    }
   }
 
   /// Check for existing authentication
@@ -3032,13 +3076,16 @@ class AuthService implements BackgroundAwareService {
 
       await prefs.setString(_kLastUsedNpubKey, keyContainer.npub);
 
+      final followingCacheKey = 'following_list_${keyContainer.publicKeyHex}';
+      final hasFollowingCache = prefs.containsKey(followingCacheKey);
+
       // Pre-fetch following list from REST API BEFORE setting auth state.
       // The router redirect fires synchronously on auth state change and reads
       // following_list_{pubkey} from SharedPreferences. If the cache is empty
       // (identity change cleared it, or first login), the redirect sends the
       // user to /explore instead of /home. By fetching here, we ensure the
       // cache is populated before the redirect fires.
-      if (_preFetchFollowing != null) {
+      if (_preFetchFollowing != null && !hasFollowingCache) {
         Log.debug(
           '_setupUserSession: pre-fetching following list...',
           name: 'AuthService',
@@ -3059,6 +3106,13 @@ class AuthService implements BackgroundAwareService {
             category: LogCategory.auth,
           );
         }
+      } else if (hasFollowingCache) {
+        Log.debug(
+          '_setupUserSession: following list already cached — '
+          'skipping pre-fetch',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
       }
 
       Log.info(

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -302,10 +302,21 @@ class _SafeNetworkImage extends StatelessWidget {
   // Set to true to debug if the issue is with flutter_cache_manager
   static const bool _useSimpleImageNetwork = false;
 
+  static bool _shouldBypassCacheManager(String url) {
+    final host = Uri.tryParse(url)?.host.toLowerCase();
+    if (host == null || host.isEmpty) return false;
+
+    // Explore/grid thumbnails are predominantly served from Divine-owned,
+    // immutable blob URLs. These load reliably with Image.network, while the
+    // CachedNetworkImage + custom cache manager path has been less reliable
+    // under concurrent grid loads on desktop.
+    return host == 'divine.video' || host.endsWith('.divine.video');
+  }
+
   @override
   Widget build(BuildContext context) {
     // Debug mode: test with plain Image.network to isolate cache issues
-    if (_useSimpleImageNetwork) {
+    if (_useSimpleImageNetwork || _shouldBypassCacheManager(url)) {
       return Image.network(
         url,
         width: width,

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -19,6 +19,8 @@ import '../test_setup.dart';
 
 class _MockSecureKeyStorage extends Mock implements SecureKeyStorage {}
 
+class _MockNostrKeyManager extends Mock implements NostrKeyManager {}
+
 class _MockUserDataCleanupService extends Mock
     implements UserDataCleanupService {}
 
@@ -57,6 +59,7 @@ void main() {
   setupTestEnvironment();
 
   late _MockSecureKeyStorage mockKeyStorage;
+  late _MockNostrKeyManager mockNostrKeyManager;
   late _MockUserDataCleanupService mockCleanupService;
   late _MockFlutterSecureStorage mockSecureStorage;
   late AuthService authService;
@@ -69,6 +72,7 @@ void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
     mockKeyStorage = _MockSecureKeyStorage();
+    mockNostrKeyManager = _MockNostrKeyManager();
     mockCleanupService = _MockUserDataCleanupService();
     mockSecureStorage = _MockFlutterSecureStorage();
     testKeyContainer = SecureKeyContainer.fromNsec(_testNsec);
@@ -100,6 +104,8 @@ void main() {
         biometricPrompt: any(named: 'biometricPrompt'),
       ),
     ).thenAnswer((_) async => true);
+    when(() => mockNostrKeyManager.publicKey).thenReturn(null);
+    when(() => mockNostrKeyManager.privateKey).thenReturn(null);
 
     when(
       () => mockCleanupService.shouldClearDataForUser(any()),
@@ -128,6 +134,7 @@ void main() {
     authService = AuthService(
       userDataCleanupService: mockCleanupService,
       keyStorage: mockKeyStorage,
+      nostrKeyManager: mockNostrKeyManager,
       flutterSecureStorage: mockSecureStorage,
     );
   });
@@ -150,25 +157,22 @@ void main() {
       );
     });
 
-    test(
-      'automatic auth source with no keys stays unauthenticated',
-      () async {
-        SharedPreferences.setMockInitialValues({
-          'authentication_source': 'automatic',
-        });
-        when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+    test('automatic auth source with no keys stays unauthenticated', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'automatic',
+      });
+      when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
 
-        await authService.initialize();
+      await authService.initialize();
 
-        expect(authService.authState, equals(AuthState.unauthenticated));
-        verify(() => mockKeyStorage.hasKeys()).called(1);
-        verifyNever(
-          () => mockKeyStorage.generateAndStoreKeys(
-            biometricPrompt: any(named: 'biometricPrompt'),
-          ),
-        );
-      },
-    );
+      expect(authService.authState, equals(AuthState.unauthenticated));
+      verify(() => mockKeyStorage.hasKeys()).called(1);
+      verifyNever(
+        () => mockKeyStorage.generateAndStoreKeys(
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      );
+    });
 
     test(
       'automatic auth source with keys restores authenticated session',
@@ -853,16 +857,10 @@ void main() {
         );
 
         // Bunker global key must be cleared
-        verify(
-          () => mockSecureStorage.delete(key: 'bunker_info'),
-        ).called(1);
+        verify(() => mockSecureStorage.delete(key: 'bunker_info')).called(1);
         // Amber global keys must be cleared
-        verify(
-          () => mockSecureStorage.delete(key: 'amber_pubkey'),
-        ).called(1);
-        verify(
-          () => mockSecureStorage.delete(key: 'amber_package'),
-        ).called(1);
+        verify(() => mockSecureStorage.delete(key: 'amber_pubkey')).called(1);
+        verify(() => mockSecureStorage.delete(key: 'amber_package')).called(1);
         // Keycast session global key must be cleared
         verify(
           () => mockSecureStorage.delete(key: 'keycast_session'),
@@ -883,16 +881,10 @@ void main() {
         );
 
         // Bunker global key must be cleared
-        verify(
-          () => mockSecureStorage.delete(key: 'bunker_info'),
-        ).called(1);
+        verify(() => mockSecureStorage.delete(key: 'bunker_info')).called(1);
         // Amber global keys must be cleared
-        verify(
-          () => mockSecureStorage.delete(key: 'amber_pubkey'),
-        ).called(1);
-        verify(
-          () => mockSecureStorage.delete(key: 'amber_package'),
-        ).called(1);
+        verify(() => mockSecureStorage.delete(key: 'amber_pubkey')).called(1);
+        verify(() => mockSecureStorage.delete(key: 'amber_package')).called(1);
         // Keycast session global key must be cleared
         verify(
           () => mockSecureStorage.delete(key: 'keycast_session'),
@@ -1233,9 +1225,39 @@ void main() {
       );
     });
 
+    test('restores per-identity key when last_used_npub is present', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'automatic',
+        'last_used_npub': accountBContainer.npub,
+        kKnownAccountsKey: '[]',
+      });
+
+      when(
+        () => mockKeyStorage.getKeyContainer(),
+      ).thenAnswer((_) async => testKeyContainer);
+      when(
+        () => mockKeyStorage.getIdentityKeyContainer(
+          accountBContainer.npub,
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      ).thenAnswer((_) async => accountBContainer);
+
+      await _ignoringDiscoveryErrors(authService.initialize);
+
+      expect(authService.authState, equals(AuthState.authenticated));
+      expect(
+        authService.currentPublicKeyHex,
+        equals(accountBContainer.publicKeyHex),
+      );
+      verifyNever(() => mockKeyStorage.getKeyContainer());
+    });
+
     test(
-      'restores per-identity key when last_used_npub is present',
+      'reuses loaded primary identity when last_used_npub matches key manager',
       () async {
+        final accountBPrivateKey = accountBContainer.withPrivateKey(
+          (privateKeyHex) => privateKeyHex,
+        );
         SharedPreferences.setMockInitialValues({
           'authentication_source': 'automatic',
           'last_used_npub': accountBContainer.npub,
@@ -1243,14 +1265,11 @@ void main() {
         });
 
         when(
-          () => mockKeyStorage.getKeyContainer(),
-        ).thenAnswer((_) async => testKeyContainer);
+          () => mockNostrKeyManager.publicKey,
+        ).thenReturn(accountBContainer.publicKeyHex);
         when(
-          () => mockKeyStorage.getIdentityKeyContainer(
-            accountBContainer.npub,
-            biometricPrompt: any(named: 'biometricPrompt'),
-          ),
-        ).thenAnswer((_) async => accountBContainer);
+          () => mockNostrKeyManager.privateKey,
+        ).thenReturn(accountBPrivateKey);
 
         await _ignoringDiscoveryErrors(authService.initialize);
 
@@ -1259,7 +1278,12 @@ void main() {
           authService.currentPublicKeyHex,
           equals(accountBContainer.publicKeyHex),
         );
-        verifyNever(() => mockKeyStorage.getKeyContainer());
+        verifyNever(
+          () => mockKeyStorage.getIdentityKeyContainer(
+            accountBContainer.npub,
+            biometricPrompt: any(named: 'biometricPrompt'),
+          ),
+        );
       },
     );
 
@@ -1316,51 +1340,101 @@ void main() {
       },
     );
 
+    test('destructive sign-out clears last_used_npub', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'automatic',
+        'last_used_npub': testKeyContainer.npub,
+        kKnownAccountsKey: '[]',
+      });
+
+      await _ignoringDiscoveryErrors(authService.createNewIdentity);
+      await authService.signOut(deleteKeys: true);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('last_used_npub'), isNull);
+    });
+
+    test('non-destructive sign-out preserves last_used_npub', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'automatic',
+        'last_used_npub': testKeyContainer.npub,
+        kKnownAccountsKey: '[]',
+      });
+
+      await _ignoringDiscoveryErrors(authService.createNewIdentity);
+      await authService.signOut();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('last_used_npub'), isNotNull);
+    });
+
+    test('_setupUserSession persists last_used_npub', () async {
+      await _ignoringDiscoveryErrors(authService.createNewIdentity);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('last_used_npub'), equals(testKeyContainer.npub));
+    });
+
     test(
-      'destructive sign-out clears last_used_npub',
+      'skips following prefetch when cache already exists for the account',
       () async {
-        SharedPreferences.setMockInitialValues({
-          'authentication_source': 'automatic',
-          'last_used_npub': testKeyContainer.npub,
-          kKnownAccountsKey: '[]',
-        });
-
-        await _ignoringDiscoveryErrors(authService.createNewIdentity);
-        await authService.signOut(deleteKeys: true);
-
-        final prefs = await SharedPreferences.getInstance();
-        expect(prefs.getString('last_used_npub'), isNull);
-      },
-    );
-
-    test(
-      'non-destructive sign-out preserves last_used_npub',
-      () async {
-        SharedPreferences.setMockInitialValues({
-          'authentication_source': 'automatic',
-          'last_used_npub': testKeyContainer.npub,
-          kKnownAccountsKey: '[]',
-        });
-
-        await _ignoringDiscoveryErrors(authService.createNewIdentity);
-        await authService.signOut();
-
-        final prefs = await SharedPreferences.getInstance();
-        expect(prefs.getString('last_used_npub'), isNotNull);
-      },
-    );
-
-    test(
-      '_setupUserSession persists last_used_npub',
-      () async {
-        await _ignoringDiscoveryErrors(authService.createNewIdentity);
-
-        final prefs = await SharedPreferences.getInstance();
-        expect(
-          prefs.getString('last_used_npub'),
-          equals(testKeyContainer.npub),
+        var prefetchCalls = 0;
+        authService = AuthService(
+          userDataCleanupService: mockCleanupService,
+          keyStorage: mockKeyStorage,
+          nostrKeyManager: mockNostrKeyManager,
+          flutterSecureStorage: mockSecureStorage,
+          preFetchFollowing: (_) async {
+            prefetchCalls++;
+          },
         );
+
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+          'following_list_${testKeyContainer.publicKeyHex}': jsonEncode([
+            'abc123',
+          ]),
+          kKnownAccountsKey: '[]',
+        });
+
+        when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => true);
+        when(
+          () => mockKeyStorage.getKeyContainer(),
+        ).thenAnswer((_) async => testKeyContainer);
+
+        await _ignoringDiscoveryErrors(authService.initialize);
+
+        expect(authService.authState, equals(AuthState.authenticated));
+        expect(prefetchCalls, 0);
       },
     );
+
+    test('prefetches following before auth when cache is missing', () async {
+      final prefetchedPubkeys = <String>[];
+      authService = AuthService(
+        userDataCleanupService: mockCleanupService,
+        keyStorage: mockKeyStorage,
+        nostrKeyManager: mockNostrKeyManager,
+        flutterSecureStorage: mockSecureStorage,
+        preFetchFollowing: (pubkeyHex) async {
+          prefetchedPubkeys.add(pubkeyHex);
+        },
+      );
+
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'automatic',
+        kKnownAccountsKey: '[]',
+      });
+
+      when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => true);
+      when(
+        () => mockKeyStorage.getKeyContainer(),
+      ).thenAnswer((_) async => testKeyContainer);
+
+      await _ignoringDiscoveryErrors(authService.initialize);
+
+      expect(authService.authState, equals(AuthState.authenticated));
+      expect(prefetchedPubkeys, [testKeyContainer.publicKeyHex]);
+    });
   });
 }

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -60,6 +60,32 @@ void main() {
       expect(find.byType(CachedNetworkImage), findsOneWidget);
     });
 
+    testWidgets(
+      'uses Image.network for Divine-hosted thumbnails to avoid cache-manager stalls',
+      (tester) async {
+        final divineHostedVideo = createTestVideoEvent(
+          id: 'test-divine',
+          thumbnailUrl:
+              'https://media.divine.video/72d7eda61074b17e077fb9f4a8b48166cdeb65cb07e053aafa6e69d5fa165995.jpg',
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: VideoThumbnailWidget(
+                video: divineHostedVideo,
+                width: 200,
+                height: 200,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(Image), findsOneWidget);
+        expect(find.byType(CachedNetworkImage), findsNothing);
+      },
+    );
+
     testWidgets('displays flat placeholder when only blurhash is available', (
       tester,
     ) async {


### PR DESCRIPTION
Closes #2453

## Summary
- bypass the custom cache-manager path for Divine-hosted thumbnails so Explore thumbnails render more reliably
- speed returning-user startup by reusing the loaded primary identity and avoiding redundant auth restore work
- reduce first Explore New load time by warming the feed after first frame

## Validation
- flutter test test/widgets/video_thumbnail_widget_test.dart test/widgets/video_thumbnail_404_test.dart test/widgets/video_thumbnail_aspect_ratio_test.dart test/services/auth_service_multi_account_test.dart test/startup/app_startup_test.dart
- dart analyze lib/widgets/video_thumbnail_widget.dart lib/services/auth_service.dart lib/providers/app_providers.dart lib/main.dart
- pre-commit and pre-push hooks passed
