### PR TITLE
fix(follow): protect against catastrophic contact list reduction

### DIFF
--- a/mobile/lib/repositories/follow_repository.dart
+++ b/mobile/lib/repositories/follow_repository.dart
@@ -1301,12 +1301,21 @@ class FollowRepository {
       // Guard: detect catastrophic list reduction from buggy external clients.
       // A common Nostr footgun is publishing a Kind 3 event without first
       // fetching the existing contact list, which overwrites the full list
-      // with only the newly followed user. When the reduction exceeds the
-      // threshold, union-merge instead of replacing and re-broadcast the
-      // merged list to fix the relay state.
-      if (_followingPubkeys.length >= _mergeMinFollows &&
+      // with only the newly followed user. We detect this by checking for
+      // two conditions simultaneously:
+      //   1. The remote list is drastically smaller than the local list.
+      //   2. The remote list contains pubkeys NOT already in the local list
+      //      (the "only-new-follow" fingerprint of buggy clients).
+      // A legitimate mass-unfollow produces a strict subset of the local
+      // list, so condition 2 filters it out.
+      final localSet = _followingPubkeys.toSet();
+      final isDrasticReduction =
+          _followingPubkeys.length >= _mergeMinFollows &&
           followedPubkeys.length <
-              (_followingPubkeys.length * _mergeMaxLossFraction).ceil()) {
+              (_followingPubkeys.length * _mergeMaxLossFraction).ceil();
+      final hasNewPubkeys = followedPubkeys.any((pk) => !localSet.contains(pk));
+
+      if (isDrasticReduction && hasNewPubkeys) {
         final merged = <String>{..._followingPubkeys, ...followedPubkeys};
 
         Log.warning(

--- a/mobile/test/repositories/follow_repository_test.dart
+++ b/mobile/test/repositories/follow_repository_test.dart
@@ -1210,6 +1210,48 @@ void main() {
       );
 
       test(
+        'accepts drastic reduction when remote is a subset (legitimate mass '
+        'unfollow)',
+        () async {
+          // Seed with 12 follows
+          final seededPubkeys = List.generate(
+            12,
+            (i) => i.toRadixString(16).padLeft(64, '0'),
+          );
+          SharedPreferences.setMockInitialValues({
+            'following_list_$testCurrentUserPubkey':
+                '[${seededPubkeys.map((p) => '"$p"').join(',')}]',
+          });
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            personalEventCache: mockPersonalEventCache,
+            indexerRelayUrls: const [],
+          );
+
+          await repository.initialize();
+          expect(repository.followingCount, 12);
+
+          // Remote event keeps only 3 of the original 12 — drastic but all
+          // entries are a subset of the local list (no new pubkeys), so this
+          // is a legitimate mass unfollow on another client.
+          final remoteEvent = Event(
+            testCurrentUserPubkey,
+            3,
+            seededPubkeys.take(3).map((p) => ['p', p]).toList(),
+            '',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 100,
+          );
+
+          realTimeStreamController.add(remoteEvent);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          // Should accept as-is (not merge) because no new pubkeys
+          expect(repository.followingCount, 3);
+        },
+      );
+
+      test(
         'accepts remote event with slightly fewer follows (legitimate unfollow)',
         () async {
           // Seed with 10 follows


### PR DESCRIPTION
Closes #2404

Related to #2404

## Summary

- Add merge-on-drastic-reduction protection in `FollowRepository._processContactListEvent()` to guard against buggy external Nostr clients that publish incomplete Kind 3 events
- When a newer Kind 3 event would drop >50% of follows (and local list has ≥10 entries), union-merge both lists and re-broadcast the corrected list to relays
- Legitimate unfollows (small reductions) and cross-device follow additions pass through unchanged

## Root Cause

External clients (e.g. Divine web app in Safari) can publish a Kind 3 contact list containing only the newly followed user without fetching the existing list first. Since Kind 3 is a replaceable event (NIP-02), this overwrites the full follow list on all relays. The mobile app's real-time sync subscription then accepts this incomplete event and replaces the local list.

## Test Plan

- [x] New test: merges lists when remote event has drastically fewer follows (12→1 becomes 13)
- [x] New test: accepts slight reduction as legitimate unfollow (10→8 accepted as-is)
- [x] New test: accepts remote event with more follows (5→10 accepted as-is)
- [x] New test: skips merge protection when local list is below threshold (5→1 replaced)
- [x] All 69 existing follow_repository tests pass
- [x] `flutter analyze` clean