### PR TITLE
feat(apps): add divine.space to integrated apps directory

### DIFF
--- a/mobile/packages/nostr_app_bridge_repository/lib/src/preloaded_nostr_apps.dart
+++ b/mobile/packages/nostr_app_bridge_repository/lib/src/preloaded_nostr_apps.dart
@@ -173,6 +173,17 @@ final List<NostrAppDirectoryEntry> preloadedNostrApps = List.unmodifiable([
     launchUrl: 'https://jumble.social/',
     sortOrder: 13,
   ),
+  _buildPreloadedApp(
+    id: 'bundled-divine-space',
+    slug: 'divine-space',
+    name: 'divine.space',
+    tagline: 'A spatial Nostr experience.',
+    description:
+        'A curated third-party Nostr app offering a spatial take '
+        'on social browsing and conversations.',
+    launchUrl: 'https://divine.space/',
+    sortOrder: 14,
+  ),
 ]);
 
 /// Per-app localStorage seeding scripts keyed by slug.


### PR DESCRIPTION
Closes #2757

## Summary
- Adds `divine.space` as a new bundled preloaded app in the vetted third-party Nostr apps catalog (`preloaded_nostr_apps.dart`)
- Uses `sortOrder: 14` so it appears after the existing curated entries
- Follows the same shared allowed methods / sign-event kinds / prompt requirements as the other bundled apps

## Test plan
- [ ] Open Settings → Integrated Apps and confirm divine.space appears in the list
- [ ] Launch divine.space from the apps directory and verify the bridge connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)