### PR TITLE
fix(video): differentiate moderation errors from missing content in video feed

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -721,12 +721,11 @@ class _PooledFullscreenItemContentState
           thumbnailUrl: video.thumbnailUrl,
           isPortrait: isPortrait,
         ),
-        errorBuilder: (context, onRetry, errorMessage) =>
-            PooledVideoErrorOverlay(
-              video: video,
-              onRetry: onRetry,
-              errorMessage: errorMessage,
-            ),
+        errorBuilder: (context, onRetry, errorType) => PooledVideoErrorOverlay(
+          video: video,
+          onRetry: onRetry,
+          errorType: errorType,
+        ),
         overlayBuilder: (context, videoController, player) {
           if (showContentWarningOverlay && !_contentWarningRevealed) {
             return ContentWarningBlurOverlay(

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -739,12 +739,11 @@ class _PooledVideoFeedItemContentState
           feedMode: widget.contextTitle,
           index: widget.index,
         ),
-        errorBuilder: (context, onRetry, errorMessage) =>
-            PooledVideoErrorOverlay(
-              video: video,
-              onRetry: onRetry,
-              errorMessage: errorMessage,
-            ),
+        errorBuilder: (context, onRetry, errorType) => PooledVideoErrorOverlay(
+          video: video,
+          onRetry: onRetry,
+          errorType: errorType,
+        ),
         overlayBuilder: (context, videoController, player) => Stack(
           children: [
             FeedVideoOverlay(

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -8,37 +8,39 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
+import 'package:pooled_video_player/pooled_video_player.dart';
 
 /// Error overlay for videos playing through the pooled video player.
 ///
-/// Shows different UI based on the error:
-/// - 403 Forbidden: Shield icon + "Content restricted" (no retry)
-/// - 404 with moderation status: Shield icon + "Content restricted" (no retry)
-/// - 401 Unauthorized: Lock icon + "Age-restricted content" + Verify Age
-/// - Divine URL generic failure: Error icon + "Video not found" + Retry
-/// - Other: Error icon + "Video playback error" + Retry
+/// Shows different UI based on the [VideoErrorType] from the controller:
+/// - [VideoErrorType.forbidden]: Shield icon + "Content restricted" (no retry)
+/// - [VideoErrorType.notFound] with moderation status: Shield icon +
+///   "Content restricted" (no retry)
+/// - [VideoErrorType.ageRestricted]: Lock icon + "Age-restricted content" +
+///   Verify Age
+/// - [VideoErrorType.notFound]: Error icon + "Video not found" + Retry
+/// - [VideoErrorType.generic]: Error icon + "Video playback error" + Retry
 class PooledVideoErrorOverlay extends ConsumerWidget {
   const PooledVideoErrorOverlay({
     required this.video,
     required this.onRetry,
-    required this.errorMessage,
+    required this.errorType,
     super.key,
   });
 
   final VideoEvent video;
   final VoidCallback onRetry;
-  final String? errorMessage;
+  final VideoErrorType? errorType;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final errorType = _VideoErrorType.fromMessage(errorMessage);
+    final type = errorType ?? VideoErrorType.generic;
     final isDivineUrl = VideoModerationStatusService.shouldCheckModeration(
       video.videoUrl,
     );
 
-    // For divine URLs, always check moderation status — mpv error strings
-    // don't reliably contain HTTP status codes, so we can't distinguish
-    // 404 from generic failures by string alone.
+    // For divine URLs, check moderation status to enrich 404/notFound
+    // errors with moderation context.
     final sha256 = isDivineUrl
         ? VideoModerationStatusService.resolveSha256(
             explicitSha256: video.sha256,
@@ -54,28 +56,21 @@ class PooledVideoErrorOverlay extends ConsumerWidget {
       data: (status) => status,
     );
     final isModerationRestricted =
-        errorType == _VideoErrorType.forbidden ||
+        type == VideoErrorType.forbidden ||
         (moderationStatus != null &&
             moderationStatus.isUnavailableDueToModeration);
 
-    // For divine URLs where the error type couldn't be parsed from the
-    // error string, treat as "not found" — this is the most common failure
-    // mode (missing upload, hash not on blossom, transcode pending).
-    final effectiveType = errorType == _VideoErrorType.generic && isDivineUrl
-        ? _VideoErrorType.notFound
-        : errorType;
-
-    final icon = effectiveType == _VideoErrorType.ageRestricted
+    final icon = type == VideoErrorType.ageRestricted
         ? DivineIconName.lockSimple
         : isModerationRestricted
         ? DivineIconName.shieldCheck
         : DivineIconName.warningCircle;
 
-    final message = effectiveType == _VideoErrorType.ageRestricted
+    final message = type == VideoErrorType.ageRestricted
         ? 'Age-restricted content'
         : isModerationRestricted
         ? 'Content restricted'
-        : effectiveType.userMessage;
+        : _userMessage(type);
 
     final showRetry = !isModerationRestricted;
 
@@ -97,24 +92,15 @@ class PooledVideoErrorOverlay extends ConsumerWidget {
                 ),
                 Text(
                   message,
-                  style: const TextStyle(
-                    color: VineTheme.whiteText,
-                    fontSize: 14,
-                  ),
+                  style: VineTheme.bodyMediumFont(),
                   textAlign: TextAlign.center,
                 ),
                 if (showRetry)
-                  ElevatedButton(
+                  DivineButton(
+                    label: 'Retry',
+                    type: DivineButtonType.tertiary,
+                    size: DivineButtonSize.small,
                     onPressed: onRetry,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: VineTheme.whiteText,
-                      foregroundColor: VineTheme.backgroundColor,
-                    ),
-                    child: Text(
-                      effectiveType == _VideoErrorType.ageRestricted
-                          ? 'Verify Age'
-                          : 'Retry',
-                    ),
                   ),
               ],
             ),
@@ -123,43 +109,11 @@ class PooledVideoErrorOverlay extends ConsumerWidget {
       ],
     );
   }
-}
 
-/// Classifies a raw error string into an actionable error type.
-enum _VideoErrorType {
-  /// 401 Unauthorized — age-gated content.
-  ageRestricted,
-
-  /// 403 Forbidden — moderation-restricted content.
-  forbidden,
-
-  /// 404 Not Found — may or may not be moderation-related.
-  notFound,
-
-  /// Any other playback failure.
-  generic
-  ;
-
-  static _VideoErrorType fromMessage(String? message) {
-    if (message == null) return generic;
-    final lower = message.toLowerCase();
-    if (lower.contains('401') || lower.contains('unauthorized')) {
-      return ageRestricted;
-    }
-    if (lower.contains('403') || lower.contains('forbidden')) {
-      return forbidden;
-    }
-    if (lower.contains('404') || lower.contains('not found')) {
-      return notFound;
-    }
-    return generic;
-  }
-
-  /// User-facing message for this error type.
-  String get userMessage => switch (this) {
-    ageRestricted => 'Age-restricted content',
-    forbidden => 'Content restricted',
-    notFound => 'Video not found',
-    generic => 'Video playback error',
+  static String _userMessage(VideoErrorType type) => switch (type) {
+    VideoErrorType.ageRestricted => 'Age-restricted content',
+    VideoErrorType.forbidden => 'Content restricted',
+    VideoErrorType.notFound => 'Video not found',
+    VideoErrorType.generic => 'Video playback error',
   };
 }

--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -162,7 +162,7 @@ class VideoFeedController extends ChangeNotifier {
   final Map<int, StreamSubscription<bool>> _bufferSubscriptions = {};
   final Map<int, StreamSubscription<bool>> _playingSubscriptions = {};
   final Map<int, StreamSubscription<String>> _errorSubscriptions = {};
-  final Map<int, String> _errorMessages = {};
+  final Map<int, VideoErrorType> _errorTypes = {};
   final Set<int> _loadingIndices = {};
   final Map<int, Timer> _positionTimers = {};
   final Map<int, Timer> _loadWatchdogTimers = {};
@@ -240,6 +240,7 @@ class VideoFeedController extends ChangeNotifier {
           loadState: _loadStates[index] ?? LoadState.none,
           videoController: _loadedPlayers[index]?.videoController,
           player: _loadedPlayers[index]?.player,
+          errorType: _errorTypes[index],
         ),
       ),
     );
@@ -269,7 +270,7 @@ class VideoFeedController extends ChangeNotifier {
         videoController: isAlive ? pooledPlayer.videoController : null,
         player: isAlive ? pooledPlayer.player : null,
         isSlowLoad: _slowLoadIndices.contains(index),
-        errorMessage: _errorMessages[index],
+        errorType: _errorTypes[index],
       );
     }
   }
