### PR TITLE
fix(dm): prevent duplicate conversations for same peer

### DIFF
--- a/mobile/lib/repositories/dm_repository.dart
+++ b/mobile/lib/repositories/dm_repository.dart
@@ -148,6 +148,9 @@ class DmRepository {
     if (rumorDecryptor != null) _rumorDecryptor = rumorDecryptor;
     if (nip04Decryptor != null) _nip04Decryptor = nip04Decryptor;
     startListening();
+
+    // Merge duplicate conversations created by extra p-tags (idempotent).
+    unawaited(_mergeDuplicateConversations());
   }
 
   /// Reset internal state so the repository can be re-initialized for a
@@ -433,10 +436,16 @@ class DmRepository {
       // Accept kind 14 (text) and kind 15 (file)
       if (!_supportedDmKinds.contains(rumorEvent.kind)) return;
 
-      // Extract conversation participants from pubkey + p tags
-      final participants = _extractParticipants(rumorEvent);
-      if (participants.length < 2) return;
+      // Extract conversation participants from pubkey + p tags, then
+      // resolve against existing conversations to prevent duplicates
+      // from non-compliant clients that add extra p-tags.
+      final rawParticipants = _extractParticipants(rumorEvent);
+      if (rawParticipants.length < 2) return;
 
+      final participants = await _resolveConversationParticipants(
+        rawParticipants,
+        rumorEvent.pubkey,
+      );
       final conversationId = computeConversationId(participants);
 
       // Extract common tags
@@ -1386,6 +1395,89 @@ class DmRepository {
   // Helpers
   // -------------------------------------------------------------------------
 
+  /// Merges duplicate conversations where the same 1:1 peer appears as
+  /// multiple conversations due to extra p-tags in NIP-17 events.
+  ///
+  /// For each peer that has more than one conversation with the current user,
+  /// keeps the canonical 1:1 conversation and merges the rest into it.
+  /// Idempotent and safe to run on every startup.
+  Future<void> _mergeDuplicateConversations() async {
+    try {
+      final allConversations = await _conversationsDao.getAllConversations(
+        ownerPubkey: _ownerPubkey,
+      );
+
+      // Group conversations by peer pubkey to find duplicates.
+      final peerGroups = <String, List<ConversationRow>>{};
+      for (final conv in allConversations) {
+        final participants = (jsonDecode(conv.participantPubkeys) as List)
+            .cast<String>();
+        final peers = participants.where((pk) => pk != _userPubkey).toList()
+          ..sort();
+        if (peers.isEmpty) continue;
+
+        // Use the first peer as the grouping key.
+        final peerKey = peers.first;
+        peerGroups.putIfAbsent(peerKey, () => []).add(conv);
+      }
+
+      for (final entry in peerGroups.entries) {
+        if (entry.value.length <= 1) continue;
+
+        final canonical1to1Participants = [_userPubkey, entry.key]..sort();
+        final canonicalId = computeConversationId(canonical1to1Participants);
+
+        // Check if the canonical 1:1 row already exists.
+        final hasCanonicalRow = entry.value.any((c) => c.id == canonicalId);
+
+        // Merge all conversations into the canonical 1:1 ID.
+        await _conversationsDao.runInTransaction(() async {
+          for (final conv in entry.value) {
+            if (conv.id == canonicalId) continue;
+
+            await _directMessagesDao.reassignConversation(
+              fromConversationId: conv.id,
+              toConversationId: canonicalId,
+              ownerPubkey: _userPubkey,
+            );
+            await _conversationsDao.deleteConversation(
+              conv.id,
+              ownerPubkey: _ownerPubkey,
+            );
+          }
+
+          // If the canonical 1:1 row didn't exist, create it from the
+          // most recent duplicate's metadata.
+          if (!hasCanonicalRow) {
+            final source = entry.value.first;
+            await _conversationsDao.upsertConversation(
+              id: canonicalId,
+              participantPubkeys: jsonEncode(canonical1to1Participants),
+              isGroup: false,
+              createdAt: source.createdAt,
+              lastMessageContent: source.lastMessageContent,
+              lastMessageTimestamp: source.lastMessageTimestamp,
+              lastMessageSenderPubkey: source.lastMessageSenderPubkey,
+              currentUserHasSent: source.currentUserHasSent,
+              ownerPubkey: source.ownerPubkey,
+              dmProtocol: source.dmProtocol,
+            );
+          }
+        });
+
+        // Refresh preview from actual messages.
+        await _refreshConversationPreview(canonicalId);
+      }
+    } catch (e, stackTrace) {
+      Log.error(
+        'Failed to merge duplicate conversations: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
   /// Compute a deterministic conversation ID from sorted participant pubkeys.
   static String computeConversationId(List<String> participants) {
     final sorted = List<String>.from(participants)..sort();
@@ -1415,6 +1507,48 @@ class DmRepository {
       }
     }
     return pubkeys.toList()..sort();
+  }
+
+  /// Resolves the participant list for conversation routing.
+  ///
+  /// When a rumor has more p-tags than a standard 1:1 (sender + us),
+  /// determines whether to route to the full participant group (if one
+  /// already exists) or to the canonical 1:1 pair.
+  ///
+  /// Priority: existing group → existing 1:1 → default to 1:1.
+  ///
+  /// Defaulting to 1:1 when no conversation exists prevents phantom
+  /// groups caused by non-compliant clients adding extra p-tags to
+  /// what should be a 1:1 DM.
+  Future<List<String>> _resolveConversationParticipants(
+    List<String> extractedParticipants,
+    String senderPubkey,
+  ) async {
+    final canonical1to1 = [_userPubkey, senderPubkey]..sort();
+
+    // Standard 1:1 message — no ambiguity.
+    if (extractedParticipants.length <= 2) return canonical1to1;
+
+    // Extra p-tags present. Check if a group conversation with the
+    // full participant set already exists — if so, it's a genuine group.
+    final fullId = computeConversationId(extractedParticipants);
+    final existingFull = await _conversationsDao.getConversation(
+      fullId,
+      ownerPubkey: _ownerPubkey,
+    );
+    if (existingFull != null) return extractedParticipants;
+
+    // No existing group. Check if a 1:1 conversation exists.
+    final canonical1to1Id = computeConversationId(canonical1to1);
+    final existing1to1 = await _conversationsDao.getConversation(
+      canonical1to1Id,
+      ownerPubkey: _ownerPubkey,
+    );
+    if (existing1to1 != null) return canonical1to1;
+
+    // Neither exists. Default to 1:1 — prevents phantom groups from
+    // non-compliant clients that add extra p-tags to 1:1 DMs.
+    return canonical1to1;
   }
 
   /// Extracts Kind 15 file metadata from event tags.

--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -257,6 +257,24 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
         .go();
   }
 
+  /// Move all messages from one conversation to another.
+  ///
+  /// Used when merging duplicate conversations into a canonical one.
+  Future<int> reassignConversation({
+    required String fromConversationId,
+    required String toConversationId,
+    String? ownerPubkey,
+  }) {
+    return (update(directMessages)..where(
+          (t) =>
+              t.conversationId.equals(fromConversationId) &
+              _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
+        ))
+        .write(
+          DirectMessagesCompanion(conversationId: Value(toConversationId)),
+        );
+  }
+
   /// Count messages in a conversation.
   Future<int> countMessages(
     String conversationId, {

--- a/mobile/test/repositories/dm_repository_test.dart
+++ b/mobile/test/repositories/dm_repository_test.dart
@@ -952,58 +952,64 @@ void main() {
         await repository.stopListening();
       });
 
-      test('handles group messages with 3+ participants', () async {
-        final giftWrap = createGiftWrapEvent();
-        final rumor = createRumorEvent(
-          tags: [
-            ['p', _validPubkeyA],
-            ['p', _validPubkeyC],
-          ],
-        );
+      test(
+        'defaults extra p-tags to 1:1 when no existing conversation',
+        () async {
+          // When a message has 3+ participants but no existing group or
+          // 1:1 conversation exists, defaults to 1:1 to prevent phantom
+          // groups from non-compliant clients.
+          final giftWrap = createGiftWrapEvent();
+          final rumor = createRumorEvent(
+            tags: [
+              ['p', _validPubkeyA],
+              ['p', _validPubkeyC],
+            ],
+          );
 
-        when(
-          () => mockDirectMessagesDao.hasGiftWrap(
-            _giftWrapEventId,
-          ),
-        ).thenAnswer((_) async => false);
-        stubDaoInserts();
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(
+              _giftWrapEventId,
+            ),
+          ).thenAnswer((_) async => false);
+          stubDaoInserts();
 
-        final controller = StreamController<Event>();
-        when(
-          () => mockNostrClient.subscribe(
-            any(),
-            subscriptionId: any(named: 'subscriptionId'),
-          ),
-        ).thenAnswer((_) => controller.stream);
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
 
-        final repository = createRepository(
-          rumorDecryptor: (_, _) async => rumor,
-        );
+          final repository = createRepository(
+            rumorDecryptor: (_, _) async => rumor,
+          );
 
-        repository.startListening();
-        controller.add(giftWrap);
-        await Future<void>.delayed(Duration.zero);
+          repository.startListening();
+          controller.add(giftWrap);
+          await Future<void>.delayed(Duration.zero);
 
-        verify(
-          () => mockConversationsDao.upsertConversation(
-            id: any(named: 'id'),
-            participantPubkeys: any(named: 'participantPubkeys'),
-            isGroup: true,
-            createdAt: any(named: 'createdAt'),
-            lastMessageContent: any(named: 'lastMessageContent'),
-            lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
-            lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
-            subject: any(named: 'subject'),
-            isRead: any(named: 'isRead'),
-            currentUserHasSent: any(named: 'currentUserHasSent'),
-            ownerPubkey: any(named: 'ownerPubkey'),
-            dmProtocol: any(named: 'dmProtocol'),
-          ),
-        ).called(1);
+          verify(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: false,
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: any(named: 'lastMessageContent'),
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+              subject: any(named: 'subject'),
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).called(1);
 
-        await controller.close();
-        await repository.stopListening();
-      });
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
 
       test('processes multiple events sequentially', () async {
         final giftWrap1 = createGiftWrapEvent();
@@ -3649,6 +3655,631 @@ void main() {
           ).called(1);
         },
       );
+    });
+
+    // -----------------------------------------------------------------
+    // Canonicalization: extra p-tags routing
+    // -----------------------------------------------------------------
+    group('canonicalize 1:1 participants', () {
+      Event createGiftWrapEvent({String? id}) {
+        return Event.fromJson({
+          'id': id ?? _giftWrapEventId,
+          'pubkey':
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          'created_at': 1700000000,
+          'kind': EventKind.giftWrap,
+          'tags': [
+            ['p', _validPubkeyA],
+          ],
+          'content': 'encrypted-content',
+          'sig': '',
+        });
+      }
+
+      Event createRumorEvent({
+        String? id,
+        String? pubkey,
+        String? content,
+        int? kind,
+        List<List<String>>? tags,
+        int? createdAt,
+      }) {
+        return Event.fromJson({
+          'id': id ?? _rumorEventId,
+          'pubkey': pubkey ?? _validPubkeyB,
+          'created_at': createdAt ?? 1700000000,
+          'kind': kind ?? EventKind.privateDirectMessage,
+          'tags':
+              tags ??
+              [
+                ['p', _validPubkeyA],
+              ],
+          'content': content ?? 'Hello from B!',
+          'sig': '',
+        });
+      }
+
+      test(
+        'routes message with extra p-tags to existing 1:1 conversation',
+        () async {
+          // Rumor from B with extra p-tag for C (e.g., reply mention).
+          final giftWrap = createGiftWrapEvent();
+          final rumor = createRumorEvent(
+            tags: [
+              ['p', _validPubkeyA],
+              ['p', _validPubkeyC],
+            ],
+          );
+
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(any()),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockDirectMessagesDao.hasMatchingMessage(
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: any(named: 'isGroup'),
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: any(named: 'lastMessageContent'),
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+              subject: any(named: 'subject'),
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockConversationsDao.getConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+
+          // Compute the canonical 1:1 conversation ID (A ↔ B).
+          final canonical1to1 = [_validPubkeyA, _validPubkeyB]..sort();
+          final canonicalId = DmRepository.computeConversationId(canonical1to1);
+
+          // Stub: an existing 1:1 conversation between A and B.
+          when(
+            () => mockConversationsDao.getConversation(
+              canonicalId,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer(
+            (_) async => ConversationRow(
+              id: canonicalId,
+              participantPubkeys: jsonEncode(canonical1to1),
+              isGroup: false,
+              lastMessageContent: 'Previous msg',
+              lastMessageTimestamp: 1699999999,
+              lastMessageSenderPubkey: _validPubkeyB,
+              isRead: true,
+              currentUserHasSent: true,
+              createdAt: 1699999999,
+            ),
+          );
+
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final repository = createRepository(
+            rumorDecryptor: (_, _) async => rumor,
+          );
+
+          repository.startListening();
+          controller.add(giftWrap);
+          await Future<void>.delayed(Duration.zero);
+
+          // Message should be stored with the canonical 1:1 ID, not the
+          // 3-party ID that the extra p-tag would have produced.
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: _rumorEventId,
+              conversationId: canonicalId,
+              senderPubkey: _validPubkeyB,
+              content: 'Hello from B!',
+              createdAt: 1700000000,
+              giftWrapId: _giftWrapEventId,
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).called(1);
+
+          // Conversation should be upserted as 1:1 (not group).
+          verify(
+            () => mockConversationsDao.upsertConversation(
+              id: canonicalId,
+              participantPubkeys: jsonEncode(canonical1to1),
+              isGroup: false,
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: 'Hello from B!',
+              lastMessageTimestamp: 1700000000,
+              lastMessageSenderPubkey: _validPubkeyB,
+              isRead: false,
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).called(1);
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+
+      test(
+        'defaults to 1:1 when extra p-tags and no existing conversation',
+        () async {
+          // Rumor from B with extra p-tag for C — no prior conversation.
+          final giftWrap = createGiftWrapEvent();
+          final rumor = createRumorEvent(
+            tags: [
+              ['p', _validPubkeyA],
+              ['p', _validPubkeyC],
+            ],
+          );
+
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(any()),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockDirectMessagesDao.hasMatchingMessage(
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: any(named: 'isGroup'),
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: any(named: 'lastMessageContent'),
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+              subject: any(named: 'subject'),
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockConversationsDao.getConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final repository = createRepository(
+            rumorDecryptor: (_, _) async => rumor,
+          );
+
+          repository.startListening();
+          controller.add(giftWrap);
+          await Future<void>.delayed(Duration.zero);
+
+          // Should default to canonical 1:1 (A <-> B), not a 3-party group.
+          final canonical1to1 = [_validPubkeyA, _validPubkeyB]..sort();
+          final canonicalId = DmRepository.computeConversationId(canonical1to1);
+
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: _rumorEventId,
+              conversationId: canonicalId,
+              senderPubkey: _validPubkeyB,
+              content: 'Hello from B!',
+              createdAt: 1700000000,
+              giftWrapId: _giftWrapEventId,
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).called(1);
+
+          // Conversation should be upserted as 1:1 (not group).
+          verify(
+            () => mockConversationsDao.upsertConversation(
+              id: canonicalId,
+              participantPubkeys: jsonEncode(canonical1to1),
+              isGroup: false,
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: 'Hello from B!',
+              lastMessageTimestamp: 1700000000,
+              lastMessageSenderPubkey: _validPubkeyB,
+              isRead: false,
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).called(1);
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+
+      test(
+        'routes to existing group when extra p-tags match it',
+        () async {
+          // Rumor from B with extra p-tag for C — group [A,B,C] exists.
+          final giftWrap = createGiftWrapEvent();
+          final rumor = createRumorEvent(
+            tags: [
+              ['p', _validPubkeyA],
+              ['p', _validPubkeyC],
+            ],
+          );
+
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(any()),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockDirectMessagesDao.hasMatchingMessage(
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: any(named: 'isGroup'),
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: any(named: 'lastMessageContent'),
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+              subject: any(named: 'subject'),
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).thenAnswer((_) async {});
+
+          // Stub: existing group conversation [A, B, C].
+          final groupParticipants = [
+            _validPubkeyA,
+            _validPubkeyB,
+            _validPubkeyC,
+          ]..sort();
+          final groupId = DmRepository.computeConversationId(groupParticipants);
+
+          // Generic fallback returns null (no conversation found).
+          when(
+            () => mockConversationsDao.getConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+          // Specific stub: group conversation exists.
+          when(
+            () => mockConversationsDao.getConversation(
+              groupId,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer(
+            (_) async => ConversationRow(
+              id: groupId,
+              participantPubkeys: jsonEncode(groupParticipants),
+              isGroup: true,
+              lastMessageContent: 'Group msg',
+              lastMessageTimestamp: 1699999999,
+              lastMessageSenderPubkey: _validPubkeyC,
+              isRead: true,
+              currentUserHasSent: true,
+              createdAt: 1699999999,
+            ),
+          );
+
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final repository = createRepository(
+            rumorDecryptor: (_, _) async => rumor,
+          );
+
+          repository.startListening();
+          controller.add(giftWrap);
+          await Future<void>.delayed(Duration.zero);
+
+          // Should route to the existing group, not create a new 1:1.
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: _rumorEventId,
+              conversationId: groupId,
+              senderPubkey: _validPubkeyB,
+              content: 'Hello from B!',
+              createdAt: 1700000000,
+              giftWrapId: _giftWrapEventId,
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).called(1);
+
+          verify(
+            () => mockConversationsDao.upsertConversation(
+              id: groupId,
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: true,
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: 'Hello from B!',
+              lastMessageTimestamp: 1700000000,
+              lastMessageSenderPubkey: _validPubkeyB,
+              isRead: false,
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).called(1);
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+
+      test('normal 1:1 message (single p-tag) is not affected', () async {
+        // Standard 1:1 message — single p-tag, no extra participants.
+        final giftWrap = createGiftWrapEvent();
+        final rumor = createRumorEvent();
+
+        when(
+          () => mockDirectMessagesDao.hasGiftWrap(any()),
+        ).thenAnswer((_) async => false);
+        when(
+          () => mockDirectMessagesDao.hasMatchingMessage(
+            conversationId: any(named: 'conversationId'),
+            senderPubkey: any(named: 'senderPubkey'),
+            content: any(named: 'content'),
+            createdAt: any(named: 'createdAt'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => false);
+        when(
+          () => mockDirectMessagesDao.insertMessage(
+            id: any(named: 'id'),
+            conversationId: any(named: 'conversationId'),
+            senderPubkey: any(named: 'senderPubkey'),
+            content: any(named: 'content'),
+            createdAt: any(named: 'createdAt'),
+            giftWrapId: any(named: 'giftWrapId'),
+            messageKind: any(named: 'messageKind'),
+            replyToId: any(named: 'replyToId'),
+            subject: any(named: 'subject'),
+            fileType: any(named: 'fileType'),
+            encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+            decryptionKey: any(named: 'decryptionKey'),
+            decryptionNonce: any(named: 'decryptionNonce'),
+            fileHash: any(named: 'fileHash'),
+            originalFileHash: any(named: 'originalFileHash'),
+            fileSize: any(named: 'fileSize'),
+            dimensions: any(named: 'dimensions'),
+            blurhash: any(named: 'blurhash'),
+            thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockConversationsDao.upsertConversation(
+            id: any(named: 'id'),
+            participantPubkeys: any(named: 'participantPubkeys'),
+            isGroup: any(named: 'isGroup'),
+            createdAt: any(named: 'createdAt'),
+            lastMessageContent: any(named: 'lastMessageContent'),
+            lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+            lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+            subject: any(named: 'subject'),
+            isRead: any(named: 'isRead'),
+            currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            dmProtocol: any(named: 'dmProtocol'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        final controller = StreamController<Event>();
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) => controller.stream);
+
+        final repository = createRepository(
+          rumorDecryptor: (_, _) async => rumor,
+        );
+
+        repository.startListening();
+        controller.add(giftWrap);
+        await Future<void>.delayed(Duration.zero);
+
+        // Should use standard 1:1 conversation ID.
+        final participants = [_validPubkeyA, _validPubkeyB]..sort();
+        final convId = DmRepository.computeConversationId(participants);
+
+        verify(
+          () => mockDirectMessagesDao.insertMessage(
+            id: _rumorEventId,
+            conversationId: convId,
+            senderPubkey: _validPubkeyB,
+            content: 'Hello from B!',
+            createdAt: 1700000000,
+            giftWrapId: _giftWrapEventId,
+            fileType: any(named: 'fileType'),
+            encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+            decryptionKey: any(named: 'decryptionKey'),
+            decryptionNonce: any(named: 'decryptionNonce'),
+            fileHash: any(named: 'fileHash'),
+            originalFileHash: any(named: 'originalFileHash'),
+            fileSize: any(named: 'fileSize'),
+            dimensions: any(named: 'dimensions'),
+            blurhash: any(named: 'blurhash'),
+            thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).called(1);
+
+        // Canonicalization should NOT have been triggered — only one
+        // getConversation call (the one inside the transaction).
+        // The canonicalize method returns early for ≤ 2 participants.
+        verify(
+          () => mockConversationsDao.upsertConversation(
+            id: convId,
+            participantPubkeys: any(named: 'participantPubkeys'),
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageContent: 'Hello from B!',
+            lastMessageTimestamp: 1700000000,
+            lastMessageSenderPubkey: _validPubkeyB,
+            isRead: false,
+            currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            dmProtocol: any(named: 'dmProtocol'),
+          ),
+        ).called(1);
+
+        await controller.close();
+        await repository.stopListening();
+      });
     });
   });
 }


### PR DESCRIPTION
Closes #2740

## Summary

- Add `_resolveConversationParticipants` with bidirectional priority chain (existing group > existing 1:1 > default to 1:1) to prevent phantom group conversations from non-compliant clients adding extra p-tags
- Add startup migration `_mergeDuplicateConversations` to consolidate existing duplicate conversations into canonical 1:1 records
- Add `reassignConversation` DAO method for moving messages between conversation IDs during merges

## Test plan

- [x] Extra p-tags + existing 1:1 → routes to existing 1:1
- [x] Extra p-tags + existing group → routes to existing group
- [x] Extra p-tags + no existing conversation → defaults to 1:1 (prevents phantom groups)
- [x] Normal 1:1 (single p-tag) → unaffected
- [x] All 74 DM repository tests pass
- [x] All 525 db_client tests pass
- [x] Zero analyzer issues
- [ ] Manual test: send DMs from another account with varying p-tag sets, verify single conversation entry