### PR TITLE
fix(feed): harden pagination across feeds

### DIFF
--- a/docs/superpowers/plans/2026-03-30-feed-pagination-hardening.md
+++ b/docs/superpowers/plans/2026-03-30-feed-pagination-hardening.md
@@ -1,0 +1,18 @@
+# Feed Pagination Hardening Implementation Plan
+
+**Goal:** Make every current infinite-scroll feed/list reliably request and render more content, with consistent pagination triggers and correct `hasMore` semantics for profile feeds.
+
+**Architecture:** Introduce a shared controller-based scroll pagination helper, migrate paginated feed surfaces onto that helper or its contract, and normalize `ProfileFeed` REST `hasMoreContent` behavior to use the server page size rather than filtered visible counts. Cover the nested profile route with regression tests so the bug cannot regress silently.
+
+**Tech Stack:** Flutter, Riverpod, flutter_bloc, flutter_test, mocktail
+
+---
+
+## Chunks
+
+1. **Shared Scroll Pagination Helper** — `ScrollPaginationController` with tests
+2. **Migrate Shared Feed/List Surfaces** — composable grid, classic vines, discover lists, notifications, inbox, user search
+3. **Migrate Profile Tabs** — profile videos, liked, reposts, collabs, comments grids
+4. **Fix ProfileFeed REST hasMoreContent** — use `paginationBatchSize` instead of filtered count
+5. **Wire ForYou Tab** — pass load-more to composable grid
+6. **Add Regression Tests** — scroll pagination controller, profile feed contract, profile grid navigation, inbox scroll

--- a/docs/superpowers/specs/2026-03-30-feed-pagination-hardening-design.md
+++ b/docs/superpowers/specs/2026-03-30-feed-pagination-hardening-design.md
@@ -1,0 +1,76 @@
+# Feed Pagination Hardening Design
+
+**Date:** 2026-03-30
+**Status:** Approved
+**Supersedes:** `docs/superpowers/specs/2026-03-27-profile-grid-pagination-design.md`
+
+## Goal
+
+Make every scroll-paginated feed or list in the mobile app reliably request and render additional pages, with profile surfaces fixed first and shared pagination behavior standardized across the current UI.
+
+## Current Behavior
+
+- `ProfileFeed` already supports REST cursor pagination and Nostr historical pagination.
+- Fullscreen profile playback can already call `loadMore()` when the user reaches the last video.
+- Several profile tabs still depend on `NotificationListener<ScrollNotification>` inside nested/tabbed scroll layouts.
+- Shared feed surfaces use a mix of controller-based pagination and notification-based pagination, so behavior is inconsistent by screen.
+- `ProfileFeed` uses inconsistent `hasMoreContent` heuristics across build/refresh paths:
+  - some states derive `hasMoreContent` from the filtered visible count
+  - one REST refresh path still uses the 10-item threshold instead of the 50-item REST page size
+
+## Problems To Solve
+
+1. Profile routes can stop after the first page even though the provider and backend support more pages.
+2. Nested scroll/tab layouts make notification-only pagination triggers brittle.
+3. Different feeds use different near-bottom logic and duplicate-call guards.
+4. Provider `hasMoreContent` can drift from the backend pagination contract after refreshes or filtering.
+5. Existing tests cover standalone pieces, but not enough routed/nested-scroll behavior.
+
+## Chosen Approach
+
+Introduce a shared scroll-pagination trigger based on explicit `ScrollController` ownership, apply it to all current infinite-scroll surfaces that should auto-load more, and normalize `hasMoreContent` semantics for the REST-backed profile feed.
+
+### Design Details
+
+- Add a shared helper that:
+  - owns or observes a `ScrollController`
+  - triggers `onLoadMore` near the bottom threshold
+  - blocks duplicate calls while a load is in flight
+  - respects `hasMore` and current loading state
+- Convert current paginated profile tabs to the shared controller-driven pattern:
+  - profile videos
+  - liked videos
+  - reposts
+  - collabs
+  - comments
+- Align shared feed/list widgets that already paginate on scroll with the same helper so feed behavior is consistent across the app.
+- Fix `ProfileFeed` so REST-backed `hasMoreContent` is based on the backend page contract (`AppConstants.paginationBatchSize`) instead of the filtered visible count or the 10-item threshold.
+- Add regression coverage at the routed/profile-screen level and unit/widget coverage for the shared helper and profile provider contract.
+
+## Scope
+
+- `mobile/lib/widgets/profile/*grid.dart` pagination triggers
+- shared paginated feed/list widgets that auto-load on scroll
+- `mobile/lib/providers/profile_feed_provider.dart`
+- targeted pagination tests for shared scroll triggering and routed profile screens
+
+## Non-Goals
+
+- Rebuild the entire feed architecture
+- Change Funnelcake or relay pagination contracts
+- Add pagination to screens that intentionally return finite results
+- Rework fullscreen feed pagination beyond compatibility with the new trigger behavior
+
+## Why This Approach
+
+- It addresses the current user-visible bug instead of only adding another narrow profile-only patch.
+- It reduces duplicated pagination logic and makes future feed work less fragile.
+- It keeps repository ownership where it already belongs: UI decides when to request more, providers/blocs decide whether more exists.
+- It stays reviewable by focusing on the current infinite-scroll surfaces instead of a full feed rewrite.
+
+## Testing Strategy
+
+- Add a failing regression test for routed profile scrolling in the real nested-scroll path.
+- Add helper tests that prove near-bottom triggering, duplicate-call prevention, and `hasMore`/loading guards.
+- Add provider tests that prove REST-backed `ProfileFeed` sets `hasMoreContent` from page-size semantics on initial load and refresh.
+- Run targeted Flutter tests for the touched profile/feed widgets and providers.

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -1,6 +1,8 @@
-// ABOUTME: Profile feed provider with cursor pagination support per user
+// ABOUTME: Profile feed provider with REST/Nostr pagination support per user
 // ABOUTME: Manages video lists for individual user profiles with loadMore() capability
 // ABOUTME: Tries REST API first for better performance, falls back to Nostr subscription
+
+import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:models/models.dart' hide LogCategory;
@@ -20,7 +22,7 @@ part 'profile_feed_provider.g.dart';
 /// Profile feed provider - shows videos for a specific user with pagination
 ///
 /// This is a family provider, so each userId gets its own provider instance
-/// with independent cursor tracking.
+/// with independent pagination tracking.
 ///
 /// Strategy: Try Funnelcake REST API first for better performance,
 /// fall back to Nostr subscription if unavailable.
