### PR TITLE
feat(e2e): multi-relay test personas for Nostr-native user coverage

### DIFF
--- a/local_stack/docker-compose.yml
+++ b/local_stack/docker-compose.yml
@@ -243,6 +243,34 @@ services:
       start_period: 10s
 
   # ---------------------------------------------------------------------------
+  # Indexer relay (stores kind 10002 + kind 0, simulates purplepag.es)
+  # ---------------------------------------------------------------------------
+  relay-indexer:
+    image: ghcr.io/verse-pbc/relay_builder:latest
+    pull_policy: always
+    ports:
+      - "47778:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8080'"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+
+  # ---------------------------------------------------------------------------
+  # External relay (stores kind 0 + videos for Nostr-native users, simulates damus)
+  # ---------------------------------------------------------------------------
+  relay-external:
+    image: ghcr.io/verse-pbc/relay_builder:latest
+    pull_policy: always
+    ports:
+      - "47779:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/8080'"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+
+  # ---------------------------------------------------------------------------
   # E2E seed data (runs once at startup)
   # ---------------------------------------------------------------------------
   e2e-seed:
@@ -254,6 +282,10 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
+      relay-indexer:
+        condition: service_healthy
+      relay-external:
+        condition: service_healthy
     environment:
       RELAY_URL: ws://funnelcake-relay:7777
       BLOSSOM_URL: http://blossom:7676
@@ -264,6 +296,10 @@ services:
       MINIO_SECRET_KEY: minioadmin
       NUM_VIDEOS: "100"
       NUM_UNIQUE_VIDEOS: ${NUM_UNIQUE_VIDEOS:-10}
+      INDEXER_RELAY_URL: ws://relay-indexer:8080
+      EXTERNAL_RELAY_URL: ws://relay-external:8080
+      RELAY_PUBLIC_URL: ws://10.0.2.2:47777
+      EXTERNAL_RELAY_PUBLIC_URL: ws://10.0.2.2:47779
     restart: "no"
 
 volumes:

--- a/local_stack/seed/seed.py
+++ b/local_stack/seed/seed.py
@@ -40,10 +40,19 @@ MINIO_BUCKET = os.environ.get("MINIO_BUCKET", "divine-blossom-local")
 MINIO_ACCESS_KEY = os.environ.get("MINIO_ACCESS_KEY", "minioadmin")
 MINIO_SECRET_KEY = os.environ.get("MINIO_SECRET_KEY", "minioadmin")
 
+INDEXER_RELAY_URL = os.environ.get("INDEXER_RELAY_URL", "ws://relay-indexer:8080")
+EXTERNAL_RELAY_URL = os.environ.get("EXTERNAL_RELAY_URL", "ws://relay-external:8080")
+RELAY_PUBLIC_URL = os.environ.get("RELAY_PUBLIC_URL", "ws://10.0.2.2:47777")
+EXTERNAL_RELAY_PUBLIC_URL = os.environ.get("EXTERNAL_RELAY_PUBLIC_URL", "ws://10.0.2.2:47779")
+
 SEED_PHRASE = "divine-e2e-seed-phrase-2026"
 NUM_AUTHORS = 20
 NUM_POPULAR = 5
 POPULAR_VIDEOS = 16  # each popular author gets ~16 videos
