### PR TITLE
fix(video-feed): restore playback and selected volume after buffering

### DIFF
--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -168,7 +168,7 @@ class VideoFeedController extends ChangeNotifier {
   bool _isActive = true;
   bool _isPaused = false;
   bool _isDisposed = false;
-  double _desiredPlaybackVolume = 1.0;
+  double _desiredPlaybackVolume = 1;
 
   // Loaded players by index
   final Map<int, PooledPlayer> _loadedPlayers = {};
@@ -725,7 +725,7 @@ class VideoFeedController extends ChangeNotifier {
 
   /// Set volume (0.0 to 1.0) for current video.
   void setVolume(double volume) {
-    _desiredPlaybackVolume = volume.clamp(0.0, 1.0).toDouble();
+    _desiredPlaybackVolume = volume.clamp(0.0, 1.0);
     final player = _loadedPlayers[_currentIndex]?.player;
     if (player != null) {
       unawaited(player.setVolume(_desiredPlayerVolume));
@@ -733,7 +733,7 @@ class VideoFeedController extends ChangeNotifier {
   }
 
   double get _desiredPlayerVolume =>
-      (_desiredPlaybackVolume * 100).clamp(0.0, 100.0).toDouble();
+      (_desiredPlaybackVolume * 100).clamp(0.0, 100.0);
 
   /// Set playback speed for current video.
   void setPlaybackSpeed(double speed) {

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -2367,7 +2367,8 @@ void main() {
       );
 
       test(
-        'current video resumes at the controller volume when initial buffering ends',
+        'current video resumes at the controller volume '
+        'when initial buffering ends',
         () async {
           final bufferingSetups = <String, MockPlayerSetup>{};
           final bufferingPool = TestablePlayerPool(


### PR DESCRIPTION
Closes #2771

## Summary
- resume the current feed item when initial buffering completes instead of only raising player volume
- preserve the controller-selected feed volume across buffer-ready resume, manual play resume, and stale-playback recovery
- add regressions for the startup buffer handoff and manual resume volume paths

## Test Plan
- [x] flutter test test/controllers/video_feed_controller_test.dart
- [x] flutter test test/screens/feed/video_feed_page_test.dart