### PR TITLE
feat(profile): allow users to dismiss session expired banner

### DIFF
--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -176,16 +176,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               // Account header
               if (isAuthenticated) ...[
                 _AccountHeader(onSwitchAccount: _handleSwitchAccount),
-                // Auth-state conditional tiles
-                if (authService.hasExpiredOAuthSession)
-                  _SettingsTile(
-                    icon: Icons.refresh,
-                    title: 'Session Expired',
-                    subtitle: 'Sign in again to restore full access',
-                    onTap: _handleSessionExpired,
-                    iconColor: VineTheme.accentOrange,
-                  )
-                else if (authService.isAnonymous)
+                if (authService.isAnonymous)
                   _SettingsTile(
                     icon: Icons.security,
                     title: 'Secure Your Account',
@@ -193,6 +184,15 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                         'Add email & password to recover your '
                         'account on any device',
                     onTap: () => context.push(SecureAccountScreen.path),
+                  ),
+                if (!authService.isAnonymous &&
+                    authService.hasExpiredOAuthSession)
+                  _SettingsTile(
+                    icon: Icons.refresh,
+                    title: 'Session Expired',
+                    subtitle: 'Sign in again to restore full access',
+                    onTap: _handleSessionExpired,
+                    iconColor: VineTheme.accentOrange,
                   ),
               ],
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -18,6 +18,7 @@ import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/pending_verification_service.dart';
 import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
+import 'package:openvine/utils/divine_login_banner_dismissal.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/nostr_timestamp.dart';
 import 'package:openvine/utils/unified_logger.dart';
@@ -298,6 +299,7 @@ class AuthService implements BackgroundAwareService {
           category: LogCategory.auth,
         );
         await refreshed.save(_flutterSecureStorage);
+        await _clearDismissedDivineLoginBannerForCurrentUser();
         await signInWithDivineOAuth(refreshed);
         return true;
       }
@@ -309,6 +311,18 @@ class AuthService implements BackgroundAwareService {
       );
     }
     return false;
+  }
+
+  Future<void> _clearDismissedDivineLoginBannerForCurrentUser([
+    String? publicKeyHex,
+  ]) async {
+    final prefs = await SharedPreferences.getInstance();
+    final targetPubkey =
+        publicKeyHex ?? prefs.getString('current_user_pubkey_hex');
+    if (targetPubkey == null || targetPubkey.isEmpty) {
+      return;
+    }
+    await clearDivineLoginBannerDismissal(prefs, targetPubkey);
   }
 
   /// Get discovered user relays (NIP-65)