+
+# Author type split: first half are Type A (Divine), second half Type B (Nostr-native)
+NUM_TYPE_A = NUM_AUTHORS // 2  # 10
+NUM_TYPE_B = NUM_AUTHORS - NUM_TYPE_A  # 10
 
 POPULAR_HASHTAGS = ["music", "dance", "comedy", "art", "nature"]
 RARE_HASHTAGS = [
@@ -113,6 +122,55 @@ def sign_event(event: dict, privkey_bytes: bytes) -> dict:
     sig = privkey.sign_schnorr(event_id)
     event["sig"] = sig.hex()
     return event
+
+
+def author_is_type_a(author_idx: int) -> bool:
+    """Author 0..NUM_TYPE_A-1 are Type A (Divine), rest are Type B (Nostr-native)."""
+    return author_idx < NUM_TYPE_A
+
+
+def build_profile_event(
+    author_privkey: bytes,
+    author_pubkey: str,
+    author_idx: int,
+) -> dict:
+    """Build and sign a kind 0 profile metadata event."""
+    persona = "divine" if author_is_type_a(author_idx) else "nostr-native"
+    name = f"e2e-{persona}-{author_idx}"
+    content = json.dumps({
+        "name": name,
+        "display_name": f"E2E {persona.title()} User {author_idx}",
+        "about": f"Test {persona} user for E2E persona testing",
+    })
+    event = {
+        "kind": 0,
+        "pubkey": author_pubkey,
+        "created_at": int(time.time()),
+        "content": content,
+        "tags": [],
+    }
+    return sign_event(event, author_privkey)
+
+
+def build_relay_list_event(
+    author_privkey: bytes,
+    author_pubkey: str,
+) -> dict:
+    """Build and sign a kind 10002 relay list event.
+
+    Uses emulator-accessible public URLs, not Docker-internal hostnames.
+    """
+    event = {
+        "kind": 10002,
+        "pubkey": author_pubkey,
+        "created_at": int(time.time()),
+        "content": "",
+        "tags": [
+            ["r", RELAY_PUBLIC_URL],
+            ["r", EXTERNAL_RELAY_PUBLIC_URL],
+        ],
+    }
+    return sign_event(event, author_privkey)
 
 
 # ---------------------------------------------------------------------------
@@ -414,17 +472,19 @@ def build_event(
 # ---------------------------------------------------------------------------
 # Relay publishing
 # ---------------------------------------------------------------------------
-def publish_events(events: list[dict]) -> tuple[int, int]:
-    """Publish events to the relay via WebSocket. Returns (ok_count, fail_count)."""
+def publish_events_to_relay(events: list[dict], relay_url: str) -> tuple[int, int]:
+    """Publish events to the specified relay. Returns (ok_count, fail_count).
+
+    Throttles to ~9 events/s to stay under relay_builder's 10/s rate limit.
+    """
     ok_count = 0
     fail_count = 0
 
-    with websockets.sync.client.connect(RELAY_URL, close_timeout=10) as ws:
+    with websockets.sync.client.connect(relay_url, close_timeout=10) as ws:
         for i, event in enumerate(events):
             msg = json.dumps(["EVENT", event])
             ws.send(msg)
 
-            # Wait for OK response
             try:
                 raw = ws.recv(timeout=10)
                 response = json.loads(raw)
@@ -443,7 +503,6 @@ def publish_events(events: list[dict]) -> tuple[int, int]:
                             file=sys.stderr,
                         )
                 else:
-                    # Unexpected response; treat as failure
                     fail_count += 1
                     print(
                         f"  Unexpected response for event {i}: {raw}",
@@ -456,7 +515,15 @@ def publish_events(events: list[dict]) -> tuple[int, int]:
             if (i + 1) % 20 == 0:
                 print(f"  Published {i + 1}/{len(events)} events...")
 
+            # Stay under relay_builder's 10/s rate limit
+            time.sleep(0.12)
+
     return ok_count, fail_count
+
+
+def publish_events(events: list[dict]) -> tuple[int, int]:
+    """Publish events to the FunnelCake relay."""
+    return publish_events_to_relay(events, RELAY_URL)
 
 
 # ---------------------------------------------------------------------------
@@ -480,18 +547,23 @@ def wait_for_services(max_retries: int = 30, delay: float = 2.0) -> None:
                 sys.exit(1)
             time.sleep(delay)
 
-    # Check relay (WebSocket connect + disconnect)
-    for attempt in range(max_retries):
-        try:
-            with websockets.sync.client.connect(RELAY_URL, close_timeout=3):
-                pass
-            print(f"  Relay ready at {RELAY_URL}")
-            break
-        except (OSError, TimeoutError, websockets.exceptions.WebSocketException):
-            if attempt == max_retries - 1:
-                print(f"Relay not ready after {max_retries} attempts", file=sys.stderr)
-                sys.exit(1)
-            time.sleep(delay)
+    # Check relays (WebSocket connect + disconnect)
+    for label, url in [
+        ("Relay", RELAY_URL),
+        ("Indexer relay", INDEXER_RELAY_URL),
+        ("External relay", EXTERNAL_RELAY_URL),
+    ]:
+        for attempt in range(max_retries):
+            try:
+                with websockets.sync.client.connect(url, close_timeout=3):
+                    pass
+                print(f"  {label} ready at {url}")
+                break
+            except (OSError, TimeoutError, websockets.exceptions.WebSocketException):
+                if attempt == max_retries - 1:
+                    print(f"{label} not ready after {max_retries} attempts", file=sys.stderr)
+                    sys.exit(1)
+                time.sleep(delay)
 
     print("All services ready.")
 
@@ -581,6 +653,10 @@ def main() -> None:
         f"Config: RELAY_URL={RELAY_URL} BLOSSOM_URL={BLOSSOM_URL} "
         f"NUM_VIDEOS={NUM_VIDEOS} NUM_UNIQUE_VIDEOS={NUM_UNIQUE_VIDEOS}"
     )
+    print(
+        f"  INDEXER_RELAY_URL={INDEXER_RELAY_URL} "
+        f"EXTERNAL_RELAY_URL={EXTERNAL_RELAY_URL}"
+    )
 
     wait_for_services()
 
@@ -592,10 +668,41 @@ def main() -> None:
     print(f"\nGenerating {NUM_AUTHORS} author keypairs...")
     keypairs = [derive_keypair(i) for i in range(NUM_AUTHORS)]
     for i, (_, pubkey) in enumerate(keypairs):
+        persona = "type-A" if author_is_type_a(i) else "type-B"
         label = "popular" if i < NUM_POPULAR else "long-tail"
-        print(f"  Author {i} ({label}): {pubkey}")
+        print(f"  Author {i} ({label}, {persona}): {pubkey}")
 
-    # 2. Generate and upload unique videos + thumbnails + variants
+    # 2. Publish kind 10002 relay list events (all authors → indexer)
+    print(f"\nPublishing {NUM_AUTHORS} relay list events to indexer relay...")
+    relay_list_events = []
+    for privkey, pubkey in keypairs:
+        relay_list_events.append(build_relay_list_event(privkey, pubkey))
+    ok, fail = publish_events_to_relay(relay_list_events, INDEXER_RELAY_URL)
+    print(f"  Relay lists: {ok} ok, {fail} failed")
+
+    # 3. Publish kind 0 profile events (routed by type)
+    print(f"\nPublishing {NUM_AUTHORS} profile events...")
+    indexer_profiles = []
+    funnelcake_profiles = []
+    external_profiles = []
+    for i, (privkey, pubkey) in enumerate(keypairs):
+        profile = build_profile_event(privkey, pubkey, i)
+        indexer_profiles.append(profile)
+        if author_is_type_a(i):
+            funnelcake_profiles.append(profile)
+        else:
+            external_profiles.append(profile)
+
+    ok, fail = publish_events_to_relay(indexer_profiles, INDEXER_RELAY_URL)
+    print(f"  Indexer profiles: {ok} ok, {fail} failed")
+    if funnelcake_profiles:
+        ok, fail = publish_events_to_relay(funnelcake_profiles, RELAY_URL)
+        print(f"  FunnelCake profiles: {ok} ok, {fail} failed")
+    if external_profiles:
+        ok, fail = publish_events_to_relay(external_profiles, EXTERNAL_RELAY_URL)
+        print(f"  External profiles: {ok} ok, {fail} failed")
+
+    # 4. Generate and upload unique videos + thumbnails + variants
     # Each video has a different noise seed so SHA-256 hashes differ,
     # preventing HTTP cache from masking download time in perf tests.
     print(f"\nGenerating {NUM_UNIQUE_VIDEOS} unique test videos (1080x1920, ~15 Mbps each)...")
@@ -608,11 +715,14 @@ def main() -> None:
 
     print(f"All {NUM_UNIQUE_VIDEOS} videos uploaded successfully")
 
-    # 3. Build events (round-robin across unique videos)
+    # 5. Build and route video events
+    # Type A authors: all videos → FunnelCake
+    # Type B authors: odd-indexed → external, even-indexed → FunnelCake
     print(f"\nBuilding {NUM_VIDEOS} events...")
     rng = random.Random(42)
     author_assignments = build_author_video_map(rng)
-    events = []
+    funnelcake_events = []
+    external_events = []
 
     for i in range(NUM_VIDEOS):
         author_idx = author_assignments[i]
@@ -634,15 +744,38 @@ def main() -> None:
             hashtags=hashtags,
             rng=rng,
         )
-        events.append(event)
 
-    # 4. Publish to relay
-    print(f"\nPublishing {len(events)} events to {RELAY_URL}...")
-    ok_count, fail_count = publish_events(events)
+        if author_is_type_a(author_idx):
+            funnelcake_events.append(event)
+        elif i % 2 == 0:
+            funnelcake_events.append(event)
+        else:
+            external_events.append(event)
 
-    # 5. Summary
-    print(f"\nPublished {ok_count}/{NUM_VIDEOS} events ({fail_count} failed)")
-    if fail_count > 0:
+    # 6. Publish video events
+    total_video_ok = 0
+    total_video_fail = 0
+
+    print(f"\nPublishing {len(funnelcake_events)} videos to FunnelCake...")
+    ok, fail = publish_events(funnelcake_events)
+    print(f"  FunnelCake videos: {ok} ok, {fail} failed")
+    total_video_ok += ok
+    total_video_fail += fail
+
+    if external_events:
+        print(f"Publishing {len(external_events)} videos to external relay...")
+        ok, fail = publish_events_to_relay(external_events, EXTERNAL_RELAY_URL)
+        print(f"  External videos: {ok} ok, {fail} failed")
+        total_video_ok += ok
+        total_video_fail += fail
+
+    # 7. Summary
+    print(f"\nSeeding complete: {total_video_ok} video events across relays")
+    print(f"  {NUM_TYPE_A} Type A (Divine) authors, {NUM_TYPE_B} Type B (Nostr-native) authors")
+    print(f"  {len(funnelcake_events)} targeted FunnelCake, {len(external_events)} targeted external")
+
+    if total_video_fail > 0:
+        print(f"\nERROR: {total_video_fail} video events failed to publish", file=sys.stderr)
         sys.exit(1)
 
 

--- a/local_stack/seed/seed.py
+++ b/local_stack/seed/seed.py
@@ -672,6 +672,13 @@ def main() -> None:
         label = "popular" if i < NUM_POPULAR else "long-tail"
         print(f"  Author {i} ({label}, {persona}): {pubkey}")
 
+    # Accumulate *all* publish failures (relay-list, profiles, videos) so the
+    # exit status surfaces any rejection, not just video failures. A seed run
+    # where every kind 10002 or kind 0 is rejected must fail the container,
+    # otherwise docker-compose reports success while the indexer has no
+    # relay-lists and profiles are missing on FunnelCake/external.
+    total_fail = 0
+
     # 2. Publish kind 10002 relay list events (all authors → indexer)
     print(f"\nPublishing {NUM_AUTHORS} relay list events to indexer relay...")
     relay_list_events = []
@@ -679,6 +686,7 @@ def main() -> None:
         relay_list_events.append(build_relay_list_event(privkey, pubkey))
     ok, fail = publish_events_to_relay(relay_list_events, INDEXER_RELAY_URL)
     print(f"  Relay lists: {ok} ok, {fail} failed")
+    total_fail += fail
 
     # 3. Publish kind 0 profile events (routed by type)
     print(f"\nPublishing {NUM_AUTHORS} profile events...")
