### PR TITLE
fix(dm): strip NIP-05 underscore prefix from handle display

### DIFF
--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -119,7 +119,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
               currentPubkey: currentPubkey,
               displayName: displayName,
               imageUrl: profile?.picture,
-              nip05: profile?.nip05,
+              nip05: profile?.displayNip05,
               onViewProfile: () {
                 final npub = NostrKeyUtils.encodePubKey(otherPubkey);
                 context.push(

--- a/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
@@ -92,7 +92,7 @@ class _ProfileContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final imageUrl = profile?.picture;
-    final nip05 = profile?.nip05;
+    final nip05 = profile?.displayNip05;
     final followerCount = profile?.followerCount;
     final videoCount = profile?.videoCount;
 

--- a/mobile/lib/screens/inbox/new_message_sheet.dart
+++ b/mobile/lib/screens/inbox/new_message_sheet.dart
@@ -297,9 +297,9 @@ class _UserTile extends StatelessWidget {
                     overflow: TextOverflow.ellipsis,
                     style: VineTheme.titleMediumFont(),
                   ),
-                  if (profile.nip05 != null && profile.nip05!.isNotEmpty)
+                  if (profile.handle.isNotEmpty)
                     Text(
-                      '@${profile.nip05}',
+                      profile.handle,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: VineTheme.bodyMediumFont(),

--- a/mobile/packages/models/lib/src/user_profile.dart
+++ b/mobile/packages/models/lib/src/user_profile.dart
@@ -179,7 +179,10 @@ class UserProfile {
   /// Prefers NIP-05 identifier, falls back to [name]. Returns an empty
   /// string when neither is available.
   String get handle {
-    if (nip05 != null && nip05!.isNotEmpty) return '@$nip05';
+    if (nip05 != null && nip05!.isNotEmpty) {
+      final dn = displayNip05!;
+      return dn.startsWith('@') ? dn : '@$dn';
+    }
     if (name != null && name!.isNotEmpty) return '@$name';
     return '';
   }


### PR DESCRIPTION
Follow-up to #2522. Closes #2521.

## Summary
- Use `displayNip05` (strips root-domain `_@` prefix) in the `handle` getter so users see `@hzrd149.com` instead of `@_@hzrd149.com`
- Apply the same fix to search results, empty-state card, and message request preview

## Test plan
- [ ] Search for a user with root-domain NIP-05 (e.g. `_@hzrd149.com`) in New Message — subtitle should show `@hzrd149.com`
- [ ] Open conversation with that user — header subtitle shows `@hzrd149.com`
- [ ] Empty conversation card shows `@hzrd149.com`
- [ ] Message request preview shows `@hzrd149.com`
- [ ] Users with regular NIP-05 (e.g. `alice@example.com`) still show `@alice@example.com`