### PR TITLE
perf(video): recycle LRU players in PlayerPool

### DIFF
--- a/mobile/packages/pooled_video_player/lib/src/controllers/player_pool.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/player_pool.dart
@@ -25,6 +25,26 @@ class PooledPlayer {
   /// Whether this player has been disposed.
   bool get isDisposed => _isDisposed;
 
+  /// Set to `true` by [recycle] to indicate this player was re-keyed from
+  /// a previous URL.
+  ///
+  /// Callers use this to defer publishing the [VideoController] to the UI
+  /// until after new media has been opened, preventing the previous video's
+  /// surface from flashing on the new index even after `stop()` has cleared it.
+  ///
+  /// Reset to `false` automatically once the caller has consumed it.
+  bool _wasRecycled = false;
+
+  /// Whether this player was recycled from another URL since the last open.
+  ///
+  /// Callers must reset this to `false` once they have deferred UI exposure
+  /// past the `open()` call.
+  bool get wasRecycled => _wasRecycled;
+
+  /// Resets the [wasRecycled] flag. Called after `open()` completes for a
+  /// recycled player.
+  void clearRecycled() => _wasRecycled = false;
+
   /// Callbacks invoked synchronously when this player is evicted (recycled
   /// or disposed).
   ///
@@ -53,6 +73,7 @@ class PooledPlayer {
   /// Is a no-op if already disposed.
   void recycle() {
     if (_isDisposed) return;
+    _wasRecycled = true;
     for (final callback in List<VoidCallback>.of(_onEvictedCallbacks)) {
       callback();
     }

--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -605,8 +605,18 @@ class VideoFeedController extends ChangeNotifier {
         'poolPlayers=${pool.playerCount}',
       );
 
-      _loadedPlayers[index] = pooledPlayer;
-      _notifyIndex(index);
+      // Recycled players must NOT be published to _loadedPlayers or exposed
+      // to the UI via _notifyIndex until after open() completes. Even though
+      // stop() was awaited in _recycleLru(), the VideoController is still
+      // bound to the previous URL's surface. Publishing it at LoadState.loading
+      // would hand a stale controller to the UI before the new media is opened.
+      // Non-recycled players are exposed immediately so the UI can show a
+      // loading spinner while buffering.
+      final isRecycled = pooledPlayer.wasRecycled;
+      if (!isRecycled) {
+        _loadedPlayers[index] = pooledPlayer;
+        _notifyIndex(index);
+      }
 
       // Register a callback so we learn when the pool evicts this player.
       // The identity check in _onPlayerEvicted ensures stale callbacks
@@ -630,14 +640,18 @@ class VideoFeedController extends ChangeNotifier {
         return;
       }
 
-      // Expose the allocated player/controller immediately so overlays can
-      // render while the media is still buffering.
-      _notifyIndex(index);
+      if (!isRecycled) {
+        // Expose the allocated player/controller immediately so overlays can
+        // render while the media is still buffering.
+        _notifyIndex(index);
+      }
 
       // Fast path: reuse player that already has media loaded.
       // When a player was released from the controller but stayed in the
       // pool, it retains its loaded media. Skip the expensive open() call
       // that would reset and rebuffer, causing a visible freeze.
+      // This path is never taken for recycled players: hadExistingPlayer is
+      // false (the new URL was not in the pool before getPlayer() was called).
       if (hadExistingPlayer &&
           pooledPlayer.player.state.duration > Duration.zero) {
         _logDebug(
@@ -705,6 +719,14 @@ class VideoFeedController extends ChangeNotifier {
 
       // Guard: index may have been released during open/setPlaylistMode.
       if (_isDisposed || !_loadingIndices.contains(index)) return;
+
+      // For recycled players, open() has now replaced the media surface.
+      // It is safe to publish the controller to the UI for the first time.
+      if (isRecycled) {
+        pooledPlayer.clearRecycled();
+        _loadedPlayers[index] = pooledPlayer;
+        _notifyIndex(index);
+      }
 
       _setupStreamSubscriptions(index, pooledPlayer);
 

--- a/mobile/packages/pooled_video_player/test/controllers/player_pool_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/player_pool_test.dart
@@ -24,11 +24,15 @@ _MockPooledPlayer _createMockPooledPlayer() {
   final mockPlayer = createMockPlayer();
   final mockController = createMockVideoController();
 
+  var recycled = false;
+
   when(() => mockPooledPlayer.player).thenReturn(mockPlayer);
   when(() => mockPooledPlayer.videoController).thenReturn(mockController);
   when(() => mockPooledPlayer.isDisposed).thenReturn(false);
+  when(() => mockPooledPlayer.wasRecycled).thenAnswer((_) => recycled);
+  when(mockPooledPlayer.clearRecycled).thenAnswer((_) => recycled = false);
+  when(mockPooledPlayer.recycle).thenAnswer((_) => recycled = true);
   when(mockPooledPlayer.dispose).thenAnswer((_) async {});
-  when(mockPooledPlayer.recycle).thenReturn(null);
 
   return mockPooledPlayer;
 }

--- a/mobile/packages/pooled_video_player/test/controllers/pooled_player_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/pooled_player_test.dart
@@ -349,6 +349,27 @@ void main() {
         expect(callCount, equals(1));
         expect(pooledPlayer.isDisposed, isTrue);
       });
+
+      test('sets wasRecycled to true', () {
+        final pooledPlayer = PooledPlayer(
+          player: mockPlayer,
+          videoController: mockVideoController,
+        );
+
+        expect(pooledPlayer.wasRecycled, isFalse);
+        pooledPlayer.recycle();
+        expect(pooledPlayer.wasRecycled, isTrue);
+      });
+
+      test('clearRecycled resets wasRecycled to false', () {
+        final pooledPlayer = PooledPlayer(
+          player: mockPlayer,
+          videoController: mockVideoController,
+        );
+
+        (pooledPlayer..recycle()).clearRecycled();
+        expect(pooledPlayer.wasRecycled, isFalse);
+      });
     });
   });
 }

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for VideoFeedController
 // ABOUTME: Validates state management, page navigation, and playback control
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -59,6 +61,8 @@ void main() {
             () => mockPooledPlayer.videoController,
           ).thenReturn(createMockVideoController());
           when(() => mockPooledPlayer.isDisposed).thenReturn(false);
