### PR TITLE
fix(feed): sync home video controller on initial mount

### DIFF
--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -137,6 +137,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     super.didChangeDependencies();
     // Initialize controller eagerly if BLoC already has videos on first build
     handleVideoController();
+    _syncControllerPlaybackState();
   }
 
   @override
@@ -199,7 +200,10 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
         active: false,
         retainCurrentPlayer: overlayState.shouldRetainPlayer,
       );
+      return;
     }
+
+    _syncControllerPlaybackState(resumeIfHome: true);
   }
 
   /// Handles new videos from pagination by adding them to the controller.
@@ -262,6 +266,29 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     }
 
     return true;
+  }
+
+  void _syncControllerPlaybackState({bool resumeIfHome = false}) {
+    final activeController = controller;
+    if (activeController == null) return;
+
+    final routeType = ref.read(pageContextProvider).asData?.value.type;
+    if (routeType != null) {
+      _isOnHomeTab = routeType == RouteType.home;
+    }
+
+    final overlayState = ref.read(overlayVisibilityProvider);
+    if (!_isOnHomeTab || overlayState.hasVisibleOverlay) {
+      activeController.setActive(
+        active: false,
+        retainCurrentPlayer: overlayState.shouldRetainPlayer,
+      );
+      return;
+    }
+
+    if (resumeIfHome) {
+      activeController.setActive(active: true);
+    }
   }
 
   @override

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -252,6 +252,79 @@ void main() {
       );
     }
 
+    Widget buildSubjectWithInitialLocation(String location) {
+      when(
+        () => videoFeedBloc.state,
+      ).thenReturn(const VideoFeedState());
+
+      return testMaterialApp(
+        additionalOverrides: [
+          routerLocationStreamProvider.overrideWith(
+            (ref) => Stream.value(location),
+          ),
+        ],
+        home: BlocProvider<VideoFeedBloc>.value(
+          value: videoFeedBloc,
+          child: VideoFeedView(controller: videoFeedController),
+        ),
+      );
+    }
+
+    testWidgets(
+      'syncs controller to a non-home route on initial mount',
+      (tester) async {
+        await tester.pumpWidget(buildSubjectWithInitialLocation('/search'));
+        await tester.pump();
+
+        verify(
+          () => videoFeedController.setActive(active: false),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'syncs controller to an already-open page overlay on initial mount',
+      (tester) async {
+        final container = ProviderContainer(
+          overrides: [
+            ...getStandardTestOverrides(),
+            routerLocationStreamProvider.overrideWith(
+              (ref) => Stream.value('/home/0'),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        container.read(overlayVisibilityProvider.notifier).setPageOpen(true);
+
+        when(
+          () => videoFeedBloc.state,
+        ).thenReturn(const VideoFeedState());
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: MaterialApp(
+              home: BlocProvider<VideoFeedBloc>.value(
+                value: videoFeedBloc,
+                child: VideoFeedView(controller: videoFeedController),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        verify(
+          () => videoFeedController.setActive(
+            active: false,
+            // Verify that initial overlay sync uses the full-release path.
+            // ignore: avoid_redundant_argument_values
+            retainCurrentPlayer: false,
+          ),
+        ).called(1);
+      },
+    );
+
     testWidgets(
       'calls setActive(active: false) when navigating away from home',
       (tester) async {


### PR DESCRIPTION
## Summary
- fixes the Home feed bug where videos could load and buffer but never actually start playing
- makes the Home feed decide immediately, on first mount or controller rebuild, whether video should be playing or paused based on the current route and whether an overlay is already open
- adds regression tests for the two startup cases that were missing: opening the feed off Home, and opening it while an overlay is already visible

## Test Plan
- [x] flutter analyze lib/screens/feed/video_feed_page.dart test/screens/feed/video_feed_page_test.dart
- [x] flutter test --no-pub test/screens/feed/video_feed_page_test.dart
- [x] git push pre-push check: flutter test test/screens/feed/video_feed_page_test.dart