### PR TITLE
fix(video): auto-repair corrupted video events with local file paths

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -29,6 +29,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/deep_link_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/popular_now_feed_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
@@ -42,6 +43,7 @@ import 'package:openvine/screens/pure/search_screen_pure.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/back_button_handler.dart';
 import 'package:openvine/services/bandwidth_tracker_service.dart';
+import 'package:openvine/services/corrupted_video_repair_service.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/deep_link_service.dart';
 import 'package:openvine/services/invite_api_service.dart';
@@ -913,6 +915,33 @@ class _DivineAppState extends ConsumerState<DivineApp> {
     // Block/mute list sync is handled by blocklistSyncBridgeProvider
     // (watched in AppShell) which reacts to auth state changes and
     // covers both already-authenticated startup and post-login scenarios.
+
+    // One-time repair for corrupted video events with local file paths (#2144)
+    unawaited(
+      Future.microtask(() async {
+        try {
+          final nostrClient = ref.read(nostrServiceProvider);
+          final authService = ref.read(authServiceProvider);
+          final env = ref.read(currentEnvironmentProvider);
+          final prefs = ref.read(sharedPreferencesProvider);
+          final videoEventService = ref.read(videoEventServiceProvider);
+          final repairService = CorruptedVideoRepairService(
+            nostrClient: nostrClient,
+            authService: authService,
+            prefs: prefs,
+            blossomBaseUrl: env.blossomUrl,
+            videoEventService: videoEventService,
+          );
+          await repairService.repairIfNeeded();
+        } catch (e) {
+          Log.warning(
+            '[INIT] Corrupted video repair failed (non-critical): $e',
+            name: 'Main',
+            category: LogCategory.system,
+          );
+        }
+      }),
+    );
   }
 
   @override

