### PR TITLE
fix(macos): fail fast when mpv framework is missing

### DIFF
--- a/mobile/macos/Podfile
+++ b/mobile/macos/Podfile
@@ -66,18 +66,23 @@ post_install do |installer|
       phase_name = 'Codesign media_kit frameworks'
       existing_phase = target.shell_script_build_phases.find { |p| p.name == phase_name }
 
-      unless existing_phase
-        phase = target.new_shell_script_build_phase(phase_name)
-        phase.shell_script = <<-SCRIPT
+      phase = existing_phase || target.new_shell_script_build_phase(phase_name)
+      phase.shell_script = <<-SCRIPT
+# Verify media_kit's mpv runtime was embedded before codesigning.
+mpv_framework="${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Contents/Frameworks/Mpv.framework/Mpv"
+if [ ! -f "$mpv_framework" ]; then
+  echo "error: Mpv.framework is missing from ${PRODUCT_NAME}.app. Clean the macOS build and verify [CP] Embed Pods Frameworks completed successfully." >&2
+  exit 1
+fi
+
 # Codesign media_kit frameworks with ad-hoc signature
 for framework in "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Contents/Frameworks"/*.framework; do
   if [ -d "$framework" ]; then
     codesign --force --deep --sign - "$framework" 2>/dev/null || true
   fi
 done
-        SCRIPT
-        phase.shell_path = '/bin/bash'
-      end
+      SCRIPT
+      phase.shell_path = '/bin/bash'
     end
   end
   main_project.save

--- a/mobile/macos/Runner.xcodeproj/project.pbxproj
+++ b/mobile/macos/Runner.xcodeproj/project.pbxproj
@@ -463,7 +463,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/bash;
-			shellScript = "# Codesign media_kit frameworks with ad-hoc signature\nfor framework in \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Contents/Frameworks\"/*.framework; do\n  if [ -d \"$framework\" ]; then\n    codesign --force --deep --sign - \"$framework\" 2>/dev/null || true\n  fi\ndone\n";
+			shellScript = "# Verify media_kit's mpv runtime was embedded before codesigning.\nmpv_framework=\"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Contents/Frameworks/Mpv.framework/Mpv\"\nif [ ! -f \"$mpv_framework\" ]; then\n  echo \"error: Mpv.framework is missing from ${PRODUCT_NAME}.app. Clean the macOS build and verify [CP] Embed Pods Frameworks completed successfully.\" >&2\n  exit 1\nfi\n\n# Codesign media_kit frameworks with ad-hoc signature\nfor framework in \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/Contents/Frameworks\"/*.framework; do\n  if [ -d \"$framework\" ]; then\n    codesign --force --deep --sign - \"$framework\" 2>/dev/null || true\n  fi\ndone\n";
 		};
 		BBC532B406767D40236ED3DB /* FlutterFire: "flutterfire upload-crashlytics-symbols" */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/mobile/test/macos/macos_mpv_embed_phase_test.dart
+++ b/mobile/test/macos/macos_mpv_embed_phase_test.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('macOS media_kit embed verification', () {
+    test('codesign build phase fails fast when Mpv.framework is missing', () {
+      final projectFile = File('macos/Runner.xcodeproj/project.pbxproj');
+      final contents = projectFile.readAsStringSync();
+
+      expect(
+        contents,
+        contains('Mpv.framework/Mpv'),
+        reason:
+            'The Runner build phase should verify that Mpv.framework was '
+            'embedded before macOS app launch.',
+      );
+    });
+
+    test('Podfile keeps the media_kit verification script in sync', () {
+      final podfile = File('macos/Podfile');
+      final contents = podfile.readAsStringSync();
+
+      expect(
+        contents,
+        contains('Mpv.framework/Mpv'),
+        reason:
+            'Podfile post_install should write the same Mpv.framework '
+            'verification script for fresh CocoaPods installs.',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #2515

## Summary
- fail the macOS media_kit codesign phase early when Mpv.framework is missing from the app bundle
- keep the Podfile post_install script in sync with the committed Xcode build phase for fresh CocoaPods setups
- add a regression test that asserts the mpv embed verification stays present

## Test Plan
- [x] flutter test test/macos/macos_mpv_embed_phase_test.dart
- [x] flutter build macos --debug
