### PR TITLE
fix(ui): remove unwanted text underlines in video grid tiles

### DIFF
--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -566,6 +566,7 @@ class _VideoInfoSection extends StatelessWidget {
               embeddedName: video.authorName,
               maxLines: 1,
               style: VineTheme.titleTinyFont().copyWith(
+                decoration: TextDecoration.none,
                 shadows: const [
                   Shadow(
                     offset: Offset(0, 1),
@@ -584,13 +585,9 @@ class _VideoInfoSection extends StatelessWidget {
               label: 'Video description: ${video.title ?? video.content}',
               child: Text(
                 video.title ?? video.content,
-                style: const TextStyle(
-                  fontFamily: 'Inter',
-                  color: VineTheme.whiteText,
-                  fontSize: 14,
-                  height: 20 / 14,
-                  letterSpacing: 0.25,
-                  shadows: [
+                style: VineTheme.bodyMediumFont().copyWith(
+                  decoration: TextDecoration.none,
+                  shadows: const [
                     Shadow(
                       offset: Offset(0, 1),
                       blurRadius: 2,


### PR DESCRIPTION
Closes #2524

## Summary
- Fixed unwanted underline decoration on author names and video titles in `ComposableVideoGrid` tiles (visible on `CategoryGalleryScreen` and other screens without a `Scaffold`/`Material` ancestor)
- Added explicit `TextDecoration.none` to author name style
- Replaced inline `TextStyle(fontFamily: 'Inter', ...)` for description text with `VineTheme.bodyMediumFont()` for consistency with the design system

## Test plan
- [ ] Open a category gallery (e.g. Golf) and verify text no longer has underlines
- [ ] Verify author names and descriptions render with correct fonts (Bricolage Grotesque for names, Inter for descriptions)
- [ ] Check other screens using `ComposableVideoGrid` (search, hashtag feed, curated lists, for you tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)