### PR TITLE
fix(ci): revert codemagic bundle_identifier to single string

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -327,9 +327,7 @@ workflows:
         BUNDLE_ID: co.openvine.app
       ios_signing:
         distribution_type: app_store
-        bundle_identifier:
-          - $BUNDLE_ID
-          - $BUNDLE_ID.NotificationServiceExtension
+        bundle_identifier: $BUNDLE_ID
     cache:
       cache_paths:
         - $HOME/Library/Caches/CocoaPods


### PR DESCRIPTION
Closes #2877

## Summary
- Reverts the invalid list syntax for `bundle_identifier` introduced in #2873
- Codemagic requires `bundle_identifier` to be a string, not a list
- Codemagic automatically matches extension profiles using `$BUNDLE_ID.*` pattern, so only the main bundle ID is needed

## Test plan
- [ ] Codemagic iOS Build workflow no longer shows "Invalid yaml configuration" error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)