### PR TITLE
chore(release): bump version to 1.0.8+497

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.7+497
+version: 1.0.8+497
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
## Summary
- bump the app marketing version from 1.0.7 to 1.0.8 in mobile/pubspec.yaml
- keep the existing build number in source since Codemagic overrides iOS build numbers during IPA builds
- unblock App Store Connect validation that rejected CFBundleShortVersionString 1.0.7 as not higher than the previously approved version

## Test Plan
- [x] cd mobile && flutter pub get
- [x] cd mobile && flutter analyze
- [ ] cd mobile && flutter test
  - started, but not used as the branch gate for this config-only change because the suite is extremely long-running in this repo
