### PR TITLE
fix(dm): prevent phantom self-conversation from NIP-17 self-wraps

### DIFF
--- a/mobile/lib/repositories/dm_repository.dart
+++ b/mobile/lib/repositories/dm_repository.dart
@@ -160,6 +160,9 @@ class DmRepository {
 
     // Merge duplicate conversations created by extra p-tags (idempotent).
     unawaited(_mergeDuplicateConversations());
+
+    // Remove phantom self-conversations created by the self-wrap bug.
+    unawaited(_cleanupSelfConversations());
   }
 
   /// Reset internal state so the repository can be re-initialized for a
@@ -441,6 +444,12 @@ class DmRepository {
         rawParticipants,
         rumorEvent.pubkey,
       );
+
+      // Reject self-conversations (all participants are the same pubkey).
+      // Defense-in-depth: should not happen after the self-wrap fix above,
+      // but guards against any future code path producing degenerate lists.
+      if (participants.toSet().length < 2) return;
+
       final conversationId = computeConversationId(participants);
 
       // Extract common tags
@@ -1527,6 +1536,44 @@ class DmRepository {
     }
   }
 
+  /// Removes phantom self-conversations created by the self-wrap bug where
+  /// `_resolveConversationParticipants` produced `[self, self]`.
+  ///
+  /// Idempotent — safe to call on every init.
+  Future<void> _cleanupSelfConversations() async {
+    try {
+      final selfConvId = computeConversationId([_userPubkey, _userPubkey]);
+      final existing = await _conversationsDao.getConversation(
+        selfConvId,
+        ownerPubkey: _ownerPubkey,
+      );
+      if (existing == null) return;
+
+      await _conversationsDao.runInTransaction(() async {
+        await _directMessagesDao.deleteConversationMessages(
+          selfConvId,
+          ownerPubkey: _ownerPubkey,
+        );
+        await _conversationsDao.deleteConversation(
+          selfConvId,
+          ownerPubkey: _ownerPubkey,
+        );
+      });
+
+      Log.info(
+        'Cleaned up phantom self-conversation',
+        category: LogCategory.system,
+      );
+    } catch (e, stackTrace) {
+      Log.error(
+        'Failed to clean up self-conversation: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
   /// Compute a deterministic conversation ID from sorted participant pubkeys.
   static String computeConversationId(List<String> participants) {
     final sorted = List<String>.from(participants)..sort();
@@ -1576,7 +1623,13 @@ class DmRepository {
     final canonical1to1 = [_userPubkey, senderPubkey]..sort();
 
     // Standard 1:1 message — no ambiguity.
-    if (extractedParticipants.length <= 2) return canonical1to1;
+    if (extractedParticipants.length <= 2) {
+      // Self-wrap: sender is the current user, so canonical1to1 would be
+      // [self, self]. Use extracted participants which contain the actual
+      // recipient from the rumor's p-tags.
+      if (_userPubkey == senderPubkey) return extractedParticipants;
+      return canonical1to1;
+    }
 
     // Extra p-tags present. Check if a group conversation with the
     // full participant set already exists — if so, it's a genuine group.

--- a/mobile/lib/services/content_blocklist_service.dart
+++ b/mobile/lib/services/content_blocklist_service.dart
@@ -388,7 +388,9 @@ class ContentBlocklistService {
         (pk) => pk != userPubkey,
         orElse: () => '',
       );
-      return otherPubkey.isEmpty || !shouldFilterFromFeeds(otherPubkey);
+      // Exclude self-conversations (no "other" participant found).
+      if (otherPubkey.isEmpty) return false;
+      return !shouldFilterFromFeeds(otherPubkey);
     }).toList();
   }
 

--- a/mobile/test/repositories/dm_repository_test.dart
+++ b/mobile/test/repositories/dm_repository_test.dart
@@ -4492,6 +4492,171 @@ void main() {
         },
       );
 
+      test(
+        'self-wrap routes to correct conversation, not self-conversation',
+        () async {
+          // Self-wrap: rumor authored by current user (A) with p-tag to B.
+          // This simulates processing our own sent-message recovery wrap.
+          final giftWrap = createGiftWrapEvent();
+          final rumor = createRumorEvent(
+            pubkey: _validPubkeyA, // Sender == current user
+            tags: [
+              ['p', _validPubkeyB], // Actual recipient
+            ],
+            content: 'Hello from me!',
+          );
+
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(any()),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockDirectMessagesDao.hasMatchingMessage(
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => false);
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: any(named: 'isGroup'),
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: any(named: 'lastMessageContent'),
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+              subject: any(named: 'subject'),
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockConversationsDao.getConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final repository = createRepository(
+            rumorDecryptor: (_, _) async => rumor,
+          );
+
+          repository.startListening();
+          controller.add(giftWrap);
+          await Future<void>.delayed(Duration.zero);
+
+          // Should use canonical 1:1 conversation ID (A <-> B),
+          // NOT a self-conversation [A, A].
+          final canonical1to1 = [_validPubkeyA, _validPubkeyB]..sort();
+          final canonicalId = DmRepository.computeConversationId(canonical1to1);
+
+          // Verify message stored in correct conversation.
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: canonicalId,
+              senderPubkey: _validPubkeyA,
+              content: 'Hello from me!',
+              createdAt: 1700000000,
+              giftWrapId: _giftWrapEventId,
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).called(1);
+
+          // Conversation should be upserted as 1:1 with correct participants.
+          verify(
+            () => mockConversationsDao.upsertConversation(
+              id: canonicalId,
+              participantPubkeys: jsonEncode(canonical1to1),
+              isGroup: false,
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: 'Hello from me!',
+              lastMessageTimestamp: 1700000000,
+              lastMessageSenderPubkey: _validPubkeyA,
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: true,
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).called(1);
+
+          // Self-conversation ID should NOT have been used.
+          final selfConvId = DmRepository.computeConversationId(
+            [_validPubkeyA, _validPubkeyA],
+          );
+          verifyNever(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: selfConvId,
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          );
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+
       test('normal 1:1 message (single p-tag) is not affected', () async {
         // Standard 1:1 message — single p-tag, no extra participants.
         final giftWrap = createGiftWrapEvent();

--- a/mobile/test/services/content_blocklist_service_test.dart
+++ b/mobile/test/services/content_blocklist_service_test.dart
@@ -154,6 +154,34 @@ void main() {
       expect(filtered, hasLength(2));
     });
 
+    test('filterBlockedConversations excludes self-conversations', () {
+      const userPubkey = 'current_user';
+
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final conversations = [
+        DmConversation(
+          id: 'self_conv',
+          participantPubkeys: const [userPubkey, userPubkey],
+          isGroup: false,
+          createdAt: now,
+        ),
+        DmConversation(
+          id: 'normal_conv',
+          participantPubkeys: const [userPubkey, 'other_user'],
+          isGroup: false,
+          createdAt: now,
+        ),
+      ];
+
+      final filtered = service.filterBlockedConversations(
+        conversations,
+        userPubkey: userPubkey,
+      );
+
+      expect(filtered, hasLength(1));
+      expect(filtered.first.id, equals('normal_conv'));
+    });
+
     test('should provide blocking stats', () {
       final stats = service.blockingStats;
 


### PR DESCRIPTION
Closes #2826

## Summary

- Fix `_resolveConversationParticipants` producing `[self, self]` when processing NIP-17 self-wraps (sent-message recovery), which created a phantom "conversation with yourself" in the DM inbox
- Add defense-in-depth guard rejecting degenerate participant lists where all pubkeys are identical
- Fix `filterBlockedConversations` accidentally passing self-conversations through (empty `otherPubkey` short-circuited the filter)
- Add one-time DB cleanup to remove existing phantom self-conversations on init

## Root Cause

When a user sends a DM, a "self-wrap" gift wrap is published for sent-message recovery (per NIP-17). When the client processes this self-wrap, `_resolveConversationParticipants` computes `canonical1to1 = [_userPubkey, senderPubkey]`. Since both are the same pubkey for self-wraps, this produces `[self, self]` instead of `[self, recipient]`.

Confirmed via production logs: conversation ID `86ecd34d...` == `sha256(userPubkey:userPubkey)`.

## Files Changed

| File | Change |
|------|--------|
| `mobile/lib/repositories/dm_repository.dart` | Self-wrap participant resolution fix + degenerate guard + DB cleanup |
| `mobile/lib/services/content_blocklist_service.dart` | Exclude self-conversations from blocklist filter |
| `mobile/test/repositories/dm_repository_test.dart` | Self-wrap routing test |
| `mobile/test/services/content_blocklist_service_test.dart` | Self-conversation exclusion test |

## Test plan

- [x] Existing 83 DM repository tests pass
- [x] Existing 28 blocklist service tests pass
- [x] New test: self-wrap routes to correct `[A, B]` conversation, not `[A, A]`
- [x] New test: `filterBlockedConversations` excludes self-conversations
- [x] `flutter analyze` clean
- [ ] Manual: send DMs between two test accounts, confirm no self-conversation appears
- [ ] Manual: verify existing self-conversations are cleaned up on app restart