### PR TITLE
fix(video): treat relay acceptance as publish success

### DIFF
--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -12,7 +12,6 @@ import 'package:models/models.dart'
     hide LogCategory, NIP71VideoKinds, PendingUpload, UploadStatus;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
-import 'package:nostr_sdk/filter.dart' as nostr;
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/models/audio_event.dart';
 import 'package:openvine/models/pending_upload.dart';
@@ -271,44 +270,6 @@ class VideoEventPublisher {
       upload.status,
       nostrEventId: event.id,
     );
-  }
-
-  Future<bool> _confirmEventVisibleOnRelays(Event event) async {
-    try {
-      final results = await _nostrService
-          .queryEvents(
-            [
-              nostr.Filter(
-                ids: [event.id],
-                limit: 1,
-              ),
-            ],
-            subscriptionId:
-                'publish_verify_${event.id}_${DateTime.now().microsecondsSinceEpoch}',
-            useCache: false,
-          )
-          .timeout(
-            const Duration(seconds: 5),
-            onTimeout: () => <Event>[],
-          );
-
-      final isVisible = results.any((candidate) => candidate.id == event.id);
-      if (!isVisible) {
-        Log.warning(
-          'Published event was not queryable from relays yet: ${event.id}',
-          name: 'VideoEventPublisher',
-          category: LogCategory.video,
-        );
-      }
-      return isVisible;
-    } catch (e) {
-      Log.warning(
-        'Failed to verify relay visibility for ${event.id}: $e',
-        name: 'VideoEventPublisher',
-        category: LogCategory.video,
-      );
-      return false;
-    }
   }
 
   /// Get publishing statistics
