### PR TITLE
fix(web): guard DivineVideoPlayer.configureCache on web to unblock startup

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -299,7 +299,15 @@ Future<void> _startOpenVineApp() async {
   // in web/index.html (already added).
 
   // Configure the native video player disk cache (500 MB, LRU eviction).
-  await DivineVideoPlayerController.configureCache();
+  // divine_video_player only ships android/ios/macos plugin platforms, so
+  // invoking configureCache() on web throws MissingPluginException. That
+  // exception gets swallowed by the runZonedGuarded + CrashReportingService
+  // chain below (Firebase Crashlytics has no web impl), and runApp() is
+  // never reached — the HTML loading spinner stays up forever with no JS
+  // errors. Skip the call on web to unblock startup.
+  if (!kIsWeb) {
+    await DivineVideoPlayerController.configureCache();
+  }
 
   StartupPerformanceService.instance.completePhase('bindings');
 


### PR DESCRIPTION
Closes #2759

## Summary

- Web builds have been hanging on the initial loading spinner indefinitely because `await DivineVideoPlayerController.configureCache()` at `mobile/lib/main.dart:302` throws `MissingPluginException` on web (the in-repo `divine_video_player` package only declares `android`/`ios`/`macos` plugin platforms).
- The exception is swallowed by the `runZonedGuarded` → `CrashReportingService.recordError` chain (Firebase Crashlytics has no web impl), so `runApp()` is never reached. No JS error surfaces because the failure lives entirely inside Dart's error zone.
- Both `app.divine.video` and `*.openvine-app.pages.dev` previews deploy from the same CF Pages project and both hang on this. Wrapping the call in `if (!kIsWeb)` is the minimal fix.

Root cause introduced by #2686 *(refactor(video-editor): replace video-player with DivineVideoPlayer)*. Tracking down this behavior required headless-Chrome CDP instrumentation to confirm that `didCreateEngineInitializer` fires and canvaskit loads but `flutter-first-frame` never does — i.e. hang is in Dart `main()`, not anywhere Flutter's JS loader would log about.

Follow-up PR will tighten `mobile/web/_headers` cache rules and retire the broken custom `/sw.js`; those are latent hygiene issues that do not cause the hang and are kept out of this PR for reviewability.

## Test plan

- [x] `flutter build web --release --pwa-strategy=none --dart-define=DEFAULT_ENV=PRODUCTION --no-source-maps` succeeds locally.
- [x] Serving `build/web/` via `python3 -m http.server` and loading in headless Chrome now fires `flutter-first-frame` and renders the welcome screen (verified by parallel debug-agent session with screenshot).
- [ ] CI `Mobile Web Production Deploy` on merge to `main`.
- [ ] Smoke-check `https://<hash>.openvine-app.pages.dev/` PR preview boots past the loading spinner.
- [ ] After deploy, verify `app.divine.video` boots. **Note:** `app.divine.video` additionally requires a one-time Cloudflare zone edge cache purge of `/main.dart.js`, `/flutter_bootstrap.js`, `/flutter_service_worker.js`, `/sw.js` due to a separate `_headers` `immutable` footgun being fixed in a follow-up PR. Without that purge the custom domain will continue serving a pre-fix `main.dart.js` from edge cache. Previews on `*.pages.dev` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)