### PR TITLE
fix(search): remove has_videos filter from user search

### DIFF
--- a/mobile/lib/blocs/user_search/user_search_bloc.dart
+++ b/mobile/lib/blocs/user_search/user_search_bloc.dart
@@ -20,7 +20,7 @@ const _pageSize = 50;
 class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
   UserSearchBloc({
     required ProfileRepository profileRepository,
-    this.hasVideos = true,
+    this.hasVideos = false,
     this.searchTimeout = const Duration(seconds: 20),
     FeedPerformanceTracker? feedTracker,
   }) : _profileRepository = profileRepository,

--- a/mobile/lib/widgets/find_people_sheet.dart
+++ b/mobile/lib/widgets/find_people_sheet.dart
@@ -62,7 +62,6 @@ class _FindPeopleSheetState extends ConsumerState<FindPeopleSheet> {
     if (profileRepo != null) {
       _searchBloc = UserSearchBloc(
         profileRepository: profileRepo,
-        hasVideos: false,
         searchTimeout: widget.searchTimeout,
       );
     }

--- a/mobile/test/blocs/user_search/user_search_bloc_test.dart
+++ b/mobile/test/blocs/user_search/user_search_bloc_test.dart
@@ -113,7 +113,6 @@ void main() {
               query: 'alice',
               limit: 50,
               sortBy: 'followers',
-              hasVideos: true,
             ),
           ).called(1);
         },
@@ -403,7 +402,6 @@ void main() {
               query: 'bob',
               limit: 50,
               sortBy: 'followers',
-              hasVideos: true,
             ),
           ).called(1);
         },
@@ -477,7 +475,6 @@ void main() {
               query: 'final',
               limit: 50,
               sortBy: 'followers',
-              hasVideos: true,
             ),
           ).called(1);
           verifyNever(
@@ -605,7 +602,6 @@ void main() {
               limit: 50,
               offset: 50,
               sortBy: 'followers',
-              hasVideos: true,
             ),
           ).thenAnswer((_) => Stream.value(createTestProfiles(10)));
         },
@@ -641,7 +637,6 @@ void main() {
               limit: 50,
               offset: 50,
               sortBy: 'followers',
-              hasVideos: true,
             ),
           ).thenAnswer((_) => Stream.fromIterable([partial, full]));
         },
@@ -677,7 +672,6 @@ void main() {
               limit: 50,
               offset: 50,
               sortBy: 'followers',
-              hasVideos: true,
             ),
           ).thenAnswer((_) => Stream.value(createTestProfiles(50)));
         },
@@ -748,7 +742,6 @@ void main() {
               limit: 50,
               offset: 50,
               sortBy: 'followers',
-              hasVideos: true,
             ),
           ).thenAnswer(
             (_) => Stream<List<UserProfile>>.error(Exception('Network error')),
@@ -795,7 +788,7 @@ void main() {
       const debounceDuration = Duration(milliseconds: 400);
 
       blocTest<UserSearchBloc, UserSearchState>(
-        'passes hasVideos: false to profileRepository when configured',
+        'passes hasVideos: true to profileRepository when configured',
         setUp: () {
           when(
             () => mockProfileRepository.searchUsersProgressive(
@@ -808,7 +801,7 @@ void main() {
         },
         build: () => UserSearchBloc(
           profileRepository: mockProfileRepository,
-          hasVideos: false,
+          hasVideos: true,
         ),
         act: (bloc) => bloc.add(const UserSearchQueryChanged('test')),
         wait: debounceDuration,
@@ -818,13 +811,14 @@ void main() {
               query: 'test',
               limit: 50,
               sortBy: 'followers',
+              hasVideos: true,
             ),
           ).called(1);
         },
       );
 
       blocTest<UserSearchBloc, UserSearchState>(
-        'passes hasVideos: false to profileRepository on load more',
+        'passes hasVideos: true to profileRepository on load more',
         setUp: () {
           when(
             () => mockProfileRepository.searchUsersProgressive(
@@ -832,12 +826,13 @@ void main() {
               limit: 50,
               offset: 50,
               sortBy: 'followers',
+              hasVideos: true,
             ),
           ).thenAnswer((_) => Stream.value(createTestProfiles(10)));
         },
         build: () => UserSearchBloc(
           profileRepository: mockProfileRepository,
-          hasVideos: false,
+          hasVideos: true,
         ),
         seed: () => UserSearchState(
           status: UserSearchStatus.success,
@@ -854,13 +849,14 @@ void main() {
               limit: 50,
               offset: 50,
               sortBy: 'followers',
+              hasVideos: true,
             ),
           ).called(1);
         },
       );
 
       blocTest<UserSearchBloc, UserSearchState>(
-        'defaults hasVideos to true when not specified',
+        'defaults hasVideos to false when not specified',
         setUp: () {
           when(
             () => mockProfileRepository.searchUsersProgressive(
@@ -875,14 +871,14 @@ void main() {
         act: (bloc) => bloc.add(const UserSearchQueryChanged('test')),
         wait: debounceDuration,
         verify: (_) {
-          verify(
+          verifyNever(
             () => mockProfileRepository.searchUsersProgressive(
               query: 'test',
               limit: 50,
               sortBy: 'followers',
               hasVideos: true,
             ),
-          ).called(1);
+          );
         },
       );
     });


### PR DESCRIPTION
Closes #2747

## Summary

- Changed `UserSearchBloc.hasVideos` default from `true` to `false` so the FunnelCake API returns all matching users, not only those with indexed videos
- Removed now-redundant `hasVideos: false` from `FindPeopleSheet` (already matched new default)
- Updated `hasVideos parameter` test group to verify the non-default (`true`) case and confirm `false` is the default

## Context

The `has_videos=true` filter was added in #1400 as a forward-looking param that the backend would "gracefully ignore until it adds support." The backend now enforces it, which silently excluded users like "Calin" (who exists at calin.divine.video) from mobile search results. The web app was unaffected because it accesses profiles via direct URL/NIP-05, not the search API.

## Test plan

- [x] 36 `UserSearchBloc` tests pass
- [x] 36 search widget tests pass
- [x] Pre-commit analyzer passes (no lint warnings)
- [x] Manual device test: searching "calin" now returns 9 users including both "Calin" profiles
- [x] Manual device test: users with videos still appear in search (no regression)
- [x] Manual device test: pagination works (50 results for broad queries)
- [x] Manual device test: DM "Find People" sheet unaffected