### PR TITLE
fix(data): use singleton AppDatabase for seed data preload

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -4,7 +4,6 @@ import 'dart:io'
     as io;
 
 import 'package:audio_session/audio_session.dart';
-import 'package:db_client/db_client.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
@@ -25,6 +24,7 @@ import 'package:openvine/features/app/startup/startup_phase.dart';
 import 'package:openvine/network/vine_cdn_http_overrides.dart'
     if (dart.library.html) 'package:openvine/utils/platform_io_web.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/deep_link_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/popular_now_feed_provider.dart';
@@ -242,7 +242,7 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
   coordinator.registerService(
     name: 'SeedDataPreload',
     phase: StartupPhase.deferred,
-    initialize: _initializeSeedDataPreload,
+    initialize: () => _initializeSeedDataPreload(container),
     optional: true,
   );
 
@@ -695,15 +695,14 @@ Future<void> _initializeVideoCacheManifest() async {
   );
 }
 
-Future<void> _initializeSeedDataPreload() async {
+Future<void> _initializeSeedDataPreload(ProviderContainer container) async {
   await _runTimedStartupTask(
     phaseName: 'seed_data_preload',
     initializationStep: 'Loading bundled seed data',
     task: () async {
-      AppDatabase? seedDb;
       try {
-        seedDb = AppDatabase();
-        await SeedDataPreloadService.loadSeedDataIfNeeded(seedDb);
+        final db = container.read(databaseProvider);
+        await SeedDataPreloadService.loadSeedDataIfNeeded(db);
       } catch (e, stack) {
         Log.error(
           '[SEED] Data preload failed (non-critical): $e',
@@ -715,8 +714,6 @@ Future<void> _initializeSeedDataPreload() async {
           name: 'Main',
           category: LogCategory.system,
         );
-      } finally {
-        await seedDb?.close();
       }
     },
   );


### PR DESCRIPTION
Closes #2706

## Summary

- Use `container.read(databaseProvider)` in `_initializeSeedDataPreload` instead of creating a second `AppDatabase()` instance
- Remove manual `seedDb?.close()` — Riverpod manages the singleton lifecycle
- Remove unused `db_client` import from `main.dart`

## What changed

`_initializeSeedDataPreload` now accepts a `ProviderContainer` parameter (matching the `_initializeCoreServices` pattern) and reads the existing database singleton rather than constructing a duplicate.

## Why

Drift detects two concurrent `AppDatabase` instances targeting the same SQLite file and warns about potential race conditions and data corruption. While startup phases are sequential (making actual corruption unlikely), this violates Drift's core invariant of one-database-per-file and its official guidance.

## Test plan

- [ ] `flutter analyze` passes (verified — pre-commit hook ran)
- [ ] Drift duplicate-database warning no longer appears on debug launch
- [ ] Seed data loads correctly on fresh install (wipe simulator, launch, verify seed content)