### PR TITLE
refactor(upload): extract Divine resumable upload protocol literals into shared constants

### DIFF
--- a/mobile/lib/constants/upload_constants.dart
+++ b/mobile/lib/constants/upload_constants.dart
@@ -1,0 +1,42 @@
+// ABOUTME: Named constants for the Divine resumable upload protocol
+// ABOUTME: Eliminates repeated header and extension token literals across
+// service code and tests
+
+/// HTTP header names for the Divine resumable upload protocol.
+///
+/// Used during capability discovery (`HEAD /upload`) and the resumable
+/// upload session lifecycle (chunk PUT, session query, completion).
+///
+/// See `docs/protocol/blossom/2026-03-26-divine-resumable-upload-sessions-bud.md`
+class DivineUploadHeaders {
+  /// Comma-separated list of supported upload extensions.
+  ///
+  /// Advertised by `HEAD /upload` response.
+  static const String extensions = 'X-Divine-Upload-Extensions';
+
+  /// Control-plane host for session management (init, complete, query).
+  ///
+  /// Advertised by `HEAD /upload` response.
+  static const String controlHost = 'X-Divine-Upload-Control-Host';
+
+  /// Data-plane host that receives chunk upload traffic.
+  ///
+  /// Advertised by `HEAD /upload` response.
+  static const String dataHost = 'X-Divine-Upload-Data-Host';
+
+  /// Current byte offset acknowledged by the server.
+  ///
+  /// Returned in chunk upload and session query responses.
+  static const String uploadOffset = 'Upload-Offset';
+
+  /// ISO-8601 timestamp when the upload session expires.
+  ///
+  /// Returned in chunk upload and session query responses.
+  static const String uploadExpiresAt = 'Upload-Expires-At';
+}
+
+/// Capability tokens advertised in [DivineUploadHeaders.extensions].
+class DivineUploadExtensions {
+  /// Resumable upload sessions with chunked transfer.
+  static const String resumableSessions = 'resumable-sessions';
+}

--- a/mobile/lib/services/blossom_upload_service.dart
+++ b/mobile/lib/services/blossom_upload_service.dart
@@ -8,6 +8,7 @@ import 'dart:math' as math;
 import 'package:dio/dio.dart';
 import 'package:image_metadata_stripper/image_metadata_stripper.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:openvine/constants/upload_constants.dart';
 import 'package:openvine/models/blossom_resumable_upload_session.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
@@ -306,13 +307,12 @@ class BlossomUploadService {
   }
 
   int? _parseUploadOffset(Headers headers) {
-    final rawOffset =
-        headers.value('Upload-Offset') ?? headers.value('upload-offset');
+    final rawOffset = headers.value(DivineUploadHeaders.uploadOffset);
     return rawOffset == null ? null : int.tryParse(rawOffset);
   }
 
   DateTime? _parseUploadExpiresAt(Headers headers) => _parseDateTimeValue(
-    headers.value('Upload-Expires-At') ?? headers.value('upload-expires-at'),
+    headers.value(DivineUploadHeaders.uploadExpiresAt),
   );
 
   Future<_DivineUploadCapability> _fetchDivineUploadCapability(
@@ -327,24 +327,20 @@ class BlossomUploadService {
           receiveTimeout: const Duration(seconds: 5),
         ),
       );
-      final extensionsHeader =
-          response.headers.value('X-Divine-Upload-Extensions') ??
-          response.headers.value('x-divine-upload-extensions');
+      final extensionsHeader = response.headers.value(
+        DivineUploadHeaders.extensions,
+      );
       final supportsResumable =
           extensionsHeader
               ?.split(',')
               .map((value) => value.trim().toLowerCase())
-              .contains('resumable-sessions') ??
+              .contains(DivineUploadExtensions.resumableSessions) ??
           false;
 
       return _DivineUploadCapability(
         supportsResumable: supportsResumable,
-        controlHost:
-            response.headers.value('X-Divine-Upload-Control-Host') ??
-            response.headers.value('x-divine-upload-control-host'),
-        dataHost:
-            response.headers.value('X-Divine-Upload-Data-Host') ??
-            response.headers.value('x-divine-upload-data-host'),
+        controlHost: response.headers.value(DivineUploadHeaders.controlHost),
+        dataHost: response.headers.value(DivineUploadHeaders.dataHost),
       );
     } on DioException catch (error) {
       Log.warning(

--- a/mobile/test/integration/blossom_resumable_upload_integration_test.dart
+++ b/mobile/test/integration/blossom_resumable_upload_integration_test.dart
@@ -7,6 +7,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:openvine/constants/upload_constants.dart';
 import 'package:openvine/models/blossom_resumable_upload_session.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/blossom_upload_service.dart';
@@ -76,9 +77,15 @@ void main() {
             requestOptions: RequestOptions(path: '/upload'),
             statusCode: 200,
             headers: Headers.fromMap({
-              'X-Divine-Upload-Extensions': ['resumable-sessions'],
-              'X-Divine-Upload-Control-Host': ['https://media.divine.video'],
-              'X-Divine-Upload-Data-Host': ['https://upload.divine.video'],
+              DivineUploadHeaders.extensions: [
+                DivineUploadExtensions.resumableSessions,
+              ],
+              DivineUploadHeaders.controlHost: [
+                'https://media.divine.video',
+              ],
+              DivineUploadHeaders.dataHost: [
+                'https://upload.divine.video',
+              ],
             }),
           );
         }
@@ -152,7 +159,7 @@ void main() {
           requestOptions: RequestOptions(path: '/sessions/up_123'),
           statusCode: 204,
           headers: Headers.fromMap({
-            'Upload-Offset': [nextOffset],
+            DivineUploadHeaders.uploadOffset: [nextOffset],
           }),
         );
       });

--- a/mobile/test/integration/blossom_upload_spec_test.dart
+++ b/mobile/test/integration/blossom_upload_spec_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/constants/upload_constants.dart';
 import 'package:openvine/services/blossom_upload_service.dart';
 
 void main() {
@@ -96,24 +97,20 @@ void main() {
     test(
       'Divine resumable capability is advertised separately from legacy PUT upload',
       () {
-        const capabilityHeader = 'resumable-sessions';
-        const controlHost = 'https://media.divine.video';
-        const dataHost = 'https://upload.divine.video';
-
         expect(
-          capabilityHeader,
+          DivineUploadExtensions.resumableSessions,
           equals('resumable-sessions'),
           reason: 'Mobile client expects this token on HEAD /upload',
         );
         expect(
-          controlHost,
-          equals(BlossomUploadService.defaultBlossomServer),
+          BlossomUploadService.defaultBlossomServer,
+          equals('https://media.divine.video'),
           reason: 'Canonical blob URLs stay on the media control-plane host',
         );
         expect(
-          dataHost,
-          equals('https://upload.divine.video'),
-          reason: 'Chunk uploads use the opaque upload-session data host',
+          DivineUploadHeaders.dataHost,
+          equals('X-Divine-Upload-Data-Host'),
+          reason: 'Data-host header name matches the protocol spec',
         );
       },
     );

--- a/mobile/test/services/blossom_upload_service_test.dart
+++ b/mobile/test/services/blossom_upload_service_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:openvine/constants/upload_constants.dart';
 import 'package:openvine/models/blossom_resumable_upload_session.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/blossom_upload_service.dart';
@@ -309,9 +310,11 @@ void main() {
               requestOptions: RequestOptions(path: '/upload'),
               statusCode: 200,
               headers: Headers.fromMap({
-                'X-Divine-Upload-Extensions': ['resumable-sessions'],
-                'X-Divine-Upload-Control-Host': ['https://media.divine.video'],
-                'X-Divine-Upload-Data-Host': ['https://upload.divine.video'],
+                DivineUploadHeaders.extensions: [
+                  DivineUploadExtensions.resumableSessions,
+                ],
+                DivineUploadHeaders.controlHost: ['https://media.divine.video'],
+                DivineUploadHeaders.dataHost: ['https://upload.divine.video'],
               }),
             ),
           );
@@ -378,7 +381,7 @@ void main() {
                 requestOptions: RequestOptions(path: '/sessions/up_123'),
                 statusCode: 204,
                 headers: Headers.fromMap({
-                  'Upload-Offset': ['4'],
+                  DivineUploadHeaders.uploadOffset: ['4'],
                 }),
               );
             }
@@ -390,7 +393,7 @@ void main() {
                 requestOptions: RequestOptions(path: '/sessions/up_123'),
                 statusCode: 204,
                 headers: Headers.fromMap({
-                  'Upload-Offset': ['8'],
+                  DivineUploadHeaders.uploadOffset: ['8'],
                 }),
               );
             }
@@ -401,7 +404,7 @@ void main() {
               requestOptions: RequestOptions(path: '/sessions/up_123'),
               statusCode: 204,
               headers: Headers.fromMap({
-                'Upload-Offset': ['10'],
+                DivineUploadHeaders.uploadOffset: ['10'],
               }),
             );
           });
@@ -589,7 +592,9 @@ void main() {
               requestOptions: RequestOptions(path: '/upload'),
               statusCode: 200,
               headers: Headers.fromMap({
-                'X-Divine-Upload-Extensions': ['resumable-sessions'],
+                DivineUploadHeaders.extensions: [
+                  DivineUploadExtensions.resumableSessions,
+                ],
               }),
             ),
           );


### PR DESCRIPTION
## Summary
Closes #2552

- Introduce `DivineUploadHeaders` and `DivineUploadExtensions` constants in `mobile/lib/constants/upload_constants.dart`, centralizing repeated protocol header names and capability tokens
- Replace all raw header string literals across the service and three test files with the shared constants
- Remove redundant lowercase header fallbacks — Dio's `Headers` class uses a case-insensitive `LinkedHashMap` internally, so the `?? headers.value('x-lowercase')` patterns were dead code

## Test plan
- [x] `flutter analyze` passes with no issues
- [x] All 28 existing tests in the affected files pass (0 failures)
- [x] Grep confirms zero remaining raw protocol literals in service or test code (only `equals(...)` assertion values remain, which verify the constant values themselves)