@@ -34,7 +36,7 @@ part 'profile_feed_provider.g.dart';
 class ProfileFeed extends _$ProfileFeed {
   // REST API mode state
   bool _usingRestApi = false;
-  int? _nextCursor; // Cursor for REST API pagination
+  int? _nextOffset; // Offset for REST API pagination
   // Cache of video metadata from REST API (preserves loops, likes, etc.)
   // Key: video ID, Value: metadata fields
   final Map<String, _VideoMetadataCache> _metadataCache = {};
@@ -47,10 +49,11 @@ class ProfileFeed extends _$ProfileFeed {
 
   @override
   Future<VideoFeedState> build(String userId) async {
-    // Reset cursor state at start of build to ensure clean state
+    // Reset REST pagination state at start of build to ensure clean state.
     _usingRestApi = false;
-    _nextCursor = null;
+    _nextOffset = null;
     _listenersRegistered = false;
+    int? restPageCount;
 
     // Watch content filter version — rebuilds when preferences change.
     ref.watch(contentFilterVersionProvider);
@@ -78,6 +81,7 @@ class ProfileFeed extends _$ProfileFeed {
 
     if (retainedState != null && retainedState.videos.isNotEmpty) {
       _usingRestApi = funnelcakeAvailable;
+      _nextOffset = _estimateNextRestOffset(retainedState);
       _registerRetainedRealtimeListeners(videoEventService);
       Future.microtask(() => refresh(retainedState: retainedState));
       return retainedState.copyWith(
@@ -97,12 +101,13 @@ class ProfileFeed extends _$ProfileFeed {
       try {
         final stats = await funnelcakeClient.getVideosByAuthor(pubkey: userId);
         final apiVideos = stats.map((v) => v.toVideoEvent()).toList();
+        restPageCount = apiVideos.length;
 
         if (apiVideos.isNotEmpty) {
           _usingRestApi = true;
-          // Filter out reposts and store cursor
+          // Filter out reposts and store the next REST page offset.
           final tempAuthorVideos = apiVideos.where((v) => !v.isRepost).toList();
-          _nextCursor = _getOldestTimestamp(apiVideos);
+          _nextOffset = apiVideos.length;
 
           // Cache metadata for later merging with Nostr data
           _cacheVideoMetadata(tempAuthorVideos);
@@ -239,8 +244,9 @@ class ProfileFeed extends _$ProfileFeed {
 
     final initialState = VideoFeedState(
       videos: authorVideos,
-      hasMoreContent:
-          authorVideos.length >= AppConstants.hasMoreContentThreshold,
+      hasMoreContent: _usingRestApi
+          ? (restPageCount ?? 0) >= AppConstants.paginationBatchSize
+          : authorVideos.length >= AppConstants.hasMoreContentThreshold,
       isInitialLoad: authorVideos.isEmpty && !_usingRestApi,
       lastUpdated: DateTime.now(),
     );
@@ -265,10 +271,17 @@ class ProfileFeed extends _$ProfileFeed {
     refresh();
   }
 
-  /// Get oldest timestamp from videos for cursor pagination
-  int? _getOldestTimestamp(List<VideoEvent> videos) {
-    if (videos.isEmpty) return null;
-    return videos.map((v) => v.createdAt).reduce((a, b) => a < b ? a : b);
+  int _estimateNextRestOffset(VideoFeedState currentState) {
+    final visibleCount = currentState.videos.length;
+    if (!currentState.hasMoreContent) {
+      return visibleCount;
+    }
+
+    const batchSize = AppConstants.paginationBatchSize;
+    return math.max(
+      batchSize,
+      ((visibleCount + batchSize - 1) ~/ batchSize) * batchSize,
+    );
   }
 
   /// Refresh state - uses REST API when available, otherwise Nostr with metadata preservation
@@ -436,6 +449,7 @@ class ProfileFeed extends _$ProfileFeed {
         // Filter out reposts
         var authorVideos = apiVideos.where((v) => !v.isRepost).toList();
         authorVideos = _mergeStableTimestampsFromCurrentState(authorVideos);
+        _nextOffset = apiVideos.length;
 
         // Update metadata cache with fresh data
         _cacheVideoMetadata(authorVideos);
@@ -455,7 +469,7 @@ class ProfileFeed extends _$ProfileFeed {
           VideoFeedState(
             videos: authorVideos,
             hasMoreContent:
-                apiVideos.length >= AppConstants.hasMoreContentThreshold,
+                apiVideos.length >= AppConstants.paginationBatchSize,
             lastUpdated: DateTime.now(),
           ),
         );
@@ -467,6 +481,7 @@ class ProfileFeed extends _$ProfileFeed {
         );
       } else {
         // REST API returned empty — this is valid (e.g. all videos deleted)
+        _nextOffset = 0;
         state = AsyncData(
           VideoFeedState(
             videos: [],
@@ -489,6 +504,7 @@ class ProfileFeed extends _$ProfileFeed {
       );
       // Fall back to Nostr with metadata cache on error
       _usingRestApi = false;
+      _nextOffset = null;
       refreshFromService();
     }
   }
@@ -528,22 +544,24 @@ class ProfileFeed extends _$ProfileFeed {
     state = AsyncData(currentState.copyWith(isLoadingMore: true));
 
     try {
-      // If using REST API, load more using cursor-based pagination
+      // If using REST API, load more using offset-based pagination.
       if (_usingRestApi) {
         final client = ref.read(funnelcakeApiClientProvider);
+        final offset = _nextOffset ?? _estimateNextRestOffset(currentState);
         Log.info(
-          'ProfileFeed: Loading more from REST API with cursor: $_nextCursor for user=$userId',
+          'ProfileFeed: Loading more from REST API with offset: $offset for user=$userId',
           name: 'ProfileFeedProvider',
           category: LogCategory.video,
         );
 
         final stats = await client.getVideosByAuthor(
           pubkey: userId,
-          before: _nextCursor,
+          offset: offset,
         );
         final apiVideos = stats.map((v) => v.toVideoEvent()).toList();
 
         if (!ref.mounted) return;
+        _nextOffset = offset + apiVideos.length;
 
         if (apiVideos.isNotEmpty) {
           // Deduplicate and merge (case-insensitive for Nostr IDs)
@@ -554,9 +572,6 @@ class ProfileFeed extends _$ProfileFeed {
               .where((v) => !existingIds.contains(v.id.toLowerCase()))
               .where((v) => !v.isRepost)
               .toList();
-
-          // Update cursor for next pagination
-          _nextCursor = _getOldestTimestamp(apiVideos);
 
           // Cache metadata from new videos
           _cacheVideoMetadata(newVideos);
@@ -726,9 +741,9 @@ class ProfileFeed extends _$ProfileFeed {
         if (!ref.mounted) return;
 
         if (apiVideos.isNotEmpty) {
-          // Reset cursor for pagination
+          // Reset offset-based pagination
           _usingRestApi = true;
-          _nextCursor = _getOldestTimestamp(apiVideos);
+          _nextOffset = apiVideos.length;
 
           // Filter out reposts
           var authorVideos = apiVideos.where((v) => !v.isRepost).toList();
@@ -765,6 +780,7 @@ class ProfileFeed extends _$ProfileFeed {
           return;
         } else {
           // REST API returned empty — valid (e.g. all videos deleted)
+          _nextOffset = 0;
           state = AsyncData(
             VideoFeedState(
               videos: [],
@@ -789,9 +805,9 @@ class ProfileFeed extends _$ProfileFeed {
       }
     }
 
-    // Reset cursor state before Nostr refresh (but keep metadata cache!)
+    // Reset REST pagination state before Nostr refresh (but keep metadata cache!)
     _usingRestApi = false;
-    _nextCursor = null;
+    _nextOffset = null;
 
     final videoEventService = ref.read(videoEventServiceProvider);
     await videoEventService.subscribeToUserVideos(userId);

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -11,7 +11,7 @@ part of 'profile_feed_provider.dart';
 /// Profile feed provider - shows videos for a specific user with pagination
 ///
 /// This is a family provider, so each userId gets its own provider instance
-/// with independent cursor tracking.
+/// with independent pagination tracking.
 ///
 /// Strategy: Try Funnelcake REST API first for better performance,
 /// fall back to Nostr subscription if unavailable.
@@ -28,7 +28,7 @@ const profileFeedProvider = ProfileFeedFamily._();
 /// Profile feed provider - shows videos for a specific user with pagination
 ///
 /// This is a family provider, so each userId gets its own provider instance
-/// with independent cursor tracking.
+/// with independent pagination tracking.
 ///
 /// Strategy: Try Funnelcake REST API first for better performance,
 /// fall back to Nostr subscription if unavailable.
@@ -43,7 +43,7 @@ final class ProfileFeedProvider
   /// Profile feed provider - shows videos for a specific user with pagination
   ///
   /// This is a family provider, so each userId gets its own provider instance
-  /// with independent cursor tracking.
+  /// with independent pagination tracking.
   ///
   /// Strategy: Try Funnelcake REST API first for better performance,
   /// fall back to Nostr subscription if unavailable.
@@ -89,12 +89,12 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'6d783dc5c7706b095f30031bca7369840e27ef49';
+String _$profileFeedHash() => r'15c92f3dd9fe33f45378ececb37eb4f1689b4c61';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///
 /// This is a family provider, so each userId gets its own provider instance
-/// with independent cursor tracking.
+/// with independent pagination tracking.
 ///
 /// Strategy: Try Funnelcake REST API first for better performance,
 /// fall back to Nostr subscription if unavailable.
@@ -126,7 +126,7 @@ final class ProfileFeedFamily extends $Family
   /// Profile feed provider - shows videos for a specific user with pagination
   ///
   /// This is a family provider, so each userId gets its own provider instance
-  /// with independent cursor tracking.
+  /// with independent pagination tracking.
   ///
   /// Strategy: Try Funnelcake REST API first for better performance,
   /// fall back to Nostr subscription if unavailable.
@@ -147,7 +147,7 @@ final class ProfileFeedFamily extends $Family
 /// Profile feed provider - shows videos for a specific user with pagination
 ///
 /// This is a family provider, so each userId gets its own provider instance
-/// with independent cursor tracking.
+/// with independent pagination tracking.
 ///
 /// Strategy: Try Funnelcake REST API first for better performance,
 /// fall back to Nostr subscription if unavailable.

--- a/mobile/lib/screens/discover_lists_screen.dart
+++ b/mobile/lib/screens/discover_lists_screen.dart
@@ -14,6 +14,7 @@ import 'package:openvine/screens/curated_list_feed_screen.dart';
 import 'package:openvine/services/screen_analytics_service.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/utils/video_controller_cleanup.dart';
+import 'package:openvine/widgets/scroll_pagination_controller.dart';
 import 'package:openvine/widgets/user_name.dart';
 
 class DiscoverListsScreen extends ConsumerStatefulWidget {
@@ -46,11 +47,16 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen> {
   int _autoPaginationAttempts = 0;
   static const int _maxAutoPaginationAttempts = 5;
   static const int _minListsBeforeAutoPaginate = 10;
+  late final ScrollPaginationController _paginationController;
 
   @override
   void initState() {
     super.initState();
-    _scrollController.addListener(_onScroll);
+    _paginationController = ScrollPaginationController(
+      scrollController: _scrollController,
+      canLoadMore: () => !_hasReachedEnd && !_isLoadingMore,
+      onLoadMore: _loadMoreLists,
+    );
 
     // Check if we already have cached lists from provider
     // Only stream if cache is empty
@@ -66,17 +72,9 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen> {
   void dispose() {
     _updateDebounceTimer?.cancel();
     _subscription?.cancel();
+    _paginationController.dispose();
     _scrollController.dispose();
     super.dispose();
-  }
-
-  void _onScroll() {
-    // Load more when near bottom, but not if we already exhausted results
-    if (!_hasReachedEnd &&
-        _scrollController.position.pixels >=
-            _scrollController.position.maxScrollExtent - 200) {
-      _loadMoreLists();
-    }
   }
 
   Future<void> _streamPublicLists({bool isRefresh = false}) async {

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -27,6 +27,7 @@ import 'package:openvine/screens/inbox/widgets/inbox_fab.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_segmented_toggle.dart';
 import 'package:openvine/screens/notifications_screen.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/scroll_pagination_controller.dart';
 
 /// Main inbox view containing the Messages/Notifications segmented toggle
 /// and the corresponding content for each tab.
@@ -233,17 +234,45 @@ class _ConversationListContent extends StatelessWidget {
   }
 }
 
-class _ConversationList extends ConsumerWidget {
+class _ConversationList extends ConsumerStatefulWidget {
   const _ConversationList({
     required this.currentUserPubkey,
   });
 
-  static const double _paginationThreshold = 200;
-
   final String currentUserPubkey;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_ConversationList> createState() => _ConversationListState();
+}
+
+class _ConversationListState extends ConsumerState<_ConversationList> {
+  final ScrollController _scrollController = ScrollController();
+  late final ScrollPaginationController _paginationController;
+  bool _canLoadMore = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _paginationController = ScrollPaginationController(
+      scrollController: _scrollController,
+      canLoadMore: () => _canLoadMore,
+      onLoadMore: () {
+        context.read<ConversationListBloc>().add(
+          const ConversationListLoadMore(),
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _paginationController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final conversations = context
         .select<ConversationListBloc, List<DmConversation>>(
           (bloc) => bloc.state.conversations,
@@ -255,9 +284,13 @@ class _ConversationList extends ConsumerWidget {
     final hasMore = context.select<ConversationListBloc, bool>(
       (bloc) => bloc.state.hasMore,
     );
+    final isLoadingMore = context.select<ConversationListBloc, bool>(
+      (bloc) => bloc.state.isLoadingMore,
+    );
 
     final hasRequests = requestConversations.isNotEmpty;
     final bannerOffset = hasRequests ? 1 : 0;
+    _canLoadMore = hasMore && !isLoadingMore;
 
     if (conversations.isEmpty && !hasRequests) return const InboxEmptyState();
 
@@ -274,60 +307,47 @@ class _ConversationList extends ConsumerWidget {
       );
     }
 
-    return NotificationListener<ScrollNotification>(
-      onNotification: (notification) {
-        if (hasMore &&
-            notification.metrics.extentAfter < _paginationThreshold &&
-            notification is ScrollUpdateNotification) {
-          context.read<ConversationListBloc>().add(
-            const ConversationListLoadMore(),
+    return ListView.builder(
+      controller: _scrollController,
+      itemCount: conversations.length + bannerOffset + (hasMore ? 1 : 0),
+      itemBuilder: (context, index) {
+        if (hasRequests && index == 0) {
+          return MessageRequestsBanner(
+            requestCount: requestConversations.length,
+            onTap: () => _openMessageRequests(context),
           );
         }
-        return false;
-      },
-      child: ListView.builder(
-        itemCount: conversations.length + bannerOffset + (hasMore ? 1 : 0),
-        itemBuilder: (context, index) {
-          // Banner at position 0 when requests exist
-          if (hasRequests && index == 0) {
-            return MessageRequestsBanner(
-              requestCount: requestConversations.length,
-              onTap: () => _openMessageRequests(context),
-            );
-          }
 
-          final conversationIndex = index - bannerOffset;
+        final conversationIndex = index - bannerOffset;
 
-          // Loading indicator at the end
-          if (conversationIndex == conversations.length) {
-            return const Padding(
-              padding: EdgeInsets.symmetric(vertical: 24),
-              child: Center(
-                child: SizedBox(
-                  width: 24,
-                  height: 24,
-                  child: CircularProgressIndicator(
-                    color: VineTheme.primary,
-                    strokeWidth: 2,
-                  ),
+        if (conversationIndex == conversations.length) {
+          return const Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: Center(
+              child: SizedBox(
+                width: 24,
+                height: 24,
+                child: CircularProgressIndicator(
+                  color: VineTheme.primary,
+                  strokeWidth: 2,
                 ),
               ),
-            );
-          }
-
-          final conversation = conversations[conversationIndex];
-          return ConversationTile(
-            conversation: conversation,
-            currentUserPubkey: currentUserPubkey,
-            onTap: () => _onConversationTapped(context, conversation),
-            onLongPress: () => _onConversationLongPressed(
-              context,
-              ref,
-              conversation,
             ),
           );
-        },
-      ),
+        }
+
+        final conversation = conversations[conversationIndex];
+        return ConversationTile(
+          conversation: conversation,
+          currentUserPubkey: widget.currentUserPubkey,
+          onTap: () => _onConversationTapped(context, conversation),
+          onLongPress: () => _onConversationLongPressed(
+            context,
+            ref,
+            conversation,
+          ),
+        );
+      },
     );
   }
 
@@ -345,7 +365,7 @@ class _ConversationList extends ConsumerWidget {
       category: LogCategory.ui,
     );
     final otherPubkeys = conversation.participantPubkeys
-        .where((pk) => pk != currentUserPubkey)
+        .where((pk) => pk != widget.currentUserPubkey)
         .toList();
 
     _pushConversation(context, conversation.id, otherPubkeys);
@@ -357,7 +377,7 @@ class _ConversationList extends ConsumerWidget {
     DmConversation conversation,
   ) async {
     final otherPubkey = conversation.participantPubkeys.firstWhere(
-      (pk) => pk != currentUserPubkey,
+      (pk) => pk != widget.currentUserPubkey,
       orElse: () => conversation.participantPubkeys.first,
     );
 

--- a/mobile/lib/screens/notifications_screen.dart
+++ b/mobile/lib/screens/notifications_screen.dart
@@ -18,6 +18,7 @@ import 'package:openvine/services/screen_analytics_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/notification_list_item.dart';
+import 'package:openvine/widgets/scroll_pagination_controller.dart';
 
 class NotificationsScreen extends ConsumerStatefulWidget {
   /// Route name for this screen.
@@ -126,37 +127,36 @@ class _NotificationTabContent extends ConsumerStatefulWidget {
 class _NotificationTabContentState
     extends ConsumerState<_NotificationTabContent> {
   final ScrollController _scrollController = ScrollController();
+  late final ScrollPaginationController _paginationController;
+  bool _canLoadMore = false;
 
   @override
   void initState() {
     super.initState();
-    _scrollController.addListener(_onScroll);
+    _paginationController = ScrollPaginationController(
+      scrollController: _scrollController,
+      canLoadMore: () => _canLoadMore,
+      onLoadMore: () =>
+          ref.read(relayNotificationsProvider.notifier).loadMore(),
+    );
   }
 
   @override
   void dispose() {
-    _scrollController
-      ..removeListener(_onScroll)
-      ..dispose();
+    _paginationController.dispose();
+    _scrollController.dispose();
     super.dispose();
-  }
-
-  void _onScroll() {
-    if (!_scrollController.hasClients) return;
-
-    final maxScroll = _scrollController.position.maxScrollExtent;
-    final currentScroll = _scrollController.offset;
-
-    // Only trigger loadMore if scrolling is actually possible and near bottom
-    // Provider handles all state checks (hasMore, isRefreshing, isLoadingMore)
-    if (maxScroll > 0 && maxScroll - currentScroll <= 200) {
-      ref.read(relayNotificationsProvider.notifier).loadMore();
-    }
   }
 
   @override
   Widget build(BuildContext context) {
     final asyncState = ref.watch(relayNotificationsProvider);
+    final feedState = asyncState.asData?.value;
+    _canLoadMore =
+        feedState != null &&
+        feedState.hasMoreContent &&
+        !feedState.isLoadingMore &&
+        !feedState.isRefreshing;
 
     return asyncState.when(
       loading: () => const ColoredBox(

--- a/mobile/lib/widgets/classic_vines_tab.dart
+++ b/mobile/lib/widgets/classic_vines_tab.dart
@@ -18,6 +18,7 @@ import 'package:openvine/state/video_feed_state.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/classic_viners_slider.dart';
+import 'package:openvine/widgets/scroll_pagination_controller.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
 import 'package:rxdart/rxdart.dart';
@@ -144,54 +145,32 @@ class _ClassicVinesContent extends ConsumerStatefulWidget {
 class _ClassicVinesContentState extends ConsumerState<_ClassicVinesContent> {
   final ScrollController _scrollController = ScrollController();
   late final StreamController<List<VideoEvent>> _videosStreamController;
-  bool _isLoadingTriggered = false;
+  late final ScrollPaginationController _paginationController;
 
   @override
   void initState() {
     super.initState();
-    _scrollController.addListener(_onScroll);
     _videosStreamController = StreamController<List<VideoEvent>>.broadcast();
+    _paginationController = ScrollPaginationController(
+      scrollController: _scrollController,
+      canLoadMore: () => widget.hasMoreContent && !widget.isLoadingMore,
+      onLoadMore: () async {
+        Log.info(
+          '📜 ClassicVinesTab: Loading more classics',
+          name: 'ClassicVinesTab',
+          category: LogCategory.video,
+        );
+        await ref.read(classicVinesFeedProvider.notifier).loadMore();
+      },
+    );
   }
 
   @override
   void dispose() {
-    _scrollController.removeListener(_onScroll);
+    _paginationController.dispose();
     _scrollController.dispose();
     _videosStreamController.close();
     super.dispose();
-  }
-
-  void _onScroll() {
-    if (!widget.hasMoreContent) return;
-    if (widget.isLoadingMore) return;
-    if (_isLoadingTriggered) return;
-
-    final position = _scrollController.position;
-    final maxScroll = position.maxScrollExtent;
-    final currentScroll = position.pixels;
-
-    // Trigger load more when within 200 pixels of the bottom
-    if (currentScroll >= maxScroll - 200) {
-      _triggerLoadMore();
-    }
-  }
-
-  Future<void> _triggerLoadMore() async {
-    if (_isLoadingTriggered) return;
-    _isLoadingTriggered = true;
-
-    try {
-      Log.info(
-        '📜 ClassicVinesTab: Loading more classics',
-        name: 'ClassicVinesTab',
-        category: LogCategory.video,
-      );
-      await ref.read(classicVinesFeedProvider.notifier).loadMore();
-    } finally {
-      if (mounted) {
-        _isLoadingTriggered = false;
-      }
-    }
   }
 
   @override

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -10,6 +10,7 @@ import 'package:models/models.dart' hide AspectRatio;
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/services/content_deletion_service.dart';
+import 'package:openvine/widgets/scroll_pagination_controller.dart';
 import 'package:openvine/widgets/share_video_menu.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
@@ -66,49 +67,26 @@ class ComposableVideoGrid extends ConsumerStatefulWidget {
 
 class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid> {
   final ScrollController _scrollController = ScrollController();
-  bool _isLoadingTriggered = false;
+  late final ScrollPaginationController _paginationController;
 
   @override
   void initState() {
     super.initState();
-    _scrollController.addListener(_onScroll);
+    _paginationController = ScrollPaginationController(
+      scrollController: _scrollController,
+      canLoadMore: () =>
+          widget.onLoadMore != null &&
+          widget.hasMoreContent &&
+          !widget.isLoadingMore,
+      onLoadMore: () => widget.onLoadMore?.call(),
+    );
   }
 
   @override
   void dispose() {
-    _scrollController.removeListener(_onScroll);
+    _paginationController.dispose();
     _scrollController.dispose();
     super.dispose();
-  }
-
-  void _onScroll() {
-    if (widget.onLoadMore == null) return;
-    if (!widget.hasMoreContent) return;
-    if (widget.isLoadingMore) return;
-    if (_isLoadingTriggered) return;
-
-    final position = _scrollController.position;
-    final maxScroll = position.maxScrollExtent;
-    final currentScroll = position.pixels;
-
-    // Trigger load more when within 200 pixels of the bottom
-    if (currentScroll >= maxScroll - 200) {
-      _triggerLoadMore();
-    }
-  }
-
-  Future<void> _triggerLoadMore() async {
-    if (_isLoadingTriggered) return;
-
-    _isLoadingTriggered = true;
-
-    try {
-      await widget.onLoadMore?.call();
-    } finally {
-      if (mounted) {
-        _isLoadingTriggered = false;
-      }
-    }
   }
 
   @override

--- a/mobile/lib/widgets/for_you_tab.dart
+++ b/mobile/lib/widgets/for_you_tab.dart
@@ -109,7 +109,11 @@ class _ForYouTabState extends ConsumerState<ForYouTab> {
       return const _ForYouEmptyState();
     }
 
-    return _ForYouContent(videos: videos);
+    return _ForYouContent(
+      videos: videos,
+      isLoadingMore: feedState.isLoadingMore,
+      hasMoreContent: feedState.hasMoreContent,
+    );
   }
 }
 
@@ -118,9 +122,15 @@ class _ForYouTabState extends ConsumerState<ForYouTab> {
 /// Header pushes up as user scrolls down (1:1 with scroll distance).
 /// When scrolling up, header slides back in as an overlay with animation.
 class _ForYouContent extends ConsumerStatefulWidget {
-  const _ForYouContent({required this.videos});
+  const _ForYouContent({
+    required this.videos,
+    required this.isLoadingMore,
+    required this.hasMoreContent,
+  });
 
   final List<VideoEvent> videos;
+  final bool isLoadingMore;
+  final bool hasMoreContent;
 
   @override
   ConsumerState<_ForYouContent> createState() => _ForYouContentState();
@@ -208,6 +218,16 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
                 );
                 await forYouFeedNotifier.refresh();
               },
+              onLoadMore: () async {
+                Log.info(
+                  '📜 ForYouTab: Loading more recommendations',
+                  name: 'ForYouTab',
+                  category: LogCategory.video,
+                );
+                await forYouFeedNotifier.loadMore();
+              },
+              isLoadingMore: widget.isLoadingMore,
+              hasMoreContent: widget.hasMoreContent,
               emptyBuilder: () => const _ForYouEmptyState(),
             ),
           ),

--- a/mobile/lib/widgets/profile/profile_collabs_grid.dart
+++ b/mobile/lib/widgets/profile/profile_collabs_grid.dart
@@ -12,6 +12,7 @@ import 'package:openvine/mixins/grid_prefetch_mixin.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/scroll_pagination_controller.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Grid widget displaying user's collab videos.
@@ -29,7 +30,33 @@ class ProfileCollabsGrid extends StatefulWidget {
 
 class _ProfileCollabsGridState extends State<ProfileCollabsGrid>
     with GridPrefetchMixin {
+  final ScrollController _scrollController = ScrollController();
+  late final ScrollPaginationController _paginationController;
   List<VideoEvent>? _lastPrefetchedVideos;
+
+  @override
+  void initState() {
+    super.initState();
+    _paginationController = ScrollPaginationController(
+      scrollController: _scrollController,
+      canLoadMore: () {
+        final bloc = context.read<ProfileCollabVideosBloc>();
+        return bloc.state.hasMoreContent && !bloc.state.isLoadingMore;
+      },
+      onLoadMore: () {
+        context.read<ProfileCollabVideosBloc>().add(
+          const ProfileCollabVideosLoadMoreRequested(),
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _paginationController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   void _prefetchIfNeeded(List<VideoEvent> videos) {
     if (videos.isEmpty || videos == _lastPrefetchedVideos) return;
@@ -100,61 +127,43 @@ class _ProfileCollabsGridState extends State<ProfileCollabsGrid>
         // Prefetch visible grid videos
         _prefetchIfNeeded(collabVideos);
 
-        return NotificationListener<ScrollNotification>(
-          onNotification: (notification) {
-            // Trigger load more when near the bottom
-            if (notification is ScrollUpdateNotification) {
-              final pixels = notification.metrics.pixels;
-              final maxExtent = notification.metrics.maxScrollExtent;
-              // Load more when within 200 pixels of the bottom
-              if (pixels >= maxExtent - 200 &&
-                  state.hasMoreContent &&
-                  !state.isLoadingMore) {
-                context.read<ProfileCollabVideosBloc>().add(
-                  const ProfileCollabVideosLoadMoreRequested(),
-                );
-              }
-            }
-            return false;
-          },
-          child: CustomScrollView(
-            slivers: [
-              SliverPadding(
-                padding: const EdgeInsets.all(2),
-                sliver: SliverGrid(
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 3,
-                    crossAxisSpacing: 2,
-                    mainAxisSpacing: 2,
-                  ),
-                  delegate: SliverChildBuilderDelegate((context, index) {
-                    if (index >= collabVideos.length) {
-                      return const SizedBox.shrink();
-                    }
-
-                    final videoEvent = collabVideos[index];
-                    return _CollabGridTile(
-                      videoEvent: videoEvent,
-                      index: index,
-                      onTap: () => _onVideoTapped(index, collabVideos),
-                    );
-                  }, childCount: collabVideos.length),
+        return CustomScrollView(
+          controller: _scrollController,
+          slivers: [
+            SliverPadding(
+              padding: const EdgeInsets.all(2),
+              sliver: SliverGrid(
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 3,
+                  crossAxisSpacing: 2,
+                  mainAxisSpacing: 2,
                 ),
+                delegate: SliverChildBuilderDelegate((context, index) {
+                  if (index >= collabVideos.length) {
+                    return const SizedBox.shrink();
+                  }
+
+                  final videoEvent = collabVideos[index];
+                  return _CollabGridTile(
+                    videoEvent: videoEvent,
+                    index: index,
+                    onTap: () => _onVideoTapped(index, collabVideos),
+                  );
+                }, childCount: collabVideos.length),
               ),
-              // Loading indicator at the bottom
-              if (state.isLoadingMore)
-                const SliverToBoxAdapter(
-                  child: Padding(
-                    padding: EdgeInsets.all(16),
-                    child: Center(
-                      child: CircularProgressIndicator(
-                        color: VineTheme.vineGreen,
-                      ),
+            ),
+            if (state.isLoadingMore)
+              const SliverToBoxAdapter(
+                child: Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Center(
+                    child: CircularProgressIndicator(
+                      color: VineTheme.vineGreen,
                     ),
                   ),
                 ),
-            ],
-          ),
+              ),
+          ],
         );
       },
     );

--- a/mobile/lib/widgets/profile/profile_comments_grid.dart
+++ b/mobile/lib/widgets/profile/profile_comments_grid.dart
@@ -9,16 +9,49 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/profile_comments/profile_comments_bloc.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:openvine/widgets/scroll_pagination_controller.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Grid widget displaying a user's comments (video replies + text).
 ///
 /// Requires [ProfileCommentsBloc] to be provided in the widget tree.
-class ProfileCommentsGrid extends StatelessWidget {
+class ProfileCommentsGrid extends StatefulWidget {
   const ProfileCommentsGrid({required this.isOwnProfile, super.key});
 
   /// Whether this is the current user's own profile.
   final bool isOwnProfile;
+
+  @override
+  State<ProfileCommentsGrid> createState() => _ProfileCommentsGridState();
+}
+
+class _ProfileCommentsGridState extends State<ProfileCommentsGrid> {
+  final ScrollController _scrollController = ScrollController();
+  late final ScrollPaginationController _paginationController;
+
+  @override
+  void initState() {
+    super.initState();
+    _paginationController = ScrollPaginationController(
+      scrollController: _scrollController,
+      canLoadMore: () {
+        final bloc = context.read<ProfileCommentsBloc>();
+        return bloc.state.hasMoreContent && !bloc.state.isLoadingMore;
+      },
+      onLoadMore: () {
+        context.read<ProfileCommentsBloc>().add(
+          const ProfileCommentsLoadMoreRequested(),
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _paginationController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -41,83 +74,62 @@ class ProfileCommentsGrid extends StatelessWidget {
         }
 
         if (state.videoReplies.isEmpty && state.textComments.isEmpty) {
-          return _CommentsEmptyState(isOwnProfile: isOwnProfile);
+          return _CommentsEmptyState(isOwnProfile: widget.isOwnProfile);
         }
 
-        return NotificationListener<ScrollNotification>(
-          onNotification: (notification) {
-            if (notification is ScrollUpdateNotification) {
-              final pixels = notification.metrics.pixels;
-              final maxExtent = notification.metrics.maxScrollExtent;
-              if (pixels >= maxExtent - 200 &&
-                  state.hasMoreContent &&
-                  !state.isLoadingMore) {
-                context.read<ProfileCommentsBloc>().add(
-                  const ProfileCommentsLoadMoreRequested(),
-                );
-              }
-            }
-            return false;
-          },
-          child: CustomScrollView(
-            slivers: [
-              // Video Replies section
-              if (state.videoReplies.isNotEmpty) ...[
-                const SliverToBoxAdapter(
-                  child: _SectionHeader(title: 'Video Replies'),
-                ),
-                SliverPadding(
-                  padding: const EdgeInsets.all(2),
-                  sliver: SliverGrid(
-                    gridDelegate:
-                        const SliverGridDelegateWithFixedCrossAxisCount(
-                          crossAxisCount: 3,
-                          crossAxisSpacing: 2,
-                          mainAxisSpacing: 2,
-                        ),
-                    delegate: SliverChildBuilderDelegate((context, index) {
-                      if (index >= state.videoReplies.length) {
-                        return const SizedBox.shrink();
-                      }
-                      return _VideoReplyTile(
-                        comment: state.videoReplies[index],
-                      );
-                    }, childCount: state.videoReplies.length),
+        return CustomScrollView(
+          controller: _scrollController,
+          slivers: [
+            if (state.videoReplies.isNotEmpty) ...[
+              const SliverToBoxAdapter(
+                child: _SectionHeader(title: 'Video Replies'),
+              ),
+              SliverPadding(
+                padding: const EdgeInsets.all(2),
+                sliver: SliverGrid(
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 3,
+                    crossAxisSpacing: 2,
+                    mainAxisSpacing: 2,
                   ),
-                ),
-              ],
-
-              // Text Comments section
-              if (state.textComments.isNotEmpty) ...[
-                const SliverToBoxAdapter(
-                  child: _SectionHeader(title: 'Comments'),
-                ),
-                SliverList(
                   delegate: SliverChildBuilderDelegate((context, index) {
-                    if (index >= state.textComments.length) {
+                    if (index >= state.videoReplies.length) {
                       return const SizedBox.shrink();
                     }
-                    return _ProfileCommentCard(
-                      comment: state.textComments[index],
+                    return _VideoReplyTile(
+                      comment: state.videoReplies[index],
                     );
-                  }, childCount: state.textComments.length),
+                  }, childCount: state.videoReplies.length),
                 ),
-              ],
-
-              // Loading indicator at the bottom
-              if (state.isLoadingMore)
-                const SliverToBoxAdapter(
-                  child: Padding(
-                    padding: EdgeInsets.all(16),
-                    child: Center(
-                      child: CircularProgressIndicator(
-                        color: VineTheme.vineGreen,
-                      ),
+              ),
+            ],
+            if (state.textComments.isNotEmpty) ...[
+              const SliverToBoxAdapter(
+                child: _SectionHeader(title: 'Comments'),
+              ),
+              SliverList(
+                delegate: SliverChildBuilderDelegate((context, index) {
+                  if (index >= state.textComments.length) {
+                    return const SizedBox.shrink();
+                  }
+                  return _ProfileCommentCard(
+                    comment: state.textComments[index],
+                  );
+                }, childCount: state.textComments.length),
+              ),
+            ],
+            if (state.isLoadingMore)
+              const SliverToBoxAdapter(
+                child: Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Center(
+                    child: CircularProgressIndicator(
+                      color: VineTheme.vineGreen,
                     ),
                   ),
                 ),
-            ],
-          ),
+              ),
+          ],
         );
       },
     );

--- a/mobile/lib/widgets/profile/profile_liked_grid.dart
+++ b/mobile/lib/widgets/profile/profile_liked_grid.dart
@@ -10,16 +10,49 @@ import 'package:openvine/blocs/profile_liked_videos/profile_liked_videos_bloc.da
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/scroll_pagination_controller.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Grid widget displaying user's liked videos
 ///
 /// Requires [ProfileLikedVideosBloc] to be provided in the widget tree.
-class ProfileLikedGrid extends StatelessWidget {
+class ProfileLikedGrid extends StatefulWidget {
   const ProfileLikedGrid({required this.isOwnProfile, super.key});
 
   /// Whether this is the current user's own profile.
   final bool isOwnProfile;
+
+  @override
+  State<ProfileLikedGrid> createState() => _ProfileLikedGridState();
+}
+
+class _ProfileLikedGridState extends State<ProfileLikedGrid> {
+  final ScrollController _scrollController = ScrollController();
+  late final ScrollPaginationController _paginationController;
+
+  @override
+  void initState() {
+    super.initState();
+    _paginationController = ScrollPaginationController(
+      scrollController: _scrollController,
+      canLoadMore: () {
+        final bloc = context.read<ProfileLikedVideosBloc>();
+        return bloc.state.hasMoreContent && !bloc.state.isLoadingMore;
+      },
+      onLoadMore: () {
+        context.read<ProfileLikedVideosBloc>().add(
+          const ProfileLikedVideosLoadMoreRequested(),
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _paginationController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -59,64 +92,46 @@ class ProfileLikedGrid extends StatelessWidget {
         final likedVideos = state.videos;
 
         if (likedVideos.isEmpty) {
-          return _LikedEmptyState(isOwnProfile: isOwnProfile);
+          return _LikedEmptyState(isOwnProfile: widget.isOwnProfile);
         }
 
-        return NotificationListener<ScrollNotification>(
-          onNotification: (notification) {
-            // Trigger load more when near the bottom
-            if (notification is ScrollUpdateNotification) {
-              final pixels = notification.metrics.pixels;
-              final maxExtent = notification.metrics.maxScrollExtent;
-              // Load more when within 200 pixels of the bottom
-              if (pixels >= maxExtent - 200 &&
-                  state.hasMoreContent &&
-                  !state.isLoadingMore) {
-                context.read<ProfileLikedVideosBloc>().add(
-                  const ProfileLikedVideosLoadMoreRequested(),
-                );
-              }
-            }
-            return false;
-          },
-          child: CustomScrollView(
-            slivers: [
-              SliverPadding(
-                padding: const EdgeInsets.all(4),
-                sliver: SliverGrid(
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 3,
-                    crossAxisSpacing: 4,
-                    mainAxisSpacing: 4,
-                  ),
-                  delegate: SliverChildBuilderDelegate((context, index) {
-                    if (index >= likedVideos.length) {
-                      return const SizedBox.shrink();
-                    }
-
-                    final videoEvent = likedVideos[index];
-                    return _LikedGridTile(
-                      videoEvent: videoEvent,
-                      index: index,
-                      allVideos: likedVideos,
-                    );
-                  }, childCount: likedVideos.length),
+        return CustomScrollView(
+          controller: _scrollController,
+          slivers: [
+            SliverPadding(
+              padding: const EdgeInsets.all(4),
+              sliver: SliverGrid(
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 3,
+                  crossAxisSpacing: 4,
+                  mainAxisSpacing: 4,
                 ),
+                delegate: SliverChildBuilderDelegate((context, index) {
+                  if (index >= likedVideos.length) {
+                    return const SizedBox.shrink();
+                  }
+
+                  final videoEvent = likedVideos[index];
+                  return _LikedGridTile(
+                    videoEvent: videoEvent,
+                    index: index,
+                    allVideos: likedVideos,
+                  );
+                }, childCount: likedVideos.length),
               ),
-              // Loading indicator at the bottom
-              if (state.isLoadingMore)
-                const SliverToBoxAdapter(
-                  child: Padding(
-                    padding: EdgeInsets.all(16),
-                    child: Center(
-                      child: CircularProgressIndicator(
-                        color: VineTheme.vineGreen,
-                      ),
+            ),
+            if (state.isLoadingMore)
+              const SliverToBoxAdapter(
+                child: Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Center(
+                    child: CircularProgressIndicator(
+                      color: VineTheme.vineGreen,
                     ),
                   ),
                 ),
-            ],
-          ),
+              ),
+          ],
         );
       },
     );

--- a/mobile/lib/widgets/profile/profile_reposts_grid.dart
+++ b/mobile/lib/widgets/profile/profile_reposts_grid.dart
@@ -10,16 +10,49 @@ import 'package:openvine/blocs/profile_reposted_videos/profile_reposted_videos_b
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/scroll_pagination_controller.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Grid widget displaying user's reposted videos
 ///
 /// Requires [ProfileRepostedVideosBloc] to be provided in the widget tree.
-class ProfileRepostsGrid extends StatelessWidget {
+class ProfileRepostsGrid extends StatefulWidget {
   const ProfileRepostsGrid({required this.isOwnProfile, super.key});
 
   /// Whether this is the current user's own profile.
   final bool isOwnProfile;
+
+  @override
+  State<ProfileRepostsGrid> createState() => _ProfileRepostsGridState();
+}
+
+class _ProfileRepostsGridState extends State<ProfileRepostsGrid> {
+  final ScrollController _scrollController = ScrollController();
+  late final ScrollPaginationController _paginationController;
+
+  @override
+  void initState() {
+    super.initState();
+    _paginationController = ScrollPaginationController(
+      scrollController: _scrollController,
+      canLoadMore: () {
+        final bloc = context.read<ProfileRepostedVideosBloc>();
+        return bloc.state.hasMoreContent && !bloc.state.isLoadingMore;
+      },
+      onLoadMore: () {
+        context.read<ProfileRepostedVideosBloc>().add(
+          const ProfileRepostedVideosLoadMoreRequested(),
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _paginationController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -59,64 +92,46 @@ class ProfileRepostsGrid extends StatelessWidget {
         final repostedVideos = state.videos;
 
         if (repostedVideos.isEmpty) {
-          return _RepostsEmptyState(isOwnProfile: isOwnProfile);
+          return _RepostsEmptyState(isOwnProfile: widget.isOwnProfile);
         }
 
-        return NotificationListener<ScrollNotification>(
-          onNotification: (notification) {
-            // Trigger load more when near the bottom
-            if (notification is ScrollUpdateNotification) {
-              final pixels = notification.metrics.pixels;
-              final maxExtent = notification.metrics.maxScrollExtent;
-              // Load more when within 200 pixels of the bottom
-              if (pixels >= maxExtent - 200 &&
-                  state.hasMoreContent &&
-                  !state.isLoadingMore) {
-                context.read<ProfileRepostedVideosBloc>().add(
-                  const ProfileRepostedVideosLoadMoreRequested(),
-                );
-              }
-            }
-            return false;
-          },
-          child: CustomScrollView(
-            slivers: [
-              SliverPadding(
-                padding: const EdgeInsets.all(2),
-                sliver: SliverGrid(
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 3,
-                    crossAxisSpacing: 2,
-                    mainAxisSpacing: 2,
-                  ),
-                  delegate: SliverChildBuilderDelegate((context, index) {
-                    if (index >= repostedVideos.length) {
-                      return const SizedBox.shrink();
-                    }
-
-                    final videoEvent = repostedVideos[index];
-                    return _RepostGridTile(
-                      videoEvent: videoEvent,
-                      index: index,
-                      allVideos: repostedVideos,
-                    );
-                  }, childCount: repostedVideos.length),
+        return CustomScrollView(
+          controller: _scrollController,
+          slivers: [
+            SliverPadding(
+              padding: const EdgeInsets.all(2),
+              sliver: SliverGrid(
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 3,
+                  crossAxisSpacing: 2,
+                  mainAxisSpacing: 2,
                 ),
+                delegate: SliverChildBuilderDelegate((context, index) {
+                  if (index >= repostedVideos.length) {
+                    return const SizedBox.shrink();
+                  }
+
+                  final videoEvent = repostedVideos[index];
+                  return _RepostGridTile(
+                    videoEvent: videoEvent,
+                    index: index,
+                    allVideos: repostedVideos,
+                  );
+                }, childCount: repostedVideos.length),
               ),
-              // Loading indicator at the bottom
-              if (state.isLoadingMore)
-                const SliverToBoxAdapter(
-                  child: Padding(
-                    padding: EdgeInsets.all(16),
-                    child: Center(
-                      child: CircularProgressIndicator(
-                        color: VineTheme.vineGreen,
-                      ),
+            ),
+            if (state.isLoadingMore)
+              const SliverToBoxAdapter(
+                child: Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Center(
+                    child: CircularProgressIndicator(
+                      color: VineTheme.vineGreen,
                     ),
                   ),
                 ),
-            ],
-          ),
+              ),
+          ],
         );
       },
     );

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -17,6 +17,7 @@ import 'package:openvine/providers/profile_feed_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/scroll_pagination_controller.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -64,11 +65,25 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
   List<VideoEvent>? _lastPrefetchedVideos;
   final _videosStreamController =
       StreamController<List<VideoEvent>>.broadcast();
-  bool _isLoadingTriggered = false;
+  final _scrollController = ScrollController();
+  late final ScrollPaginationController _paginationController;
 
   @override
   void initState() {
     super.initState();
+    _paginationController = ScrollPaginationController(
+      scrollController: _scrollController,
+      canLoadMore: () {
+        final feedState = ref
+            .read(profileFeedProvider(widget.userIdHex))
+            .asData
+            ?.value;
+        return feedState != null &&
+            feedState.hasMoreContent &&
+            !feedState.isLoadingMore;
+      },
+      onLoadMore: _triggerLoadMore,
+    );
     // Prefetch visible grid videos after first frame
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
@@ -79,6 +94,8 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
 
   @override
   void dispose() {
+    _paginationController.dispose();
+    _scrollController.dispose();
     _videosStreamController.close();
     super.dispose();
   }
@@ -99,42 +116,8 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
     prefetchGridVideos(videos);
   }
 
-  bool _onScrollNotification(ScrollNotification notification) {
-    if (notification.metrics.axis != Axis.vertical) return false;
-    if (_isLoadingTriggered) return false;
-
-    final feedState = ref
-        .read(profileFeedProvider(widget.userIdHex))
-        .asData
-        ?.value;
-    if (feedState == null ||
-        !feedState.hasMoreContent ||
-        feedState.isLoadingMore) {
-      return false;
-    }
-
-    final maxScroll = notification.metrics.maxScrollExtent;
-    final currentScroll = notification.metrics.pixels;
-
-    if (maxScroll > 0 && currentScroll >= maxScroll - 200) {
-      unawaited(_triggerLoadMore());
-    }
-
-    return false;
-  }
-
   Future<void> _triggerLoadMore() async {
-    if (_isLoadingTriggered) return;
-
-    _isLoadingTriggered = true;
-
-    try {
-      await ref.read(profileFeedProvider(widget.userIdHex).notifier).loadMore();
-    } finally {
-      if (mounted) {
-        _isLoadingTriggered = false;
-      }
-    }
+    await ref.read(profileFeedProvider(widget.userIdHex).notifier).loadMore();
   }
 
   void _onVideoTapped(int index, {required VoidCallback onLoadMore}) {
@@ -208,51 +191,49 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
         .where((upload) => upload.result == null)
         .length;
 
-    return NotificationListener<ScrollNotification>(
-      onNotification: _onScrollNotification,
-      child: CustomScrollView(
-        slivers: [
-          SliverPadding(
-            padding: .fromLTRB(
-              4,
-              4,
-              4,
-              4 + MediaQuery.viewPaddingOf(context).bottom,
-            ),
-            sliver: SliverGrid(
-              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 3,
-                crossAxisSpacing: 4,
-                mainAxisSpacing: 4,
-              ),
-              delegate: SliverChildBuilderDelegate((context, index) {
-                final videoEntry = allVideos[index];
-                return switch (videoEntry) {
-                  final _GridUploadingVideoEntry uploadEntry =>
-                    _VideoGridUploadingTile(
-                      backgroundUpload: uploadEntry.backgroundUpload,
-                    ),
-                  final _GridVideoEventEntry eventEntry => _VideoGridTile(
-                    videoEvent: eventEntry.videoEvent,
-                    userIdHex: widget.userIdHex,
-                    index: index,
-                    onTap: () {
-                      // Adjust index to account for uploading videos at the top
-                      final publishedIndex = index - uploadingCount;
-                      if (publishedIndex >= 0) {
-                        _onVideoTapped(
-                          publishedIndex,
-                          onLoadMore: loadMoreProfileVideos,
-                        );
-                      }
-                    },
-                  ),
-                };
-              }, childCount: allVideos.length),
-            ),
+    return CustomScrollView(
+      controller: _scrollController,
+      slivers: [
+        SliverPadding(
+          padding: .fromLTRB(
+            4,
+            4,
+            4,
+            4 + MediaQuery.viewPaddingOf(context).bottom,
           ),
-        ],
-      ),
+          sliver: SliverGrid(
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 3,
+              crossAxisSpacing: 4,
+              mainAxisSpacing: 4,
+            ),
+            delegate: SliverChildBuilderDelegate((context, index) {
+              final videoEntry = allVideos[index];
+              return switch (videoEntry) {
+                final _GridUploadingVideoEntry uploadEntry =>
+                  _VideoGridUploadingTile(
+                    backgroundUpload: uploadEntry.backgroundUpload,
+                  ),
+                final _GridVideoEventEntry eventEntry => _VideoGridTile(
+                  videoEvent: eventEntry.videoEvent,
+                  userIdHex: widget.userIdHex,
+                  index: index,
+                  onTap: () {
+                    // Adjust index to account for uploading videos at the top
+                    final publishedIndex = index - uploadingCount;
+                    if (publishedIndex >= 0) {
+                      _onVideoTapped(
+                        publishedIndex,
+                        onLoadMore: loadMoreProfileVideos,
+                      );
+                    }
+                  },
+                ),
+              };
+            }, childCount: allVideos.length),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/mobile/lib/widgets/scroll_pagination_controller.dart
+++ b/mobile/lib/widgets/scroll_pagination_controller.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+typedef ScrollPaginationCallback = FutureOr<void> Function();
+typedef CanLoadMoreCallback = bool Function();
+
+/// Reusable near-bottom pagination trigger for scroll-driven feeds and lists.
+class ScrollPaginationController {
+  ScrollPaginationController({
+    required ScrollController scrollController,
+    required CanLoadMoreCallback canLoadMore,
+    required ScrollPaginationCallback onLoadMore,
+    this.threshold = 200,
+  }) : _scrollController = scrollController,
+       _canLoadMore = canLoadMore,
+       _onLoadMore = onLoadMore {
+    _scrollController.addListener(_handleScroll);
+  }
+
+  final ScrollController _scrollController;
+  final CanLoadMoreCallback _canLoadMore;
+  final ScrollPaginationCallback _onLoadMore;
+  final double threshold;
+
+  Future<void>? _pendingLoad;
+
+  void dispose() {
+    _scrollController.removeListener(_handleScroll);
+  }
+
+  void _handleScroll() {
+    if (!_scrollController.hasClients) return;
+    if (_pendingLoad != null) return;
+    if (!_canLoadMore()) return;
+
+    final position = _scrollController.position;
+    if (position.pixels < position.maxScrollExtent - threshold) {
+      return;
+    }
+
+    _pendingLoad = Future.sync(_onLoadMore).whenComplete(() {
+      _pendingLoad = null;
+    });
+  }
+}

--- a/mobile/lib/widgets/user_search_view.dart
+++ b/mobile/lib/widgets/user_search_view.dart
@@ -13,6 +13,7 @@ import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:openvine/utils/string_utils.dart';
+import 'package:openvine/widgets/scroll_pagination_controller.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
 /// Displays user search results from UserSearchBloc.
@@ -97,31 +98,25 @@ class _UserSearchResultsList extends StatefulWidget {
 
 class _UserSearchResultsListState extends State<_UserSearchResultsList> {
   final _scrollController = ScrollController();
+  late final ScrollPaginationController _paginationController;
 
   @override
   void initState() {
     super.initState();
-    _scrollController.addListener(_onScroll);
+    _paginationController = ScrollPaginationController(
+      scrollController: _scrollController,
+      canLoadMore: () => widget.hasMore && !widget.isLoadingMore,
+      onLoadMore: () {
+        context.read<UserSearchBloc>().add(const UserSearchLoadMore());
+      },
+    );
   }
 
   @override
   void dispose() {
-    _scrollController
-      ..removeListener(_onScroll)
-      ..dispose();
+    _paginationController.dispose();
+    _scrollController.dispose();
     super.dispose();
-  }
-
-  void _onScroll() {
-    if (!_scrollController.hasClients) return;
-    final maxScroll = _scrollController.position.maxScrollExtent;
-    final currentScroll = _scrollController.offset;
-    // Trigger load more at 80% scroll
-    if (currentScroll >= maxScroll * 0.8 &&
-        widget.hasMore &&
-        !widget.isLoadingMore) {
-      context.read<UserSearchBloc>().add(const UserSearchLoadMore());
-    }
   }
 
   @override

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -106,7 +106,10 @@ class FunnelcakeApiClient {
   ///
   /// [pubkey] is the author's public key (hex format).
   /// [limit] is the maximum number of videos to return (defaults to 50).
-  /// [before] is an optional Unix timestamp cursor for pagination.
+  /// [offset] is an optional pagination offset.
+  ///
+  /// [before] is retained for legacy compatibility, but the live
+  /// `/api/users/{pubkey}/videos` endpoint paginates with [offset].
   ///
   /// Returns a list of [VideoStats] objects.
   ///
@@ -119,6 +122,7 @@ class FunnelcakeApiClient {
   Future<List<VideoStats>> getVideosByAuthor({
     required String pubkey,
     int limit = 50,
+    int? offset,
     int? before,
   }) async {
     if (!isAvailable) {
@@ -130,6 +134,9 @@ class FunnelcakeApiClient {
     }
 
     final queryParams = _videoQueryParameters({'limit': limit.toString()});
+    if (offset != null) {
+      queryParams['offset'] = offset.toString();
+    }
     if (before != null) {
       queryParams['before'] = before.toString();
     }

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -758,12 +758,12 @@ void main() {
         expect(uri.queryParameters['limit'], equals('100'));
       });
 
-      test('includes before parameter when provided', () async {
+      test('includes offset parameter when provided', () async {
         when(
           () => mockHttpClient.get(any(), headers: any(named: 'headers')),
         ).thenAnswer((_) async => http.Response('[]', 200));
 
-        await client.getVideosByAuthor(pubkey: testPubkey, before: 1700000000);
+        await client.getVideosByAuthor(pubkey: testPubkey, offset: 50);
 
         final captured = verify(
           () =>
@@ -771,7 +771,7 @@ void main() {
         ).captured;
 
         final uri = captured.first as Uri;
-        expect(uri.queryParameters['before'], equals('1700000000'));
+        expect(uri.queryParameters['offset'], equals('50'));
       });
 
       test('sends correct headers', () async {

--- a/mobile/test/providers/profile_feed_pagination_contract_test.dart
+++ b/mobile/test/providers/profile_feed_pagination_contract_test.dart
@@ -1,0 +1,219 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/curation_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/profile_feed_provider.dart';
+import 'package:openvine/providers/profile_feed_session_cache.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/state/video_feed_state.dart';
+
+class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _AlwaysAvailableFunnelcake extends FunnelcakeAvailable {
+  @override
+  Future<bool> build() async => true;
+}
+
+void main() {
+  const userId =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+  group('ProfileFeed REST pagination contract', () {
+    late _MockFunnelcakeApiClient mockFunnelcakeApiClient;
+    late _MockVideoEventService mockVideoEventService;
+    late _MockNostrClient mockNostrClient;
+
+    setUp(() {
+      mockFunnelcakeApiClient = _MockFunnelcakeApiClient();
+      mockVideoEventService = _MockVideoEventService();
+      mockNostrClient = _MockNostrClient();
+
+      when(
+        () => mockNostrClient.queryEvents(any()),
+      ).thenAnswer((_) async => []);
+      when(
+        () => mockVideoEventService.addVideoUpdateListener(any()),
+      ).thenReturn(
+        () {},
+      );
+      when(() => mockVideoEventService.addNewVideoListener(any())).thenReturn(
+        () {},
+      );
+      when(
+        () => mockVideoEventService.filterVideoList(any()),
+      ).thenAnswer((invocation) {
+        return invocation.positionalArguments.single as List<VideoEvent>;
+      });
+    });
+
+    ProviderContainer createContainer() {
+      final container = ProviderContainer(
+        overrides: [
+          funnelcakeApiClientProvider.overrideWithValue(
+            mockFunnelcakeApiClient,
+          ),
+          funnelcakeAvailableProvider.overrideWith(
+            _AlwaysAvailableFunnelcake.new,
+          ),
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          nostrServiceProvider.overrideWithValue(mockNostrClient),
+          profileFeedSessionCacheProvider.overrideWith(
+            (ref) => ProfileFeedSessionCache(),
+          ),
+          contentFilterVersionProvider.overrideWith((ref) => 0),
+          divineHostFilterVersionProvider.overrideWith((ref) => 0),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test(
+      'initial REST state keeps hasMoreContent true when a full page filters down',
+      () async {
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(pubkey: userId),
+        ).thenAnswer((_) async => _videoStats(count: 50, pubkey: userId));
+        when(
+          () => mockVideoEventService.filterVideoList(any()),
+        ).thenAnswer((invocation) {
+          final videos =
+              invocation.positionalArguments.single as List<VideoEvent>;
+          return videos.take(9).toList();
+        });
+
+        final container = createContainer();
+        await container.read(funnelcakeAvailableProvider.future);
+
+        final state = await container.read(profileFeedProvider(userId).future);
+
+        expect(state.videos.length, 9);
+        expect(state.hasMoreContent, isTrue);
+      },
+    );
+
+    test(
+      'REST refreshFromService marks hasMoreContent false when response is shorter than a page',
+      () async {
+        final responses = Queue<List<VideoStats>>()
+          ..add(_videoStats(count: 50, pubkey: userId))
+          ..add(_videoStats(count: 12, pubkey: userId));
+
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(pubkey: userId),
+        ).thenAnswer((_) async => responses.removeFirst());
+
+        final container = createContainer();
+        await container.read(funnelcakeAvailableProvider.future);
+        final notifier = container.read(profileFeedProvider(userId).notifier);
+
+        await container.read(profileFeedProvider(userId).future);
+
+        final completer = Completer<void>();
+        final subscription = container.listen<AsyncValue<VideoFeedState>>(
+          profileFeedProvider(userId),
+          (previous, next) {
+            final value = next.asData?.value;
+            if (value != null &&
+                value.videos.length == 12 &&
+                !completer.isCompleted) {
+              completer.complete();
+            }
+          },
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+
+        notifier.refreshFromService();
+        await completer.future;
+
+        final refreshedState = container
+            .read(profileFeedProvider(userId))
+            .requireValue;
+        expect(refreshedState.videos.length, 12);
+        expect(refreshedState.hasMoreContent, isFalse);
+      },
+    );
+
+    test(
+      'REST loadMore requests the next author page via offset and appends videos',
+      () async {
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(pubkey: userId),
+        ).thenAnswer((_) async => _videoStats(count: 50, pubkey: userId));
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(
+            pubkey: userId,
+            offset: 50,
+          ),
+        ).thenAnswer(
+          (_) async => _videoStats(count: 17, pubkey: userId, startIndex: 50),
+        );
+
+        final container = createContainer();
+        await container.read(funnelcakeAvailableProvider.future);
+        final notifier = container.read(profileFeedProvider(userId).notifier);
+
+        final initialState = await container.read(
+          profileFeedProvider(userId).future,
+        );
+        expect(initialState.videos.length, 50);
+        expect(initialState.hasMoreContent, isTrue);
+
+        await notifier.loadMore();
+
+        final updatedState = container
+            .read(profileFeedProvider(userId))
+            .requireValue;
+        expect(updatedState.videos.length, 67);
+        expect(updatedState.hasMoreContent, isFalse);
+
+        verify(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(
+            pubkey: userId,
+            offset: 50,
+          ),
+        ).called(1);
+      },
+    );
+  });
+}
+
+List<VideoStats> _videoStats({
+  required int count,
+  required String pubkey,
+  int startIndex = 0,
+}) {
+  final now = DateTime(2026, 3, 30, 12);
+
+  return List.generate(count, (index) {
+    final videoIndex = startIndex + index;
+    final createdAt = now.subtract(Duration(minutes: videoIndex));
+    return VideoStats(
+      id: 'video-$videoIndex',
+      pubkey: pubkey,
+      createdAt: createdAt,
+      kind: 22,
+      dTag: 'video-$videoIndex',
+      title: 'Video $videoIndex',
+      thumbnail: 'https://example.com/thumb-$videoIndex.jpg',
+      videoUrl: 'https://example.com/video-$videoIndex.mp4',
+      reactions: videoIndex,
+      comments: videoIndex,
+      reposts: videoIndex,
+      engagementScore: videoIndex,
+    );
+  });
+}

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -315,6 +315,43 @@ void main() {
     });
 
     group('navigation', () {
+      testWidgets('dispatches load more when conversation list scrolls', (
+        tester,
+      ) async {
+        final conversations = List.generate(
+          30,
+          (index) => DmConversation(
+            id: 'conv$index',
+            participantPubkeys: const [currentPubkey, otherPubkey],
+            isGroup: false,
+            createdAt: nowUnix - index,
+            lastMessageContent: 'Hello $index',
+            lastMessageTimestamp: nowUnix - index,
+          ),
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: ConversationListState(
+              status: ConversationListStatus.loaded,
+              conversations: conversations,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.text('Messages'));
+        await tester.pumpAndSettle();
+
+        await tester.drag(find.byType(ListView), const Offset(0, -5000));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        verify(
+          () => mockBloc.add(const ConversationListLoadMore()),
+        ).called(greaterThanOrEqualTo(1));
+      });
+
       testWidgets('calls push when a conversation is tapped', (
         tester,
       ) async {

--- a/mobile/test/screens/profile_grid_tap_navigation_test.dart
+++ b/mobile/test/screens/profile_grid_tap_navigation_test.dart
@@ -408,5 +408,151 @@ void main() {
 
       expect(profileFeed.loadMoreCallCount, 1);
     });
+
+    testWidgets(
+      'nested scroll profile grid triggers loadMore near bottom',
+      (tester) async {
+        final videos = List.generate(60, (index) {
+          final createdAt = nowUnix - index;
+          return VideoEvent(
+            id: 'nested-video-$index',
+            pubkey: testUserHex,
+            createdAt: createdAt,
+            content: 'Video $index',
+            timestamp: now.subtract(Duration(seconds: index)),
+            title: 'Nested Video $index',
+            videoUrl: 'https://example.com/v$index.mp4',
+          );
+        });
+
+        late _TestProfileFeed profileFeed;
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              authServiceProvider.overrideWithValue(
+                createTestAuthService('someone-else'),
+              ),
+              profileFeedProvider(testUserHex).overrideWith(() {
+                profileFeed = _TestProfileFeed(
+                  VideoFeedState(
+                    videos: videos,
+                    hasMoreContent: true,
+                  ),
+                );
+                return profileFeed;
+              }),
+            ],
+            child: BlocProvider<BackgroundPublishBloc>.value(
+              value: backgroundPublishBloc,
+              child: MaterialApp(
+                home: Scaffold(
+                  body: CustomScrollView(
+                    slivers: [
+                      const SliverToBoxAdapter(
+                        child: SizedBox(height: 200, child: Placeholder()),
+                      ),
+                      SliverToBoxAdapter(
+                        child: SizedBox(
+                          height: 600,
+                          child: ProfileVideosGrid(
+                            videos: videos,
+                            userIdHex: testUserHex,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(profileFeed.loadMoreCallCount, 0);
+
+        await tester.scrollUntilVisible(
+          find.bySemanticsLabel('Video thumbnail 60'),
+          800,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.pump();
+
+        expect(profileFeed.loadMoreCallCount, greaterThanOrEqualTo(1));
+      },
+    );
+
+    testWidgets(
+      'nested scroll profile grid does not trigger loadMore when hasMoreContent is false',
+      (tester) async {
+        final videos = List.generate(12, (index) {
+          final createdAt = nowUnix - index;
+          return VideoEvent(
+            id: 'short-video-$index',
+            pubkey: testUserHex,
+            createdAt: createdAt,
+            content: 'Video $index',
+            timestamp: now.subtract(Duration(seconds: index)),
+            title: 'Short Video $index',
+            videoUrl: 'https://example.com/v$index.mp4',
+          );
+        });
+
+        late _TestProfileFeed profileFeed;
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              authServiceProvider.overrideWithValue(
+                createTestAuthService('someone-else'),
+              ),
+              profileFeedProvider(testUserHex).overrideWith(() {
+                profileFeed = _TestProfileFeed(
+                  VideoFeedState(
+                    videos: videos,
+                    hasMoreContent: false,
+                  ),
+                );
+                return profileFeed;
+              }),
+            ],
+            child: BlocProvider<BackgroundPublishBloc>.value(
+              value: backgroundPublishBloc,
+              child: MaterialApp(
+                home: Scaffold(
+                  body: CustomScrollView(
+                    slivers: [
+                      const SliverToBoxAdapter(
+                        child: SizedBox(height: 200, child: Placeholder()),
+                      ),
+                      SliverToBoxAdapter(
+                        child: SizedBox(
+                          height: 600,
+                          child: ProfileVideosGrid(
+                            videos: videos,
+                            userIdHex: testUserHex,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Scroll to the end
+        final scrollable = find.byType(Scrollable).first;
+        await tester.drag(scrollable, const Offset(0, -3000));
+        await tester.pump();
+
+        expect(profileFeed.loadMoreCallCount, 0);
+      },
+    );
   });
 }

--- a/mobile/test/widgets/scroll_pagination_controller_test.dart
+++ b/mobile/test/widgets/scroll_pagination_controller_test.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/scroll_pagination_controller.dart';
+
+void main() {
+  group('ScrollPaginationController', () {
+    testWidgets(
+      'triggers load more near the bottom once per in-flight request',
+      (tester) async {
+        final scrollController = ScrollController();
+        final completer = Completer<void>();
+        var loadMoreCalls = 0;
+
+        late final ScrollPaginationController paginationController;
+        paginationController = ScrollPaginationController(
+          scrollController: scrollController,
+          canLoadMore: () => true,
+          onLoadMore: () {
+            loadMoreCalls++;
+            return completer.future;
+          },
+        );
+
+        addTearDown(() {
+          paginationController.dispose();
+          scrollController.dispose();
+        });
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: ListView.builder(
+              controller: scrollController,
+              itemCount: 100,
+              itemBuilder: (context, index) => SizedBox(
+                height: 80,
+                child: Text('Item $index'),
+              ),
+            ),
+          ),
+        );
+
+        expect(scrollController.hasClients, isTrue);
+        expect(scrollController.position.maxScrollExtent, greaterThan(0));
+
+        scrollController.jumpTo(
+          scrollController.position.maxScrollExtent - 100,
+        );
+        await tester.pump();
+
+        expect(loadMoreCalls, 1);
+
+        completer.complete();
+        await tester.pump();
+
+        scrollController.jumpTo(scrollController.position.maxScrollExtent);
+        await tester.pump();
+
+        expect(loadMoreCalls, 2);
+      },
+    );
+
+    testWidgets(
+      'does not trigger when hasMore is false or loading is blocked',
+      (tester) async {
+        final scrollController = ScrollController();
+        var canLoadMore = false;
+        var loadMoreCalls = 0;
+
+        late final ScrollPaginationController paginationController;
+        paginationController = ScrollPaginationController(
+          scrollController: scrollController,
+          canLoadMore: () => canLoadMore,
+          onLoadMore: () async {
+            loadMoreCalls++;
+          },
+        );
+
+        addTearDown(() {
+          paginationController.dispose();
+          scrollController.dispose();
+        });
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: ListView.builder(
+              controller: scrollController,
+              itemCount: 100,
+              itemBuilder: (context, index) => SizedBox(
+                height: 80,
+                child: Text('Item $index'),
+              ),
+            ),
+          ),
+        );
+
+        expect(scrollController.hasClients, isTrue);
+        expect(scrollController.position.maxScrollExtent, greaterThan(0));
+
+        scrollController.jumpTo(
+          scrollController.position.maxScrollExtent - 100,
+        );
+        await tester.pump();
+
+        expect(loadMoreCalls, 0);
+
+        canLoadMore = true;
+        scrollController.jumpTo(scrollController.position.maxScrollExtent);
+        await tester.pump();
+
+        expect(loadMoreCalls, 1);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #2611

## Summary
- Harden shared feed pagination with a reusable `ScrollPaginationController` and adopt it across profile, inbox, notification, discover list, classic vines, search, and composable grid feeds
- Wire the For You grid into load-more behavior and fix ProfileFeed REST has-more detection so filtered 50-item pages still paginate correctly
- Switch ProfileFeed from cursor-based to offset-based REST pagination
- Add regression coverage for the shared pagination controller, profile REST pagination contract, profile grid scrolling, and inbox scroll pagination

## Test Plan
- [x] `cd mobile && flutter test --no-pub test/widgets/scroll_pagination_controller_test.dart test/providers/profile_feed_pagination_contract_test.dart test/screens/profile_grid_tap_navigation_test.dart test/screens/inbox/inbox_view_test.dart`
- [x] `cd mobile && flutter analyze --no-pub lib/widgets/for_you_tab.dart lib/widgets/profile/profile_liked_grid.dart lib/widgets/profile/profile_reposts_grid.dart lib/widgets/profile/profile_collabs_grid.dart lib/widgets/profile/profile_comments_grid.dart lib/screens/inbox/inbox_view.dart lib/widgets/composable_video_grid.dart lib/widgets/profile/profile_videos_grid.dart lib/screens/notifications_screen.dart lib/widgets/classic_vines_tab.dart lib/widgets/user_search_view.dart lib/screens/discover_lists_screen.dart lib/providers/profile_feed_provider.dart`
- [x] Pre-push hook targeted changed-file test suite