### PR TITLE
chore(zapstore): update release source to 1.0.8

### DIFF
--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,5 +1,5 @@
 repository: https://github.com/divinevideo/divine-mobile
-release_source: https://github.com/divinevideo/divine-mobile/releases/tag/1.0.7
+release_source: https://github.com/divinevideo/divine-mobile/releases/tag/1.0.8
 name: Divine
 description: |
   Divine is a new 6-second looping video app, inspired by Vine, with a


### PR DESCRIPTION
Closes #2773

## Summary
- update `zapstore.yaml` release_source to the `1.0.8` GitHub release
- align Zapstore metadata with the current app version in `mobile/pubspec.yaml`

## Test Plan
- [x] `git diff --check`
- [x] `zsp publish --check zapstore.yaml`