@@ -695,12 +703,15 @@ def main() -> None:
 
     ok, fail = publish_events_to_relay(indexer_profiles, INDEXER_RELAY_URL)
     print(f"  Indexer profiles: {ok} ok, {fail} failed")
+    total_fail += fail
     if funnelcake_profiles:
         ok, fail = publish_events_to_relay(funnelcake_profiles, RELAY_URL)
         print(f"  FunnelCake profiles: {ok} ok, {fail} failed")
+        total_fail += fail
     if external_profiles:
         ok, fail = publish_events_to_relay(external_profiles, EXTERNAL_RELAY_URL)
         print(f"  External profiles: {ok} ok, {fail} failed")
+        total_fail += fail
 
     # 4. Generate and upload unique videos + thumbnails + variants
     # Each video has a different noise seed so SHA-256 hashes differ,
@@ -769,13 +780,23 @@ def main() -> None:
         total_video_ok += ok
         total_video_fail += fail
 
+    total_fail += total_video_fail
+
     # 7. Summary
     print(f"\nSeeding complete: {total_video_ok} video events across relays")
     print(f"  {NUM_TYPE_A} Type A (Divine) authors, {NUM_TYPE_B} Type B (Nostr-native) authors")
     print(f"  {len(funnelcake_events)} targeted FunnelCake, {len(external_events)} targeted external")
 
-    if total_video_fail > 0:
-        print(f"\nERROR: {total_video_fail} video events failed to publish", file=sys.stderr)
+    if total_fail > 0:
+        # total_fail spans relay-list, profile, and video publish failures.
+        # Any rejection fails the container so docker-compose surfaces it
+        # instead of reporting success with partially seeded data.
+        print(
+            f"\nERROR: {total_fail} event(s) failed to publish "
+            f"(videos: {total_video_fail}, "
+            f"other: {total_fail - total_video_fail})",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
 

--- a/local_stack/seed/seed.py
+++ b/local_stack/seed/seed.py
@@ -42,6 +42,24 @@ MINIO_SECRET_KEY = os.environ.get("MINIO_SECRET_KEY", "minioadmin")
 
 INDEXER_RELAY_URL = os.environ.get("INDEXER_RELAY_URL", "ws://relay-indexer:8080")
 EXTERNAL_RELAY_URL = os.environ.get("EXTERNAL_RELAY_URL", "ws://relay-external:8080")
+# Public URLs written into kind 10002 relay-list r-tags — clients use these
+# to connect from outside the docker network.
+#
+# Defaults target the Android emulator, which aliases the host as 10.0.2.2.
+# The rest of the local stack (BLOSSOM_PUBLIC_URL above, app config via
+# EnvironmentConfig.local) shares that assumption, so the defaults are
+# consistent with the rest of the stack.
+#
+# Override these when running a client that does NOT alias 10.0.2.2 — iOS
+# simulator, macOS host, CI without a socat alias — otherwise the app's
+# outbox-routing code will fail to connect to the relays advertised in the
+# seeded kind 10002 events. Example:
+#
+#   RELAY_PUBLIC_URL=ws://host.docker.internal:47777 \
+#   EXTERNAL_RELAY_PUBLIC_URL=ws://host.docker.internal:47779 \
+#   docker compose up seed
+#
+# or `ws://localhost:47777` on a macOS host.
 RELAY_PUBLIC_URL = os.environ.get("RELAY_PUBLIC_URL", "ws://10.0.2.2:47777")
 EXTERNAL_RELAY_PUBLIC_URL = os.environ.get("EXTERNAL_RELAY_PUBLIC_URL", "ws://10.0.2.2:47779")
 
@@ -727,8 +745,13 @@ def main() -> None:
     print(f"All {NUM_UNIQUE_VIDEOS} videos uploaded successfully")
 
     # 5. Build and route video events
-    # Type A authors: all videos → FunnelCake
-    # Type B authors: odd-indexed → external, even-indexed → FunnelCake
+    # Type A (Divine) authors: videos → FunnelCake (matches profile placement
+    #   on FunnelCake + indexer).
+    # Type B (Nostr-native) authors: videos → external relay (matches profile
+    #   placement on external + indexer). This keeps each author's profile and
+    #   content on the same relay so the E2E fixtures and the seeded data model
+    #   the same persona shape — a Type B author who has videos on FunnelCake
+    #   but no kind-0 there would be an incoherent, unrealistic state.
     print(f"\nBuilding {NUM_VIDEOS} events...")
     rng = random.Random(42)
     author_assignments = build_author_video_map(rng)
@@ -757,8 +780,6 @@ def main() -> None:
         )
 
         if author_is_type_a(author_idx):
-            funnelcake_events.append(event)
-        elif i % 2 == 0:
             funnelcake_events.append(event)
         else:
             external_events.append(event)

--- a/mobile/integration_test/e2e/persona_test.dart
+++ b/mobile/integration_test/e2e/persona_test.dart
@@ -2,8 +2,6 @@
 // ABOUTME: Verifies that seeded Type A (Divine) and Type B (Nostr-native) users
 // ABOUTME: are discoverable and displayable across different relay configurations
 
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -80,29 +78,33 @@ Future<String> _registerAndVerify(WidgetTester tester) async {
   return testEmail;
 }
 
-/// Verify the FunnelCake REST API is reachable via the relay proxy.
+/// Verify the FunnelCake notifications route is reachable via the relay
+/// proxy.
 ///
-/// Returns true if `/api/videos` responds with HTTP 200. This is a
-/// smoke test for the local stack's nginx routing — it confirms the
-/// funnelcake-proxy routes `/api/*` requests to the REST API correctly.
+/// Probes `GET /api/users/{pubkey}/notifications?limit=1` through the
+/// funnelcake-proxy and returns true if the response proves the route
+/// exists. A generic `/api/videos` probe would not catch a regression
+/// specific to the notifications routing path; probing the actual
+/// notifications endpoint does.
+///
+/// Acceptable responses: 200 OK, 401 Unauthorized, 403 Forbidden. All of
+/// these prove the route exists and is wired to the upstream notifications
+/// handler — the test harness doesn't construct a NIP-98 auth header, so a
+/// 401 from an auth-required endpoint is expected and fine.
+///
+/// Rejected: 404 (route missing from nginx/upstream), 5xx (upstream error).
+/// Network failures return false as well.
 ///
 /// Note: this calls the endpoint directly from the test harness, so it
