### PR TITLE
feat(search): full video search with navigation and pagination

### DIFF
--- a/mobile/lib/blocs/video_search/video_search_bloc.dart
+++ b/mobile/lib/blocs/video_search/video_search_bloc.dart
@@ -1,6 +1,6 @@
 // ABOUTME: BLoC for searching videos via VideosRepository.
 // ABOUTME: Delegates search to the repository layer via a progressive stream.
-// ABOUTME: Uses emit.forEach on VideosRepository.searchVideos().
+// ABOUTME: Supports pagination via VideoSearchLoadMore for infinite scroll.
 
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
@@ -12,6 +12,9 @@ import 'package:videos_repository/videos_repository.dart';
 
 part 'video_search_event.dart';
 part 'video_search_state.dart';
+
+/// Page size for API pagination.
+const _pageSize = 50;
 
 /// Event transformer that debounces and restarts on new events
 EventTransformer<E> _debounceRestartable<E>() {
@@ -33,6 +36,9 @@ EventTransformer<E> _debounceRestartable<E>() {
 /// 1. Local cache results (instant)
 /// 2. API or relay results (whichever finishes first)
 /// 3. Remaining source results (all done)
+///
+/// After the initial search, [VideoSearchLoadMore] fetches additional
+/// pages from the API for infinite scroll.
 class VideoSearchBloc extends Bloc<VideoSearchEvent, VideoSearchState> {
   VideoSearchBloc({required VideosRepository videosRepository})
     : _videosRepository = videosRepository,
@@ -42,6 +48,7 @@ class VideoSearchBloc extends Bloc<VideoSearchEvent, VideoSearchState> {
       transformer: _debounceRestartable(),
     );
     on<VideoSearchCleared>(_onCleared);
+    on<VideoSearchLoadMore>(_onLoadMore, transformer: sequential());
   }
 
   final VideosRepository _videosRepository;
@@ -80,6 +87,10 @@ class VideoSearchBloc extends Bloc<VideoSearchEvent, VideoSearchState> {
         status: VideoSearchStatus.searching,
         query: query,
         resultCount: null,
+        apiOffset: 0,
+        totalApiCount: null,
+        hasMore: false,
+        isLoadingMore: false,
       ),
     );
 
@@ -92,9 +103,54 @@ class VideoSearchBloc extends Bloc<VideoSearchEvent, VideoSearchState> {
           resultCount: videos.length,
         ),
       );
-      emit(state.copyWith(status: VideoSearchStatus.success));
-    } on Exception {
+      // Progressive stream complete — set pagination state.
+      // One API page was consumed during the stream; assume more exist
+      // only if we actually received results.
+      emit(
+        state.copyWith(
+          status: VideoSearchStatus.success,
+          apiOffset: _pageSize,
+          hasMore: state.videos.isNotEmpty,
+        ),
+      );
+    } on Exception catch (e, stackTrace) {
+      addError(e, stackTrace);
       emit(state.copyWith(status: VideoSearchStatus.failure));
+    }
+  }
+
+  Future<void> _onLoadMore(
+    VideoSearchLoadMore event,
+    Emitter<VideoSearchState> emit,
+  ) async {
+    if (!state.hasMore || state.isLoadingMore || state.query.isEmpty) return;
+
+    emit(state.copyWith(isLoadingMore: true));
+
+    try {
+      final result = await _videosRepository.searchVideosViaApi(
+        query: state.query,
+        offset: state.apiOffset,
+      );
+
+      final merged = _videosRepository.deduplicateAndSortVideos(
+        [...state.videos, ...result.videos],
+      );
+      final newOffset = state.apiOffset + _pageSize;
+
+      emit(
+        state.copyWith(
+          videos: merged,
+          resultCount: merged.length,
+          apiOffset: newOffset,
+          totalApiCount: result.totalCount,
+          hasMore: newOffset < result.totalCount,
+          isLoadingMore: false,
+        ),
+      );
+    } on Exception catch (e, stackTrace) {
+      addError(e, stackTrace);
+      emit(state.copyWith(isLoadingMore: false));
     }
   }
 

--- a/mobile/lib/blocs/video_search/video_search_event.dart
+++ b/mobile/lib/blocs/video_search/video_search_event.dart
@@ -29,3 +29,8 @@ final class VideoSearchQueryChanged extends VideoSearchEvent {
 final class VideoSearchCleared extends VideoSearchEvent {
   const VideoSearchCleared();
 }
+
+/// Request to load the next page of video search results from the API
+final class VideoSearchLoadMore extends VideoSearchEvent {
+  const VideoSearchLoadMore();
+}

--- a/mobile/lib/blocs/video_search/video_search_state.dart
+++ b/mobile/lib/blocs/video_search/video_search_state.dart
@@ -1,5 +1,5 @@
 // ABOUTME: State class for the VideoSearchBloc
-// ABOUTME: Represents search state with status, query, and results
+// ABOUTME: Represents search state with status, query, results, and pagination
 
 part of 'video_search_bloc.dart';
 
@@ -25,6 +25,10 @@ final class VideoSearchState extends Equatable {
     this.query = '',
     this.videos = const [],
     this.resultCount,
+    this.apiOffset = 0,
+    this.totalApiCount,
+    this.hasMore = false,
+    this.isLoadingMore = false,
   });
 
   /// The current status of the search
@@ -39,12 +43,28 @@ final class VideoSearchState extends Equatable {
   /// Lightweight count for tab badges when full results were not fetched.
   final int? resultCount;
 
+  /// Tracks how many results have been fetched from the API for pagination.
+  final int apiOffset;
+
+  /// Total API result count from `X-Total-Count` header (null until known).
+  final int? totalApiCount;
+
+  /// Whether more API pages are available.
+  final bool hasMore;
+
+  /// Whether a load-more request is currently in flight.
+  final bool isLoadingMore;
+
   /// Create a copy with updated values
   VideoSearchState copyWith({
     VideoSearchStatus? status,
     String? query,
     List<VideoEvent>? videos,
     Object? resultCount = _unset,
+    int? apiOffset,
+    Object? totalApiCount = _unset,
+    bool? hasMore,
+    bool? isLoadingMore,
   }) {
     return VideoSearchState(
       status: status ?? this.status,
@@ -53,11 +73,26 @@ final class VideoSearchState extends Equatable {
       resultCount: identical(resultCount, _unset)
           ? this.resultCount
           : resultCount as int?,
+      apiOffset: apiOffset ?? this.apiOffset,
+      totalApiCount: identical(totalApiCount, _unset)
+          ? this.totalApiCount
+          : totalApiCount as int?,
+      hasMore: hasMore ?? this.hasMore,
+      isLoadingMore: isLoadingMore ?? this.isLoadingMore,
     );
   }
 
   @override
-  List<Object> get props => [status, query, videos, resultCount ?? -1];
+  List<Object> get props => [
+    status,
+    query,
+    videos,
+    resultCount ?? -1,
+    apiOffset,
+    totalApiCount ?? -1,
+    hasMore,
+    isLoadingMore,
+  ];
 
   static const Object _unset = Object();
 }

--- a/mobile/lib/screens/search_results/view/search_results_view.dart
+++ b/mobile/lib/screens/search_results/view/search_results_view.dart
@@ -14,6 +14,9 @@ enum SearchResultsFilter {
 
   /// Show only the full hashtag list.
   tags('Tags'),
+
+  /// Show only the full paginated video grid.
+  videos('Videos'),
   ;
 
   const SearchResultsFilter(this.label);
@@ -44,9 +47,11 @@ class SearchResultsView extends StatelessWidget {
         SearchResultsFilter.all => _AllSectionsView(
           onSeeAllPeople: () => onFilterChanged(SearchResultsFilter.people),
           onSeeAllTags: () => onFilterChanged(SearchResultsFilter.tags),
+          onSeeAllVideos: () => onFilterChanged(SearchResultsFilter.videos),
         ),
         SearchResultsFilter.people => const UserSearchView(),
         SearchResultsFilter.tags => const HashtagSearchView(),
+        SearchResultsFilter.videos => const VideoSearchView(),
       },
     );
   }
@@ -56,10 +61,12 @@ class _AllSectionsView extends StatelessWidget {
   const _AllSectionsView({
     required this.onSeeAllPeople,
     required this.onSeeAllTags,
+    required this.onSeeAllVideos,
   });
 
   final VoidCallback onSeeAllPeople;
   final VoidCallback onSeeAllTags;
+  final VoidCallback onSeeAllVideos;
 
   @override
   Widget build(BuildContext context) {
@@ -67,7 +74,7 @@ class _AllSectionsView extends StatelessWidget {
       slivers: [
         PeopleSection(onSeeAll: onSeeAllPeople),
         TagsSection(onSeeAll: onSeeAllTags),
-        const VideosSection(),
+        VideosSection(onSeeAll: onSeeAllVideos),
       ],
     );
   }

--- a/mobile/lib/screens/search_results/widgets/video_search_view.dart
+++ b/mobile/lib/screens/search_results/widgets/video_search_view.dart
@@ -1,0 +1,151 @@
+import 'dart:async';
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+import 'package:go_router/go_router.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_search/video_search_bloc.dart';
+import 'package:openvine/mixins/scroll_pagination_mixin.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/screens/search_results/widgets/videos_section.dart';
+import 'package:openvine/services/view_event_publisher.dart';
+import 'package:rxdart/rxdart.dart';
+
+/// Full paginated video grid for the "Videos" search results filter.
+///
+/// Mirrors [UserSearchView] — uses [ScrollPaginationMixin] for infinite scroll
+/// and dispatches [VideoSearchLoadMore] when nearing the bottom.
+class VideoSearchView extends StatelessWidget {
+  const VideoSearchView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final videos = context.select(
+      (VideoSearchBloc bloc) => bloc.state.videos,
+    );
+    final hasMore = context.select(
+      (VideoSearchBloc bloc) => bloc.state.hasMore,
+    );
+    final isLoadingMore = context.select(
+      (VideoSearchBloc bloc) => bloc.state.isLoadingMore,
+    );
+
+    return _VideoSearchGrid(
+      videos: videos,
+      hasMore: hasMore,
+      isLoadingMore: isLoadingMore,
+    );
+  }
+}
+
+class _VideoSearchGrid extends StatefulWidget {
+  const _VideoSearchGrid({
+    required this.videos,
+    required this.hasMore,
+    required this.isLoadingMore,
+  });
+
+  final List<VideoEvent> videos;
+  final bool hasMore;
+  final bool isLoadingMore;
+
+  @override
+  State<_VideoSearchGrid> createState() => _VideoSearchGridState();
+}
+
+class _VideoSearchGridState extends State<_VideoSearchGrid>
+    with ScrollPaginationMixin {
+  final _scrollController = ScrollController();
+  late final StreamController<List<VideoEvent>> _videosStreamController;
+
+  @override
+  ScrollController get paginationScrollController => _scrollController;
+
+  @override
+  bool canLoadMore() => widget.hasMore && !widget.isLoadingMore;
+
+  @override
+  FutureOr<void> onLoadMore() {
+    context.read<VideoSearchBloc>().add(const VideoSearchLoadMore());
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    initPagination();
+    _videosStreamController = StreamController<List<VideoEvent>>.broadcast();
+  }
+
+  @override
+  void didUpdateWidget(_VideoSearchGrid oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.videos != widget.videos) {
+      _videosStreamController.add(widget.videos);
+    }
+  }
+
+  @override
+  void dispose() {
+    disposePagination();
+    _videosStreamController.close();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onVideoTap(int index) {
+    context.push(
+      PooledFullscreenVideoFeedScreen.path,
+      extra: PooledFullscreenVideoFeedArgs(
+        videosStream: _videosStreamController.stream.startWith(widget.videos),
+        initialIndex: index,
+        onLoadMore: () => context.read<VideoSearchBloc>().add(
+          const VideoSearchLoadMore(),
+        ),
+        contextTitle: 'Search Results',
+        trafficSource: ViewTrafficSource.search,
+        sourceDetail: context.read<VideoSearchBloc>().state.query,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.videos.isEmpty) {
+      return const Center(
+        child: Text(
+          'No videos found',
+          style: TextStyle(color: VineTheme.lightText),
+        ),
+      );
+    }
+
+    final screenWidth = MediaQuery.of(context).size.width;
+    final crossAxisCount = screenWidth >= 600 ? 3 : 2;
+    final itemCount = widget.videos.length + (widget.isLoadingMore ? 1 : 0);
+
+    return MasonryGridView.count(
+      controller: _scrollController,
+      padding: const EdgeInsets.all(4),
+      crossAxisCount: crossAxisCount,
+      mainAxisSpacing: 4,
+      crossAxisSpacing: 4,
+      itemCount: itemCount,
+      itemBuilder: (context, index) {
+        if (index >= widget.videos.length) {
+          return const Padding(
+            padding: EdgeInsets.symmetric(vertical: 16),
+            child: Center(
+              child: CircularProgressIndicator(color: VineTheme.vineGreen),
+            ),
+          );
+        }
+        return SearchVideoTile(
+          video: widget.videos[index],
+          onTap: () => _onVideoTap(index),
+        );
+      },
+    );
+  }
+}

--- a/mobile/lib/screens/search_results/widgets/videos_section.dart
+++ b/mobile/lib/screens/search_results/widgets/videos_section.dart
@@ -1,33 +1,97 @@
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_search/video_search_bloc.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/search_results/widgets/section_header.dart';
+import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
+import 'package:rxdart/rxdart.dart';
 
-/// Always-visible Videos section with a "Videos" header.
+/// Always-visible Videos section with a "Videos" header and optional
+/// "See all" chevron.
 ///
 /// Returns a [SliverMainAxisGroup] so the header and content participate
 /// natively in the parent [CustomScrollView]'s sliver protocol.
 class VideosSection extends StatelessWidget {
-  const VideosSection({super.key});
+  const VideosSection({this.onSeeAll, super.key});
+
+  /// Called when the user taps the "Videos" header chevron.
+  final VoidCallback? onSeeAll;
 
   @override
   Widget build(BuildContext context) {
-    return const SliverMainAxisGroup(
+    return SliverMainAxisGroup(
       slivers: [
-        SliverToBoxAdapter(child: SectionHeader(title: 'Videos')),
-        _VideosContent(),
+        SliverToBoxAdapter(
+          child: SectionHeader(title: 'Videos', onTap: onSeeAll),
+        ),
+        const _VideosContent(),
       ],
     );
   }
 }
 
-class _VideosContent extends StatelessWidget {
+class _VideosContent extends StatefulWidget {
   const _VideosContent();
+
+  @override
+  State<_VideosContent> createState() => _VideosContentState();
+}
+
+class _VideosContentState extends State<_VideosContent> {
+  late final StreamController<List<VideoEvent>> _videosStreamController;
+
+  @override
+  void initState() {
+    super.initState();
+    _videosStreamController = StreamController<List<VideoEvent>>.broadcast();
+  }
+
+  @override
+  void dispose() {
+    _videosStreamController.close();
+    super.dispose();
+  }
+
+  void _onVideoTap(List<VideoEvent> videos, int index) {
+    context.push(
+      PooledFullscreenVideoFeedScreen.path,
+      extra: PooledFullscreenVideoFeedArgs(
+        videosStream: _videosStreamController.stream.startWith(videos),
+        initialIndex: index,
+        onLoadMore: () => context.read<VideoSearchBloc>().add(
+          const VideoSearchLoadMore(),
+        ),
+        contextTitle: 'Search Results',
+        trafficSource: ViewTrafficSource.search,
+        sourceDetail: context.read<VideoSearchBloc>().state.query,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<VideoSearchBloc, VideoSearchState>(
+      listenWhen: (prev, curr) => prev.videos != curr.videos,
+      listener: (context, state) {
+        _videosStreamController.add(state.videos);
+      },
+      child: _VideosGrid(onVideoTap: _onVideoTap),
+    );
+  }
+}
+
+class _VideosGrid extends StatelessWidget {
+  const _VideosGrid({required this.onVideoTap});
+
+  final void Function(List<VideoEvent> videos, int index) onVideoTap;
 
   @override
   Widget build(BuildContext context) {
@@ -38,7 +102,9 @@ class _VideosContent extends StatelessWidget {
       (VideoSearchBloc bloc) => bloc.state.videos,
     );
 
-    if ((status == .initial || status == .searching) && videos.isEmpty) {
+    if ((status == VideoSearchStatus.initial ||
+            status == VideoSearchStatus.searching) &&
+        videos.isEmpty) {
       return const SliverToBoxAdapter(
         child: Padding(
           padding: EdgeInsets.symmetric(vertical: 24),
@@ -64,10 +130,9 @@ class _VideosContent extends StatelessWidget {
         crossAxisSpacing: 4,
         childCount: videos.length,
         itemBuilder: (context, index) {
-          return _SearchVideoTile(
+          return SearchVideoTile(
             video: videos[index],
-            index: index,
-            videos: videos,
+            onTap: () => onVideoTap(videos, index),
           );
         },
       ),
@@ -75,23 +140,24 @@ class _VideosContent extends StatelessWidget {
   }
 }
 
-class _SearchVideoTile extends StatelessWidget {
-  const _SearchVideoTile({
+/// A video thumbnail tile for search results with author name overlay.
+///
+/// Shared between [VideosSection] (all-filter overview) and
+/// [VideoSearchView] (dedicated videos-filter grid).
+class SearchVideoTile extends StatelessWidget {
+  const SearchVideoTile({
     required this.video,
-    required this.index,
-    required this.videos,
+    required this.onTap,
+    super.key,
   });
 
   final VideoEvent video;
-  final int index;
-  final List<VideoEvent> videos;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () {
-        // TODO(#2473): Navigate to video feed mode
-      },
+      onTap: onTap,
       child: ClipRRect(
         borderRadius: BorderRadius.circular(4),
         child: Stack(

--- a/mobile/lib/screens/search_results/widgets/widgets.dart
+++ b/mobile/lib/screens/search_results/widgets/widgets.dart
@@ -4,4 +4,5 @@ export 'search_tag_chip.dart';
 export 'search_user_tile.dart';
 export 'section_header.dart';
 export 'tags_section.dart';
+export 'video_search_view.dart';
 export 'videos_section.dart';

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -795,9 +795,10 @@ class FunnelcakeApiClient {
   /// - [FunnelcakeApiException] if the request fails.
   /// - [FunnelcakeTimeoutException] if the request times out.
   /// - [FunnelcakeException] for other errors.
-  Future<List<VideoStats>> searchVideos({
+  Future<VideoSearchResponse> searchVideos({
     required String query,
     int limit = 50,
+    int offset = 0,
   }) async {
     if (!isAvailable) {
       throw const FunnelcakeNotConfiguredException();
@@ -808,9 +809,17 @@ class FunnelcakeApiClient {
       throw const FunnelcakeException('Search query cannot be empty');
     }
 
+    final queryParams = <String, String>{
+      'q': trimmedQuery,
+      'limit': limit.toString(),
+    };
+    if (offset > 0) {
+      queryParams['offset'] = offset.toString();
+    }
+
     final uri = Uri.parse(
       '$_baseUrl/api/search',
-    ).replace(queryParameters: {'q': trimmedQuery, 'limit': limit.toString()});
+    ).replace(queryParameters: queryParams);
 
     try {
       final response = await _get(uri);
@@ -818,10 +827,19 @@ class FunnelcakeApiClient {
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as List<dynamic>;
 
-        return data
+        final videos = data
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
+
+        final totalCount =
+            int.tryParse(response.headers['x-total-count'] ?? '') ??
+            videos.length;
+
+        return VideoSearchResponse(
+          videos: videos,
+          totalCount: totalCount,
+        );
       } else {
         throw FunnelcakeApiException(
           message: 'Failed to search videos',

--- a/mobile/packages/funnelcake_api_client/lib/src/models/models.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/models.dart
@@ -1,2 +1,3 @@
 export 'video_comment.dart';
 export 'video_comments_response.dart';
+export 'video_search_response.dart';

--- a/mobile/packages/funnelcake_api_client/lib/src/models/video_search_response.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/video_search_response.dart
@@ -1,0 +1,19 @@
+import 'package:models/models.dart';
+
+/// Response model for the video search endpoint (`/api/search`).
+///
+/// Pairs the paginated video results with the total count reported by the
+/// `X-Total-Count` response header so callers can drive infinite-scroll UI.
+class VideoSearchResponse {
+  /// Creates a parsed response for a video search page.
+  const VideoSearchResponse({
+    required this.videos,
+    required this.totalCount,
+  });
+
+  /// The videos returned for this page.
+  final List<VideoStats> videos;
+
+  /// Total number of videos matching the query (from `X-Total-Count` header).
+  final int totalCount;
+}

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -2040,10 +2040,11 @@ void main() {
           () => mockHttpClient.get(any(), headers: any(named: 'headers')),
         ).thenAnswer((_) async => http.Response(validResponseBody, 200));
 
-        final videos = await client.searchVideos(query: 'flutter');
+        final result = await client.searchVideos(query: 'flutter');
 
-        expect(videos, hasLength(1));
-        expect(videos.first.id, equals('search123'));
+        expect(result, isA<VideoSearchResponse>());
+        expect(result.videos, hasLength(1));
+        expect(result.videos.first.id, equals('search123'));
       });
 
       test('constructs correct URL', () async {
@@ -2158,6 +2159,52 @@ void main() {
           ),
         );
       });
+
+      test('includes offset query parameter when greater than 0', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response('[]', 200));
+
+        await client.searchVideos(query: 'flutter', offset: 20);
+
+        final captured = verify(
+          () =>
+              mockHttpClient.get(captureAny(), headers: any(named: 'headers')),
+        ).captured;
+
+        final uri = captured.first as Uri;
+        expect(uri.queryParameters['offset'], equals('20'));
+      });
+
+      test('parses X-Total-Count header into totalCount', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async => http.Response(
+            validResponseBody,
+            200,
+            headers: {'x-total-count': '42'},
+          ),
+        );
+
+        final result = await client.searchVideos(query: 'flutter');
+
+        expect(result.totalCount, equals(42));
+        expect(result.videos, hasLength(1));
+      });
+
+      test(
+        'defaults totalCount to videos length when header is missing',
+        () async {
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer((_) async => http.Response(validResponseBody, 200));
+
+          final result = await client.searchVideos(query: 'flutter');
+
+          expect(result.totalCount, equals(result.videos.length));
+        },
+      );
     });
 
     group('getClassicVines', () {

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -1021,24 +1021,32 @@ class VideosRepository {
   /// - [query]: The search query string. Returns empty if blank.
   /// - [limit]: Maximum number of results (default 50).
   ///
-  /// Returns a list of matching [VideoEvent]s (unsorted — call
-  /// [deduplicateAndSortVideos] to rank).
-  Future<List<VideoEvent>> searchVideosViaApi({
+  /// Returns a record of matching [VideoEvent]s (unsorted — call
+  /// [deduplicateAndSortVideos] to rank) and the total API result count.
+  Future<({List<VideoEvent> videos, int totalCount})> searchVideosViaApi({
     required String query,
     int limit = 50,
+    int offset = 0,
   }) async {
     final trimmed = query.trim();
-    if (trimmed.isEmpty) return [];
+    if (trimmed.isEmpty) {
+      return (videos: <VideoEvent>[], totalCount: 0);
+    }
     if (_funnelcakeApiClient == null || !_funnelcakeApiClient.isAvailable) {
-      return [];
+      return (videos: <VideoEvent>[], totalCount: 0);
     }
 
     try {
-      final stats = await _funnelcakeApiClient.searchVideos(
+      final response = await _funnelcakeApiClient.searchVideos(
         query: trimmed,
         limit: limit,
+        offset: offset,
       );
-      return _transformVideoStats(stats, sortByCreatedAt: false);
+      final videos = _transformVideoStats(
+        response.videos,
+        sortByCreatedAt: false,
+      );
+      return (videos: videos, totalCount: response.totalCount);
     } on FunnelcakeException catch (e, stackTrace) {
       developer.log(
         'searchVideosViaApi failed for "$trimmed"',
@@ -1046,7 +1054,7 @@ class VideosRepository {
         error: e,
         stackTrace: stackTrace,
       );
-      return [];
+      return (videos: <VideoEvent>[], totalCount: 0);
     }
   }
 
@@ -1093,9 +1101,12 @@ class VideosRepository {
 
     // Phase 2: Funnelcake API (fast)
     try {
-      final apiResults = await searchVideosViaApi(query: trimmed, limit: limit);
-      if (apiResults.isNotEmpty) {
-        accumulated = deduplicateAndSortVideos([...accumulated, ...apiResults]);
+      final apiResult = await searchVideosViaApi(query: trimmed, limit: limit);
+      if (apiResult.videos.isNotEmpty) {
+        accumulated = deduplicateAndSortVideos([
+          ...accumulated,
+          ...apiResult.videos,
+        ]);
         yield accumulated;
       }
     } on Exception catch (e, stackTrace) {

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -4629,18 +4629,18 @@ void main() {
     group('searchVideosViaApi', () {
       test('returns empty list when query is empty', () async {
         final result = await repository.searchVideosViaApi(query: '');
-        expect(result, isEmpty);
+        expect(result.videos, isEmpty);
       });
 
       test('returns empty list when query is whitespace only', () async {
         final result = await repository.searchVideosViaApi(query: '   ');
-        expect(result, isEmpty);
+        expect(result.videos, isEmpty);
       });
 
       test('returns empty list when funnelcakeApiClient is null', () async {
         // Default repository has no funnelcake client
         final result = await repository.searchVideosViaApi(query: 'flutter');
-        expect(result, isEmpty);
+        expect(result.videos, isEmpty);
       });
 
       test(
@@ -4655,7 +4655,7 @@ void main() {
           );
 
           final result = await repoWithApi.searchVideosViaApi(query: 'flutter');
-          expect(result, isEmpty);
+          expect(result.videos, isEmpty);
         },
       );
 
@@ -4668,14 +4668,17 @@ void main() {
             limit: any(named: 'limit'),
           ),
         ).thenAnswer(
-          (_) async => [
-            _createVideoStats(
-              id: 'api-1',
-              pubkey: 'pubkey-1',
-              dTag: 'api-1',
-              videoUrl: 'https://example.com/api.mp4',
-            ),
-          ],
+          (_) async => VideoSearchResponse(
+            videos: [
+              _createVideoStats(
+                id: 'api-1',
+                pubkey: 'pubkey-1',
+                dTag: 'api-1',
+                videoUrl: 'https://example.com/api.mp4',
+              ),
+            ],
+            totalCount: 1,
+          ),
         );
 
         final repoWithApi = VideosRepository(
@@ -4685,7 +4688,7 @@ void main() {
 
         final result = await repoWithApi.searchVideosViaApi(query: 'flutter');
 
-        expect(result, hasLength(1));
+        expect(result.videos, hasLength(1));
         verify(() => mockFunnelcake.searchVideos(query: 'flutter')).called(1);
       });
 
@@ -4705,7 +4708,7 @@ void main() {
         );
 
         final result = await repoWithApi.searchVideosViaApi(query: 'flutter');
-        expect(result, isEmpty);
+        expect(result.videos, isEmpty);
       });
 
       test('applies block filter to API results', () async {
@@ -4720,20 +4723,23 @@ void main() {
             limit: any(named: 'limit'),
           ),
         ).thenAnswer(
-          (_) async => [
-            _createVideoStats(
-              id: 'ok-video',
-              pubkey: 'good-pubkey',
-              dTag: 'ok-video',
-              videoUrl: 'https://example.com/ok.mp4',
-            ),
-            _createVideoStats(
-              id: 'blocked-video',
-              pubkey: 'blocked-pubkey',
-              dTag: 'blocked-video',
-              videoUrl: 'https://example.com/blocked.mp4',
-            ),
-          ],
+          (_) async => VideoSearchResponse(
+            videos: [
+              _createVideoStats(
+                id: 'ok-video',
+                pubkey: 'good-pubkey',
+                dTag: 'ok-video',
+                videoUrl: 'https://example.com/ok.mp4',
+              ),
+              _createVideoStats(
+                id: 'blocked-video',
+                pubkey: 'blocked-pubkey',
+                dTag: 'blocked-video',
+                videoUrl: 'https://example.com/blocked.mp4',
+              ),
+            ],
+            totalCount: 2,
+          ),
         );
 
         final repoWithFilter = VideosRepository(
@@ -4744,7 +4750,7 @@ void main() {
 
         final result = await repoWithFilter.searchVideosViaApi(query: 'video');
 
-        expect(result, hasLength(1));
+        expect(result.videos, hasLength(1));
       });
 
       test('passes custom limit to API', () async {
@@ -4755,7 +4761,12 @@ void main() {
             query: any(named: 'query'),
             limit: any(named: 'limit'),
           ),
-        ).thenAnswer((_) async => []);
+        ).thenAnswer(
+          (_) async => const VideoSearchResponse(
+            videos: [],
+            totalCount: 0,
+          ),
+        );
 
         final repoWithApi = VideosRepository(
           nostrClient: mockNostrClient,
@@ -4914,14 +4925,17 @@ void main() {
             limit: any(named: 'limit'),
           ),
         ).thenAnswer(
-          (_) async => [
-            _createVideoStats(
-              id: 'api-1',
-              pubkey: 'pubkey-2',
-              dTag: 'api-1',
-              videoUrl: 'https://example.com/api.mp4',
-            ),
-          ],
+          (_) async => VideoSearchResponse(
+            videos: [
+              _createVideoStats(
+                id: 'api-1',
+                pubkey: 'pubkey-2',
+                dTag: 'api-1',
+                videoUrl: 'https://example.com/api.mp4',
+              ),
+            ],
+            totalCount: 1,
+          ),
         );
 
         when(

--- a/mobile/test/blocs/video_search/video_search_bloc_test.dart
+++ b/mobile/test/blocs/video_search/video_search_bloc_test.dart
@@ -51,6 +51,18 @@ void main() {
         () =>
             mockVideosRepository.countVideosLocally(query: any(named: 'query')),
       ).thenAnswer((_) async => 0);
+      when(
+        () => mockVideosRepository.searchVideosViaApi(
+          query: any(named: 'query'),
+          limit: any(named: 'limit'),
+          offset: any(named: 'offset'),
+        ),
+      ).thenAnswer(
+        (_) async => (videos: <VideoEvent>[], totalCount: 0),
+      );
+      when(
+        () => mockVideosRepository.deduplicateAndSortVideos(any()),
+      ).thenAnswer((inv) => inv.positionalArguments.first as List<VideoEvent>);
     });
 
     VideoSearchBloc createBloc() =>
@@ -260,6 +272,7 @@ void main() {
             VideoSearchStatus.failure,
           ),
         ],
+        errors: () => [isA<Exception>()],
       );
 
       blocTest<VideoSearchBloc, VideoSearchState>(
@@ -459,7 +472,16 @@ void main() {
           videos: videos,
         );
 
-        expect(state.props, [VideoSearchStatus.success, 'test', videos, -1]);
+        expect(state.props, [
+          VideoSearchStatus.success,
+          'test',
+          videos,
+          -1,
+          0,
+          -1,
+          false,
+          false,
+        ]);
       });
 
       test('two states with same values are equal', () {
@@ -481,6 +503,139 @@ void main() {
 
         expect(state1, isNot(equals(state2)));
       });
+
+      test('copyWith updates pagination fields', () {
+        const state = VideoSearchState();
+
+        final updated = state.copyWith(
+          apiOffset: 50,
+          totalApiCount: 120,
+          hasMore: true,
+          isLoadingMore: true,
+        );
+
+        expect(updated.apiOffset, 50);
+        expect(updated.totalApiCount, 120);
+        expect(updated.hasMore, isTrue);
+        expect(updated.isLoadingMore, isTrue);
+      });
+
+      test('copyWith can clear totalApiCount to null', () {
+        const state = VideoSearchState(totalApiCount: 100);
+
+        final updated = state.copyWith(totalApiCount: null);
+
+        expect(updated.totalApiCount, isNull);
+      });
+    });
+
+    group('VideoSearchLoadMore', () {
+      blocTest<VideoSearchBloc, VideoSearchState>(
+        'fetches next page and appends results',
+        setUp: () {
+          when(
+            () => mockVideosRepository.searchVideosViaApi(
+              query: 'flutter',
+              offset: 50,
+            ),
+          ).thenAnswer(
+            (_) async => (
+              videos: [createVideo(id: 'v2', title: 'Page 2')],
+              totalCount: 75,
+            ),
+          );
+        },
+        build: createBloc,
+        seed: () => VideoSearchState(
+          status: VideoSearchStatus.success,
+          query: 'flutter',
+          videos: [createVideo(id: 'v1', title: 'Page 1')],
+          apiOffset: 50,
+          hasMore: true,
+        ),
+        act: (bloc) => bloc.add(const VideoSearchLoadMore()),
+        expect: () => [
+          isA<VideoSearchState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            isTrue,
+          ),
+          isA<VideoSearchState>()
+              .having((s) => s.videos, 'videos', hasLength(2))
+              .having((s) => s.apiOffset, 'apiOffset', 100)
+              .having((s) => s.totalApiCount, 'totalApiCount', 75)
+              .having((s) => s.hasMore, 'hasMore', isFalse)
+              .having((s) => s.isLoadingMore, 'isLoadingMore', isFalse),
+        ],
+      );
+
+      blocTest<VideoSearchBloc, VideoSearchState>(
+        'does nothing when hasMore is false',
+        build: createBloc,
+        seed: () => const VideoSearchState(
+          status: VideoSearchStatus.success,
+          query: 'flutter',
+        ),
+        act: (bloc) => bloc.add(const VideoSearchLoadMore()),
+        expect: () => <VideoSearchState>[],
+      );
+
+      blocTest<VideoSearchBloc, VideoSearchState>(
+        'does nothing when already loading more',
+        build: createBloc,
+        seed: () => const VideoSearchState(
+          status: VideoSearchStatus.success,
+          query: 'flutter',
+          hasMore: true,
+          isLoadingMore: true,
+        ),
+        act: (bloc) => bloc.add(const VideoSearchLoadMore()),
+        expect: () => <VideoSearchState>[],
+      );
+
+      blocTest<VideoSearchBloc, VideoSearchState>(
+        'does nothing when query is empty',
+        build: createBloc,
+        seed: () => const VideoSearchState(
+          status: VideoSearchStatus.success,
+          hasMore: true,
+        ),
+        act: (bloc) => bloc.add(const VideoSearchLoadMore()),
+        expect: () => <VideoSearchState>[],
+      );
+
+      blocTest<VideoSearchBloc, VideoSearchState>(
+        'emits isLoadingMore false on error and reports via addError',
+        setUp: () {
+          when(
+            () => mockVideosRepository.searchVideosViaApi(
+              query: 'flutter',
+              offset: 50,
+            ),
+          ).thenThrow(Exception('network error'));
+        },
+        build: createBloc,
+        seed: () => const VideoSearchState(
+          status: VideoSearchStatus.success,
+          query: 'flutter',
+          apiOffset: 50,
+          hasMore: true,
+        ),
+        act: (bloc) => bloc.add(const VideoSearchLoadMore()),
+        expect: () => [
+          isA<VideoSearchState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            isTrue,
+          ),
+          isA<VideoSearchState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            isFalse,
+          ),
+        ],
+        errors: () => [isA<Exception>()],
+      );
     });
   });
 }

--- a/mobile/test/screens/search_results/cubit/search_results_filter_cubit_test.dart
+++ b/mobile/test/screens/search_results/cubit/search_results_filter_cubit_test.dart
@@ -39,5 +39,20 @@ void main() {
         SearchResultsFilter.all,
       ],
     );
+
+    blocTest<SearchResultsFilterCubit, SearchResultsFilter>(
+      'emits [videos] when setFilter is called with videos',
+      build: SearchResultsFilterCubit.new,
+      act: (cubit) => cubit.setFilter(SearchResultsFilter.videos),
+      expect: () => const [SearchResultsFilter.videos],
+    );
+
+    blocTest<SearchResultsFilterCubit, SearchResultsFilter>(
+      'emits [all] when setFilter is called with all from videos',
+      build: SearchResultsFilterCubit.new,
+      seed: () => SearchResultsFilter.videos,
+      act: (cubit) => cubit.setFilter(SearchResultsFilter.all),
+      expect: () => const [SearchResultsFilter.all],
+    );
   });
 }

--- a/mobile/test/screens/search_results/view/search_results_view_test.dart
+++ b/mobile/test/screens/search_results/view/search_results_view_test.dart
@@ -201,5 +201,53 @@ void main() {
         expect(find.byType(VideosSection), findsNothing);
       });
     });
+
+    group('videos filter', () {
+      testWidgets('renders $VideoSearchView', (tester) async {
+        await tester.pumpWidget(
+          createTestWidget(filter: SearchResultsFilter.videos),
+        );
+        await tester.pump();
+
+        expect(find.byType(VideoSearchView), findsOneWidget);
+      });
+
+      testWidgets('does not render $PeopleSection', (tester) async {
+        await tester.pumpWidget(
+          createTestWidget(filter: SearchResultsFilter.videos),
+        );
+        await tester.pump();
+
+        expect(find.byType(PeopleSection), findsNothing);
+      });
+
+      testWidgets('does not render $VideosSection', (tester) async {
+        await tester.pumpWidget(
+          createTestWidget(filter: SearchResultsFilter.videos),
+        );
+        await tester.pump();
+
+        expect(find.byType(VideosSection), findsNothing);
+      });
+    });
+
+    group('all filter — see all videos', () {
+      testWidgets(
+        'calls onFilterChanged with videos when Videos header is tapped',
+        (tester) async {
+          SearchResultsFilter? changedFilter;
+
+          await tester.pumpWidget(
+            createTestWidget(onFilterChanged: (f) => changedFilter = f),
+          );
+          await tester.pump();
+
+          await tester.tap(find.text('Videos'));
+          await tester.pump();
+
+          expect(changedFilter, equals(SearchResultsFilter.videos));
+        },
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

- **Fix video tap navigation** — tapping a video in search results now opens `PooledFullscreenVideoFeedScreen` with stream-based updates and load-more support
- **Add offset-based pagination** to `VideoSearchBloc` using the Funnelcake API's new `offset` + `X-Total-Count` support (divinevideo/divine-funnelcake#185)
- **Add "Videos" filter** — new `SearchResultsFilter.videos` with a dedicated `VideoSearchView` widget using `ScrollPaginationMixin` for infinite scroll
- **Add "See all" chevron** to the Videos section header in the All view

## Changes by layer

### Client (`funnelcake_api_client`)
- `searchVideos()` accepts `offset` param, parses `X-Total-Count` header
- New `VideoSearchResponse` model pairs videos with total count

### Repository (`videos_repository`)
- `searchVideosViaApi()` accepts `offset`, returns `({videos, totalCount})` record
- Progressive `searchVideos()` stream updated for new return type

### BLoC (`video_search`)
- State: `apiOffset`, `totalApiCount`, `hasMore`, `isLoadingMore`
- Event: `VideoSearchLoadMore` with `sequential()` transformer
- `_onLoadMore` fetches next API page, deduplicates, updates pagination
- `addError()` called in both exception handlers per project standards

### Presentation
- `VideosSection`: `StatefulWidget` with `StreamController` for fullscreen feed navigation + "See all" chevron
- `VideoSearchView`: full paginated masonry grid with `ScrollPaginationMixin`
- `SearchResultsFilter.videos` enum + wiring in `SearchResultsView`
- `SearchVideoTile` extracted as shared widget

## Test plan

- [x] `VideoSearchBloc` — 28 tests (5 new LoadMore: append, guards, error + addError)
- [x] `SearchResultsFilterCubit` — 6 tests (2 new for `.videos`)
- [x] `SearchResultsView` — 12 tests (4 new: videos filter renders, see-all wiring)
- [x] `VideosRepository` — 218 tests (updated for record return type)
- [x] `FunnelcakeApiClient` — 239 tests (3 new: offset param, X-Total-Count, fallback)
- [x] `flutter analyze` — zero issues
- [x] Device tested on iOS simulator (empty results, populated results, videos filter, pagination scroll)

Closes #2544