### PR TITLE
style(share): restore const list literals for short-video kind queries

### DIFF
--- a/mobile/lib/repositories/sounds_repository.dart
+++ b/mobile/lib/repositories/sounds_repository.dart
@@ -289,7 +289,7 @@ class SoundsRepository {
       // Query for Kind 34236 video events that reference this audio event
       final result = await _nostrClient.countEvents([
         Filter(
-          kinds: [NIP71VideoKinds.addressableShortVideo],
+          kinds: const [NIP71VideoKinds.addressableShortVideo],
           e: [audioEventId], // Events referencing this audio
         ),
       ]);
@@ -332,7 +332,7 @@ class SoundsRepository {
     try {
       final events = await _nostrClient.queryEvents([
         Filter(
-          kinds: [NIP71VideoKinds.addressableShortVideo],
+          kinds: const [NIP71VideoKinds.addressableShortVideo],
           e: [audioEventId],
           limit: limit,
         ),

--- a/mobile/lib/screens/relay_diagnostic_screen.dart
+++ b/mobile/lib/screens/relay_diagnostic_screen.dart
@@ -118,7 +118,7 @@ class _RelayDiagnosticScreenState extends ConsumerState<RelayDiagnosticScreen> {
         try {
           final videoEvents = await nostrService.queryEvents([
             nostr.Filter(
-              kinds: [NIP71VideoKinds.addressableShortVideo],
+              kinds: const [NIP71VideoKinds.addressableShortVideo],
               limit: 10,
             ),
           ]);
@@ -433,7 +433,7 @@ class _RelayDiagnosticScreenState extends ConsumerState<RelayDiagnosticScreen> {
       // Query for video events directly from relay
       final videoEvents = await nostrService.queryEvents([
         nostr.Filter(
-          kinds: [NIP71VideoKinds.addressableShortVideo],
+          kinds: const [NIP71VideoKinds.addressableShortVideo],
           limit: 100,
         ),
       ]);

--- a/mobile/lib/scripts/bulk_thumbnail_generator.dart
+++ b/mobile/lib/scripts/bulk_thumbnail_generator.dart
@@ -165,7 +165,7 @@ Examples:
 
       // Create filter for video events
       final filter = Filter(
-        kinds: [NIP71VideoKinds.addressableShortVideo],
+        kinds: const [NIP71VideoKinds.addressableShortVideo],
         limit: limit,
       );
 


### PR DESCRIPTION
## Summary
- Restores `const` on list literals containing `NIP71VideoKinds.addressableShortVideo` that lost the annotation during #2596
- Adds `const` to two additional sites in `relay_diagnostic_screen.dart` and `bulk_thumbnail_generator.dart` for consistency
- No behavioral change — purely avoids unnecessary allocations

## Files Changed
- `sounds_repository.dart` — 2 sites (const restored)
- `relay_diagnostic_screen.dart` — 2 sites (const added)
- `bulk_thumbnail_generator.dart` — 1 site (const added)

## Test plan
- [x] `flutter analyze` passes on all three files
- [x] Pre-commit hooks pass (format + analyze)
- No test changes needed — behavior is identical

Closes #2614