### PR TITLE
feat(funnelcake): add in-memory caching

### DIFF
--- a/mobile/lib/blocs/categories/categories_bloc.dart
+++ b/mobile/lib/blocs/categories/categories_bloc.dart
@@ -6,17 +6,20 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:models/models.dart';
 import 'package:openvine/models/video_category.dart';
+import 'package:openvine/repositories/categories_repository.dart';
 
 part 'categories_event.dart';
 part 'categories_state.dart';
 
 /// BLoC for video categories.
 ///
-/// Fetches category list from the Funnelcake REST API and manages
-/// loading videos for a selected category with pagination.
+/// Fetches the category list via [CategoriesRepository] (which owns the
+/// in-memory TTL cache) and manages loading videos for a selected category
+/// with pagination.
 class CategoriesBloc extends Bloc<CategoriesEvent, CategoriesState> {
-  CategoriesBloc({required FunnelcakeApiClient funnelcakeApiClient})
-    : _apiClient = funnelcakeApiClient,
+  CategoriesBloc({required CategoriesRepository categoriesRepository})
+    : _categoriesRepository = categoriesRepository,
+      _apiClient = categoriesRepository.apiClient,
       super(const CategoriesState()) {
     on<CategoriesLoadRequested>(_onLoadRequested);
     on<CategorySelected>(_onCategorySelected);
@@ -25,6 +28,7 @@ class CategoriesBloc extends Bloc<CategoriesEvent, CategoriesState> {
     on<CategoryDeselected>(_onDeselected);
   }
 
+  final CategoriesRepository _categoriesRepository;
   final FunnelcakeApiClient _apiClient;
 
   Future<void> _onLoadRequested(
@@ -36,29 +40,12 @@ class CategoriesBloc extends Bloc<CategoriesEvent, CategoriesState> {
     emit(state.copyWith(categoriesStatus: CategoriesStatus.loading));
 
     try {
-      final categoriesJson = await _apiClient.getCategories(limit: 100);
-      final categories = categoriesJson
-          .map(VideoCategory.fromJson)
-          .where((c) => c.name.isNotEmpty && c.videoCount > 0)
-          .toList();
-      final indexedCategories = categories.indexed.toList()
-        ..sort((left, right) {
-          final featuredComparison = left.$2.featuredRank.compareTo(
-            right.$2.featuredRank,
-          );
-          if (featuredComparison != 0) {
-            return featuredComparison;
-          }
-          return left.$1.compareTo(right.$1);
-        });
-      final orderedCategories = indexedCategories
-          .map((entry) => entry.$2)
-          .toList();
+      final categories = await _categoriesRepository.getCategories();
 
       emit(
         state.copyWith(
           categoriesStatus: CategoriesStatus.loaded,
-          categories: orderedCategories,
+          categories: categories,
         ),
       );
     } on FunnelcakeException catch (e) {

--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -289,10 +289,9 @@ class VideoInteractionsBloc
     VideoInteractionsCommentCountUpdated event,
     Emitter<VideoInteractionsState> emit,
   ) {
-    _commentsRepository.updateCachedCommentCount(
-      _eventId,
-      event.commentCount,
-    );
+    // Only update the BLoC's own display state. Repository cache coherence is
+    // handled automatically by CommentsRepository.loadComments(), which updates
+    // _commentCountCache with the authoritative count on every full load.
     emit(state.copyWith(commentCount: event.commentCount));
   }
 }

--- a/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
+++ b/mobile/lib/features/creator_analytics/creator_analytics_repository.dart
@@ -51,11 +51,38 @@ abstract class CreatorAnalyticsRepository {
 }
 
 /// Funnelcake-backed implementation with layered fallbacks.
+///
+/// Social counts are cached per-pubkey for [socialCountsCacheDuration]
+/// (default 5 min) to avoid redundant requests when the analytics screen
+/// is reopened within a short period.
 class FunnelcakeCreatorAnalyticsRepository
     implements CreatorAnalyticsRepository {
-  FunnelcakeCreatorAnalyticsRepository(this._client);
+  FunnelcakeCreatorAnalyticsRepository(
+    this._client, {
+    Duration socialCountsCacheDuration = const Duration(minutes: 5),
+  }) : _socialCountsCacheDuration = socialCountsCacheDuration;
 
   final FunnelcakeApiClient _client;
+  final Duration _socialCountsCacheDuration;
+
+  final _socialCountsCache = <String, SocialCounts?>{};
+  final _socialCountsCachedAt = <String, DateTime>{};
+
+  bool _isSocialCountsCacheValid(String pubkey) {
+    final cachedAt = _socialCountsCachedAt[pubkey];
+    return cachedAt != null &&
+        DateTime.now().difference(cachedAt) < _socialCountsCacheDuration;
+  }
+
+  Future<SocialCounts?> _getSocialCounts(String pubkey) async {
+    if (_isSocialCountsCacheValid(pubkey)) {
+      return _socialCountsCache[pubkey];
+    }
+    final result = await _client.getSocialCounts(pubkey);
+    _socialCountsCache[pubkey] = result;
+    _socialCountsCachedAt[pubkey] = DateTime.now();
+    return result;
+  }
 
   @override
   Future<CreatorAnalyticsSnapshot> fetchCreatorAnalytics(String pubkey) async {
@@ -68,7 +95,7 @@ class FunnelcakeCreatorAnalyticsRepository
 
     final sourcesUsed = <AnalyticsDataSource>{};
 
-    final socialFuture = _client.getSocialCounts(pubkey);
+    final socialFuture = _getSocialCounts(pubkey);
     final videos = await _fetchAuthorVideos(pubkey);
     if (videos.isNotEmpty) {
       sourcesUsed.add(AnalyticsDataSource.authorVideos);

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -26,6 +26,7 @@ import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/repositories/categories_repository.dart';
 import 'package:openvine/repositories/dm_repository.dart';
 import 'package:openvine/repositories/follow_repository.dart';
 import 'package:openvine/services/account_deletion_service.dart';
@@ -1209,6 +1210,15 @@ HashtagRepository hashtagRepository(Ref ref) {
       return results;
     },
   );
+}
+
+/// Provider for CategoriesRepository instance.
+///
+/// Keep-alive so the categories cache survives tab and screen transitions.
+@Riverpod(keepAlive: true)
+CategoriesRepository categoriesRepository(Ref ref) {
+  final funnelcakeClient = ref.watch(funnelcakeApiClientProvider);
+  return CategoriesRepository(funnelcakeApiClient: funnelcakeClient);
 }
 
 /// Provider for ProfileRepository instance

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -2878,6 +2878,65 @@ final class HashtagRepositoryProvider
 
 String _$hashtagRepositoryHash() => r'aacff5fc9d7d369a80b68ffa4595628b18ab1f99';
 
+/// Provider for CategoriesRepository instance.
+///
+/// Keep-alive so the categories cache survives tab and screen transitions.
+
+@ProviderFor(categoriesRepository)
+const categoriesRepositoryProvider = CategoriesRepositoryProvider._();
+
+/// Provider for CategoriesRepository instance.
+///
+/// Keep-alive so the categories cache survives tab and screen transitions.
+
+final class CategoriesRepositoryProvider
+    extends
+        $FunctionalProvider<
+          CategoriesRepository,
+          CategoriesRepository,
+          CategoriesRepository
+        >
+    with $Provider<CategoriesRepository> {
+  /// Provider for CategoriesRepository instance.
+  ///
+  /// Keep-alive so the categories cache survives tab and screen transitions.
+  const CategoriesRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'categoriesRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$categoriesRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<CategoriesRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  CategoriesRepository create(Ref ref) {
+    return categoriesRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(CategoriesRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<CategoriesRepository>(value),
+    );
+  }
+}
+
+String _$categoriesRepositoryHash() =>
+    r'6a3a483ae2565033933e9891b1742571c6e15fa8';
+
 /// Provider for ProfileRepository instance
 ///
 /// Creates a ProfileRepository for managing user profiles (Kind 0 metadata).

--- a/mobile/lib/repositories/categories_repository.dart
+++ b/mobile/lib/repositories/categories_repository.dart
@@ -1,0 +1,81 @@
+// ABOUTME: Repository for video categories from the Funnelcake REST API.
+// ABOUTME: Owns the in-memory TTL cache for the categories list.
+
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
+import 'package:openvine/models/video_category.dart';
+
+/// Repository for fetching and caching video categories.
+///
+/// Wraps [FunnelcakeApiClient.getCategories] and applies featured-first ordering.
+/// Results are cached in memory for [cacheDuration] (default 10 min) so that
+/// repeated screen opens do not fire redundant network requests.
+class CategoriesRepository {
+  CategoriesRepository({
+    required FunnelcakeApiClient funnelcakeApiClient,
+    Duration cacheDuration = const Duration(minutes: 10),
+  }) : _funnelcakeApiClient = funnelcakeApiClient,
+       _cacheDuration = cacheDuration;
+
+  final FunnelcakeApiClient _funnelcakeApiClient;
+  final Duration _cacheDuration;
+
+  /// Exposes the underlying API client so callers can make video-level requests
+  /// (e.g. [FunnelcakeApiClient.getVideosByCategory]) directly without going
+  /// through this repository.
+  FunnelcakeApiClient get apiClient => _funnelcakeApiClient;
+
+  List<VideoCategory>? _cache;
+  DateTime? _cachedAt;
+
+  bool get _isCacheValid =>
+      _cache != null &&
+      _cachedAt != null &&
+      DateTime.now().difference(_cachedAt!) < _cacheDuration;
+
+  /// Returns the ordered list of categories.
+  ///
+  /// Returns the in-memory cached result when available and not expired.
+  /// When [forceRefresh] is `true` the cache is bypassed and a fresh request
+  /// is made. On success the cache is updated.
+  ///
+  /// Throws:
+  /// - [FunnelcakeNotConfiguredException] if the API is not configured.
+  /// - [FunnelcakeApiException] on server error.
+  /// - [FunnelcakeTimeoutException] on timeout.
+  /// - [FunnelcakeException] for other errors.
+  Future<List<VideoCategory>> getCategories({bool forceRefresh = false}) async {
+    if (!forceRefresh && _isCacheValid) {
+      return _cache!;
+    }
+
+    final categoriesJson = await _funnelcakeApiClient.getCategories(limit: 100);
+    final categories = categoriesJson
+        .map(VideoCategory.fromJson)
+        .where((c) => c.name.isNotEmpty && c.videoCount > 0)
+        .toList();
+
+    final indexedCategories = categories.indexed.toList()
+      ..sort((left, right) {
+        final featuredComparison = left.$2.featuredRank.compareTo(
+          right.$2.featuredRank,
+        );
+        if (featuredComparison != 0) {
+          return featuredComparison;
+        }
+        return left.$1.compareTo(right.$1);
+      });
+
+    final ordered = indexedCategories.map((entry) => entry.$2).toList();
+
+    _cache = ordered;
+    _cachedAt = DateTime.now();
+
+    return ordered;
+  }
+
+  /// Clears the in-memory cache so the next call fetches fresh data.
+  void invalidateCache() {
+    _cache = null;
+    _cachedAt = null;
+  }
+}

--- a/mobile/lib/screens/category_gallery_screen.dart
+++ b/mobile/lib/screens/category_gallery_screen.dart
@@ -11,7 +11,7 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/categories/categories_bloc.dart';
 import 'package:openvine/models/video_category.dart';
-import 'package:openvine/providers/curation_providers.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/widgets/categories/category_visuals.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
@@ -46,11 +46,11 @@ class _CategoryGalleryScreenState extends ConsumerState<CategoryGalleryScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final apiClient = ref.watch(funnelcakeApiClientProvider);
+    final categoriesRepository = ref.watch(categoriesRepositoryProvider);
 
     return BlocProvider(
       create: (_) =>
-          CategoriesBloc(funnelcakeApiClient: apiClient)
+          CategoriesBloc(categoriesRepository: categoriesRepository)
             ..add(CategorySelected(widget.category)),
       child: BlocListener<CategoriesBloc, CategoriesState>(
         listenWhen: (previous, current) => previous.videos != current.videos,

--- a/mobile/lib/widgets/categories_tab.dart
+++ b/mobile/lib/widgets/categories_tab.dart
@@ -7,7 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/categories/categories_bloc.dart';
 import 'package:openvine/models/video_category.dart';
-import 'package:openvine/providers/curation_providers.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/category_gallery_screen.dart';
 import 'package:openvine/widgets/categories/category_visuals.dart';
 
@@ -16,11 +16,11 @@ class CategoriesTab extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final apiClient = ref.watch(funnelcakeApiClientProvider);
+    final categoriesRepository = ref.watch(categoriesRepositoryProvider);
 
     return BlocProvider(
       create: (_) =>
-          CategoriesBloc(funnelcakeApiClient: apiClient)
+          CategoriesBloc(categoriesRepository: categoriesRepository)
             ..add(const CategoriesLoadRequested()),
       child: BlocBuilder<CategoriesBloc, CategoriesState>(
         builder: (context, state) {

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -49,8 +49,9 @@ class CommentsRepository {
   /// In-memory cache of comment counts keyed by root event ID.
   ///
   /// Prevents redundant relay queries when the same video is scrolled
-  /// back into view. Adjusted on post/delete and can be set externally
-  /// via [updateCachedCommentCount] (e.g. from the comments sheet).
+  /// back into view. Adjusted on post/delete, and automatically updated
+  /// when [loadComments] receives an authoritative total count from the
+  /// server or relay (so callers never need to push counts back in).
   final Map<String, int> _commentCountCache = {};
 
   /// Subscription ID for the active comment watch, if any.
@@ -102,12 +103,17 @@ class CommentsRepository {
             offset: offset,
           );
           if (response != null) {
-            return _buildThreadFromRestComments(
+            final thread = _buildThreadFromRestComments(
               response,
               rootEventId,
               rootEventKind,
               rootAddressableId: rootAddressableId,
             );
+            // Auto-update the count cache with the authoritative REST total.
+            if (thread.totalCount > 0) {
+              _commentCountCache[rootEventId] = thread.totalCount;
+            }
+            return thread;
           }
         } on FunnelcakeException {
           // Fall back to relay query when REST bootstrap is unavailable.
@@ -125,6 +131,8 @@ class CommentsRepository {
         limit: limit,
         until: untilTimestamp,
       );
+
+      CommentThread thread;
 
       // If we have an addressable ID, also query by uppercase A tag
       // Some clients may reference addressable events using A instead of E
@@ -151,21 +159,30 @@ class CommentsRepository {
           eventMap[event.id] = event;
         }
 
-        return _buildThreadFromEvents(
+        thread = _buildThreadFromEvents(
           eventMap.values.toList(),
           rootEventId,
           rootEventKind,
           rootAddressableId: rootAddressableId,
         );
+      } else {
+        // No addressable ID - just query by E tag
+        final events = await _nostrClient.queryEvents([filterByE]);
+        thread = _buildThreadFromEvents(
+          events,
+          rootEventId,
+          rootEventKind,
+        );
       }
 
-      // No addressable ID - just query by E tag
-      final events = await _nostrClient.queryEvents([filterByE]);
-      return _buildThreadFromEvents(
-        events,
-        rootEventId,
-        rootEventKind,
-      );
+      // Auto-update the count cache with the authoritative total so that
+      // callers (e.g. VideoInteractionsBloc) don't need to push counts back
+      // into the repository manually.
+      if (before == null && thread.totalCount > 0) {
+        _commentCountCache[rootEventId] = thread.totalCount;
+      }
+
+      return thread;
     } on Exception catch (e) {
       throw LoadCommentsFailedException('Failed to load comments: $e');
     }

--- a/mobile/test/blocs/categories/categories_bloc_test.dart
+++ b/mobile/test/blocs/categories/categories_bloc_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for the CategoriesBloc
 // ABOUTME: Verifies category loading, selection, pagination, sorting, and deselection
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
@@ -8,32 +10,39 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/categories/categories_bloc.dart';
 import 'package:openvine/models/video_category.dart';
+import 'package:openvine/repositories/categories_repository.dart';
+
+class _MockCategoriesRepository extends Mock implements CategoriesRepository {}
 
 class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
 
 void main() {
+  late _MockCategoriesRepository mockRepository;
   late _MockFunnelcakeApiClient mockApiClient;
 
   setUp(() {
     mockApiClient = _MockFunnelcakeApiClient();
+    mockRepository = _MockCategoriesRepository();
+    // CategoriesBloc uses repository.apiClient for video-level calls.
+    when(() => mockRepository.apiClient).thenReturn(mockApiClient);
   });
 
   group(CategoriesBloc, () {
     group('CategoriesLoadRequested', () {
-      final categoriesJson = [
-        {'name': 'music', 'video_count': 1500},
-        {'name': 'comedy', 'video_count': 900},
-        {'name': 'dance', 'video_count': 800},
+      final categories = [
+        const VideoCategory(name: 'music', videoCount: 1500),
+        const VideoCategory(name: 'comedy', videoCount: 900),
+        const VideoCategory(name: 'dance', videoCount: 800),
       ];
 
       blocTest<CategoriesBloc, CategoriesState>(
         'emits [loading, loaded] when categories load successfully',
         setUp: () {
           when(
-            () => mockApiClient.getCategories(limit: 100),
-          ).thenAnswer((_) async => categoriesJson);
+            () => mockRepository.getCategories(),
+          ).thenAnswer((_) async => categories);
         },
-        build: () => CategoriesBloc(funnelcakeApiClient: mockApiClient),
+        build: () => CategoriesBloc(categoriesRepository: mockRepository),
         act: (bloc) => bloc.add(const CategoriesLoadRequested()),
         expect: () => [
           const CategoriesState(categoriesStatus: CategoriesStatus.loading),
@@ -47,18 +56,18 @@ void main() {
           ),
         ],
         verify: (_) {
-          verify(() => mockApiClient.getCategories(limit: 100)).called(1);
+          verify(() => mockRepository.getCategories()).called(1);
         },
       );
 
       blocTest<CategoriesBloc, CategoriesState>(
-        'emits [loading, error] when API throws',
+        'emits [loading, error] when repository throws',
         setUp: () {
           when(
-            () => mockApiClient.getCategories(limit: 100),
+            () => mockRepository.getCategories(),
           ).thenThrow(const FunnelcakeException('Network error'));
         },
-        build: () => CategoriesBloc(funnelcakeApiClient: mockApiClient),
+        build: () => CategoriesBloc(categoriesRepository: mockRepository),
         act: (bloc) => bloc.add(const CategoriesLoadRequested()),
         expect: () => [
           const CategoriesState(categoriesStatus: CategoriesStatus.loading),
@@ -72,58 +81,33 @@ void main() {
         ],
       );
 
-      blocTest<CategoriesBloc, CategoriesState>(
-        'filters out categories with empty names or zero videos',
-        setUp: () {
-          when(() => mockApiClient.getCategories(limit: 100)).thenAnswer(
-            (_) async => [
-              {'name': 'music', 'video_count': 100},
-              {'name': '', 'video_count': 50},
-              {'name': 'dance', 'video_count': 0},
-            ],
-          );
-        },
-        build: () => CategoriesBloc(funnelcakeApiClient: mockApiClient),
-        act: (bloc) => bloc.add(const CategoriesLoadRequested()),
-        expect: () => [
-          const CategoriesState(categoriesStatus: CategoriesStatus.loading),
-          const CategoriesState(
-            categoriesStatus: CategoriesStatus.loaded,
-            categories: [VideoCategory(name: 'music', videoCount: 100)],
-          ),
-        ],
-      );
+      test(
+        'does not re-fetch while a load is already in progress',
+        () async {
+          // Use a Completer to keep the first request suspended so the second
+          // event arrives while the bloc is still in loading state.
+          final completer = Completer<List<VideoCategory>>();
+          when(
+            () => mockRepository.getCategories(),
+          ).thenAnswer((_) => completer.future);
 
-      blocTest<CategoriesBloc, CategoriesState>(
-        'orders featured categories first using the curated design order',
-        setUp: () {
-          when(() => mockApiClient.getCategories(limit: 100)).thenAnswer(
-            (_) async => [
-              {'name': 'technology', 'video_count': 30},
-              {'name': 'music', 'video_count': 20},
-              {'name': 'fashion', 'video_count': 10},
-              {'name': 'animals', 'video_count': 40},
-              {'name': 'comedy', 'video_count': 15},
-              {'name': 'art', 'video_count': 50},
-            ],
-          );
+          final bloc = CategoriesBloc(categoriesRepository: mockRepository);
+
+          // First request — bloc enters loading state.
+          bloc.add(const CategoriesLoadRequested());
+          await Future<void>.delayed(Duration.zero);
+
+          // Second request while first is still suspended.
+          bloc.add(const CategoriesLoadRequested());
+          await Future<void>.delayed(Duration.zero);
+
+          // Only one network call should have been made.
+          verify(() => mockRepository.getCategories()).called(1);
+
+          // Clean up.
+          completer.complete([]);
+          await bloc.close();
         },
-        build: () => CategoriesBloc(funnelcakeApiClient: mockApiClient),
-        act: (bloc) => bloc.add(const CategoriesLoadRequested()),
-        expect: () => [
-          const CategoriesState(categoriesStatus: CategoriesStatus.loading),
-          const CategoriesState(
-            categoriesStatus: CategoriesStatus.loaded,
-            categories: [
-              VideoCategory(name: 'animals', videoCount: 40),
-              VideoCategory(name: 'fashion', videoCount: 10),
-              VideoCategory(name: 'music', videoCount: 20),
-              VideoCategory(name: 'art', videoCount: 50),
-              VideoCategory(name: 'technology', videoCount: 30),
-              VideoCategory(name: 'comedy', videoCount: 15),
-            ],
-          ),
-        ],
       );
     });
 
@@ -144,7 +128,7 @@ void main() {
             ),
           ).thenAnswer((_) async => mockVideoStats);
         },
-        build: () => CategoriesBloc(funnelcakeApiClient: mockApiClient),
+        build: () => CategoriesBloc(categoriesRepository: mockRepository),
         act: (bloc) => bloc.add(const CategorySelected(category)),
         expect: () => [
           const CategoriesState(
@@ -172,7 +156,7 @@ void main() {
             ),
           ).thenThrow(const FunnelcakeException('Failed'));
         },
-        build: () => CategoriesBloc(funnelcakeApiClient: mockApiClient),
+        build: () => CategoriesBloc(categoriesRepository: mockRepository),
         act: (bloc) => bloc.add(const CategorySelected(category)),
         expect: () => [
           const CategoriesState(
@@ -207,7 +191,7 @@ void main() {
           selectedCategory: category,
           videosStatus: CategoriesVideosStatus.loaded,
         ),
-        build: () => CategoriesBloc(funnelcakeApiClient: mockApiClient),
+        build: () => CategoriesBloc(categoriesRepository: mockRepository),
         act: (bloc) => bloc.add(const CategoryVideosSortChanged('classic')),
         expect: () => [
           isA<CategoriesState>()
@@ -229,7 +213,7 @@ void main() {
 
       blocTest<CategoriesBloc, CategoriesState>(
         'does nothing when no category selected',
-        build: () => CategoriesBloc(funnelcakeApiClient: mockApiClient),
+        build: () => CategoriesBloc(categoriesRepository: mockRepository),
         act: (bloc) => bloc.add(const CategoryVideosSortChanged('classic')),
         expect: () => <CategoriesState>[],
       );
@@ -242,7 +226,7 @@ void main() {
           selectedCategory: VideoCategory(name: 'music', videoCount: 1500),
           videosStatus: CategoriesVideosStatus.loaded,
         ),
-        build: () => CategoriesBloc(funnelcakeApiClient: mockApiClient),
+        build: () => CategoriesBloc(categoriesRepository: mockRepository),
         act: (bloc) => bloc.add(const CategoryDeselected()),
         expect: () => [
           isA<CategoriesState>()

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -911,7 +911,7 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'writes updated count back to repository cache',
+        'does not call repository when updating comment count display',
         build: createBloc,
         seed: () => const VideoInteractionsState(
           status: VideoInteractionsStatus.success,
@@ -919,12 +919,11 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoInteractionsCommentCountUpdated(12)),
         verify: (_) {
-          verify(
-            () => mockCommentsRepository.updateCachedCommentCount(
-              testEventId,
-              12,
-            ),
-          ).called(1);
+          // Repository cache coherence is now owned by
+          // CommentsRepository.loadComments(), not the BLoC.
+          verifyNever(
+            () => mockCommentsRepository.updateCachedCommentCount(any(), any()),
+          );
         },
       );
     });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Adds in-memory TTL caching to `CategoriesRepository` (new) and `CreatorAnalyticsRepository` so repeated opens of the categories and analytics screens avoid redundant network requests. Moves category-list caching out of `CategoriesBloc` into a dedicated `CategoriesRepository`, and removes the BLoC-to-repository cache push in `VideoInteractionsBloc` by having `CommentsRepository.loadComments` auto-update its own count cache on every authoritative load - so repositories own their own cache coherence rather than relying on BLoCs to push data back in.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #2357, Closes #2418

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore