### PR TITLE
fix(feed): recover stalled videos in main native feed

### DIFF
--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -111,6 +113,9 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   /// or injected via [VideoFeedView.controller] for testing.
   VideoFeedController? controller;
 
+  /// Key for accessing the rendered pooled feed state for programmatic skips.
+  final _feedKey = GlobalKey<PooledVideoFeedState>();
+
   /// Tracks the current fractional page position for scroll-driven overlay opacity.
   late final ValueNotifier<double> _pagePosition;
 
@@ -154,6 +159,16 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     }
   }
 
+  void _skipToNextVideoIfPossible() {
+    final feedState = _feedKey.currentState;
+    if (feedState == null) return;
+
+    final nextIndex = feedState.controller.currentIndex + 1;
+    if (nextIndex >= feedState.controller.videoCount) return;
+
+    unawaited(feedState.animateToPage(nextIndex));
+  }
+
   /// Handles the controller changes.
   ///
   /// Called from [didChangeDependencies] for eager setup and from
@@ -185,6 +200,10 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
           _hasMarkedVideoReady = true;
           StartupPerformanceService.instance.markVideoReady();
         }
+      },
+      onVideoStalled: (index) {
+        if (!mounted) return;
+        _skipToNextVideoIfPossible();
       },
     );
 
@@ -403,78 +422,90 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                     },
                   )
                 else
-                  PooledVideoFeed(
+                  KeyedSubtree(
                     key: ValueKey(state.mode),
-                    videos: pooledVideos,
-                    maxLoopDuration: VideoEditorConstants.maxDuration,
-                    controller: controller,
-                    onScrollOffsetChanged: (page) => _pagePosition.value = page,
-                    itemBuilder: (context, video, index, {required isActive}) {
-                      final originalEvent = eventsById[video.id];
-                      if (originalEvent == null) {
-                        Log.debug(
-                          'Feed item missing original event: '
-                          'mode=${state.mode.name}, index=$index, '
-                          'videoId=${video.id}, playbackUrl=${video.url}, '
-                          'stateVideoCount=${state.videos.length}',
-                          name: 'VideoFeedPage',
-                          category: LogCategory.video,
+                    child: PooledVideoFeed(
+                      key: _feedKey,
+                      videos: pooledVideos,
+                      maxLoopDuration: VideoEditorConstants.maxDuration,
+                      controller: controller,
+                      onScrollOffsetChanged: (page) =>
+                          _pagePosition.value = page,
+                      itemBuilder:
+                          (
+                            context,
+                            video,
+                            index, {
+                            required isActive,
+                          }) {
+                            final originalEvent = eventsById[video.id];
+                            if (originalEvent == null) {
+                              Log.debug(
+                                'Feed item missing original event: '
+                                'mode=${state.mode.name}, index=$index, '
+                                'videoId=${video.id}, playbackUrl=${video.url}, '
+                                'stateVideoCount=${state.videos.length}',
+                                name: 'VideoFeedPage',
+                                category: LogCategory.video,
+                              );
+                              return const ColoredBox(
+                                color: VineTheme.backgroundColor,
+                              );
+                            }
+                            Log.debug(
+                              'Feed item build: mode=${state.mode.name}, index=$index, '
+                              'eventId=${originalEvent.id}, isActive=$isActive, '
+                              'playbackUrl=${video.url}, originalUrl=${originalEvent.videoUrl}, '
+                              'thumbnailUrl=${originalEvent.thumbnailUrl}',
+                              name: 'VideoFeedPage',
+                              category: LogCategory.video,
+                            );
+                            final listSources =
+                                state.listOnlyVideoIds.contains(
+                                  originalEvent.id,
+                                )
+                                ? state.videoListSources[originalEvent.id]
+                                : null;
+                            return _PooledVideoFeedItem(
+                              video: originalEvent,
+                              index: index,
+                              isActive: isActive,
+                              pagePosition: _pagePosition,
+                              contextTitle: state.mode.name,
+                              listSources: listSources,
+                            );
+                          },
+                      onActiveVideoChanged: (video, index) {
+                        FeedPerformanceTracker().startVideoSwipeTracking(
+                          video.id,
                         );
-                        return const ColoredBox(
-                          color: VineTheme.backgroundColor,
+                        final sourceIndex = state.videos.indexWhere(
+                          (event) => event.id == video.id,
                         );
-                      }
-                      Log.debug(
-                        'Feed item build: mode=${state.mode.name}, index=$index, '
-                        'eventId=${originalEvent.id}, isActive=$isActive, '
-                        'playbackUrl=${video.url}, originalUrl=${originalEvent.videoUrl}, '
-                        'thumbnailUrl=${originalEvent.thumbnailUrl}',
-                        name: 'VideoFeedPage',
-                        category: LogCategory.video,
-                      );
-                      final listSources =
-                          state.listOnlyVideoIds.contains(originalEvent.id)
-                          ? state.videoListSources[originalEvent.id]
-                          : null;
-                      return _PooledVideoFeedItem(
-                        video: originalEvent,
-                        index: index,
-                        isActive: isActive,
-                        pagePosition: _pagePosition,
-                        contextTitle: state.mode.name,
-                        listSources: listSources,
-                      );
-                    },
-                    onActiveVideoChanged: (video, index) {
-                      FeedPerformanceTracker().startVideoSwipeTracking(
-                        video.id,
-                      );
-                      final sourceIndex = state.videos.indexWhere(
-                        (event) => event.id == video.id,
-                      );
-                      if (sourceIndex != -1) {
-                        final event = state.videos[sourceIndex];
-                        Log.info(
-                          '📺 Feed active video: mode=${state.mode.name}, '
-                          'index=$index, eventId=${event.id}, pubkey=${event.pubkey}, '
-                          'playbackUrl=${video.url}, originalUrl=${event.videoUrl}, '
-                          'thumbnailUrl=${event.thumbnailUrl}',
-                          name: 'VideoFeedPage',
-                          category: LogCategory.video,
-                        );
-                      }
-                    },
-                    onNearEnd: (index) {
-                      // PooledVideoFeed fires this when the user is within
-                      // nearEndThreshold (default 3) of the end, using the
-                      // controller's actual video count (not the BlocBuilder's
-                      // list length, which may differ due to deduplication).
-                      if (state.hasMore) {
-                        context.read<VideoFeedBloc>().add(
-                          const VideoFeedLoadMoreRequested(),
-                        );
-                      }
-                    },
+                        if (sourceIndex != -1) {
+                          final event = state.videos[sourceIndex];
+                          Log.info(
+                            '📺 Feed active video: mode=${state.mode.name}, '
+                            'index=$index, eventId=${event.id}, pubkey=${event.pubkey}, '
+                            'playbackUrl=${video.url}, originalUrl=${event.videoUrl}, '
+                            'thumbnailUrl=${event.thumbnailUrl}',
+                            name: 'VideoFeedPage',
+                            category: LogCategory.video,
+                          );
+                        }
+                      },
+                      onNearEnd: (index) {
+                        // PooledVideoFeed fires this when the user is within
+                        // nearEndThreshold (default 3) of the end, using the
+                        // controller's actual video count (not the BlocBuilder's
+                        // list length, which may differ due to deduplication).
+                        if (state.hasMore) {
+                          context.read<VideoFeedBloc>().add(
+                            const VideoFeedLoadMoreRequested(),
+                          );
+                        }
+                      },
+                    ),
                   ),
                 const FeedModeSwitch(),
               ],

--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -65,6 +65,7 @@ class VideoFeedController extends ChangeNotifier {
     this.preloadBehind = 1,
     this.mediaSourceResolver,
     this.onVideoReady,
+    this.onVideoStalled,
     this.positionCallback,
     this.positionCallbackInterval = const Duration(milliseconds: 250),
     this.slowLoadThreshold = const Duration(seconds: 8),
@@ -100,6 +101,10 @@ class VideoFeedController extends ChangeNotifier {
   ///
   /// Used for triggering background caching, analytics, etc.
   final VideoReadyCallback? onVideoReady;
+
+  /// Hook: Called when the current video repeatedly stalls and should be
+  /// skipped.
+  final VideoStalledCallback? onVideoStalled;
 
   /// Hook: Called periodically with position updates.
   ///
@@ -151,9 +156,13 @@ class VideoFeedController extends ChangeNotifier {
   final Map<int, Timer> _loadWatchdogTimers = {};
   final Map<int, Stopwatch> _loadStopwatches = {};
   final Map<int, String> _openedSources = {};
+  final Map<int, int> _stallRetryCount = {};
+  final Set<int> _readyVideosAwaitingRecovery = {};
   final Set<int> _slowLoadIndices = {};
   int _preloadGeneration = 0;
   Timer? _stuckPlaybackTimer;
+
+  static const _maxStallRetries = 1;
 
   /// Stale-position recovery: tracks the last observed position and how many
   /// consecutive heartbeats it has remained unchanged while the player reports
@@ -312,8 +321,7 @@ class VideoFeedController extends ChangeNotifier {
           );
           timer.cancel();
           _loadWatchdogTimers.remove(index);
-          _loadStates[index] = LoadState.error;
-          _notifyIndex(index);
+          _markVideoError(index, notifyStalled: true);
           return;
         }
       }
@@ -334,6 +342,16 @@ class VideoFeedController extends ChangeNotifier {
   void _stopLoadWatchdog(int index) {
     _loadWatchdogTimers[index]?.cancel();
     _loadWatchdogTimers.remove(index);
+  }
+
+  void _markVideoError(int index, {bool notifyStalled = false}) {
+    _stallRetryCount.remove(index);
+    _readyVideosAwaitingRecovery.remove(index);
+    _loadStates[index] = LoadState.error;
+    _notifyIndex(index);
+    if (notifyStalled) {
+      onVideoStalled?.call(index);
+    }
   }
 
   ({String primary, String? fallback}) _resolvePlaybackSources(
@@ -752,8 +770,7 @@ class VideoFeedController extends ChangeNotifier {
       );
       _stopLoadWatchdog(index);
       if (!_isDisposed) {
-        _loadStates[index] = LoadState.error;
-        _notifyIndex(index);
+        _markVideoError(index, notifyStalled: index == _currentIndex);
       }
     } finally {
       _loadingIndices.remove(index);
@@ -782,6 +799,8 @@ class VideoFeedController extends ChangeNotifier {
     _stopLoadWatchdog(index);
     _loadStopwatches.remove(index)?.stop();
     _openedSources.remove(index);
+    _stallRetryCount.remove(index);
+    _readyVideosAwaitingRecovery.remove(index);
     _slowLoadIndices.remove(index);
     _loadedPlayers.remove(index);
     _loadStates.remove(index);
@@ -868,17 +887,45 @@ class VideoFeedController extends ChangeNotifier {
         'positionMs='
         '${pooledPlayer.player.state.position.inMilliseconds}',
       );
-      if (!isBuffering) {
-        if (_loadStates[index] == LoadState.loading) {
-          _onBufferReady(index);
-        } else if (_loadStates[index] == LoadState.ready &&
-            index == _currentIndex &&
-            _isActive &&
-            !_isPaused) {
-          final player = _loadedPlayers[index]?.player;
-          if (player != null) {
-            unawaited(player.play());
+      if (isBuffering) {
+        if (_loadStates[index] == LoadState.ready) {
+          _readyVideosAwaitingRecovery.add(index);
+        }
+        return;
+      }
+
+      if (_loadStates[index] == LoadState.loading) {
+        _onBufferReady(index);
+      } else if (_loadStates[index] == LoadState.ready &&
+          index == _currentIndex &&
+          _isActive &&
+          !_isPaused) {
+        final player = _loadedPlayers[index]?.player;
+        if (player != null) {
+          final wasRecovering = _readyVideosAwaitingRecovery.remove(index);
+          if (wasRecovering) {
+            final positionMs =
+                pooledPlayer.player.state.position.inMilliseconds;
+            final durationMs =
+                pooledPlayer.player.state.duration.inMilliseconds;
+
+            if (positionMs == 0 && durationMs == 0) {
+              final retries = _stallRetryCount[index] =
+                  (_stallRetryCount[index] ?? 0) + 1;
+              if (retries > _maxStallRetries) {
+                _logDebug(
+                  'stall_circuit_breaker ${_videoDebugDetails(index)} '
+                  'retries=$retries — giving up',
+                );
+                _markVideoError(index, notifyStalled: true);
+                return;
+              }
+            } else {
+              _stallRetryCount.remove(index);
+            }
           }
+
+          unawaited(player.play());
         }
       }
     });
@@ -901,6 +948,9 @@ class VideoFeedController extends ChangeNotifier {
   void _playVideo(int index) {
     final player = _loadedPlayers[index]?.player;
     if (player == null) return;
+
+    _stallRetryCount.remove(index);
+    _readyVideosAwaitingRecovery.remove(index);
 
     // The player is paused (from _onBufferReady or _pauseVideo).
     // Unmute and play, seeking to zero only if the video reached the end
@@ -945,8 +995,7 @@ class VideoFeedController extends ChangeNotifier {
           'stuck_playback ${_videoDebugDetails(index)} '
           'giving up',
         );
-        _loadStates[index] = LoadState.error;
-        _notifyIndex(index);
+        _markVideoError(index, notifyStalled: true);
       }
     });
   }
@@ -1089,8 +1138,7 @@ class VideoFeedController extends ChangeNotifier {
           '${_videoDebugDetails(index)}',
         );
         _staleRecoveryAttempts = 0;
-        _loadStates[index] = LoadState.error;
-        _notifyIndex(index);
+        _markVideoError(index, notifyStalled: true);
         return;
       }
 
@@ -1181,6 +1229,8 @@ class VideoFeedController extends ChangeNotifier {
     _stopLoadWatchdog(index);
     _loadStopwatches.remove(index)?.stop();
     _openedSources.remove(index);
+    _stallRetryCount.remove(index);
+    _readyVideosAwaitingRecovery.remove(index);
     _slowLoadIndices.remove(index);
     _loadedPlayers.remove(index);
     _loadStates.remove(index);
@@ -1242,6 +1292,8 @@ class VideoFeedController extends ChangeNotifier {
     }
     _loadStopwatches.clear();
     _openedSources.clear();
+    _stallRetryCount.clear();
+    _readyVideosAwaitingRecovery.clear();
 
     // Notify all index listeners that their video is gone.  This causes
     // ValueListenableBuilder to rebuild with videoController == null,

--- a/mobile/packages/pooled_video_player/lib/src/models/video_pool_config.dart
+++ b/mobile/packages/pooled_video_player/lib/src/models/video_pool_config.dart
@@ -11,6 +11,9 @@ typedef MediaSourceResolver = String? Function(VideoItem video);
 /// Called when a video becomes ready for playback.
 typedef VideoReadyCallback = void Function(int index, Player player);
 
+/// Called when a current video repeatedly stalls and should be skipped.
+typedef VideoStalledCallback = void Function(int index);
+
 /// Called periodically with position updates for the active video.
 typedef PositionCallback = void Function(int index, Duration position);
 

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -2793,6 +2793,48 @@ void main() {
         verify(setup.player.play).called(greaterThanOrEqualTo(1));
       });
 
+      test(
+        'allows the first real zero-duration rebuffer recovery before '
+        'marking error on the second',
+        () async {
+          final videos = createTestVideos(count: 1);
+          final controller = VideoFeedController(videos: videos, pool: pool);
+          addTearDown(controller.dispose);
+
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          final setup = playerSetups[videos[0].url]!;
+
+          // Initial ready transition.
+          setup.bufferingController.add(false);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          expect(controller.getLoadState(0), equals(LoadState.ready));
+
+          clearInteractions(setup.player);
+
+          // First real rebuffer cycle: should still attempt recovery.
+          setup.bufferingController.add(true);
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          setup.bufferingController.add(false);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          expect(controller.getLoadState(0), equals(LoadState.ready));
+          verify(setup.player.play).called(greaterThanOrEqualTo(1));
+
+          clearInteractions(setup.player);
+
+          // Second real rebuffer cycle with no media metadata: give up.
+          setup.bufferingController.add(true);
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          setup.bufferingController.add(false);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          expect(controller.getLoadState(0), equals(LoadState.error));
+          verifyNever(setup.player.play);
+        },
+      );
+
       test('rebuffer after seek calls player.play() '
           'for current active video', () async {
         final videos = createTestVideos(count: 3);

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -17,6 +17,7 @@ import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:pooled_video_player/pooled_video_player.dart';
 
 import '../../helpers/test_provider_overrides.dart';
+import '../../test_data/video_test_data.dart';
 
 class _MockVideoFeedBloc extends MockBloc<VideoFeedEvent, VideoFeedState>
     implements VideoFeedBloc {}
@@ -398,6 +399,74 @@ void main() {
         verify(
           () => videoFeedController.setActive(active: true),
         ).called(1);
+      },
+    );
+  });
+
+  group('VideoFeedView native feed wiring', () {
+    late VideoFeedBloc videoFeedBloc;
+    late VideoFeedController videoFeedController;
+
+    setUp(() async {
+      await PlayerPool.init();
+      videoFeedBloc = _MockVideoFeedBloc();
+      videoFeedController = _MockVideoFeedController();
+
+      when(() => videoFeedController.videoCount).thenReturn(1);
+      when(
+        () => videoFeedController.videos,
+      ).thenReturn([
+        const VideoItem(id: 'video-1', url: 'https://example.com/video.mp4'),
+      ]);
+      when(() => videoFeedController.addListener(any())).thenReturn(null);
+      when(() => videoFeedController.removeListener(any())).thenReturn(null);
+      when(() => videoFeedController.dispose()).thenReturn(null);
+      when(
+        () => videoFeedController.setActive(
+          active: any(named: 'active'),
+          retainCurrentPlayer: any(named: 'retainCurrentPlayer'),
+        ),
+      ).thenReturn(null);
+    });
+
+    tearDown(() async {
+      await PlayerPool.reset();
+    });
+
+    Widget buildSubject(VideoFeedState state) {
+      when(() => videoFeedBloc.state).thenReturn(state);
+
+      return testMaterialApp(
+        home: BlocProvider<VideoFeedBloc>.value(
+          value: videoFeedBloc,
+          child: VideoFeedView(controller: videoFeedController),
+        ),
+      );
+    }
+
+    testWidgets(
+      'renders native pooled feed with a state key for programmatic control',
+      (
+        tester,
+      ) async {
+        final state = VideoFeedState(
+          status: VideoFeedStatus.success,
+          videos: [
+            createTestVideoEvent(videoUrl: 'https://example.com/video.mp4'),
+          ],
+        );
+
+        await tester.pumpWidget(buildSubject(state));
+        await tester.pump();
+
+        final pooledVideoFeed = tester.widget<PooledVideoFeed>(
+          find.byType(PooledVideoFeed),
+        );
+
+        expect(
+          pooledVideoFeed.key,
+          isA<GlobalKey<PooledVideoFeedState>>(),
+        );
       },
     );
   });


### PR DESCRIPTION
Closes #2550

## Summary
- attach the main native feed to a real `GlobalKey<PooledVideoFeedState>` while preserving mode-based remounts
- skip forward when the current native feed video is marked stalled
- only count stall retries after a real ready -> buffering -> ready recovery cycle so initial readiness does not burn the retry budget

## Testing
- flutter test test/screens/feed/video_feed_page_test.dart
- flutter test packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
- flutter test packages/pooled_video_player/test/widgets/pooled_video_feed_test.dart
- flutter test packages/pooled_video_player/test/models/video_pool_config_test.dart
- pre-push hook reran changed-file suites successfully