### PR TITLE
chore(dm): backfill currentUserHasSent on post-migration legacy rows

### DIFF
--- a/mobile/lib/repositories/dm_repository.dart
+++ b/mobile/lib/repositories/dm_repository.dart
@@ -158,11 +158,9 @@ class DmRepository {
     // backlog onto the UI isolate at app launch and scale linearly with
     // lifetime DM count. See docs/plans/2026-04-05-dm-scaling-fix-design.md.
 
-    // Merge duplicate conversations created by extra p-tags (idempotent).
-    unawaited(_mergeDuplicateConversations());
-
-    // Remove phantom self-conversations created by the self-wrap bug.
-    unawaited(_cleanupSelfConversations());
+    // Run post-auth maintenance sequentially so each step operates on the
+    // final state of the previous one (e.g. backfill runs after merge).
+    unawaited(_runPostAuthMaintenance());
   }
 
   /// Reset internal state so the repository can be re-initialized for a
@@ -1567,6 +1565,44 @@ class DmRepository {
     } catch (e, stackTrace) {
       Log.error(
         'Failed to clean up self-conversation: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  /// Runs post-auth cleanup and migration tasks sequentially so each step
+  /// operates on the final state of the previous one (e.g. backfill runs
+  /// after merge creates canonical conversation rows).
+  Future<void> _runPostAuthMaintenance() async {
+    await _mergeDuplicateConversations();
+    await _cleanupSelfConversations();
+    await _backfillCurrentUserHasSent();
+  }
+
+  /// Backfills `currentUserHasSent` for conversations where the column
+  /// was added with DEFAULT 0 but the user has actually sent messages.
+  ///
+  /// Fixes #2834 — without this, all pre-existing conversations appear
+  /// as message requests instead of in the Messages tab.
+  ///
+  /// Idempotent — safe to call on every init. Becomes a no-op once all
+  /// conversations are correctly flagged.
+  Future<void> _backfillCurrentUserHasSent() async {
+    try {
+      final updated = await _conversationsDao.backfillCurrentUserHasSent(
+        _userPubkey,
+      );
+      if (updated > 0) {
+        Log.info(
+          'Backfilled currentUserHasSent for $updated conversations',
+          category: LogCategory.system,
+        );
+      }
+    } catch (e, stackTrace) {
+      Log.error(
+        'Failed to backfill currentUserHasSent: $e',
         category: LogCategory.system,
         error: e,
         stackTrace: stackTrace,

--- a/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
@@ -295,6 +295,32 @@ class ConversationsDao extends DatabaseAccessor<AppDatabase>
     return delete(conversations).go();
   }
 
+  /// Backfill `current_user_has_sent` for conversations where the user
+  /// has sent messages but the flag is still `false`.
+  ///
+  /// Fixes a migration gap where the column was added with DEFAULT 0
+  /// without retroactively checking existing messages. Idempotent: only
+  /// flips `false` to `true`, never `true` to `false`.
+  ///
+  /// Returns the number of conversations updated.
+  Future<int> backfillCurrentUserHasSent(String userPubkey) {
+    return customUpdate(
+      'UPDATE conversations SET current_user_has_sent = 1 '
+      'WHERE current_user_has_sent = 0 '
+      'AND (owner_pubkey = ? OR owner_pubkey IS NULL) '
+      'AND id IN (SELECT DISTINCT conversation_id '
+      'FROM direct_messages WHERE sender_pubkey = ? '
+      'AND (owner_pubkey = ? OR owner_pubkey IS NULL))',
+      variables: [
+        Variable(userPubkey),
+        Variable(userPubkey),
+        Variable(userPubkey),
+      ],
+      updates: {attachedDatabase.conversations},
+      updateKind: UpdateKind.update,
+    );
+  }
+
   /// Returns the newest `last_message_timestamp` across all conversations
   /// for the given owner, or `null` if no conversations exist.
   Future<int?> getNewestMessageTimestamp({String? ownerPubkey}) async {

--- a/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
@@ -558,5 +558,125 @@ void main() {
         expect(countB, equals(1));
       });
     });
+
+    group('backfillCurrentUserHasSent', () {
+      const userA = 'pubkey_a';
+      const userB = 'pubkey_b';
+
+      test('sets flag for conversations where user sent messages', () async {
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["$userA","$userB"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          ownerPubkey: userA,
+        );
+        await database.directMessagesDao.insertMessage(
+          id: 'msg_1',
+          conversationId: 'conv_1',
+          senderPubkey: userA,
+          content: 'hello',
+          createdAt: 1700000001,
+          giftWrapId: 'gw_1',
+          ownerPubkey: userA,
+        );
+
+        final updated = await dao.backfillCurrentUserHasSent(userA);
+
+        expect(updated, equals(1));
+        final conv = await dao.getConversation('conv_1', ownerPubkey: userA);
+        expect(conv!.currentUserHasSent, isTrue);
+      });
+
+      test('does not flip true back to false', () async {
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["$userA","$userB"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          currentUserHasSent: true,
+          ownerPubkey: userA,
+        );
+
+        final updated = await dao.backfillCurrentUserHasSent(userA);
+
+        expect(updated, equals(0));
+        final conv = await dao.getConversation('conv_1', ownerPubkey: userA);
+        expect(conv!.currentUserHasSent, isTrue);
+      });
+
+      test('skips conversations with no sent messages from user', () async {
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["$userA","$userB"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          ownerPubkey: userA,
+        );
+        // Only a received message (sender is userB, not userA).
+        await database.directMessagesDao.insertMessage(
+          id: 'msg_1',
+          conversationId: 'conv_1',
+          senderPubkey: userB,
+          content: 'hey',
+          createdAt: 1700000001,
+          giftWrapId: 'gw_1',
+          ownerPubkey: userA,
+        );
+
+        final updated = await dao.backfillCurrentUserHasSent(userA);
+
+        expect(updated, equals(0));
+        final conv = await dao.getConversation('conv_1', ownerPubkey: userA);
+        expect(conv!.currentUserHasSent, isFalse);
+      });
+
+      test('idempotent — second run is a no-op', () async {
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["$userA","$userB"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          ownerPubkey: userA,
+        );
+        await database.directMessagesDao.insertMessage(
+          id: 'msg_1',
+          conversationId: 'conv_1',
+          senderPubkey: userA,
+          content: 'hello',
+          createdAt: 1700000001,
+          giftWrapId: 'gw_1',
+          ownerPubkey: userA,
+        );
+
+        await dao.backfillCurrentUserHasSent(userA);
+        final secondRun = await dao.backfillCurrentUserHasSent(userA);
+
+        expect(secondRun, equals(0));
+      });
+
+      test('handles legacy rows with null owner_pubkey', () async {
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["$userA","$userB"]',
+          isGroup: false,
+          createdAt: 1700000000,
+        );
+        await database.directMessagesDao.insertMessage(
+          id: 'msg_1',
+          conversationId: 'conv_1',
+          senderPubkey: userA,
+          content: 'hello',
+          createdAt: 1700000001,
+          giftWrapId: 'gw_1',
+        );
+
+        final updated = await dao.backfillCurrentUserHasSent(userA);
+
+        expect(updated, equals(1));
+        final conv = await dao.getConversation('conv_1');
+        expect(conv!.currentUserHasSent, isTrue);
+      });
+    });
   });
 }

--- a/mobile/test/repositories/dm_repository_test.dart
+++ b/mobile/test/repositories/dm_repository_test.dart
@@ -114,6 +114,11 @@ void main() {
         ),
       ).thenAnswer((_) async => []);
 
+      // Stub backfillCurrentUserHasSent for _backfillCurrentUserHasSent().
+      when(
+        () => mockConversationsDao.backfillCurrentUserHasSent(any()),
+      ).thenAnswer((_) async => 0);
+
       // Global stub for runInTransaction — executes the callback directly.
       // Stub both <void> and <Null> since Dart infers different type args
       // depending on whether the callback returns or is void-typed.
@@ -1416,6 +1421,29 @@ void main() {
         );
         // But the repository should still be initialized so send() works.
         expect(repository.isInitialized, isTrue);
+      });
+
+      test('setCredentials triggers backfillCurrentUserHasSent', () async {
+        final repository = DmRepository(
+          nostrClient: mockNostrClient,
+          directMessagesDao: mockDirectMessagesDao,
+          conversationsDao: mockConversationsDao,
+        );
+
+        repository.setCredentials(
+          userPubkey: _validPubkeyA,
+          signer: LocalNostrSigner(_validPrivateKey),
+          messageService: mockMessageService,
+        );
+
+        // Let the unawaited _runPostAuthMaintenance() settle.
+        await Future<void>.delayed(Duration.zero);
+
+        verify(
+          () => mockConversationsDao.backfillCurrentUserHasSent(
+            _validPubkeyA,
+          ),
+        ).called(1);
       });
 
       test('startListening does not poll the relay', () async {


### PR DESCRIPTION
## Summary

Backfills `current_user_has_sent = 1` for conversation rows where the user
has sent messages but the flag is still `false` due to the schema migration
at `mobile/packages/db_client/lib/src/database/app_database.dart` adding the
column with `DEFAULT 0` without retroactive population.

Runs via a new `_runPostAuthMaintenance` step in `DmRepository.setCredentials`,
sequentially after existing `_mergeDuplicateConversations` and
`_cleanupSelfConversations` cleanup steps, so it operates on the merged
canonical conversation set.

## Why not the fix for #2834

Initial hypothesis was that #2834 (previous DMs missing after TestFlight
update) was caused by this misclassification — users seeing an empty Messages
tab because all legacy conversations were classified as Requests.

@hm21 verified on Discord with the affected user that the DMs are NOT visible
in the Requests tab either, so the actual symptom isn't explained by
misclassification. #2834 is being investigated separately.

## Tests

- `ConversationsDao.backfillCurrentUserHasSent` — unit tests cover the
  happy path, idempotency, null-owner legacy rows, and no-flip on
  already-true rows.
- `DmRepository` — verifies backfill is invoked via `setCredentials`.

Closes #2875
