### PR TITLE
refactor(share): replace literal 34236 with named video-kind constant

### DIFF
--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -7,6 +7,7 @@ import 'package:comments_repository/comments_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:likes_repository/likes_repository.dart';
+import 'package:models/models.dart' show NIP71VideoKinds;
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 
@@ -180,12 +181,13 @@ class VideoInteractionsBloc
 
     try {
       // Pass addressable ID and target kind for proper a-tag tagging
-      // Kind 34236 is the video kind (NIP-71 addressable short videos)
       final isNowLiked = await _likesRepository.toggleLike(
         eventId: _eventId,
         authorPubkey: _authorPubkey,
         addressableId: _addressableId,
-        targetKind: _addressableId != null ? 34236 : null,
+        targetKind: _addressableId != null
+            ? NIP71VideoKinds.addressableShortVideo
+            : null,
       );
 
       // Update local state with new like status and adjusted count

--- a/mobile/lib/providers/environment_provider.dart
+++ b/mobile/lib/providers/environment_provider.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Exposes environment config and developer mode state to widgets
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:models/models.dart' show NIP71VideoKinds;
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
@@ -67,8 +68,10 @@ Future<void> switchEnvironment(
   // Cancel all active relay subscriptions before switching
   await subscriptionManager.cancelAllSubscriptions();
 
-  // Clear cached video events (kind 34236) and metrics from database
-  await db.nostrEventsDao.deleteEventsByKind(34236);
+  // Clear cached video events and metrics from database
+  await db.nostrEventsDao.deleteEventsByKind(
+    NIP71VideoKinds.addressableShortVideo,
+  );
   await db.videoMetricsDao.deleteAllVideoMetrics();
 
   // Switch the environment (this also clears persisted relay list)

--- a/mobile/lib/repositories/sounds_repository.dart
+++ b/mobile/lib/repositories/sounds_repository.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:models/models.dart' show NIP71VideoKinds;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/models/audio_event.dart';
@@ -288,7 +289,7 @@ class SoundsRepository {
       // Query for Kind 34236 video events that reference this audio event
       final result = await _nostrClient.countEvents([
         Filter(
-          kinds: const [34236], // Video event kind
+          kinds: [NIP71VideoKinds.addressableShortVideo],
           e: [audioEventId], // Events referencing this audio
         ),
       ]);
@@ -331,7 +332,7 @@ class SoundsRepository {
     try {
       final events = await _nostrClient.queryEvents([
         Filter(
-          kinds: const [34236], // Video event kind
+          kinds: [NIP71VideoKinds.addressableShortVideo],
           e: [audioEventId],
           limit: limit,
         ),

--- a/mobile/lib/screens/relay_diagnostic_screen.dart
+++ b/mobile/lib/screens/relay_diagnostic_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:http/http.dart' as http;
+import 'package:models/models.dart' show NIP71VideoKinds;
 import 'package:nostr_client/nostr_client.dart' show RelayState;
 import 'package:nostr_sdk/filter.dart' as nostr;
 import 'package:openvine/providers/app_providers.dart';
@@ -116,7 +117,10 @@ class _RelayDiagnosticScreenState extends ConsumerState<RelayDiagnosticScreen> {
         // Query for video events specifically to see if any exist
         try {
           final videoEvents = await nostrService.queryEvents([
-            nostr.Filter(kinds: [34236], limit: 10),
+            nostr.Filter(
+              kinds: [NIP71VideoKinds.addressableShortVideo],
+              limit: 10,
+            ),
           ]);
           Log.info(
             'Found ${videoEvents.length} video events in relay cache',
@@ -428,7 +432,10 @@ class _RelayDiagnosticScreenState extends ConsumerState<RelayDiagnosticScreen> {
     try {
       // Query for video events directly from relay
       final videoEvents = await nostrService.queryEvents([
-        nostr.Filter(kinds: [34236], limit: 100),
+        nostr.Filter(
+          kinds: [NIP71VideoKinds.addressableShortVideo],
+          limit: 100,
+        ),
       ]);
 
       Log.info(

--- a/mobile/lib/scripts/bulk_thumbnail_generator.dart
+++ b/mobile/lib/scripts/bulk_thumbnail_generator.dart
@@ -165,7 +165,7 @@ Examples:
 
       // Create filter for video events
       final filter = Filter(
-        kinds: [34236], // Kind 34236 addressable short video events
+        kinds: [NIP71VideoKinds.addressableShortVideo],
         limit: limit,
       );
 


### PR DESCRIPTION
## Summary
- Replace all remaining hardcoded `34236` literals in app code with `NIP71VideoKinds.addressableShortVideo`
- Adds `models` import to 4 files that were missing it; `bulk_thumbnail_generator.dart` already had it

## Changed files
| File | Change |
|------|--------|
| `sounds_repository.dart` | 2 filter literals → constant |
| `environment_provider.dart` | 1 `deleteEventsByKind` arg → constant |
| `relay_diagnostic_screen.dart` | 2 filter literals → constant |
| `video_interactions_bloc.dart` | 1 `targetKind` arg → constant |
| `bulk_thumbnail_generator.dart` | 1 filter literal → constant |

## Test plan
- [x] `dart analyze` passes on all 5 files
- [x] Pre-commit hooks pass (format + analyze)
- [ ] CI green

Closes #2580