### PR TITLE
fix(android): remove proofmode not implemented fatal

### DIFF
--- a/mobile/android/app/src/main/kotlin/co/openvine/app/proofmode/HardwareAttestationNotarizationProvider.kt
+++ b/mobile/android/app/src/main/kotlin/co/openvine/app/proofmode/HardwareAttestationNotarizationProvider.kt
@@ -35,7 +35,7 @@ class HardwareAttestationNotarizationProvider (_context: Context) : Notarization
     }
 
     override fun getProof(p0: String?): String? {
-        TODO("Not yet implemented")
+        return null
     }
 
     override fun getNotarizationFileExtension(): String? {

--- a/mobile/android/app/src/test/kotlin/co/openvine/app/proofmode/HardwareAttestationNotarizationProviderTest.kt
+++ b/mobile/android/app/src/test/kotlin/co/openvine/app/proofmode/HardwareAttestationNotarizationProviderTest.kt
@@ -1,0 +1,22 @@
+package co.openvine.app.proofmode
+
+import io.mockk.mockk
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HardwareAttestationNotarizationProviderTest {
+
+    @Test
+    fun `getProof returns null when no cached proof is available`() {
+        val provider = HardwareAttestationNotarizationProvider(mockk(relaxed = true))
+
+        assertNull(provider.getProof("missing-proof-hash"))
+    }
+
+    @Test
+    fun `getProof returns null for a null proof hash`() {
+        val provider = HardwareAttestationNotarizationProvider(mockk(relaxed = true))
+
+        assertNull(provider.getProof(null))
+    }
+}


### PR DESCRIPTION
Closes #2808

## Summary
- stop ProofMode hardware attestation from throwing `TODO()` in production
- return `null` when no cached proof is available instead of crashing the activity teardown path
- add a regression test for the no-proof case

## Test Plan
- [x] JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" /Users/rabble/code/divine/divine-mobile/mobile/android/gradlew -p /Users/rabble/code/divine/divine-mobile/.worktrees/fix-android-proofmode-not-implemented/mobile/android :app:testDebugUnitTest --tests "co.openvine.app.proofmode.HardwareAttestationNotarizationProviderTest"