### PR TITLE
fix(camera): enforce one-shot flutter results

### DIFF
--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
@@ -13,6 +13,7 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.view.TextureRegistry
+import java.util.concurrent.atomic.AtomicBoolean
 
 /** DivineCameraPlugin */
 class DivineCameraPlugin :
@@ -35,9 +36,10 @@ class DivineCameraPlugin :
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {
+        val oneShotResult = OneShotMethodResult(result)
         when (call.method) {
             "getPlatformVersion" -> {
-                result.success("Android ${android.os.Build.VERSION.RELEASE}")
+                oneShotResult.success("Android ${android.os.Build.VERSION.RELEASE}")
             }
 
             "initializeCamera" -> {
@@ -46,79 +48,79 @@ class DivineCameraPlugin :
                 val enableScreenFlash = call.argument<Boolean>("enableScreenFlash") ?: true
                 val mirrorFrontCameraOutput = call.argument<Boolean>("mirrorFrontCameraOutput") ?: true
                 val enableAutoLensSwitch = call.argument<Boolean>("enableAutoLensSwitch") ?: true
-                initializeCamera(lens, videoQuality, enableScreenFlash, mirrorFrontCameraOutput, enableAutoLensSwitch, result)
+                initializeCamera(lens, videoQuality, enableScreenFlash, mirrorFrontCameraOutput, enableAutoLensSwitch, oneShotResult)
             }
 
             "disposeCamera" -> {
-                disposeCamera(result)
+                disposeCamera(oneShotResult)
             }
 
             "setFlashMode" -> {
                 val mode = call.argument<String>("mode") ?: "off"
-                setFlashMode(mode, result)
+                setFlashMode(mode, oneShotResult)
             }
 
             "setFocusPoint" -> {
                 val x = call.argument<Double>("x") ?: 0.5
                 val y = call.argument<Double>("y") ?: 0.5
-                setFocusPoint(x.toFloat(), y.toFloat(), result)
+                setFocusPoint(x.toFloat(), y.toFloat(), oneShotResult)
             }
 
             "setExposurePoint" -> {
                 val x = call.argument<Double>("x") ?: 0.5
                 val y = call.argument<Double>("y") ?: 0.5
-                setExposurePoint(x.toFloat(), y.toFloat(), result)
+                setExposurePoint(x.toFloat(), y.toFloat(), oneShotResult)
             }
 
             "cancelFocusAndMetering" -> {
-                cancelFocusAndMetering(result)
+                cancelFocusAndMetering(oneShotResult)
             }
 
             "setZoomLevel" -> {
                 val level = call.argument<Double>("level") ?: 1.0
-                setZoomLevel(level.toFloat(), result)
+                setZoomLevel(level.toFloat(), oneShotResult)
             }
 
             "switchCamera" -> {
                 val lens = call.argument<String>("lens") ?: "back"
-                switchCamera(lens, result)
+                switchCamera(lens, oneShotResult)
             }
 
             "startRecording" -> {
                 val maxDurationMs = call.argument<Int>("maxDurationMs")
                 val useCache = call.argument<Boolean>("useCache") ?: true
                 val outputDirectory = call.argument<String>("outputDirectory")
-                startRecording(maxDurationMs, useCache, outputDirectory, result)
+                startRecording(maxDurationMs, useCache, outputDirectory, oneShotResult)
             }
 
             "stopRecording" -> {
-                stopRecording(result)
+                stopRecording(oneShotResult)
             }
 
             "pausePreview" -> {
-                pausePreview(result)
+                pausePreview(oneShotResult)
             }
 
             "resumePreview" -> {
-                resumePreview(result)
+                resumePreview(oneShotResult)
             }
 
             "getCameraState" -> {
-                getCameraState(result)
+                getCameraState(oneShotResult)
             }
 
             "setRemoteRecordControlEnabled" -> {
                 val enabled = call.argument<Boolean>("enabled") ?: false
-                setRemoteRecordControlEnabled(enabled, result)
+                setRemoteRecordControlEnabled(enabled, oneShotResult)
             }
 
             "setVolumeKeysEnabled" -> {
                 val enabled = call.argument<Boolean>("enabled") ?: true
-                setVolumeKeysEnabled(enabled, result)
+                setVolumeKeysEnabled(enabled, oneShotResult)
             }
 
             else -> {
-                result.notImplemented()
+                oneShotResult.notImplemented()
             }
         }
     }
@@ -389,4 +391,30 @@ class DivineCameraPlugin :
     override fun onDetachedFromActivity() {
         activity = null
     }
+}
+
+internal class OneShotMethodResult(
+    private val delegate: Result
+) : Result {
+    private val replied = AtomicBoolean(false)
+
+    override fun success(result: Any?) {
+        if (markReplied()) {
+            delegate.success(result)
+        }
+    }
+
+    override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+        if (markReplied()) {
+            delegate.error(errorCode, errorMessage, errorDetails)
+        }
+    }
+
+    override fun notImplemented() {
+        if (markReplied()) {
+            delegate.notImplemented()
+        }
+    }
+
+    private fun markReplied(): Boolean = replied.compareAndSet(false, true)
 }

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/DivineCameraPluginTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/DivineCameraPluginTest.kt
@@ -2,8 +2,9 @@ package co.openvine.divine_camera
 
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
-import org.mockito.Mockito
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 /*
  * This demonstrates a simple unit test of the Kotlin portion of this plugin's implementation.
@@ -19,9 +20,88 @@ internal class DivineCameraPluginTest {
         val plugin = DivineCameraPlugin()
 
         val call = MethodCall("getPlatformVersion", null)
-        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
-        plugin.onMethodCall(call, mockResult)
+        val result = RecordingResult()
+        plugin.onMethodCall(call, result)
 
-        Mockito.verify(mockResult).success("Android " + android.os.Build.VERSION.RELEASE)
+        assertEquals(1, result.successCount)
+        assertEquals("Android " + android.os.Build.VERSION.RELEASE, result.lastSuccessValue)
+        assertEquals(0, result.errorCount)
+        assertEquals(0, result.notImplementedCount)
+    }
+
+    @Test
+    fun oneShotResult_initializeStyleFlow_answersFlutterOnlyOnce() {
+        val result = RecordingResult()
+        val oneShot = OneShotMethodResult(result)
+
+        oneShot.success(mapOf("textureId" to 42L))
+        oneShot.error("INIT_ERROR", "late failure", null)
+
+        assertEquals(1, result.successCount)
+        assertEquals(mapOf("textureId" to 42L), result.lastSuccessValue)
+        assertEquals(0, result.errorCount)
+        assertEquals(0, result.notImplementedCount)
+    }
+
+    @Test
+    fun oneShotResult_switchStyleFlow_answersFlutterOnlyOnce() {
+        val result = RecordingResult()
+        val oneShot = OneShotMethodResult(result)
+
+        oneShot.error("SWITCH_ERROR", "first failure", null)
+        oneShot.success(mapOf("camera" to "back"))
+
+        assertEquals(0, result.successCount)
+        assertEquals(1, result.errorCount)
+        assertEquals("SWITCH_ERROR", result.lastErrorCode)
+        assertEquals("first failure", result.lastErrorMessage)
+        assertEquals(0, result.notImplementedCount)
+    }
+
+    @Test
+    fun oneShotResult_recordStyleFlow_answersFlutterOnlyOnce() {
+        val result = RecordingResult()
+        val oneShot = OneShotMethodResult(result)
+
+        oneShot.success(null)
+        oneShot.success(mapOf("filePath" to "/tmp/video.mp4"))
+
+        assertEquals(1, result.successCount)
+        assertNull(result.lastSuccessValue)
+        assertEquals(0, result.errorCount)
+        assertEquals(0, result.notImplementedCount)
+    }
+
+    private class RecordingResult : MethodChannel.Result {
+        var successCount: Int = 0
+            private set
+        var errorCount: Int = 0
+            private set
+        var notImplementedCount: Int = 0
+            private set
+        var lastSuccessValue: Any? = null
+            private set
+        var lastErrorCode: String? = null
+            private set
+        var lastErrorMessage: String? = null
+            private set
+        var lastErrorDetails: Any? = null
+            private set
+
+        override fun success(result: Any?) {
+            successCount += 1
+            lastSuccessValue = result
+        }
+
+        override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
+            errorCount += 1
+            lastErrorCode = errorCode
+            lastErrorMessage = errorMessage
+            lastErrorDetails = errorDetails
+        }
+
+        override fun notImplemented() {
+            notImplementedCount += 1
+        }
     }
 }


### PR DESCRIPTION
Closes #2804

## Summary
- wrap every Android camera plugin method result in a one-shot guard at the plugin boundary
- ignore duplicate success or error replies instead of crashing Flutter with `Reply already submitted`
- add regression tests for duplicate initialize, switch, and record-style reply flows

## Test Plan
- [x] flutter pub get
- [x] JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" /Users/rabble/code/divine/divine-mobile/mobile/android/gradlew -p /Users/rabble/code/divine/divine-mobile/.worktrees/fix-android-camera-one-shot-results/mobile/android :app:testDebugUnitTest
