### PR TITLE
fix(test): await startUpload future in serialization test to prevent async leak

### DIFF
--- a/mobile/test/services/upload_manager_resumable_upload_test.dart
+++ b/mobile/test/services/upload_manager_resumable_upload_test.dart
@@ -248,12 +248,14 @@ void main() {
           return uploadCompleter.future;
         });
 
-        unawaited(
-          uploadManager.startUpload(
-            videoFile: videoFile,
-            nostrPubkey: 'test-pubkey',
-            title: 'Serialization test',
-          ),
+        // Start the upload — startUpload blocks until the upload completes,
+        // but we need to interact with the callback mid-upload so we don't
+        // await yet. We await uploadFuture at the end so the full
+        // post-upload logic finishes before tearDown disposes the manager.
+        final uploadFuture = uploadManager.startUpload(
+          videoFile: videoFile,
+          nostrPubkey: 'test-pubkey',
+          title: 'Serialization test',
         );
 
         await TestHelpers.waitForCondition(
@@ -296,6 +298,8 @@ void main() {
         );
         expect(persisted.uploadProgress, closeTo(expectedProgress, 0.001));
 
+        // Complete the upload future and await the full startUpload so
+        // post-upload logic finishes before tearDown disposes the manager.
         uploadCompleter.complete(
           const BlossomUploadResult(
             success: true,
@@ -304,6 +308,7 @@ void main() {
             fallbackUrl: 'https://media.divine.video/video-serial',
           ),
         );
+        await uploadFuture;
       },
     );
 


### PR DESCRIPTION
Closes #2650

## Summary
- Fixes async leak in the resumable upload serialization test where `unawaited(startUpload(...))` caused the upload future to outlive the test, triggering spurious "test failed after it had already completed" errors
- Captures the future and awaits it after completing the upload so post-upload logic finishes before `tearDown` disposes the manager

Extracted from #2626 (closed — the bounded resume method was dead code per review from @ryzizub and @hm21).

## Test plan
- [x] `flutter test test/services/upload_manager_resumable_upload_test.dart` — all 11 tests pass
- [x] `flutter analyze` clean
- [x] Pre-commit hooks pass