### PR TITLE
refactor: extract CountFormatter into a package

### DIFF
--- a/.github/workflows/count_formatter.yaml
+++ b/.github/workflows/count_formatter.yaml
@@ -1,0 +1,26 @@
+# ABOUTME: CI workflow for the count_formatter package.
+# ABOUTME: Runs tests, formatting, and analysis only when count_formatter files change.
+
+name: Count Formatter CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "mobile/packages/count_formatter/**"
+      - ".github/workflows/count_formatter.yaml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "mobile/packages/count_formatter/**"
+      - ".github/workflows/count_formatter.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+    with:
+      working_directory: "mobile/packages/count_formatter"

--- a/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
@@ -1,6 +1,7 @@
 // ABOUTME: View for the message request preview screen.
 // ABOUTME: Shows sender profile info, message count, and accept/decline actions.
 
+import 'package:count_formatter/count_formatter.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -12,7 +13,6 @@ import 'package:openvine/blocs/dm/message_requests/request_preview_cubit.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
-import 'package:openvine/utils/count_formatter.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 

--- a/mobile/packages/count_formatter/analysis_options.yaml
+++ b/mobile/packages/count_formatter/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:very_good_analysis/analysis_options.yaml

--- a/mobile/packages/count_formatter/lib/count_formatter.dart
+++ b/mobile/packages/count_formatter/lib/count_formatter.dart
@@ -1,0 +1,1 @@
+export 'src/count_formatter.dart';

--- a/mobile/packages/count_formatter/lib/src/count_formatter.dart
+++ b/mobile/packages/count_formatter/lib/src/count_formatter.dart
@@ -1,10 +1,8 @@
-// ABOUTME: Utility for formatting numbers in compact notation (1.2k, 3m).
+// ABOUTME: Utility for formatting numbers in compact human-readable notation.
 // ABOUTME: Used for follower counts, video counts, and similar metrics.
 
 /// Formats numbers in compact human-readable notation.
-class CountFormatter {
-  const CountFormatter._();
-
+abstract class CountFormatter {
   /// Formats [count] as a compact string (e.g., 1.2k, 3m).
   static String formatCompact(Object count) {
     final n = count is int ? count : int.tryParse('$count') ?? 0;

--- a/mobile/packages/count_formatter/pubspec.yaml
+++ b/mobile/packages/count_formatter/pubspec.yaml
@@ -1,0 +1,12 @@
+name: count_formatter
+description: Utility for formatting numbers in compact human-readable notation.
+version: 0.1.0+1
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.11.0
+
+dev_dependencies:
+  test: ^1.26.3
+  very_good_analysis: ^10.0.0

--- a/mobile/packages/count_formatter/test/src/count_formatter_test.dart
+++ b/mobile/packages/count_formatter/test/src/count_formatter_test.dart
@@ -1,0 +1,88 @@
+import 'package:count_formatter/count_formatter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(CountFormatter, () {
+    group('formatCompact', () {
+      group('below 1000', () {
+        test('returns "0" for 0', () {
+          expect(CountFormatter.formatCompact(0), equals('0'));
+        });
+
+        test('returns the number as-is for 999', () {
+          expect(CountFormatter.formatCompact(999), equals('999'));
+        });
+
+        test('accepts string input', () {
+          expect(CountFormatter.formatCompact('42'), equals('42'));
+        });
+
+        test('returns "0" for unparseable string', () {
+          expect(CountFormatter.formatCompact('abc'), equals('0'));
+        });
+      });
+
+      group('thousands (1k–999k)', () {
+        test('returns "1k" for 1000', () {
+          expect(CountFormatter.formatCompact(1000), equals('1k'));
+        });
+
+        test('returns "1.2k" for 1200', () {
+          expect(CountFormatter.formatCompact(1200), equals('1.2k'));
+        });
+
+        test('returns "10k" for 10000', () {
+          expect(CountFormatter.formatCompact(10000), equals('10k'));
+        });
+
+        test('returns "999k" for 999000', () {
+          expect(CountFormatter.formatCompact(999000), equals('999k'));
+        });
+
+        test('rounds to 1 decimal place for 1500', () {
+          expect(CountFormatter.formatCompact(1500), equals('1.5k'));
+        });
+
+        test('omits decimal when whole number for 2000', () {
+          expect(CountFormatter.formatCompact(2000), equals('2k'));
+        });
+      });
+
+      group('boundary near 1m (999950 threshold)', () {
+        test('returns "999.9k" for 999900', () {
+          expect(CountFormatter.formatCompact(999900), equals('999.9k'));
+        });
+
+        test('returns "1m" for 999950 (rounds up to 1m)', () {
+          expect(CountFormatter.formatCompact(999950), equals('1m'));
+        });
+      });
+
+      group('millions (1m+)', () {
+        test('returns "1m" for 1000000', () {
+          expect(CountFormatter.formatCompact(1000000), equals('1m'));
+        });
+
+        test('returns "1.2m" for 1200000', () {
+          expect(CountFormatter.formatCompact(1200000), equals('1.2m'));
+        });
+
+        test('returns "3m" for 3000000', () {
+          expect(CountFormatter.formatCompact(3000000), equals('3m'));
+        });
+
+        test('returns "10m" for 10000000', () {
+          expect(CountFormatter.formatCompact(10000000), equals('10m'));
+        });
+
+        test('omits decimal when whole number for 5000000', () {
+          expect(CountFormatter.formatCompact(5000000), equals('5m'));
+        });
+
+        test('rounds to 1 decimal place for 1500000', () {
+          expect(CountFormatter.formatCompact(1500000), equals('1.5m'));
+        });
+      });
+    });
+  });
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -24,6 +24,7 @@ environment:
 
 workspace:
   - packages/comments_repository
+  - packages/count_formatter
   - packages/curated_list_repository
   - packages/divine_ui
   - packages/db_client
@@ -142,6 +143,9 @@ dependencies:
 
   # TV static noise effect
   tv_static_effect:
+
+  # Count Formatter - Compact number formatting
+  count_formatter:
 
   # Divine UI - Shared UI components
   divine_ui:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Extracts `CountFormatter` from `mobile/lib/utils/count_formatter.dart` into a new standalone workspace package at `mobile/packages/count_formatter/`, matching the pattern established by `time_formatter`. Adds unit tests covering all formatting thresholds and edge cases (0, sub-1k, 1k, boundary at 999950, 1m+).

<!--- Describe your changes in detail -->

**Related Issue:** #Closes #2287

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore