### PR TITLE
fix(auth): require isAuthenticated in email verification poll guard

### DIFF
--- a/mobile/lib/blocs/email_verification/email_verification_cubit.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_cubit.dart
@@ -183,7 +183,14 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
     // Guard: stop polling if user completed OAuth sign-in on this auth service.
     // Use isRegistered (not isAuthenticated) because anonymous users are
     // authenticated but still need polling to complete the secure-account flow.
-    if (_authService.isRegistered) {
+    //
+    // isAuthenticated is also required: isRegistered checks _authSource which
+    // persists across sign-outs and remains divineOAuth even when authState is
+    // unauthenticated. Without this gate, a new user registering on a device
+    // that previously had a signed-out OAuth session would have polling killed
+    // on the first tick — leaving them stuck on "Waiting for verification"
+    // even after clicking the email link.
+    if (_authService.isAuthenticated && _authService.isRegistered) {
       Log.info(
         'Auth already registered, stopping orphaned poll '
         '(cubit=$hashCode)',

--- a/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
+++ b/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
@@ -425,6 +425,73 @@ void main() {
       });
     });
 
+    group('stale authSource guard', () {
+      // Regression test for: isRegistered returns true based on _authSource
+      // which persists across sign-outs. On a device with a prior OAuth session,
+      // _authSource stays divineOAuth even after auth state goes unauthenticated.
+      // The polling guard must require isAuthenticated AND isRegistered or it
+      // kills legitimate new-user registration polls on the first tick.
+      test(
+        'does not stop polling when isRegistered=true but isAuthenticated=false',
+        () async {
+          // Simulate stale authSource: device had a prior OAuth session (signed
+          // out), so isRegistered=true but isAuthenticated=false.
+          when(() => mockAuthService.isAuthenticated).thenReturn(false);
+          when(() => mockAuthService.isRegistered).thenReturn(true);
+          when(
+            () => mockOAuth.pollForCode(testDeviceCode),
+          ).thenAnswer((_) async => PollResult.pending());
+
+          final cubit = buildCubit();
+          cubit.startPolling(
+            deviceCode: testDeviceCode,
+            verifier: testVerifier,
+            email: testEmail,
+          );
+
+          // Let two poll cycles run
+          await Future<void>.delayed(const Duration(seconds: 7));
+
+          // Polling should still be running — guard must NOT have fired
+          expect(cubit.state.status, EmailVerificationStatus.polling);
+          verify(() => mockOAuth.pollForCode(testDeviceCode)).called(
+            greaterThanOrEqualTo(2),
+          );
+
+          await cubit.close();
+        },
+      );
+
+      test(
+        'stops polling when both isAuthenticated=true and isRegistered=true',
+        () async {
+          // Guard should still fire for the legitimate zombie-cubit case:
+          // user IS authenticated AND registered (completed sign-in elsewhere).
+          when(() => mockAuthService.isAuthenticated).thenReturn(true);
+          when(() => mockAuthService.isRegistered).thenReturn(true);
+          when(
+            () => mockOAuth.pollForCode(testDeviceCode),
+          ).thenAnswer((_) async => PollResult.pending());
+
+          final cubit = buildCubit();
+          cubit.startPolling(
+            deviceCode: testDeviceCode,
+            verifier: testVerifier,
+            email: testEmail,
+          );
+
+          // Let the first poll cycle run
+          await Future<void>.delayed(const Duration(seconds: 4));
+
+          // Guard fires before the network call — pollForCode never called.
+          // (The cubit stops its timer silently without emitting a state change.)
+          verifyNever(() => mockOAuth.pollForCode(any()));
+
+          await cubit.close();
+        },
+      );
+    });
+
     group('close', () {
       test('cleans up timers on close', () async {
         final cubit = buildCubit();


### PR DESCRIPTION
## Description

Fixes users getting permanently stuck on "Waiting for verification" when registering a new account on a device that previously had a signed-out OAuth session. `_authSource` persists across sign-outs and remains `divineOAuth` even when `authState` is `unauthenticated`, causing `isRegistered` to return `true` and the polling guard to kill legitimate new-user registration polls on the first tick — before the verification email link is even clicked. Adding `isAuthenticated` to the guard condition ensures it only fires when a user is genuinely signed in.

**Related Issue:** Closes #2701

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore