### PR TITLE
feat(share): update shared video copy to use 'Divine' instead of 'vine'

### DIFF
--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -334,10 +334,10 @@ class VideoSharingService {
       buffer.writeln();
     }
 
-    buffer.writeln('🎬 Check out this vine:');
-
     if (video.title != null && video.title!.isNotEmpty) {
-      buffer.writeln('"${video.title}"');
+      buffer.writeln('Check out this Divine: ${video.title}');
+    } else {
+      buffer.writeln('Check out this Divine');
     }
 
     if (video.videoUrl != null) {

--- a/mobile/test/services/video_sharing_service_test.dart
+++ b/mobile/test/services/video_sharing_service_test.dart
@@ -475,6 +475,93 @@ void main() {
       expect(captured.first as String, contains('Check this out!'));
     });
 
+    test('share message says "Check out this Divine: <title>"', () async {
+      when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(
+        () => mockDmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+        ),
+      ).thenAnswer(
+        (_) async => NIP17SendResult.success(
+          messageEventId: 'nip17-msg-id',
+          recipientPubkey: _recipientPubkey,
+        ),
+      );
+      when(
+        () => mockProfileRepository.fetchFreshProfile(
+          pubkey: any(named: 'pubkey'),
+        ),
+      ).thenAnswer((_) async => null);
+
+      final now = DateTime.now();
+      await nip17Service.shareVideoWithUser(
+        video: VideoEvent(
+          id: 'video1',
+          pubkey: _testPubkey,
+          createdAt: now.millisecondsSinceEpoch ~/ 1000,
+          timestamp: now,
+          content: 'Test',
+          title: 'Indigenous cultures',
+        ),
+        recipientPubkey: _recipientPubkey,
+      );
+
+      final captured = verify(
+        () => mockDmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: captureAny(named: 'content'),
+        ),
+      ).captured;
+
+      final message = captured.first as String;
+      expect(message, contains('Check out this Divine: Indigenous cultures'));
+      expect(message, isNot(matches(RegExp(r'\bvine\b'))));
+    });
+
+    test('share message without title says "Check out this Divine"', () async {
+      when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(
+        () => mockDmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+        ),
+      ).thenAnswer(
+        (_) async => NIP17SendResult.success(
+          messageEventId: 'nip17-msg-id',
+          recipientPubkey: _recipientPubkey,
+        ),
+      );
+      when(
+        () => mockProfileRepository.fetchFreshProfile(
+          pubkey: any(named: 'pubkey'),
+        ),
+      ).thenAnswer((_) async => null);
+
+      final now = DateTime.now();
+      await nip17Service.shareVideoWithUser(
+        video: VideoEvent(
+          id: 'video1',
+          pubkey: _testPubkey,
+          createdAt: now.millisecondsSinceEpoch ~/ 1000,
+          timestamp: now,
+          content: 'Test',
+        ),
+        recipientPubkey: _recipientPubkey,
+      );
+
+      final captured = verify(
+        () => mockDmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: captureAny(named: 'content'),
+        ),
+      ).captured;
+
+      final message = captured.first as String;
+      expect(message, contains('Check out this Divine'));
+      expect(message, isNot(contains('vine:')));
+    });
+
     test('computes correct conversationId', () async {
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
       when(


### PR DESCRIPTION
## Summary
- Replace `"🎬 Check out this vine:"` with `"Check out this Divine: <Title>"` in the video share message to match Divine branding
- Handle missing title gracefully (falls back to `"Check out this Divine"`)
- Add tests verifying the new share message format

## Test plan
- [x] `flutter test test/services/video_sharing_service_test.dart` — 23/23 passing
- [ ] Manual: share a video with a title → message should read `Check out this Divine: <Title>`
- [ ] Manual: share a video without a title → message should read `Check out this Divine`

Closes #2536