### PR TITLE
fix(ci-test): handle curl SSL failures in NIP-98 live integration test

### DIFF
--- a/mobile/test/services/nip98_auth_live_test.dart
+++ b/mobile/test/services/nip98_auth_live_test.dart
@@ -14,7 +14,7 @@ import 'package:nostr_sdk/event.dart';
 /// Runs curl to make an HTTP request (bypasses Flutter's HTTP interception).
 Future<(int, String)> curlGet(String url, String authHeader) async {
   final result = await Process.run('curl', [
-    '-s',
+    '-sk',
     '-w',
     r'\n%{http_code}',
     '-H',
@@ -23,6 +23,12 @@ Future<(int, String)> curlGet(String url, String authHeader) async {
     'Accept: application/json',
     url,
   ]);
+  if (result.exitCode != 0) {
+    fail(
+      'curl failed with exit code ${result.exitCode}: '
+      '${result.stderr}',
+    );
+  }
   final output = (result.stdout as String).trim();
   final lines = output.split('\n');
   final statusCode = int.parse(lines.last);


### PR DESCRIPTION
Closes #2529

 
## Description

Fix NIP-98 live integration test failing with silent curl SSL errors (exit code 60). Adds the `-k` flag to skip certificate verification and an explicit exit-code check so curl failures surface clearly instead of returning HTTP status `0`.

Note in the future we will migrate that tests as mentioned in #2527

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore