### PR TITLE
fix(upload): parse live resumable expiry fields

### DIFF
--- a/mobile/lib/services/blossom_upload_service.dart
+++ b/mobile/lib/services/blossom_upload_service.dart
@@ -303,6 +303,17 @@ class BlossomUploadService {
       return null;
     }
 
+    final numericMatch = RegExp(r'^-?\d+$').firstMatch(value);
+    if (numericMatch != null) {
+      final epochValue = int.tryParse(value);
+      if (epochValue == null) {
+        return null;
+      }
+
+      final epochMillis = value.length <= 10 ? epochValue * 1000 : epochValue;
+      return DateTime.fromMillisecondsSinceEpoch(epochMillis, isUtc: true);
+    }
+
     return DateTime.tryParse(value);
   }
 
@@ -312,7 +323,8 @@ class BlossomUploadService {
   }
 
   DateTime? _parseUploadExpiresAt(Headers headers) => _parseDateTimeValue(
-    headers.value(DivineUploadHeaders.uploadExpiresAt),
+    headers.value(DivineUploadHeaders.uploadExpiresAt) ??
+        headers.value('Upload-Expires'),
   );
 
   Future<_DivineUploadCapability> _fetchDivineUploadCapability(

--- a/mobile/test/services/blossom_upload_service_test.dart
+++ b/mobile/test/services/blossom_upload_service_test.dart
@@ -274,6 +274,10 @@ void main() {
       test(
         'uses resumable init flow for Divine servers that advertise support',
         () async {
+          final expectedExpiresAt = DateTime.fromMillisecondsSinceEpoch(
+            1774827544000,
+            isUtc: true,
+          );
           const testPublicKey =
               '0223456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
@@ -334,6 +338,7 @@ void main() {
                 data: {
                   'uploadId': 'up_123',
                   'uploadUrl': 'https://upload.divine.video/sessions/up_123',
+                  'expiresAt': '1774827544',
                   'chunkSize': 4,
                   'nextOffset': 0,
                   'requiredHeaders': {'Authorization': 'Bearer session-token'},
@@ -435,6 +440,7 @@ void main() {
             8,
             10,
           ]);
+          expect(sessionUpdates.first.expiresAt, equals(expectedExpiresAt));
 
           verifyInOrder([
             () => mockDio.head(
@@ -460,6 +466,41 @@ void main() {
           ]);
 
           await tempDir.delete(recursive: true);
+        },
+      );
+
+      test(
+        'resumeUploadSession parses upload-expires unix seconds from session HEAD',
+        () async {
+          final expectedExpiresAt = DateTime.fromMillisecondsSinceEpoch(
+            1774827600000,
+            isUtc: true,
+          );
+
+          when(
+            () => mockDio.head(any(), options: any(named: 'options')),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/sessions/up_123'),
+              statusCode: 204,
+              headers: Headers.fromMap({
+                'upload-offset': ['262144'],
+                'upload-expires': ['1774827600'],
+              }),
+            ),
+          );
+
+          final session = await service.resumeUploadSession(
+            session: const BlossomResumableUploadSession(
+              uploadId: 'up_123',
+              uploadUrl: 'https://upload.divine.video/sessions/up_123',
+              chunkSize: 8388608,
+              nextOffset: 0,
+            ),
+          );
+
+          expect(session.nextOffset, equals(262144));
+          expect(session.expiresAt, equals(expectedExpiresAt));
         },
       );
 


### PR DESCRIPTION
Closes #2589

## Summary
- parse numeric resumable expiry values as Unix epoch timestamps instead of feeding them to 
- accept live  session headers in addition to 
- add regressions covering init  and session  expiry parsing

## Test Plan
- [x] flutter analyze lib/services/blossom_upload_service.dart test/services/blossom_upload_service_test.dart
- [x] flutter test test/services/blossom_upload_service_test.dart test/services/blossom_upload_proofmode_test.dart test/services/upload_manager_resumable_upload_test.dart
- [x] pre-push changed-file suite
