### PR TITLE
fix(blossom-upload): fix ProofMode header encoding for String values

### DIFF
--- a/mobile/lib/services/blossom_upload_service.dart
+++ b/mobile/lib/services/blossom_upload_service.dart
@@ -915,9 +915,11 @@ class BlossomUploadService {
         );
       }
 
-      if (manifestMap['c2pa_manifest_id'] != null) {
+      final c2paManifestId =
+          manifestMap['c2paManifestId'] ?? manifestMap['c2pa_manifest_id'];
+      if (c2paManifestId != null) {
         headers['X-ProofMode-C2PA'] = _encodeHeaderValue(
-          manifestMap['c2pa_manifest_id'],
+          c2paManifestId,
         );
       }
 

--- a/mobile/test/services/blossom_upload_proofmode_test.dart
+++ b/mobile/test/services/blossom_upload_proofmode_test.dart
@@ -9,6 +9,7 @@ import 'dart:typed_data';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show NativeProofData;
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/blossom_upload_service.dart';
@@ -256,6 +257,38 @@ void main() {
         expect(decodedMap['id'], equals('c2pa-123'));
         expect(decodedMap['alg'], equals('sha256'));
       });
+
+      test(
+        'encodes c2paManifestId from NativeProofData JSON shape',
+        () async {
+          arrangeUploadMocks();
+          final mockFile = createMockFile();
+
+          final manifest = jsonEncode(
+            const NativeProofData(
+              videoHash: 'abc123',
+              c2paManifestId: 'c2pa-test-id',
+            ).toJson(),
+          );
+
+          await service.uploadVideo(
+            description: 'test',
+            videoFile: mockFile,
+            nostrPubkey: _testPubkey,
+            title: 'test',
+            hashtags: const [],
+            proofManifestJson: manifest,
+          );
+
+          final headers = capturedOptions!.headers!;
+          expect(headers, contains('X-ProofMode-C2PA'));
+
+          final decoded = utf8.decode(
+            base64.decode(headers['X-ProofMode-C2PA'] as String),
+          );
+          expect(decoded, equals('c2pa-test-id'));
+        },
+      );
 
       test('omits signature header when pgpSignature is null', () async {
         arrangeUploadMocks();


### PR DESCRIPTION
Closes #2479

## Description

Fix ProofMode header encoding in Blossom uploads where `pgpSignature` and `deviceAttestation` were incorrectly cast as `Map<String, dynamic>` instead of handled as their actual `String` type. This caused `_addProofModeHeaders` to silently fail, potentially leading to upload rejections on certain devices. A new `_encodeHeaderValue` helper now safely handles both `String` and `Map` values.


**Related Issue:** #2455


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore