### PR TITLE
fix(funnelcake): send rest requests to api.divine.video

### DIFF
--- a/docs/superpowers/plans/2026-03-31-funnelcake-rest-api-host.md
+++ b/docs/superpowers/plans/2026-03-31-funnelcake-rest-api-host.md
@@ -1,0 +1,87 @@
+# Funnelcake REST API Host Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Send Funnelcake REST requests to `https://api.divine.video` without changing websocket/Nostr relay hosts.
+
+**Architecture:** Keep websocket relay configuration untouched in `EnvironmentConfig.relayUrl`, but make Funnelcake REST resolution explicit in the production environment fallback and in the helper that derives REST hosts from configured relay URLs. Cover the behavior with small focused tests first.
+
+**Tech Stack:** Flutter, Dart, flutter_test
+
+---
+
+## Chunk 1: Reproduce The REST Host Mismatch
+
+### Task 1: Add failing tests for the production REST host
+
+**Files:**
+- Modify: `mobile/test/models/environment_config_test.dart`
+- Create: `mobile/test/utils/relay_url_utils_test.dart`
+- Test: `mobile/test/models/environment_config_test.dart`
+- Test: `mobile/test/utils/relay_url_utils_test.dart`
+
+- [ ] **Step 1: Write the failing tests**
+
+```dart
+expect(config.apiBaseUrl, 'https://api.divine.video');
+expect(
+  resolveApiBaseUrlFromRelays(
+    configuredRelays: ['wss://relay.divine.video'],
+    fallbackBaseUrl: 'https://api.divine.video',
+  ),
+  'https://api.divine.video',
+);
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `flutter test test/models/environment_config_test.dart test/utils/relay_url_utils_test.dart`
+Expected: FAIL because production and relay-derived Funnelcake URLs still point
+to `https://relay.divine.video`
+
+## Chunk 2: Point Funnelcake REST At The API Host
+
+### Task 2: Implement the minimal REST host change
+
+**Files:**
+- Modify: `mobile/lib/models/environment_config.dart`
+- Modify: `mobile/lib/utils/relay_url_utils.dart`
+- Modify: `mobile/test/models/environment_config_test.dart`
+- Create: `mobile/test/utils/relay_url_utils_test.dart`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dart
+// Return https://api.divine.video for production Funnelcake REST traffic and
+// special-case relay.divine.video in the Funnelcake URL resolver.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `flutter test test/models/environment_config_test.dart test/utils/relay_url_utils_test.dart`
+Expected: PASS
+
+### Task 3: Re-run dependent provider coverage
+
+**Files:**
+- Modify: `mobile/lib/models/environment_config.dart`
+- Modify: `mobile/lib/utils/relay_url_utils.dart`
+- Test: `mobile/test/providers/funnelcake_available_provider_test.dart`
+- Test: `mobile/test/providers/relay_notification_api_service_provider_test.dart`
+
+- [ ] **Step 5: Run targeted verification**
+
+Run: `flutter test test/providers/funnelcake_available_provider_test.dart test/providers/relay_notification_api_service_provider_test.dart`
+Expected: PASS
+
+- [ ] **Step 6: Review diff and commit**
+
+```bash
+git add docs/superpowers/specs/2026-03-31-funnelcake-rest-api-host-design.md \
+        docs/superpowers/plans/2026-03-31-funnelcake-rest-api-host.md \
+        mobile/lib/models/environment_config.dart \
+        mobile/lib/utils/relay_url_utils.dart \
+        mobile/test/models/environment_config_test.dart \
+        mobile/test/utils/relay_url_utils_test.dart
+git commit -m "fix(funnelcake): send rest requests to api.divine.video"
+```

--- a/docs/superpowers/specs/2026-03-31-funnelcake-rest-api-host-design.md
+++ b/docs/superpowers/specs/2026-03-31-funnelcake-rest-api-host-design.md
@@ -1,0 +1,47 @@
+# Funnelcake REST API Host Design
+
+**Date:** 2026-03-31
+**Status:** Approved
+
+## Goal
+
+Route Funnelcake REST requests to `https://api.divine.video` while keeping
+websocket and Nostr traffic on `wss://relay.divine.video`.
+
+## Current Behavior
+
+- Production `EnvironmentConfig.apiBaseUrl` derives directly from
+  `relayUrl`, which currently produces `https://relay.divine.video`.
+- Funnelcake REST providers also resolve a base URL from configured relay URLs
+  through `relay_url_utils.dart`.
+- When the active relay list includes `wss://relay.divine.video`, Funnelcake
+  REST traffic continues to use the relay host instead of the new Fastly-backed
+  API host.
+
+## Chosen Approach
+
+Keep the relay websocket host unchanged and make the REST host explicit only
+where Funnelcake base URLs are resolved.
+
+- Change production `EnvironmentConfig.apiBaseUrl` to return
+  `https://api.divine.video`.
+- Update the Funnelcake relay-to-HTTP helper so
+  `wss://relay.divine.video` resolves to `https://api.divine.video`.
+- Leave generic websocket relay URLs untouched so Nostr traffic keeps using
+  `wss://relay.divine.video`.
+
+## Why This Approach
+
+- It fixes both code paths that currently choose the REST base URL.
+- It avoids broad host rewriting for unrelated websocket behavior.
+- It keeps staging, test, local, and relay notification behavior aligned with
+  their existing hosts.
+
+## Testing
+
+- Update environment config tests to assert production REST traffic uses
+  `https://api.divine.video`.
+- Add focused URL resolution tests for the Funnelcake helper so divine relay
+  URLs map to the API host while non-divine relays still derive normally.
+- Re-run the existing provider tests that exercise Funnelcake availability and
+  relay notification base URL selection.

--- a/mobile/lib/models/environment_config.dart
+++ b/mobile/lib/models/environment_config.dart
@@ -10,6 +10,7 @@ const localRelayPort = 47777;
 const localApiPort = 43001;
 const localBlossomPort = 43003;
 const localInvitePort = 43004;
+const productionApiBaseUrl = 'https://api.divine.video';
 
 /// Build-time default environment
 /// Set via: --dart-define=DEFAULT_ENV=STAGING
