### PR TITLE
test(upload): add BackgroundPublishBloc coordination tests

### DIFF
--- a/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
+++ b/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
@@ -134,12 +134,17 @@ void main() {
             ),
             const BackgroundPublishState(),
           ],
+          verify: (_) {
+            verify(
+              () => mockDraftStorageService.deleteDraft(draftId),
+            ).called(1);
+          },
         );
       });
 
       group('when the upload is a failure', () {
         blocTest(
-          'is kept on the uploads list',
+          'is kept on the uploads list and persists failed status',
           build: () => BackgroundPublishBloc(
             videoPublishServiceFactory: defaultVieoPublishServiceFactory,
             draftStorageService: mockDraftStorageService,
@@ -166,6 +171,15 @@ void main() {
               ],
             ),
           ],
+          verify: (_) {
+            verify(
+              () => mockDraftStorageService.updatePublishStatus(
+                draftId: draftId,
+                status: PublishStatus.failed,
+                publishError: 'ops',
+              ),
+            ).called(1);
+          },
         );
       });
 
@@ -364,6 +378,65 @@ void main() {
             ),
           ).called(1);
         },
+      );
+    });
+
+    group('BackgroundPublishFailed', () {
+      final draft = _MockVineDraft();
+
+      const draftId = '1';
+
+      setUp(() {
+        when(() => draft.id).thenReturn(draftId);
+      });
+
+      blocTest<BackgroundPublishBloc, BackgroundPublishState>(
+        'adds interrupted upload to state with error result',
+        build: () => BackgroundPublishBloc(
+          videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+          draftStorageService: mockDraftStorageService,
+        ),
+        act: (bloc) => bloc.add(
+          BackgroundPublishFailed(
+            draft: draft,
+            userMessage: 'This upload was interrupted.',
+          ),
+        ),
+        expect: () => [
+          BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(
+                draft: draft,
+                result: const PublishError('This upload was interrupted.'),
+                progress: 0,
+              ),
+            ],
+          ),
+        ],
+      );
+
+      blocTest<BackgroundPublishBloc, BackgroundPublishState>(
+        'does not duplicate when the same draft is already tracked',
+        build: () => BackgroundPublishBloc(
+          videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+          draftStorageService: mockDraftStorageService,
+        ),
+        seed: () => BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(
+              draft: draft,
+              result: const PublishError('Previous error'),
+              progress: 1.0,
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          BackgroundPublishFailed(
+            draft: draft,
+            userMessage: 'This upload was interrupted.',
+          ),
+        ),
+        expect: () => <BackgroundPublishState>[],
       );
     });
 


### PR DESCRIPTION
## Summary
- Adds `BackgroundPublishFailed` event tests — the coordination point between `resumePendingPublishes` and the bloc that was previously untested
- Verifies `DraftStorageService.deleteDraft` is called on successful publish
- Verifies `DraftStorageService.updatePublishStatus` persists failed status with error message
- Verifies deduplication: re-firing `BackgroundPublishFailed` for an already-tracked draft emits no new state

## Context
PR #2607 removed silent auto-resume and made the bottom sheet the sole recovery path, closing the race condition described in #2612. This PR completes the issue's "done when" by covering the coordination flow with tests.

## Test plan
- [x] `BackgroundPublishFailed` adds interrupted upload to state with error result
- [x] `BackgroundPublishFailed` deduplicates when same draft is already tracked
- [x] `BackgroundPublishRequested` success verifies `deleteDraft` side effect
- [x] `BackgroundPublishRequested` failure verifies `updatePublishStatus` side effect
- [x] All 18 BackgroundPublishBloc tests pass
- [x] Pre-commit hooks pass

Closes #2612