### PR TITLE
fix(ci): add NSE bundle identifier to Codemagic iOS signing

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -327,7 +327,9 @@ workflows:
         BUNDLE_ID: co.openvine.app
       ios_signing:
         distribution_type: app_store
-        bundle_identifier: $BUNDLE_ID
+        bundle_identifier:
+          - $BUNDLE_ID
+          - $BUNDLE_ID.NotificationServiceExtension
     cache:
       cache_paths:
         - $HOME/Library/Caches/CocoaPods


### PR DESCRIPTION
Closes #2874

## Summary
- Adds `co.openvine.app.NotificationServiceExtension` to the Codemagic iOS signing config
- Required for PR #2848 (push notifications) — the Notification Service Extension needs its own provisioning profile

## Context
Codemagic iOS builds fail because `ios_signing.bundle_identifier` only listed the main app bundle ID. The NSE target added in #2848 needs Codemagic to generate a provisioning profile for its bundle ID too.

## Test plan
- [ ] Codemagic iOS Build workflow succeeds with both bundle IDs signed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)