### PR TITLE
fix(video): add retry to default error state and structured pooled player logs

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -23,6 +23,7 @@ import 'package:openvine/router/app_router.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/view_event_publisher.dart';
+import 'package:openvine/utils/pooled_player_logger.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/pooled_video_metrics_tracker.dart';
 import 'package:openvine/widgets/share_video_menu.dart';
@@ -331,6 +332,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
         );
       },
       maxLoopDuration: VideoEditorConstants.maxDuration,
+      onLog: pooledPlayerLogCallback(),
     );
   }
 

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -20,6 +20,7 @@ import 'package:openvine/screens/feed/feed_mode_switch.dart';
 import 'package:openvine/screens/feed/feed_video_overlay.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:openvine/services/startup_performance_service.dart';
+import 'package:openvine/utils/pooled_player_logger.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
@@ -206,6 +207,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
         if (!mounted) return;
         _skipToNextVideoIfPossible();
       },
+      onLog: pooledPlayerLogCallback(),
     );
 
     controllerMode = effectiveState.mode;

--- a/mobile/lib/utils/pooled_player_logger.dart
+++ b/mobile/lib/utils/pooled_player_logger.dart
@@ -1,0 +1,34 @@
+// ABOUTME: Bridges pooled_video_player debug logs into the app's unified logger
+// ABOUTME: Enables production log exports to include video player diagnostics
+
+import 'package:openvine/utils/unified_logger.dart';
+
+/// Creates a logging callback for [VideoFeedController.onLog] that forwards
+/// messages into the app's structured logging system.
+///
+/// Without this bridge, pooled player logs only go to `debugPrint` and are
+/// invisible in user-facing log exports.
+void Function(String level, String message) pooledPlayerLogCallback() {
+  return (String level, String message) {
+    switch (level) {
+      case 'error':
+        Log.error(
+          message,
+          name: 'PooledPlayer',
+          category: LogCategory.video,
+        );
+      case 'warning':
+        Log.warning(
+          message,
+          name: 'PooledPlayer',
+          category: LogCategory.video,
+        );
+      default:
+        Log.debug(
+          message,
+          name: 'PooledPlayer',
+          category: LogCategory.video,
+        );
+    }
+  };
+}

--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -85,6 +85,7 @@ class VideoFeedController extends ChangeNotifier {
     this.positionCallbackInterval = const Duration(milliseconds: 250),
     this.slowLoadThreshold = const Duration(seconds: 8),
     this.maxLoopDuration,
+    this.onLog,
   }) : pool = pool ?? PlayerPool.instance,
        _videos = List.from(videos),
        _currentIndex = initialIndex.clamp(
@@ -148,6 +149,13 @@ class VideoFeedController extends ChangeNotifier {
   /// When `null`, no loop enforcement is applied (the player's own
   /// [PlaylistMode] controls looping).
   final Duration? maxLoopDuration;
+
+  /// Optional structured logging callback.
+  ///
+  /// When provided, log messages are forwarded to this callback in addition
+  /// to `debugPrint`. Use this to pipe pooled player diagnostics into the
+  /// app's structured logging system (e.g., for production log exports).
+  final void Function(String level, String message)? onLog;
 
   /// Unmodifiable list of videos.
   List<VideoItem> get videos => List.unmodifiable(_videos);
@@ -299,6 +307,17 @@ class VideoFeedController extends ChangeNotifier {
 
   void _logDebug(String message) {
     debugPrint('[POOLED] $message');
+    onLog?.call('debug', message);
+  }
+
+  void _logWarning(String message) {
+    debugPrint('[POOLED] ⚠️ $message');
+    onLog?.call('warning', message);
+  }
+
+  void _logError(String message) {
+    debugPrint('[POOLED] ❌ $message');
+    onLog?.call('error', message);
   }
 
   void _logLoadingSnapshot(int index, {required String reason}) {
@@ -344,7 +363,7 @@ class VideoFeedController extends ChangeNotifier {
         // Current video stuck in buffering too long — try next source
         // before giving up completely.
         if (index == _currentIndex) {
-          _logDebug(
+          _logWarning(
             'load_gave_up ${_videoDebugDetails(index)} '
             'elapsedMs=$elapsedMs',
           );
@@ -482,6 +501,12 @@ class VideoFeedController extends ChangeNotifier {
     // If no message, _errorTypes[index] may already be set from the
     // error stream handler. Fall back to generic if nothing was stored.
     _errorTypes[index] ??= VideoErrorType.generic;
+    _logError(
+      'mark_load_error ${_videoDebugDetails(index)} '
+      'errorMessage=$errorMessage '
+      'errorType=${_errorTypes[index]} '
+      'openedSource=${_openedSources[index]}',
+    );
     _notifyIndex(index);
     if (notifyStalled) {
       onVideoStalled?.call(index);
@@ -492,7 +517,7 @@ class VideoFeedController extends ChangeNotifier {
     final pooledPlayer = _loadedPlayers[index];
     final player = pooledPlayer?.player;
     if (player == null) {
-      _logDebug('stuck_playback ${_videoDebugDetails(index)} giving up');
+      _logError('stuck_playback ${_videoDebugDetails(index)} giving up');
       _markLoadError(index: index, notifyStalled: true);
       return;
     }
@@ -502,12 +527,12 @@ class VideoFeedController extends ChangeNotifier {
     final nextSourceIndex = currentSourceIndex + 1;
 
     if (playbackSources == null || nextSourceIndex >= playbackSources.length) {
-      _logDebug('stuck_playback ${_videoDebugDetails(index)} giving up');
+      _logError('stuck_playback ${_videoDebugDetails(index)} giving up');
       _markLoadError(index: index, notifyStalled: true);
       return;
     }
 
-    _logDebug(
+    _logWarning(
       'stuck_failover ${_videoDebugDetails(index)} '
       'failedSource=${_openedSources[index]} '
       'retrySource=${playbackSources[nextSourceIndex]}',
@@ -540,10 +565,10 @@ class VideoFeedController extends ChangeNotifier {
       if (!player.state.buffering) {
         _onBufferReady(index);
       }
-    } on Exception catch (error, stack) {
-      debugPrint(
-        '[POOLED] stuck_retry_failed ${_videoDebugDetails(index)} '
-        'error=$error\n$stack',
+    } on Exception catch (error) {
+      _logError(
+        'stuck_retry_failed ${_videoDebugDetails(index)} '
+        'error=$error',
       );
       _markLoadError(
         index: index,
@@ -943,8 +968,8 @@ class VideoFeedController extends ChangeNotifier {
         _onBufferReady(index);
       }
     } on Exception catch (e, stack) {
-      debugPrint(
-        '[POOLED] load_failed ${_videoDebugDetails(index)} '
+      _logError(
+        'load_failed ${_videoDebugDetails(index)} '
         'videoCount=${_videos.length} '
         'elapsedMs=${_loadStopwatches[index]?.elapsedMilliseconds} '
         'error=$e\n$stack',
@@ -1131,11 +1156,12 @@ class VideoFeedController extends ChangeNotifier {
     _errorSubscriptions[index] = pooledPlayer.player.stream.error.listen((
       error,
     ) {
-      _logDebug(
+      final loadState = _loadStates[index];
+      _logWarning(
         'player_error ${_videoDebugDetails(index)} '
         'error=$error '
         'source=${_openedSources[index]} '
-        'loadState=${_loadStates[index]}',
+        'loadState=$loadState',
       );
       // Classify the error immediately so the type is available if retry
       // exhausts all sources and _markLoadError is called without a message.
@@ -1144,7 +1170,7 @@ class VideoFeedController extends ChangeNotifier {
       // successfully (LoadState.ready), mpv may emit non-critical errors
       // (e.g. on loop seeks, transient network hiccups) that should not
       // trigger a source failover.
-      if (_loadStates[index] == LoadState.loading) {
+      if (loadState == LoadState.loading) {
         unawaited(_retryCurrentVideoWithNextSource(index));
       }
     });
@@ -1342,9 +1368,10 @@ class VideoFeedController extends ChangeNotifier {
       // After repeated failed recoveries, the stream is likely corrupt
       // (e.g. missing h264 PPS headers). Give up so the user can swipe past.
       if (_staleRecoveryAttempts > _maxStaleRecoveryAttempts) {
-        _logDebug(
+        _logError(
           'stale_gave_up index=$index '
           'attempts=$_staleRecoveryAttempts '
+          'positionMs=$positionMs '
           '${_videoDebugDetails(index)}',
         );
         _staleRecoveryAttempts = 0;

--- a/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_player.dart
+++ b/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_player.dart
@@ -127,12 +127,12 @@ class PooledVideoPlayer extends StatelessWidget {
               if (loadState == .error)
                 errorBuilder?.call(
                       context,
-                      () => feedController.retryLoad(
-                        feedController.currentIndex,
-                      ),
+                      () => feedController.retryLoad(index),
                       state.errorType,
                     ) ??
-                    const _DefaultErrorState()
+                    _DefaultErrorState(
+                      onRetry: () => feedController.retryLoad(index),
+                    )
               else ...[
                 /// Thumbnail / spinner shown until the first frame.
                 loadingBuilder?.call(context) ??
@@ -419,22 +419,39 @@ class _DefaultLoadingState extends StatelessWidget {
 
 /// Default error state.
 class _DefaultErrorState extends StatelessWidget {
-  const _DefaultErrorState();
+  const _DefaultErrorState({this.onRetry});
+
+  final VoidCallback? onRetry;
 
   @override
   Widget build(BuildContext context) {
-    return const ColoredBox(
-      color: Color(0xFF000000),
+    return ColoredBox(
+      color: const Color(0xFF000000),
       child: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.error_outline, color: Color(0xB3FFFFFF), size: 48),
-            SizedBox(height: 16),
-            Text(
+            const Icon(
+              Icons.error_outline,
+              color: Color(0xB3FFFFFF),
+              size: 48,
+            ),
+            const SizedBox(height: 16),
+            const Text(
               'Failed to load video',
               style: TextStyle(color: Color(0xB3FFFFFF), fontSize: 16),
             ),
+            if (onRetry != null) ...[
+              const SizedBox(height: 16),
+              TextButton.icon(
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh, color: Color(0xFFFFFFFF)),
+                label: const Text(
+                  'Tap to retry',
+                  style: TextStyle(color: Color(0xFFFFFFFF)),
+                ),
+              ),
+            ],
           ],
         ),
       ),

--- a/mobile/packages/pooled_video_player/test/widgets/pooled_video_player_test.dart
+++ b/mobile/packages/pooled_video_player/test/widgets/pooled_video_player_test.dart
@@ -532,13 +532,15 @@ void main() {
         );
       });
 
-      testWidgets('shows default error when LoadState is error', (
+      testWidgets('shows default error with retry when LoadState is error', (
         tester,
       ) async {
         await tester.pumpWidget(buildWidget());
 
         expect(find.byIcon(Icons.error_outline), findsOneWidget);
         expect(find.text('Failed to load video'), findsOneWidget);
+        expect(find.text('Tap to retry'), findsOneWidget);
+        expect(find.byIcon(Icons.refresh), findsOneWidget);
       });
 
       testWidgets('shows custom errorBuilder when provided', (tester) async {


### PR DESCRIPTION
Closes #2755

## Summary

Users hit **"Failed to load video"** with no way to recover, and we have no logs to diagnose why. This PR fixes both issues.

### The bug
A user reported a video that played briefly then showed "Failed to load video" with **no retry button**. Three tap attempts from the profile grid all hit the same state. From the log export there was no way to see what the pooled player was doing because its `[POOLED]` diagnostics only go to `debugPrint` — they never reach the structured log exports users upload for support.

### Root causes
1. `_DefaultErrorState` in `pooled_video_player.dart` had no retry button — it's a fallback that shows if a consumer forgets to pass an `errorBuilder`, but since the retry callback is wired through `PooledVideoPlayer` anyway, there's no reason not to expose it.
2. The retry closure passed `feedController.currentIndex` instead of the errored video's `index`. These usually match but can drift after a swipe.
3. `VideoFeedController` emits rich diagnostics via `_logDebug` → `debugPrint`, which is invisible in release log exports.

## Changes

- **Retry in default error state:** `_DefaultErrorState` accepts an optional `onRetry` and renders a "Tap to retry" button when provided. `PooledVideoPlayer` now passes the correct per-item `index` into both the user's `errorBuilder` and the fallback.
- **Structured logging bridge:** `VideoFeedController` gains an optional `onLog(level, message)` callback. New `_logWarning` / `_logError` helpers forward to both `debugPrint` and `onLog`. Key error paths upgraded from debug to warning/error severity: `mark_load_error`, `player_error`, `stale_gave_up`, `stuck_playback`, `load_failed`, `load_gave_up`, `stuck_failover`, `stuck_retry_failed`.
- **App wiring:** New `mobile/lib/utils/pooled_player_logger.dart` builds the callback and routes messages into the unified logger as `[PooledPlayer]` / `LogCategory.video`. Both `PooledFullscreenVideoFeedScreen` and `VideoFeedPage` now pass `onLog: pooledPlayerLogCallback()` when creating their `VideoFeedController`.

## Test plan

- [x] `flutter analyze` on all touched files — clean
- [x] `flutter test packages/pooled_video_player/test/` — 411 tests passing, including the updated assertion that the default error state shows "Tap to retry" and a refresh icon
- [x] `flutter test test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart` — passing
- [x] `flutter test test/widgets/pooled_video_error_overlay_test.dart` — passing
- [ ] Manual: reproduce the freshly-uploaded-video failure and confirm a retry button now appears; confirm `[PooledPlayer]` entries appear in the log export when playback fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)