### PR TITLE
test(video): cover preloaded rebuffer regression

### DIFF
--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -3894,7 +3894,8 @@ void main() {
       });
 
       test(
-        'non-current ready preload ignores buffering=false until it becomes current',
+        'non-current ready preload ignores '
+        'buffering=false until it becomes current',
         () async {
           final videos = createTestVideos(count: 3);
           final controller = VideoFeedController(


### PR DESCRIPTION
Closes #2870.

## Summary
- add a regression test for non-current preloaded videos receiving a later `buffering=false`
- verify the player stays paused while off-screen
- verify playback still resumes once the user swipes to that video

## Verification
- `flutter test test/controllers/video_feed_controller_test.dart`