### PR TITLE
fix(android): align media3 runtime for video editor

### DIFF
--- a/mobile/android/build.gradle.kts
+++ b/mobile/android/build.gradle.kts
@@ -24,6 +24,16 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
+subprojects {
+    configurations.configureEach {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "androidx.media3") {
+                useVersion("1.10.0")
+            }
+        }
+    }
+}
+
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
 }


### PR DESCRIPTION
Closes #2807

## Summary
- force a single `androidx.media3` version from the shared Android root build so app and plugin subprojects resolve the same runtime artifacts
- target the Media3 mismatch behind the `ChannelMixingMatrix` `NoSuchMethodError` seen in `pro_video_editor`
- keep the change isolated to Gradle dependency resolution

## Test Plan
- [x] flutter pub get
- [x] JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" /Users/rabble/code/divine/divine-mobile/mobile/android/gradlew -p /Users/rabble/code/divine/divine-mobile/.worktrees/fix-android-media3-channelmixing-compat/mobile/android :app:assembleDebug
