### PR TITLE
test(search): cover unconstrained suffix icon in search bar

### DIFF
--- a/mobile/packages/divine_ui/test/src/search_bar/divine_search_bar_test.dart
+++ b/mobile/packages/divine_ui/test/src/search_bar/divine_search_bar_test.dart
@@ -40,9 +40,7 @@ void main() {
     });
 
     testWidgets('renders with custom hint text', (tester) async {
-      await tester.pumpWidget(
-        buildTestWidget(hintText: 'Search videos...'),
-      );
+      await tester.pumpWidget(buildTestWidget(hintText: 'Search videos...'));
 
       expect(find.text('Search videos...'), findsOneWidget);
     });
@@ -103,12 +101,29 @@ void main() {
 
     testWidgets('renders suffixIcon when provided', (tester) async {
       await tester.pumpWidget(
-        buildTestWidget(
-          suffixIcon: const Icon(Icons.filter_list),
-        ),
+        buildTestWidget(suffixIcon: const Icon(Icons.filter_list)),
       );
 
       expect(find.byIcon(Icons.filter_list), findsOneWidget);
+    });
+
+    testWidgets('does not force suffixIcon to default minimum constraints', (
+      tester,
+    ) async {
+      const suffixKey = Key('suffix');
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          suffixIcon: const SizedBox(
+            key: suffixKey,
+            width: 20,
+            height: 12,
+            child: ColoredBox(color: Colors.red),
+          ),
+        ),
+      );
+
+      expect(tester.getSize(find.byKey(suffixKey)), const Size(20, 12));
     });
 
     testWidgets('renders no suffix when suffixIcon is null', (tester) async {


### PR DESCRIPTION
Closes #2918

## Description

Adds a focused regression test for DivineSearchBar to verify that the shared suffixIconConstraints change does not force custom suffix widgets into the default minimum size.

This was split into a follow-up PR because #2909 merged before the test-only commit was ready.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Build configuration change
- [ ] Documentation
- [x] Chore