### PR TITLE
fix(web): guard DivineVideoPlayerController.configureCache behind kIsWeb

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -299,7 +299,14 @@ Future<void> _startOpenVineApp() async {
   // in web/index.html (already added).
 
   // Configure the native video player disk cache (500 MB, LRU eviction).
-  await DivineVideoPlayerController.configureCache();
+  // divine_video_player has no web implementation, so calling its method
+  // channel on web throws MissingPluginException. That exception is caught by
+  // runZonedGuarded in main() and silently swallowed by the non-web Crashlytics
+  // handler, which means runApp() is never reached and the app hangs on the
+  // initial loading spinner forever. Skip on web.
+  if (!kIsWeb) {
+    await DivineVideoPlayerController.configureCache();
+  }
 
   StartupPerformanceService.instance.completePhase('bindings');
 


### PR DESCRIPTION
Closes #2761

## Summary

Web builds (`app.divine.video` and `*.openvine-app.pages.dev`) hang on the initial loading spinner and never boot. All assets return 200, canvaskit loads, the Flutter engine initializes and adds `<flt-semantics-placeholder>` to the DOM — but `flutter-first-frame` never fires and there are zero JS errors.

**Root cause:** `mobile/lib/main.dart` calls `await DivineVideoPlayerController.configureCache()` before `runApp()`. The `divine_video_player` in-repo package (`mobile/packages/divine_video_player/pubspec.yaml`) only declares `android`, `ios`, and `macos` plugin platforms — no `web`. On Flutter web, `MethodChannel.invokeMethod('configureCache')` therefore throws `MissingPluginException`.

That exception propagates up through `_startOpenVineApp()`'s async chain and is caught by `runZonedGuarded` in `main()`, whose handler only reports via `CrashReportingService.recordError`. Firebase Crashlytics has no web implementation, so `recordError` itself errors, the inner `try/catch` swallows it, and the original `MissingPluginException` is silently lost. `runApp()` is never reached, no first frame is ever rendered, and the HTML `#initial-loader` spinner (z-index 9999) stays visible forever. No JS errors appear because the exception lives entirely inside Dart's error zone.

**Regression:** Introduced in `86c720981` (feat(video-player): configure native video player cache and preload clips for instant playback, Apr 2). The commit added the `await` without a `kIsWeb` guard.

**Fix:** wrap the call in `if (!kIsWeb)`, matching the pattern used throughout `main.dart` for other native-only services. Mobile behavior is unchanged; web no longer hangs.

## Verification

- `flutter analyze lib/main.dart` — no issues.
- `flutter build web --release --tree-shake-icons --pwa-strategy=none --dart-define=DEFAULT_ENV=PRODUCTION --no-source-maps` — builds successfully.
- Served `build/web/` locally and loaded it in a fresh headless Chrome profile via Chrome DevTools Protocol with a pre-navigation `flutter-first-frame` listener. Result: `firstFrame: true` at ~1.1s, loader overlay hidden, `<flutter-view>` present, welcome screen renders with the "Authentic moments. Human creativity." hero and the "Create a new Divine account" / "Sign in with a different account" buttons.
- No mobile behavior is changed — the guard only skips the call on `kIsWeb`.

## Scope

- [x] Single-file change: `mobile/lib/main.dart`
- [x] No behavior change on iOS / Android / macOS
- [x] No test changes required (the existing mobile tests still exercise the unguarded path on non-web)

## Related / not in this PR

- Stale Cloudflare edge cache and the aggressive custom `mobile/web/sw.js` cache-first service worker also contribute to the user-visible symptom for returning visitors, but are separate concerns addressed in a follow-up PR. This PR fixes fresh loads on current `main`.
- After this lands and deploys, a one-time Cloudflare zone cache purge for `/main.dart.js`, `/flutter_bootstrap.js`, `/flutter_service_worker.js`, `/sw.js` on `app.divine.video` is recommended so returning users don't continue to hit the stale pinned edge entries.

## Test plan

- [ ] Merge triggers `mobile_web_production_deploy.yml` → CF Pages deploy to `openvine-app` project.
- [ ] Manual smoke test on `https://app.divine.video/` in an incognito window after purge: welcome screen renders within a few seconds instead of the spinner.
- [ ] Confirm iOS TestFlight build still initializes the native video player cache on cold start (manual smoke).
- [ ] Confirm Android internal build still initializes the native video player cache on cold start (manual smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)