### PR TITLE
fix(db): migrate legacy database path from documents to application support

### DIFF
--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -23,9 +23,62 @@ QueryExecutor openConnection() {
 /// Get path to shared database file
 ///
 /// Path: {appSupport}/openvine/database/divine_db.db
+///
+/// The database lived under `getApplicationDocumentsDirectory()` until the
+/// change that shipped in PR #2840. When it moved to Application Support,
+/// no migration was included, which orphans every user's local data on
+/// upgrade (DMs, drafts, clips, upload queue, reactions, reposts,
+/// notifications, bookmarks, NIP-05 verifications, etc.). This function
+/// migrates the legacy file on first run after upgrade.
 Future<String> getSharedDatabasePath() async {
   final appSupportDir = await getApplicationSupportDirectory();
-  return buildSharedDatabasePath(appSupportDir.path);
+  final newPath = buildSharedDatabasePath(appSupportDir.path);
+
+  final docDir = await getApplicationDocumentsDirectory();
+  final legacyPath = p.join(
+    docDir.path,
+    'openvine',
+    'database',
+    'divine_db.db',
+  );
+  await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
+
+  return newPath;
+}
+
+/// One-time migration from the pre-PR #2840 Documents-directory location
+/// to the current Application Support location.
+///
+/// No-op when:
+/// * the new location already has a database (never clobber existing data),
+/// * or the legacy file does not exist (fresh install / post-migration run).
+///
+/// Also migrates the SQLite `-wal` and `-shm` sidecar files if present, so
+/// any unsynced writes in the write-ahead log are preserved.
+@visibleForTesting
+Future<void> migrateLegacyDatabase({
+  required String legacyPath,
+  required String newPath,
+}) async {
+  final newFile = File(newPath);
+  if (newFile.existsSync()) {
+    return;
+  }
+
+  final legacyFile = File(legacyPath);
+  if (!legacyFile.existsSync()) {
+    return;
+  }
+
+  Directory(p.dirname(newPath)).createSync(recursive: true);
+  legacyFile.renameSync(newPath);
+
+  for (final suffix in const ['-wal', '-shm']) {
+    final legacySidecar = File('$legacyPath$suffix');
+    if (legacySidecar.existsSync()) {
+      legacySidecar.renameSync('$newPath$suffix');
+    }
+  }
 }
 
 /// Builds the shared database path from a platform-specific writable base.

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -45,4 +45,116 @@ void main() {
       );
     });
   });
