### PR TITLE
fix(video_clip): enable duration badge display by default

### DIFF
--- a/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
@@ -22,7 +22,7 @@ class VideoClipThumbnailCard extends StatefulWidget {
     required this.onLongPress,
     this.isSelected = false,
     this.disabled = false,
-    this.showDurationBadge = false,
+    this.showDurationBadge = true,
     super.key,
   });
 


### PR DESCRIPTION
Closes #2483

## Description

This PR only corrects the default value of the 'Clip Duration' badge from 'false' to 'true'.

**Related Issue:** Closes #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore