### PR TITLE
fix(dm): show username in conversation header when displayName is empty

### DIFF
--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -94,10 +94,9 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
         : '';
     final profileAsync = ref.watch(fetchUserProfileProvider(otherPubkey));
     final profile = profileAsync.asData?.value;
-    final displayName =
-        profile?.displayName ??
-        profile?.name ??
-        NostrKeyUtils.truncateNpub(otherPubkey);
+    final displayName = profile?.displayName?.isNotEmpty == true
+        ? profile!.displayName!
+        : profile?.name ?? NostrKeyUtils.truncateNpub(otherPubkey);
     final handle = profile?.handle ?? '';
 
     return Scaffold(


### PR DESCRIPTION
Closes #2521

## Summary
- Fix conversation header showing only the NIP-05 handle (`@_@hzrd149.com`) instead of the user's display name
- Root cause: `??` (null-coalescing) didn't catch empty-string `displayName` values, so the title was blank and only the subtitle (handle) was visible
- Switch to `isNotEmpty` check, matching the existing logic in `conversation_tile.dart`

## Test plan
- [ ] Open a DM conversation with a user whose Nostr profile has an empty `displayName` but a non-empty `name`
- [ ] Verify the header now shows the username as the title
- [ ] Verify conversations where `displayName` is set still display correctly
- [ ] Verify the conversation list tile still displays correctly