+
+  group('migrateLegacyDatabase', () {
+    late Directory tempRoot;
+    late String legacyPath;
+    late String newPath;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_migrate_legacy_test_',
+      );
+      legacyPath = p.join(
+        tempRoot.path,
+        'legacy',
+        'openvine',
+        'database',
+        'divine_db.db',
+      );
+      newPath = p.join(
+        tempRoot.path,
+        'support',
+        'openvine',
+        'database',
+        'divine_db.db',
+      );
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) {
+        tempRoot.deleteSync(recursive: true);
+      }
+    });
+
+    test('moves the legacy database when the new location is empty', () async {
+      final legacyFile = File(legacyPath);
+      legacyFile.parent.createSync(recursive: true);
+      legacyFile.writeAsBytesSync(const [1, 2, 3, 4]);
+
+      await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
+
+      expect(File(newPath).existsSync(), isTrue);
+      expect(File(newPath).readAsBytesSync(), equals(const [1, 2, 3, 4]));
+      expect(File(legacyPath).existsSync(), isFalse);
+    });
+
+    test('creates the destination directory tree when missing', () async {
+      final legacyFile = File(legacyPath);
+      legacyFile.parent.createSync(recursive: true);
+      legacyFile.writeAsBytesSync(const [42]);
+
+      expect(Directory(p.dirname(newPath)).existsSync(), isFalse);
+
+      await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
+
+      expect(Directory(p.dirname(newPath)).existsSync(), isTrue);
+      expect(File(newPath).existsSync(), isTrue);
+    });
+
+    test('never clobbers an existing database at the new location', () async {
+      final legacyFile = File(legacyPath);
+      legacyFile.parent.createSync(recursive: true);
+      legacyFile.writeAsBytesSync(const [1, 2, 3]);
+
+      final newFile = File(newPath);
+      newFile.parent.createSync(recursive: true);
+      newFile.writeAsBytesSync(const [9, 9, 9]);
+
+      await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
+
+      // New location untouched, legacy left in place.
+      expect(newFile.readAsBytesSync(), equals(const [9, 9, 9]));
+      expect(legacyFile.existsSync(), isTrue);
+      expect(legacyFile.readAsBytesSync(), equals(const [1, 2, 3]));
+    });
+
+    test('no-op when no legacy database exists (fresh install)', () async {
+      expect(File(legacyPath).existsSync(), isFalse);
+      expect(File(newPath).existsSync(), isFalse);
+
+      await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
+
+      expect(File(newPath).existsSync(), isFalse);
+      expect(Directory(p.dirname(newPath)).existsSync(), isFalse);
+    });
+
+    test('migrates WAL and SHM sidecar files alongside the database', () async {
+      final legacyFile = File(legacyPath);
+      legacyFile.parent.createSync(recursive: true);
+      legacyFile.writeAsBytesSync(const [1]);
+      File('$legacyPath-wal').writeAsBytesSync(const [2]);
+      File('$legacyPath-shm').writeAsBytesSync(const [3]);
+
+      await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
+
+      expect(File(newPath).readAsBytesSync(), equals(const [1]));
+      expect(File('$newPath-wal').readAsBytesSync(), equals(const [2]));
+      expect(File('$newPath-shm').readAsBytesSync(), equals(const [3]));
+      expect(File('$legacyPath-wal').existsSync(), isFalse);
+      expect(File('$legacyPath-shm').existsSync(), isFalse);
+    });
+
+    test('migrates database even when no sidecar files are present', () async {
+      final legacyFile = File(legacyPath);
+      legacyFile.parent.createSync(recursive: true);
+      legacyFile.writeAsBytesSync(const [7]);
+
+      await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
+
+      expect(File(newPath).readAsBytesSync(), equals(const [7]));
+      expect(File('$newPath-wal').existsSync(), isFalse);
+      expect(File('$newPath-shm').existsSync(), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Add a one-time migration inside `getSharedDatabasePath()` that moves the legacy SQLite database from `getApplicationDocumentsDirectory()` to `getApplicationSupportDirectory()` on first run after upgrade
- Migrate the SQLite `-wal` and `-shm` sidecar files alongside the main `.db` file so any unsynced writes in the write-ahead log are preserved
- Add 6 unit tests covering the migration logic (8 total in the file, all passing)

## Why

PR #2840 (`fix(notifications): sign inbox fetches with full request url`, merged 2026-04-07) shipped an unrelated squashed commit that changed the database path without a migration. On the next TestFlight or production build, every iOS/macOS user will create a fresh empty database at the new path while their existing database is orphaned at the old path. Blast radius: every Drift-persisted feature — DMs, drafts, clips, upload queue, video metrics, personal reactions, personal reposts, notifications, bookmarks, NIP-05 verifications, etc.

Verified against the actual diff of PR #2840 and against current main HEAD at `mobile/packages/db_client/lib/src/database/connection/connection_native.dart:26-29`.

The move to Application Support is itself defensible (it is the correct sandbox location for hidden app data per Apple's guidelines), so this PR keeps the new location and adds the missing migration rather than reverting.

## What changed

**`mobile/packages/db_client/lib/src/database/connection/connection_native.dart`**
- `getSharedDatabasePath()` now computes the new path, then calls `migrateLegacyDatabase()` before returning
- New `@visibleForTesting Future<void> migrateLegacyDatabase({required String legacyPath, required String newPath})`:
  - No-op when the new location already has a database (never clobber existing data)
  - No-op when no legacy database exists (fresh install)
  - Creates the destination directory tree
  - Moves the main `.db` file via `renameSync`
  - Moves `-wal` and `-shm` sidecar files if present

**`mobile/packages/db_client/test/src/database/connection/connection_native_test.dart`**
- 6 new tests under `group('migrateLegacyDatabase')`:
  - moves the legacy database when the new location is empty
  - creates the destination directory tree when missing
  - never clobbers an existing database at the new location
  - no-op when no legacy database exists (fresh install)
  - migrates WAL and SHM sidecar files alongside the database
  - migrates database even when no sidecar files are present

## Local checks

- `dart format` — clean (0 changes)
- `flutter analyze lib test` from `mobile/packages/db_client/` — **No issues found**
- `flutter test test/src/database/connection/connection_native_test.dart` — **8/8 passing** (2 existing + 6 new)
- Pre-commit hooks ran on commit — format and analyzer checks both passed

## Relationship to #2834

#2834 (`fix: previous DMs missing after latest TestFlight update`) was filed 2026-04-06T16:58:52Z, **~10 hours before** PR #2840 merged at 2026-04-07T02:36:58Z. Therefore PR #2840 is **NOT** the cause of #2834's original report. However, PR #2840 would reproduce the same symptom for every user upgrading to a build containing it. Shipping this fix prevents a new wave of data-loss reports and closes the window in which #2834's original (still-unknown) root cause could be reproduced.

#2834 still needs its own root-cause investigation — see `tasks/investigation_599_dm.md` for the 4 live hypotheses (top confidence 0.55) and the SQLite + prefs dump that would collapse them.

---

## Device Test Plan

**Risk level**: HIGH — migration runs once per user on upgrade; a bug here means permanent data loss for that user. **Required for merge**: Scenarios 1 and 2 must pass on at least one iOS device and one Android device.

### Build setup

| Baseline | Commit | State |
|---|---|---|
| Pre-PR #2840 (legacy DB at Documents) | `c55bd2227` | DB at Documents directory |
| Post-PR #2840 (buggy) | `3affed39f` | DB at Application Support, no migration |

```bash
# Build the pre-PR #2840 baseline
git fetch origin
git checkout c55bd2227
cd mobile && flutter clean && flutter pub get
# Build + install on device

# After using the app and creating data, upgrade:
git checkout fix/db-path-migration-pr2840
cd mobile && flutter pub get
# Build + install on the SAME device (upgrade, do not uninstall)
```

### Scenario 1 — Upgrade with legacy data (PRIMARY, must pass)

1. Check out `c55bd2227` and install on device
2. Sign in with a test account
3. Create observable data:
   - [ ] Send 1–2 DMs to a test contact (and receive at least one reply if possible)
   - [ ] Like 3 videos
   - [ ] Repost 1 video
   - [ ] Start a clip draft (do not publish)
   - [ ] Add 1 bookmark
   - [ ] Follow 1 user
   - [ ] Open a few videos so view metrics get cached
4. **Force-close the app** (swipe up on iOS / back out + clear recent on Android). This ensures the WAL is checkpointed
5. Verify the legacy DB exists at the Documents location (see "Inspecting file paths" below)
6. Check out `fix/db-path-migration-pr2840` and install on the same device **without uninstalling**
7. Open the app and verify:
   - [ ] App launches without crash
   - [ ] DMs from step 3 are still visible
   - [ ] Liked videos still show as liked
   - [ ] Reposted video still shows as reposted
   - [ ] Clip draft is still available
   - [ ] Bookmark is still present
   - [ ] Following list still contains the followed user
   - [ ] View counts persisted where applicable
8. Inspect file paths after upgrade:
   - [ ] New DB exists at Application Support location
   - [ ] Legacy DB no longer exists at Documents location
   - [ ] Any `-wal` / `-shm` sidecar files moved with it

### Scenario 2 — Fresh install on a clean device

1. **Uninstall** any previous version
2. Install `fix/db-path-migration-pr2840`
3. Sign in (or register fresh)
4. Use the app for a few minutes:
   - [ ] App launches with no errors
   - [ ] Feed loads
   - [ ] Profile loads
   - [ ] Inbox opens
   - [ ] Can like, follow, comment, repost
5. Inspect:
   - [ ] DB created at Application Support location
   - [ ] No orphan at Documents location

### Scenario 3 — Upgrade from buggy build (data already lost)

Covers users already hit by PR #2840.

1. Check out `3affed39f` and install
2. Sign in, create new data (DMs, likes)
3. Force-close
4. Upgrade to `fix/db-path-migration-pr2840` without uninstalling
5. Verify:
   - [ ] App launches without crash
   - [ ] Data from step 2 is still present (new-location DB not clobbered, since legacy Documents path is empty)

### Scenario 4 — Both locations populated (edge case)

iOS Simulator setup:
```bash
SIM_ID=$(xcrun simctl list devices booted | awk -F '[()]' '/Booted/{print $2}' | head -1)
APP_CONTAINER=$(xcrun simctl get_app_container "$SIM_ID" video.divine.app data)
mkdir -p "$APP_CONTAINER/Documents/openvine/database"
echo "legacy-db-marker" > "$APP_CONTAINER/Documents/openvine/database/divine_db.db"
mkdir -p "$APP_CONTAINER/Library/Application Support/openvine/database"
echo "new-db-marker" > "$APP_CONTAINER/Library/Application Support/openvine/database/divine_db.db"
```

Android emulator setup:
```bash
PKG=video.divine.app
adb shell "run-as $PKG mkdir -p files/openvine/database"
adb shell "run-as $PKG sh -c 'echo new-db-marker > files/openvine/database/divine_db.db'"
adb shell "run-as $PKG mkdir -p app_flutter/openvine/database"
adb shell "run-as $PKG sh -c 'echo legacy-db-marker > app_flutter/openvine/database/divine_db.db'"
```

Launch the app, then verify:
- [ ] New location still contains `new-db-marker` (untouched)
- [ ] Legacy location still contains `legacy-db-marker` (untouched)

### Scenario 5 — Legacy DB with dirty WAL

1. Check out `c55bd2227` and install
2. Sign in, create a DM
3. **Hard-kill via `adb shell am force-stop` (Android) or via Instruments / Xcode (iOS)** — do NOT swipe away. Hard kill leaves WAL in place
4. Verify `divine_db.db-wal` exists at the legacy Documents path
5. Upgrade to fix branch without uninstalling
6. Open the app, navigate to the DM
7. Verify:
   - [ ] DM from step 2 is visible (proof WAL was migrated and Drift read the unsynced write)
   - [ ] No SQLite errors in logs
   - [ ] `-wal` and `-shm` files now at the new location, not the legacy one

### Inspecting device file paths

**iOS Simulator**
```bash
SIM_ID=$(xcrun simctl list devices booted | awk -F '[()]' '/Booted/{print $2}' | head -1)
APP_CONTAINER=$(xcrun simctl get_app_container "$SIM_ID" video.divine.app data)
ls -la "$APP_CONTAINER/Documents/openvine/database/"
ls -la "$APP_CONTAINER/Library/Application Support/openvine/database/"
```

**Android Emulator / Device** (debug build only — `run-as` requires debuggable)
```bash
PKG=video.divine.app
adb shell "run-as $PKG ls -la app_flutter/openvine/database/"
adb shell "run-as $PKG ls -la files/openvine/database/"
```

**macOS**
```bash
ls -la ~/Documents/openvine/database/
ls -la ~/Library/Application\ Support/openvine/database/
```

### Log watching

Run during Scenario 1's upgrade.

**iOS**
```bash
xcrun simctl spawn booted log stream --predicate 'process == "Runner"' 2>&1 | grep -iE "database|sqlite|migrate|drift"
```

**Android**
```bash
adb logcat | grep -iE "database|sqlite|migrate|drift|flutter"
```

Look for any `SqliteException`, `FileSystemException`, or `unable to open database file`.

### Sign-off matrix

| Scenario | iOS Sim | iOS Device | Android Emu | Android Device |
|---|---|---|---|---|
| 1. Upgrade with legacy data | ⬜ | ⬜ | ⬜ | ⬜ |
| 2. Fresh install | ⬜ | ⬜ | ⬜ | ⬜ |
| 3. Upgrade from buggy build | ⬜ | ⬜ | ⬜ | ⬜ |
| 4. Both locations populated | ⬜ | ⬜ | ⬜ | ⬜ |
| 5. Dirty WAL migration | ⬜ | ⬜ | ⬜ | ⬜ |

### Rollback plan

If any Scenario 1 check fails for a tester, do NOT ship to TestFlight.

1. **Best**: figure out why and fix (file the finding in this PR with device model + OS version + repro)
2. **Acceptable fallback**: ship the migration scaffolding behind a remote feature flag, default off, internal testers only
3. **Last resort**: revert PR #2840's db_client change on the next build (rolls back to Documents directory, no data loss but undoes the intended Application Support move)

---

Closes #2886