### PR TITLE
refactor(nostr): replace remaining raw 34236/34235 literals with NIP71VideoKinds constants

### DIFF
--- a/mobile/lib/screens/inbox/conversation/widgets/video_link_preview_cubit.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/video_link_preview_cubit.dart
@@ -79,7 +79,7 @@ class VideoLinkPreviewCubit extends Cubit<VideoLinkPreviewState> {
       if (event == null) {
         final results = await _nostrClient.queryEvents([
           Filter(
-            kinds: [NIP71VideoKinds.addressableShortVideo],
+            kinds: const [NIP71VideoKinds.addressableShortVideo],
             d: [_videoStableId],
             limit: 1,
           ),

--- a/mobile/lib/services/curation_service.dart
+++ b/mobile/lib/services/curation_service.dart
@@ -166,7 +166,7 @@ class CurationService {
 
       // Subscribe to fetch videos from Divine Team authors
       final filter = Filter(
-        kinds: [34236], // NIP-71 video events
+        kinds: const [NIP71VideoKinds.addressableShortVideo],
         authors: AppConstants.divineTeamPubkeys,
         limit: 500, // Get all their videos
       );

--- a/mobile/lib/services/event_router.dart
+++ b/mobile/lib/services/event_router.dart
@@ -99,7 +99,7 @@ class EventRouter {
         break;
 
       case 6: // Reposts
-      case 34236: // Videos
+      case NIP71VideoKinds.addressableShortVideo: // Videos
         // Already in events table, queryable via DAO
         break;
 

--- a/mobile/lib/services/notification_target_resolver.dart
+++ b/mobile/lib/services/notification_target_resolver.dart
@@ -1,3 +1,4 @@
+import 'package:models/models.dart' show NIP71VideoKinds;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/services/video_event_service.dart';
 
@@ -24,7 +25,9 @@ class NotificationTargetResolver {
       return null;
     }
 
-    if (event.kind == 22 || event.kind == 34235 || event.kind == 34236) {
+    if (event.kind == NIP71VideoKinds.shortVideo ||
+        event.kind == NIP71VideoKinds.addressableNormalVideo ||
+        event.kind == NIP71VideoKinds.addressableShortVideo) {
       return targetId;
     }
 

--- a/mobile/lib/services/social_service.dart
+++ b/mobile/lib/services/social_service.dart
@@ -832,8 +832,8 @@ class SocialService {
           ['k', '7'], // Request deletion of Kind 7 (reaction) events
           [
             'k',
-            '34236',
-          ], // Request deletion of Kind 34236 (addressable short video) events per NIP-71
+            '${NIP71VideoKinds.addressableShortVideo}',
+          ], // Request deletion of addressable short video events per NIP-71
         ],
       );
 

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -1896,9 +1896,10 @@ class VideoEventService extends ChangeNotifier {
     SubscriptionType subscriptionType,
     Event originalEvent,
   ) {
-    // Check if this is a replaceable event (kinds 34235, 34236 are parameterized replaceable)
+    // Check if this is a replaceable event (parameterized replaceable kinds)
     final isReplaceable =
-        originalEvent.kind == 34235 || originalEvent.kind == 34236;
+        originalEvent.kind == NIP71VideoKinds.addressableNormalVideo ||
+        originalEvent.kind == NIP71VideoKinds.addressableShortVideo;
 
     if (!isReplaceable) {
       return true; // Not replaceable, allow normal processing
@@ -5506,7 +5507,10 @@ class VideoEventService extends ChangeNotifier {
       );
 
       final directQueryEvents = await _nostrService.queryEvents([
-        Filter(kinds: [34236], limit: 100),
+        Filter(
+          kinds: const [NIP71VideoKinds.addressableShortVideo],
+          limit: 100,
+        ),
       ]);
 
       Log.warning(

--- a/mobile/lib/services/view_event_publisher.dart
+++ b/mobile/lib/services/view_event_publisher.dart
@@ -118,10 +118,11 @@ class ViewEventPublisher {
 
     try {
       // Build the addressable coordinate (a tag)
-      // Format: "34236:author_pubkey:d_tag"
+      // Format: "<kind>:author_pubkey:d_tag"
       // Use event ID as fallback if vineId (d-tag) is null
       final dTag = video.vineId ?? video.id;
-      final aTag = '34236:${video.pubkey}:$dTag';
+      final aTag =
+          '${NIP71VideoKinds.addressableShortVideo}:${video.pubkey}:$dTag';
 
       // Get relay hint
       String relayHint = _defaultRelayHint;
@@ -248,7 +249,8 @@ class ViewEventPublisher {
 
     try {
       final dTag = video.vineId ?? video.id;
-      final aTag = '34236:${video.pubkey}:$dTag';
+      final aTag =
+          '${NIP71VideoKinds.addressableShortVideo}:${video.pubkey}:$dTag';
 
       String relayHint = _defaultRelayHint;
       if (_nostrService.connectedRelays.isNotEmpty) {


### PR DESCRIPTION
## Summary
- Replaces all remaining raw `34236`/`34235`/`22` kind literals with named `NIP71VideoKinds` constants, completing the work started in #2596
- Adds `const` to list literals where applicable
- Adds missing `NIP71VideoKinds` import to `notification_target_resolver.dart`

## Changes by category

**Filter lists** (raw literal → named constant + `const`):
- `curation_service.dart` — `kinds: [34236]` → `const [NIP71VideoKinds.addressableShortVideo]`
- `video_event_service.dart:5509` — same pattern
- `video_link_preview_cubit.dart` — added missing `const`

**Switch/comparisons** (raw literal → named constant):
- `event_router.dart` — `case 34236:` → `case NIP71VideoKinds.addressableShortVideo:`
- `notification_target_resolver.dart` — `event.kind == 22 || ... == 34235 || ... == 34236` → named constants
- `video_event_service.dart:1901` — `originalEvent.kind == 34235 || ... == 34236` → named constants

**String construction** (a-tags, k-tags):
- `view_event_publisher.dart` — 2 sites: `'34236:...'` → `'${NIP71VideoKinds.addressableShortVideo}:...'`
- `social_service.dart` — deletion k-tag `'34236'` → interpolated constant

## Test plan
- [x] `flutter analyze` passes on all 7 changed files
- [x] Pre-commit hooks pass (format + analyze)
- No test changes needed — all changes are identifier substitutions with identical runtime values

Closes #2618