--- a/mobile/lib/services/corrupted_video_repair_service.dart
+++ b/mobile/lib/services/corrupted_video_repair_service.dart
@@ -1,0 +1,235 @@
+// ABOUTME: One-time repair for corrupted kind 34236 events that have local
+// ABOUTME: file paths instead of HTTP URLs in their imeta tags (issue #2144).
+// ABOUTME: Reconstructs correct blossom URLs from the SHA-256 hash and
+// ABOUTME: republishes corrected events via parameterized replaceable semantics.
+
+import 'package:models/models.dart' show VideoEvent;
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/utils/unified_logger.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Scans the current user's kind 34236 video events for corrupted imeta URLs
+/// (local file paths instead of HTTP URLs) and republishes corrected events.
+///
+/// This is a one-time migration gated by a SharedPreferences flag.
+/// Safe to run because kind 34236 is parameterized replaceable — publishing
+/// a new event with the same `d` tag replaces the old one on the relay.
+class CorruptedVideoRepairService {
+  CorruptedVideoRepairService({
+    required NostrClient nostrClient,
+    required AuthService authService,
+    required SharedPreferences prefs,
+    required String blossomBaseUrl,
+    VideoEventService? videoEventService,
+  }) : _nostrClient = nostrClient,
+       _authService = authService,
+       _prefs = prefs,
+       _blossomBaseUrl = blossomBaseUrl,
+       _videoEventService = videoEventService;
+
+  final NostrClient _nostrClient;
+  final AuthService _authService;
+  final SharedPreferences _prefs;
+  final String _blossomBaseUrl;
+  final VideoEventService? _videoEventService;
+
+  static const String _completedKey = 'corrupted_video_repair_v1_completed';
+  static const String _logName = 'CorruptedVideoRepair';
+
+  /// Run the repair if it hasn't been completed yet.
+  /// Returns the number of events repaired, or -1 if skipped (already done).
+  Future<int> repairIfNeeded() async {
+    if (_prefs.getBool(_completedKey) == true) return -1;
+
+    try {
+      final repaired = await _repairCorruptedEvents();
+      await _prefs.setBool(_completedKey, true);
+      return repaired;
+    } catch (e, s) {
+      Log.error(
+        'Repair failed, will retry on next startup: $e',
+        name: _logName,
+        category: LogCategory.video,
+        error: e,
+        stackTrace: s,
+      );
+      // Don't set the completed flag — retry on next startup.
+      return 0;
+    }
+  }
+
+  Future<int> _repairCorruptedEvents() async {
+    if (!_authService.isAuthenticated) {
+      Log.debug(
+        'Not authenticated, skipping repair',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return 0;
+    }
+
+    final pubkey = _nostrClient.publicKey;
+    if (pubkey.isEmpty) {
+      Log.debug(
+        'No public key available, skipping repair',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return 0;
+    }
+
+    // Query all of the user's own kind 34236 events from relay
+    final filter = Filter(
+      kinds: [EventKind.videoVertical],
+      authors: [pubkey],
+    );
+
+    final events = await _nostrClient.queryEvents(
+      [filter],
+      useCache: false,
+    );
+
+    Log.info(
+      'Scanning ${events.length} video events for corrupted URLs',
+      name: _logName,
+      category: LogCategory.video,
+    );
+
+    var repairedCount = 0;
+
+    for (final event in events) {
+      final repairedTags = _repairEventTags(event.tags);
+      if (repairedTags == null) continue;
+
+      // Use AuthService for proper signing (handles NIP-46 RPC + validation)
+      // createdAt + 1: minimal bump to trigger relay replacement while
+      // preserving the original publication date.
+      final signedEvent = await _authService.createAndSignEvent(
+        kind: EventKind.videoVertical,
+        content: event.content,
+        tags: repairedTags,
+        createdAt: event.createdAt + 1,
+      );
+
+      if (signedEvent == null) {
+        Log.warning(
+          'Failed to sign repaired event for ${event.id}',
+          name: _logName,
+          category: LogCategory.video,
+        );
+        continue;
+      }
+
+      final sent = await _nostrClient.publishEvent(signedEvent);
+      if (sent != null) {
+        repairedCount++;
+        Log.info(
+          'Repaired event ${event.id} '
+          '(d-tag: ${_getDTag(event.tags)})',
+          name: _logName,
+          category: LogCategory.video,
+        );
+
+        // Update local cache so the fix is visible immediately
+        _videoEventService?.updateVideoEvent(
+          VideoEvent.fromNostrEvent(sent),
+        );
+      } else {
+        Log.warning(
+          'Failed to publish repaired event for ${event.id}',
+          name: _logName,
+          category: LogCategory.video,
+        );
+      }
+    }
+
+    Log.info(
+      'Repair complete: $repairedCount/${events.length} events fixed',
+      name: _logName,
+      category: LogCategory.video,
+    );
+
+    return repairedCount;
+  }
+
+  /// Inspects and repairs imeta tags that have local file paths.
+  /// Returns the full repaired tag list, or null if nothing was actually fixed.
+  /// Corruption without a hash (unrepairable) is logged but not republished.
+  List<List<String>>? _repairEventTags(List<List<String>> tags) {
+    var hasRepair = false;
+
+    final repairedTags = tags.map((tag) {
+      if (tag.isEmpty || tag[0] != 'imeta') return tag;
+
+      final repairedComponents = <String>[];
+      String? sha256Hash;
+
+      // First pass: extract sha256 hash from the imeta components
+      for (final component in tag.skip(1)) {
+        if (component.startsWith('x ')) {
+          sha256Hash = component.substring(2).trim();
+        }
+      }
+
+      // Second pass: repair corrupted url components
+      for (var i = 0; i < tag.length; i++) {
+        if (i == 0) {
+          repairedComponents.add(tag[i]); // 'imeta'
+          continue;
+        }
+
+        final component = tag[i];
+        if (component.startsWith('url ')) {
+          final url = component.substring(4).trim();
+          if (_isLocalFilePath(url)) {
+            if (sha256Hash != null && sha256Hash.isNotEmpty) {
+              hasRepair = true;
+              final repairedUrl = '$_blossomBaseUrl/$sha256Hash';
+              repairedComponents.add('url $repairedUrl');
+              Log.debug(
+                'Repairing URL: $url -> $repairedUrl',
+                name: _logName,
+                category: LogCategory.video,
+              );
+            } else {
+              // No hash — cannot reconstruct, skip republishing.
+              repairedComponents.add(component);
+              Log.warning(
+                'Cannot repair URL (no x hash): $url',
+                name: _logName,
+                category: LogCategory.video,
+              );
+            }
+          } else {
+            repairedComponents.add(component);
+          }
+        } else {
+          repairedComponents.add(component);
+        }
+      }
+
+      return repairedComponents;
+    }).toList();
+
+    return hasRepair ? repairedTags : null;
+  }
+
+  /// Checks if a URL is a local file path instead of an HTTP URL.
+  static bool _isLocalFilePath(String url) {
+    if (url.startsWith('http://') || url.startsWith('https://')) return false;
+    // Common local path patterns from the corrupted events:
+    // /var/mobile/Containers/... (iOS)
+    // /data/user/0/... (Android)
+    return url.startsWith('/') || url.startsWith('file://');
+  }
+
+  static String? _getDTag(List<List<String>> tags) {
+    for (final tag in tags) {
+      if (tag.length >= 2 && tag[0] == 'd') return tag[1];
+    }
+    return null;
+  }
+}

--- a/mobile/test/unit/services/corrupted_video_repair_service_test.dart
+++ b/mobile/test/unit/services/corrupted_video_repair_service_test.dart
@@ -1,0 +1,432 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/corrupted_video_repair_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _FakeEvent extends Fake implements Event {}
+
+const _testPubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _blossomBaseUrl = 'https://media.divine.video';
+const _testSha256 =
+    '9783bc5788da2fc2bab7600521ea923d873ef3379d18da1b865f513f76e1bf6f';
+
+Event _createVideoEvent({
+  required String id,
+  required List<List<String>> tags,
+  String content = '',
+  int createdAt = 1000000,
+}) {
+  final event = Event(
+    _testPubkey,
+    EventKind.videoVertical,
+    tags,
+    content,
+    createdAt: createdAt,
+  );
+  event.id = id;
+  return event;
+}
+
+void main() {
+  late _MockNostrClient mockNostrClient;
+  late _MockAuthService mockAuthService;
+  late _MockVideoEventService mockVideoEventService;
+  late SharedPreferences prefs;
+  late CorruptedVideoRepairService repairService;
+  late List<Event> publishedEvents;
+
+  setUpAll(() {
+    registerFallbackValue(<Filter>[]);
+    registerFallbackValue(_FakeEvent());
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+
+    mockNostrClient = _MockNostrClient();
+    mockAuthService = _MockAuthService();
+    mockVideoEventService = _MockVideoEventService();
+    publishedEvents = [];
+
+    when(() => mockNostrClient.publicKey).thenReturn(_testPubkey);
+    when(() => mockAuthService.isAuthenticated).thenReturn(true);
+
+    repairService = CorruptedVideoRepairService(
+      nostrClient: mockNostrClient,
+      authService: mockAuthService,
+      prefs: prefs,
+      blossomBaseUrl: _blossomBaseUrl,
+      videoEventService: mockVideoEventService,
+    );
+  });
+
+  /// Stubs createAndSignEvent to return a signed event, and publishEvent
+  /// to capture it.
+  void stubSignAndPublishSuccess() {
+    when(
+      () => mockAuthService.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+        createdAt: any(named: 'createdAt'),
+      ),
+    ).thenAnswer((invocation) async {
+      final tags =
+          invocation.namedArguments[#tags] as List<List<String>>? ?? [];
+      final content = invocation.namedArguments[#content] as String;
+      final createdAt = invocation.namedArguments[#createdAt] as int?;
+      final event = Event(
+        _testPubkey,
+        EventKind.videoVertical,
+        tags,
+        content,
+        createdAt: createdAt,
+      );
+      event.sig = 'a' * 128;
+      return event;
+    });
+
+    when(
+      () => mockNostrClient.publishEvent(any()),
+    ).thenAnswer((invocation) async {
+      final event = invocation.positionalArguments[0] as Event;
+      publishedEvents.add(event);
+      return event;
+    });
+  }
+
+  group(CorruptedVideoRepairService, () {
+    group('repairIfNeeded', () {
+      test('skips if already completed', () async {
+        await prefs.setBool('corrupted_video_repair_v1_completed', true);
+
+        final result = await repairService.repairIfNeeded();
+
+        expect(result, equals(-1));
+      });
+
+      test('repairs event with corrupted iOS local file path', () async {
+        final corruptedEvent = _createVideoEvent(
+          id: 'event1',
+          tags: [
+            ['d', 'video_123'],
+            [
+              'imeta',
+              'url /var/mobile/Containers/Data/Application/xxx/cache/video.mp4',
+              'm video/mp4',
+              'x $_testSha256',
+            ],
+            ['title', 'My Video'],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            useCache: false,
+          ),
+        ).thenAnswer((_) async => [corruptedEvent]);
+
+        stubSignAndPublishSuccess();
+
+        final result = await repairService.repairIfNeeded();
+
+        expect(result, equals(1));
+        expect(publishedEvents, hasLength(1));
+
+        final captured = publishedEvents.first;
+
+        // Verify repaired blossom URL
+        final imetaTag = captured.tags.firstWhere(
+          (t) => t.isNotEmpty && t[0] == 'imeta',
+        );
+        final urlComponent = imetaTag.firstWhere(
+          (c) => c.startsWith('url '),
+        );
+        expect(urlComponent, equals('url $_blossomBaseUrl/$_testSha256'));
+
+        // Verify d-tag preserved
+        final dTag = captured.tags.firstWhere(
+          (t) => t.isNotEmpty && t[0] == 'd',
+        );
+        expect(dTag[1], equals('video_123'));
+
+        // Verify title preserved
+        final titleTag = captured.tags.firstWhere(
+          (t) => t.isNotEmpty && t[0] == 'title',
+        );
+        expect(titleTag[1], equals('My Video'));
+
+        // Verify created_at bumped by 1
+        expect(captured.createdAt, equals(1000001));
+
+        // Verify completion flag set
+        expect(prefs.getBool('corrupted_video_repair_v1_completed'), isTrue);
+      });
+
+      test('skips events with valid HTTP URLs', () async {
+        final validEvent = _createVideoEvent(
+          id: 'event1',
+          tags: [
+            ['d', 'video_123'],
+            [
+              'imeta',
+              'url https://media.divine.video/$_testSha256',
+              'm video/mp4',
+              'x $_testSha256',
+            ],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            useCache: false,
+          ),
+        ).thenAnswer((_) async => [validEvent]);
+
+        final result = await repairService.repairIfNeeded();
+
+        expect(result, equals(0));
+        expect(publishedEvents, isEmpty);
+        expect(prefs.getBool('corrupted_video_repair_v1_completed'), isTrue);
+      });
+
+      test('skips corrupted event without x hash', () async {
+        final corruptedNoHash = _createVideoEvent(
+          id: 'event1',
+          tags: [
+            ['d', 'video_123'],
+            [
+              'imeta',
+              'url /data/user/0/co.openvine.app/cache/video.mp4',
+              'm video/mp4',
+            ],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            useCache: false,
+          ),
+        ).thenAnswer((_) async => [corruptedNoHash]);
+
+        final result = await repairService.repairIfNeeded();
+
+        // Cannot repair without hash
+        expect(result, equals(0));
+        expect(publishedEvents, isEmpty);
+      });
+
+      test('repairs Android local file paths', () async {
+        final corruptedEvent = _createVideoEvent(
+          id: 'event1',
+          tags: [
+            ['d', 'video_456'],
+            [
+              'imeta',
+              'url /data/user/0/co.openvine.app/cache/openvine_video_cache/video.mp4',
+              'm video/mp4',
+              'x $_testSha256',
+            ],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            useCache: false,
+          ),
+        ).thenAnswer((_) async => [corruptedEvent]);
+
+        stubSignAndPublishSuccess();
+
+        final result = await repairService.repairIfNeeded();
+
+        expect(result, equals(1));
+
+        final imetaTag = publishedEvents.first.tags.firstWhere(
+          (t) => t.isNotEmpty && t[0] == 'imeta',
+        );
+        final urlComponent = imetaTag.firstWhere(
+          (c) => c.startsWith('url '),
+        );
+        expect(urlComponent, equals('url $_blossomBaseUrl/$_testSha256'));
+      });
+
+      test('does not set completion flag on query failure', () async {
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            useCache: false,
+          ),
+        ).thenThrow(Exception('Relay connection failed'));
+
+        final result = await repairService.repairIfNeeded();
+
+        expect(result, equals(0));
+        expect(
+          prefs.getBool('corrupted_video_repair_v1_completed'),
+          isNull,
+        );
+      });
+
+      test('skips when not authenticated', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+
+        final result = await repairService.repairIfNeeded();
+
+        expect(result, equals(0));
+        expect(publishedEvents, isEmpty);
+      });
+
+      test('skips when no public key available', () async {
+        when(() => mockNostrClient.publicKey).thenReturn('');
+
+        final result = await repairService.repairIfNeeded();
+
+        expect(result, equals(0));
+        expect(publishedEvents, isEmpty);
+      });
+
+      test('handles signing failure gracefully', () async {
+        final corruptedEvent = _createVideoEvent(
+          id: 'event1',
+          tags: [
+            ['d', 'video_789'],
+            [
+              'imeta',
+              'url /var/mobile/Containers/cache/video.mp4',
+              'm video/mp4',
+              'x $_testSha256',
+            ],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            useCache: false,
+          ),
+        ).thenAnswer((_) async => [corruptedEvent]);
+
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+            createdAt: any(named: 'createdAt'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        final result = await repairService.repairIfNeeded();
+
+        expect(result, equals(0));
+        expect(publishedEvents, isEmpty);
+        expect(prefs.getBool('corrupted_video_repair_v1_completed'), isTrue);
+      });
+
+      test('handles publish failure gracefully', () async {
+        final corruptedEvent = _createVideoEvent(
+          id: 'event1',
+          tags: [
+            ['d', 'video_789'],
+            [
+              'imeta',
+              'url /var/mobile/Containers/cache/video.mp4',
+              'm video/mp4',
+              'x $_testSha256',
+            ],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            useCache: false,
+          ),
+        ).thenAnswer((_) async => [corruptedEvent]);
+
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+            createdAt: any(named: 'createdAt'),
+          ),
+        ).thenAnswer((_) async {
+          final event = Event(_testPubkey, EventKind.videoVertical, [], '');
+          event.sig = 'a' * 128;
+          return event;
+        });
+
+        when(
+          () => mockNostrClient.publishEvent(any()),
+        ).thenAnswer((_) async => null);
+
+        final result = await repairService.repairIfNeeded();
+
+        expect(result, equals(0));
+        expect(prefs.getBool('corrupted_video_repair_v1_completed'), isTrue);
+      });
+
+      test('only repairs corrupted URLs, preserves valid ones', () async {
+        final mixedEvent = _createVideoEvent(
+          id: 'event1',
+          tags: [
+            ['d', 'video_mixed'],
+            [
+              'imeta',
+              'url /var/mobile/Containers/cache/video.mp4',
+              'url https://media.divine.video/existing_valid_url',
+              'm video/mp4',
+              'x $_testSha256',
+            ],
+          ],
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            useCache: false,
+          ),
+        ).thenAnswer((_) async => [mixedEvent]);
+
+        stubSignAndPublishSuccess();
+
+        final result = await repairService.repairIfNeeded();
+
+        expect(result, equals(1));
+
+        final imetaTag = publishedEvents.first.tags.firstWhere(
+          (t) => t.isNotEmpty && t[0] == 'imeta',
+        );
+        final urlComponents = imetaTag
+            .where((c) => c.startsWith('url '))
+            .toList();
+
+        expect(
+          urlComponents[0],
+          equals('url $_blossomBaseUrl/$_testSha256'),
+        );
+        expect(
+          urlComponents[1],
+          equals('url https://media.divine.video/existing_valid_url'),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Closes #2144 — also addresses #2033 (repair strategy).

- Adds `CorruptedVideoRepairService` that scans the user's own kind 34236 events on startup, detects imeta tags with local file paths instead of HTTP URLs, reconstructs correct blossom URLs from the SHA-256 hash, and republishes corrected events
- Gated by a SharedPreferences flag — runs only once per user, retries on next startup if the relay query fails

## Context

PR #2032 fixed the root cause (the app was overwriting video URLs with local cache file paths via `_resolveCachePaths`). However, 8 already-corrupted events across 4 users remain on `relay.divine.video` with local paths like `/var/mobile/.../openvine_video_cache/xxx.mp4` in their imeta tags. These videos appear on profiles (thumbnail is correct) but fail to play (videoUrl is rejected by `_isValidVideoUrl`).

Since kind 34236 is parameterized replaceable, publishing a new event with the same `d` tag and `created_at + 1` replaces the corrupted event on the relay.

## Changes

| File | Change |
|------|--------|
| `mobile/lib/services/corrupted_video_repair_service.dart` | New one-time repair service |
| `mobile/lib/main.dart` | Wire repair into `_initializeBackgroundServices()` (fire-and-forget after first frame) |
| `mobile/test/unit/services/corrupted_video_repair_service_test.dart` | 11 unit tests |

## Design decisions

- **`AuthService.createAndSignEvent()`** for signing — handles NIP-46 RPC, drift tolerance, and post-sign validation
- **`created_at + 1`** (not current time) — minimal metadata change, preserves original publication date
- **`VideoEventService.updateVideoEvent()`** after republish — fixes local cache so the video is playable immediately without restart
- **Only republishes when repairable** — events with local paths but no `x` hash are logged but not republished with broken data
- **Completion flag not set on error** — ensures retry on next startup

## Test plan

- [x] 11 unit tests: iOS path repair, Android path repair, valid URL no-op, no-hash skip, already-completed skip, auth failure skip, empty pubkey skip, signing failure, publish failure, mixed-URL selective repair, query failure retry
- [x] `flutter analyze` — no issues
- [x] `dart format` — no changes
- [ ] Manual: after deploying, verify the 4 affected users' profile videos become playable