### PR TITLE
feat(audio): show audio attribution on all videos, enable reuse by default

### DIFF
--- a/docs/superpowers/specs/2026-04-09-audio-attribution-all-videos-design.md
+++ b/docs/superpowers/specs/2026-04-09-audio-attribution-all-videos-design.md
@@ -1,0 +1,74 @@
+# Audio Attribution on All Videos (TikTok-Style)
+
+**Date:** 2026-04-09
+**Status:** Draft
+
+## Problem
+
+The audio attribution row (`♪ Sound name · Creator`) only appears on videos that have an explicit `["e", ..., "audio"]` tag — meaning the creator opted into audio reuse and published a separate Kind 1063 audio event. Most videos don't have this tag, so the attribution row never appears.
+
+TikTok shows "Original sound - @creator" on every video. This builds awareness of audio as a feature, makes the feed feel richer, and drives audio reuse adoption.
+
+## Design
+
+### Always show audio attribution
+
+Remove the `if (video.hasAudioReference)` gate. Every video in the feed shows an audio attribution row at the bottom of the overlay.
+
+### Two display modes
+
+**Mode 1 — Explicit audio reference (existing)**
+When `video.hasAudioReference == true`:
+- Display: `♪ Sound name · Creator` (unchanged)
+- On tap: navigate to SoundDetailScreen with "Use Sound" button (unchanged)
+- This is the existing flow, no changes needed
+
+**Mode 2 — Original sound (new)**
+When `video.hasAudioReference == false`:
+- Display: `♪ Original sound - @creator_display_name`
+- On tap: navigate to SoundDetailScreen in a "view-only" mode
+  - Shows creator info, the source video
+  - No "Use Sound" button (audio isn't separately available)
+  - Could show a message like "This creator hasn't shared their audio for reuse"
+
+### UI Changes
+
+1. **`video_feed_item.dart`** — Remove the `if (video.hasAudioReference)` condition around `AudioAttributionRow`
+2. **`feed_video_overlay.dart`** — Same removal if it has the same gate
+3. **`AudioAttributionRow`** — Handle the case where there's no audio event:
+   - Instead of returning `SizedBox.shrink()` when `!hasAudioReference`, show "Original sound - @creator"
+   - Fetch creator display name from the video's pubkey
+   - On tap, navigate to SoundDetailScreen with a synthetic/minimal context (video pubkey, no audio event)
+4. **`SoundDetailScreen`** — Add support for "original sound" mode:
+   - Accept either an `AudioEvent` or a video pubkey + video reference
+   - When no audio event: show creator info, source video, but hide "Use Sound" button
+   - Show encouragement text for creators to share their audio
+
+### Data flow
+
+No new Nostr events. No audio extraction. No new network requests beyond what's already needed to display the creator's name (which is already fetched for the video overlay).
+
+The `AudioAttributionRow` widget gets the creator display name from the video's author profile, which is already loaded by the feed.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `mobile/lib/widgets/video_feed_item/video_feed_item.dart` | Remove `hasAudioReference` gate |
+| `mobile/lib/widgets/video_feed_item/feed_video_overlay.dart` | Remove `hasAudioReference` gate (if present) |
+| `mobile/lib/widgets/video_feed_item/audio_attribution_row.dart` | Handle no-audio-event case with "Original sound" display |
+| `mobile/lib/screens/sound_detail_screen.dart` | Support "original sound" mode (no audio event) |
+
+## Out of scope
+
+- On-demand audio extraction (user taps "Use Sound" on a video without shared audio)
+- Auto-extracting audio for all videos at publish time
+- Changing the default for "allow audio reuse" toggle
+- Audio waveform visualization for original sounds
+
+## Testing
+
+- Widget test: AudioAttributionRow renders "Original sound - @creator" when video has no audio reference
+- Widget test: AudioAttributionRow renders sound name when video has audio reference (existing)
+- Widget test: SoundDetailScreen hides "Use Sound" when in original-sound mode
+- Widget test: Tapping original sound row navigates to SoundDetailScreen

--- a/mobile/lib/models/audio_event.dart
+++ b/mobile/lib/models/audio_event.dart
@@ -1,6 +1,7 @@
 // ABOUTME: AudioEvent model for NIP-94 Kind 1063 audio file metadata events
 // ABOUTME: Used for audio reuse feature - parsing audio shared for use in other videos
 
+import 'package:models/models.dart' show VideoEvent;
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/models/vine_sound.dart';
 
@@ -139,6 +140,29 @@ class AudioEvent {
       source: source,
     );
   }
+
+  /// Create a synthetic AudioEvent from a video's audio track.
+  ///
+  /// Uses the video URL as the audio source. The audio player can extract
+  /// the audio track from video files. The ID is prefixed with `video_`
+  /// to distinguish from real Kind 1063 events.
+  factory AudioEvent.fromVideoOriginalSound(
+    VideoEvent video, {
+    required String creatorName,
+  }) {
+    return AudioEvent(
+      id: 'video_${video.id}',
+      pubkey: video.pubkey,
+      createdAt: video.createdAt,
+      url: video.videoUrl,
+      title: 'Original sound - $creatorName',
+      source: 'Original Sound',
+      sourceVideoReference: '34236:${video.pubkey}:${video.vineId ?? video.id}',
+    );
+  }
+
+  /// Whether this audio is derived from a video's original sound.
+  bool get isOriginalSound => id.startsWith('video_');
 
   /// Whether this audio is a bundled sound (from app assets).
   bool get isBundled => id.startsWith('${bundledMarker}_');