@@ -936,30 +897,15 @@ class VideoEventPublisher {
 
       // Retry up to 3 times with exponential backoff.
       // A successful send (relay accepted the event) is treated as success.
-      // The visibility confirmation is best-effort diagnostics only — relay
-      // indexing lag can cause the read-back to time out even though the
-      // event was accepted and is already being delivered via subscriptions.
+      // We intentionally skip read-back verification because relay indexing
+      // lag can cause timeouts even though the event was accepted and is
+      // already being delivered via subscriptions.
       const maxRetries = 3;
       var publishResult = false;
 
       for (var attempt = 1; attempt <= maxRetries; attempt++) {
-        final sendResult = await _publishEventToNostr(event);
-
-        if (sendResult) {
-          // Relay accepted the event — treat as success regardless of
-          // whether the read-back confirmation succeeds.
+        if (await _publishEventToNostr(event)) {
           publishResult = true;
-
-          final confirmed = await _confirmEventVisibleOnRelays(event);
-          if (!confirmed) {
-            Log.warning(
-              '⚠️ Event accepted by relay but not yet queryable '
-              '(attempt $attempt): ${event.id}',
-              name: 'VideoEventPublisher',
-              category: LogCategory.video,
-            );
-          }
-
           if (attempt > 1) {
             Log.info(
               '✅ Publish succeeded on attempt $attempt',

--- a/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
+++ b/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
@@ -3,7 +3,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show VideoEvent;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
-import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -25,8 +24,6 @@ class _MockVideoEventService extends Mock implements VideoEventService {}
 
 class _FakeEvent extends Fake implements Event {}
 
-class _FakeFilter extends Fake implements Filter {}
-
 class _FakeVideoEvent extends Fake implements VideoEvent {}
 
 void main() {
@@ -42,9 +39,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(_FakeEvent());
-    registerFallbackValue(_FakeFilter());
     registerFallbackValue(_FakeVideoEvent());
-    registerFallbackValue(<Filter>[]);
     registerFallbackValue(UploadStatus.pending);
   });
 
@@ -134,26 +129,13 @@ void main() {
     ).thenAnswer((_) async => event);
   }
 
-  group('VideoEventPublisher direct publish confirmation', () {
+  group('VideoEventPublisher direct publish', () {
     test(
-      'succeeds when relay accepts the event even if visibility '
-      'confirmation fails',
+      'succeeds when relay accepts the event',
       () async {
         final signedEvent = createSignedEvent();
         stubSigning(signedEvent);
         stubPublish(signedEvent);
-        // Relay accepts the event (publishEvent returns non-null) but
-        // the read-back query returns empty — should still succeed.
-        when(
-          () => mockNostrClient.queryEvents(
-            any(),
-            subscriptionId: any(named: 'subscriptionId'),
-            tempRelays: any(named: 'tempRelays'),
-            relayTypes: any(named: 'relayTypes'),
-            sendAfterAuth: any(named: 'sendAfterAuth'),
-            useCache: any(named: 'useCache'),
-          ),
-        ).thenAnswer((_) async => <Event>[]);
 
         final result = await publisher.publishDirectUpload(createUpload());
 
@@ -203,16 +185,6 @@ void main() {
         () => mockPersonalEventCache.getEventById(signedEvent.id),
       ).thenReturn(signedEvent);
       stubPublish(signedEvent);
-      when(
-        () => mockNostrClient.queryEvents(
-          any(),
-          subscriptionId: any(named: 'subscriptionId'),
-          tempRelays: any(named: 'tempRelays'),
-          relayTypes: any(named: 'relayTypes'),
-          sendAfterAuth: any(named: 'sendAfterAuth'),
-          useCache: any(named: 'useCache'),
-        ),
-      ).thenAnswer((_) async => <Event>[signedEvent]);
 
       final result = await publisher.publishDirectUpload(retryUpload);
 
@@ -226,36 +198,5 @@ void main() {
       );
       verify(() => mockNostrClient.publishEvent(signedEvent)).called(1);
     });
-
-    test(
-      'marks publish successful only after the event is queryable from relays',
-      () async {
-        final signedEvent = createSignedEvent();
-        stubSigning(signedEvent);
-        stubPublish(signedEvent);
-        when(
-          () => mockNostrClient.queryEvents(
-            any(),
-            subscriptionId: any(named: 'subscriptionId'),
-            tempRelays: any(named: 'tempRelays'),
-            relayTypes: any(named: 'relayTypes'),
-            sendAfterAuth: any(named: 'sendAfterAuth'),
-            useCache: any(named: 'useCache'),
-          ),
-        ).thenAnswer((_) async => <Event>[signedEvent]);
-
-        final result = await publisher.publishDirectUpload(createUpload());
-
-        expect(result, isTrue);
-        verify(
-          () => mockUploadManager.updateUploadStatus(
-            'test-upload-id',
-            UploadStatus.published,
-            nostrEventId: signedEvent.id,
-          ),
-        ).called(1);
-        verify(() => mockVideoEventService.addVideoEvent(any())).called(1);
-      },
-    );
   });
 }


### PR DESCRIPTION
Closes #2708

## Summary

- Treat relay event acceptance (`sendResult == true`) as publish success, regardless of whether the read-back visibility confirmation succeeds.
- Demote `_confirmEventVisibleOnRelays` failure from a hard error to a warning log — relay indexing lag should not fail the upload.
- Add a dedicated test for the actual failure path (relay rejects the event on all attempts).

## Changes

| File | Change |
|------|--------|
| `video_event_publisher.dart` | Once relay accepts, set `publishResult = true`; log warning if read-back times out instead of failing |
| `video_event_publisher_publish_confirmation_test.dart` | Update existing test to expect success on accept-but-no-readback; add new test for relay rejection |

## Root Cause

The retry loop in `publishDirectUpload` was gating success on `_confirmEventVisibleOnRelays`, which queries the relay to verify the event is indexed. Relay indexing lag caused this read-back to time out, making the publisher treat an already-accepted event as a failure.

## Test Plan

- [x] Existing confirmation test updated — relay accepts but read-back fails → now expects `true`
- [x] New test — relay rejects on all attempts → expects `false`
- [ ] Manual: publish a video and verify no false failure toast