### PR TITLE
fix(editor): constrain text/sticker layers to feed-safe zone

### DIFF
--- a/mobile/lib/constants/video_editor_constants.dart
+++ b/mobile/lib/constants/video_editor_constants.dart
@@ -104,6 +104,18 @@ class VideoEditorConstants {
   /// Maximum font scale multiplier for text overlays.
   static const double maxFontScale = 4.0;
 
+  /// Fraction of the canvas height reserved at the top as a feed-safe zone.
+  ///
+  /// Prevents text/sticker layers from overlapping feed UI overlays
+  /// (status bar, header, badges) during playback.
+  static const double feedSafeZoneTopFraction = 0.12;
+
+  /// Fraction of the canvas height reserved at the bottom as a feed-safe zone.
+  ///
+  /// Prevents text/sticker layers from overlapping feed UI overlays
+  /// (author info, action buttons, home indicator) during playback.
+  static const double feedSafeZoneBottomFraction = 0.10;
+
   /// Background color for the text editor overlay.
   static const Color textEditorBackground = Color(0x9B000000);
 

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -155,6 +155,30 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
     super.dispose();
   }
 
+  /// Clamps the vertical offset of [layer] to stay within the feed-safe zone.
+  ///
+  /// Text and sticker layers placed outside this zone overlap with fixed feed
+  /// UI overlays (header, badges, author info, action buttons) during playback.
+  /// Layer offsets are relative to the editor center, so the valid vertical
+  /// range is from `-(halfHeight - topInset)` to `(halfHeight - bottomInset)`.
+  void _clampLayerToFeedSafeZone(Layer layer) {
+    if (layer is! TextLayer && layer is! WidgetLayer) return;
+
+    final height = widget.renderSize.height;
+    final halfHeight = height / 2;
+    final topInset = height * VideoEditorConstants.feedSafeZoneTopFraction;
+    final bottomInset =
+        height * VideoEditorConstants.feedSafeZoneBottomFraction;
+
+    final clampedDy = layer.offset.dy.clamp(
+      -(halfHeight - topInset),
+      halfHeight - bottomInset,
+    );
+    if (clampedDy != layer.offset.dy) {
+      layer.offset = Offset(layer.offset.dx, clampedDy);
+    }
+  }
+
   /// Handles playback restart requests from BLoC.
   void _onPlaybackRestartRequested() {
     if (!_isPlayerReadyNotifier.value) return;
@@ -743,6 +767,8 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
                       category: LogCategory.video,
                     );
                     scope.editor?.activeLayers.remove(_selectedLayer);
+                  } else {
+                    _clampLayerToFeedSafeZone(_selectedLayer!);
                   }
 
                   _onStateHistoryChange(scope, bloc);
@@ -752,6 +778,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
                 _wasOverRemoveArea = false;
                 bloc.add(const VideoEditorLayerInteractionEnded());
               },
+              onUpdateLayer: _clampLayerToFeedSafeZone,
               onAddLayer: (layer) {
                 Log.debug(
                   '🎬 Layer added: ${layer.runtimeType}',


### PR DESCRIPTION
Closes #2577

## Summary

- Clamp text and sticker layer vertical positions to a feed-safe zone during drag interaction
- Top 12% and bottom 10% of the canvas height are reserved for feed overlay clearance
- Uses `onUpdateLayer` callback which fires after `calculateMovement` but before the widget rebuilds, giving jitter-free clamping
- Safety-net clamp also runs in `onScaleEnd` before state history is persisted

### Why this approach (creation-side, not consumption-side)

PR #2578 tried clamping `TextScaler` on the consumption side. Reviewers (@hm21, @untreu2) correctly identified that the root cause is a **creation-flow constraint problem** — users can place text stickers anywhere on the video canvas, including areas that will be covered by fixed feed UI overlays during playback. This PR constrains placement at creation time instead.

### How it works

Layer offsets in `pro_image_editor` are relative to the editor center (0,0 = centered). The valid vertical range for text/sticker layers is clamped to:

| Zone | Fraction | Purpose |
|------|----------|---------|
| Top | 12% | Clears status bar + "Following/For You" header + badges |
| Bottom | 10% | Clears author info + action buttons + home indicator |

The `onUpdateLayer` callback fires after the package's `calculateMovement()` updates `layer.offset` but before `layer.key.currentState?.setState()` rebuilds the widget — so the clamped position is what renders. No visual jitter.

### Files changed

| File | What |
|------|------|
| `video_editor_constants.dart` | Added `feedSafeZoneTopFraction` and `feedSafeZoneBottomFraction` constants |
| `video_editor_canvas.dart` | Added `_clampLayerToFeedSafeZone` method, `onUpdateLayer` callback, and safety-net clamp in `onScaleEnd` |

## Test plan

- [ ] Open video editor, add a text layer, drag it toward the top — verify it stops at the safe zone boundary
- [ ] Add a text layer, drag it toward the bottom — verify it stops at the safe zone boundary
- [ ] Add a sticker, drag it toward top/bottom — verify same clamping
- [ ] Draw on the canvas (paint layer) — verify drawing is NOT constrained by the safe zone
- [ ] Add text at center, scale/rotate it — verify no unexpected position changes
- [ ] Publish a video with text near the safe zone boundary, view in feed — verify no overlap with header/badges/author info
- [ ] Verify no visual regression on default font size feed playback