--- a/mobile/lib/models/divine_video_draft.dart
+++ b/mobile/lib/models/divine_video_draft.dart
@@ -28,7 +28,7 @@ class DivineVideoDraft {
     required this.publishStatus,
     required this.publishAttempts,
     this.publishError,
-    this.allowAudioReuse = false,
+    this.allowAudioReuse = true,
     this.expireTime,
     this.proofManifestJson,
     this.editorStateHistory = const {},
@@ -49,7 +49,7 @@ class DivineVideoDraft {
     required String description,
     required Set<String> hashtags,
     required String selectedApproach,
-    bool allowAudioReuse = false,
+    bool allowAudioReuse = true,
     Duration? expireTime,
     String? id,
     String? proofManifestJson,
@@ -151,7 +151,7 @@ class DivineVideoDraft {
       publishStatus: json['publishStatus'] != null
           ? PublishStatus.values.byName(json['publishStatus'] as String)
           : PublishStatus.draft, // Migration: default for old drafts
-      allowAudioReuse: json['allowAudioReuse'] as bool? ?? false,
+      allowAudioReuse: json['allowAudioReuse'] as bool? ?? true,
       publishError: json['publishError'] as String?,
       publishAttempts: json['publishAttempts'] as int? ?? 0,
       proofManifestJson: json['proofManifestJson'] as String?,

--- a/mobile/lib/models/video_editor/video_editor_meta.dart
+++ b/mobile/lib/models/video_editor/video_editor_meta.dart
@@ -10,7 +10,7 @@ class VideoEditorMeta {
     required this.title,
     required this.description,
     required this.hashtags,
-    this.allowAudioReuse = false,
+    this.allowAudioReuse = true,
     this.expireTime,
   });
 

--- a/mobile/lib/models/video_editor/video_editor_provider_state.dart
+++ b/mobile/lib/models/video_editor/video_editor_provider_state.dart
@@ -21,7 +21,7 @@ class VideoEditorProviderState {
   VideoEditorProviderState({
     this.isProcessing = false,
     this.isSavingDraft = false,
-    this.allowAudioReuse = false,
+    this.allowAudioReuse = true,
     this.title = '',
     this.description = '',
     this.tags = const {},

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -9,6 +9,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:models/models.dart' show VideoEvent;
 import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
 import 'package:openvine/models/audio_event.dart';
 import 'package:openvine/models/video_category.dart';
@@ -50,6 +51,7 @@ import 'package:openvine/screens/key_management_screen.dart';
 import 'package:openvine/screens/library_screen.dart';
 import 'package:openvine/screens/liked_videos_screen_router.dart';
 import 'package:openvine/screens/notification_settings_screen.dart';
+import 'package:openvine/screens/original_sound_detail_screen.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/screens/profile_setup_screen.dart';
@@ -645,10 +647,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
               ? state.extra! as NostrAppDirectoryEntry
               : null;
           final appId = state.pathParameters['appId'] ?? '';
-          return ResolvedSandboxRouteScreen(
-            appId: appId,
-            initialApp: app,
-          );
+          return ResolvedSandboxRouteScreen(appId: appId, initialApp: app);
         },
       ),
       GoRoute(
@@ -659,10 +658,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           final initialEntry = state.extra is NostrAppDirectoryEntry
               ? state.extra! as NostrAppDirectoryEntry
               : null;
-          return AppDetailScreen(
-            slug: slug,
-            initialEntry: initialEntry,
-          );
+          return AppDetailScreen(slug: slug, initialEntry: initialEntry);
         },
       ),
       GoRoute(
@@ -881,6 +877,25 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           return SoundDetailLoader(soundId: soundId);
         },
       ),
+      // Original sound detail route (for videos without shared audio)
+      GoRoute(
+        path: OriginalSoundDetailScreen.path,
+        name: OriginalSoundDetailScreen.routeName,
+        builder: (ctx, st) {
+          final pubkey = st.pathParameters['pubkey'];
+          final video = st.extra as VideoEvent?;
+          if (pubkey == null || pubkey.isEmpty) {
+            return const Scaffold(
+              appBar: DiVineAppBar(title: 'Error'),
+              body: Center(child: Text('Invalid creator')),
+            );
+          }
+          return OriginalSoundDetailScreen(
+            creatorPubkey: pubkey,
+            sourceVideo: video,
+          );
+        },
+      ),
       // Video editor route (requires video passed via extra)
       GoRoute(
         path: VideoRecorderScreen.path,
@@ -927,10 +942,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           final categoryName = st.pathParameters['categoryName'];
           final category =
               st.extra as VideoCategory? ??
-              VideoCategory(
-                name: categoryName ?? '',
-                videoCount: 0,
-              );
+              VideoCategory(name: categoryName ?? '', videoCount: 0);
 
           if (category.name.isEmpty) {
             return const Scaffold(

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -861,17 +861,28 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         name: SoundDetailScreen.routeName,
         builder: (ctx, st) {
           final soundId = st.pathParameters['id'];
-          final sound = st.extra as AudioEvent?;
           if (soundId == null || soundId.isEmpty) {
             return const Scaffold(
               appBar: DiVineAppBar(title: 'Error'),
               body: Center(child: Text('Invalid sound ID')),
             );
           }
-          // If sound was passed via extra, use it directly
-          // Otherwise, SoundDetailScreen will need to fetch it
+          // Extra can be an AudioEvent directly or a Map with both
+          // sound and sourceVideo (for original sounds).
+          final extra = st.extra;
+          AudioEvent? sound;
+          VideoEvent? sourceVideo;
+          if (extra is AudioEvent) {
+            sound = extra;
+          } else if (extra is Map<String, dynamic>) {
+            sound = extra['sound'] as AudioEvent?;
+            sourceVideo = extra['sourceVideo'] as VideoEvent?;
+          }
           if (sound != null) {
-            return SoundDetailScreen(sound: sound);
+            return SoundDetailScreen(
+              sound: sound,
+              sourceVideo: sourceVideo,
+            );
           }
           // Wrap in a loader that fetches the sound by ID
           return SoundDetailLoader(soundId: soundId);

--- a/mobile/lib/screens/feed/feed_video_overlay.dart
+++ b/mobile/lib/screens/feed/feed_video_overlay.dart
@@ -221,10 +221,7 @@ class _FeedVideoOverlayState extends ConsumerState<FeedVideoOverlay> {
             final opacity = scrollDrivenOpacity(distance);
             return Opacity(
               opacity: opacity,
-              child: IgnorePointer(
-                ignoring: opacity < 0.01,
-                child: child,
-              ),
+              child: IgnorePointer(ignoring: opacity < 0.01, child: child),
             );
           },
           child: Stack(
@@ -368,11 +365,9 @@ class _AuthorInfoSection extends ConsumerWidget {
             const SizedBox(height: 4),
             InspiredByAttributionRow(video: video, isActive: true),
           ],
-          // Audio attribution
-          if (video.hasAudioReference) ...[
-            const SizedBox(height: 4),
-            AudioAttributionRow(video: video),
-          ],
+          // Audio attribution (shown on all videos)
+          const SizedBox(height: 4),
+          AudioAttributionRow(video: video),
           // List attribution (curated lists)
           if (listSources != null && listSources!.isNotEmpty) ...[
             const SizedBox(height: 4),

--- a/mobile/lib/screens/feed/feed_video_overlay.dart
+++ b/mobile/lib/screens/feed/feed_video_overlay.dart
@@ -365,9 +365,11 @@ class _AuthorInfoSection extends ConsumerWidget {
             const SizedBox(height: 4),
             InspiredByAttributionRow(video: video, isActive: true),
           ],
-          // Audio attribution (shown on all videos)
-          const SizedBox(height: 4),
-          AudioAttributionRow(video: video),
+          // Audio attribution (only for videos with shared audio)
+          if (video.hasAudioReference) ...[
+            const SizedBox(height: 4),
+            AudioAttributionRow(video: video),
+          ],
           // List attribution (curated lists)
           if (listSources != null && listSources!.isNotEmpty) ...[
             const SizedBox(height: 4),

--- a/mobile/lib/screens/original_sound_detail_screen.dart
+++ b/mobile/lib/screens/original_sound_detail_screen.dart
@@ -1,0 +1,204 @@
+// ABOUTME: Detail screen for "original sound" on videos without shared audio.
+// ABOUTME: Shows creator info and the source video, no "Use Sound" button.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
+
+/// Screen showing "original sound" details for videos without shared audio.
+///
+/// Displays the creator's profile info and a note that the audio
+/// hasn't been shared for reuse. No "Use Sound" or "Preview" buttons.
+class OriginalSoundDetailScreen extends ConsumerWidget {
+  /// Route name for this screen.
+  static const routeName = 'originalSound';
+
+  /// Base path for original sound routes.
+  static const basePath = '/original-sound';
+
+  /// Path pattern for this route.
+  static const path = '/original-sound/:pubkey';
+
+  /// Build path for a specific creator pubkey.
+  static String pathForPubkey(String pubkey) => '$basePath/$pubkey';
+
+  /// Creates an OriginalSoundDetailScreen.
+  const OriginalSoundDetailScreen({
+    required this.creatorPubkey,
+    this.sourceVideo,
+    super.key,
+  });
+
+  /// The pubkey of the video creator.
+  final String creatorPubkey;
+
+  /// The source video, if available (passed via route extra).
+  final VideoEvent? sourceVideo;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final creatorProfile = ref
+        .watch(userProfileReactiveProvider(creatorPubkey))
+        .value;
+    final creatorName =
+        creatorProfile?.bestDisplayName ??
+        sourceVideo?.authorName ??
+        UserProfile.generatedNameFor(creatorPubkey);
+
+    Log.info(
+      'Showing original sound detail for creator: $creatorPubkey',
+      name: 'OriginalSoundDetailScreen',
+      category: LogCategory.ui,
+    );
+
+    return Scaffold(
+      backgroundColor: VineTheme.backgroundColor,
+      appBar: DiVineAppBar(
+        title: 'Sound',
+        showBackButton: true,
+        onBackPressed: context.pop,
+        backgroundColor: VineTheme.cardBackground,
+      ),
+      body: Semantics(
+        identifier: 'original_sound_detail_screen',
+        container: true,
+        child: Column(
+          children: [
+            // Sound header
+            _OriginalSoundHeader(
+              creatorName: creatorName,
+              creatorAvatarUrl: creatorProfile?.picture,
+              videoTitle: sourceVideo?.title,
+              videoThumbnailUrl: sourceVideo?.thumbnailUrl,
+            ),
+
+            const Divider(color: VineTheme.cardBackground, height: 1),
+
+            // Info section
+            Expanded(
+              child: Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(32),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.music_off_outlined,
+                        size: 64,
+                        color: VineTheme.lightText.withValues(alpha: 0.5),
+                      ),
+                      const SizedBox(height: 16),
+                      const Text(
+                        'Original sound',
+                        style: TextStyle(
+                          color: VineTheme.whiteText,
+                          fontSize: 18,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      const Text(
+                        'Audio from this video is not available '
+                        'separately.',
+                        style: TextStyle(
+                          color: VineTheme.onSurfaceMuted,
+                          fontSize: 14,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Header section for original sound detail.
+class _OriginalSoundHeader extends StatelessWidget {
+  const _OriginalSoundHeader({
+    required this.creatorName,
+    this.creatorAvatarUrl,
+    this.videoTitle,
+    this.videoThumbnailUrl,
+  });
+
+  final String creatorName;
+  final String? creatorAvatarUrl;
+  final String? videoTitle;
+  final String? videoThumbnailUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      color: VineTheme.cardBackground,
+      child: Row(
+        children: [
+          // Sound icon with thumbnail or placeholder
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              color: VineTheme.vineGreen.withValues(alpha: 0.2),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            clipBehavior: Clip.antiAlias,
+            child: videoThumbnailUrl != null
+                ? VineCachedImage(
+                    imageUrl: videoThumbnailUrl!,
+                    errorWidget: (_, _, _) => const Icon(
+                      Icons.music_note,
+                      color: VineTheme.vineGreen,
+                      size: 28,
+                    ),
+                  )
+                : const Icon(
+                    Icons.music_note,
+                    color: VineTheme.vineGreen,
+                    size: 28,
+                  ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              spacing: 4,
+              children: [
+                Text(
+                  'Original sound - $creatorName',
+                  style: const TextStyle(
+                    color: VineTheme.whiteText,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (videoTitle != null && videoTitle!.isNotEmpty)
+                  Text(
+                    videoTitle!,
+                    style: const TextStyle(
+                      color: VineTheme.secondaryText,
+                      fontSize: 14,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -42,10 +42,19 @@ class SoundDetailScreen extends ConsumerStatefulWidget {
   /// Creates a SoundDetailScreen.
   ///
   /// [sound] is the audio event to display.
-  const SoundDetailScreen({required this.sound, super.key});
+  /// [sourceVideo] is optional — provided for original sounds to show
+  /// the video this sound came from.
+  const SoundDetailScreen({
+    required this.sound,
+    this.sourceVideo,
+    super.key,
+  });
 
   /// The audio event to display details for.
   final AudioEvent sound;
+
+  /// The source video for original sounds (when [AudioEvent.isOriginalSound]).
+  final VideoEvent? sourceVideo;
 
   @override
   ConsumerState<SoundDetailScreen> createState() => _SoundDetailScreenState();
@@ -248,19 +257,21 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
                 const Divider(color: VineTheme.cardBackground, height: 1),
 
                 // Videos section header
-                const Padding(
-                  padding: EdgeInsets.all(16),
+                Padding(
+                  padding: const EdgeInsets.all(16),
                   child: Row(
                     children: [
-                      Icon(
+                      const Icon(
                         Icons.videocam,
                         color: VineTheme.vineGreen,
                         size: 20,
                       ),
-                      SizedBox(width: 8),
+                      const SizedBox(width: 8),
                       Text(
-                        'Videos using this sound',
-                        style: TextStyle(
+                        widget.sound.isOriginalSound
+                            ? 'Source video'
+                            : 'Videos using this sound',
+                        style: const TextStyle(
                           color: VineTheme.whiteText,
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
@@ -270,12 +281,19 @@ class _SoundDetailScreenState extends ConsumerState<SoundDetailScreen> {
                   ),
                 ),
 
-                // Videos grid
+                // Videos grid — for original sounds, show the source video
+                // directly instead of querying by audio event ID
                 Expanded(
-                  child: _VideosGrid(
-                    audioEventId: widget.sound.id,
-                    onVideoTap: _navigateToVideo,
-                  ),
+                  child:
+                      widget.sound.isOriginalSound && widget.sourceVideo != null
+                      ? _SourceVideoGrid(
+                          video: widget.sourceVideo!,
+                          onVideoTap: _navigateToVideo,
+                        )
+                      : _VideosGrid(
+                          audioEventId: widget.sound.id,
+                          onVideoTap: _navigateToVideo,
+                        ),
                 ),
               ],
             ),
@@ -552,6 +570,43 @@ class _AttributionInfo extends StatelessWidget {
           ],
         ],
       ),
+    );
+  }
+}
+
+/// Grid showing the single source video for an original sound.
+class _SourceVideoGrid extends StatelessWidget {
+  const _SourceVideoGrid({required this.video, required this.onVideoTap});
+
+  final VideoEvent video;
+  final void Function(String videoId, int index, List<VideoEvent> videos)
+  onVideoTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final videosList = [video];
+    return CustomScrollView(
+      slivers: [
+        SliverPadding(
+          padding: const EdgeInsets.all(2),
+          sliver: SliverGrid(
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 3,
+              crossAxisSpacing: 2,
+              mainAxisSpacing: 2,
+            ),
+            delegate: SliverChildBuilderDelegate(
+              (context, index) {
+                return _VideoGridTile(
+                  video: video,
+                  onTap: () => onVideoTap(video.id, 0, videosList),
+                );
+              },
+              childCount: 1,
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
+++ b/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Audio attribution row widget for displaying sound info on video feed.
-// ABOUTME: Shows sound name and creator with tap navigation to SoundDetailScreen.
+// ABOUTME: Audio attribution row shown on every video in the feed.
+// ABOUTME: Navigates to SoundDetailScreen (shared audio) or OriginalSoundDetailScreen.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -8,22 +8,22 @@ import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/models/audio_event.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/original_sound_detail_screen.dart';
 import 'package:openvine/screens/sound_detail_screen.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/unified_logger.dart';
 
-/// A tappable row showing audio attribution when a video uses external audio.
+/// A tappable row showing audio attribution on every video.
 ///
-/// Displays the sound name and creator info in the format:
-/// "♪ Sound name · creator"
-///
-/// Tapping navigates to [SoundDetailScreen] for that audio.
-/// Shows nothing if the video has no audio reference or if audio is unavailable.
+/// Two modes:
+/// - **Explicit audio**: When [VideoEvent.hasAudioReference] is true, fetches
+///   the Kind 1063 audio event and displays "♪ Sound name · creator".
+///   Tapping navigates to [SoundDetailScreen].
+/// - **Original sound**: When no audio reference exists, displays
+///   "♪ Original sound - @creator" using the video author's profile.
+///   Tapping navigates to [SoundDetailScreen] in view-only mode.
 class AudioAttributionRow extends ConsumerWidget {
   /// Creates an AudioAttributionRow.
-  ///
-  /// [video] must have a non-null [VideoEvent.audioEventId] for this widget
-  /// to display anything.
   const AudioAttributionRow({required this.video, super.key});
 
   /// The video event to display audio attribution for.
@@ -31,12 +31,24 @@ class AudioAttributionRow extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Only show if video has an audio reference
-    if (!video.hasAudioReference || video.audioEventId == null) {
-      return const SizedBox.shrink();
+    // If video has an explicit audio reference, show the fetched audio info
+    if (video.hasAudioReference && video.audioEventId != null) {
+      return _ExplicitAudioAttribution(video: video);
     }
 
-    // Watch the audio event asynchronously
+    // Otherwise show "Original sound - @creator"
+    return _OriginalSoundAttribution(video: video);
+  }
+}
+
+/// Displays attribution for a video with an explicit Kind 1063 audio reference.
+class _ExplicitAudioAttribution extends ConsumerWidget {
+  const _ExplicitAudioAttribution({required this.video});
+
+  final VideoEvent video;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
     final audioAsync = ref.watch(soundByIdProvider(video.audioEventId!));
 
     return audioAsync.when(
@@ -48,7 +60,8 @@ class AudioAttributionRow extends ConsumerWidget {
             name: 'AudioAttributionRow',
             category: LogCategory.ui,
           );
-          return const SizedBox.shrink();
+          // Fall back to original sound display
+          return _OriginalSoundAttribution(video: video);
         }
 
         return _AudioAttributionContent(audio: audio);
@@ -60,13 +73,87 @@ class AudioAttributionRow extends ConsumerWidget {
           name: 'AudioAttributionRow',
           category: LogCategory.ui,
         );
-        return const SizedBox.shrink();
+        // Fall back to original sound display on error
+        return _OriginalSoundAttribution(video: video);
       },
     );
   }
 }
 
-/// The actual content showing audio attribution.
+/// Displays "Original sound - @creator" for videos without explicit audio.
+class _OriginalSoundAttribution extends ConsumerWidget {
+  const _OriginalSoundAttribution({required this.video});
+
+  final VideoEvent video;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final creatorProfile = ref
+        .watch(userProfileReactiveProvider(video.pubkey))
+        .value;
+    final creatorName =
+        creatorProfile?.bestDisplayName ??
+        video.authorName ??
+        UserProfile.generatedNameFor(video.pubkey);
+
+    return GestureDetector(
+      onTap: () => _navigateToOriginalSound(context),
+      child: Semantics(
+        identifier: 'audio_attribution_row_original',
+        button: true,
+        label:
+            'Original sound by $creatorName. '
+            'Tap to view sound details.',
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: VineTheme.backgroundColor.withValues(alpha: 0.3),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                Icons.music_note,
+                size: 14,
+                color: VineTheme.vineGreen,
+              ),
+              const SizedBox(width: 4),
+              Flexible(
+                child: Text(
+                  'Original sound - $creatorName',
+                  style: const TextStyle(
+                    color: VineTheme.whiteText,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500,
+                    shadows: [Shadow(blurRadius: 4)],
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _navigateToOriginalSound(BuildContext context) {
+    Log.info(
+      'Navigating to original sound for video: ${video.id}',
+      name: 'AudioAttributionRow',
+      category: LogCategory.ui,
+    );
+
+    context.pushWithVideoPause(
+      OriginalSoundDetailScreen.pathForPubkey(video.pubkey),
+      extra: video,
+    );
+  }
+}
+
+/// The actual content showing audio attribution for an explicit audio event.
 class _AudioAttributionContent extends ConsumerWidget {
   const _AudioAttributionContent({required this.audio});
 
@@ -149,8 +236,6 @@ class _AudioAttributionContent extends ConsumerWidget {
       extra: audio,
     );
   }
-
-  /// Format pubkey for display (short version with ellipsis in middle).
 }
 
 /// Skeleton loading state for audio attribution.

--- a/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
+++ b/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
@@ -8,7 +8,6 @@ import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/models/audio_event.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
-import 'package:openvine/screens/original_sound_detail_screen.dart';
 import 'package:openvine/screens/sound_detail_screen.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/unified_logger.dart';
@@ -96,59 +95,40 @@ class _OriginalSoundAttribution extends ConsumerWidget {
         video.authorName ??
         UserProfile.generatedNameFor(video.pubkey);
 
-    return GestureDetector(
-      onTap: () => _navigateToOriginalSound(context),
-      child: Semantics(
-        identifier: 'audio_attribution_row_original',
-        button: true,
-        label:
-            'Original sound by $creatorName. '
-            'Tap to view sound details.',
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-          decoration: BoxDecoration(
-            color: VineTheme.backgroundColor.withValues(alpha: 0.3),
-            borderRadius: BorderRadius.circular(4),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.music_note,
-                size: 14,
-                color: VineTheme.vineGreen,
-              ),
-              const SizedBox(width: 4),
-              Flexible(
-                child: Text(
-                  'Original sound - $creatorName',
-                  style: const TextStyle(
-                    color: VineTheme.whiteText,
-                    fontSize: 12,
-                    fontWeight: FontWeight.w500,
-                    shadows: [Shadow(blurRadius: 4)],
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+    return Semantics(
+      identifier: 'audio_attribution_row_original',
+      label: 'Original sound by $creatorName.',
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: VineTheme.backgroundColor.withValues(alpha: 0.3),
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.music_note,
+              size: 14,
+              color: VineTheme.vineGreen,
+            ),
+            const SizedBox(width: 4),
+            Flexible(
+              child: Text(
+                'Original sound - $creatorName',
+                style: const TextStyle(
+                  color: VineTheme.whiteText,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                  shadows: [Shadow(blurRadius: 4)],
                 ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
-    );
-  }
-
-  void _navigateToOriginalSound(BuildContext context) {
-    Log.info(
-      'Navigating to original sound for video: ${video.id}',
-      name: 'AudioAttributionRow',
-      category: LogCategory.ui,
-    );
-
-    context.pushWithVideoPause(
-      OriginalSoundDetailScreen.pathForPubkey(video.pubkey),
-      extra: video,
     );
   }
 }

--- a/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
+++ b/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Audio attribution row shown on every video in the feed.
-// ABOUTME: Navigates to SoundDetailScreen (shared audio) or OriginalSoundDetailScreen.
+// ABOUTME: Audio attribution row widget for displaying sound info on video feed.
+// ABOUTME: Shows sound name and creator with tap navigation to SoundDetailScreen.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -12,17 +12,18 @@ import 'package:openvine/screens/sound_detail_screen.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/unified_logger.dart';
 
-/// A tappable row showing audio attribution on every video.
+/// A tappable row showing audio attribution when a video uses external audio.
 ///
-/// Two modes:
-/// - **Explicit audio**: When [VideoEvent.hasAudioReference] is true, fetches
-///   the Kind 1063 audio event and displays "♪ Sound name · creator".
-///   Tapping navigates to [SoundDetailScreen].
-/// - **Original sound**: When no audio reference exists, displays
-///   "♪ Original sound - @creator" using the video author's profile.
-///   Tapping navigates to [SoundDetailScreen] in view-only mode.
+/// Displays the sound name and creator info in the format:
+/// "♪ Sound name · creator"
+///
+/// Tapping navigates to [SoundDetailScreen] for that audio.
+/// Shows nothing if the video has no audio reference or if audio is unavailable.
 class AudioAttributionRow extends ConsumerWidget {
   /// Creates an AudioAttributionRow.
+  ///
+  /// [video] must have a non-null [VideoEvent.audioEventId] for this widget
+  /// to display anything.
   const AudioAttributionRow({required this.video, super.key});
 
   /// The video event to display audio attribution for.
@@ -30,24 +31,12 @@ class AudioAttributionRow extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // If video has an explicit audio reference, show the fetched audio info
-    if (video.hasAudioReference && video.audioEventId != null) {
-      return _ExplicitAudioAttribution(video: video);
+    // Only show if video has an audio reference
+    if (!video.hasAudioReference || video.audioEventId == null) {
+      return const SizedBox.shrink();
     }
 
-    // Otherwise show "Original sound - @creator"
-    return _OriginalSoundAttribution(video: video);
-  }
-}
-
-/// Displays attribution for a video with an explicit Kind 1063 audio reference.
-class _ExplicitAudioAttribution extends ConsumerWidget {
-  const _ExplicitAudioAttribution({required this.video});
-
-  final VideoEvent video;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
+    // Watch the audio event asynchronously
     final audioAsync = ref.watch(soundByIdProvider(video.audioEventId!));
 
     return audioAsync.when(
@@ -59,8 +48,7 @@ class _ExplicitAudioAttribution extends ConsumerWidget {
             name: 'AudioAttributionRow',
             category: LogCategory.ui,
           );
-          // Fall back to original sound display
-          return _OriginalSoundAttribution(video: video);
+          return const SizedBox.shrink();
         }
 
         return _AudioAttributionContent(audio: audio);
@@ -72,68 +60,13 @@ class _ExplicitAudioAttribution extends ConsumerWidget {
           name: 'AudioAttributionRow',
           category: LogCategory.ui,
         );
-        // Fall back to original sound display on error
-        return _OriginalSoundAttribution(video: video);
+        return const SizedBox.shrink();
       },
     );
   }
 }
 
-/// Displays "Original sound - @creator" for videos without explicit audio.
-class _OriginalSoundAttribution extends ConsumerWidget {
-  const _OriginalSoundAttribution({required this.video});
-
-  final VideoEvent video;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final creatorProfile = ref
-        .watch(userProfileReactiveProvider(video.pubkey))
-        .value;
-    final creatorName =
-        creatorProfile?.bestDisplayName ??
-        video.authorName ??
-        UserProfile.generatedNameFor(video.pubkey);
-
-    return Semantics(
-      identifier: 'audio_attribution_row_original',
-      label: 'Original sound by $creatorName.',
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-        decoration: BoxDecoration(
-          color: VineTheme.backgroundColor.withValues(alpha: 0.3),
-          borderRadius: BorderRadius.circular(4),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(
-              Icons.music_note,
-              size: 14,
-              color: VineTheme.vineGreen,
-            ),
-            const SizedBox(width: 4),
-            Flexible(
-              child: Text(
-                'Original sound - $creatorName',
-                style: const TextStyle(
-                  color: VineTheme.whiteText,
-                  fontSize: 12,
-                  fontWeight: FontWeight.w500,
-                  shadows: [Shadow(blurRadius: 4)],
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-/// The actual content showing audio attribution for an explicit audio event.
+/// The actual content showing audio attribution.
 class _AudioAttributionContent extends ConsumerWidget {
   const _AudioAttributionContent({required this.audio});
 

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -160,7 +160,10 @@ class _OriginalSoundSection extends ConsumerWidget {
       if (!hostContext.mounted) return;
       hostContext.pushWithVideoPause(
         SoundDetailScreen.pathForId(syntheticAudio.id),
-        extra: syntheticAudio,
+        extra: <String, dynamic>{
+          'sound': syntheticAudio,
+          'sourceVideo': video,
+        },
       );
     });
   }

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -75,6 +75,10 @@ class _SharedAudioSection extends ConsumerWidget {
 }
 
 /// Section showing "Original sound - @creator" for videos without shared audio.
+///
+/// Tapping creates a synthetic [AudioEvent] from the video's audio track
+/// and navigates to [SoundDetailScreen] where the user can preview and
+/// select the sound for recording.
 class _OriginalSoundSection extends ConsumerWidget {
   const _OriginalSoundSection({required this.video});
 
@@ -92,37 +96,73 @@ class _OriginalSoundSection extends ConsumerWidget {
 
     return MetadataSection(
       label: 'Sounds',
-      child: Row(
-        spacing: 16,
-        children: [
-          const DivineIcon(
-            icon: DivineIconName.waveform,
-            color: VineTheme.onSurfaceVariant,
-          ),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Original sound',
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: VineTheme.titleMediumFont(),
+      child: Semantics(
+        button: true,
+        label: 'Original sound by $creatorName. Tap to use this sound.',
+        child: GestureDetector(
+          onTap: () => _navigateToSoundDetail(context, creatorName),
+          child: Row(
+            spacing: 16,
+            children: [
+              const DivineIcon(
+                icon: DivineIconName.waveform,
+                color: VineTheme.onSurfaceVariant,
+              ),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Original sound',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: VineTheme.titleMediumFont(),
+                    ),
+                    Text(
+                      creatorName,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: VineTheme.bodyMediumFont(
+                        color: VineTheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
                 ),
-                Text(
-                  creatorName,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: VineTheme.bodyMediumFont(
-                    color: VineTheme.onSurfaceVariant,
-                  ),
-                ),
-              ],
-            ),
+              ),
+              const Icon(
+                Icons.chevron_right,
+                color: VineTheme.onSurfaceVariant,
+                size: 20,
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
+  }
+
+  void _navigateToSoundDetail(BuildContext context, String creatorName) {
+    Log.info(
+      'Navigating to original sound detail for video: ${video.id}',
+      name: 'MetadataSoundsSection',
+      category: LogCategory.ui,
+    );
+
+    final syntheticAudio = AudioEvent.fromVideoOriginalSound(
+      video,
+      creatorName: creatorName,
+    );
+
+    // Dismiss the sheet first, then navigate from the root navigator context.
+    final hostContext = Navigator.of(context, rootNavigator: true).context;
+    Navigator.of(context).pop();
+    Future<void>.delayed(Duration.zero).then((_) {
+      if (!hostContext.mounted) return;
+      hostContext.pushWithVideoPause(
+        SoundDetailScreen.pathForId(syntheticAudio.id),
+        extra: syntheticAudio,
+      );
+    });
   }
 }
 

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Sounds section for the metadata expanded sheet.
-// ABOUTME: Shows audio cover art, title, and artist in a list-item layout.
+// ABOUTME: Shows audio info for all videos - shared audio or "Original sound".
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -13,12 +13,13 @@ import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_section.dart';
 
-/// Sounds section showing audio attribution with cover art.
+/// Sounds section showing audio attribution in the metadata sheet.
 ///
-/// Returns [SizedBox.shrink] when the video has no audio reference.
-///
-/// Layout matches Figma node `I11251:226991;9071:175984`: a list item
-/// with 40px rounded album cover, title, and artist subtitle.
+/// Two modes:
+/// - **Shared audio**: Video has a Kind 1063 audio event — shows sound name,
+///   artist, and tapping navigates to [SoundDetailScreen].
+/// - **Original sound**: No audio event — shows "Original sound - @creator"
+///   as display-only info.
 class MetadataSoundsSection extends ConsumerWidget {
   const MetadataSoundsSection({required this.video, super.key});
 
@@ -26,15 +27,32 @@ class MetadataSoundsSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (!video.hasAudioReference || video.audioEventId == null) {
-      return const SizedBox.shrink();
+    // If video has an explicit audio reference, show the fetched audio info
+    if (video.hasAudioReference && video.audioEventId != null) {
+      return _SharedAudioSection(video: video);
     }
 
+    // Otherwise show "Original sound - @creator"
+    return _OriginalSoundSection(video: video);
+  }
+}
+
+/// Section for videos with an explicit Kind 1063 audio reference.
+class _SharedAudioSection extends ConsumerWidget {
+  const _SharedAudioSection({required this.video});
+
+  final VideoEvent video;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
     final audioAsync = ref.watch(soundByIdProvider(video.audioEventId!));
 
     return audioAsync.when(
       data: (audio) {
-        if (audio == null) return const SizedBox.shrink();
+        if (audio == null) {
+          // Audio event not found, fall back to original sound display
+          return _OriginalSoundSection(video: video);
+        }
         return MetadataSection(
           label: 'Sounds',
           child: _SoundListItem(audio: audio),
@@ -50,13 +68,66 @@ class MetadataSoundsSection extends ConsumerWidget {
           name: 'MetadataSoundsSection',
           category: LogCategory.ui,
         );
-        return const SizedBox.shrink();
+        return _OriginalSoundSection(video: video);
       },
     );
   }
 }
 
+/// Section showing "Original sound - @creator" for videos without shared audio.
+class _OriginalSoundSection extends ConsumerWidget {
+  const _OriginalSoundSection({required this.video});
+
+  final VideoEvent video;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final creatorProfile = ref
+        .watch(userProfileReactiveProvider(video.pubkey))
+        .value;
+    final creatorName =
+        creatorProfile?.bestDisplayName ??
+        video.authorName ??
+        UserProfile.generatedNameFor(video.pubkey);
+
+    return MetadataSection(
+      label: 'Sounds',
+      child: Row(
+        spacing: 16,
+        children: [
+          const DivineIcon(
+            icon: DivineIconName.waveform,
+            color: VineTheme.onSurfaceVariant,
+          ),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Original sound',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: VineTheme.titleMediumFont(),
+                ),
+                Text(
+                  creatorName,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: VineTheme.bodyMediumFont(
+                    color: VineTheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 /// A list item showing audio cover, title, and artist name.
+/// Tapping navigates to the [SoundDetailScreen].
 class _SoundListItem extends ConsumerWidget {
   const _SoundListItem({required this.audio});
 
@@ -111,6 +182,11 @@ class _SoundListItem extends ConsumerWidget {
                 ],
               ),
             ),
+            const Icon(
+              Icons.chevron_right,
+              color: VineTheme.onSurfaceVariant,
+              size: 20,
+            ),
           ],
         ),
       ),
@@ -125,12 +201,8 @@ class _SoundListItem extends ConsumerWidget {
     );
 
     // Dismiss the sheet first, then navigate from the root navigator context.
-    // GoRouter extensions can throw when called from inside a modal bottom
-    // sheet (the router is not in the modal's widget tree).
     final hostContext = Navigator.of(context, rootNavigator: true).context;
     Navigator.of(context).pop();
-    // Defer navigation to the next microtask so the pop animation
-    // completes and the modal route is fully removed before pushing.
     Future<void>.delayed(Duration.zero).then((_) {
       if (!hostContext.mounted) return;
       hostContext.pushWithVideoPause(SoundDetailScreen.pathForId(audio.id));

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -1680,11 +1680,9 @@ class VideoOverlayActions extends ConsumerWidget {
                           isActive: isActive,
                         ),
                       ],
-                      // Audio attribution row (if video uses external audio)
-                      if (video.hasAudioReference) ...[
-                        const SizedBox(height: 4),
-                        AudioAttributionRow(video: video),
-                      ],
+                      // Audio attribution row (shown on all videos)
+                      const SizedBox(height: 4),
+                      AudioAttributionRow(video: video),
                       const SizedBox(
                         height: 8,
                       ), // Bottom spacing only when description exists
@@ -2190,10 +2188,7 @@ class _ContentWarningDetailsSheet extends StatelessWidget {
                   size: 22,
                 ),
                 const SizedBox(width: 8),
-                Text(
-                  'Content Warnings',
-                  style: VineTheme.titleMediumFont(),
-                ),
+                Text('Content Warnings', style: VineTheme.titleMediumFont()),
               ],
             ),
             const SizedBox(height: 4),

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -1680,9 +1680,11 @@ class VideoOverlayActions extends ConsumerWidget {
                           isActive: isActive,
                         ),
                       ],
-                      // Audio attribution row (shown on all videos)
-                      const SizedBox(height: 4),
-                      AudioAttributionRow(video: video),
+                      // Audio attribution row (only for videos with shared audio)
+                      if (video.hasAudioReference) ...[
+                        const SizedBox(height: 4),
+                        AudioAttributionRow(video: video),
+                      ],
                       const SizedBox(
                         height: 8,
                       ), // Bottom spacing only when description exists

--- a/mobile/test/models/video_editor_state_test.dart
+++ b/mobile/test/models/video_editor_state_test.dart
@@ -14,7 +14,7 @@ void main() {
 
       expect(state.isProcessing, isFalse);
       expect(state.isSavingDraft, isFalse);
-      expect(state.allowAudioReuse, isFalse);
+      expect(state.allowAudioReuse, isTrue);
       expect(state.title, isEmpty);
       expect(state.description, isEmpty);
       expect(state.tags, isEmpty);
@@ -54,7 +54,6 @@ void main() {
       final state = VideoEditorProviderState(
         isProcessing: true,
         isSavingDraft: true,
-        allowAudioReuse: true,
         title: 'Test Title',
         description: 'Test Description',
         tags: const {'tag1', 'tag2'},

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -48,8 +48,8 @@ void main() {
         );
         expect(
           state.allowAudioReuse,
-          false,
-          reason: 'allowAudioReuse should default to false',
+          true,
+          reason: 'allowAudioReuse should default to true',
         );
         expect(state.title, isEmpty, reason: 'title should default to empty');
         expect(
@@ -632,7 +632,6 @@ void main() {
       final original = VideoEditorProviderState(
         isProcessing: true,
         isSavingDraft: true,
-        allowAudioReuse: true,
         title: 'Test',
         description: 'Desc',
         tags: const {'tag1'},

--- a/mobile/test/screens/original_sound_detail_screen_test.dart
+++ b/mobile/test/screens/original_sound_detail_screen_test.dart
@@ -1,0 +1,176 @@
+// ABOUTME: Tests for OriginalSoundDetailScreen - view-only sound detail
+// ABOUTME: for videos without shared audio events.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/screens/original_sound_detail_screen.dart';
+
+void main() {
+  group(OriginalSoundDetailScreen, () {
+    const testPubkey =
+        'pubkey123456789abcdef0123456789abcdef0123456789abcdef0123456789ab';
+    const testVideoId =
+        'video0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab';
+
+    VideoEvent createTestVideo({String? authorName}) {
+      final now = DateTime.now();
+      return VideoEvent(
+        id: testVideoId,
+        pubkey: testPubkey,
+        content: 'Test video',
+        videoUrl: 'https://example.com/video.mp4',
+        createdAt: now.millisecondsSinceEpoch ~/ 1000,
+        timestamp: now,
+        title: 'Cat Video',
+        authorName: authorName,
+        thumbnailUrl: 'https://example.com/thumb.jpg',
+      );
+    }
+
+    Widget buildTestWidget({
+      String pubkey = testPubkey,
+      VideoEvent? sourceVideo,
+    }) {
+      return ProviderScope(
+        child: MaterialApp(
+          theme: VineTheme.theme,
+          home: OriginalSoundDetailScreen(
+            creatorPubkey: pubkey,
+            sourceVideo: sourceVideo,
+          ),
+        ),
+      );
+    }
+
+    group('Header', () {
+      testWidgets('shows "Original sound" with creator name', (tester) async {
+        final video = createTestVideo(authorName: 'Jake Lara');
+
+        await tester.pumpWidget(buildTestWidget(sourceVideo: video));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.textContaining('Original sound - Jake Lara'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('shows video title when available', (tester) async {
+        final video = createTestVideo(authorName: 'Jake Lara');
+
+        await tester.pumpWidget(buildTestWidget(sourceVideo: video));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Cat Video'), findsOneWidget);
+      });
+
+      testWidgets('shows generated name when no author name', (tester) async {
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        // Should show some form of display name (generated from pubkey)
+        // Both header and body contain "Original sound" text
+        expect(
+          find.textContaining('Original sound'),
+          findsAtLeastNWidgets(1),
+        );
+      });
+    });
+
+    group('Content', () {
+      testWidgets('does not show Use Sound button', (tester) async {
+        final video = createTestVideo(authorName: 'Jake Lara');
+
+        await tester.pumpWidget(buildTestWidget(sourceVideo: video));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Use Sound'), findsNothing);
+      });
+
+      testWidgets('does not show Preview button', (tester) async {
+        final video = createTestVideo(authorName: 'Jake Lara');
+
+        await tester.pumpWidget(buildTestWidget(sourceVideo: video));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Preview'), findsNothing);
+      });
+
+      testWidgets('shows info message about audio not shared', (tester) async {
+        final video = createTestVideo(authorName: 'Jake Lara');
+
+        await tester.pumpWidget(buildTestWidget(sourceVideo: video));
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('not available separately'), findsOneWidget);
+      });
+
+      testWidgets('shows music_off icon', (tester) async {
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.music_off_outlined), findsOneWidget);
+      });
+    });
+
+    group('App bar', () {
+      testWidgets('shows Sound title', (tester) async {
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('Sound'), findsOneWidget);
+      });
+
+      testWidgets('renders DiVineAppBar', (tester) async {
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byType(DiVineAppBar), findsOneWidget);
+      });
+    });
+
+    group('Accessibility', () {
+      testWidgets('has correct semantics identifier', (tester) async {
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        final semantics = tester.widget<Semantics>(
+          find
+              .descendant(
+                of: find.byType(OriginalSoundDetailScreen),
+                matching: find.byWidgetPredicate(
+                  (w) =>
+                      w is Semantics &&
+                      w.properties.identifier == 'original_sound_detail_screen',
+                ),
+              )
+              .first,
+        );
+
+        expect(
+          semantics.properties.identifier,
+          equals('original_sound_detail_screen'),
+        );
+      });
+    });
+
+    group('Route helpers', () {
+      test('pathForPubkey generates correct path', () {
+        expect(
+          OriginalSoundDetailScreen.pathForPubkey(testPubkey),
+          equals('/original-sound/$testPubkey'),
+        );
+      });
+
+      test('path constant matches expected pattern', () {
+        expect(
+          OriginalSoundDetailScreen.path,
+          equals('/original-sound/:pubkey'),
+        );
+      });
+    });
+  });
+}

--- a/mobile/test/widgets/audio_attribution_row_test.dart
+++ b/mobile/test/widgets/audio_attribution_row_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Tests for AudioAttributionRow widget - displays sound attribution on videos.
-// ABOUTME: Verifies dark theme colors, tap navigation, loading states, and graceful errors.
+// ABOUTME: Tests for AudioAttributionRow widget - displays sound attribution
+// ABOUTME: on videos. Tests both explicit audio and original sound modes.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -11,7 +11,7 @@ import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/widgets/video_feed_item/audio_attribution_row.dart';
 
 void main() {
-  group('AudioAttributionRow', () {
+  group(AudioAttributionRow, () {
     // Full 64-character Nostr IDs as required by CLAUDE.md
     const testAudioEventId =
         'audio0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab';
@@ -48,7 +48,7 @@ void main() {
       );
     }
 
-    VideoEvent createVideoWithoutAudio() {
+    VideoEvent createVideoWithoutAudio({String? authorName}) {
       final now = DateTime.now();
       return VideoEvent(
         id: testVideoId,
@@ -58,6 +58,7 @@ void main() {
         createdAt: now.millisecondsSinceEpoch ~/ 1000,
         timestamp: now,
         title: 'Test Video',
+        authorName: authorName,
       );
     }
 
@@ -82,49 +83,7 @@ void main() {
       );
     }
 
-    group('Visibility', () {
-      testWidgets('shows nothing when video has no audio reference', (
-        tester,
-      ) async {
-        final video = createVideoWithoutAudio();
-
-        await tester.pumpWidget(buildTestWidget(video: video));
-        await tester.pumpAndSettle();
-
-        // Should render nothing (SizedBox.shrink)
-        expect(find.byType(AudioAttributionRow), findsOneWidget);
-        expect(find.byIcon(Icons.music_note), findsNothing);
-        expect(find.textContaining('sound'), findsNothing);
-      });
-
-      testWidgets('shows nothing when audio event is null', (tester) async {
-        final video = createVideoWithAudio();
-
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              soundByIdProvider(testAudioEventId).overrideWith((ref) async {
-                return null;
-              }),
-            ],
-            child: MaterialApp(
-              theme: VineTheme.theme,
-              home: Scaffold(
-                backgroundColor: Colors.black,
-                body: AudioAttributionRow(video: video),
-              ),
-            ),
-          ),
-        );
-
-        await tester.pumpAndSettle();
-
-        // Should hide when audio not found
-        expect(find.byIcon(Icons.music_note), findsNothing);
-      });
-    });
-
-    group('Content display', () {
+    group('Explicit audio reference', () {
       testWidgets('displays music note icon with vineGreen color', (
         tester,
       ) async {
@@ -189,20 +148,125 @@ void main() {
         );
         expect(text.style?.color, equals(Colors.white));
       });
+
+      testWidgets('falls back to original sound when audio event is null', (
+        tester,
+      ) async {
+        final video = createVideoWithAudio();
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              soundByIdProvider(testAudioEventId).overrideWith((ref) async {
+                return null;
+              }),
+            ],
+            child: MaterialApp(
+              theme: VineTheme.theme,
+              home: Scaffold(
+                backgroundColor: Colors.black,
+                body: AudioAttributionRow(video: video),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Should fall back to original sound display
+        expect(find.byIcon(Icons.music_note), findsOneWidget);
+        expect(find.textContaining('Original sound'), findsOneWidget);
+      });
+    });
+
+    group('Original sound (no audio reference)', () {
+      testWidgets('shows music note icon', (tester) async {
+        final video = createVideoWithoutAudio();
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.music_note), findsOneWidget);
+      });
+
+      testWidgets('renders "Original sound" text', (tester) async {
+        final video = createVideoWithoutAudio();
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('Original sound'), findsOneWidget);
+      });
+
+      testWidgets('shows author name when available', (tester) async {
+        final video = createVideoWithoutAudio(authorName: 'Jake Lara');
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.textContaining('Original sound - Jake Lara'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('does not show chevron right icon', (tester) async {
+        final video = createVideoWithoutAudio();
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        // Original sound row has no chevron (simpler display)
+        expect(find.byIcon(Icons.chevron_right), findsNothing);
+      });
+
+      testWidgets('has correct semantics identifier', (tester) async {
+        final video = createVideoWithoutAudio();
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        final semantics = tester.widget<Semantics>(
+          find
+              .descendant(
+                of: find.byType(AudioAttributionRow),
+                matching: find.byType(Semantics),
+              )
+              .first,
+        );
+
+        expect(
+          semantics.properties.identifier,
+          equals('audio_attribution_row_original'),
+        );
+      });
+
+      testWidgets('is marked as button for tap interaction', (tester) async {
+        final video = createVideoWithoutAudio();
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        final semantics = tester.widget<Semantics>(
+          find
+              .descendant(
+                of: find.byType(AudioAttributionRow),
+                matching: find.byType(Semantics),
+              )
+              .first,
+        );
+
+        expect(semantics.properties.button, isTrue);
+      });
     });
 
     group('Loading state', () {
       testWidgets('shows skeleton during loading', (tester) async {
         final video = createVideoWithAudio();
 
-        // Use a Completer to control when the Future resolves
-        // This avoids timer issues in tests
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
-              // Override with a provider that stays in loading state
-              // by returning a Future that resolves immediately but
-              // we check the skeleton before pumpAndSettle
               soundByIdProvider(testAudioEventId).overrideWith((ref) async {
                 return testAudio;
               }),
@@ -230,7 +294,9 @@ void main() {
     });
 
     group('Accessibility', () {
-      testWidgets('has correct semantics identifier', (tester) async {
+      testWidgets('explicit audio has correct semantics identifier', (
+        tester,
+      ) async {
         final video = createVideoWithAudio();
 
         await tester.pumpWidget(buildTestWidget(video: video));
@@ -251,7 +317,9 @@ void main() {
         );
       });
 
-      testWidgets('has semantic label with sound info', (tester) async {
+      testWidgets('explicit audio has semantic label with sound info', (
+        tester,
+      ) async {
         final video = createVideoWithAudio();
 
         await tester.pumpWidget(buildTestWidget(video: video));
@@ -272,7 +340,7 @@ void main() {
         );
       });
 
-      testWidgets('is marked as button for tap interaction', (tester) async {
+      testWidgets('explicit audio is marked as button', (tester) async {
         final video = createVideoWithAudio();
 
         await tester.pumpWidget(buildTestWidget(video: video));
@@ -312,14 +380,8 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(
-          find.textContaining('Oh No No No Crowd'),
-          findsOneWidget,
-        );
-        expect(
-          find.textContaining('ThePauny via Freesound'),
-          findsOneWidget,
-        );
+        expect(find.textContaining('Oh No No No Crowd'), findsOneWidget);
+        expect(find.textContaining('ThePauny via Freesound'), findsOneWidget);
       });
 
       testWidgets('does not try to fetch profile for bundled sounds', (

--- a/mobile/test/widgets/audio_attribution_row_test.dart
+++ b/mobile/test/widgets/audio_attribution_row_test.dart
@@ -241,7 +241,7 @@ void main() {
         );
       });
 
-      testWidgets('is marked as button for tap interaction', (tester) async {
+      testWidgets('is not marked as button (display only)', (tester) async {
         final video = createVideoWithoutAudio();
 
         await tester.pumpWidget(buildTestWidget(video: video));
@@ -256,7 +256,7 @@ void main() {
               .first,
         );
 
-        expect(semantics.properties.button, isTrue);
+        expect(semantics.properties.button, isNull);
       });
     });
 

--- a/mobile/test/widgets/audio_attribution_row_test.dart
+++ b/mobile/test/widgets/audio_attribution_row_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Tests for AudioAttributionRow widget - displays sound attribution
-// ABOUTME: on videos. Tests both explicit audio and original sound modes.
+// ABOUTME: Tests for AudioAttributionRow widget - displays sound attribution on videos.
+// ABOUTME: Verifies dark theme colors, tap navigation, loading states, and graceful errors.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -11,7 +11,7 @@ import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/widgets/video_feed_item/audio_attribution_row.dart';
 
 void main() {
-  group(AudioAttributionRow, () {
+  group('AudioAttributionRow', () {
     // Full 64-character Nostr IDs as required by CLAUDE.md
     const testAudioEventId =
         'audio0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab';
@@ -48,7 +48,7 @@ void main() {
       );
     }
 
-    VideoEvent createVideoWithoutAudio({String? authorName}) {
+    VideoEvent createVideoWithoutAudio() {
       final now = DateTime.now();
       return VideoEvent(
         id: testVideoId,
@@ -58,7 +58,6 @@ void main() {
         createdAt: now.millisecondsSinceEpoch ~/ 1000,
         timestamp: now,
         title: 'Test Video',
-        authorName: authorName,
       );
     }
 
@@ -83,7 +82,49 @@ void main() {
       );
     }
 
-    group('Explicit audio reference', () {
+    group('Visibility', () {
+      testWidgets('shows nothing when video has no audio reference', (
+        tester,
+      ) async {
+        final video = createVideoWithoutAudio();
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        // Should render nothing (SizedBox.shrink)
+        expect(find.byType(AudioAttributionRow), findsOneWidget);
+        expect(find.byIcon(Icons.music_note), findsNothing);
+        expect(find.textContaining('sound'), findsNothing);
+      });
+
+      testWidgets('shows nothing when audio event is null', (tester) async {
+        final video = createVideoWithAudio();
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              soundByIdProvider(testAudioEventId).overrideWith((ref) async {
+                return null;
+              }),
+            ],
+            child: MaterialApp(
+              theme: VineTheme.theme,
+              home: Scaffold(
+                backgroundColor: Colors.black,
+                body: AudioAttributionRow(video: video),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Should hide when audio not found
+        expect(find.byIcon(Icons.music_note), findsNothing);
+      });
+    });
+
+    group('Content display', () {
       testWidgets('displays music note icon with vineGreen color', (
         tester,
       ) async {
@@ -148,125 +189,20 @@ void main() {
         );
         expect(text.style?.color, equals(Colors.white));
       });
-
-      testWidgets('falls back to original sound when audio event is null', (
-        tester,
-      ) async {
-        final video = createVideoWithAudio();
-
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              soundByIdProvider(testAudioEventId).overrideWith((ref) async {
-                return null;
-              }),
-            ],
-            child: MaterialApp(
-              theme: VineTheme.theme,
-              home: Scaffold(
-                backgroundColor: Colors.black,
-                body: AudioAttributionRow(video: video),
-              ),
-            ),
-          ),
-        );
-
-        await tester.pumpAndSettle();
-
-        // Should fall back to original sound display
-        expect(find.byIcon(Icons.music_note), findsOneWidget);
-        expect(find.textContaining('Original sound'), findsOneWidget);
-      });
-    });
-
-    group('Original sound (no audio reference)', () {
-      testWidgets('shows music note icon', (tester) async {
-        final video = createVideoWithoutAudio();
-
-        await tester.pumpWidget(buildTestWidget(video: video));
-        await tester.pumpAndSettle();
-
-        expect(find.byIcon(Icons.music_note), findsOneWidget);
-      });
-
-      testWidgets('renders "Original sound" text', (tester) async {
-        final video = createVideoWithoutAudio();
-
-        await tester.pumpWidget(buildTestWidget(video: video));
-        await tester.pumpAndSettle();
-
-        expect(find.textContaining('Original sound'), findsOneWidget);
-      });
-
-      testWidgets('shows author name when available', (tester) async {
-        final video = createVideoWithoutAudio(authorName: 'Jake Lara');
-
-        await tester.pumpWidget(buildTestWidget(video: video));
-        await tester.pumpAndSettle();
-
-        expect(
-          find.textContaining('Original sound - Jake Lara'),
-          findsOneWidget,
-        );
-      });
-
-      testWidgets('does not show chevron right icon', (tester) async {
-        final video = createVideoWithoutAudio();
-
-        await tester.pumpWidget(buildTestWidget(video: video));
-        await tester.pumpAndSettle();
-
-        // Original sound row has no chevron (simpler display)
-        expect(find.byIcon(Icons.chevron_right), findsNothing);
-      });
-
-      testWidgets('has correct semantics identifier', (tester) async {
-        final video = createVideoWithoutAudio();
-
-        await tester.pumpWidget(buildTestWidget(video: video));
-        await tester.pumpAndSettle();
-
-        final semantics = tester.widget<Semantics>(
-          find
-              .descendant(
-                of: find.byType(AudioAttributionRow),
-                matching: find.byType(Semantics),
-              )
-              .first,
-        );
-
-        expect(
-          semantics.properties.identifier,
-          equals('audio_attribution_row_original'),
-        );
-      });
-
-      testWidgets('is not marked as button (display only)', (tester) async {
-        final video = createVideoWithoutAudio();
-
-        await tester.pumpWidget(buildTestWidget(video: video));
-        await tester.pumpAndSettle();
-
-        final semantics = tester.widget<Semantics>(
-          find
-              .descendant(
-                of: find.byType(AudioAttributionRow),
-                matching: find.byType(Semantics),
-              )
-              .first,
-        );
-
-        expect(semantics.properties.button, isNull);
-      });
     });
 
     group('Loading state', () {
       testWidgets('shows skeleton during loading', (tester) async {
         final video = createVideoWithAudio();
 
+        // Use a Completer to control when the Future resolves
+        // This avoids timer issues in tests
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              // Override with a provider that stays in loading state
+              // by returning a Future that resolves immediately but
+              // we check the skeleton before pumpAndSettle
               soundByIdProvider(testAudioEventId).overrideWith((ref) async {
                 return testAudio;
               }),
@@ -294,9 +230,7 @@ void main() {
     });
 
     group('Accessibility', () {
-      testWidgets('explicit audio has correct semantics identifier', (
-        tester,
-      ) async {
+      testWidgets('has correct semantics identifier', (tester) async {
         final video = createVideoWithAudio();
 
         await tester.pumpWidget(buildTestWidget(video: video));
@@ -317,9 +251,7 @@ void main() {
         );
       });
 
-      testWidgets('explicit audio has semantic label with sound info', (
-        tester,
-      ) async {
+      testWidgets('has semantic label with sound info', (tester) async {
         final video = createVideoWithAudio();
 
         await tester.pumpWidget(buildTestWidget(video: video));
@@ -340,7 +272,7 @@ void main() {
         );
       });
 
-      testWidgets('explicit audio is marked as button', (tester) async {
+      testWidgets('is marked as button for tap interaction', (tester) async {
         final video = createVideoWithAudio();
 
         await tester.pumpWidget(buildTestWidget(video: video));
@@ -380,8 +312,14 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.textContaining('Oh No No No Crowd'), findsOneWidget);
-        expect(find.textContaining('ThePauny via Freesound'), findsOneWidget);
+        expect(
+          find.textContaining('Oh No No No Crowd'),
+          findsOneWidget,
+        );
+        expect(
+          find.textContaining('ThePauny via Freesound'),
+          findsOneWidget,
+        );
       });
 
       testWidgets('does not try to fetch profile for bundled sounds', (

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -1,0 +1,183 @@
+// ABOUTME: Tests for MetadataSoundsSection - audio info in metadata sheet.
+// ABOUTME: Tests both shared audio and original sound display modes.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/models/audio_event.dart';
+import 'package:openvine/providers/sounds_providers.dart';
+import 'package:openvine/widgets/video_feed_item/metadata/metadata_sounds_section.dart';
+
+void main() {
+  group(MetadataSoundsSection, () {
+    const testAudioEventId =
+        'audio0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab';
+    const testPubkey =
+        'pubkey123456789abcdef0123456789abcdef0123456789abcdef0123456789ab';
+    const testVideoId =
+        'video0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab';
+
+    late AudioEvent testAudio;
+
+    setUp(() {
+      testAudio = const AudioEvent(
+        id: testAudioEventId,
+        pubkey: testPubkey,
+        createdAt: 1704067200,
+        title: 'Cool Beat',
+        duration: 6.2,
+        url: 'https://blossom.example/audio.aac',
+        mimeType: 'audio/aac',
+      );
+    });
+
+    VideoEvent createVideoWithAudio() {
+      final now = DateTime.now();
+      return VideoEvent(
+        id: testVideoId,
+        pubkey: testPubkey,
+        content: 'Test video with audio',
+        videoUrl: 'https://example.com/video.mp4',
+        createdAt: now.millisecondsSinceEpoch ~/ 1000,
+        timestamp: now,
+        title: 'Test Video',
+        audioEventId: testAudioEventId,
+      );
+    }
+
+    VideoEvent createVideoWithoutAudio({String? authorName}) {
+      final now = DateTime.now();
+      return VideoEvent(
+        id: testVideoId,
+        pubkey: testPubkey,
+        content: 'Test video without audio',
+        videoUrl: 'https://example.com/video.mp4',
+        createdAt: now.millisecondsSinceEpoch ~/ 1000,
+        timestamp: now,
+        title: 'Test Video',
+        authorName: authorName,
+      );
+    }
+
+    Widget buildTestWidget({
+      required VideoEvent video,
+      AudioEvent? audioOverride,
+    }) {
+      return ProviderScope(
+        overrides: [
+          soundByIdProvider(testAudioEventId).overrideWith((ref) async {
+            return audioOverride ?? testAudio;
+          }),
+        ],
+        child: MaterialApp(
+          theme: VineTheme.theme,
+          home: Scaffold(
+            backgroundColor: Colors.black,
+            body: MetadataSoundsSection(video: video),
+          ),
+        ),
+      );
+    }
+
+    group('Shared audio', () {
+      testWidgets('shows sound title for video with audio reference', (
+        tester,
+      ) async {
+        final video = createVideoWithAudio();
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Cool Beat'), findsOneWidget);
+      });
+
+      testWidgets('shows Sounds label', (tester) async {
+        final video = createVideoWithAudio();
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Sounds'), findsOneWidget);
+      });
+
+      testWidgets('shows chevron for tappable shared audio', (tester) async {
+        final video = createVideoWithAudio();
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+      });
+    });
+
+    group('Original sound', () {
+      testWidgets('shows "Original sound" for video without audio reference', (
+        tester,
+      ) async {
+        final video = createVideoWithoutAudio();
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Original sound'), findsOneWidget);
+      });
+
+      testWidgets('shows Sounds label', (tester) async {
+        final video = createVideoWithoutAudio();
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Sounds'), findsOneWidget);
+      });
+
+      testWidgets('shows author name when available', (tester) async {
+        final video = createVideoWithoutAudio(authorName: 'Jake Lara');
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Jake Lara'), findsOneWidget);
+      });
+
+      testWidgets('does not show chevron (not tappable)', (tester) async {
+        final video = createVideoWithoutAudio();
+
+        await tester.pumpWidget(buildTestWidget(video: video));
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.chevron_right), findsNothing);
+      });
+
+      testWidgets('falls back to original sound when audio event is null', (
+        tester,
+      ) async {
+        final video = createVideoWithAudio();
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              soundByIdProvider(testAudioEventId).overrideWith((ref) async {
+                return null;
+              }),
+            ],
+            child: MaterialApp(
+              theme: VineTheme.theme,
+              home: Scaffold(
+                backgroundColor: Colors.black,
+                body: MetadataSoundsSection(video: video),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Should fall back to original sound
+        expect(find.text('Original sound'), findsOneWidget);
+      });
+    });
+  });
+}

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -142,13 +142,13 @@ void main() {
         expect(find.text('Jake Lara'), findsOneWidget);
       });
 
-      testWidgets('does not show chevron (not tappable)', (tester) async {
+      testWidgets('shows chevron (tappable to use sound)', (tester) async {
         final video = createVideoWithoutAudio();
 
         await tester.pumpWidget(buildTestWidget(video: video));
         await tester.pumpAndSettle();
 
-        expect(find.byIcon(Icons.chevron_right), findsNothing);
+        expect(find.byIcon(Icons.chevron_right), findsOneWidget);
       });
 
       testWidgets('falls back to original sound when audio event is null', (

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -590,14 +590,16 @@ void main() {
       expect(find.text('Test Sound'), findsOneWidget);
     });
 
-    testWidgets('hides when no audio reference', (tester) async {
+    testWidgets('shows original sound when no audio reference', (tester) async {
       final video = _makeVideo();
 
       await tester.pumpWidget(
         buildSubject(child: MetadataSoundsSection(video: video)),
       );
+      await tester.pumpAndSettle();
 
-      expect(find.text('Sounds'), findsNothing);
+      expect(find.text('Sounds'), findsOneWidget);
+      expect(find.text('Original sound'), findsOneWidget);
     });
   });
 
@@ -731,7 +733,14 @@ void main() {
       expect(find.text('Collaborators'), findsNothing);
       expect(find.text('Inspired by'), findsNothing);
       expect(find.text('Reposted by'), findsNothing);
-      expect(find.text('Sounds'), findsNothing);
+
+      // Sounds section is always present (shows "Original sound")
+      // Scroll down to find it
+      final listFinder = find.byType(ListView);
+      await tester.drag(listFinder, const Offset(0, -300));
+      await tester.pumpAndSettle();
+      expect(find.text('Sounds'), findsOneWidget);
+      expect(find.text('Original sound'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Closes #2957

Partially addresses #2938

## Summary

- Add original-sound handling in the sound metadata flow for videos without a shared Kind 1063 audio event
- Enable audio extraction and publishing by default for all new videos (`allowAudioReuse` now defaults to `true`)
- Add `OriginalSoundDetailScreen` and synthetic original-sound support in sound detail routing

## Changes

**Metadata / sound detail flow:**
- `MetadataSoundsSection` now shows a `Sounds` section for videos without shared audio
- Original-sound taps create a synthetic `AudioEvent` from the source video and route into sound detail with source video context
- `SoundDetailScreen` can now render original-sound context and show the source video
- `OriginalSoundDetailScreen` and route helpers were added for view-only original-sound presentation

**Audio reuse enabled by default:**
- `allowAudioReuse` defaults to `true` in `VideoEditorProviderState`, `VideoEditorMeta`, and `DivineVideoDraft`
- New videos will extract audio, upload to Blossom, and publish Kind 1063 events unless the creator opts out

## Out of Scope / Follow-up

- The main feed overlay still only shows audio attribution for videos with shared audio
- Showing `♪ Original sound - @creator` directly in the feed on videos without shared audio is tracked as follow-up work

## Test plan

- [x] Widget tests for `OriginalSoundDetailScreen`
- [x] Widget tests for `MetadataSoundsSection`
- [x] Existing video editor/provider/sound detail tests updated for the default flip
- [ ] Manual: verify original-sound behavior in the metadata sheet
- [ ] Manual: verify tapping shared sound still navigates to `SoundDetailScreen`
- [ ] Manual: publish a new video and verify Kind 1063 audio event is created
