### PR TITLE
fix(ci): restore Codemagic bundle identifier schema

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -327,9 +327,7 @@ workflows:
         BUNDLE_ID: co.openvine.app
       ios_signing:
         distribution_type: app_store
-        bundle_identifier:
-          - $BUNDLE_ID
-          - $BUNDLE_ID.NotificationServiceExtension
+        bundle_identifier: $BUNDLE_ID
     cache:
       cache_paths:
         - $HOME/Library/Caches/CocoaPods


### PR DESCRIPTION
Closes #2885

## Summary
- switch `ios_signing.bundle_identifier` back to the string schema Codemagic currently validates
- keep using the new Apple/Codemagic provisioning profiles for both `co.openvine.app` and `co.openvine.app.NotificationServiceExtension`

## Root cause
Codemagic now rejects an array value for `ios_signing.bundle_identifier` and reports that the main bundle identifier should be a string. With the extension profile now present in Apple Developer and Codemagic, the supported config is the single base bundle identifier.

## Verification
- parsed `codemagic.yaml` and confirmed `workflows.ios-build.environment.ios_signing.bundle_identifier` is now a string
