### PR TITLE
fix(nostr): guard against empty pubkey in event-sending methods

### DIFF
--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -53,6 +53,22 @@ class Nostr {
     _cachedPublicKey = key ?? '';
   }
 
+  /// Returns the cached public key, refreshing from the signer if empty.
+  ///
+  /// Throws [StateError] if the signer has no public key available
+  /// (e.g. not yet configured or session expired).
+  Future<String> _ensurePublicKey() async {
+    if (_cachedPublicKey.isEmpty) {
+      await refreshPublicKey();
+    }
+    if (_cachedPublicKey.isEmpty) {
+      throw StateError(
+        'No public key available — signer may not be configured',
+      );
+    }
+    return _cachedPublicKey;
+  }
+
   RelayPool get relayPool => _pool;
 
   Future<Event?> sendLike(
@@ -80,7 +96,8 @@ class Nostr {
       tags.add(["k", targetKind.toString()]);
     }
 
-    Event event = Event(_cachedPublicKey, EventKind.reaction, tags, content);
+    final pk = await _ensurePublicKey();
+    Event event = Event(pk, EventKind.reaction, tags, content);
     return await sendEvent(
       event,
       tempRelays: tempRelays,
@@ -93,7 +110,8 @@ class Nostr {
     List<String>? tempRelays,
     List<String>? targetRelays,
   }) async {
-    Event event = Event(_cachedPublicKey, EventKind.eventDeletion, [
+    final pk = await _ensurePublicKey();
+    Event event = Event(pk, EventKind.eventDeletion, [
       ["e", eventId],
     ], "delete");
     return await sendEvent(
@@ -113,12 +131,8 @@ class Nostr {
       tags.add(["e", eventId]);
     }
 
-    Event event = Event(
-      _cachedPublicKey,
-      EventKind.eventDeletion,
-      tags,
-      "delete",
-    );
+    final pk = await _ensurePublicKey();
+    Event event = Event(pk, EventKind.eventDeletion, tags, "delete");
     return await sendEvent(
       event,
       tempRelays: tempRelays,
@@ -137,7 +151,8 @@ class Nostr {
     if (StringUtil.isNotBlank(relayAddr)) {
       tag.add(relayAddr!);
     }
-    Event event = Event(_cachedPublicKey, EventKind.repost, [tag], content);
+    final pk = await _ensurePublicKey();
+    Event event = Event(pk, EventKind.repost, [tag], content);
     return await sendEvent(
       event,
       tempRelays: tempRelays,
@@ -152,7 +167,8 @@ class Nostr {
     List<String>? targetRelays,
   }) async {
     final tags = contacts.toJson();
-    final event = Event(_cachedPublicKey, EventKind.contactList, tags, content);
+    final pk = await _ensurePublicKey();
+    final event = Event(pk, EventKind.contactList, tags, content);
     return await sendEvent(
       event,
       tempRelays: tempRelays,

--- a/mobile/packages/nostr_sdk/test/unit/nostr_ensure_public_key_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_ensure_public_key_test.dart
@@ -1,0 +1,172 @@
+// ABOUTME: Tests for Nostr._ensurePublicKey() lazy-refresh guard.
+// ABOUTME: Verifies that event-sending methods refresh the cached public key
+// ABOUTME: when it is empty, and throw StateError when the signer has no key.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+/// A signer that returns null for getPublicKey (simulates unconfigured signer).
+class _NullKeySigner implements NostrSigner {
+  @override
+  Future<String?> getPublicKey() async => null;
+
+  @override
+  Future<Event?> signEvent(Event event) async => null;
+
+  @override
+  Future<Map?> getRelays() async => null;
+
+  @override
+  Future<String?> encrypt(String pubkey, String plaintext) async => null;
+
+  @override
+  Future<String?> decrypt(String pubkey, String ciphertext) async => null;
+
+  @override
+  Future<String?> nip44Encrypt(String pubkey, String plaintext) async => null;
+
+  @override
+  Future<String?> nip44Decrypt(String pubkey, String ciphertext) async => null;
+
+  @override
+  void close() {}
+}
+
+void main() {
+  group('Nostr _ensurePublicKey guard', () {
+    const testPrivateKey =
+        '5ee1c8000ab28edd64d74a7d951ac2dd559814887b1b9e1ac7c5f89e96125c12';
+    const testEventId =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    Relay dummyRelay(String url) => RelayBase(url, RelayStatus(url));
+
+    group('sendLike', () {
+      test('succeeds when publicKey is already cached', () async {
+        final signer = LocalNostrSigner(testPrivateKey);
+        final nostr = Nostr(signer, [], dummyRelay);
+        await nostr.refreshPublicKey();
+
+        // sendLike creates the Event without error (no relays → returns null)
+        final result = await nostr.sendLike(testEventId);
+        // null because no relays are connected, but no ArgumentError thrown
+        expect(result, isNull);
+      });
+
+      test('lazily refreshes publicKey when cache is empty', () async {
+        final signer = LocalNostrSigner(testPrivateKey);
+        final nostr = Nostr(signer, [], dummyRelay);
+        // Do NOT call refreshPublicKey — cache is empty ''
+
+        expect(nostr.publicKey, isEmpty);
+
+        // sendLike should lazy-refresh and NOT throw ArgumentError
+        final result = await nostr.sendLike(testEventId);
+        expect(result, isNull); // null because no relays
+        expect(nostr.publicKey, isNotEmpty);
+      });
+
+      test('throws StateError when signer returns null', () async {
+        final signer = _NullKeySigner();
+        final nostr = Nostr(signer, [], dummyRelay);
+
+        await expectLater(
+          nostr.sendLike(testEventId),
+          throwsA(isA<StateError>()),
+        );
+      });
+    });
+
+    group('deleteEvent', () {
+      test('lazily refreshes publicKey when cache is empty', () async {
+        final signer = LocalNostrSigner(testPrivateKey);
+        final nostr = Nostr(signer, [], dummyRelay);
+
+        expect(nostr.publicKey, isEmpty);
+
+        final result = await nostr.deleteEvent(testEventId);
+        expect(result, isNull);
+        expect(nostr.publicKey, isNotEmpty);
+      });
+
+      test('throws StateError when signer returns null', () async {
+        final signer = _NullKeySigner();
+        final nostr = Nostr(signer, [], dummyRelay);
+
+        await expectLater(
+          nostr.deleteEvent(testEventId),
+          throwsA(isA<StateError>()),
+        );
+      });
+    });
+
+    group('deleteEvents', () {
+      test('lazily refreshes publicKey when cache is empty', () async {
+        final signer = LocalNostrSigner(testPrivateKey);
+        final nostr = Nostr(signer, [], dummyRelay);
+
+        expect(nostr.publicKey, isEmpty);
+
+        final result = await nostr.deleteEvents([testEventId]);
+        expect(result, isNull);
+        expect(nostr.publicKey, isNotEmpty);
+      });
+
+      test('throws StateError when signer returns null', () async {
+        final signer = _NullKeySigner();
+        final nostr = Nostr(signer, [], dummyRelay);
+
+        await expectLater(
+          nostr.deleteEvents([testEventId]),
+          throwsA(isA<StateError>()),
+        );
+      });
+    });
+
+    group('sendRepost', () {
+      test('lazily refreshes publicKey when cache is empty', () async {
+        final signer = LocalNostrSigner(testPrivateKey);
+        final nostr = Nostr(signer, [], dummyRelay);
+
+        expect(nostr.publicKey, isEmpty);
+
+        final result = await nostr.sendRepost(testEventId);
+        expect(result, isNull);
+        expect(nostr.publicKey, isNotEmpty);
+      });
+
+      test('throws StateError when signer returns null', () async {
+        final signer = _NullKeySigner();
+        final nostr = Nostr(signer, [], dummyRelay);
+
+        await expectLater(
+          nostr.sendRepost(testEventId),
+          throwsA(isA<StateError>()),
+        );
+      });
+    });
+
+    group('sendContactList', () {
+      test('lazily refreshes publicKey when cache is empty', () async {
+        final signer = LocalNostrSigner(testPrivateKey);
+        final nostr = Nostr(signer, [], dummyRelay);
+
+        expect(nostr.publicKey, isEmpty);
+
+        final result = await nostr.sendContactList(ContactList(), '');
+        expect(result, isNull);
+        expect(nostr.publicKey, isNotEmpty);
+      });
+
+      test('throws StateError when signer returns null', () async {
+        final signer = _NullKeySigner();
+        final nostr = Nostr(signer, [], dummyRelay);
+
+        await expectLater(
+          nostr.sendContactList(ContactList(), ''),
+          throwsA(isA<StateError>()),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes #2777

- `Nostr._cachedPublicKey` starts as `""` and is only populated asynchronously via `NostrClient.initialize()` → `refreshPublicKey()`. If a user taps like (or any event-creating action) before initialization completes, `Event("", ...)` throws `ArgumentError("Invalid key")`.
- Added `_ensurePublicKey()` — a lazy guard that refreshes the key from the signer on first use if the cache is empty. Applied to all five event-creation call sites: `sendLike`, `deleteEvent`, `deleteEvents`, `sendRepost`, `sendContactList`.
- Throws `StateError` with a clear message when the signer genuinely has no key (instead of the cryptic `ArgumentError`).

## Root Cause

`NostrClient.initialize()` runs asynchronously via `Future.microtask()` after the provider builds. `VideoInteractionsBloc` is created synchronously in `initState()` with no readiness gate. A user can tap "like" before `refreshPublicKey()` has populated `_cachedPublicKey`, causing all `Event(_cachedPublicKey, ...)` calls to fail with an empty-string pubkey.

## Test plan

- [x] 11 new unit tests in `nostr_ensure_public_key_test.dart` covering lazy refresh and null-signer paths for all five methods
- [x] Existing `video_interactions_bloc_test.dart` (39 tests) passes with no regressions
- [x] Existing `nostr_sdk` unit tests pass
- [x] `flutter analyze` clean
- [ ] Manual: cold-start the app and rapidly tap like on the first visible video