-/// does NOT exercise the app's own API/relay resolution path.
-Future<bool> _verifyFunnelcakeApiReachable() async {
-  final client = HttpClient();
-  try {
-    final uri = Uri.parse(
-      'http://$localHost:$localRelayPort/api/videos?limit=1',
-    );
-    final request = await client.getUrl(uri);
-    final response = await request.close();
-    await response.drain<void>();
-    return response.statusCode == 200;
-  } on Exception {
-    return false;
-  } finally {
-    client.close();
-  }
+/// does NOT exercise the app's own URL-resolution path.
+Future<bool> _verifyFunnelcakeNotificationsRouteReachable(
+  String pubkey,
+) async {
+  final status = await probeFunnelcakeNotificationsStatus(pubkey);
+  // -1 = network/exception
+  // 404 = route missing
+  // 5xx = upstream failure
+  return status == 200 || status == 401 || status == 403;
 }
 
 void main() {
@@ -225,15 +227,24 @@ void main() {
           );
         }
 
-        // Check if the display name resolved from the external relay
+        // The profile was published to the external relay and the kind 10002
+        // relay-list event was published to the indexer relay. This assertion
+        // is the core of the test: the app must resolve the author's relay
+        // list from the indexer, then fetch the kind 0 from the external
+        // relay, and render the display name. Without this expect(), the
+        // test passes even if external-relay profile resolution is broken.
         final foundDisplayName = await waitForText(
           tester,
           'Nostr Native Browse Test',
           maxSeconds: 10,
         );
-        logPhase(
-          'Type B display name resolved: $foundDisplayName '
-          '(profile discovery ${foundDisplayName ? "succeeded" : "pending"})',
+        expect(
+          foundDisplayName,
+          isTrue,
+          reason:
+              'Type B display name must resolve from the external relay via '
+              'the indexer. Failure indicates outbox-routing or external '
+              'relay profile fetch is broken.',
         );
 
         // Verify the video grid shows the published video
@@ -304,11 +315,22 @@ void main() {
           relayPort: localExternalRelayPort,
         );
 
-        // Wait for FunnelCake to index the videos
-        final videoIndexed = await waitForFunnelcakeVideo(typeBPubkey);
-        expect(videoIndexed, isTrue);
+        // Wait until BOTH FunnelCake videos are indexed. A bare
+        // waitForFunnelcakeVideo returns on the first indexed video and the
+        // follow-up `>= 2` assertion would flake under indexer load.
+        final bothVideosIndexed = await waitForFunnelcakeVideoCount(
+          typeBPubkey,
+          minCount: 2,
+        );
+        expect(
+          bothVideosIndexed,
+          isTrue,
+          reason:
+              "FunnelCake should index both of the Type B author's videos "
+              'within the poll window.',
+        );
 
-        // Verify FunnelCake API returns at least 2 videos
+        // Confirm the post-wait query still sees both videos.
         final fcVideos = await queryFunnelcakeVideos(typeBPubkey);
         expect(
           fcVideos.length,
@@ -356,17 +378,47 @@ void main() {
           reason: 'Profile grid should show video thumbnails',
         );
 
-        // Verify at least 2 thumbnails rendered (FunnelCake videos)
+        // The profile grid must show all three videos: 2 FunnelCake +
+        // 1 external. Asserting on `video_thumbnail_2` (the third position)
+        // is what binds the external-relay video to a UI assertion —
+        // without it the earlier `video_thumbnail_0` / `_1` checks could be
+        // satisfied entirely by the two FunnelCake videos, and a regression
+        // that silently dropped the external relay from the fetch path
+        // would still pass this test.
         final thumb1 = find.byWidgetPredicate(
           (widget) =>
               widget is Semantics &&
               widget.properties.identifier == 'video_thumbnail_1',
         );
-        final hasSecondThumb = thumb1.evaluate().isNotEmpty;
         expect(
-          hasSecondThumb,
+          thumb1,
+          findsOneWidget,
+          reason:
+              'Profile grid should show the second FunnelCake video '
+              '(video_thumbnail_1).',
+        );
+
+        // Wait for the external-relay video to appear in the grid. This
+        // explicitly verifies cross-relay video aggregation — the video
+        // was published to the external relay only, so the app had to
+        // follow the author's kind 10002 relay list and fetch from there.
+        final foundExternalVideoInGrid = await waitForWidget(
+          tester,
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is Semantics &&
+                widget.properties.identifier == 'video_thumbnail_2',
+          ),
+          maxSeconds: 20,
+        );
+        expect(
+          foundExternalVideoInGrid,
           isTrue,
-          reason: 'Profile grid should show at least 2 video thumbnails',
+          reason:
+              'Profile grid should show the external-relay video '
+              '(video_thumbnail_2). Missing third thumbnail indicates the '
+              'app failed to aggregate from the external relay despite the '
+              'kind 10002 relay list advertising it.',
         );
 
         logPhase('Persona Test 2 complete');
@@ -394,24 +446,33 @@ void main() {
         logPhase('── Persona Test 3: Register + verify ──');
         final testEmail = await _registerAndVerify(tester);
 
-        // ── Phase 2: Smoke-test FunnelCake API routing ──
-        logPhase('── Persona Test 3: Checking FunnelCake API routing ──');
+        // ── Phase 2: Smoke-test FunnelCake notifications routing ──
+        logPhase(
+          '── Persona Test 3: Checking FunnelCake notifications routing ──',
+        );
 
-        // Get the logged-in user's pubkey from the database
+        // Get the logged-in user's pubkey from the database. The
+        // notifications probe is keyed by pubkey, so we need the real one.
         final userPubkey = await getUserPubkeyByEmail(testEmail);
         expect(userPubkey, isNotNull, reason: 'Should find user in DB');
 
-        // Verify the FunnelCake REST API endpoint is reachable through
-        // the local stack's nginx proxy. This is a direct HTTP call from
-        // the test harness — it confirms the proxy routes /api/* to the
-        // REST API, but does NOT exercise the app's own URL resolution.
-        final notificationsApiOk = await _verifyFunnelcakeApiReachable();
+        // Verify the notifications endpoint itself is reachable through
+        // the local stack's nginx proxy. Probing a generic videos endpoint
+        // would pass even if notifications routing were broken; probing
+        // `/api/users/{pubkey}/notifications` specifically catches
+        // regressions in the notifications routing path. This is still a
+        // direct HTTP call from the test harness — it does NOT exercise
+        // the app's own URL resolution path.
+        final notificationsRouteOk =
+            await _verifyFunnelcakeNotificationsRouteReachable(userPubkey!);
         expect(
-          notificationsApiOk,
+          notificationsRouteOk,
           isTrue,
           reason:
-              'FunnelCake REST API should return 200 via the relay proxy. '
-              'Failure indicates a local stack routing problem.',
+              'FunnelCake notifications route should be reachable via the '
+              'relay proxy (accepting 200 / 401 / 403 — anything that proves '
+              'the endpoint exists). A 404 or 5xx indicates the route is '
+              'missing or the upstream is broken.',
         );
 
         // ── Phase 3: Navigate to inbox/notifications in the UI ──
@@ -439,17 +500,24 @@ void main() {
         await tester.tap(notificationsTab);
         await pumpUntilSettled(tester);
 
-        // For a fresh user with no authored content, empty state is expected.
-        // The key assertion is that the tab renders (API resolved correctly)
-        // and the API returned 200 (verified above).
-        final hasEmptyState = find
-            .text('No notifications yet')
-            .evaluate()
-            .isNotEmpty;
-        logPhase(
-          'Notifications tab rendered. '
-          'Empty state: $hasEmptyState (expected for fresh user). '
-          'FunnelCake API returned 200 via proxy.',
+        // A fresh user has no notifications, so the notifications tab body
+        // must render the empty-state placeholder. Without this expect(),
+        // an error widget or a blank screen would still pass as long as
+        // the 'Notifications' label existed in the tab bar, and the test
+        // would give almost no signal about the notifications surface.
+        final hasEmptyState = await waitForText(
+          tester,
+          'No notifications yet',
+          maxSeconds: 10,
+        );
+        expect(
+          hasEmptyState,
+          isTrue,
+          reason:
+              'Notifications tab body should render the empty-state '
+              'placeholder for a fresh user. An error widget or blank body '
+              'here indicates the notifications UI is broken even though '
+              'the tab label renders.',
         );
 
         logPhase('Persona Test 3 complete');

--- a/mobile/integration_test/e2e/persona_test.dart
+++ b/mobile/integration_test/e2e/persona_test.dart
@@ -1,0 +1,458 @@
+// ABOUTME: E2E tests for multi-relay user personas
+// ABOUTME: Verifies that seeded Type A (Divine) and Type B (Nostr-native) users
+// ABOUTME: are discoverable and displayable across different relay configurations
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:openvine/main.dart' as app;
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/screens/other_profile_screen.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:patrol/patrol.dart';
+
+import '../helpers/constants.dart';
+
+import '../helpers/db_helpers.dart';
+import '../helpers/http_helpers.dart';
+import '../helpers/navigation_helpers.dart';
+import '../helpers/relay_helpers.dart';
+import '../helpers/test_setup.dart';
+
+/// Register a new user, verify via deep link, and wait for the main app.
+///
+/// Returns the test email used for registration.
+Future<String> _registerAndVerify(WidgetTester tester) async {
+  final testEmail =
+      'persona-${DateTime.now().millisecondsSinceEpoch}@test.divine.video';
+  const password = 'TestPass123!';
+
+  await navigateToCreateAccount(tester);
+  await registerNewUser(tester, testEmail, password);
+
+  final foundVerifyScreen = await waitForText(
+    tester,
+    'Complete your registration',
+  );
+  expect(
+    foundVerifyScreen,
+    isTrue,
+    reason: 'Should navigate to email verification screen',
+  );
+
+  final verifyToken = await getVerificationToken(testEmail);
+  expect(verifyToken, isNotEmpty);
+
+  final container = ProviderScope.containerOf(
+    tester.element(find.byType(MaterialApp)),
+  );
+  final emailListener = container.read(emailVerificationListenerProvider);
+  await emailListener.handleUri(
+    Uri.parse('https://login.divine.video/verify-email?token=$verifyToken'),
+  );
+
+  final leftVerifyScreen = await waitForTextGone(
+    tester,
+    'Complete your registration',
+  );
+  expect(
+    leftVerifyScreen,
+    isTrue,
+    reason: 'Polling should detect verification and navigate away',
+  );
+
+  await pumpUntilSettled(tester);
+
+  final hasMainApp =
+      find.byType(BottomNavigationBar).evaluate().isNotEmpty ||
+      find.text('Popular').evaluate().isNotEmpty ||
+      find.text('Trending').evaluate().isNotEmpty;
+  expect(
+    hasMainApp,
+    isTrue,
+    reason: 'Should land on main app after verification',
+  );
+
+  return testEmail;
+}
+
+/// Verify the FunnelCake REST API is reachable via the relay proxy.
+///
+/// Returns true if `/api/videos` responds with HTTP 200. This is a
+/// smoke test for the local stack's nginx routing — it confirms the
+/// funnelcake-proxy routes `/api/*` requests to the REST API correctly.
+///
+/// Note: this calls the endpoint directly from the test harness, so it
+/// does NOT exercise the app's own API/relay resolution path.
+Future<bool> _verifyFunnelcakeApiReachable() async {
+  final client = HttpClient();
+  try {
+    final uri = Uri.parse(
+      'http://$localHost:$localRelayPort/api/videos?limit=1',
+    );
+    final request = await client.getUrl(uri);
+    final response = await request.close();
+    await response.drain<void>();
+    return response.statusCode == 200;
+  } on Exception {
+    return false;
+  } finally {
+    client.close();
+  }
+}
+
+void main() {
+  group('Persona E2E Tests', () {
+    patrolTest(
+      'can browse Type B (Nostr-native) profile from external relay',
+      timeout: const Timeout(Duration(minutes: 5)),
+      ($) async {
+        final tester = $.tester;
+        final originalOnError = suppressSetStateErrors();
+        final originalErrorBuilder = saveErrorWidgetBuilder();
+        final semanticsHandle = tester.ensureSemantics();
+
+        launchAppGuarded(app.main);
+        await tester.pumpAndSettle(const Duration(seconds: 3));
+
+        // ── Phase 1: Register and verify ──
+        logPhase('── Persona Test 1: Register + verify ──');
+        await _registerAndVerify(tester);
+
+        // ── Phase 2: Seed a Type B user with relay presence ──
+        logPhase('── Persona Test 1: Seeding Type B user ──');
+        final typeBKey = generatePrivateKey();
+        final typeBPubkey = getPublicKey(typeBKey);
+
+        await setupTypeBPresence(
+          privateKey: typeBKey,
+          name: 'nostr-native-browse-test',
+          displayName: 'Nostr Native Browse Test',
+          about: 'E2E Type B profile discovery test',
+        );
+
+        // Publish a video on FunnelCake so the user is discoverable
+        await publishTestVideoEvent(
+          title: 'Type B Video Browse Test',
+          privateKey: typeBKey,
+        );
+
+        // Wait for FunnelCake to index the video
+        final videoIndexed = await waitForFunnelcakeVideo(typeBPubkey);
+        expect(
+          videoIndexed,
+          isTrue,
+          reason: 'FunnelCake should index the Type B video',
+        );
+
+        // ── Phase 3: Navigate to explore and find the video ──
+        logPhase('── Persona Test 1: Navigate to explore ──');
+        await tapBottomNavTab(tester, 'explore_tab');
+
+        final foundNewTab = await waitForText(tester, 'New', maxSeconds: 10);
+        expect(foundNewTab, isTrue, reason: 'Explore should show New tab');
+        await tester.tap(find.text('New'));
+        await tester.pump(const Duration(seconds: 1));
+
+        // Wait for video thumbnails to appear
+        final foundThumbnails = await waitForWidget(
+          tester,
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is Semantics &&
+                widget.properties.identifier == 'video_thumbnail_0',
+          ),
+          maxSeconds: 20,
+        );
+        expect(
+          foundThumbnails,
+          isTrue,
+          reason: 'Explore grid should show video thumbnails',
+        );
+
+        // ── Phase 4: Navigate to Type B profile page ──
+        logPhase('── Persona Test 1: Navigate to Type B profile ──');
+        final typeBNpub = NostrKeyUtils.encodePubKey(typeBPubkey);
+        final router = GoRouter.of(tester.element(find.byType(Scaffold).first));
+        router.push(OtherProfileScreen.pathForNpub(typeBNpub));
+        await pumpUntilSettled(tester);
+
+        // Verify profile page rendered (ProfileGrid or loading state)
+        // The profile page should at minimum load without crashing.
+        // If profile resolution works, the display name should appear.
+        final foundProfilePage = await waitForWidget(
+          tester,
+          find
+              .byWidgetPredicate(
+                (widget) =>
+                    widget is Semantics &&
+                    widget.properties.identifier == 'profile_tab',
+              )
+              .hitTestable(),
+        );
+
+        // Profile page is rendered if we can see the profile tab in
+        // the background, OR if the profile view itself is shown.
+        // Use a fallback: check for any profile-related widget.
+        if (!foundProfilePage) {
+          // Profile page should still be visible even without bottom nav
+          // (OtherProfileScreen is pushed outside shell route).
+          // Check for the back button or profile grid.
+          final hasBackButton = find
+              .bySemanticsLabel('Go back')
+              .evaluate()
+              .isNotEmpty;
+          final hasProfileContent =
+              find.text('Videos').evaluate().isNotEmpty ||
+              find.text('Likes').evaluate().isNotEmpty ||
+              find.text('Reposts').evaluate().isNotEmpty;
+          expect(
+            hasBackButton || hasProfileContent,
+            isTrue,
+            reason:
+                'Type B profile page should load (back button or '
+                'profile content tabs visible)',
+          );
+        }
+
+        // Check if the display name resolved from the external relay
+        final foundDisplayName = await waitForText(
+          tester,
+          'Nostr Native Browse Test',
+          maxSeconds: 10,
+        );
+        logPhase(
+          'Type B display name resolved: $foundDisplayName '
+          '(profile discovery ${foundDisplayName ? "succeeded" : "pending"})',
+        );
+
+        // Verify the video grid shows the published video
+        final foundVideoInProfile = await waitForWidget(
+          tester,
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is Semantics &&
+                widget.properties.identifier == 'video_thumbnail_0',
+          ),
+        );
+        expect(
+          foundVideoInProfile,
+          isTrue,
+          reason: 'Type B profile should show video published to FunnelCake',
+        );
+
+        logPhase('Persona Test 1 complete');
+
+        semanticsHandle.dispose();
+        drainAsyncErrors(tester);
+        restoreErrorHandler(originalOnError);
+        restoreErrorWidgetBuilder(originalErrorBuilder);
+      },
+    );
+
+    patrolTest(
+      'Type B profile shows videos from both FunnelCake and external relay',
+      timeout: const Timeout(Duration(minutes: 5)),
+      ($) async {
+        final tester = $.tester;
+        final originalOnError = suppressSetStateErrors();
+        final originalErrorBuilder = saveErrorWidgetBuilder();
+        final semanticsHandle = tester.ensureSemantics();
+
+        launchAppGuarded(app.main);
+        await tester.pumpAndSettle(const Duration(seconds: 3));
+
+        // ── Phase 1: Register and verify ──
+        logPhase('── Persona Test 2: Register + verify ──');
+        await _registerAndVerify(tester);
+
+        // ── Phase 2: Seed a Type B user with videos on both relays ──
+        logPhase('── Persona Test 2: Seeding Type B user with videos ──');
+        final typeBKey = generatePrivateKey();
+        final typeBPubkey = getPublicKey(typeBKey);
+
+        await setupTypeBPresence(
+          privateKey: typeBKey,
+          name: 'nostr-native-videos-test',
+          displayName: 'Multi Video Test User',
+        );
+
+        // Publish 2 videos on FunnelCake
+        await publishTestVideoEvent(
+          title: 'Type B Video FC One',
+          privateKey: typeBKey,
+        );
+        await publishTestVideoEvent(
+          title: 'Type B Video FC Two',
+          privateKey: typeBKey,
+        );
+
+        // Publish 1 video on external relay (mixed-relay scenario)
+        await publishTestVideoEvent(
+          title: 'Type B Video External',
+          privateKey: typeBKey,
+          relayPort: localExternalRelayPort,
+        );
+
+        // Wait for FunnelCake to index the videos
+        final videoIndexed = await waitForFunnelcakeVideo(typeBPubkey);
+        expect(videoIndexed, isTrue);
+
+        // Verify FunnelCake API returns at least 2 videos
+        final fcVideos = await queryFunnelcakeVideos(typeBPubkey);
+        expect(
+          fcVideos.length,
+          greaterThanOrEqualTo(2),
+          reason: 'FunnelCake API should return at least 2 videos',
+        );
+
+        // Verify external relay also has the video
+        final externalVideos = await queryRelay({
+          'kinds': [34236],
+          'authors': [typeBPubkey],
+          'limit': 10,
+        }, relayPort: localExternalRelayPort);
+        expect(
+          externalVideos,
+          isNotEmpty,
+          reason: 'External relay should have at least 1 video',
+        );
+
+        logPhase(
+          'Seeded ${fcVideos.length} FunnelCake + '
+          '${externalVideos.length} external videos',
+        );
+
+        // ── Phase 3: Navigate to profile and check video grid ──
+        logPhase('── Persona Test 2: Navigate to profile ──');
+        final typeBNpub = NostrKeyUtils.encodePubKey(typeBPubkey);
+        final router = GoRouter.of(tester.element(find.byType(Scaffold).first));
+        router.push(OtherProfileScreen.pathForNpub(typeBNpub));
+        await pumpUntilSettled(tester);
+
+        // Wait for the video grid to populate
+        final foundGrid = await waitForWidget(
+          tester,
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is Semantics &&
+                widget.properties.identifier == 'video_thumbnail_0',
+          ),
+          maxSeconds: 20,
+        );
+        expect(
+          foundGrid,
+          isTrue,
+          reason: 'Profile grid should show video thumbnails',
+        );
+
+        // Verify at least 2 thumbnails rendered (FunnelCake videos)
+        final thumb1 = find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              widget.properties.identifier == 'video_thumbnail_1',
+        );
+        final hasSecondThumb = thumb1.evaluate().isNotEmpty;
+        expect(
+          hasSecondThumb,
+          isTrue,
+          reason: 'Profile grid should show at least 2 video thumbnails',
+        );
+
+        logPhase('Persona Test 2 complete');
+
+        semanticsHandle.dispose();
+        drainAsyncErrors(tester);
+        restoreErrorHandler(originalOnError);
+        restoreErrorWidgetBuilder(originalErrorBuilder);
+      },
+    );
+
+    patrolTest(
+      'notifications UI renders and FunnelCake API is routable',
+      timeout: const Timeout(Duration(minutes: 5)),
+      ($) async {
+        final tester = $.tester;
+        final originalOnError = suppressSetStateErrors();
+        final originalErrorBuilder = saveErrorWidgetBuilder();
+        final semanticsHandle = tester.ensureSemantics();
+
+        launchAppGuarded(app.main);
+        await tester.pumpAndSettle(const Duration(seconds: 3));
+
+        // ── Phase 1: Register and verify ──
+        logPhase('── Persona Test 3: Register + verify ──');
+        final testEmail = await _registerAndVerify(tester);
+
+        // ── Phase 2: Smoke-test FunnelCake API routing ──
+        logPhase('── Persona Test 3: Checking FunnelCake API routing ──');
+
+        // Get the logged-in user's pubkey from the database
+        final userPubkey = await getUserPubkeyByEmail(testEmail);
+        expect(userPubkey, isNotNull, reason: 'Should find user in DB');
+
+        // Verify the FunnelCake REST API endpoint is reachable through
+        // the local stack's nginx proxy. This is a direct HTTP call from
+        // the test harness — it confirms the proxy routes /api/* to the
+        // REST API, but does NOT exercise the app's own URL resolution.
+        final notificationsApiOk = await _verifyFunnelcakeApiReachable();
+        expect(
+          notificationsApiOk,
+          isTrue,
+          reason:
+              'FunnelCake REST API should return 200 via the relay proxy. '
+              'Failure indicates a local stack routing problem.',
+        );
+
+        // ── Phase 3: Navigate to inbox/notifications in the UI ──
+        logPhase('── Persona Test 3: Navigate to notifications ──');
+        await tapBottomNavTab(tester, 'inbox_tab');
+        await tester.pump(const Duration(seconds: 3));
+
+        // Verify the inbox screen rendered (Messages/Notifications tabs)
+        final hasInboxTabs =
+            find.text('Messages').evaluate().isNotEmpty ||
+            find.text('Notifications').evaluate().isNotEmpty;
+        expect(
+          hasInboxTabs,
+          isTrue,
+          reason: 'Inbox screen should render Messages/Notifications toggle',
+        );
+
+        // Tap Notifications tab and verify it renders without error
+        final notificationsTab = find.text('Notifications');
+        expect(
+          notificationsTab,
+          findsOneWidget,
+          reason: 'Notifications tab should be visible',
+        );
+        await tester.tap(notificationsTab);
+        await pumpUntilSettled(tester);
+
+        // For a fresh user with no authored content, empty state is expected.
+        // The key assertion is that the tab renders (API resolved correctly)
+        // and the API returned 200 (verified above).
+        final hasEmptyState = find
+            .text('No notifications yet')
+            .evaluate()
+            .isNotEmpty;
+        logPhase(
+          'Notifications tab rendered. '
+          'Empty state: $hasEmptyState (expected for fresh user). '
+          'FunnelCake API returned 200 via proxy.',
+        );
+
+        logPhase('Persona Test 3 complete');
+
+        semanticsHandle.dispose();
+        drainAsyncErrors(tester);
+        restoreErrorHandler(originalOnError);
+        restoreErrorWidgetBuilder(originalErrorBuilder);
+      },
+    );
+  });
+}

--- a/mobile/integration_test/e2e/persona_test.dart
+++ b/mobile/integration_test/e2e/persona_test.dart
@@ -108,7 +108,13 @@ Future<bool> _verifyFunnelcakeApiReachable() async {
 void main() {
   group('Persona E2E Tests', () {
     patrolTest(
-      'can browse Type B (Nostr-native) profile from external relay',
+      // The Type B profile lives on the external relay + indexer (see
+      // `setupTypeBPresence`), but this test's video is published to
+      // FunnelCake via `publishTestVideoEvent` with no `relayPort`. So the
+      // scenario exercised is: profile resolves from external-via-indexer
+      // while the video is served from FunnelCake — a mixed-relay render
+      // path, not a pure external-only fetch.
+      'browse Type B profile (external relay) with a FunnelCake-hosted video',
       timeout: const Timeout(Duration(minutes: 5)),
       ($) async {
         final tester = $.tester;

--- a/mobile/integration_test/helpers/constants.dart
+++ b/mobile/integration_test/helpers/constants.dart
@@ -1,11 +1,13 @@
 // ABOUTME: Shared constants for E2E integration tests
-// ABOUTME: Re-exports environment config constants, adds test-only values
+// ABOUTME: Re-exports environment config constants (FunnelCake, indexer, external relay ports)
 
 export 'package:openvine/models/environment_config.dart'
     show
         localApiPort,
         localBlossomPort,
+        localExternalRelayPort,
         localHost,
+        localIndexerRelayPort,
         localInvitePort,
         localKeycastPort,
         localRelayPort;

--- a/mobile/integration_test/helpers/http_helpers.dart
+++ b/mobile/integration_test/helpers/http_helpers.dart
@@ -77,6 +77,61 @@ Future<bool> waitForFunnelcakeVideo(
   return false;
 }
 
+/// Wait for at least [minCount] videos by [pubkey] to appear in the
+/// Funnelcake REST API.
+///
+/// Polls every second until `queryFunnelcakeVideos(pubkey).length >= minCount`
+/// or [maxSeconds] elapses. Use this instead of [waitForFunnelcakeVideo]
+/// when the caller has published more than one video and must assert on a
+/// specific count — [waitForFunnelcakeVideo] returns on the first indexed
+/// video and does NOT guarantee subsequent ones are indexed yet, so a
+/// follow-up `expect(videos.length, >= N)` flakes under indexer load.
+///
+/// Returns true if at least [minCount] videos were found, false on timeout.
+Future<bool> waitForFunnelcakeVideoCount(
+  String pubkey, {
+  required int minCount,
+  int maxSeconds = 30,
+}) async {
+  for (var i = 0; i < maxSeconds; i++) {
+    final videos = await queryFunnelcakeVideos(pubkey);
+    if (videos.length >= minCount) return true;
+    await Future<void>.delayed(const Duration(seconds: 1));
+  }
+  return false;
+}
+
+/// Probe the Funnelcake notifications endpoint for a given [pubkey].
+///
+/// Hits `GET /api/users/{pubkey}/notifications?limit=1` through the relay
+/// proxy and returns the HTTP status code (or -1 on network failure).
+///
+/// Use this in place of a generic `/api/videos` probe when the goal is to
+/// catch a regression in the *notifications* routing path specifically. A
+/// generic videos probe would pass even if `/api/users/.../notifications`
+/// were broken or missing from the upstream router.
+///
+/// Accepted as "routing works" by callers: any status code that proves the
+/// endpoint exists and responded — 200, 401 (auth required), 403. Reject
+/// 404 (route missing) and 5xx (upstream failure).
+Future<int> probeFunnelcakeNotificationsStatus(String pubkey) async {
+  final client = HttpClient();
+  try {
+    final uri = Uri.parse(
+      'http://$localHost:$localRelayPort'
+      '/api/users/$pubkey/notifications?limit=1',
+    );
+    final request = await client.getUrl(uri);
+    final response = await request.close();
+    await response.drain<void>();
+    return response.statusCode;
+  } on Exception {
+    return -1;
+  } finally {
+    client.close();
+  }
+}
+
 /// Wait for videos by [pubkey] to disappear from the Funnelcake REST API.
 ///
 /// Polls every second until the API returns an empty list or [maxSeconds]

--- a/mobile/integration_test/helpers/relay_helpers.dart
+++ b/mobile/integration_test/helpers/relay_helpers.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Relay helpers for E2E integration tests
-// ABOUTME: Publish test Nostr events directly to the local FunnelCake relay
+// ABOUTME: Publish test Nostr events to local relays (FunnelCake, indexer, external)
 
 import 'dart:async';
 import 'dart:convert';
@@ -20,6 +20,43 @@ typedef PublishedVideo = ({String eventId, String pubkey, String privateKey});
 /// Result of publishing a test profile event.
 typedef PublishedProfile = ({String pubkey, String privateKey});
 
+/// Result of publishing a test relay list event.
+typedef PublishedRelayList = ({
+  String eventId,
+  String pubkey,
+  String privateKey,
+});
+
+/// Publish a kind 10002 relay list event to the indexer relay.
+///
+/// Creates a new keypair (or uses [privateKey] if provided), builds a NIP-65
+/// relay list event with the given relay URLs, signs it, and sends it to the
+/// indexer relay.
+///
+/// [relayUrls] are the relay URLs to include in the `r` tags. These must be
+/// emulator-accessible URLs (e.g., ws://10.0.2.2:47777), not Docker-internal.
+///
+/// Returns the event ID, pubkey, and private key.
+Future<PublishedRelayList> publishTestRelayListEvent({
+  required List<String> relayUrls,
+  String? privateKey,
+}) async {
+  final privKey = privateKey ?? generatePrivateKey();
+  final pubKey = getPublicKey(privKey);
+
+  final tags = relayUrls.map((url) => ['r', url]).toList();
+
+  final event = Event(pubKey, 10002, tags, '');
+  event.sign(privKey);
+
+  final eventId = await _publishEvent(
+    event,
+    relayPort: localIndexerRelayPort,
+  );
+  debugPrint('Published relay list event: $eventId (pubkey: $pubKey)');
+  return (eventId: eventId, pubkey: pubKey, privateKey: privKey);
+}
+
 /// Publish a kind 34236 video event to the local relay.
 ///
 /// Creates a new keypair (or uses [privateKey] if provided), builds a minimal
@@ -32,6 +69,7 @@ typedef PublishedProfile = ({String pubkey, String privateKey});
 Future<PublishedVideo> publishTestVideoEvent({
   required String title,
   String? privateKey,
+  int? relayPort,
 }) async {
   final privKey = privateKey ?? generatePrivateKey();
   final pubKey = getPublicKey(privKey);
@@ -62,7 +100,7 @@ Future<PublishedVideo> publishTestVideoEvent({
   );
   event.sign(privKey);
 
-  final eventId = await _publishEvent(event);
+  final eventId = await _publishEvent(event, relayPort: relayPort);
   debugPrint('Published test video event: $eventId (author: $pubKey)');
   return (eventId: eventId, pubkey: pubKey, privateKey: privKey);
 }
@@ -80,6 +118,7 @@ Future<PublishedProfile> publishTestProfileEvent({
   String? displayName,
   String? about,
   String? privateKey,
+  int? relayPort,
 }) async {
   final privKey = privateKey ?? generatePrivateKey();
   final pubKey = getPublicKey(privKey);
@@ -93,7 +132,7 @@ Future<PublishedProfile> publishTestProfileEvent({
   final event = Event(pubKey, 0, [], content);
   event.sign(privKey);
 
-  final eventId = await _publishEvent(event);
+  final eventId = await _publishEvent(event, relayPort: relayPort);
   debugPrint('Published test profile event: $eventId (pubkey: $pubKey)');
   return (pubkey: pubKey, privateKey: privKey);
 }
@@ -234,9 +273,13 @@ Future<Uint8List> _generateTestThumbnail() async {
 ///
 /// Opens a WebSocket, sends a REQ, collects EVENT messages until EOSE,
 /// then closes the connection. Returns all matching events.
-Future<List<Event>> queryRelay(Map<String, dynamic> filter) async {
+Future<List<Event>> queryRelay(
+  Map<String, dynamic> filter, {
+  int? relayPort,
+}) async {
+  final port = relayPort ?? localRelayPort;
   final channel = WebSocketChannel.connect(
-    Uri.parse('ws://$localHost:$localRelayPort'),
+    Uri.parse('ws://$localHost:$port'),
   );
 
   final subId = 'query-${DateTime.now().millisecondsSinceEpoch}';
@@ -263,6 +306,81 @@ Future<List<Event>> queryRelay(Map<String, dynamic> filter) async {
   }
 }
 
+/// Set up a Type A (Divine) user's relay presence.
+///
+/// Publishes kind 10002 (relay list) to the indexer relay and kind 0
+/// (profile) to both FunnelCake and the indexer relay.
+Future<void> setupTypeAPresence({
+  required String privateKey,
+  required String name,
+  String? displayName,
+  String? about,
+}) async {
+  // Kind 10002 → indexer, listing both relays
+  await publishTestRelayListEvent(
+    relayUrls: [
+      'ws://$localHost:$localRelayPort',
+      'ws://$localHost:$localExternalRelayPort',
+    ],
+    privateKey: privateKey,
+  );
+
+  // Kind 0 → FunnelCake
+  await publishTestProfileEvent(
+    name: name,
+    displayName: displayName,
+    about: about,
+    privateKey: privateKey,
+  );
+
+  // Kind 0 → indexer relay
+  await publishTestProfileEvent(
+    name: name,
+    displayName: displayName,
+    about: about,
+    privateKey: privateKey,
+    relayPort: localIndexerRelayPort,
+  );
+}
+
+/// Set up a Type B (Nostr-native) user's relay presence.
+///
+/// Publishes kind 10002 (relay list) to the indexer relay and kind 0
+/// (profile) to the external relay and indexer relay.
+Future<void> setupTypeBPresence({
+  required String privateKey,
+  required String name,
+  String? displayName,
+  String? about,
+}) async {
+  // Kind 10002 → indexer, listing both relays
+  await publishTestRelayListEvent(
+    relayUrls: [
+      'ws://$localHost:$localRelayPort',
+      'ws://$localHost:$localExternalRelayPort',
+    ],
+    privateKey: privateKey,
+  );
+
+  // Kind 0 → external relay
+  await publishTestProfileEvent(
+    name: name,
+    displayName: displayName,
+    about: about,
+    privateKey: privateKey,
+    relayPort: localExternalRelayPort,
+  );
+
+  // Kind 0 → indexer relay
+  await publishTestProfileEvent(
+    name: name,
+    displayName: displayName,
+    about: about,
+    privateKey: privateKey,
+    relayPort: localIndexerRelayPort,
+  );
+}
+
 /// Publish a NIP-09 kind 5 deletion event targeting [eventId].
 ///
 /// Signs with [privateKey] (must be the same author as the target event).
@@ -273,6 +391,7 @@ Future<String> publishDeleteEvent({
   required String eventId,
   required int kind,
   required String privateKey,
+  int? relayPort,
 }) async {
   final pubKey = getPublicKey(privateKey);
 
@@ -282,15 +401,39 @@ Future<String> publishDeleteEvent({
   ], '');
   deleteEvent.sign(privateKey);
 
-  final deletionId = await _publishEvent(deleteEvent);
+  final deletionId = await _publishEvent(deleteEvent, relayPort: relayPort);
   debugPrint('Published delete event: $deletionId (target: $eventId)');
   return deletionId;
 }
 
+/// Publish a kind 7 reaction event to the specified relay.
+///
+/// Creates a reaction ("+") from [privateKey] targeting [targetEventId]
+/// by [targetPubkey]. Used to seed notification data for testing.
+Future<String> publishTestReactionEvent({
+  required String targetEventId,
+  required String targetPubkey,
+  required String privateKey,
+  int? relayPort,
+}) async {
+  final pubKey = getPublicKey(privateKey);
+
+  final event = Event(pubKey, 7, [
+    ['e', targetEventId],
+    ['p', targetPubkey],
+  ], '+');
+  event.sign(privateKey);
+
+  final eventId = await _publishEvent(event, relayPort: relayPort);
+  debugPrint('Published reaction event: $eventId (target: $targetEventId)');
+  return eventId;
+}
+
 /// Send an event to the local relay and wait for OK confirmation.
-Future<String> _publishEvent(Event event) async {
+Future<String> _publishEvent(Event event, {int? relayPort}) async {
+  final port = relayPort ?? localRelayPort;
   final channel = WebSocketChannel.connect(
-    Uri.parse('ws://$localHost:$localRelayPort'),
+    Uri.parse('ws://$localHost:$port'),
   );
 
   final completer = Completer<String>();

--- a/mobile/integration_test/helpers/relay_helpers.dart
+++ b/mobile/integration_test/helpers/relay_helpers.dart
@@ -406,29 +406,6 @@ Future<String> publishDeleteEvent({
   return deletionId;
 }
 
-/// Publish a kind 7 reaction event to the specified relay.
-///
-/// Creates a reaction ("+") from [privateKey] targeting [targetEventId]
-/// by [targetPubkey]. Used to seed notification data for testing.
-Future<String> publishTestReactionEvent({
-  required String targetEventId,
-  required String targetPubkey,
-  required String privateKey,
-  int? relayPort,
-}) async {
-  final pubKey = getPublicKey(privateKey);
-
-  final event = Event(pubKey, 7, [
-    ['e', targetEventId],
-    ['p', targetPubkey],
-  ], '+');
-  event.sign(privateKey);
-
-  final eventId = await _publishEvent(event, relayPort: relayPort);
-  debugPrint('Published reaction event: $eventId (target: $targetEventId)');
-  return eventId;
-}
-
 /// Send an event to the local relay and wait for OK confirmation.
 Future<String> _publishEvent(Event event, {int? relayPort}) async {
   final port = relayPort ?? localRelayPort;

--- a/mobile/lib/models/environment_config.dart
+++ b/mobile/lib/models/environment_config.dart
@@ -14,6 +14,8 @@ const int localApiPort = localRelayPort;
 const localBlossomPort = 43003;
 const localInvitePort = 43004;
 const productionApiBaseUrl = 'https://api.divine.video';
+const localIndexerRelayPort = 47778;
+const localExternalRelayPort = 47779;
 
 /// Build-time default environment
 /// Set via: --dart-define=DEFAULT_ENV=STAGING
@@ -104,7 +106,7 @@ class EnvironmentConfig {
   /// wasting time querying external indexers for test-created users.
   List<String> get indexerRelays {
     if (environment == AppEnvironment.local) {
-      return ['ws://$localHost:$localRelayPort'];
+      return ['ws://$localHost:$localIndexerRelayPort'];
     }
     return const [
       'wss://purplepag.es',

--- a/mobile/test/models/environment_config_test.dart
+++ b/mobile/test/models/environment_config_test.dart
@@ -75,6 +75,22 @@ void main() {
       });
     });
 
+    group('indexerRelays', () {
+      test('local returns indexer relay on dedicated port', () {
+        const config = EnvironmentConfig(environment: AppEnvironment.local);
+        expect(config.indexerRelays, ['ws://10.0.2.2:47778']);
+      });
+
+      test('production returns public indexer relays', () {
+        const config = EnvironmentConfig(
+          environment: AppEnvironment.production,
+        );
+        expect(config.indexerRelays, contains('wss://purplepag.es'));
+        expect(config.indexerRelays, contains('wss://user.kindpag.es'));
+        expect(config.indexerRelays, contains('wss://relay.nos.social'));
+      });
+    });
+
     test('blossomUrl is same for all environments', () {
       const poc = EnvironmentConfig(environment: AppEnvironment.poc);
       const staging = EnvironmentConfig(environment: AppEnvironment.staging);


### PR DESCRIPTION
Closes #2509

## Description

Add multi-relay infrastructure to the local Docker stack and E2E test personas to catch bugs that only affect Nostr-native users (like the notifications URL bug in PR #2463). Two relay_builder containers (indexer + external relay) join FunnelCake, the seed script publishes kind 0 profiles and kind 10002 relay lists across all three relays for two persona types (Divine users and Nostr-native users), and new E2E tests verify cross-relay profile discovery and content loading.

**Related Issue:** N/A

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore