### PR TITLE
fix(logging): stop proofmode badge rebuild log spam

### DIFF
--- a/docs/superpowers/plans/2026-03-25-proofmode-log-spam.md
+++ b/docs/superpowers/plans/2026-03-25-proofmode-log-spam.md
@@ -1,0 +1,67 @@
+# ProofMode Log Spam Reduction Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `ProofModeBadgeRow` from flooding captured logs during routine widget rebuilds while preserving badge behavior.
+
+**Architecture:** Keep the fix local to the badge row. Remove the per-build diagnostic log and narrow the moderation provider selection to the AI score only so routine loading-state churn does not trigger extra rebuilds.
+
+**Tech Stack:** Flutter, Riverpod, flutter_test, mocktail
+
+---
+
+## Chunk 1: Regression Coverage
+
+### Task 1: Add a failing widget test for rebuild log spam
+
+**Files:**
+- Modify: `mobile/test/widgets/proofmode_badge_row_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that:
+- clears `LogCaptureService`
+- builds `ProofModeBadgeRow`
+- forces one or more parent rebuilds
+- asserts there are no captured log entries with `name == 'ProofModeBadgeRow'`
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/widgets/proofmode_badge_row_test.dart --plain-name "does not capture badge decision logs during rebuilds"`
+Expected: FAIL because the widget currently logs from `build()`
+
+## Chunk 2: Minimal Fix
+
+### Task 2: Remove per-build logging and narrow rebuild triggers
+
+**Files:**
+- Modify: `mobile/lib/widgets/proofmode_badge_row.dart`
+
+- [ ] **Step 1: Remove the badge-decision `Log.verbose(...)` call**
+
+Delete the per-build diagnostic log so the widget has no logging side effects during normal rendering.
+
+- [ ] **Step 2: Simplify the moderation provider selection**
+
+Change the `select(...)` call to watch only the AI score instead of a tuple that includes loading and error state, so null-to-null transitions do not trigger extra rebuilds.
+
+- [ ] **Step 3: Keep badge behavior unchanged**
+
+Retain the existing badge decision rules and moderation lookup behavior.
+
+## Chunk 3: Verification
+
+### Task 3: Verify the regression and surrounding behavior
+
+**Files:**
+- Verify: `mobile/test/widgets/proofmode_badge_row_test.dart`
+
+- [ ] **Step 1: Run the focused badge-row test file**
+
+Run: `flutter test test/widgets/proofmode_badge_row_test.dart`
+Expected: PASS
+
+- [ ] **Step 2: Review the diff**
+
+Run: `git diff -- mobile/lib/widgets/proofmode_badge_row.dart mobile/test/widgets/proofmode_badge_row_test.dart docs/superpowers/plans/2026-03-25-proofmode-log-spam.md`
+Expected: only the planned log-spam reduction changes

--- a/mobile/lib/widgets/proofmode_badge_row.dart
+++ b/mobile/lib/widgets/proofmode_badge_row.dart
@@ -11,7 +11,6 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/utils/proofmode_helpers.dart';
-import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/proofmode_badge.dart';
 import 'package:openvine/widgets/user_name.dart';
 
@@ -40,7 +39,6 @@ class ProofModeBadgeRow extends ConsumerWidget {
       explicitSha256: video.sha256,
       videoUrl: video.videoUrl,
     );
