### PR TITLE
ci: deploy web to app.divine.video on merge to main

### DIFF
--- a/.github/workflows/mobile_web_production_deploy.yml
+++ b/.github/workflows/mobile_web_production_deploy.yml
@@ -1,0 +1,59 @@
+# ABOUTME: Builds and deploys Flutter web to Cloudflare Pages on every merge to main
+# ABOUTME: Production site at app.divine.video via the openvine-app Pages project
+
+name: Mobile Web Production Deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "mobile/**"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    name: Build & Deploy to app.divine.video
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.4"
+          channel: stable
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build Flutter web
+        run: |
+          flutter build web \
+            --release \
+            --tree-shake-icons \
+            --optimization-level=4 \
+            --pwa-strategy=none \
+            --dart-define=DEFAULT_ENV=PRODUCTION \
+            --no-source-maps
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: >-
+            pages deploy mobile/build/web
+            --project-name=openvine-app
+            --branch=main


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that builds Flutter web and deploys to Cloudflare Pages on every merge to main
- Deploys to the existing `openvine-app` Pages project on the `main` branch (production)
- Uses the same `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets as PR previews
- Custom domain `app.divine.video` should be configured in the Cloudflare Pages dashboard

## Test plan
- [ ] Verify `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets are set in the repo
- [ ] Merge to main and confirm workflow triggers and deploys successfully
- [ ] Verify `app.divine.video` serves the Flutter web app after deploy
- [ ] Configure custom domain in Cloudflare Pages dashboard if not already done

🤖 Generated with [Claude Code](https://claude.com/claude-code)