+          when(() => mockPooledPlayer.wasRecycled).thenReturn(false);
+          when(mockPooledPlayer.clearRecycled).thenReturn(null);
           when(mockPooledPlayer.dispose).thenAnswer((_) async {});
 
           createdPlayers.add(mockPooledPlayer);
@@ -426,6 +430,8 @@ void main() {
                 () => mockPooledPlayer.videoController,
               ).thenReturn(createMockVideoController());
               when(() => mockPooledPlayer.isDisposed).thenReturn(false);
+              when(() => mockPooledPlayer.wasRecycled).thenReturn(false);
+              when(mockPooledPlayer.clearRecycled).thenReturn(null);
               when(mockPooledPlayer.dispose).thenAnswer((_) async {});
 
               createdPlayers.add(mockPooledPlayer);
@@ -1005,6 +1011,8 @@ void main() {
               () => mockPooledPlayer.videoController,
             ).thenReturn(createMockVideoController());
             when(() => mockPooledPlayer.isDisposed).thenReturn(false);
+            when(() => mockPooledPlayer.wasRecycled).thenReturn(false);
+            when(mockPooledPlayer.clearRecycled).thenReturn(null);
             when(mockPooledPlayer.dispose).thenAnswer((_) async {});
             return mockPooledPlayer;
           },
@@ -1044,6 +1052,8 @@ void main() {
               () => mockPooledPlayer.videoController,
             ).thenReturn(createMockVideoController());
             when(() => mockPooledPlayer.isDisposed).thenReturn(false);
