### PR TITLE
fix(android): guard back navigation after engine detach

### DIFF
--- a/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
@@ -110,31 +110,15 @@ class MainActivity : FlutterActivity() {
             return
         }
 
-        // Notify Flutter about back button press via MethodChannel
-        navigationChannel?.invokeMethod("onBackPressed", null, object : MethodChannel.Result {
-            override fun success(result: Any?) {
-                val handled = result as? Boolean ?: false
-                Log.d(NAV_TAG, "Flutter handled back: $handled")
-
-                if (!handled) {
-                    // Flutter didn't handle it, use default behavior (exit app)
-                    Log.d(NAV_TAG, "Flutter didn't handle back, calling super.onBackPressed()")
-                    super@MainActivity.onBackPressed()
-                }
-            }
-
-            override fun error(error: String, message: String?, details: Any?) {
-                Log.e(NAV_TAG, "Error from Flutter: $error - $message")
-                // On error, use default behavior
+        dispatchBackPressToFlutter(
+            channelProvider = { navigationChannel },
+            isActivityDestroyed = { isActivityDestroyed },
+            isFinishing = { isFinishing },
+            onFallback = {
+                Log.d(NAV_TAG, "Back handling fell through to default behavior")
                 super@MainActivity.onBackPressed()
-            }
-
-            override fun notImplemented() {
-                Log.w(NAV_TAG, "Back handling not implemented in Flutter")
-                // If not implemented, use default behavior
-                super@MainActivity.onBackPressed()
-            }
-        })
+            },
+        )
     }
 
     private fun setupNavigationChannel(flutterEngine: FlutterEngine) {
@@ -160,27 +144,12 @@ class MainActivity : FlutterActivity() {
             return
         }
 
-        // Notify Flutter about back button press via MethodChannel
-        navigationChannel?.invokeMethod("onBackPressed", null, object : MethodChannel.Result {
-            override fun success(result: Any?) {
-                val handled = result as? Boolean ?: false
-
-                if (!handled) {
-                    // Flutter didn't handle it, finish activity (exit app)
-                    finish()
-                }
-            }
-
-            override fun error(error: String, message: String?, details: Any?) {
-                // On error, finish activity
-                finish()
-            }
-
-            override fun notImplemented() {
-                // If not implemented, finish activity
-                finish()
-            }
-        })
+        dispatchBackPressToFlutter(
+            channelProvider = { navigationChannel },
+            isActivityDestroyed = { isActivityDestroyed },
+            isFinishing = { isFinishing },
+            onFallback = { finish() },
+        )
     }
 
     override fun onDestroy() {
@@ -557,5 +526,53 @@ class MainActivity : FlutterActivity() {
         }
 
         Log.d(ZENDESK_TAG, "Zendesk platform channel registered")
+    }
+}
+
+internal fun dispatchBackPressToFlutter(
+    channelProvider: () -> MethodChannel?,
+    isActivityDestroyed: () -> Boolean,
+    isFinishing: () -> Boolean,
+    onFallback: () -> Unit,
+) {
+    if (isActivityDestroyed() || isFinishing()) {
+        onFallback()
+        return
+    }
+
+    val channel = channelProvider() ?: run {
+        onFallback()
+        return
+    }
+
+    // Re-check immediately before invoking Flutter so we degrade safely if the
+    // engine detaches between the initial back-navigation pre-check and the call.
+    if (isActivityDestroyed() || isFinishing()) {
+        onFallback()
+        return
+    }
+
+    try {
+        channel.invokeMethod("onBackPressed", null, object : MethodChannel.Result {
+            override fun success(result: Any?) {
+                val handled = result as? Boolean ?: false
+                if (!handled) {
+                    onFallback()
+                }
+            }
+
+            override fun error(error: String, message: String?, details: Any?) {
+                onFallback()
+            }
+
+            override fun notImplemented() {
+                onFallback()
+            }
+        })
+    } catch (e: RuntimeException) {
+        runCatching {
+            Log.w("OpenVineNavigation", "Back navigation invokeMethod failed after detach", e)
+        }
+        onFallback()
     }
 }

--- a/mobile/android/app/src/test/kotlin/co/openvine/app/FlutterJNILifecycleGuardTest.kt
+++ b/mobile/android/app/src/test/kotlin/co/openvine/app/FlutterJNILifecycleGuardTest.kt
@@ -1,14 +1,10 @@
 package co.openvine.app
 
-import android.os.Handler
-import android.os.Looper
 import io.flutter.plugin.common.MethodChannel
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkConstructor
-import io.mockk.mockkStatic
-import io.mockk.slot
 import io.mockk.verify
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 
@@ -168,5 +164,63 @@ class FlutterJNILifecycleGuardTest {
         // Second call is dropped
         guard.postResult(result, "second")
         verify(exactly = 0) { result.success("second") }
+    }
+
+    @Test
+    fun `back navigation invokes flutter method channel when activity stays alive`() {
+        val channel = mockk<MethodChannel>()
+        every { channel.invokeMethod("onBackPressed", null, any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            (args[2] as MethodChannel.Result).success(true)
+        }
+
+        var fallbackCount = 0
+
+        dispatchBackPressToFlutter(
+            channelProvider = { channel },
+            isActivityDestroyed = { false },
+            isFinishing = { false },
+            onFallback = { fallbackCount++ },
+        )
+
+        verify(exactly = 1) { channel.invokeMethod("onBackPressed", null, any()) }
+        assertEquals(0, fallbackCount)
+    }
+
+    @Test
+    fun `back navigation skips invoke when lifecycle changes before invokeMethod`() {
+        val channel = mockk<MethodChannel>(relaxed = true)
+        var destroyedChecks = 0
+        var fallbackCount = 0
+
+        dispatchBackPressToFlutter(
+            channelProvider = { channel },
+            isActivityDestroyed = { destroyedChecks++ > 0 },
+            isFinishing = { false },
+            onFallback = { fallbackCount++ },
+        )
+
+        verify(exactly = 0) { channel.invokeMethod(any(), any(), any()) }
+        assertEquals(1, fallbackCount)
+    }
+
+    @Test
+    fun `back navigation falls back when invokeMethod throws after detach`() {
+        val channel = mockk<MethodChannel>()
+        every { channel.invokeMethod(any(), any(), any()) } throws RuntimeException(
+            "Cannot execute operation because FlutterJNI is not attached to native",
+        )
+
+        var fallbackCount = 0
+
+        dispatchBackPressToFlutter(
+            channelProvider = { channel },
+            isActivityDestroyed = { false },
+            isFinishing = { false },
+            onFallback = { fallbackCount++ },
+        )
+
+        verify(exactly = 1) { channel.invokeMethod("onBackPressed", null, any()) }
+        assertEquals(1, fallbackCount)
     }
 }


### PR DESCRIPTION
Closes #2803

## Summary
- centralize Android back-navigation dispatch through a guarded helper
- re-check lifecycle state immediately before invoking Flutter and fall back safely on detached-engine failures
- add regression coverage for the alive, pre-detach, and post-detach paths

## Test Plan
- [x] JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" /Users/rabble/code/divine/divine-mobile/mobile/android/gradlew -p /Users/rabble/code/divine/divine-mobile/.worktrees/fix-android-flutterjni-back-nav-race/mobile/android :app:testDebugUnitTest --tests "co.openvine.app.FlutterJNILifecycleGuardTest"
