### PR TITLE
fix(auth): redirect to login options when session expires on welcome screen

### DIFF
--- a/mobile/lib/blocs/welcome/welcome_bloc.dart
+++ b/mobile/lib/blocs/welcome/welcome_bloc.dart
@@ -175,7 +175,8 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
       );
     } on SessionExpiredException {
       Log.warning(
-        'WelcomeBloc: session expired for ${account.pubkeyHex}',
+        'WelcomeBloc: session expired for ${account.pubkeyHex} '
+        '— redirecting to login options',
         name: 'WelcomeBloc',
         category: LogCategory.auth,
       );
@@ -186,6 +187,10 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
           clearSigningIn: true,
         ),
       );
+      // Session cannot be restored silently — redirect to full login flow.
+      await _authService.acceptTerms();
+      emit(state.copyWith(status: WelcomeStatus.navigatingToLoginOptions));
+      emit(state.copyWith(status: WelcomeStatus.loaded, clearError: true));
     } catch (e) {
       Log.error(
         'WelcomeBloc: failed to log back in as ${account.pubkeyHex}: $e',

--- a/mobile/test/blocs/welcome/welcome_bloc_test.dart
+++ b/mobile/test/blocs/welcome/welcome_bloc_test.dart
@@ -311,7 +311,8 @@ void main() {
       );
 
       blocTest<WelcomeBloc, WelcomeState>(
-        'emits user-friendly error on $SessionExpiredException',
+        'emits error then navigates to login options on '
+        '$SessionExpiredException',
         setUp: () {
           when(
             () => mockAuthService.signInForAccount(any(), any()),
@@ -334,7 +335,19 @@ void main() {
             previousAccounts: [_testPreviousAccount],
             error: 'Your session has expired. Please sign in again.',
           ),
+          const WelcomeState(
+            status: WelcomeStatus.navigatingToLoginOptions,
+            previousAccounts: [_testPreviousAccount],
+            error: 'Your session has expired. Please sign in again.',
+          ),
+          const WelcomeState(
+            status: WelcomeStatus.loaded,
+            previousAccounts: [_testPreviousAccount],
+          ),
         ],
+        verify: (_) {
+          verify(() => mockAuthService.acceptTerms()).called(1);
+        },
       );
     });
 

--- a/mobile/test/screens/welcome_screen_test.dart
+++ b/mobile/test/screens/welcome_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/models/known_account.dart';
@@ -329,6 +330,26 @@ void main() {
           ),
         ).called(1);
       });
+
+      testWidgets(
+        'navigates to login options when session is expired',
+        (tester) async {
+          when(
+            () => mockAuthService.signInForAccount(any(), any()),
+          ).thenThrow(SessionExpiredException());
+
+          await tester.binding.setSurfaceSize(const Size(800, 1200));
+          addTearDown(() => tester.binding.setSurfaceSize(null));
+          await tester.pumpWidget(createTestWidget());
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.text('Sign back in'));
+          await tester.pumpAndSettle();
+
+          verify(() => mockAuthService.acceptTerms()).called(1);
+          expect(find.text('Sign in'), findsOneWidget);
+        },
+      );
 
       testWidgets(
         'tapping "Create a new Divine account" calls acceptTerms and navigates',


### PR DESCRIPTION
## Summary
- When a returning user taps "Sign back in" and the OAuth session is expired, the button remained enabled after showing the error snackbar — tapping it again always produced the same error
- After showing the session-expired snackbar, now automatically navigates to the login options screen so the user can re-authenticate through the full OAuth flow

Closes #2526

## Test plan
- [ ] Run `flutter test test/blocs/welcome/welcome_bloc_test.dart` — all 26 tests pass
- [ ] Run `flutter test test/screens/welcome_screen_test.dart` — all 22 tests pass
- [ ] Manual: start local stack, register a divineOAuth user, sign out, expire tokens via DB, tap "Sign back in" — should show snackbar then navigate to login options