### PR TITLE
fix(video-feed): avoid replaying videos after initial buffering

### DIFF
--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -190,7 +190,11 @@ class VideoFeedController extends ChangeNotifier {
   int _preloadGeneration = 0;
   Timer? _stuckPlaybackTimer;
 
-  static const _maxStallRetries = 1;
+  /// How many zero-duration rebuffer cycles to tolerate before marking the
+  /// video as an error. Set to 2 so a single transient network hiccup doesn't
+  /// immediately kill playback — but a genuinely broken stream still fails
+  /// within a few seconds.
+  static const _maxStallRetries = 2;
 
   /// Stale-position recovery: tracks the last observed position and how many
   /// consecutive heartbeats it has remained unchanged while the player reports

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -3028,8 +3028,8 @@ void main() {
       });
 
       test(
-        'allows the first real zero-duration rebuffer recovery before '
-        'marking error on the second',
+        'allows two zero-duration rebuffer recoveries before '
+        'marking error on the third',
         () async {
           final videos = createTestVideos(count: 1);
           final controller = VideoFeedController(videos: videos, pool: pool);
@@ -3058,7 +3058,18 @@ void main() {
 
           clearInteractions(setup.player);
 
-          // Second real rebuffer cycle with no media metadata: give up.
+          // Second real rebuffer cycle: still recovers (maxStallRetries = 2).
+          setup.bufferingController.add(true);
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          setup.bufferingController.add(false);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          expect(controller.getLoadState(0), equals(LoadState.ready));
+          verify(setup.player.play).called(greaterThanOrEqualTo(1));
+
+          clearInteractions(setup.player);
+
+          // Third real rebuffer cycle with no media metadata: give up.
           setup.bufferingController.add(true);
           await Future<void>.delayed(const Duration(milliseconds: 10));
           setup.bufferingController.add(false);


### PR DESCRIPTION
Closes #2789

## Summary
- **Core fix**: avoid issuing a redundant `play()` during the initial muted-buffering handoff when the current player is already playing — this was causing visible pause/restart stutter
- **Buffer-based stall recovery**: track ready videos that re-enter buffering via `_readyVideosAwaitingRecovery` set; on rebuffer completion, validate position/duration and apply a circuit breaker (`_maxStallRetries = 2`) before marking as error
- **Stale heartbeat threshold**: raised from 3 (300ms) to 8 (800ms) — iOS AVFoundation decoders can legitimately pause position updates for 300-500ms during normal playback without being stuck
- **Volume preservation**: new `_desiredPlaybackVolume` field ensures recovery paths and `_resume()` restore the user-set volume instead of always hardcoding 100
- **Structured logging**: added `onLog` callback, `_logWarning()` / `_logError()` helpers, and `STUTTER_DEBUG` instrumentation for ongoing investigation
- **Stall notification**: new `onVideoStalled` callback and `notifyStalled` flag on `_markLoadError()` so consumers can react to permanently stalled videos
- **`_markLoadError` refactor**: changed from positional to named parameters for clarity
- Regression test covering the initial-buffering handoff, stall retry tolerance, and volume restoration

## Test Plan
- [x] `flutter test packages/pooled_video_player/test/controllers/video_feed_controller_test.dart` — 163 tests passing
- [x] repo pre-commit analyzer hook during `git commit`
- [x] repo pre-push hook reran tests