### PR TITLE
fix(dm): restore reliable DM delivery outside inbox and Divine-only relay fallback

### DIFF
--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -3,8 +3,6 @@
 // ABOUTME: updates, marking conversations as read, and splitting conversations
 // ABOUTME: into normal inbox vs message requests based on follow state.
 
-import 'dart:async';
-
 import 'package:bloc/bloc.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
@@ -59,9 +57,9 @@ class ConversationListBloc
     ConversationListStarted event,
     Emitter<ConversationListState> emit,
   ) async {
-    // Start the DM relay subscription when the inbox opens (#2766).
-    // The subscription is lazy — it only runs while this BLoC is alive.
-    unawaited(_dmRepository.startListening());
+    // The gift-wrap subscription is started by `dmRepositoryProvider` for
+    // the whole authenticated session — this BLoC just consumes the
+    // already-running stream via the DAO. See #2931.
 
     // Only show the loading spinner and reset limit on first load.
     if (state.status == ConversationListStatus.initial) {
@@ -195,8 +193,8 @@ class ConversationListBloc
 
   @override
   Future<void> close() {
-    // Stop the DM relay subscription when the inbox is closed (#2766).
-    _dmRepository.stopListening();
+    // The gift-wrap subscription is owned by `dmRepositoryProvider` for the
+    // whole authenticated session — do NOT stop it here. See #2931.
     return super.close();
   }
 }

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -2059,9 +2059,16 @@ BugReportService bugReportService(Ref ref) {
 /// and sending encrypted direct messages. Works with any [NostrSigner]
 /// (local keys, Keycast RPC, Amber, etc.).
 ///
-/// Sets auth credentials eagerly so read/send operations work immediately.
-/// The relay subscription is NOT started here — it is driven by the inbox
-/// UI lifecycle via [ConversationListBloc] (#2766).
+/// Sets auth credentials eagerly so read/send operations work immediately,
+/// then starts the gift-wrap subscription so DMs are ingested for the whole
+/// authenticated session — not just while [InboxPage] is mounted (#2931).
+///
+/// Cold-start cost is bounded by two existing mechanisms that landed with
+/// the original lazy-inbox work (#2766):
+/// - The `since: newestSyncedAt - 2d` filter in [DmRepository.startListening]
+///   limits the relay backlog to recent events on every open after the first.
+/// - Decryption is offloaded to a background isolate via
+///   `dm_decryption_worker.dart`, keeping the UI thread responsive.
 ///
 /// Uses `keepAlive: true` because the repository must survive transient
 /// dependency rebuilds (e.g. `isNostrReadyProvider` polling,
@@ -2084,18 +2091,15 @@ DmRepository dmRepository(Ref ref) {
 
   ref.onDispose(repository.stopListening);
 
-  // Set credentials when the signer's public key is available.
-  // This does NOT start the relay subscription — that is lazy (#2766).
+  // Set credentials and open the gift-wrap subscription as soon as the
+  // signer is ready. The subscription is auth-session-scoped (not inbox-
+  // scoped) so DMs are ingested even when the user never visits /inbox.
+  // See docs/plans/2026-04-05-dm-scaling-fix-design.md and #2931.
   if (ref.watch(isNostrReadyProvider)) {
     final publicKey = nostrService.publicKey;
     if (publicKey.isNotEmpty) {
       final signer = nostrService.signer;
 
-      // initialize() wires credentials only — it does NOT open the
-      // gift-wrap subscription. The inbox screen (InboxPage) starts the
-      // subscription via startListening() on mount and tears it down on
-      // dispose so cold start does no DM network/decrypt work.
-      // See docs/plans/2026-04-05-dm-scaling-fix-design.md.
       repository.setCredentials(
         userPubkey: publicKey,
         signer: signer,
@@ -2105,6 +2109,11 @@ DmRepository dmRepository(Ref ref) {
           nostrService: nostrService,
         ),
       );
+
+      // Open the gift-wrap subscription for the whole authenticated
+      // session. Bounded by `since: newestSyncedAt - 2d` and isolate
+      // decrypt so cold start stays cheap regardless of lifetime DM count.
+      unawaited(repository.startListening());
     }
   }
 

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -4459,9 +4459,16 @@ String _$bugReportServiceHash() => r'a243bf5fae16e223b148a829b14f9857af1c4592';
 /// and sending encrypted direct messages. Works with any [NostrSigner]
 /// (local keys, Keycast RPC, Amber, etc.).
 ///
-/// Sets auth credentials eagerly so read/send operations work immediately.
-/// The relay subscription is NOT started here — it is driven by the inbox
-/// UI lifecycle via [ConversationListBloc] (#2766).
+/// Sets auth credentials eagerly so read/send operations work immediately,
+/// then starts the gift-wrap subscription so DMs are ingested for the whole
+/// authenticated session — not just while [InboxPage] is mounted (#2931).
+///
+/// Cold-start cost is bounded by two existing mechanisms that landed with
+/// the original lazy-inbox work (#2766):
+/// - The `since: newestSyncedAt - 2d` filter in [DmRepository.startListening]
+///   limits the relay backlog to recent events on every open after the first.
+/// - Decryption is offloaded to a background isolate via
+///   `dm_decryption_worker.dart`, keeping the UI thread responsive.
 ///
 /// Uses `keepAlive: true` because the repository must survive transient
 /// dependency rebuilds (e.g. `isNostrReadyProvider` polling,
@@ -4479,9 +4486,16 @@ const dmRepositoryProvider = DmRepositoryProvider._();
 /// and sending encrypted direct messages. Works with any [NostrSigner]
 /// (local keys, Keycast RPC, Amber, etc.).
 ///
-/// Sets auth credentials eagerly so read/send operations work immediately.
-/// The relay subscription is NOT started here — it is driven by the inbox
-/// UI lifecycle via [ConversationListBloc] (#2766).
+/// Sets auth credentials eagerly so read/send operations work immediately,
+/// then starts the gift-wrap subscription so DMs are ingested for the whole
+/// authenticated session — not just while [InboxPage] is mounted (#2931).
+///
+/// Cold-start cost is bounded by two existing mechanisms that landed with
+/// the original lazy-inbox work (#2766):
+/// - The `since: newestSyncedAt - 2d` filter in [DmRepository.startListening]
+///   limits the relay backlog to recent events on every open after the first.
+/// - Decryption is offloaded to a background isolate via
+///   `dm_decryption_worker.dart`, keeping the UI thread responsive.
 ///
 /// Uses `keepAlive: true` because the repository must survive transient
 /// dependency rebuilds (e.g. `isNostrReadyProvider` polling,
@@ -4499,9 +4513,16 @@ final class DmRepositoryProvider
   /// and sending encrypted direct messages. Works with any [NostrSigner]
   /// (local keys, Keycast RPC, Amber, etc.).
   ///
-  /// Sets auth credentials eagerly so read/send operations work immediately.
-  /// The relay subscription is NOT started here — it is driven by the inbox
-  /// UI lifecycle via [ConversationListBloc] (#2766).
+  /// Sets auth credentials eagerly so read/send operations work immediately,
+  /// then starts the gift-wrap subscription so DMs are ingested for the whole
+  /// authenticated session — not just while [InboxPage] is mounted (#2931).
+  ///
+  /// Cold-start cost is bounded by two existing mechanisms that landed with
+  /// the original lazy-inbox work (#2766):
+  /// - The `since: newestSyncedAt - 2d` filter in [DmRepository.startListening]
+  ///   limits the relay backlog to recent events on every open after the first.
+  /// - Decryption is offloaded to a background isolate via
+  ///   `dm_decryption_worker.dart`, keeping the UI thread responsive.
   ///
   /// Uses `keepAlive: true` because the repository must survive transient
   /// dependency rebuilds (e.g. `isNostrReadyProvider` polling,
@@ -4542,7 +4563,7 @@ final class DmRepositoryProvider
   }
 }
 
-String _$dmRepositoryHash() => r'30503db56d4371ec8d639cebcaf711fa372966bd';
+String _$dmRepositoryHash() => r'a2fa1b080fa8ff0db62cc19074de841115603487';
 
 /// Provider for CommentsRepository instance
 ///

--- a/mobile/lib/repositories/dm_repository.dart
+++ b/mobile/lib/repositories/dm_repository.dart
@@ -123,10 +123,15 @@ class DmRepository {
 
   /// Set auth credentials on the repository.
   ///
-  /// Called by the provider when the user's keys become available. Read
-  /// methods work before this; send requires it. The relay subscription
-  /// is NOT started here — callers (the inbox screen) are responsible for
-  /// invoking [startListening] when they need live gift-wrap delivery.
+  /// Called by `dmRepositoryProvider` when the user's keys become
+  /// available. Read methods work before this; send requires it.
+  ///
+  /// This wires credentials only — the gift-wrap subscription is opened
+  /// separately by the provider via [startListening] right after this
+  /// returns, so DM ingestion runs for the whole authenticated session.
+  /// Cold-start cost stays bounded thanks to the count-based windowing
+  /// (`since: newestSyncedAt - 2d`) and the isolate decryption worker.
+  /// See docs/plans/2026-04-05-dm-scaling-fix-design.md and #2931.
   ///
   /// Safe to call multiple times — subsequent calls for the same user are
   /// no-ops. If called with a different user, resets and re-initializes.
@@ -153,10 +158,6 @@ class DmRepository {
     _messageService = messageService;
     if (rumorDecryptor != null) _rumorDecryptor = rumorDecryptor;
     if (nip04Decryptor != null) _nip04Decryptor = nip04Decryptor;
-    // Subscription is started by the inbox screen via startListening().
-    // Do NOT start it here — doing so would replay the full gift-wrap
-    // backlog onto the UI isolate at app launch and scale linearly with
-    // lifetime DM count. See docs/plans/2026-04-05-dm-scaling-fix-design.md.
 
     // Run post-auth maintenance sequentially so each step operates on the
     // final state of the previous one (e.g. backfill runs after merge).
@@ -278,10 +279,10 @@ class DmRepository {
       },
     );
 
-    // No poll timer: the live subscription is the sole event source while
-    // the inbox is open. Poller was removed because it re-fetched duplicate
-    // events every 10s forever on the UI isolate. See
-    // docs/plans/2026-04-05-dm-scaling-fix-design.md.
+    // No poll timer: the live WebSocket subscription is the sole event
+    // source for the entire authenticated session. Poller was removed
+    // because it re-fetched duplicate events every 10s forever on the UI
+    // isolate. See docs/plans/2026-04-05-dm-scaling-fix-design.md and #2931.
   }
 
   /// Fetches an older page of DM events (gift wraps, NIP-04, deletions)
@@ -326,8 +327,9 @@ class DmRepository {
   Future<void> stopListening() async {
     // Don't set _disposed = true here — _disposed is reserved for
     // _resetState() (user switch). Setting it would make a subsequent
-    // startListening() call a silent no-op, breaking re-open flows like
-    // "user leaves the inbox tab and comes back later".
+    // startListening() call a silent no-op, breaking re-open flows such
+    // as the post-signOut cleanup in UserDataCleanupService that may be
+    // followed by a fresh sign-in on the same repository instance.
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
     _eventLock = null;

--- a/mobile/lib/screens/inbox/inbox_page.dart
+++ b/mobile/lib/screens/inbox/inbox_page.dart
@@ -1,10 +1,8 @@
 // ABOUTME: Inbox page that provides BLoC dependencies for the inbox view.
-// ABOUTME: Sets up ConversationListBloc, DmUnreadCountCubit,
-// ABOUTME: MyFollowingBloc from Riverpod providers, and drives the
-// ABOUTME: DmRepository gift-wrap subscription lifecycle — the
-// ABOUTME: subscription is only open while the inbox is visible.
-
-import 'dart:async';
+// ABOUTME: Sets up ConversationListBloc, DmUnreadCountCubit, and
+// ABOUTME: MyFollowingBloc from Riverpod providers. The DmRepository
+// ABOUTME: gift-wrap subscription is auth-session-scoped via
+// ABOUTME: dmRepositoryProvider, not driven by this screen's lifecycle.
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -17,17 +15,15 @@ import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
-import 'package:openvine/repositories/dm_repository.dart';
 import 'package:openvine/screens/inbox/inbox_view.dart';
 
 /// Inbox page (DM conversation list + notifications).
 ///
 /// Provides [ConversationListBloc], [DmUnreadCountCubit], and
-/// [MyFollowingBloc] to the widget tree. Drives the [DmRepository]
-/// gift-wrap subscription lifecycle so DM processing only runs while
-/// the inbox is on screen — see
-/// docs/plans/2026-04-05-dm-scaling-fix-design.md.
-class InboxPage extends ConsumerStatefulWidget {
+/// [MyFollowingBloc] to the widget tree. The gift-wrap subscription that
+/// powers DM ingestion is owned by `dmRepositoryProvider` for the entire
+/// authenticated session — this screen does NOT start or stop it (#2931).
+class InboxPage extends ConsumerWidget {
   const InboxPage({super.key});
 
   /// Route name for this screen.
@@ -37,32 +33,8 @@ class InboxPage extends ConsumerStatefulWidget {
   static const path = '/inbox';
 
   @override
-  ConsumerState<InboxPage> createState() => _InboxPageState();
-}
-
-class _InboxPageState extends ConsumerState<InboxPage> {
-  late final DmRepository _dmRepository;
-
-  @override
-  void initState() {
-    super.initState();
-    _dmRepository = ref.read(dmRepositoryProvider);
-    // Open the gift-wrap subscription only while the inbox is visible.
-    // This keeps cold start and background time off the DM decrypt path.
-    _dmRepository.startListening();
-  }
-
-  @override
-  void dispose() {
-    // Tear down the subscription when the inbox closes so the main
-    // isolate stops processing gift wraps in the background.
-    unawaited(_dmRepository.stopListening());
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final dmRepository = _dmRepository;
+  Widget build(BuildContext context, WidgetRef ref) {
+    final dmRepository = ref.watch(dmRepositoryProvider);
     final followRepository = ref.watch(followRepositoryProvider);
     final blocklistService = ref.watch(contentBlocklistServiceProvider);
     final prefs = ref.watch(sharedPreferencesProvider);
@@ -90,9 +62,7 @@ class _InboxPageState extends ConsumerState<InboxPage> {
               contentBlocklistService: blocklistService,
             )..add(const MyFollowingListLoadRequested()),
           ),
-          BlocProvider(
-            create: (_) => ConversationMuteCubit(prefs: prefs),
-          ),
+          BlocProvider(create: (_) => ConversationMuteCubit(prefs: prefs)),
           BlocProvider(
             create: (_) => ConversationActionsCubit(
               contentReportingService: reportingService,

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -3758,13 +3758,12 @@ class AuthService implements BackgroundAwareService {
   /// surfaced to embedded Nostr apps via the bridge. The fallback set is a
   /// reachability mechanism, not a relay list the user has chosen. See #2931.
   void _connectToFallbackRelays() {
-    for (final url in IndexerRelayConfig.safeFallbackRelays) {
-      Log.info(
-        '  - $url (fallback)',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
+    Log.info(
+      'Fallback relays: '
+      '${IndexerRelayConfig.safeFallbackRelays.join(', ')}',
+      name: 'AuthService',
+      category: LogCategory.auth,
+    );
     _onUserRelaysDiscovered?.call(IndexerRelayConfig.safeFallbackRelays);
   }
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -142,6 +142,7 @@ class AuthService implements BackgroundAwareService {
     PreFetchFollowingCallback? preFetchFollowing,
     String? profileCheckIndexerUrl,
     List<String>? indexerRelays,
+    RelayDiscoveryService? relayDiscoveryService,
   }) : _keyStorage = keyStorage ?? SecureKeyStorage(),
        _nostrKeyManager = nostrKeyManager,
        _userDataCleanupService = userDataCleanupService,
@@ -150,9 +151,9 @@ class AuthService implements BackgroundAwareService {
        _pendingVerificationService = pendingVerificationService,
        _preFetchFollowing = preFetchFollowing,
        _profileCheckIndexerUrl = profileCheckIndexerUrl,
-       _relayDiscoveryService = RelayDiscoveryService(
-         indexerRelays: indexerRelays,
-       ),
+       _relayDiscoveryService =
+           relayDiscoveryService ??
+           RelayDiscoveryService(indexerRelays: indexerRelays),
        _oauthConfig =
            oauthConfig ??
            const OAuthConfig(serverUrl: '', clientId: '', redirectUri: '');
@@ -3687,6 +3688,14 @@ class AuthService implements BackgroundAwareService {
   /// Always runs discovery (with 24h cache to avoid redundant indexer queries).
   /// Discovered relays are ADDED to the main client's existing connections,
   /// so user's manual relay edits are preserved (addRelay skips duplicates).
+  ///
+  /// When discovery returns empty or fails (e.g. imported account that
+  /// never published a kind 10002 list), [IndexerRelayConfig.safeFallbackRelays]
+  /// is added to the client's connected pool so DM reachability degrades
+  /// gracefully instead of leaving the client connected only to the Divine
+  /// relay. The fallback set is NOT stored in [userRelays] — that getter
+  /// continues to report only the user's own published relays so embedded
+  /// Nostr apps querying via the bridge see accurate data. See #2931.
   Future<void> _discoverUserRelays(String npub) async {
     try {
       final result = await _relayDiscoveryService.discoverRelays(npub);
@@ -3717,21 +3726,55 @@ class AuthService implements BackgroundAwareService {
         _userRelays = [];
 
         Log.warning(
-          '⚠️ No relay list found for user on any indexer',
+          '⚠️ No relay list found for user on any indexer — '
+          'connecting to safe DM-friendly fallback relay set',
           name: 'AuthService',
           category: LogCategory.auth,
         );
+        _connectToFallbackRelays();
       }
     } catch (e) {
       _userRelays = [];
 
       Log.error(
-        '❌ Relay discovery failed: $e - falling back to Divine relay only',
+        '❌ Relay discovery failed: $e — '
+        'connecting to safe DM-friendly fallback relay set',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+      _connectToFallbackRelays();
+    }
+  }
+
+  /// Notify the NostrService callback to connect the client to
+  /// [IndexerRelayConfig.safeFallbackRelays].
+  ///
+  /// Used when NIP-65 discovery returns empty or fails. Without this, the
+  /// client stays connected only to the Divine relay, which silently
+  /// breaks NIP-17 DM delivery for peers writing on other relays.
+  ///
+  /// Intentionally does NOT mutate [_userRelays]: that field semantically
+  /// represents the user's *own* published relay list (kind 10002) and is
+  /// surfaced to embedded Nostr apps via the bridge. The fallback set is a
+  /// reachability mechanism, not a relay list the user has chosen. See #2931.
+  void _connectToFallbackRelays() {
+    for (final url in IndexerRelayConfig.safeFallbackRelays) {
+      Log.info(
+        '  - $url (fallback)',
         name: 'AuthService',
         category: LogCategory.auth,
       );
     }
+    _onUserRelaysDiscovered?.call(IndexerRelayConfig.safeFallbackRelays);
   }
+
+  /// Test seam exposing the private NIP-65 discovery routine so unit
+  /// tests can drive the fallback path with a mocked discovery service.
+  /// Production callers should not invoke this — discovery runs as part
+  /// of the normal sign-in flow via [_setupUserSession].
+  @visibleForTesting
+  Future<void> debugDiscoverUserRelays(String npub) =>
+      _discoverUserRelays(npub);
 
   /// Check if user has an existing profile (kind 0) on indexer relays.
   ///

--- a/mobile/lib/services/relay_discovery_service.dart
+++ b/mobile/lib/services/relay_discovery_service.dart
@@ -22,6 +22,29 @@ class IndexerRelayConfig {
     // nos-event-service, giving it broad NIP-65 coverage.
     'wss://relay.nos.social',
   ];
+
+  /// Safe fallback relay set for users without a discoverable NIP-65 relay
+  /// list (kind 10002).
+  ///
+  /// Imported accounts that have never published a relay list — or whose
+  /// relay list is hosted on a non-indexed relay — would otherwise stay
+  /// connected only to the Divine relay, which makes NIP-17 DMs invisible
+  /// to peers writing on other relays. This list is added to the user's
+  /// connected pool whenever NIP-65 discovery returns empty or fails, so
+  /// DM reachability degrades gracefully instead of silently breaking.
+  ///
+  /// These are general-purpose public Nostr relays that accept gift wraps
+  /// (kind 1059). The set is intentionally small to bound bandwidth and
+  /// keep first-connect latency reasonable. Users can still override this
+  /// by adding their own relays via Settings → Relays.
+  ///
+  /// See #2931.
+  static const List<String> safeFallbackRelays = [
+    'wss://relay.nos.social',
+    'wss://relay.damus.io',
+    'wss://nos.lol',
+    'wss://relay.primal.net',
+  ];
 }
 
 /// Represents a discovered relay with read/write permissions

--- a/mobile/lib/services/relay_discovery_service.dart
+++ b/mobile/lib/services/relay_discovery_service.dart
@@ -38,6 +38,13 @@ class IndexerRelayConfig {
   /// keep first-connect latency reasonable. Users can still override this
   /// by adding their own relays via Settings → Relays.
   ///
+  /// NOTE: relay.damus.io was removed from [defaultIndexers] because it
+  /// returns 503 sporadically (see comment above). It is acceptable here
+  /// because fallback connections are fire-and-forget — a single relay's
+  /// transient 503 does not block the others, and [RelayPool.add] will
+  /// retry on reconnect. If it proves persistently unreliable, replace it
+  /// with another general-purpose relay that accepts kind 1059.
+  ///
   /// See #2931.
   static const List<String> safeFallbackRelays = [
     'wss://relay.nos.social',

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -1104,10 +1104,10 @@ void main() {
   });
 
   // -------------------------------------------------------------------
-  // Subscription lifecycle (#2766)
+  // Subscription lifecycle (#2931)
   // -------------------------------------------------------------------
 
-  group('subscription lifecycle (#2766)', () {
+  group('subscription lifecycle (#2931)', () {
     late _MockDmRepository mockDmRepository;
     late _MockFollowRepository mockFollowRepository;
 
@@ -1125,7 +1125,7 @@ void main() {
     });
 
     blocTest<ConversationListBloc, ConversationListState>(
-      'calls startListening when $ConversationListStarted is added',
+      'does not call startListening — auth-scoped via dmRepositoryProvider',
       build: () {
         _stubStreams(mockDmRepository);
         return ConversationListBloc(
@@ -1135,11 +1135,16 @@ void main() {
       },
       act: (bloc) => bloc.add(const ConversationListStarted()),
       verify: (_) {
-        verify(() => mockDmRepository.startListening()).called(1);
+        // Regression guard for #2931: the gift-wrap subscription lives
+        // for the whole authenticated session via `dmRepositoryProvider`.
+        // The BLoC must not start it on its own — that would break the
+        // session-wide ingestion contract by creating overlapping
+        // subscription bookkeeping.
+        verifyNever(() => mockDmRepository.startListening());
       },
     );
 
-    test('calls stopListening when BLoC is closed', () async {
+    test('does not call stopListening on close', () async {
       _stubStreams(mockDmRepository);
       final bloc = ConversationListBloc(
         dmRepository: mockDmRepository,
@@ -1148,28 +1153,10 @@ void main() {
 
       await bloc.close();
 
-      verify(() => mockDmRepository.stopListening()).called(1);
+      // Regression guard for #2931: closing the BLoC must NOT stop the
+      // gift-wrap subscription. Doing so would silently break DM ingestion
+      // for users who navigated away from the inbox tab.
+      verifyNever(() => mockDmRepository.stopListening());
     });
-
-    blocTest<ConversationListBloc, ConversationListState>(
-      'startListening is idempotent across multiple Started events',
-      build: () {
-        _stubStreams(mockDmRepository);
-        return ConversationListBloc(
-          dmRepository: mockDmRepository,
-          followRepository: mockFollowRepository,
-        );
-      },
-      act: (bloc) {
-        bloc
-          ..add(const ConversationListStarted())
-          ..add(const ConversationListStarted());
-      },
-      verify: (_) {
-        // startListening is called once per event, but the repository's
-        // internal guard makes it a no-op after the first.
-        verify(() => mockDmRepository.startListening()).called(2);
-      },
-    );
   });
 }

--- a/mobile/test/providers/dm_repository_provider_test.dart
+++ b/mobile/test/providers/dm_repository_provider_test.dart
@@ -1,0 +1,169 @@
+// ABOUTME: Tests that dmRepositoryProvider drives the gift-wrap subscription
+// ABOUTME: lifecycle for the entire authenticated session, not just while
+// ABOUTME: InboxPage is mounted. Regression guard for #2931.
+
+import 'dart:async';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart' as nostr_filter;
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _FakeFilter extends Fake implements nostr_filter.Filter {}
+
+void main() {
+  // 64-character hex pubkey for tests.
+  const testPubkey =
+      'a1b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012';
+  // 64-character hex private key for tests.
+  const testPrivateKey =
+      '0000000000000000000000000000000000000000000000000000000000000001';
+
+  setUpAll(() {
+    registerFallbackValue(<nostr_filter.Filter>[_FakeFilter()]);
+  });
+
+  group('dmRepositoryProvider (#2931)', () {
+    late _MockNostrClient mockNostrClient;
+    late _MockAuthService mockAuthService;
+    late LocalNostrSigner signer;
+    late AppDatabase database;
+    late SharedPreferences prefs;
+
+    setUp(() async {
+      mockNostrClient = _MockNostrClient();
+      mockAuthService = _MockAuthService();
+      signer = LocalNostrSigner(testPrivateKey);
+      database = AppDatabase.test(NativeDatabase.memory());
+
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
+
+      // NostrClient stubs needed by DmRepository.startListening()'s
+      // diagnostic logging and subscription path.
+      when(() => mockNostrClient.connectedRelayCount).thenReturn(1);
+      when(() => mockNostrClient.configuredRelayCount).thenReturn(1);
+      when(() => mockNostrClient.publicKey).thenReturn(testPubkey);
+      when(() => mockNostrClient.signer).thenReturn(signer);
+      when(
+        () => mockNostrClient.subscribe(
+          any(),
+          subscriptionId: any(named: 'subscriptionId'),
+        ),
+      ).thenAnswer((_) => const Stream<Event>.empty());
+      when(
+        () => mockNostrClient.unsubscribe(any()),
+      ).thenAnswer((_) async {});
+
+      // AuthService stubs for auth-state-driven providers.
+      when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkey);
+      when(() => mockAuthService.currentIdentity).thenReturn(null);
+      when(() => mockAuthService.userRelays).thenReturn(const []);
+      when(
+        () => mockAuthService.authStateStream,
+      ).thenAnswer((_) => const Stream<AuthState>.empty());
+    });
+
+    tearDown(() async {
+      await database.close();
+    });
+
+    ProviderContainer createContainer({required bool isReady}) {
+      return ProviderContainer(
+        overrides: [
+          nostrServiceProvider.overrideWithValue(mockNostrClient),
+          authServiceProvider.overrideWithValue(mockAuthService),
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+          isNostrReadyProvider.overrideWithValue(isReady),
+          databaseProvider.overrideWithValue(database),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+        ],
+      );
+    }
+
+    test(
+      'opens gift-wrap subscription when isNostrReady is true',
+      () async {
+        // ARRANGE
+        final container = createContainer(isReady: true);
+        addTearDown(container.dispose);
+
+        // ACT — touching the provider triggers the build
+        final repository = container.read(dmRepositoryProvider);
+
+        // The provider calls startListening() asynchronously via unawaited(),
+        // so let microtasks drain before asserting.
+        await Future<void>.delayed(Duration.zero);
+
+        // ASSERT — the gift-wrap subscription was opened on the relay
+        // client. This is the proof that the auth-scoped lifecycle is
+        // active and DMs will be ingested even without InboxPage mounting.
+        verify(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).called(1);
+        expect(repository.isInitialized, isTrue);
+        expect(repository.userPubkey, equals(testPubkey));
+      },
+    );
+
+    test(
+      'does NOT open subscription when isNostrReady is false',
+      () async {
+        // ARRANGE — pre-auth or initialization-pending state
+        final container = createContainer(isReady: false);
+        addTearDown(container.dispose);
+
+        // ACT
+        final repository = container.read(dmRepositoryProvider);
+        await Future<void>.delayed(Duration.zero);
+
+        // ASSERT — the repository exists for read-only operations but no
+        // relay traffic is generated until isNostrReady flips true.
+        verifyNever(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        );
+        expect(repository.isInitialized, isFalse);
+      },
+    );
+
+    test(
+      'tears down subscription on container dispose',
+      () async {
+        // ARRANGE
+        final container = createContainer(isReady: true);
+        container.read(dmRepositoryProvider);
+        await Future<void>.delayed(Duration.zero);
+
+        // ACT — disposing the container fires ref.onDispose hooks, which
+        // include repository.stopListening.
+        container.dispose();
+        await Future<void>.delayed(Duration.zero);
+
+        // ASSERT — unsubscribe was called on the relay client.
+        verify(() => mockNostrClient.unsubscribe(any())).called(1);
+      },
+    );
+  });
+}

--- a/mobile/test/screens/inbox/inbox_page_test.dart
+++ b/mobile/test/screens/inbox/inbox_page_test.dart
@@ -121,7 +121,7 @@ void main() {
 
     group('dm subscription lifecycle', () {
       testWidgets(
-        'calls startListening on mount and stopListening on dispose',
+        'does not start or stop the subscription — auth-scoped (#2931)',
         (tester) async {
           await tester.pumpWidget(
             testMaterialApp(
@@ -148,14 +148,19 @@ void main() {
           );
           await tester.pump();
 
-          verify(() => mockDmRepository.startListening()).called(1);
+          // Regression guard for #2931: the gift-wrap subscription is owned
+          // by `dmRepositoryProvider` for the entire authenticated session,
+          // not by this screen. Mounting and unmounting the inbox must NOT
+          // touch the subscription lifecycle, otherwise users who never
+          // open the inbox would never receive DMs.
+          verifyNever(() => mockDmRepository.startListening());
           verifyNever(() => mockDmRepository.stopListening());
 
-          // Replace the InboxPage with an empty widget to trigger dispose.
           await tester.pumpWidget(const SizedBox.shrink());
           await tester.pump();
 
-          verify(() => mockDmRepository.stopListening()).called(1);
+          verifyNever(() => mockDmRepository.startListening());
+          verifyNever(() => mockDmRepository.stopListening());
         },
       );
     });

--- a/mobile/test/services/auth_service_relay_fallback_test.dart
+++ b/mobile/test/services/auth_service_relay_fallback_test.dart
@@ -1,0 +1,163 @@
+// ABOUTME: Tests that AuthService applies the safe fallback relay set
+// ABOUTME: when NIP-65 relay discovery returns empty or fails, so DM
+// ABOUTME: reachability degrades gracefully for imported accounts. #2931.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/relay_discovery_service.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../test_setup.dart';
+
+class _MockUserDataCleanupService extends Mock
+    implements UserDataCleanupService {}
+
+/// Test double for [RelayDiscoveryService] that lets each test scenario
+/// control the discovery outcome (success / empty / throw) without hitting
+/// real WebSockets.
+class _ControllableRelayDiscoveryService extends RelayDiscoveryService {
+  _ControllableRelayDiscoveryService({required this.outcome})
+    : super(indexerRelays: const ['wss://test.invalid']);
+
+  final RelayDiscoveryResult Function() outcome;
+
+  @override
+  Future<RelayDiscoveryResult> discoverRelays(String npub) async {
+    return outcome();
+  }
+}
+
+void main() {
+  setupTestEnvironment();
+
+  // 64-character hex npub for tests; the value isn't validated by
+  // the test double, only passed through.
+  const testNpub =
+      'npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsutm2dy';
+
+  group('AuthService relay fallback (#2931)', () {
+    late _MockUserDataCleanupService mockCleanupService;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      mockCleanupService = _MockUserDataCleanupService();
+    });
+
+    AuthService buildAuthService(_ControllableRelayDiscoveryService discovery) {
+      return AuthService(
+        userDataCleanupService: mockCleanupService,
+        relayDiscoveryService: discovery,
+      );
+    }
+
+    test(
+      'connects to safeFallbackRelays when discovery returns empty',
+      () async {
+        // ARRANGE: discovery returns success but with no relays — the
+        // imported-account-without-NIP-65-list scenario from the bug report.
+        final discovery = _ControllableRelayDiscoveryService(
+          outcome: () => RelayDiscoveryResult.failure('No relay list found'),
+        );
+        final authService = buildAuthService(discovery);
+
+        // Capture the URLs the AuthService asks NostrService to add.
+        List<String>? capturedRelayUrls;
+        authService.registerUserRelaysDiscoveredCallback(
+          (urls) => capturedRelayUrls = urls,
+        );
+
+        // ACT: drive the discovery routine directly via the test seam.
+        await authService.debugDiscoverUserRelays(testNpub);
+
+        // ASSERT: the callback received the curated fallback relay set.
+        // This is the wire that connects "discovery failed" to "client
+        // connects to broader relay set", which is the actual user-facing
+        // fix for #2931.
+        expect(
+          capturedRelayUrls,
+          equals(IndexerRelayConfig.safeFallbackRelays),
+        );
+
+        // ASSERT: userRelays getter does NOT include the fallback set.
+        // The bridge to embedded Nostr apps reads userRelays via NIP-07's
+        // getRelays(); polluting it with fallback relays would lie to apps
+        // about the user's published relay list.
+        expect(authService.userRelays, isEmpty);
+      },
+    );
+
+    test(
+      'connects to safeFallbackRelays when discovery throws',
+      () async {
+        // ARRANGE: indexer connection failure — relay discovery throws
+        // before any indexer responds.
+        final discovery = _ControllableRelayDiscoveryService(
+          outcome: () => throw Exception('connection refused'),
+        );
+        final authService = buildAuthService(discovery);
+
+        List<String>? capturedRelayUrls;
+        authService.registerUserRelaysDiscoveredCallback(
+          (urls) => capturedRelayUrls = urls,
+        );
+
+        // ACT
+        await authService.debugDiscoverUserRelays(testNpub);
+
+        // ASSERT
+        expect(
+          capturedRelayUrls,
+          equals(IndexerRelayConfig.safeFallbackRelays),
+        );
+        expect(authService.userRelays, isEmpty);
+      },
+    );
+
+    test(
+      'does NOT apply fallback when discovery returns the user relays',
+      () async {
+        // ARRANGE: happy path — discovery finds the user's published
+        // relay list.
+        final userRelays = [
+          const DiscoveredRelay(url: 'wss://relay.example.com'),
+          const DiscoveredRelay(url: 'wss://relay.user-chosen.org'),
+        ];
+        final discovery = _ControllableRelayDiscoveryService(
+          outcome: () => RelayDiscoveryResult.success(
+            userRelays,
+            'wss://test-indexer',
+          ),
+        );
+        final authService = buildAuthService(discovery);
+
+        List<String>? capturedRelayUrls;
+        authService.registerUserRelaysDiscoveredCallback(
+          (urls) => capturedRelayUrls = urls,
+        );
+
+        // ACT
+        await authService.debugDiscoverUserRelays(testNpub);
+
+        // ASSERT: callback receives the user's actual relays, not the
+        // fallback set.
+        expect(
+          capturedRelayUrls,
+          equals(['wss://relay.example.com', 'wss://relay.user-chosen.org']),
+        );
+        expect(
+          capturedRelayUrls,
+          isNot(equals(IndexerRelayConfig.safeFallbackRelays)),
+        );
+
+        // userRelays getter reflects the discovered list (this is the
+        // semantic source of truth for the embedded-app bridge).
+        expect(
+          authService.userRelays.map((r) => r.url).toList(),
+          equals(['wss://relay.example.com', 'wss://relay.user-chosen.org']),
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/services/relay_discovery_service_test.dart
+++ b/mobile/test/services/relay_discovery_service_test.dart
@@ -260,4 +260,31 @@ void main() {
       );
     });
   });
+
+  group(IndexerRelayConfig, () {
+    group('safeFallbackRelays (#2931)', () {
+      test('is non-empty so DM reachability degrades gracefully', () {
+        // Regression guard for #2931: when NIP-65 discovery fails or
+        // returns empty, AuthService applies this list so the client is
+        // not stuck Divine-only. An empty list would silently break DM
+        // delivery for imported accounts without a published kind 10002.
+        expect(IndexerRelayConfig.safeFallbackRelays, isNotEmpty);
+      });
+
+      test('contains only secure WebSocket URLs', () {
+        for (final url in IndexerRelayConfig.safeFallbackRelays) {
+          expect(
+            url,
+            startsWith('wss://'),
+            reason: 'fallback relay $url must use wss:// for secure transport',
+          );
+        }
+      });
+
+      test('contains only unique entries', () {
+        const urls = IndexerRelayConfig.safeFallbackRelays;
+        expect(urls.toSet().length, equals(urls.length));
+      });
+    });
+  });
 }


### PR DESCRIPTION
## Description

Two compounding bugs were silently breaking NIP-17 DM delivery for users in production. Both are deliberate-but-known limitations from PR #2769 / #2775 (the lazy-inbox scaling work) that the design doc explicitly listed as v2 candidates — they've now landed as a S2 user-facing regression.

### Bug A — Lifecycle: DM ingestion required visiting `/inbox`

`DmRepository.startListening()` was only being called from `InboxPage.initState()` (and `ConversationListBloc._onStarted`), and torn down in `dispose()` / `close()`. A user who never opened `/inbox` after sign-in never ingested any gift wraps — so DMs sat on the relay invisibly, the unread badge stayed at 0, and notifications never fired.

**Fix**: Move ownership of the gift-wrap subscription up to `dmRepositoryProvider`. The provider now calls `setCredentials()` AND `unawaited(startListening())` together once `isNostrReady` flips true, so the subscription runs for the entire authenticated session — not just while the inbox is mounted.

**Why this is safe**: The cold-start cost the original lazy-inbox work was protecting against is still bounded by:
- The `since: newestSyncedAt - 2d` filter in `DmRepository.startListening()` — limits the relay backlog to recent events on every open after the first.
- The `dm_decryption_worker.dart` isolate offload — keeps NIP-44 crypto off the UI thread.

Both protections from PR #2769 are still active. The auth-scoped lifecycle is safe even with a large lifetime DM count, and was a v2 candidate explicitly listed in `mobile/docs/plans/2026-04-05-dm-scaling-fix-design.md` §"Open questions".

`InboxPage` becomes a `ConsumerWidget` and `ConversationListBloc` no longer touches the lifecycle. Both keep regression guards asserting they do **not** touch `startListening`/`stopListening`, so a future refactor can't quietly re-introduce the bug.

### Bug B — Relay fallback: imported accounts stayed Divine-only

When NIP-65 discovery returned empty (e.g. an imported account with no published kind 10002) or threw, `AuthService._discoverUserRelays` set `_userRelays = []` and called nothing — leaving the `NostrClient` connected to **only** the Divine relay. NIP-17 DMs published anywhere else were invisible both inbound (the subscription wasn't on those relays) and outbound (`publishEvent` only sends to `_relayManager.connectedRelays`).

**Fix**: Add a curated `IndexerRelayConfig.safeFallbackRelays` set of general-purpose public Nostr relays that accept gift wraps. When discovery fails, dispatch the fallback set via the existing `_onUserRelaysDiscovered` callback. The relay manager's `autoSubscribe: true` flag (verified in `mobile/packages/nostr_sdk/lib/relay/relay_pool.dart:117-130`) re-sends any active subscriptions to newly added relays, so the auth-scoped DM subscription opened by `dmRepositoryProvider` extends to the fallback set without any additional plumbing.

**Why the fallback is NOT stored in `userRelays`**: That getter is consumed by `_AuthServiceBridgeAdapter` to answer NIP-07's `getRelays()` for embedded Nostr apps. Polluting it with our defaults would lie to apps about the user's chosen relay configuration. The fallback is purely a reachability mechanism for the connected pool. `userRelays` continues to report only the user's own published kind 10002, with `[]` when none exists.

**Related Issue:** Closes #2931

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Architecture and design decisions

- **Layered architecture**: Lifecycle ownership moved from UI (`InboxPage`) and BLoC (`ConversationListBloc`) back down to the provider/repository layer, where it belongs per `.claude/rules/architecture.md`. The fallback strategy lives in `AuthService` (service layer) using a constant from `IndexerRelayConfig` (data layer).
- **No hardcoded values**: Fallback relays live in `IndexerRelayConfig.safeFallbackRelays` per `.claude/rules/code_style.md`.
- **Constructor injection**: Added optional `RelayDiscoveryService` parameter to `AuthService` so unit tests can drive the discovery routine without real WebSockets. Default behavior unchanged.
- **Idempotency**: `setCredentials()` early-returns for the same user. `startListening()` early-returns when already subscribed. Provider rebuilds (e.g. on `isNostrReady` polling, on `nostrServiceProvider` rebuild) are safe.
- **`autoSubscribe` propagation verified**: Read `RelayPool.add()` in `nostr_sdk` to confirm that subscriptions opened before relays are added still flow to those relays once they connect. This is what makes opening the DM subscription early on Divine-only safe — Layer 2's fallback relays receive the existing subscription when added.

## Test plan

### Automated coverage (regression guards from #2931)

- [x] **"authenticated session with inbox never opened"** — `test/providers/dm_repository_provider_test.dart`
  - `opens gift-wrap subscription when isNostrReady is true` (proves the provider opens the subscription **without** `InboxPage` mounting)
  - `does NOT open subscription when isNostrReady is false` (verifies the gating)
  - `tears down subscription on container dispose` (verifies the cleanup hook)
- [x] **Regression guards on the old call sites**:
  - `test/screens/inbox/inbox_page_test.dart` — `does not start or stop the subscription — auth-scoped (#2931)`
  - `test/blocs/dm/conversation_list/conversation_list_bloc_test.dart` — `does not call startListening / does not call stopListening on close`
- [x] **"imported account with no relay list"** — `test/services/auth_service_relay_fallback_test.dart`
  - `connects to safeFallbackRelays when discovery returns empty`
  - `connects to safeFallbackRelays when discovery throws`
  - `does NOT apply fallback when discovery returns the user relays` (happy path)
- [x] **Constant contract** — `test/services/relay_discovery_service_test.dart`
  - `safeFallbackRelays is non-empty so DM reachability degrades gracefully`
  - `contains only secure WebSocket URLs`
  - `contains only unique entries`
- [x] **"DM receipt across reconnects and client rebuilds"**: existing `dm_repository_test.dart` reconnect tests still passing (85 tests, unchanged behavior). The provider's `ref.onDispose(stopListening)` covers the rebuild path.
- [x] `flutter analyze lib test integration_test` — clean
- [x] **202 tests passing** across 9 affected test suites:
  - `test/providers/dm_repository_provider_test.dart` (3 new)
  - `test/services/auth_service_relay_fallback_test.dart` (3 new)
  - `test/services/relay_discovery_service_test.dart` (3 new + existing)
  - `test/screens/inbox/inbox_page_test.dart` (updated)
  - `test/blocs/dm/conversation_list/conversation_list_bloc_test.dart` (updated)
  - `test/repositories/dm_repository_test.dart` (unchanged)
  - `test/services/auth_service_signout_cleanup_test.dart` (sanity, unchanged)
  - `test/services/user_data_cleanup_service_test.dart` (sanity, unchanged)
  - `test/screens/apps/nostr_app_sandbox_screen_test.dart` (sanity for the bridge — confirms `userRelays` semantics not regressed)

### Manual QA suggestions

- [ ] Sign in with a fresh account that has no published kind 10002. Verify logs show `connecting to safe DM-friendly fallback relay set` and the connected relay count climbs above 1 within a few seconds.
- [ ] Stay on `/home` after sign-in. Have a peer send a NIP-17 DM. Verify the unread badge increments without ever visiting `/inbox`.
- [ ] Open `/inbox` after the badge increments. Verify the conversation populates correctly.
- [ ] Send a DM from an imported account (no kind 10002) to a peer who only reads from non-Divine relays. Verify the peer receives it.
- [ ] Sign out and sign back in with a different account. Verify no leaked subscription on the old user.

## Open questions / follow-up work

The four relays in `safeFallbackRelays` (`relay.nos.social`, `relay.damus.io`, `nos.lol`, `relay.primal.net`) are a defensible default but **not product-approved**. If product/@rabble would prefer a different set, the constant is a single change. I've kept it small (4 relays) to bound bandwidth and first-connect latency.

This PR does **not** address app-closed reachability — server-side push (extending #2848's `PushNotificationService` for DMs) is a separate, larger piece of work and was out of scope. The lifecycle change here does mean that **anyone with the app open in the background still ingests DMs**, which closes the most common reported gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)