### PR TITLE
chore(video-editor): update pro_video_editor to version 1.14.2

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1747,10 +1747,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "44495cc3a2a8b8768ed4c8930ff49a38b118f774dad3039a0d682fde61689afe"
+      sha256: cfed1424b3ca3d5981cc81efdd20b844c995c0ad2818e185eb5bc06a8674f728
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.2"
+    version: "1.14.2"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -179,7 +179,7 @@ dependencies:
   firebase_performance: ^0.11.1+4
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^1.13.2
+  pro_video_editor: ^1.14.2
   pro_image_editor: ^12.0.13
   linked_scroll_controller: ^0.2.0
   flutter_colorpicker: ^1.1.0


### PR DESCRIPTION
## Description

Updates `pro_video_editor` to 1.14.2. This is an important update for Android because it upgrades `androidx.media3` to version `1.10.0` from `1.9.0`.

The issue is that Android always uses the newest package version if any dependency requires it. Unfortunately, the Android team introduced breaking changes in `1.10.0`, which broke the editor that depended on `1.9.0`. This meant that if any other package required `1.10.0`, video rendering would fail, especially for videos with a separate audio track.


**Related Issue:** Closes #2685

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore