### PR TITLE
fix(profile): paginate videos grid on scroll

### DIFF
--- a/docs/superpowers/plans/2026-03-27-profile-grid-pagination.md
+++ b/docs/superpowers/plans/2026-03-27-profile-grid-pagination.md
@@ -1,0 +1,71 @@
+# Profile Grid Pagination Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Load more profile videos when the user scrolls to the bottom of the profile grid.
+
+**Architecture:** Keep pagination ownership in `ProfileFeed` and add only the missing UI trigger in `ProfileVideosGrid`. Verify the behavior with a widget test that fails before the implementation and passes after the grid listens for near-bottom scroll.
+
+**Tech Stack:** Flutter, Riverpod, flutter_test, mocktail
+
+---
+
+## Chunk 1: Reproduce The Missing Grid Trigger
+
+### Task 1: Add a failing widget test for profile grid pagination
+
+**Files:**
+- Modify: `mobile/test/screens/profile_grid_tap_navigation_test.dart`
+- Test: `mobile/test/screens/profile_grid_tap_navigation_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+testWidgets('scrolling profile grid near bottom requests more videos', ...)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `flutter test test/screens/profile_grid_tap_navigation_test.dart`
+Expected: FAIL because the grid never calls `loadMore()`
+
+## Chunk 2: Add Grid-Only Pagination
+
+### Task 2: Trigger existing profile pagination from the grid
+
+**Files:**
+- Modify: `mobile/lib/widgets/profile/profile_videos_grid.dart`
+- Test: `mobile/test/screens/profile_grid_tap_navigation_test.dart`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// Listen to profile feed state, observe scroll position, and call
+// profileFeedProvider(userIdHex).notifier.loadMore() near the bottom.
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `flutter test test/screens/profile_grid_tap_navigation_test.dart`
+Expected: PASS with the new pagination test green
+
+### Task 3: Verify surrounding behavior
+
+**Files:**
+- Modify: `mobile/lib/widgets/profile/profile_videos_grid.dart`
+- Test: `mobile/test/providers/profile_feed_provider_test.dart`
+
+- [ ] **Step 5: Run targeted verification**
+
+Run: `flutter test test/providers/profile_feed_provider_test.dart`
+Expected: PASS
+
+- [ ] **Step 6: Review diff and commit**
+
+```bash
+git add docs/superpowers/specs/2026-03-27-profile-grid-pagination-design.md \
+        docs/superpowers/plans/2026-03-27-profile-grid-pagination.md \
+        mobile/lib/widgets/profile/profile_videos_grid.dart \
+        mobile/test/screens/profile_grid_tap_navigation_test.dart
+git commit -m "fix(profile): paginate videos grid on scroll"
+```

--- a/docs/superpowers/specs/2026-03-27-profile-grid-pagination-design.md
+++ b/docs/superpowers/specs/2026-03-27-profile-grid-pagination-design.md
@@ -1,0 +1,38 @@
+# Profile Grid Pagination Design
+
+**Date:** 2026-03-27
+**Status:** Approved
+
+## Goal
+
+Load additional profile videos when the user scrolls to the bottom of the profile grid, without changing fullscreen profile pagination behavior.
+
+## Current Behavior
+
+- `ProfileFeed.loadMore()` already exists and supports profile pagination.
+- Fullscreen profile playback calls `loadMore()` when the user reaches the last video.
+- The profile grid uses its own `CustomScrollView` and `SliverGrid`, but does not listen for near-bottom scroll position.
+- Result: profile grids stop after the first page, currently 50 videos.
+
+## Chosen Approach
+
+Add bottom-of-scroll pagination to `ProfileVideosGrid` only.
+
+- Keep the existing `ProfileFeed` provider contract and `loadMore()` logic unchanged.
+- Detect when the profile grid scroll position is near the end.
+- Trigger the existing provider `loadMore()` callback only when:
+  - the videos tab has more content,
+  - a load is not already in flight,
+  - the user is near the bottom of the scroll extent.
+- Show the existing grid content model unchanged, including upload placeholders for the owner profile.
+
+## Why This Approach
+
+- It fixes the specific missing behavior instead of reworking shared pagination.
+- It preserves the already-working fullscreen load-more path.
+- It follows the existing repository pattern used in other scroll-driven pagination widgets.
+
+## Testing
+
+- Add a widget test that reproduces the grid bug: scrolling near the bottom should call the profile feed notifier `loadMore()`.
+- Keep the scope narrow to the videos grid path.

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -64,6 +64,7 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
   List<VideoEvent>? _lastPrefetchedVideos;
   final _videosStreamController =
       StreamController<List<VideoEvent>>.broadcast();
+  bool _isLoadingTriggered = false;
 
   @override
   void initState() {
@@ -96,6 +97,44 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
     if (videos.isEmpty || videos == _lastPrefetchedVideos) return;
     _lastPrefetchedVideos = videos;
     prefetchGridVideos(videos);
+  }
+
+  bool _onScrollNotification(ScrollNotification notification) {
+    if (notification.metrics.axis != Axis.vertical) return false;
+    if (_isLoadingTriggered) return false;
+
+    final feedState = ref
+        .read(profileFeedProvider(widget.userIdHex))
+        .asData
+        ?.value;
+    if (feedState == null ||
+        !feedState.hasMoreContent ||
+        feedState.isLoadingMore) {
+      return false;
+    }
+
+    final maxScroll = notification.metrics.maxScrollExtent;
+    final currentScroll = notification.metrics.pixels;
+
+    if (maxScroll > 0 && currentScroll >= maxScroll - 200) {
+      unawaited(_triggerLoadMore());
+    }
+
+    return false;
+  }
+
+  Future<void> _triggerLoadMore() async {
+    if (_isLoadingTriggered) return;
+
+    _isLoadingTriggered = true;
+
+    try {
+      await ref.read(profileFeedProvider(widget.userIdHex).notifier).loadMore();
+    } finally {
+      if (mounted) {
+        _isLoadingTriggered = false;
+      }
+    }
   }
 
   void _onVideoTapped(int index, {required VoidCallback onLoadMore}) {
@@ -169,48 +208,51 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
         .where((upload) => upload.result == null)
         .length;
 
-    return CustomScrollView(
-      slivers: [
-        SliverPadding(
-          padding: .fromLTRB(
-            4,
-            4,
-            4,
-            4 + MediaQuery.viewPaddingOf(context).bottom,
-          ),
-          sliver: SliverGrid(
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 3,
-              crossAxisSpacing: 4,
-              mainAxisSpacing: 4,
+    return NotificationListener<ScrollNotification>(
+      onNotification: _onScrollNotification,
+      child: CustomScrollView(
+        slivers: [
+          SliverPadding(
+            padding: .fromLTRB(
+              4,
+              4,
+              4,
+              4 + MediaQuery.viewPaddingOf(context).bottom,
             ),
-            delegate: SliverChildBuilderDelegate((context, index) {
-              final videoEntry = allVideos[index];
-              return switch (videoEntry) {
-                final _GridUploadingVideoEntry uploadEntry =>
-                  _VideoGridUploadingTile(
-                    backgroundUpload: uploadEntry.backgroundUpload,
+            sliver: SliverGrid(
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 3,
+                crossAxisSpacing: 4,
+                mainAxisSpacing: 4,
+              ),
+              delegate: SliverChildBuilderDelegate((context, index) {
+                final videoEntry = allVideos[index];
+                return switch (videoEntry) {
+                  final _GridUploadingVideoEntry uploadEntry =>
+                    _VideoGridUploadingTile(
+                      backgroundUpload: uploadEntry.backgroundUpload,
+                    ),
+                  final _GridVideoEventEntry eventEntry => _VideoGridTile(
+                    videoEvent: eventEntry.videoEvent,
+                    userIdHex: widget.userIdHex,
+                    index: index,
+                    onTap: () {
+                      // Adjust index to account for uploading videos at the top
+                      final publishedIndex = index - uploadingCount;
+                      if (publishedIndex >= 0) {
+                        _onVideoTapped(
+                          publishedIndex,
+                          onLoadMore: loadMoreProfileVideos,
+                        );
+                      }
+                    },
                   ),
-                final _GridVideoEventEntry eventEntry => _VideoGridTile(
-                  videoEvent: eventEntry.videoEvent,
-                  userIdHex: widget.userIdHex,
-                  index: index,
-                  onTap: () {
-                    // Adjust index to account for uploading videos at the top
-                    final publishedIndex = index - uploadingCount;
-                    if (publishedIndex >= 0) {
-                      _onVideoTapped(
-                        publishedIndex,
-                        onLoadMore: loadMoreProfileVideos,
-                      );
-                    }
-                  },
-                ),
-              };
-            }, childCount: allVideos.length),
+                };
+              }, childCount: allVideos.length),
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/mobile/test/screens/profile_grid_tap_navigation_test.dart
+++ b/mobile/test/screens/profile_grid_tap_navigation_test.dart
@@ -1,24 +1,50 @@
 // ABOUTME: Tests for profile grid → fullscreen video navigation
 // ABOUTME: Verifies tapping grid item navigates to correct video index and autoplays
 
+import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/providers/active_video_provider.dart';
 import 'package:openvine/providers/app_lifecycle_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/profile_feed_provider.dart';
 import 'package:openvine/providers/profile_feed_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/state/video_feed_state.dart';
+import 'package:openvine/widgets/profile/profile_videos_grid.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../helpers/test_provider_overrides.dart';
+
+class _MockBackgroundPublishBloc
+    extends MockBloc<BackgroundPublishEvent, BackgroundPublishState>
+    implements BackgroundPublishBloc {}
+
+class _TestProfileFeed extends ProfileFeed {
+  _TestProfileFeed(this._initialState);
+
+  final VideoFeedState _initialState;
+  int loadMoreCallCount = 0;
+
+  @override
+  Future<VideoFeedState> build(String userId) async => _initialState;
+
+  @override
+  Future<void> loadMore() async {
+    loadMoreCallCount++;
+    final currentState = state.asData?.value ?? _initialState;
+    state = AsyncData(currentState.copyWith(isLoadingMore: true));
+  }
+}
 
 void main() {
   setUpAll(() async {
@@ -304,4 +330,83 @@ void main() {
     });
     // TODO(any): Fix and re-enable tests
   }, skip: true);
+
+  group('Profile grid pagination', () {
+    late _MockBackgroundPublishBloc backgroundPublishBloc;
+
+    setUp(() {
+      backgroundPublishBloc = _MockBackgroundPublishBloc();
+      when(() => backgroundPublishBloc.state).thenReturn(
+        const BackgroundPublishState(),
+      );
+      whenListen(
+        backgroundPublishBloc,
+        const Stream<BackgroundPublishState>.empty(),
+        initialState: const BackgroundPublishState(),
+      );
+    });
+
+    testWidgets('scrolling profile grid near bottom requests more videos', (
+      tester,
+    ) async {
+      final videos = List.generate(60, (index) {
+        final createdAt = nowUnix - index;
+        return VideoEvent(
+          id: 'grid-video-$index',
+          pubkey: testUserHex,
+          createdAt: createdAt,
+          content: 'Video $index',
+          timestamp: now.subtract(Duration(seconds: index)),
+          title: 'Grid Video $index',
+          videoUrl: 'https://example.com/v$index.mp4',
+        );
+      });
+
+      late _TestProfileFeed profileFeed;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authServiceProvider.overrideWithValue(
+              createTestAuthService('someone-else'),
+            ),
+            profileFeedProvider(testUserHex).overrideWith(() {
+              profileFeed = _TestProfileFeed(
+                VideoFeedState(
+                  videos: videos,
+                  hasMoreContent: true,
+                ),
+              );
+              return profileFeed;
+            }),
+          ],
+          child: BlocProvider<BackgroundPublishBloc>.value(
+            value: backgroundPublishBloc,
+            child: MaterialApp(
+              home: Scaffold(
+                body: ProfileVideosGrid(
+                  videos: videos,
+                  userIdHex:
+                      '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738',
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(profileFeed.loadMoreCallCount, 0);
+
+      await tester.scrollUntilVisible(
+        find.bySemanticsLabel('Video thumbnail 60'),
+        800,
+        scrollable: find.byType(Scrollable).first,
+      );
+      await tester.pump();
+
+      expect(profileFeed.loadMoreCallCount, 1);
+    });
+  });
 }


### PR DESCRIPTION
Closes #2517

## Summary
- add bottom-of-grid pagination triggering for profile videos without changing fullscreen pagination
- cover the regression with a widget test that scrolls to the end of the profile grid and asserts `loadMore()` is requested
- include a short spec and implementation plan for the scoped grid-only fix

## Test Plan
- [x] `flutter test test/screens/profile_grid_tap_navigation_test.dart`
- [x] `flutter test test/providers/profile_feed_provider_test.dart`
- [x] `flutter analyze lib/widgets/profile/profile_videos_grid.dart test/screens/profile_grid_tap_navigation_test.dart`
- [x] repo pre-push hook (`test/screens/profile_grid_tap_navigation_test.dart`, `test/widgets/profile/profile_videos_grid_test.dart`)
