### PR TITLE
fix(profile): normalise legacy NIP-05 display format

### DIFF
--- a/mobile/packages/models/lib/src/user_profile.dart
+++ b/mobile/packages/models/lib/src/user_profile.dart
@@ -187,10 +187,19 @@ class UserProfile {
     return '';
   }
 
-  /// NIP-05 formatted for display (strips leading underscore).
+  /// NIP-05 formatted for display.
+  ///
+  /// Normalises all divine.video / openvine.co identifiers to the canonical
+  /// `@username.divine.video` form. External identifiers (e.g.
+  /// `alice@example.com`) are returned unchanged.
   String? get displayNip05 {
     if (nip05 == null || nip05!.isEmpty) return null;
+    // New subdomain format: _@username.divine.video → @username.divine.video
     if (nip05!.startsWith('_@')) return nip05!.substring(1);
+    // Legacy divine.video/openvine.co → @username.divine.video
+    final username = divineUsername;
+    if (username != null) return '@$username.divine.video';
+    // External domain: keep as-is
     return nip05;
   }
 

--- a/mobile/packages/models/test/src/user_profile_test.dart
+++ b/mobile/packages/models/test/src/user_profile_test.dart
@@ -839,6 +839,79 @@ void main() {
       });
     });
 
+    group('displayNip05', () {
+      test('returns @user.divine.video for subdomain format', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: '_@alice.divine.video',
+        );
+
+        expect(profile.displayNip05, equals('@alice.divine.video'));
+      });
+
+      test('normalises legacy user@divine.video to @user.divine.video', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: 'heybob@divine.video',
+        );
+
+        expect(profile.displayNip05, equals('@heybob.divine.video'));
+      });
+
+      test('normalises legacy user@openvine.co to @user.divine.video', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: 'charlie@openvine.co',
+        );
+
+        expect(profile.displayNip05, equals('@charlie.divine.video'));
+      });
+
+      test('preserves external NIP-05 unchanged', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: 'alice@example.com',
+        );
+
+        expect(profile.displayNip05, equals('alice@example.com'));
+      });
+
+      test('returns null when nip05 is null', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+        );
+
+        expect(profile.displayNip05, isNull);
+      });
+
+      test('returns null when nip05 is empty', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          nip05: '',
+        );
+
+        expect(profile.displayNip05, isNull);
+      });
+    });
+
     group('divineUsername', () {
       test('extracts username from subdomain format _@user.divine.video', () {
         final profile = UserProfile(


### PR DESCRIPTION
Closes #2602

## Summary

- Update `UserProfile.displayNip05` to normalise legacy `username@divine.video` and `username@openvine.co` formats to the canonical `@username.divine.video` form
- External NIP-05 identifiers (e.g. `alice@example.com`) remain unchanged
- Also fixes a secondary bug where the `handle` getter produced `@heybob@divine.video` (double `@`) for legacy formats

## Test plan

- [x] Added 6 unit tests for `displayNip05` covering subdomain, legacy divine.video, legacy openvine.co, external domains, null, and empty
- [x] Existing `watermark_text_resolver` tests pass
- [x] Existing `handle` getter tests pass