### PR TITLE
fix(ci): patch iOS Swift package deployment target

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -38,6 +38,33 @@ definitions:
     - &enable_spm
       name: Enable Swift Package Manager
       script: flutter config --enable-swift-package-manager
+    - &prepare_ios_spm_packages
+      name: Prepare iOS Swift package deployment targets
+      script: |
+        flutter build ios --config-only
+
+        ruby <<'RUBY'
+        files = [
+          'ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift',
+          'ios/Flutter/ephemeral/Packages/.packages/FlutterFramework/Package.swift',
+        ]
+
+        files.each do |path|
+          contents = File.read(path)
+          updated = contents.gsub('.iOS("13.0")', '.iOS("16.0")')
+
+          unless updated.include?('.iOS("16.0")')
+            abort("expected #{path} to declare iOS 16.0")
+          end
+
+          if updated != contents
+            File.write(path, updated)
+            puts "patched #{path} to iOS 16.0"
+          else
+            puts "#{path} already targets iOS 16.0"
+          end
+        end
+        RUBY
     - &flutter_pub_get
       name: Get Flutter dependencies
       script: flutter pub get
@@ -338,6 +365,7 @@ workflows:
       - *setup_code_signing_xcode
       - *install_flutterfire
       - *enable_spm
+      - *prepare_ios_spm_packages
       - *pod_install
       - *build_ios
       - *upload_dsyms_to_crashlytics


### PR DESCRIPTION
Closes #2915

## Summary
- add a Codemagic iOS prep step that regenerates Flutter Swift package metadata
- patch generated Flutter Swift package deployment targets from iOS 13.0 to 16.0 before archive

## Root cause
Codemagic is now getting past signing, but the archive fails in Xcode because `FlutterGeneratedPluginSwiftPackage` is generated with `.iOS("13.0")` while `firebase_*` plugins require iOS 15.0 and `c2pa_flutter` requires iOS 16.0.

## Evidence
Local archive reproduction on commit `86f247887` produced these Xcode errors:
- `firebase-performance` requires minimum platform version 15.0
- `firebase-core` requires minimum platform version 15.0
- `firebase-messaging` requires minimum platform version 15.0
- `firebase-crashlytics` requires minimum platform version 15.0
- `firebase-analytics` requires minimum platform version 15.0
- `c2pa-flutter` requires minimum platform version 16.0

## Verification
- `codemagic.yaml` parses successfully
- the patch logic updates generated `Package.swift` files to `.iOS("16.0")`