@@ -2280,6 +2294,7 @@ class AuthService implements BackgroundAwareService {
 
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString('current_user_pubkey_hex', publicKeyHex);
+      await _clearDismissedDivineLoginBannerForCurrentUser(publicKeyHex);
 
       Log.info(
         '✅ Divine oauth listener setting auth state to authenticated.',

--- a/mobile/lib/utils/divine_login_banner_dismissal.dart
+++ b/mobile/lib/utils/divine_login_banner_dismissal.dart
@@ -1,0 +1,41 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+const Duration divineLoginBannerDismissalTtl = Duration(days: 30);
+const _dismissedDivineLoginBannerPrefix = 'dismissed_divine_login_banner_';
+
+String divineLoginBannerDismissalKey(String userIdHex) =>
+    '$_dismissedDivineLoginBannerPrefix$userIdHex';
+
+bool isDivineLoginBannerDismissed(
+  SharedPreferences prefs,
+  String userIdHex, {
+  DateTime? now,
+}) {
+  final rawValue = prefs.get(divineLoginBannerDismissalKey(userIdHex));
+  if (rawValue is! int) {
+    return false;
+  }
+
+  final dismissedAt = DateTime.fromMillisecondsSinceEpoch(rawValue);
+  final comparisonTime = now ?? DateTime.now();
+  return comparisonTime.difference(dismissedAt) < divineLoginBannerDismissalTtl;
+}
+
+Future<void> dismissDivineLoginBanner(
+  SharedPreferences prefs,
+  String userIdHex, {
+  DateTime? now,
+}) {
+  final dismissedAt = now ?? DateTime.now();
+  return prefs.setInt(
+    divineLoginBannerDismissalKey(userIdHex),
+    dismissedAt.millisecondsSinceEpoch,
+  );
+}
+
+Future<void> clearDivineLoginBannerDismissal(
+  SharedPreferences prefs,
+  String userIdHex,
+) {
+  return prefs.remove(divineLoginBannerDismissalKey(userIdHex));
+}

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -12,11 +12,13 @@ import 'package:openvine/blocs/email_verification/email_verification_cubit.dart'
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/auth/secure_account_screen.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/utils/clipboard_utils.dart';
+import 'package:openvine/utils/divine_login_banner_dismissal.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/user_profile_utils.dart';
 import 'package:openvine/widgets/profile/profile_followers_stat.dart';
@@ -100,6 +102,11 @@ class ProfileHeaderWidget extends ConsumerWidget {
     ref.watch(currentAuthStateProvider);
     final isAnonymous = authService.isAnonymous;
     final hasExpiredSession = authService.hasExpiredOAuthSession;
+    final prefs = ref.watch(sharedPreferencesProvider);
+    final isDivineLoginBannerHidden = isDivineLoginBannerDismissed(
+      prefs,
+      userIdHex,
+    );
 
     // Use profile color as header background (like original Vine)
     // Color covers avatar/stats, then fades to dark for name/bio readability
@@ -137,14 +144,20 @@ class ProfileHeaderWidget extends ConsumerWidget {
                     onSetupProfile != null)
                   _SetupProfileBanner(onSetup: onSetupProfile!),
 
-                // Session expired banner for divineOAuth users (only on own
-                // profile) — prompts re-login instead of "Secure Your Account"
-                if (isOwnProfile && hasExpiredSession)
-                  const _SessionExpiredBanner()
                 // Secure account banner for anonymous users (only on own
                 // profile)
-                else if (isOwnProfile && isAnonymous)
+                if (isOwnProfile && isAnonymous)
                   const _IdentityNotRecoverableBanner(),
+                // Session expired banner for divineOAuth users (only on own
+                // profile) — anonymous users should still see the secure
+                // account prompt even if a stale expired-session flag leaked.
+                if (isOwnProfile &&
+                    !isAnonymous &&
+                    hasExpiredSession &&
+                    !isDivineLoginBannerHidden)
+                  _SessionExpiredBanner(
+                    userIdHex: userIdHex,
+                  ),
 
                 // Profile picture and stats row
                 Row(
@@ -439,7 +452,9 @@ class _IdentityNotRecoverableBanner extends StatelessWidget {
 /// Prompts the user to sign in again instead of showing "Secure Your Account".
 /// Attempts a silent token refresh first; navigates to login only if that fails.
 class _SessionExpiredBanner extends ConsumerStatefulWidget {
-  const _SessionExpiredBanner();
+  const _SessionExpiredBanner({required this.userIdHex});
+
+  final String userIdHex;
 
   @override
   ConsumerState<_SessionExpiredBanner> createState() =>
@@ -448,6 +463,13 @@ class _SessionExpiredBanner extends ConsumerStatefulWidget {
 
 class _SessionExpiredBannerState extends ConsumerState<_SessionExpiredBanner> {
   bool _isRefreshing = false;
+  bool _isDismissed = false;
+
+  Future<void> _dismissBanner() async {
+    setState(() => _isDismissed = true);
+    final prefs = ref.read(sharedPreferencesProvider);
+    await dismissDivineLoginBanner(prefs, widget.userIdHex);
+  }
 
   Future<void> _onSignIn() async {
     setState(() => _isRefreshing = true);
@@ -465,6 +487,8 @@ class _SessionExpiredBannerState extends ConsumerState<_SessionExpiredBanner> {
 
   @override
   Widget build(BuildContext context) {
+    if (_isDismissed) return const SizedBox.shrink();
+
     return Container(
       margin: const EdgeInsets.only(bottom: 16),
       padding: const EdgeInsets.all(16),
@@ -517,6 +541,11 @@ class _SessionExpiredBannerState extends ConsumerState<_SessionExpiredBanner> {
                       color: VineTheme.accentOrange,
                     ),
                   ),
+          ),
+          IconButton(
+            onPressed: _dismissBanner,
+            icon: const Icon(Icons.close, color: VineTheme.whiteText, size: 20),
+            tooltip: 'Dismiss',
           ),
         ],
       ),

--- a/mobile/test/utils/divine_login_banner_dismissal_test.dart
+++ b/mobile/test/utils/divine_login_banner_dismissal_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/divine_login_banner_dismissal.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const pubkey = 'test_pubkey_hex';
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('dismissal remains active within 30 days', () async {
+    final prefs = await SharedPreferences.getInstance();
+
+    await dismissDivineLoginBanner(
+      prefs,
+      pubkey,
+      now: DateTime(2026, 3, 22),
+    );
+
+    expect(
+      isDivineLoginBannerDismissed(
+        prefs,
+        pubkey,
+        now: DateTime(2026, 4, 20),
+      ),
+      isTrue,
+    );
+  });
+
+  test('dismissal expires after 30 days', () async {
+    final prefs = await SharedPreferences.getInstance();
+
+    await dismissDivineLoginBanner(
+      prefs,
+      pubkey,
+      now: DateTime(2026, 3, 22),
+    );
+
+    expect(
+      isDivineLoginBannerDismissed(
+        prefs,
+        pubkey,
+        now: DateTime(2026, 4, 22),
+      ),
+      isFalse,
+    );
+  });
+
+  test('returns false when no dismissal stored', () async {
+    final prefs = await SharedPreferences.getInstance();
+
+    expect(isDivineLoginBannerDismissed(prefs, pubkey), isFalse);
+  });
+
+  test('clearDivineLoginBannerDismissal removes the key', () async {
+    final prefs = await SharedPreferences.getInstance();
+
+    await dismissDivineLoginBanner(prefs, pubkey);
+    expect(isDivineLoginBannerDismissed(prefs, pubkey), isTrue);
+
+    await clearDivineLoginBannerDismissal(prefs, pubkey);
+    expect(isDivineLoginBannerDismissed(prefs, pubkey), isFalse);
+  });
+
+  test('dismissalKey includes user pubkey', () {
+    expect(
+      divineLoginBannerDismissalKey(pubkey),
+      equals('dismissed_divine_login_banner_$pubkey'),
+    );
+  });
+}

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -89,9 +89,13 @@ class MockNostrClient extends Mock implements NostrClient {
 }
 
 class MockAuthService extends Mock implements AuthService {
-  MockAuthService({this.isAnonymousValue = false});
+  MockAuthService({
+    this.isAnonymousValue = false,
+    this.hasExpiredOAuthSessionValue = false,
+  });
 
   final bool isAnonymousValue;
+  final bool hasExpiredOAuthSessionValue;
 
   @override
   bool get isAnonymous => isAnonymousValue;
@@ -107,11 +111,12 @@ class MockAuthService extends Mock implements AuthService {
       Stream.value(AuthState.authenticated);
 
   @override
-  bool get hasExpiredOAuthSession => false;
+  bool get hasExpiredOAuthSession => hasExpiredOAuthSessionValue;
 }
 
 const testUserHex =
     '78a5c21b5166dc1474b64ddf7454bf79e6b5d6b4a77148593bf1e866b73c2738';
+const _dismissedDivineLoginBannerPrefix = 'dismissed_divine_login_banner_';
 
 void main() {
   group('ProfileHeaderWidget', () {
@@ -163,10 +168,15 @@ void main() {
       bool profileIsLoading = false,
       VoidCallback? onSetupProfile,
       bool isAnonymous = false,
+      bool hasExpiredSession = false,
+      SharedPreferences? sharedPreferences,
       String? displayNameHint,
       String? avatarUrlHint,
     }) {
-      final authService = MockAuthService(isAnonymousValue: isAnonymous);
+      final authService = MockAuthService(
+        isAnonymousValue: isAnonymous,
+        hasExpiredOAuthSessionValue: hasExpiredSession,
+      );
 
       Widget header = ProfileHeaderWidget(
         userIdHex: userIdHex,
@@ -209,6 +219,7 @@ void main() {
         overrides: [
           ...getStandardTestOverrides(
             mockNostrService: mockNostrClient,
+            mockSharedPreferences: sharedPreferences,
             mockNip05VerificationService: createMockNip05VerificationService(),
           ),
           fetchUserProfileProvider(userIdHex).overrideWith(
@@ -677,6 +688,133 @@ void main() {
         // Verify the button has correct styling
         final button = tester.widget<ElevatedButton>(registerButton);
         expect(button.onPressed, isNotNull);
+      });
+    });
+
+    group('Session Expired Banner', () {
+      testWidgets('shows session expired banner when session is expired', (
+        tester,
+      ) async {
+        final testProfile = createTestProfile(displayName: 'Test User');
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: testProfile,
+            hasExpiredSession: true,
+            sharedPreferences: prefs,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Session Expired'), findsOneWidget);
+      });
+
+      testWidgets('session expired banner stays hidden within 30 days', (
+        tester,
+      ) async {
+        final testProfile = createTestProfile(displayName: 'Test User');
+        final dismissedAt = DateTime.now()
+            .subtract(const Duration(days: 29))
+            .millisecondsSinceEpoch;
+
+        SharedPreferences.setMockInitialValues({
+          '$_dismissedDivineLoginBannerPrefix$testUserHex': dismissedAt,
+        });
+        final prefs = await SharedPreferences.getInstance();
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: testProfile,
+            hasExpiredSession: true,
+            sharedPreferences: prefs,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Session Expired'), findsNothing);
+      });
+
+      testWidgets('session expired banner returns after 30 days', (
+        tester,
+      ) async {
+        final testProfile = createTestProfile(displayName: 'Test User');
+        final dismissedAt = DateTime.now()
+            .subtract(const Duration(days: 31))
+            .millisecondsSinceEpoch;
+
+        SharedPreferences.setMockInitialValues({
+          '$_dismissedDivineLoginBannerPrefix$testUserHex': dismissedAt,
+        });
+        final prefs = await SharedPreferences.getInstance();
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: testProfile,
+            hasExpiredSession: true,
+            sharedPreferences: prefs,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Session Expired'), findsOneWidget);
+      });
+
+      testWidgets(
+        'shows secure account instead of session expired for anonymous users',
+        (tester) async {
+          final testProfile = createTestProfile(displayName: 'Test User');
+          SharedPreferences.setMockInitialValues({});
+          final prefs = await SharedPreferences.getInstance();
+
+          await tester.pumpWidget(
+            buildTestWidget(
+              userIdHex: testUserHex,
+              isOwnProfile: true,
+              profile: testProfile,
+              isAnonymous: true,
+              hasExpiredSession: true,
+              sharedPreferences: prefs,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.text('Secure Your Account'), findsOneWidget);
+          expect(find.text('Session Expired'), findsNothing);
+        },
+      );
+
+      testWidgets('dismiss button hides the session expired banner', (
+        tester,
+      ) async {
+        final testProfile = createTestProfile(displayName: 'Test User');
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: testProfile,
+            hasExpiredSession: true,
+            sharedPreferences: prefs,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Session Expired'), findsOneWidget);
+
+        await tester.tap(find.byTooltip('Dismiss'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Session Expired'), findsNothing);
       });
     });
   });

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -144,12 +144,41 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Session Expired'), findsOneWidget);
-      // Should NOT show Secure Your Account when session expired
-      expect(find.text('Secure Your Account'), findsNothing);
 
       await tester.pumpWidget(const SizedBox());
       await tester.pump();
     });
+
+    testWidgets(
+      'shows secure account tile instead of session expired for anonymous '
+      'users',
+      (tester) async {
+        when(() => mockAuthService.isAnonymous).thenReturn(true);
+        when(
+          () => mockAuthService.hasExpiredOAuthSession,
+        ).thenReturn(true);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+              authServiceProvider.overrideWithValue(mockAuthService),
+              currentAuthStateProvider.overrideWithValue(
+                AuthState.authenticated,
+              ),
+            ],
+            child: const MaterialApp(home: SettingsScreen()),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Secure Your Account'), findsOneWidget);
+        expect(find.text('Session Expired'), findsNothing);
+
+        await tester.pumpWidget(const SizedBox());
+        await tester.pump();
+      },
+    );
 
     testWidgets('hides Secure Your Account for non-anonymous users', (
       tester,


### PR DESCRIPTION
Closes #2333

## Summary

- Adds a dismiss button (X) to the session expired banner on the profile page
- Dismissal is stored as a timestamp per-account in SharedPreferences with a 30-day TTL — banner re-appears after 30 days if the session is still expired
- Dismissal is cleared when OAuth recovery succeeds (both via manual refresh and OAuth listener)
- Fixes anonymous users incorrectly seeing "Session Expired" instead of "Secure Your Account" when a stale expired-session flag leaks across auth-mode changes

Supersedes #2214 (fresh implementation against current main, no conflicts).

## Changes

| File | Change |
|------|--------|
| `lib/utils/divine_login_banner_dismissal.dart` | New utility: TTL read/write/clear for per-account dismissal |
| `lib/widgets/profile/profile_header_widget.dart` | Add dismiss button, TTL check, reorder banner priority |
| `lib/screens/settings/settings_screen.dart` | Reorder: anonymous users see "Secure Your Account" even with stale expired flag |
| `lib/services/auth_service.dart` | Clear dismissal on successful OAuth refresh |

## Test plan

- [x] `test/utils/divine_login_banner_dismissal_test.dart` — 5 tests: TTL active, TTL expired, no dismissal, clear, key format
- [x] `test/widgets/profile/profile_header_widget_test.dart` — 5 new tests: banner shows, hidden within 30 days, returns after 30 days, anonymous sees secure account instead, dismiss button hides banner
- [x] `test/widgets/settings_screen_test.dart` — 1 new test: anonymous + expired session shows secure account
- [x] All existing tests pass (62 auth service tests, 29 profile header tests, 9 settings tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
