### PR TITLE
fix(upload): serialize resumable session persistence per upload

### DIFF
--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -108,6 +108,7 @@ class UploadManager {
   final Map<String, StreamSubscription<double>> _progressSubscriptions = {};
   final Map<String, UploadMetrics> _uploadMetrics = {};
   final Map<String, Timer> _retryTimers = {};
+  final Map<String, Future<void>> _sessionPersistFutures = {};
 
   bool _isInitialized = false;
 
@@ -878,12 +879,10 @@ class UploadManager {
             proofManifestJson: upload.proofManifestJson,
             resumableSession: upload.resumableSession,
             onResumableSessionUpdated: (session) {
-              unawaited(
-                _storeResumableSessionProgress(
-                  upload.id,
-                  session,
-                  videoFile.lengthSync(),
-                ),
+              _enqueueSessionPersist(
+                upload.id,
+                session,
+                videoFile.lengthSync(),
               );
             },
             onProgress: (value) {
@@ -1125,6 +1124,29 @@ class UploadManager {
         uploadProgress: persistedProgress,
       ),
     );
+  }
+
+  /// Enqueues a session persistence write so that rapid chunk callbacks
+  /// are serialized per upload, preventing interleaved Hive writes.
+  void _enqueueSessionPersist(
+    String uploadId,
+    BlossomResumableUploadSession session,
+    int fileSizeBytes,
+  ) {
+    final previous = _sessionPersistFutures[uploadId] ?? Future<void>.value();
+    _sessionPersistFutures[uploadId] = previous.then((_) async {
+      try {
+        await _storeResumableSessionProgress(uploadId, session, fileSizeBytes);
+      } catch (e, s) {
+        Log.error(
+          'Failed to persist resumable session progress for $uploadId: $e',
+          name: 'UploadManager',
+          category: LogCategory.video,
+          error: e,
+          stackTrace: s,
+        );
+      }
+    });
   }
 
   bool _isExpiredResumableSessionError(dynamic error) {
@@ -1532,6 +1554,7 @@ class UploadManager {
     // Cancel progress subscription
     _progressSubscriptions[uploadId]?.cancel();
     _progressSubscriptions.remove(uploadId);
+    _sessionPersistFutures.remove(uploadId);
 
     // Remove from storage
     await _uploadsBox?.delete(uploadId);
@@ -2456,6 +2479,9 @@ Upload Timeout Failure:
       timer.cancel();
     }
     _retryTimers.clear();
+
+    // Discard pending session persistence futures
+    _sessionPersistFutures.clear();
 
     // Cancel save queue timer
     _saveQueueTimer?.cancel();

--- a/mobile/test/services/upload_manager_resumable_upload_test.dart
+++ b/mobile/test/services/upload_manager_resumable_upload_test.dart
@@ -211,5 +211,111 @@ void main() {
         expect(failedUpload.errorMessage, contains('session expired'));
       },
     );
+
+    test(
+      'serializes rapid session-progress writes so the latest offset wins',
+      () async {
+        const chunkSize = 8;
+        const fileSize = 80;
+
+        // Create a file of the expected size so lengthSync() is consistent.
+        videoFile = File('${tempDir.path}/video_serial.mp4')
+          ..writeAsBytesSync(List<int>.generate(fileSize, (i) => i));
+
+        final uploadCompleter = Completer<BlossomUploadResult>();
+
+        // Capture the onResumableSessionUpdated callback so we can call it
+        // rapidly ourselves.
+        void Function(BlossomResumableUploadSession)? capturedCallback;
+
+        when(
+          () => mockBlossomService.uploadVideo(
+            videoFile: any(named: 'videoFile'),
+            nostrPubkey: any(named: 'nostrPubkey'),
+            title: any(named: 'title'),
+            description: any(named: 'description'),
+            hashtags: any(named: 'hashtags'),
+            proofManifestJson: any(named: 'proofManifestJson'),
+            resumableSession: any(named: 'resumableSession'),
+            onResumableSessionUpdated: any(
+              named: 'onResumableSessionUpdated',
+            ),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedCallback =
+              invocation.namedArguments[#onResumableSessionUpdated]
+                  as void Function(BlossomResumableUploadSession)?;
+
+          return uploadCompleter.future;
+        });
+
+        // Start the upload without awaiting — startUpload blocks until the
+        // upload completes, but we need to interact with the callback
+        // mid-upload.
+        unawaited(
+          uploadManager.startUpload(
+            videoFile: videoFile,
+            nostrPubkey: 'test-pubkey',
+            title: 'Serialization test',
+          ),
+        );
+
+        // Wait for the mock to capture the callback.
+        await TestHelpers.waitForCondition(
+          () => capturedCallback != null,
+          timeout: const Duration(seconds: 2),
+        );
+
+        // Grab the upload ID from the box since startUpload hasn't returned.
+        final uploads = uploadManager.pendingUploads;
+        expect(uploads, isNotEmpty);
+        final uploadId = uploads.first.id;
+
+        // Fire 5 rapid session updates without awaiting (simulates real
+        // chunk-completion callbacks arriving in quick succession).
+        for (var i = 1; i <= 5; i++) {
+          capturedCallback!(
+            BlossomResumableUploadSession(
+              uploadId: 'up_serial',
+              uploadUrl: 'https://upload.divine.video/sessions/up_serial',
+              chunkSize: chunkSize,
+              nextOffset: chunkSize * i,
+            ),
+          );
+        }
+
+        // Allow the serialized futures to drain.
+        await TestHelpers.waitForCondition(
+          () {
+            final u = uploadManager.getUpload(uploadId);
+            if (u == null) return false;
+            const expectedOffset = chunkSize * 5;
+            return u.resumableSession?.nextOffset == expectedOffset;
+          },
+          timeout: const Duration(seconds: 2),
+          checkInterval: const Duration(milliseconds: 20),
+        );
+
+        final persisted = uploadManager.getUpload(uploadId)!;
+        expect(persisted.resumableSession?.nextOffset, equals(chunkSize * 5));
+
+        final expectedProgress = ((chunkSize * 5) / fileSize * 0.8).clamp(
+          0.0,
+          0.8,
+        );
+        expect(persisted.uploadProgress, closeTo(expectedProgress, 0.001));
+
+        // Complete the upload future to let tearDown dispose cleanly.
+        uploadCompleter.complete(
+          const BlossomUploadResult(
+            success: true,
+            videoId: 'video-serial',
+            url: 'https://media.divine.video/video-serial',
+            fallbackUrl: 'https://media.divine.video/video-serial',
+          ),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- Serializes resumable-session persistence writes per upload ID so rapid `onResumableSessionUpdated` chunk callbacks cannot interleave Hive writes
- Adds a `_sessionPersistFutures` future-chain map that guarantees FIFO ordering per upload, with try-catch so a failed write doesn't block subsequent ones
- Cleans up the map on upload deletion and `dispose()`

Closes #2553

## Test plan
- [x] New test fires 5 rapid session updates and asserts the final persisted `nextOffset` and `uploadProgress` match the last update deterministically
- [x] Existing resumable upload tests (restart from offset, expired session fallback) still pass
- [x] `flutter analyze` clean, pre-commit hooks pass