@@ -68,10 +69,14 @@ class EnvironmentConfig {
   /// Get REST API base URL (FunnelCake REST API)
   ///
   /// For local environment, the API runs on a separate port from the relay.
-  /// For all other environments, derives from relayUrl to stay in sync.
+  /// Production uses the Fastly-backed API host while other environments
+  /// derive from the relay URL to stay in sync.
   String get apiBaseUrl {
     if (environment == AppEnvironment.local) {
       return 'http://$localHost:$localApiPort';
+    }
+    if (environment == AppEnvironment.production) {
+      return productionApiBaseUrl;
     }
     final url = relayUrl;
     if (url.startsWith('wss://')) {

--- a/mobile/lib/utils/relay_url_utils.dart
+++ b/mobile/lib/utils/relay_url_utils.dart
@@ -1,6 +1,9 @@
 // ABOUTME: Helpers for resolving API base URLs from Nostr relay WebSocket URLs.
 // ABOUTME: Keeps REST endpoints aligned with active relay configuration.
 
+const _divineRelayHost = 'relay.divine.video';
+const _divineApiBaseUrl = 'https://api.divine.video';
+
 /// Convert a relay WebSocket URL to an HTTP(S) base URL.
 ///
 /// Examples:
@@ -25,7 +28,7 @@ String relayWsToHttpBase(String relayUrl) {
 String resolveApiBaseUrlFromRelays({
   required List<String> configuredRelays,
   required String fallbackBaseUrl,
-  String preferredRelayHost = 'relay.divine.video',
+  String preferredRelayHost = _divineRelayHost,
 }) {
   if (configuredRelays.isEmpty) return fallbackBaseUrl;
 
@@ -38,6 +41,11 @@ String resolveApiBaseUrlFromRelays({
       ? preferred.first
       : configuredRelays.first;
 
+  final selectedHost = Uri.tryParse(selectedRelay)?.host.toLowerCase();
+  if (selectedHost == _divineRelayHost) {
+    return _divineApiBaseUrl;
+  }
+
   return relayWsToHttpBase(selectedRelay);
 }
 
@@ -49,7 +57,7 @@ String resolveApiBaseUrlFromRelays({
 String resolvePinnedApiBaseUrlFromRelays({
   required List<String> configuredRelays,
   required String fallbackBaseUrl,
-  String pinnedRelayHost = 'relay.divine.video',
+  String pinnedRelayHost = _divineRelayHost,
 }) {
   final pinnedRelay = configuredRelays.where((url) {
     final host = Uri.tryParse(url)?.host.toLowerCase();

--- a/mobile/test/models/environment_config_test.dart
+++ b/mobile/test/models/environment_config_test.dart
@@ -47,8 +47,6 @@ void main() {
     });
 
     group('apiBaseUrl', () {
-      // apiBaseUrl is derived from relayUrl by converting wss:// to https://
-      // This ensures the API URL always matches the relay being used
       test('poc derives from relay URL', () {
         const config = EnvironmentConfig(environment: AppEnvironment.poc);
         expect(config.apiBaseUrl, 'https://relay.poc.dvines.org');
@@ -69,11 +67,11 @@ void main() {
         expect(config.apiBaseUrl, 'http://10.0.2.2:43001');
       });
 
-      test('production derives from relay URL', () {
+      test('production uses api.divine.video for Funnelcake REST', () {
         const config = EnvironmentConfig(
           environment: AppEnvironment.production,
         );
-        expect(config.apiBaseUrl, 'https://relay.divine.video');
+        expect(config.apiBaseUrl, 'https://api.divine.video');
       });
     });
 

--- a/mobile/test/utils/relay_url_utils_test.dart
+++ b/mobile/test/utils/relay_url_utils_test.dart
@@ -1,0 +1,38 @@
+// ABOUTME: Tests Funnelcake REST URL resolution from configured relay URLs.
+// ABOUTME: Keeps divine websocket relay host separate from the Fastly REST host.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/relay_url_utils.dart';
+
+void main() {
+  group('relayWsToHttpBase', () {
+    test('keeps generic relay host conversion unchanged', () {
+      expect(
+        relayWsToHttpBase('wss://relay.divine.video'),
+        'https://relay.divine.video',
+      );
+    });
+  });
+
+  group('resolveApiBaseUrlFromRelays', () {
+    test('maps relay.divine.video to api.divine.video for REST', () {
+      expect(
+        resolveApiBaseUrlFromRelays(
+          configuredRelays: const ['wss://relay.divine.video'],
+          fallbackBaseUrl: 'https://api.divine.video',
+        ),
+        'https://api.divine.video',
+      );
+    });
+
+    test('uses the first configured non-divine relay when needed', () {
+      expect(
+        resolveApiBaseUrlFromRelays(
+          configuredRelays: const ['wss://relay.staging.dvines.org'],
+          fallbackBaseUrl: 'https://relay.staging.dvines.org',
+        ),
+        'https://relay.staging.dvines.org',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #2640

## Summary
- send production Funnelcake REST traffic to `https://api.divine.video`
- map `wss://relay.divine.video` to the API host only in Funnelcake REST resolution
- add focused tests for environment and relay-derived REST URL selection

## Test Plan
- [x] `flutter test test/models/environment_config_test.dart test/utils/relay_url_utils_test.dart test/providers/funnelcake_available_provider_test.dart test/providers/relay_notification_api_service_provider_test.dart`
- [x] pre-commit hook: formatter + analyzer
- [x] pre-push hook: targeted changed-file tests