@@ -428,12 +429,44 @@ class VideoFeedController extends ChangeNotifier {
     }
   }
 
+  /// Classifies a raw error string into a [VideoErrorType].
+  ///
+  /// Checks for HTTP status code patterns (401, 403, 404) in the error
+  /// message. For divine-hosted URLs where the error string is unparseable,
+  /// falls back to [VideoErrorType.notFound] since missing content is the
+  /// most common failure mode.
+  VideoErrorType _classifyError(String? errorMessage, int index) {
+    if (errorMessage != null) {
+      final lower = errorMessage.toLowerCase();
+      if (lower.contains('401') || lower.contains('unauthorized')) {
+        return VideoErrorType.ageRestricted;
+      }
+      if (lower.contains('403') || lower.contains('forbidden')) {
+        return VideoErrorType.forbidden;
+      }
+      if (lower.contains('404') || lower.contains('not found')) {
+        return VideoErrorType.notFound;
+      }
+    }
+    // For divine-hosted URLs, generic errors most likely mean missing
+    // content (hash not on blossom, transcode pending). Non-divine URLs
+    // keep the generic classification.
+    if (index >= 0 && index < _videos.length) {
+      final hash = _extractCanonicalDivineBlobHash(_videos[index].url);
+      if (hash != null) return VideoErrorType.notFound;
+    }
+    return VideoErrorType.generic;
+  }
+
   void _markLoadError(int index, [String? errorMessage]) {
     if (_isDisposed) return;
     _loadStates[index] = LoadState.error;
     if (errorMessage != null) {
-      _errorMessages[index] = errorMessage;
+      _errorTypes[index] = _classifyError(errorMessage, index);
     }
+    // If no message, _errorTypes[index] may already be set from the
+    // error stream handler. Fall back to generic if nothing was stored.
+    _errorTypes[index] ??= VideoErrorType.generic;
     _notifyIndex(index);
   }
 
