### PR TITLE
fix(upload): add per-chunk retry for resumable Blossom uploads

### DIFF
--- a/mobile/lib/services/blossom_upload_service.dart
+++ b/mobile/lib/services/blossom_upload_service.dart
@@ -101,6 +101,10 @@ class BlossomUploadService {
   static const String _useBlossomKey = 'use_blossom_upload';
   static const String defaultBlossomServer = 'https://media.divine.video';
 
+  /// Maximum retries for a single chunk PUT before bubbling to the caller.
+  static const int _maxChunkRetries = 2;
+  static const Duration _chunkRetryDelay = Duration(seconds: 1);
+
   final AuthService authService;
   final Dio dio;
   final String _defaultServerUrl;
@@ -286,6 +290,21 @@ class BlossomUploadService {
 
   bool _validateHttpStatus(int? statusCode) =>
       statusCode != null && statusCode < 500;
+
+  /// Whether a [DioException] from a chunk PUT is safe to retry.
+  /// Returns `true` for 5xx server errors and transient network issues.
+  bool _isTransientChunkError(DioException e) {
+    final statusCode = e.response?.statusCode;
+    if (statusCode != null && statusCode >= 500) return true;
+
+    return switch (e.type) {
+      DioExceptionType.connectionTimeout ||
+      DioExceptionType.sendTimeout ||
+      DioExceptionType.receiveTimeout ||
+      DioExceptionType.connectionError => true,
+      _ => false,
+    };
+  }
 
   Map<String, String>? _parseRequiredHeaders(dynamic headersData) {
     if (headersData is! Map) {
@@ -488,26 +507,48 @@ class BlossomUploadService {
         await fileReader.setPosition(start);
         final chunkBytes = await fileReader.read(chunkLength);
 
-        final response = await dio.put(
-          currentSession.uploadUrl,
-          data: chunkBytes,
-          options: Options(
-            headers: {
-              'Content-Type': 'application/octet-stream',
-              'Content-Length': chunkLength.toString(),
-              'Content-Range': 'bytes $start-${endExclusive - 1}/$fileSize',
-              ...?currentSession.requiredHeaders,
-            },
-            validateStatus: _validateHttpStatus,
-          ),
-          onSendProgress: (sent, total) {
-            if (fileSize <= 0) {
-              return;
+        // Per-chunk retry for transient 5xx / network errors.
+        // Chunk bytes are already in memory so retries are cheap.
+        late Response<dynamic> response;
+        var chunkAttempt = 0;
+        while (true) {
+          try {
+            response = await dio.put(
+              currentSession.uploadUrl,
+              data: chunkBytes,
+              options: Options(
+                headers: {
+                  'Content-Type': 'application/octet-stream',
+                  'Content-Length': chunkLength.toString(),
+                  'Content-Range': 'bytes $start-${endExclusive - 1}/$fileSize',
+                  ...?currentSession.requiredHeaders,
+                },
+                validateStatus: _validateHttpStatus,
+              ),
+              onSendProgress: (sent, total) {
+                if (fileSize <= 0) {
+                  return;
+                }
+                final progress = 0.2 + ((start + sent) / fileSize) * 0.7;
+                onProgress?.call(progress.clamp(0.2, 0.9));
+              },
+            );
+            break;
+          } on DioException catch (e) {
+            chunkAttempt++;
+            if (chunkAttempt > _maxChunkRetries || !_isTransientChunkError(e)) {
+              rethrow;
             }
-            final progress = 0.2 + ((start + sent) / fileSize) * 0.7;
-            onProgress?.call(progress.clamp(0.2, 0.9));
-          },
-        );
+            Log.warning(
+              'Chunk PUT failed at offset $start '
+              '(attempt $chunkAttempt/$_maxChunkRetries): '
+              '${e.response?.statusCode ?? e.type}',
+              name: 'BlossomUploadService',
+              category: LogCategory.video,
+            );
+            await Future.delayed(_chunkRetryDelay);
+          }
+        }
 
         if (response.statusCode == 404 || response.statusCode == 410) {
           throw BlossomResumableUploadException(

--- a/mobile/test/integration/blossom_resumable_upload_integration_test.dart
+++ b/mobile/test/integration/blossom_resumable_upload_integration_test.dart
@@ -368,4 +368,338 @@ void main() {
       await tempDir.delete(recursive: true);
     },
   );
+
+  group('per-chunk retry', () {
+    late _MockAuthService mockAuthService;
+    late _MockDio mockDio;
+    late BlossomUploadService service;
+    late Directory tempDir;
+    late File videoFile;
+
+    const testPublicKey =
+        '0223456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+
+      mockAuthService = _MockAuthService();
+      mockDio = _MockDio();
+      service = BlossomUploadService(
+        authService: mockAuthService,
+        dio: mockDio,
+      );
+
+      when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(
+        () => mockAuthService.currentPublicKeyHex,
+      ).thenReturn(testPublicKey);
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer(
+        (_) async => Event(
+          testPublicKey,
+          24242,
+          const [],
+          'Upload video to Blossom server',
+        ),
+      );
+
+      tempDir = await Directory.systemTemp.createTemp(
+        'blossom_chunk_retry_',
+      );
+      // 8-byte file → two 4-byte chunks
+      videoFile = File('${tempDir.path}/video.mp4')
+        ..writeAsBytesSync(List<int>.generate(8, (i) => i));
+
+      // Capability HEAD — always returns resumable support
+      when(
+        () => mockDio.head(any(), options: any(named: 'options')),
+      ).thenAnswer(
+        (_) async => Response(
+          requestOptions: RequestOptions(path: '/upload'),
+          statusCode: 200,
+          headers: Headers.fromMap({
+            DivineUploadHeaders.extensions: [
+              DivineUploadExtensions.resumableSessions,
+            ],
+            DivineUploadHeaders.controlHost: ['https://media.divine.video'],
+            DivineUploadHeaders.dataHost: ['https://upload.divine.video'],
+          }),
+        ),
+      );
+
+      // Init POST — returns session with 4-byte chunks
+      when(
+        () => mockDio.post(
+          any(),
+          data: any(named: 'data'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((invocation) async {
+        final url = invocation.positionalArguments.first as String;
+        if (url.endsWith('/upload/init')) {
+          return Response(
+            requestOptions: RequestOptions(path: '/upload/init'),
+            statusCode: 200,
+            data: {
+              'uploadId': 'up_retry',
+              'uploadUrl': 'https://upload.divine.video/sessions/up_retry',
+              'chunkSize': 4,
+              'nextOffset': 0,
+              'requiredHeaders': {'Authorization': 'Bearer token'},
+            },
+          );
+        }
+        if (url.endsWith('/upload/up_retry/complete')) {
+          return Response(
+            requestOptions: RequestOptions(path: '/upload/up_retry/complete'),
+            statusCode: 200,
+            data: {
+              'url': 'https://media.divine.video/final',
+              'fallbackUrl': 'https://media.divine.video/final',
+            },
+          );
+        }
+        throw StateError('Unexpected POST url: $url');
+      });
+    });
+
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    Response<dynamic> chunkSuccessResponse(String nextOffset) => Response(
+      requestOptions: RequestOptions(path: '/sessions/up_retry'),
+      statusCode: 204,
+      headers: Headers.fromMap({
+        DivineUploadHeaders.uploadOffset: [nextOffset],
+      }),
+    );
+
+    test(
+      'retries a transient 502 on the first chunk and completes',
+      () async {
+        var putCallCount = 0;
+
+        when(
+          () => mockDio.put(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          putCallCount++;
+          final options = invocation.namedArguments[#options] as Options;
+          final contentRange = options.headers?['Content-Range'] as String;
+
+          // First PUT for chunk 1 → 502, second PUT for chunk 1 → success
+          if (contentRange == 'bytes 0-3/8' && putCallCount == 1) {
+            throw DioException(
+              requestOptions: RequestOptions(path: '/sessions/up_retry'),
+              response: Response(
+                requestOptions: RequestOptions(path: '/sessions/up_retry'),
+                statusCode: 502,
+              ),
+              type: DioExceptionType.badResponse,
+            );
+          }
+
+          final nextOffset = switch (contentRange) {
+            'bytes 0-3/8' => '4',
+            'bytes 4-7/8' => '8',
+            _ => throw StateError('Unexpected range: $contentRange'),
+          };
+          return chunkSuccessResponse(nextOffset);
+        });
+
+        final sessionUpdates = <BlossomResumableUploadSession>[];
+        final result = await service.uploadVideo(
+          videoFile: videoFile,
+          nostrPubkey: testPublicKey,
+          title: 'retry test',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+          onResumableSessionUpdated: sessionUpdates.add,
+        );
+
+        expect(result.success, isTrue);
+        // 1 failed + 1 success for chunk 1, 1 success for chunk 2 = 3
+        expect(putCallCount, equals(3));
+        expect(sessionUpdates.map((s) => s.nextOffset), [0, 4, 8]);
+      },
+    );
+
+    test(
+      'retries a DioException.connectionError and completes',
+      () async {
+        var putCallCount = 0;
+
+        when(
+          () => mockDio.put(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          putCallCount++;
+          final options = invocation.namedArguments[#options] as Options;
+          final contentRange = options.headers?['Content-Range'] as String;
+
+          // First chunk, first attempt → network error
+          if (contentRange == 'bytes 0-3/8' && putCallCount == 1) {
+            throw DioException(
+              requestOptions: RequestOptions(path: '/sessions/up_retry'),
+              type: DioExceptionType.connectionError,
+              error: 'Connection reset by peer',
+            );
+          }
+
+          final nextOffset = switch (contentRange) {
+            'bytes 0-3/8' => '4',
+            'bytes 4-7/8' => '8',
+            _ => throw StateError('Unexpected range: $contentRange'),
+          };
+          return chunkSuccessResponse(nextOffset);
+        });
+
+        final result = await service.uploadVideo(
+          videoFile: videoFile,
+          nostrPubkey: testPublicKey,
+          title: 'network retry test',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+        );
+
+        expect(result.success, isTrue);
+        expect(putCallCount, equals(3));
+      },
+    );
+
+    test(
+      'does not retry a 404 session-expired response',
+      () async {
+        when(
+          () => mockDio.put(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          // 404 is < 500, so Dio returns it as a response (not exception).
+          // _uploadChunks should throw BlossomResumableUploadException
+          // without retrying.
+          return Response(
+            requestOptions: RequestOptions(path: '/sessions/up_retry'),
+            statusCode: 404,
+          );
+        });
+
+        final result = await service.uploadVideo(
+          videoFile: videoFile,
+          nostrPubkey: testPublicKey,
+          title: 'expired session test',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+        );
+
+        // Upload fails because the session-expired error propagates
+        // through the server loop catch and returns a failed result.
+        expect(result.success, isFalse);
+
+        // PUT was called only once — no retry for 404
+        verify(
+          () => mockDio.put(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'rethrows after exhausting per-chunk retries',
+      () async {
+        var putCallCount = 0;
+
+        when(
+          () => mockDio.put(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((_) async {
+          putCallCount++;
+          throw DioException(
+            requestOptions: RequestOptions(path: '/sessions/up_retry'),
+            response: Response(
+              requestOptions: RequestOptions(path: '/sessions/up_retry'),
+              statusCode: 503,
+            ),
+            type: DioExceptionType.badResponse,
+          );
+        });
+
+        final result = await service.uploadVideo(
+          videoFile: videoFile,
+          nostrPubkey: testPublicKey,
+          title: 'exhausted retries test',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+        );
+
+        expect(result.success, isFalse);
+        // 1 initial + 2 retries = 3 total attempts
+        expect(putCallCount, equals(3));
+      },
+    );
+
+    test(
+      'does not retry a non-transient DioException (e.g. cancel)',
+      () async {
+        var putCallCount = 0;
+
+        when(
+          () => mockDio.put(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((_) async {
+          putCallCount++;
+          throw DioException(
+            requestOptions: RequestOptions(path: '/sessions/up_retry'),
+            type: DioExceptionType.cancel,
+          );
+        });
+
+        final result = await service.uploadVideo(
+          videoFile: videoFile,
+          nostrPubkey: testPublicKey,
+          title: 'cancel test',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+        );
+
+        expect(result.success, isFalse);
+        // No retry — cancel is not transient
+        expect(putCallCount, equals(1));
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- Wrap the per-chunk `dio.put()` inside `_uploadChunks` with a retry loop (max 2 retries, 1 s delay)
- Transient 5xx and network/timeout errors retry in-place; session-expired (404/410) and non-transient errors propagate immediately
- Add 5 focused integration tests covering 502-then-success, network-error-then-success, 404-fails-fast, retries-exhausted, and cancel-not-retried

## Test plan
- [x] `flutter test test/integration/blossom_resumable_upload_integration_test.dart` — 7/7 pass (2 existing + 5 new)
- [x] `flutter test test/services/blossom_upload_service_test.dart test/services/blossom_upload_proofmode_test.dart test/services/upload_manager_resumable_upload_test.dart` — 32/32 pass, no regressions
- [x] `flutter analyze` — no issues
- [x] Pre-commit and pre-push hooks pass

Closes #2555