### PR TITLE
refactor(bug-report): consolidate log summary caps into BugReportConfig

### DIFF
--- a/mobile/lib/config/bug_report_config.dart
+++ b/mobile/lib/config/bug_report_config.dart
@@ -25,6 +25,16 @@ class BugReportConfig {
   /// Maximum bug report size in bytes (~1MB)
   static const int maxReportSizeBytes = 1024 * 1024;
 
+  /// Max characters per individual log entry in the Zendesk summary.
+  /// 500 chars is enough for error type + message context without
+  /// including full SQL statements or serialized event payloads.
+  static const int maxLogEntryLength = 500;
+
+  /// Max total characters for the log summary sent to Zendesk.
+  /// Zendesk description limit is 64K; logs share that space with
+  /// device info, steps to reproduce, etc. 32KB leaves headroom.
+  static const int maxLogSummaryLength = 32 * 1024;
+
   /// Sensitive data patterns to sanitize
   static final List<RegExp> sensitivePatterns = [
     RegExp(

--- a/mobile/lib/widgets/bug_report_dialog.dart
+++ b/mobile/lib/widgets/bug_report_dialog.dart
@@ -8,27 +8,19 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' show LogEntry, LogLevel;
+import 'package:openvine/config/bug_report_config.dart';
 import 'package:openvine/services/bug_report_service.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/support_dialog_utils.dart';
 
-/// Max characters per individual log entry in the summary.
-/// 500 chars is enough for error type + message context without
-/// including full SQL statements or serialized event payloads.
-const int _maxEntryLength = 500;
-
-/// Max total characters for the entire log summary.
-/// Zendesk description limit is 64K; logs share that space with
-/// device info, steps to reproduce, etc. 32KB leaves headroom.
-const int _maxSummaryLength = 32 * 1024;
-
 /// Build a log summary prioritizing errors/warnings with recent context.
 /// Returns null if logs are empty.
 /// Takes up to 200 most recent error/warning entries plus the last 50
 /// entries of any level, deduplicates, and sorts chronologically.
-/// Individual entries are truncated to [_maxEntryLength] characters and
-/// the total summary is capped at [_maxSummaryLength] characters.
+/// Individual entries are truncated to [BugReportConfig.maxLogEntryLength]
+/// characters and the total summary is capped at
+/// [BugReportConfig.maxLogSummaryLength] characters.
 String? buildLogsSummary(List<LogEntry> logs) {
   if (logs.isEmpty) return null;
 
@@ -52,11 +44,14 @@ String? buildLogsSummary(List<LogEntry> logs) {
   final buffer = StringBuffer();
   for (var i = 0; i < merged.length; i++) {
     var line = merged[i].toFormattedString();
-    if (line.length > _maxEntryLength) {
-      line = '${line.substring(0, _maxEntryLength)}... [truncated]';
+    if (line.length > BugReportConfig.maxLogEntryLength) {
+      line =
+          '${line.substring(0, BugReportConfig.maxLogEntryLength)}... [truncated]';
     }
-    if (buffer.length + line.length + 1 > _maxSummaryLength) {
-      buffer.writeln('... [${merged.length - i} entries truncated]');
+    if (buffer.length + line.length + 1 > BugReportConfig.maxLogSummaryLength) {
+      final remaining = merged.length - i;
+      final noun = remaining == 1 ? 'entry' : 'entries';
+      buffer.writeln('... [$remaining $noun truncated]');
       break;
     }
     buffer.writeln(line);


### PR DESCRIPTION
Closes #2864

## Summary

Follow-up cleanup to #2859. Hoists the log summary size caps out of private
file-level constants in `bug_report_dialog.dart` and into `BugReportConfig`
alongside the existing `maxLogEntries` and `maxReportSizeBytes`, so all bug
report tunables live in one place. Also fixes a small grammar issue in the
truncation marker for the singular case.

## Changes

- **Move constants to config**: `_maxEntryLength` → `BugReportConfig.maxLogEntryLength`, `_maxSummaryLength` → `BugReportConfig.maxLogSummaryLength`
- **Grammar fix**: `1 entries truncated` → `1 entry truncated` (pluralisation branch on the remaining-count)

Pure refactor, no behavior change. Existing tests in `bug_report_dialog_log_summary_test.dart` pass unchanged (10/10).

## Files changed

- `mobile/lib/config/bug_report_config.dart` — add `maxLogEntryLength` and `maxLogSummaryLength`
- `mobile/lib/widgets/bug_report_dialog.dart` — import `BugReportConfig`, reference the config constants, add singular/plural noun for truncation marker

## Test plan

- [x] `flutter test test/widgets/bug_report_dialog_log_summary_test.dart` — 10/10 passing
- [x] `flutter analyze lib/widgets/bug_report_dialog.dart lib/config/bug_report_config.dart test/widgets/bug_report_dialog_log_summary_test.dart` — clean