@@ -442,7 +475,7 @@ class VideoFeedController extends ChangeNotifier {
     final player = pooledPlayer?.player;
     if (player == null) {
       _logDebug('stuck_playback ${_videoDebugDetails(index)} giving up');
-      _markLoadError(index, _errorMessages[index] ?? 'player_unavailable');
+      _markLoadError(index);
       return;
     }
 
@@ -452,7 +485,7 @@ class VideoFeedController extends ChangeNotifier {
 
     if (playbackSources == null || nextSourceIndex >= playbackSources.length) {
       _logDebug('stuck_playback ${_videoDebugDetails(index)} giving up');
-      _markLoadError(index, _errorMessages[index] ?? 'sources_exhausted');
+      _markLoadError(index);
       return;
     }
 
@@ -1050,9 +1083,9 @@ class VideoFeedController extends ChangeNotifier {
         'source=${_openedSources[index]} '
         'loadState=${_loadStates[index]}',
       );
-      // Store the latest error message so the UI can differentiate error
-      // types (e.g. 401/403/404 HTTP status codes from blossom servers).
-      _errorMessages[index] = error;
+      // Classify the error immediately so the type is available if retry
+      // exhausts all sources and _markLoadError is called without a message.
+      _errorTypes[index] = _classifyError(error, index);
       // Only act on errors during initial load. Once the video is playing
       // successfully (LoadState.ready), mpv may emit non-critical errors
       // (e.g. on loop seeks, transient network hiccups) that should not
@@ -1354,7 +1387,7 @@ class VideoFeedController extends ChangeNotifier {
     _slowLoadIndices.remove(index);
     _loadedPlayers.remove(index);
     _loadStates.remove(index);
-    _errorMessages.remove(index);
+    _errorTypes.remove(index);
     _loadingIndices.remove(index);
     _notifyIndex(index);
   }

--- a/mobile/packages/pooled_video_player/lib/src/models/video_index_state.dart
+++ b/mobile/packages/pooled_video_player/lib/src/models/video_index_state.dart
@@ -4,6 +4,24 @@ import 'package:media_kit_video/media_kit_video.dart';
 
 import 'package:pooled_video_player/src/controllers/video_feed_controller.dart';
 
+/// Classifies a video playback error into an actionable type.
+///
+/// Set by [VideoFeedController] when a video fails to load. The consuming
+/// UI reads this to decide which icon, message, and actions to show.
+enum VideoErrorType {
+  /// 401 Unauthorized — age-gated content.
+  ageRestricted,
+
+  /// 403 Forbidden — moderation-restricted content.
+  forbidden,
+
+  /// 404 Not Found — may or may not be moderation-related.
+  notFound,
+
+  /// Any other playback failure.
+  generic,
+}
+
 /// State of a video at a specific index in the feed.
 ///
 /// Used by [VideoFeedController] to notify individual video player
@@ -16,7 +34,7 @@ class VideoIndexState extends Equatable {
     this.videoController,
     this.player,
     this.isSlowLoad = false,
-    this.errorMessage,
+    this.errorType,
   });
 
   /// The loading state of the video.
@@ -35,12 +53,11 @@ class VideoIndexState extends Equatable {
   /// or skip action for externally hosted videos.
   final bool isSlowLoad;
 
-  /// The error message when [loadState] is [LoadState.error], or null.
+  /// The classified error type when [loadState] is [LoadState.error].
   ///
-  /// Contains the raw error string from media_kit (e.g. HTTP status codes
-  /// like "403", "forbidden") so the consuming UI can differentiate error
-  /// types (moderation, age-gate, missing content).
-  final String? errorMessage;
+  /// Set by [VideoFeedController] based on the raw error string from
+  /// media_kit (e.g. HTTP status codes like "403", "forbidden").
+  final VideoErrorType? errorType;
 
   /// Whether the video is ready for playback.
   bool get isReady => loadState == LoadState.ready;
@@ -57,6 +74,6 @@ class VideoIndexState extends Equatable {
     videoController,
     player,
     isSlowLoad,
-    errorMessage,
+    errorType,
   ];
 }

--- a/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_player.dart
+++ b/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_player.dart
@@ -28,14 +28,13 @@ typedef OverlayBuilder =
 
 /// Builder for the error state.
 ///
-/// [errorMessage] contains the raw error string from the player (e.g. HTTP
-/// status codes like "403", "forbidden") when available. May be null for
-/// errors without a message (e.g. stale playback timeout).
+/// [errorType] contains the classified error type from the controller when
+/// available. May be null for errors that occurred before classification.
 typedef ErrorBuilder =
     Widget Function(
       BuildContext context,
       VoidCallback onRetry,
-      String? errorMessage,
+      VideoErrorType? errorType,
     );
 
 /// Video player widget that displays a video from [VideoFeedController].
@@ -131,7 +130,7 @@ class PooledVideoPlayer extends StatelessWidget {
                       () => feedController.retryLoad(
                         feedController.currentIndex,
                       ),
-                      state.errorMessage,
+                      state.errorType,
                     ) ??
                     const _DefaultErrorState()
               else ...[

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -4374,5 +4374,268 @@ void main() {
         },
       );
     });