-    AsyncValue<VideoModerationStatus?>? moderationStatusAsync;
     AIDetectionResult? aiResult = _lookupAIDetection(
       labelService,
       resolvedSha256,
@@ -51,28 +49,15 @@ class ProofModeBadgeRow extends ConsumerWidget {
     // Use select() to only rebuild when the AI score actually changes,
     // avoiding excessive rebuilds during scroll.
     if (aiResult == null && video.isFromDivineServer) {
-      final selectedData = ref.watch(
+      final aiScore = ref.watch(
         videoModerationStatusProvider(resolvedSha256).select(
-          (asyncValue) => (
-            aiScore: asyncValue.whenOrNull(
-              data: (status) => status?.aiScore,
-            ),
-            isLoading: asyncValue.isLoading,
-            hasError: asyncValue.hasError,
-          ),
+          (asyncValue) =>
+              asyncValue.whenOrNull(data: (status) => status?.aiScore),
         ),
       );
-      moderationStatusAsync = selectedData.isLoading
-          ? const AsyncValue<VideoModerationStatus?>.loading()
-          : selectedData.hasError
-          ? const AsyncValue<VideoModerationStatus?>.error(
-              'error',
-              StackTrace.empty,
-            )
-          : null;
-      if (selectedData.aiScore != null) {
+      if (aiScore != null) {
         aiResult = AIDetectionResult(
-          score: selectedData.aiScore!,
+          score: aiScore,
           source: 'moderation-service',
         );
       }
@@ -100,25 +85,21 @@ class ProofModeBadgeRow extends ConsumerWidget {
         aiResult == null;
 
     final badges = <Widget>[];
-    final badgeLabels = <String>[];
 
     // Add ProofMode badge for proof-backed content or a clean AI scan.
     if (video.shouldShowProofModeBadge || hasAIScanBadge) {
       badges.add(ProofModeBadge(level: effectiveLevel, size: size));
-      badgeLabels.add('proofmode:${effectiveLevel.name}');
     }
 
     // Add "Possibly AI-Generated" badge for high AI scores
     if (isPossiblyAI && !video.shouldShowProofModeBadge) {
       badges.add(PossiblyAIBadge(size: size));
-      badgeLabels.add('possibly_ai');
     }
 
     // Divine-hosted videos should surface pending AI status instead of
     // rendering blank while scan results are unavailable.
     if (isCheckingForAI) {
       badges.add(CheckingForAIBadge(size: size));
-      badgeLabels.add('checking_ai');
     }
 
     // Add "Not Divine Hosted" badge for external content (tappable)
@@ -133,29 +114,12 @@ class ProofModeBadgeRow extends ConsumerWidget {
           child: NotDivineBadge(size: size),
         ),
       );
-      badgeLabels.add('not_divine');
     }
 
     // Add Original Vine badge for vintage recovered vines
     if (video.shouldShowVineBadge) {
       badges.add(OriginalVineBadge(size: size));
-      badgeLabels.add('original_vine');
     }
-
-    // Only log badge decisions at verbose level to avoid flooding during scroll
-    Log.verbose(
-      'Badge decision: eventId=${video.id}, resolvedSha256=$resolvedSha256, '
-      'isFromDivine=${video.isFromDivineServer}, hasProofMode=${video.hasProofMode}, '
-      'proofBadge=${video.shouldShowProofModeBadge}, vineBadge=${video.shouldShowVineBadge}, '
-      'notDivine=${video.shouldShowNotDivineBadge}, '
-      'aiScore=${aiResult?.score}, aiSource=${aiResult?.source}, '
-      'checkingForAI=$isCheckingForAI, '
-      'moderationLoading=${moderationStatusAsync?.isLoading ?? false}, '
-      'moderationHasError=${moderationStatusAsync?.hasError ?? false}, '
-      'badgeLabels=${badgeLabels.join(',')}',
-      name: 'ProofModeBadgeRow',
-      category: LogCategory.video,
-    );
 
     if (badges.isEmpty) {
       return const SizedBox.shrink();

--- a/mobile/test/widgets/proofmode_badge_row_test.dart
+++ b/mobile/test/widgets/proofmode_badge_row_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/log_capture_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/widgets/proofmode_badge_row.dart';
@@ -14,11 +15,40 @@ class _MockModerationLabelService extends Mock
 class _MockVideoModerationStatusService extends Mock
     implements VideoModerationStatusService {}
 
+class _RebuildHost extends StatefulWidget {
+  const _RebuildHost({required this.video, super.key});
+
+  final VideoEvent video;
+
+  @override
+  State<_RebuildHost> createState() => _RebuildHostState();
+}
+
+class _RebuildHostState extends State<_RebuildHost> {
+  int rebuildCount = 0;
+
+  void triggerRebuild() {
+    setState(() {
+      rebuildCount++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text('rebuild:$rebuildCount'),
+        ProofModeBadgeRow(video: widget.video),
+      ],
+    );
+  }
+}
+
 void main() {
   late _MockModerationLabelService mockLabelService;
   late _MockVideoModerationStatusService mockVideoModerationStatusService;
 
-  setUp(() {
+  setUp(() async {
     mockLabelService = _MockModerationLabelService();
     mockVideoModerationStatusService = _MockVideoModerationStatusService();
     when(() => mockLabelService.getAIDetectionResult(any())).thenReturn(null);
@@ -26,6 +56,7 @@ void main() {
     when(
       () => mockVideoModerationStatusService.fetchStatus(any()),
     ).thenAnswer((_) async => null);
+    await LogCaptureService.instance.clearAllLogs();
   });
 
   Widget buildSubject(VideoEvent video) {
@@ -38,6 +69,25 @@ void main() {
       ],
       child: MaterialApp(
         home: Scaffold(body: ProofModeBadgeRow(video: video)),
+      ),
+    );
+  }
+
+  Widget buildRebuildSubject({
+    required VideoEvent video,
+    required GlobalKey<_RebuildHostState> hostKey,
+  }) {
+    return ProviderScope(
+      overrides: [
+        moderationLabelServiceProvider.overrideWithValue(mockLabelService),
+        videoModerationStatusServiceProvider.overrideWithValue(
+          mockVideoModerationStatusService,
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: _RebuildHost(key: hostKey, video: video),
+        ),
       ),
     );
   }
@@ -194,5 +244,42 @@ void main() {
       expect(find.text('Human Made'), findsOneWidget);
       expect(find.text('Hosted on Divine'), findsNothing);
     });
+
+    testWidgets(
+      'does not capture badge decision logs during rebuilds',
+      (tester) async {
+        final hostKey = GlobalKey<_RebuildHostState>();
+        final video = VideoEvent(
+          id: 'proof_backed_rebuild_video',
+          pubkey: 'pubkey_rebuild',
+          createdAt: DateTime.now().millisecondsSinceEpoch,
+          content: 'proof backed video for rebuild logging',
+          timestamp: DateTime.now(),
+          videoUrl: 'https://media.divine.video/proof_backed_rebuild_video.mp4',
+          rawTags: const {
+            'verification': 'verified_mobile',
+            'proofmode': '{"proof":"present"}',
+          },
+        );
+
+        await tester.pumpWidget(
+          buildRebuildSubject(video: video, hostKey: hostKey),
+        );
+        await tester.pump();
+
+        hostKey.currentState!.triggerRebuild();
+        await tester.pump();
+
+        hostKey.currentState!.triggerRebuild();
+        await tester.pump();
+
+        final proofModeLogs = LogCaptureService.instance
+            .getRecentLogs()
+            .where((entry) => entry.name == 'ProofModeBadgeRow')
+            .toList();
+
+        expect(proofModeLogs, isEmpty);
+      },
+    );
   });
 }


### PR DESCRIPTION
Closes #2458

## Summary
- remove the per-build `ProofModeBadgeRow` diagnostic log that was flooding captured logs
- narrow the moderation provider select to `aiScore` so loading/error churn does not trigger extra badge-row rebuilds
- add a regression test proving rebuilds no longer capture `ProofModeBadgeRow` log entries

## Verification
- flutter test test/widgets/proofmode_badge_row_test.dart
- flutter analyze lib/widgets/proofmode_badge_row.dart test/widgets/proofmode_badge_row_test.dart