### PR TITLE
fix(mobile): route ProofMode uploads through PUT

### DIFF
--- a/mobile/lib/services/blossom_upload_service.dart
+++ b/mobile/lib/services/blossom_upload_service.dart
@@ -1039,13 +1039,18 @@ class BlossomUploadService {
           final capability = await _fetchDivineUploadCapability(serverUrl);
           final hasProofModeData =
               proofManifestJson != null && proofManifestJson.isNotEmpty;
-          final useResumable = capability.supportsResumable;
+          final useResumable =
+              capability.supportsResumable && !hasProofModeData;
 
           if (useResumable) {
             Log.info(
-              hasProofModeData
-                  ? 'Using Divine resumable upload flow for $serverUrl with ProofMode metadata on completion'
-                  : 'Using Divine resumable upload flow for $serverUrl',
+              'Using Divine resumable upload flow for $serverUrl',
+              name: 'BlossomUploadService',
+              category: LogCategory.video,
+            );
+          } else if (hasProofModeData) {
+            Log.info(
+              'Using legacy Blossom PUT upload for $serverUrl with ProofMode metadata',
               name: 'BlossomUploadService',
               category: LogCategory.video,
             );

--- a/mobile/test/integration/blossom_resumable_upload_integration_test.dart
+++ b/mobile/test/integration/blossom_resumable_upload_integration_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Integration-style coverage for the Divine resumable Blossom upload flow
 // ABOUTME: Verifies capability discovery, opaque uploadUrl handling, and canonical completion URLs
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dio/dio.dart';
@@ -198,7 +199,7 @@ void main() {
   );
 
   test(
-    'Divine resumable uploads keep ProofMode metadata on the completion request',
+    'Divine ProofMode uploads stay on the legacy PUT path even when resumable is advertised',
     () async {
       SharedPreferences.setMockInitialValues({});
 
@@ -273,41 +274,7 @@ void main() {
           data: any(named: 'data'),
           options: any(named: 'options'),
         ),
-      ).thenAnswer((invocation) async {
-        final url = invocation.positionalArguments.first as String;
-        final options = invocation.namedArguments[#options] as Options;
-        final data = invocation.namedArguments[#data];
-
-        if (url.endsWith('/upload/init')) {
-          return Response(
-            requestOptions: RequestOptions(path: '/upload/init'),
-            statusCode: 200,
-            data: {
-              'uploadId': 'up_123',
-              'uploadUrl': 'https://upload.divine.video/sessions/up_123',
-              'chunkSize': 4,
-              'nextOffset': 0,
-              'requiredHeaders': {'Authorization': 'Bearer session-token'},
-            },
-          );
-        }
-
-        if (url.endsWith('/upload/up_123/complete')) {
-          expect(options.headers?['X-ProofMode-Manifest'], isNotNull);
-          expect(data, isA<Map>());
-          expect((data as Map)['sha256'], isNotEmpty);
-          return Response(
-            requestOptions: RequestOptions(path: '/upload/up_123/complete'),
-            statusCode: 200,
-            data: {
-              'url': 'https://media.divine.video/final',
-              'fallbackUrl': 'https://media.divine.video/final',
-            },
-          );
-        }
-
-        throw StateError('Unexpected POST url: $url');
-      });
+      ).thenThrow(StateError('Unexpected POST request for ProofMode PUT flow'));
 
       when(
         () => mockDio.put(
@@ -317,34 +284,26 @@ void main() {
           onSendProgress: any(named: 'onSendProgress'),
         ),
       ).thenAnswer((invocation) async {
+        final url = invocation.positionalArguments.first as String;
         final options = invocation.namedArguments[#options] as Options;
+
+        expect(url, equals('https://media.divine.video/upload'));
         expect(
           options.headers?['Authorization'],
-          equals('Bearer session-token'),
+          isNotNull,
         );
         expect(
           options.headers?['X-ProofMode-Manifest'],
-          isNull,
+          equals(base64.encode(utf8.encode(proofManifest))),
         );
-        expect(
-          invocation.positionalArguments.first,
-          equals('https://upload.divine.video/sessions/up_123'),
-        );
-
-        final contentRange = options.headers?['Content-Range'] as String;
-        final nextOffset = switch (contentRange) {
-          'bytes 0-3/10' => '4',
-          'bytes 4-7/10' => '8',
-          'bytes 8-9/10' => '10',
-          _ => throw StateError('Unexpected content range: $contentRange'),
-        };
 
         return Response(
-          requestOptions: RequestOptions(path: '/sessions/up_123'),
-          statusCode: 204,
-          headers: Headers.fromMap({
-            DivineUploadHeaders.uploadOffset: [nextOffset],
-          }),
+          requestOptions: RequestOptions(path: '/upload'),
+          statusCode: 200,
+          data: {
+            'url': 'https://media.divine.video/final',
+            'fallbackUrl': 'https://media.divine.video/final',
+          },
         );
       });
 
@@ -364,12 +323,7 @@ void main() {
         result.cdnUrl,
         equals('https://media.divine.video/${result.videoId}'),
       );
-      expect(sessionUpdates.map((session) => session.nextOffset), [
-        0,
-        4,
-        8,
-        10,
-      ]);
+      expect(sessionUpdates, isEmpty);
 
       await tempDir.delete(recursive: true);
     },

--- a/mobile/test/services/blossom_upload_service_test.dart
+++ b/mobile/test/services/blossom_upload_service_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for BlossomUploadService verifying NIP-98 auth and multi-server support
 // ABOUTME: Tests configuration persistence, server selection, and upload flow
 
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -598,7 +599,7 @@ void main() {
       );
 
       test(
-        'uses resumable upload when ProofMode data is present and sends ProofMode headers on complete',
+        'uses legacy PUT upload when ProofMode data is present even if resumable is supported',
         () async {
           const testPublicKey =
               '0223456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
@@ -654,50 +655,9 @@ void main() {
               data: any(named: 'data'),
               options: any(named: 'options'),
             ),
-          ).thenAnswer((invocation) async {
-            final url = invocation.positionalArguments.first as String;
-            final options = invocation.namedArguments[#options] as Options;
-            final data = invocation.namedArguments[#data];
-
-            if (url == 'https://media.divine.video/upload/init') {
-              expect(
-                options.headers?['Authorization'],
-                isNotNull,
-              );
-              return Response(
-                requestOptions: RequestOptions(path: '/upload/init'),
-                statusCode: 200,
-                data: {
-                  'uploadId': 'up_proof',
-                  'uploadUrl': 'https://upload.divine.video/sessions/up_proof',
-                  'chunkSize': 5,
-                  'nextOffset': 0,
-                  'requiredHeaders': {'Authorization': 'Bearer session-token'},
-                },
-              );
-            }
-
-            if (url == 'https://media.divine.video/upload/up_proof/complete') {
-              expect(
-                options.headers?['X-ProofMode-Manifest'],
-                isNotNull,
-              );
-              expect(data, isA<Map>());
-              expect((data as Map)['sha256'], isNotEmpty);
-              return Response(
-                requestOptions: RequestOptions(
-                  path: '/upload/up_proof/complete',
-                ),
-                statusCode: 200,
-                data: {
-                  'url': 'https://media.divine.video/final',
-                  'fallbackUrl': 'https://media.divine.video/final',
-                },
-              );
-            }
-
-            throw StateError('Unexpected POST url: $url');
-          });
+          ).thenThrow(
+            StateError('Unexpected POST request for ProofMode PUT flow'),
+          );
 
           when(
             () => mockDio.put(
@@ -710,25 +670,23 @@ void main() {
             final url = invocation.positionalArguments.first as String;
             final options = invocation.namedArguments[#options] as Options;
 
-            expect(
-              url,
-              equals('https://upload.divine.video/sessions/up_proof'),
-            );
+            expect(url, equals('https://media.divine.video/upload'));
             expect(
               options.headers?['Authorization'],
-              equals('Bearer session-token'),
+              isNotNull,
             );
             expect(
               options.headers?['X-ProofMode-Manifest'],
-              isNull,
+              equals(base64.encode(utf8.encode(proofManifest))),
             );
 
             return Response(
-              requestOptions: RequestOptions(path: '/sessions/up_proof'),
-              statusCode: 204,
-              headers: Headers.fromMap({
-                DivineUploadHeaders.uploadOffset: ['5'],
-              }),
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              data: {
+                'url': 'https://media.divine.video/final',
+                'fallbackUrl': 'https://media.divine.video/final',
+              },
             );
           });
 
@@ -744,37 +702,30 @@ void main() {
           expect(result.success, isTrue);
 
           verify(
-            () => mockDio.post(
-              'https://media.divine.video/upload/init',
-              data: any(named: 'data'),
-              options: any(named: 'options'),
-            ),
-          ).called(1);
-          verify(
             () => mockDio.put(
-              'https://upload.divine.video/sessions/up_proof',
+              'https://media.divine.video/upload',
               data: any(named: 'data'),
               options: any(named: 'options'),
               onSendProgress: any(named: 'onSendProgress'),
             ),
           ).called(1);
-          verify(
+          verifyNever(
+            () => mockDio.post(
+              'https://media.divine.video/upload/init',
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+            ),
+          );
+          verifyNever(
             () => mockDio.post(
               'https://media.divine.video/upload/up_proof/complete',
               data: any(named: 'data'),
-              options: any(
-                named: 'options',
-                that: isA<Options>().having(
-                  (opts) => opts.headers?['X-ProofMode-Manifest'],
-                  'X-ProofMode-Manifest',
-                  isNotNull,
-                ),
-              ),
+              options: any(named: 'options'),
             ),
-          ).called(1);
+          );
           verifyNever(
             () => mockDio.put(
-              'https://media.divine.video/upload',
+              'https://upload.divine.video/sessions/up_proof',
               data: any(named: 'data'),
               options: any(named: 'options'),
               onSendProgress: any(named: 'onSendProgress'),


### PR DESCRIPTION
## Summary
- route ProofMode uploads through the legacy `PUT /upload` path even when Divine advertises resumable support
- keep resumable uploads enabled for non-ProofMode uploads
- add regression coverage for ProofMode routing in service and integration tests

## Why
Prod is no longer the missing rollout here: `divine-upload-server` is already on `6029669`, but `mobile/main` still sends ProofMode uploads through the older resumable `/complete` path. This hotfix removes that risk for beta testers and matches the current safe prod traffic pattern.

## Testing
- flutter test test/services/blossom_upload_service_test.dart --plain-name "uses legacy PUT upload when ProofMode data is present even if resumable is supported"
- flutter test test/integration/blossom_resumable_upload_integration_test.dart --plain-name "Divine ProofMode uploads stay on the legacy PUT path even when resumable is advertised"
- pre-push hook: changed-file upload test suite