+
+    group('retryLoad', () {
+      test('releases player and re-triggers preload', () async {
+        final videos = createTestVideos(count: 3);
+
+        final controller = VideoFeedController(
+          videos: videos,
+          pool: pool,
+          preloadAhead: 0,
+          preloadBehind: 0,
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        // Video 0 should have a player loaded
+        expect(controller.getLoadState(0), isNot(LoadState.none));
+
+        // Retry releases and re-loads
+        controller.retryLoad(0);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        // After retry, the preload window should be re-evaluated
+        // and the video should be loading again
+        expect(controller.getLoadState(0), isNot(LoadState.none));
+
+        controller.dispose();
+      });
+
+      test('clears error state on retry', () async {
+        // Use a failing pool so the video enters error state.
+        var shouldFail = true;
+        final retryPool = TestablePlayerPool(
+          maxPlayers: 10,
+          mockPlayerFactory: (url) {
+            final setup = createMockPlayerSetup();
+            final mock = _MockPooledPlayer();
+            when(() => mock.player).thenReturn(setup.player);
+            when(
+              () => mock.videoController,
+            ).thenReturn(createMockVideoController());
+            when(() => mock.isDisposed).thenReturn(false);
+            when(() => mock.wasRecycled).thenReturn(false);
+            when(mock.clearRecycled).thenReturn(null);
+            when(mock.dispose).thenAnswer((_) async {});
+            when(
+              () => setup.player.open(
+                any(),
+                play: any(named: 'play'),
+              ),
+            ).thenAnswer((_) async {
+              if (shouldFail) {
+                throw Exception('403 Forbidden');
+              }
+            });
+            return mock;
+          },
+        );
+
+        final controller = VideoFeedController(
+          videos: createTestVideos(count: 1),
+          pool: retryPool,
+          preloadAhead: 0,
+          preloadBehind: 0,
+        );
+
+        await Future<void>.delayed(
+          const Duration(milliseconds: 50),
+        );
+
+        expect(
+          controller.getLoadState(0),
+          equals(LoadState.error),
+        );
+        expect(
+          controller.getIndexNotifier(0).value.errorType,
+          isNotNull,
+        );
+
+        // Allow retry to succeed
+        shouldFail = false;
+        controller.retryLoad(0);
+        await Future<void>.delayed(
+          const Duration(milliseconds: 50),
+        );
+
+        expect(
+          controller.getLoadState(0),
+          isNot(LoadState.error),
+        );
+
+        controller.dispose();
+        await retryPool.dispose();
+      });
+    });
+
+    group('error type classification', () {
+      /// Creates a pool where open() always throws [errorMessage].
+      /// This triggers the _loadVideo catch block which calls
+      /// _markLoadError → _classifyError.
+      TestablePlayerPool failingPool(String errorMessage) {
+        return TestablePlayerPool(
+          maxPlayers: 10,
+          mockPlayerFactory: (url) {
+            final setup = createMockPlayerSetup();
+            final mock = _MockPooledPlayer();
+            when(() => mock.player).thenReturn(setup.player);
+            when(
+              () => mock.videoController,
+            ).thenReturn(createMockVideoController());
+            when(() => mock.isDisposed).thenReturn(false);
+            when(() => mock.wasRecycled).thenReturn(false);
+            when(mock.clearRecycled).thenReturn(null);
+            when(mock.dispose).thenAnswer((_) async {});
+            // Make open() throw so _loadVideo catch fires.
+            when(
+              () => setup.player.open(
+                any(),
+                play: any(named: 'play'),
+              ),
+            ).thenThrow(Exception(errorMessage));
+            return mock;
+          },
+        );
+      }
+
+      test('classifies 403 as forbidden', () async {
+        final fp = failingPool('403 Forbidden');
+        final controller = VideoFeedController(
+          videos: createTestVideos(count: 1),
+          pool: fp,
+          preloadAhead: 0,
+          preloadBehind: 0,
+        );
+        await Future<void>.delayed(
+          const Duration(milliseconds: 50),
+        );
+
+        final state = controller.getIndexNotifier(0).value;
+        expect(state.loadState, equals(LoadState.error));
+        expect(
+          state.errorType,
+          equals(VideoErrorType.forbidden),
+        );
+
+        controller.dispose();
+        await fp.dispose();
+      });
+
+      test('classifies 401 as ageRestricted', () async {
+        final fp = failingPool('401 Unauthorized');
+        final controller = VideoFeedController(
+          videos: createTestVideos(count: 1),
+          pool: fp,
+          preloadAhead: 0,
+          preloadBehind: 0,
+        );
+        await Future<void>.delayed(
+          const Duration(milliseconds: 50),
+        );
+
+        final state = controller.getIndexNotifier(0).value;
+        expect(state.loadState, equals(LoadState.error));
+        expect(
+          state.errorType,
+          equals(VideoErrorType.ageRestricted),
+        );
+
+        controller.dispose();
+        await fp.dispose();
+      });
+
+      test('classifies 404 as notFound', () async {
+        final fp = failingPool('404 Not Found');
+        final controller = VideoFeedController(
+          videos: createTestVideos(count: 1),
+          pool: fp,
+          preloadAhead: 0,
+          preloadBehind: 0,
+        );
+        await Future<void>.delayed(
+          const Duration(milliseconds: 50),
+        );
+
+        final state = controller.getIndexNotifier(0).value;
+        expect(state.loadState, equals(LoadState.error));
+        expect(
+          state.errorType,
+          equals(VideoErrorType.notFound),
+        );
+
+        controller.dispose();
+        await fp.dispose();
+      });
+
+      test(
+        'classifies generic error on divine URL as notFound',
+        () async {
+          final fp = failingPool('Failed to open stream');
+          final videos = [
+            const VideoItem(
+              id: 'divine_video',
+              url:
+                  'https://media.divine.video/'
+                  'a1b2c3d4e5f6a1b2c3d4'
+                  'e5f6a1b2c3d4e5f6a1b2'
+                  'c3d4e5f6a1b2c3d4e5f6a1b2',
+            ),
+          ];
+
+          final controller = VideoFeedController(
+            videos: videos,
+            pool: fp,
+            preloadAhead: 0,
+            preloadBehind: 0,
+          );
+          await Future<void>.delayed(
+            const Duration(milliseconds: 50),
+          );
+
+          final state = controller.getIndexNotifier(0).value;
+          expect(
+            state.loadState,
+            equals(LoadState.error),
+          );
+          expect(
+            state.errorType,
+            equals(VideoErrorType.notFound),
+          );
+
+          controller.dispose();
+          await fp.dispose();
+        },
+      );
+
+      test(
+        'classifies generic error on non-divine URL as generic',
+        () async {
+          final fp = failingPool('decode error');
+          final controller = VideoFeedController(
+            videos: createTestVideos(count: 1),
+            pool: fp,
+            preloadAhead: 0,
+            preloadBehind: 0,
+          );
+          await Future<void>.delayed(
+            const Duration(milliseconds: 50),
+          );
+
+          final state = controller.getIndexNotifier(0).value;
+          expect(
+            state.loadState,
+            equals(LoadState.error),
+          );
+          expect(
+            state.errorType,
+            equals(VideoErrorType.generic),
+          );
+
+          controller.dispose();
+          await fp.dispose();
+        },
+      );
+    });
   });
 }

