### PR TITLE
fix(notifications): comment notification navigates to non-video event (#2218)

### DIFF
--- a/mobile/lib/services/notification_target_resolver.dart
+++ b/mobile/lib/services/notification_target_resolver.dart
@@ -25,12 +25,18 @@ class NotificationTargetResolver {
       return null;
     }
 
-    if (event.kind == NIP71VideoKinds.shortVideo ||
-        event.kind == NIP71VideoKinds.addressableNormalVideo ||
-        event.kind == NIP71VideoKinds.addressableShortVideo) {
+    if (NIP71VideoKinds.isAcceptableVideoKind(event.kind)) {
       return targetId;
     }
 
+    // NIP-22: uppercase E tag = root scope, always points to root video
+    for (final tag in event.tags) {
+      if (tag.length >= 2 && tag[0] == 'E' && tag[1].isNotEmpty) {
+        return tag[1];
+      }
+    }
+
+    // Fallback: lowercase e tags (NIP-10 style / older events)
     String? replyId;
     String? firstEtagId;
 

--- a/mobile/test/screens/notifications_navigation_test.dart
+++ b/mobile/test/screens/notifications_navigation_test.dart
@@ -72,8 +72,14 @@ void main() {
     'd' * 64,
     1111,
     [
-      ['e', rootVideoId, '', 'root'],
-      ['e', 'parent_comment', '', 'reply'],
+      // NIP-22: uppercase = root scope (video)
+      ['E', rootVideoId, '', 'video_author_pubkey'],
+      ['K', '34236'],
+      ['P', 'video_author_pubkey'],
+      // NIP-22: lowercase = parent item (comment being replied to)
+      ['e', 'parent_comment', '', 'parent_author_pubkey'],
+      ['k', '1111'],
+      ['p', 'parent_author_pubkey'],
     ],
     'comment body',
   );

--- a/mobile/test/services/notification_target_resolver_test.dart
+++ b/mobile/test/services/notification_target_resolver_test.dart
@@ -37,32 +37,157 @@ void main() {
       expect(resolved, equals('video_1'));
     });
 
-    test('resolves root video id from comment event e-tags', () async {
-      when(() => videoEventService.getVideoById('comment_1')).thenReturn(null);
-      when(() => nostrClient.fetchEventById('comment_1')).thenAnswer(
-        (_) async => Event(
-          'b' * 64,
-          1111,
-          const [
-            ['e', 'root_video_1', '', 'root'],
-            ['e', 'parent_comment_1', '', 'reply'],
-          ],
-          'comment',
-        ),
-      );
+    test('recognizes kind 21 (normalVideo) as a direct video', () async {
+      when(() => videoEventService.getVideoById('video_21')).thenReturn(null);
+      when(
+        () => nostrClient.fetchEventById('video_21'),
+      ).thenAnswer((_) async => Event('a' * 64, 21, const [], 'video'));
 
       final resolved = await resolver.resolveVideoEventIdFromNotificationTarget(
-        'comment_1',
+        'video_21',
       );
 
-      expect(resolved, equals('root_video_1'));
+      expect(resolved, equals('video_21'));
     });
 
+    test(
+      'resolves root video from NIP-22 uppercase E tag on nested reply',
+      () async {
+        const rootVideoId = 'root_video_nip22';
+        const parentCommentId = 'parent_comment_nip22';
+        const parentAuthorPubkey = 'parent_author_pubkey_hex';
+        const videoAuthorPubkey = 'video_author_pubkey_hex';
+
+        when(
+          () => videoEventService.getVideoById('comment_nested'),
+        ).thenReturn(null);
+        when(() => nostrClient.fetchEventById('comment_nested')).thenAnswer(
+          (_) async => Event(
+            'b' * 64,
+            1111,
+            const [
+              // NIP-22: uppercase = root scope (video)
+              ['E', rootVideoId, '', videoAuthorPubkey],
+              ['K', '34236'],
+              ['P', videoAuthorPubkey],
+              // NIP-22: lowercase = parent item (comment being replied to)
+              ['e', parentCommentId, '', parentAuthorPubkey],
+              ['k', '1111'],
+              ['p', parentAuthorPubkey],
+            ],
+            'reply to comment',
+          ),
+        );
+
+        final resolved = await resolver
+            .resolveVideoEventIdFromNotificationTarget(
+              'comment_nested',
+            );
+
+        expect(resolved, equals(rootVideoId));
+      },
+    );
+
+    test(
+      'resolves root video from NIP-22 uppercase E tag on top-level comment',
+      () async {
+        const rootVideoId = 'root_video_toplevel';
+        const videoAuthorPubkey = 'video_author_pubkey_hex';
+
+        when(
+          () => videoEventService.getVideoById('comment_top'),
+        ).thenReturn(null);
+        when(() => nostrClient.fetchEventById('comment_top')).thenAnswer(
+          (_) async => Event(
+            'c' * 64,
+            1111,
+            const [
+              // NIP-22: uppercase = root scope (video)
+              ['E', rootVideoId, '', videoAuthorPubkey],
+              ['K', '34236'],
+              ['P', videoAuthorPubkey],
+              // NIP-22: lowercase = parent (same as root for top-level)
+              ['e', rootVideoId, '', videoAuthorPubkey],
+              ['k', '34236'],
+              ['p', videoAuthorPubkey],
+            ],
+            'top-level comment',
+          ),
+        );
+
+        final resolved = await resolver
+            .resolveVideoEventIdFromNotificationTarget(
+              'comment_top',
+            );
+
+        expect(resolved, equals(rootVideoId));
+      },
+    );
+
+    test(
+      'resolves from only uppercase E tag when no lowercase e tags exist',
+      () async {
+        const rootVideoId = 'root_video_only_E';
+
+        when(
+          () => videoEventService.getVideoById('comment_minimal'),
+        ).thenReturn(null);
+        when(() => nostrClient.fetchEventById('comment_minimal')).thenAnswer(
+          (_) async => Event(
+            'd' * 64,
+            1111,
+            const [
+              ['E', rootVideoId, '', 'author_pub'],
+              ['K', '34236'],
+              ['P', 'author_pub'],
+            ],
+            'minimal comment',
+          ),
+        );
+
+        final resolved = await resolver
+            .resolveVideoEventIdFromNotificationTarget(
+              'comment_minimal',
+            );
+
+        expect(resolved, equals(rootVideoId));
+      },
+    );
+
+    test(
+      'falls back to NIP-10 e-tag root marker when no uppercase E tag exists',
+      () async {
+        when(
+          () => videoEventService.getVideoById('comment_1'),
+        ).thenReturn(null);
+        when(() => nostrClient.fetchEventById('comment_1')).thenAnswer(
+          (_) async => Event(
+            'e' * 64,
+            1111,
+            const [
+              ['e', 'root_video_1', '', 'root'],
+              ['e', 'parent_comment_1', '', 'reply'],
+            ],
+            'comment',
+          ),
+        );
+
+        final resolved = await resolver
+            .resolveVideoEventIdFromNotificationTarget(
+              'comment_1',
+            );
+
+        expect(resolved, equals('root_video_1'));
+      },
+    );
+
     test('returns null when no resolvable video tags exist', () async {
-      when(() => videoEventService.getVideoById('comment_2')).thenReturn(null);
+      when(
+        () => videoEventService.getVideoById('comment_2'),
+      ).thenReturn(null);
       when(() => nostrClient.fetchEventById('comment_2')).thenAnswer(
         (_) async => Event(
-          'c' * 64,
+          'f' * 64,
           1111,
           const [
             ['p', 'author_pubkey'],


### PR DESCRIPTION
## Summary

- Fix `NotificationTargetResolver` to parse NIP-22 uppercase `E` tags (root scope) before falling back to lowercase `e` tags (NIP-10 compat)
- Replace manual video kind check with `NIP71VideoKinds.isAcceptableVideoKind()` (adds missing kind 21)
- Update tests to use realistic NIP-22 tag structure matching what `CommentsRepository` actually produces

## Root cause

The resolver only scanned lowercase `e` tags with NIP-10 markers (`root`/`reply`), but the app's comments use NIP-22 conventions where the root video is in an uppercase `E` tag and position [3] contains the author pubkey. For nested reply notifications, the only lowercase `e` tag pointed to the parent comment, so the resolver returned a comment event ID — causing `VideoEvent.fromNostrEvent()` to throw on a kind 1111 event and the UI to show "Video not found".

## Test plan

- [x] 7 unit tests pass for `NotificationTargetResolver` (4 new NIP-22 tests, 1 NIP-10 fallback, 1 kind 21, 1 null case)
- [x] 2 navigation integration tests pass with updated NIP-22 tags
- [x] `flutter analyze` clean
- [ ] Manual: trigger reply-to-comment notification against local stack and verify video opens

Closes #2218