### PR TITLE
refactor(divine_ui): deduplicate headerless VineBottomSheet drag handle spacing

### DIFF
--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
@@ -223,6 +223,19 @@ class VineBottomSheet extends StatelessWidget {
   }
 }
 
+/// Standalone drag handle shown when [VineBottomSheet.showHeader] is false.
+class _HeaderlessDragHandle extends StatelessWidget {
+  const _HeaderlessDragHandle();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.only(top: 8, bottom: 20),
+      child: Center(child: VineBottomSheetDragHandle()),
+    );
+  }
+}
+
 class _ScrollableContent extends StatelessWidget {
   const _ScrollableContent({
     required this.showHeader,
@@ -261,10 +274,7 @@ class _ScrollableContent extends StatelessWidget {
           )
         else
           // Drag handle only — content manages its own layout below
-          const Padding(
-            padding: EdgeInsets.only(top: 8, bottom: 20),
-            child: Center(child: VineBottomSheetDragHandle()),
-          ),
+          const _HeaderlessDragHandle(),
 
         // Scrollable content area (contentTitle is first element inside)
         Expanded(
@@ -343,10 +353,7 @@ class _FixedContent extends StatelessWidget {
             )
           else
             // Drag handle only
-            const Padding(
-              padding: EdgeInsets.only(top: 8, bottom: 20),
-              child: Center(child: VineBottomSheetDragHandle()),
-            ),
+            const _HeaderlessDragHandle(),
 
           // Fixed content area with minimum height for menu entries (2 × 56px)
           Flexible(


### PR DESCRIPTION
## Summary
- Extract the repeated `Padding` + `Center` + `VineBottomSheetDragHandle` tree (used in both `_ScrollableContent` and `_FixedContent` when `showHeader: false`) into a shared `_HeaderlessDragHandle` private widget
- Future sheet-chrome spacing tweaks now only need one edit instead of two

## Test plan
- [x] Existing `vine_bottom_sheet_test.dart` passes (15/15), including both `showHeader: false` tests for scrollable and fixed modes
- [x] `flutter analyze` clean
- [x] Pre-commit hooks pass

Closes #2613