--- a/mobile/packages/pooled_video_player/test/widgets/pooled_video_player_test.dart
+++ b/mobile/packages/pooled_video_player/test/widgets/pooled_video_player_test.dart
@@ -544,7 +544,7 @@ void main() {
       testWidgets('shows custom errorBuilder when provided', (tester) async {
         await tester.pumpWidget(
           buildWidget(
-            errorBuilder: (context, onRetry, errorMessage) {
+            errorBuilder: (context, onRetry, errorType) {
               return TextButton(
                 key: const Key('retry_button'),
                 onPressed: onRetry,
@@ -565,7 +565,7 @@ void main() {
 
         await tester.pumpWidget(
           buildWidget(
-            errorBuilder: (context, onRetry, errorMessage) {
+            errorBuilder: (context, onRetry, errorType) {
               return TextButton(
                 key: const Key('retry_button'),
                 onPressed: () {

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Tests for PooledVideoErrorOverlay widget
-// ABOUTME: Verifies error differentiation for 401, 403, 404, and generic
-// ABOUTME: errors in the pooled video player path.
+// ABOUTME: Verifies UI rendering for each VideoErrorType and moderation
+// ABOUTME: enrichment for divine URL 404 errors.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
+import 'package:pooled_video_player/pooled_video_player.dart';
 
 import '../builders/test_video_event_builder.dart';
 
@@ -17,7 +18,8 @@ Finder _findDivineIcon(DivineIconName name) =>
 
 void main() {
   group(PooledVideoErrorOverlay, () {
-    late VideoEvent testVideo;
+    late VideoEvent divineVideo;
+    late VideoEvent thirdPartyVideo;
     late bool retryPressed;
 
     // Valid 64-char hex sha256 for moderation status resolution.
@@ -25,15 +27,19 @@ void main() {
         'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
 
     setUp(() {
-      testVideo = TestVideoEventBuilder.create(
+      divineVideo = TestVideoEventBuilder.create(
         id: 'test-video-id',
         videoUrl: 'https://blossom.divine.video/$testSha256.mp4',
+      );
+      thirdPartyVideo = TestVideoEventBuilder.create(
+        id: 'third-party-video',
+        videoUrl: 'https://cdn.example.com/video.mp4',
       );
       retryPressed = false;
     });
 
     Widget buildWidget({
-      String? errorMessage,
+      VideoErrorType? errorType,
       VideoEvent? video,
     }) {
       return ProviderScope(
@@ -45,9 +51,9 @@ void main() {
         child: MaterialApp(
           home: Scaffold(
             body: PooledVideoErrorOverlay(
-              video: video ?? testVideo,
+              video: video ?? divineVideo,
               onRetry: () => retryPressed = true,
-              errorMessage: errorMessage,
+              errorType: errorType,
             ),
           ),
         ),
@@ -55,7 +61,7 @@ void main() {
     }
 
     Widget buildWidgetWithModeration({
-      required String? errorMessage,
+      required VideoErrorType? errorType,
       required VideoModerationStatus moderationStatus,
       VideoEvent? video,
     }) {
@@ -68,21 +74,21 @@ void main() {
         child: MaterialApp(
           home: Scaffold(
             body: PooledVideoErrorOverlay(
-              video: video ?? testVideo,
+              video: video ?? divineVideo,
               onRetry: () => retryPressed = true,
-              errorMessage: errorMessage,
+              errorType: errorType,
             ),
           ),
         ),
       );
     }
 
-    group('403 Forbidden', () {
+    group('forbidden', () {
       testWidgets('shows shield icon and "Content restricted"', (
         tester,
       ) async {
         await tester.pumpWidget(
-          buildWidget(errorMessage: 'HttpException: 403 Forbidden'),
+          buildWidget(errorType: VideoErrorType.forbidden),
         );
         await tester.pumpAndSettle();
 
@@ -92,32 +98,20 @@ void main() {
 
       testWidgets('does not show retry button', (tester) async {
         await tester.pumpWidget(
-          buildWidget(errorMessage: 'HttpException: 403 Forbidden'),
+          buildWidget(errorType: VideoErrorType.forbidden),
         );
         await tester.pumpAndSettle();
 
         expect(find.text('Retry'), findsNothing);
       });
-
-      testWidgets('detects "forbidden" keyword variant', (tester) async {
-        await tester.pumpWidget(
-          buildWidget(errorMessage: 'forbidden'),
-        );
-        await tester.pumpAndSettle();
-
-        expect(_findDivineIcon(DivineIconName.shieldCheck), findsOneWidget);
-        expect(find.text('Content restricted'), findsOneWidget);
-      });
     });
 
-    group('401 Unauthorized', () {
+    group('ageRestricted', () {
       testWidgets('shows lock icon and "Age-restricted content"', (
         tester,
       ) async {
         await tester.pumpWidget(
-          buildWidget(
-            errorMessage: 'HttpException: Invalid statusCode: 401',
-          ),
+          buildWidget(errorType: VideoErrorType.ageRestricted),
         );
         await tester.pumpAndSettle();
 
@@ -125,48 +119,34 @@ void main() {
         expect(find.text('Age-restricted content'), findsOneWidget);
       });
 
-      testWidgets('shows "Verify Age" button', (tester) async {
+      testWidgets('shows Retry button', (tester) async {
         await tester.pumpWidget(
-          buildWidget(
-            errorMessage: 'HttpException: Invalid statusCode: 401',
-          ),
+          buildWidget(errorType: VideoErrorType.ageRestricted),
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Verify Age'), findsOneWidget);
-      });
-
-      testWidgets('detects "unauthorized" keyword variant', (tester) async {
-        await tester.pumpWidget(
-          buildWidget(errorMessage: 'unauthorized'),
-        );
-        await tester.pumpAndSettle();
-
-        expect(_findDivineIcon(DivineIconName.lockSimple), findsOneWidget);
+        expect(find.text('Retry'), findsOneWidget);
       });
     });
 
-    group('404 Not Found', () {
-      testWidgets(
-        'shows "Video not found" with retry for explicit 404',
-        (tester) async {
-          await tester.pumpWidget(
-            buildWidget(errorMessage: '404 not found'),
-          );
-          await tester.pumpAndSettle();
+    group('notFound', () {
+      testWidgets('shows "Video not found" with retry', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(errorType: VideoErrorType.notFound),
+        );
+        await tester.pumpAndSettle();
 
-          expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
-          expect(find.text('Video not found'), findsOneWidget);
-          expect(find.text('Retry'), findsOneWidget);
-        },
-      );
+        expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
+        expect(find.text('Video not found'), findsOneWidget);
+        expect(find.text('Retry'), findsOneWidget);
+      });
 
       testWidgets(
         'shows shield icon when moderation status indicates blocked',
         (tester) async {
           await tester.pumpWidget(
             buildWidgetWithModeration(
-              errorMessage: '404 not found',
+              errorType: VideoErrorType.notFound,
               moderationStatus: const VideoModerationStatus(
                 moderated: true,
                 blocked: true,
@@ -190,7 +170,7 @@ void main() {
         (tester) async {
           await tester.pumpWidget(
             buildWidgetWithModeration(
-              errorMessage: '404 not found',
+              errorType: VideoErrorType.notFound,
               moderationStatus: const VideoModerationStatus(
                 moderated: true,
                 blocked: false,
@@ -211,13 +191,9 @@ void main() {
       testWidgets(
         'skips moderation lookup for non-divine video URLs',
         (tester) async {
-          final thirdPartyVideo = TestVideoEventBuilder.create(
-            id: 'third-party-video',
-            videoUrl: 'https://cdn.example.com/$testSha256.mp4',
-          );
           await tester.pumpWidget(
             buildWidgetWithModeration(
-              errorMessage: '404 not found',
+              errorType: VideoErrorType.notFound,
               moderationStatus: const VideoModerationStatus(
                 moderated: true,
                 blocked: true,
@@ -239,32 +215,38 @@ void main() {
       );
     });
 
-    group('divine URL generic fallback', () {
-      testWidgets(
-        'shows "Video not found" for divine URLs with unparseable errors',
-        (tester) async {
-          // media_kit error strings often lack HTTP status codes, so divine
-          // URLs with a generic error should fall back to "Video not found".
-          await tester.pumpWidget(
-            buildWidget(
-              errorMessage: 'PlatformException: Failed to open stream',
-            ),
-          );
-          await tester.pumpAndSettle();
+    group('generic', () {
+      testWidgets('shows "Video playback error" with retry', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(
+            errorType: VideoErrorType.generic,
+            video: thirdPartyVideo,
+          ),
+        );
+        await tester.pumpAndSettle();
 
-          expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
-          expect(find.text('Video not found'), findsOneWidget);
-          expect(find.text('Retry'), findsOneWidget);
-        },
-      );
+        expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
+        expect(find.text('Video playback error'), findsOneWidget);
+        expect(find.text('Retry'), findsOneWidget);
+      });
+
+      testWidgets('shows generic error for null error type', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(video: thirdPartyVideo),
+        );
+        await tester.pumpAndSettle();
+
+        expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
+        expect(find.text('Video playback error'), findsOneWidget);
+        expect(find.text('Retry'), findsOneWidget);
+      });
 
       testWidgets(
-        'shows "Content restricted" for divine URL generic error '
-        'when moderation status indicates blocked',
+        'shows "Content restricted" when moderation status indicates blocked',
         (tester) async {
           await tester.pumpWidget(
             buildWidgetWithModeration(
-              errorMessage: 'Failed to open stream',
+              errorType: VideoErrorType.notFound,
               moderationStatus: const VideoModerationStatus(
                 moderated: true,
                 blocked: true,
@@ -284,52 +266,11 @@ void main() {
       );
     });
 
-    group('non-divine generic errors', () {
-      testWidgets('shows "Video playback error" for third-party URLs', (
-        tester,
-      ) async {
-        final thirdPartyVideo = TestVideoEventBuilder.create(
-          id: 'third-party-video',
-          videoUrl: 'https://cdn.example.com/video.mp4',
-        );
-        await tester.pumpWidget(
-          buildWidget(
-            errorMessage: 'PlatformException: video decode error',
-            video: thirdPartyVideo,
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
-        expect(find.text('Video playback error'), findsOneWidget);
-        expect(find.text('Retry'), findsOneWidget);
-      });
-
-      testWidgets('shows generic error for null error message', (
-        tester,
-      ) async {
-        final thirdPartyVideo = TestVideoEventBuilder.create(
-          id: 'third-party-video',
-          videoUrl: 'https://cdn.example.com/video.mp4',
-        );
-        await tester.pumpWidget(
-          buildWidget(video: thirdPartyVideo),
-        );
-        await tester.pumpAndSettle();
-
-        expect(_findDivineIcon(DivineIconName.warningCircle), findsOneWidget);
-        expect(find.text('Video playback error'), findsOneWidget);
-        expect(find.text('Retry'), findsOneWidget);
-      });
-
+    group('retry', () {
       testWidgets('retry button calls onRetry', (tester) async {
-        final thirdPartyVideo = TestVideoEventBuilder.create(
-          id: 'third-party-video',
-          videoUrl: 'https://cdn.example.com/video.mp4',
-        );
         await tester.pumpWidget(
           buildWidget(
-            errorMessage: 'some error',
+            errorType: VideoErrorType.generic,
             video: thirdPartyVideo,
           ),
         );


### PR DESCRIPTION
## Summary

Closes #2427

When a video returns an HTTP error from the blossom server, the app now distinguishes **moderation-restricted content** (403 Forbidden, or 404 with moderation status) from **genuinely missing content** (404 without moderation), instead of showing the same generic "Failed to load video" message for all failures.

**This targets the active pooled video player path** (home feed + all fullscreen feeds), not the legacy `individualVideoControllerProvider` path which only serves `ProfileVideoFeedView` (tracked in #2683).

- **403 Forbidden**: Shield icon + "Content restricted" — no retry button
- **404 with moderation status (blocked/quarantined)**: Shield icon + "Content restricted" — enriched via `VideoModerationStatusService`
- **404 without moderation**: Error icon + "Video not found" + Retry
- **401 Unauthorized**: Lock icon + "Age-restricted content" + Verify Age
- **Other errors**: Error icon + "Video playback error" + Retry

## Changes

### pooled_video_player package
- **`VideoFeedController`**: Store error messages per index (`_errorMessages` map), pass to `_markLoadError()` and `_notifyIndex()`
- **`VideoIndexState`**: Add `errorMessage` field so the UI can inspect the raw error string
- **`ErrorBuilder` typedef**: Updated to `Widget Function(BuildContext, VoidCallback, String?)` — passes the error message to consuming screens

### App layer
- **`PooledVideoErrorOverlay`** (new widget): Classifies errors by type (401/403/404/generic), integrates `VideoModerationStatusService` for 404 enrichment, shows appropriate icon/message/action
- **`video_feed_page.dart`**: Wire `errorBuilder` into home feed `PooledVideoPlayer`
- **`pooled_fullscreen_video_feed_screen.dart`**: Wire `errorBuilder` into fullscreen feed `PooledVideoPlayer`
- **Reverted** legacy `individual_video_providers.dart` and `VideoErrorOverlay` changes (deferred to #2683)

### Tests
- 12 new tests for `PooledVideoErrorOverlay` (403 shield/message/no-retry, forbidden keyword, 401 lock/verify-age, 404 plain vs blocked vs quarantined, generic errors, null message, retry callback)
- Updated 2 existing `pooled_video_player` tests for new `ErrorBuilder` signature
- All 426 tests pass, 0 analyzer issues

## Test plan

- [ ] Verify 403 errors show shield icon + "Content restricted" with no retry button (home feed)
- [ ] Verify 404 from a divine.video URL with blocked moderation status shows "Content restricted" (home feed)
- [ ] Verify 404 from a non-divine URL still shows "Video not found" + Retry
- [ ] Verify 401 age-restricted shows lock icon + "Verify Age" button
- [ ] Verify generic errors show "Video playback error" + Retry
- [ ] Verify same behavior in fullscreen feed (explore, profile, hashtag grids)
- [ ] Run `flutter test packages/pooled_video_player/test/ test/widgets/pooled_video_error_overlay_test.dart` — all pass

## Related

- Issue #2427 (differentiate moderation errors)
- Issue #2683 (migrate ProfileVideoFeedView to pooled_video_player — follow-up)
- Epic #604 (Content Moderation)