### PR TITLE
fix(ci): restore Codemagic iOS NSE signing

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -327,7 +327,9 @@ workflows:
         BUNDLE_ID: co.openvine.app
       ios_signing:
         distribution_type: app_store
-        bundle_identifier: $BUNDLE_ID
+        bundle_identifier:
+          - $BUNDLE_ID
+          - $BUNDLE_ID.NotificationServiceExtension
     cache:
       cache_paths:
         - $HOME/Library/Caches/CocoaPods


### PR DESCRIPTION
Closes #2883

## Summary
- restore multi-bundle iOS signing in Codemagic for the notification service extension
- provision both `co.openvine.app` and `co.openvine.app.NotificationServiceExtension` during the iOS build

## Root cause
`main` reverted Codemagic iOS signing to a single bundle identifier in commit `8b3c877`, but the iOS project now includes push entitlements and a Notification Service Extension added in `f31643df6`.

## Remaining manual work
Codemagic/Apple signing still needs to be updated outside the repo:
- enable `Push Notifications` for `co.openvine.app`
- enable `App Groups` for `co.openvine.app`
- add `group.co.openvine.app` to the app ID
- create or refresh the App Store profile for `co.openvine.app`
- create or refresh the App Store profile for `co.openvine.app.NotificationServiceExtension`
