### PR TITLE
fix(dm): show unread count on message requests badge instead of total count

### DIFF
--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -286,15 +286,16 @@ class _ConversationListState extends ConsumerState<_ConversationList>
         .select<ConversationListBloc, List<DmConversation>>(
           (bloc) => bloc.state.conversations,
         );
-    final requestConversations = context
-        .select<ConversationListBloc, List<DmConversation>>(
-          (bloc) => bloc.state.requestConversations,
-        );
+    final hasRequests = context.select<ConversationListBloc, bool>(
+      (bloc) => bloc.state.requestConversations.isNotEmpty,
+    );
+    final requestUnreadCount = context.select<ConversationListBloc, int>(
+      (bloc) => bloc.state.requestUnreadCount,
+    );
     final hasMore = context.select<ConversationListBloc, bool>(
       (bloc) => bloc.state.hasMore,
     );
 
-    final hasRequests = requestConversations.isNotEmpty;
     final bannerOffset = hasRequests ? 1 : 0;
 
     if (conversations.isEmpty && !hasRequests) return const InboxEmptyState();
@@ -304,7 +305,7 @@ class _ConversationListState extends ConsumerState<_ConversationList>
       return Column(
         children: [
           MessageRequestsBanner(
-            requestCount: requestConversations.length,
+            requestCount: requestUnreadCount,
             onTap: () => _openMessageRequests(context),
           ),
           const Expanded(child: InboxEmptyState()),
@@ -318,7 +319,7 @@ class _ConversationListState extends ConsumerState<_ConversationList>
       itemBuilder: (context, index) {
         if (hasRequests && index == 0) {
           return MessageRequestsBanner(
-            requestCount: requestConversations.length,
+            requestCount: requestUnreadCount,
             onTap: () => _openMessageRequests(context),
           );
         }

--- a/mobile/lib/screens/inbox/message_requests/widgets/message_requests_banner.dart
+++ b/mobile/lib/screens/inbox/message_requests/widgets/message_requests_banner.dart
@@ -47,7 +47,7 @@ class MessageRequestsBanner extends StatelessWidget {
                     style: VineTheme.titleMediumFont(),
                   ),
                 ),
-                _RequestCountBadge(count: requestCount),
+                if (requestCount > 0) _RequestCountBadge(count: requestCount),
                 const SizedBox(width: 8),
                 const DivineIcon(
                   icon: DivineIconName.caretRight,

--- a/mobile/test/screens/inbox/message_requests/widgets/message_requests_banner_test.dart
+++ b/mobile/test/screens/inbox/message_requests/widgets/message_requests_banner_test.dart
@@ -40,6 +40,22 @@ void main() {
         expect(find.text('42'), findsOneWidget);
       });
 
+      testWidgets('hides count badge when requestCount is 0', (tester) async {
+        await tester.pumpWidget(
+          testMaterialApp(
+            home: Scaffold(
+              body: MessageRequestsBanner(
+                requestCount: 0,
+                onTap: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Message requests'), findsOneWidget);
+        expect(find.text('0'), findsNothing);
+      });
+
       testWidgets('renders "99+" when count exceeds 99', (tester) async {
         await tester.pumpWidget(
           testMaterialApp(


### PR DESCRIPTION
Closes #2665

## Summary

- **`inbox_view.dart`**: Select `requestUnreadCount` (filters to `!c.isRead`) instead of `requestConversations.length` for the badge value. Also narrowed the request conversations selector to a `bool` since only existence matters for showing the banner.
- **`message_requests_banner.dart`**: Hide the red count badge when `requestCount` is 0 — the banner row itself still renders so users can navigate to their requests.
- **`message_requests_banner_test.dart`**: Added test verifying the badge is hidden when count is 0.

## Test plan

- [ ] Existing inbox and banner tests pass (16/16)
- [ ] `flutter analyze` clean on changed files
- [ ] Manual: receive message requests → view them → badge clears
- [ ] Manual: unread requests still show correct count
- [ ] Manual: banner still visible (without badge) when all requests are read