+            when(() => mockPooledPlayer.wasRecycled).thenReturn(false);
+            when(mockPooledPlayer.clearRecycled).thenReturn(null);
             when(mockPooledPlayer.dispose).thenAnswer((_) async {});
             return mockPooledPlayer;
           },
@@ -1238,6 +1248,8 @@ void main() {
               () => mockPooledPlayer.videoController,
             ).thenReturn(createMockVideoController());
             when(() => mockPooledPlayer.isDisposed).thenReturn(false);
+            when(() => mockPooledPlayer.wasRecycled).thenReturn(false);
+            when(mockPooledPlayer.clearRecycled).thenReturn(null);
             when(mockPooledPlayer.dispose).thenAnswer((_) async {});
             return mockPooledPlayer;
           },
@@ -1813,6 +1825,7 @@ void main() {
 
             final mockPooledPlayer = _MockPooledPlayer();
             final callbacks = <VoidCallback>[];
+            var recycled = false;
             when(() => mockPooledPlayer.player).thenReturn(setup.player);
             when(
               () => mockPooledPlayer.videoController,
@@ -1821,6 +1834,12 @@ void main() {
             when(
               () => mockPooledPlayer.isDisposed,
             ).thenAnswer((_) => disposedState[url]!);
+            when(
+              () => mockPooledPlayer.wasRecycled,
+            ).thenAnswer((_) => recycled);
+            when(
+              mockPooledPlayer.clearRecycled,
+            ).thenAnswer((_) => recycled = false);
             // Track onDisposed callbacks so dispose() fires them (like the
             // real PooledPlayer). Required because current-video
             // prioritization means eviction happens after _loadPlayer
@@ -1842,6 +1861,7 @@ void main() {
             // recycle() fires callbacks synchronously without disposing
             // native resources (mirrors real PooledPlayer.recycle()).
             when(mockPooledPlayer.recycle).thenAnswer((_) {
+              recycled = true;
               disposedState[url] = true;
               for (final cb in List<VoidCallback>.of(callbacks)) {
                 cb();
@@ -2054,6 +2074,7 @@ void main() {
             playerCallbacks[url] = <VoidCallback>[];
 
             final mockPooledPlayer = _MockPooledPlayer();
+            var recycled = false;
             when(() => mockPooledPlayer.player).thenReturn(setup.player);
             when(
               () => mockPooledPlayer.videoController,
@@ -2061,6 +2082,12 @@ void main() {
             when(
               () => mockPooledPlayer.isDisposed,
             ).thenAnswer((_) => callbackDisposedState[url]!);
+            when(
+              () => mockPooledPlayer.wasRecycled,
+            ).thenAnswer((_) => recycled);
+            when(
+              mockPooledPlayer.clearRecycled,
+            ).thenAnswer((_) => recycled = false);
 
             // Track disposal callbacks (mirrors real PooledPlayer behavior).
             when(
@@ -2081,6 +2108,7 @@ void main() {
             // recycle() fires callbacks synchronously without disposing
             // native resources (mirrors real PooledPlayer.recycle()).
             when(mockPooledPlayer.recycle).thenAnswer((_) {
+              recycled = true;
               callbackDisposedState[url] = true;
               for (final cb in List<VoidCallback>.of(playerCallbacks[url]!)) {
                 cb();
@@ -2401,6 +2429,8 @@ void main() {
             () => pooledPlayer.videoController,
           ).thenReturn(createMockVideoController());
           when(() => pooledPlayer.isDisposed).thenReturn(false);
+          when(() => pooledPlayer.wasRecycled).thenReturn(false);
+          when(pooledPlayer.clearRecycled).thenReturn(null);
           when(pooledPlayer.dispose).thenAnswer((_) async {});
 
           final localPool = TestablePlayerPool(
@@ -2473,6 +2503,8 @@ void main() {
           () => pooledPlayer.videoController,
         ).thenReturn(createMockVideoController());
         when(() => pooledPlayer.isDisposed).thenReturn(false);
+        when(() => pooledPlayer.wasRecycled).thenReturn(false);
+        when(pooledPlayer.clearRecycled).thenReturn(null);
         when(pooledPlayer.dispose).thenAnswer((_) async {});
 
         final localPool = TestablePlayerPool(
@@ -3094,6 +3126,80 @@ void main() {
         },
       );
     });
+    group('recycled player UI deferral', () {
+      test(
+        'recycled player controller is not published to UI until after open()',
+        () async {
+          // Pool has capacity 1. When the second video is requested, the
+          // first player is recycled (wasRecycled=true). _loadPlayer must
+          // NOT store it in _loadedPlayers or notify the UI until after
+          // open() completes.
+          final openCompleter = Completer<void>();
+          final setup = createMockPlayerSetup(isBuffering: true);
+
+          // Block open() so we can observe the pre-open state.
+          when(
+            () => setup.player.open(any(), play: any(named: 'play')),
+          ).thenAnswer((_) => openCompleter.future);
+
+          // Use createMockPooledPlayerFromSetup so wasRecycled/clearRecycled
+          // are wired up correctly (recycle() sets wasRecycled=true,
+          // clearRecycled() resets it).
+          final mockPlayer = createMockPooledPlayerFromSetup(setup);
+
+          final deferralPool = TestablePlayerPool(
+            maxPlayers: 1,
+            mockPlayerFactory: (_) => mockPlayer,
+          );
+          addTearDown(() async {
+            await setup.dispose();
+            await deferralPool.dispose();
+          });
+
+          final videos = createTestVideos(count: 2);
+          final controller = VideoFeedController(
+            videos: videos,
+            pool: deferralPool,
+            preloadAhead: 0,
+            preloadBehind: 0,
+          );
+          addTearDown(controller.dispose);
+
+          // Wait for video 0 to load (open() is blocked — video 0 stays
+          // at LoadState.loading, but that's fine for this test).
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          final notifier1 = controller.getIndexNotifier(1);
+
+          // Swipe to video 1 — pool recycles video 0's player.
+          // wasRecycled is now true; open() for video 1 is blocked.
+          controller.onPageChanged(1);
+
+          // Yield but don't complete open() — the recycled controller must
+          // not be exposed to the UI yet.
+          await Future<void>.delayed(Duration.zero);
+          expect(
+            controller.getVideoController(1),
+            isNull,
+            reason:
+                'Recycled VideoController must not be published before open()',
+          );
+          expect(
+            notifier1.value.videoController,
+            isNull,
+            reason:
+                'Notifier must not expose recycled controller before open()',
+          );
+
+          // Unblock open() — controller should now be published.
+          openCompleter.complete();
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          expect(controller.getVideoController(1), isNotNull);
+        },
+      );
+    });
+
     group('current-video prioritization', () {
       test(
         'current video open() completes before any preload open() starts',
@@ -3120,6 +3226,8 @@ void main() {
                 () => mockPooledPlayer.videoController,
               ).thenReturn(createMockVideoController());
               when(() => mockPooledPlayer.isDisposed).thenReturn(false);
+              when(() => mockPooledPlayer.wasRecycled).thenReturn(false);
+              when(mockPooledPlayer.clearRecycled).thenReturn(null);
               when(mockPooledPlayer.dispose).thenAnswer((_) async {});
               when(
                 () => mockPooledPlayer.addOnEvictedCallback(any()),
@@ -3173,6 +3281,8 @@ void main() {
                 () => mockPooledPlayer.videoController,
               ).thenReturn(createMockVideoController());
               when(() => mockPooledPlayer.isDisposed).thenReturn(false);
+              when(() => mockPooledPlayer.wasRecycled).thenReturn(false);
+              when(mockPooledPlayer.clearRecycled).thenReturn(null);
               when(mockPooledPlayer.dispose).thenAnswer((_) async {});
               when(
                 () => mockPooledPlayer.addOnEvictedCallback(any()),
@@ -3431,6 +3541,8 @@ void main() {
               () => mockPooledPlayer.videoController,
             ).thenReturn(createMockVideoController());
             when(() => mockPooledPlayer.isDisposed).thenReturn(false);
+            when(() => mockPooledPlayer.wasRecycled).thenReturn(false);
+            when(mockPooledPlayer.clearRecycled).thenReturn(null);
             when(mockPooledPlayer.dispose).thenAnswer((_) async {});
 
             return mockPooledPlayer;
@@ -3753,6 +3865,8 @@ void main() {
               () => mockPooledPlayer.videoController,
             ).thenReturn(createMockVideoController());
             when(() => mockPooledPlayer.isDisposed).thenReturn(false);
+            when(() => mockPooledPlayer.wasRecycled).thenReturn(false);
+            when(mockPooledPlayer.clearRecycled).thenReturn(null);
             when(mockPooledPlayer.dispose).thenAnswer((_) async {});
 
             return mockPooledPlayer;

--- a/mobile/packages/pooled_video_player/test/helpers/test_helpers.dart
+++ b/mobile/packages/pooled_video_player/test/helpers/test_helpers.dart
@@ -199,6 +199,8 @@ PooledPlayer createMockPooledPlayer({
   when(() => mockPooledPlayer.player).thenReturn(mockPlayer);
   when(() => mockPooledPlayer.videoController).thenReturn(mockController);
   when(() => mockPooledPlayer.isDisposed).thenReturn(isDisposed);
+  when(() => mockPooledPlayer.wasRecycled).thenReturn(false);
+  when(mockPooledPlayer.clearRecycled).thenReturn(null);
   when(mockPooledPlayer.recycle).thenReturn(null);
   when(mockPooledPlayer.dispose).thenAnswer((_) async {});
 
@@ -213,11 +215,15 @@ PooledPlayer createMockPooledPlayerFromSetup(MockPlayerSetup setup) {
   final mockPooledPlayer = _MockPooledPlayer();
   final callbacks = <VoidCallback>[];
 
+  var recycled = false;
+
   when(() => mockPooledPlayer.player).thenReturn(setup.player);
   when(
     () => mockPooledPlayer.videoController,
   ).thenReturn(createMockVideoController());
   when(() => mockPooledPlayer.isDisposed).thenReturn(false);
+  when(() => mockPooledPlayer.wasRecycled).thenAnswer((_) => recycled);
+  when(mockPooledPlayer.clearRecycled).thenAnswer((_) => recycled = false);
   when(() => mockPooledPlayer.addOnEvictedCallback(any())).thenAnswer((inv) {
     callbacks.add(inv.positionalArguments.first as VoidCallback);
   });
@@ -227,6 +233,7 @@ PooledPlayer createMockPooledPlayerFromSetup(MockPlayerSetup setup) {
     callbacks.remove(inv.positionalArguments.first as VoidCallback);
   });
   when(mockPooledPlayer.recycle).thenAnswer((_) {
+    recycled = true;
     for (final cb in List<VoidCallback>.of(callbacks)) {
       cb();
     }


### PR DESCRIPTION

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
When `PlayerPool` reaches capacity, it previously disposed the LRU native player (stop → 50 ms delay → dispose) and allocated a brand new one on every swipe that introduced a new URL. Since `VideoFeedController._loadPlayer()` always calls `player.open(Media(url))` to replace media anyway, the native player instance can be reused directly. This PR adds `PooledPlayer.recycle()` and `PlayerPool._recycleLru()` to re-key the LRU player under the new URL instead of tearing it down, eliminating native player allocation/deallocation and the 50 ms disposal delay from the scroll path entirely.

**Related Issue:** Closes #1983

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore