### PR TITLE
fix(notifications): share signed inbox request uri

### DIFF
--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -1801,13 +1801,16 @@ class FunnelcakeApiClient {
     required String pubkey,
     int limit = 50,
     String? cursor,
+    Uri? requestUri,
     Map<String, String>? authHeaders,
   }) async {
-    final url = notificationsUri(
-      pubkey: pubkey,
-      limit: limit,
-      cursor: cursor,
-    );
+    final url =
+        requestUri ??
+        notificationsUri(
+          pubkey: pubkey,
+          limit: limit,
+          cursor: cursor,
+        );
 
     try {
       final response = await _httpClient

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart
@@ -140,6 +140,42 @@ void main() {
         expect(headers['Authorization'], equals('Nostr abc123'));
       });
 
+      test('uses the provided requestUri without rebuilding it', () async {
+        when(
+          () => mockHttpClient.get(
+            any(),
+            headers: any(named: 'headers'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            jsonEncode({
+              'notifications': <Map<String, dynamic>>[],
+              'unread_count': 0,
+              'has_more': false,
+            }),
+            200,
+          ),
+        );
+
+        final requestUri = Uri.parse(
+          '$baseUrl/api/users/$testPubkey/notifications'
+          '?limit=50&before=custom_cursor_123',
+        );
+
+        await client.getNotifications(
+          pubkey: testPubkey,
+          requestUri: requestUri,
+        );
+
+        final captured = verify(
+          () => mockHttpClient.get(
+            captureAny(),
+            headers: any(named: 'headers'),
+          ),
+        ).captured;
+        expect(captured.first, same(requestUri));
+      });
+
       test('returns empty response on 404', () async {
         when(
           () => mockHttpClient.get(

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -82,6 +82,7 @@ class NotificationRepository {
       final response = await _funnelcakeApiClient.getNotifications(
         pubkey: _userPubkey,
         cursor: effectiveCursor,
+        requestUri: Uri.parse(requestUrl),
         authHeaders: authHeaders,
       );
 

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -108,6 +108,7 @@ void main() {
       () => funnelcakeApiClient.getNotifications(
         pubkey: any(named: 'pubkey'),
         cursor: any(named: 'cursor'),
+        requestUri: any(named: 'requestUri'),
         authHeaders: any(named: 'authHeaders'),
         limit: any(named: 'limit'),
       ),
@@ -249,6 +250,7 @@ void main() {
           () => funnelcakeApiClient.getNotifications(
             pubkey: any(named: 'pubkey'),
             cursor: any(named: 'cursor'),
+            requestUri: any(named: 'requestUri'),
             authHeaders: any(named: 'authHeaders'),
             limit: any(named: 'limit'),
           ),
@@ -277,11 +279,85 @@ void main() {
           () => funnelcakeApiClient.getNotifications(
             pubkey: userPubkey,
             cursor: 'cursor_abc',
+            requestUri: any(named: 'requestUri'),
             authHeaders: any(named: 'authHeaders'),
             limit: any(named: 'limit'),
           ),
         ).called(1);
       });
+
+      test(
+        'passes the same first-page URI to signing and request execution',
+        () async {
+        var signedUrl = '';
+        Uri? requestedUri;
+        repository = NotificationRepository(
+          funnelcakeApiClient: funnelcakeApiClient,
+          profileRepository: profileRepository,
+          notificationsDao: notificationsDao,
+          userPubkey: userPubkey,
+          nostrClient: nostrClient,
+          authHeadersProvider: (url, method) async {
+            signedUrl = url;
+            return {'Authorization': 'Nostr test-token'};
+          },
+        );
+        stubNotifications([]);
+        stubProfiles({});
+
+        await repository.getNotifications();
+
+        requestedUri = verify(
+          () => funnelcakeApiClient.getNotifications(
+            pubkey: userPubkey,
+            cursor: any(named: 'cursor'),
+            requestUri: captureAny(named: 'requestUri'),
+            authHeaders: any(named: 'authHeaders'),
+            limit: any(named: 'limit'),
+          ),
+        ).captured.single as Uri;
+
+        expect(requestedUri.toString(), equals(signedUrl));
+        },
+      );
+
+      test(
+        'passes the same paginated URI to signing and request execution',
+        () async {
+        var signedUrl = '';
+        Uri? requestedUri;
+        repository = NotificationRepository(
+          funnelcakeApiClient: funnelcakeApiClient,
+          profileRepository: profileRepository,
+          notificationsDao: notificationsDao,
+          userPubkey: userPubkey,
+          nostrClient: nostrClient,
+          authHeadersProvider: (url, method) async {
+            signedUrl = url;
+            return {'Authorization': 'Nostr test-token'};
+          },
+        );
+        stubNotifications([], nextCursor: 'cursor_abc', hasMore: true);
+        stubProfiles({});
+
+        await repository.getNotifications();
+        stubNotifications([], nextCursor: 'cursor_def');
+
+        await repository.getNotifications();
+
+        requestedUri = verify(
+          () => funnelcakeApiClient.getNotifications(
+            pubkey: userPubkey,
+            cursor: 'cursor_abc',
+            requestUri: captureAny(named: 'requestUri'),
+            authHeaders: any(named: 'authHeaders'),
+            limit: any(named: 'limit'),
+          ),
+        ).captured.single as Uri;
+
+        expect(requestedUri.toString(), equals(signedUrl));
+        },
+      );
     });
 
     group('like grouping', () {
@@ -677,6 +753,8 @@ void main() {
         verify(
           () => funnelcakeApiClient.getNotifications(
             pubkey: userPubkey,
+            cursor: any(named: 'cursor'),
+            requestUri: any(named: 'requestUri'),
             authHeaders: any(named: 'authHeaders'),
             limit: any(named: 'limit'),
           ),
@@ -770,6 +848,7 @@ void main() {
           () => funnelcakeApiClient.getNotifications(
             pubkey: userPubkey,
             cursor: any(named: 'cursor'),
+            requestUri: any(named: 'requestUri'),
             authHeaders: {'Authorization': 'Nostr abc123'},
             limit: any(named: 'limit'),
           ),


### PR DESCRIPTION
## Summary
- use one shared notifications `Uri` for both NIP-98 signing and the actual Inbox request
- let `FunnelcakeApiClient.getNotifications()` accept a prebuilt request `Uri` instead of regenerating first-page `before` timestamps
- add regression coverage for first-page and paginated requests so the signed URL and requested URL stay identical

## Root cause
PR #2840 introduced shared notifications URL building, but the repository still called `notificationsUri()` to sign while `getNotifications()` called it again internally to perform the request. On first-page loads, both calls could generate different `before` timestamps, recreating the same URL-mismatch class that caused the original blank notifications bug.

## Validation
- `flutter test test/src/notification_repository_test.dart`
- `flutter test test/src/funnelcake_api_client_notification_test.dart`
- `flutter analyze packages/notification_repository/lib/src/notification_repository.dart packages/notification_repository/test/src/notification_repository_test.dart packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart packages/funnelcake_api_client/test/src/funnelcake_api_client_notification_test.dart`

Closes #2846