### PR TITLE
fix(pooled_video_player): force seek to zero on first preload→current resume

### DIFF
--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -251,6 +251,28 @@ class VideoFeedController extends ChangeNotifier {
   final Map<int, int> _diagStuckFailovers = {};
   final Set<int> _readyVideosAwaitingRecovery = {};
   final Set<int> _slowLoadIndices = {};
+
+  /// Indices that have ever been the user's "current video" in their
+  /// current player generation.
+  ///
+  /// Used by [_resume] to distinguish two cases that look identical from
+  /// the player's perspective but mean very different things:
+  ///
+  /// - **First transition from preload→current** (index NOT in set):
+  ///   The player was prepared by [_pauseAndRewindPreloaded], which on
+  ///   iOS via media_kit/mpv may have failed to actually rewind to
+  ///   position 0 — `player.state.position` cannot be trusted. The
+  ///   resume must explicitly seek to zero before play().
+  ///
+  /// - **Swipe-back to a previously-watched video** (index IN set):
+  ///   The player was paused by the swipe-away path at the user's
+  ///   actual last-watched position. That position is meaningful and
+  ///   must be preserved — no force-seek.
+  ///
+  /// The entry is added when [_resume] runs for an index, and cleared
+  /// when the index is released or its player is evicted, so a fresh
+  /// preload after a release is treated as a new "first transition".
+  final Set<int> _userVisitedIndices = {};
   final Map<int, Completer<void>> _readyCompleters = {};
   int _preloadGeneration = 0;
   Timer? _stuckPlaybackTimer;
@@ -1225,6 +1247,9 @@ class VideoFeedController extends ChangeNotifier {
     _loadedPlayers.remove(index);
     _loadStates.remove(index);
     _loadingIndices.remove(index);
+    // Same reason as in [_releasePlayer]: a fresh preload after an
+    // eviction should be treated as a new "first transition".
+    _userVisitedIndices.remove(index);
     _notifyIndex(index);
   }
 
@@ -1509,12 +1534,40 @@ class VideoFeedController extends ChangeNotifier {
     bool forcePlay = true,
   }) async {
     try {
-      // Seek to zero only when the video has reached the end so it loops.
-      // Mid-playback position is preserved for swiped-away videos.
-      // Preloaded videos are already at position zero from _onBufferReady.
-      final duration = player.state.duration;
-      if (duration > Duration.zero && player.state.position >= duration) {
+      // First-resume force-seek to zero.
+      //
+      // _pauseAndRewindPreloaded is supposed to leave preloaded players
+      // at position 0, but on iOS via media_kit/mpv the seek-to-zero
+      // silently fails: by the time the user swipes here,
+      // `player.state.position` reports the muted-buffer-fill stop point
+      // (~400ms typical, sometimes near end-of-video). The previous
+      // implementation trusted "preloaded videos are at zero" and only
+      // seeked at end-of-video, so every preloaded clip started ~400ms
+      // in. See journal:
+      // 2026-04-10-flutter-pooled-player-preload-rewind-silent-failure.md
+      //
+      // Fix: on the FIRST resume of an index in its current player
+      // generation, unconditionally seek to zero. Subsequent resumes
+      // (swipe-back to a video the user has already watched) preserve
+      // the user's last-watched position via the existing path below.
+      final isFirstResume = !_userVisitedIndices.contains(index);
+      if (isFirstResume) {
+        final positionBeforeMs = player.state.position.inMilliseconds;
+        _logDebug(
+          'resume_force_seek_zero ${_videoDebugDetails(index)} '
+          'positionBefore=$positionBeforeMs '
+          'reason=preload_to_current',
+        );
         await player.seek(Duration.zero);
+        _userVisitedIndices.add(index);
+      } else {
+        // Loop-end seek for swipe-backs: if the previous playback ran
+        // off the end of the clip and was paused there, seek to zero on
+        // resume so the loop restarts.
+        final duration = player.state.duration;
+        if (duration > Duration.zero && player.state.position >= duration) {
+          await player.seek(Duration.zero);
+        }
       }
 
       // Guard: user may have scrolled away during the seek.
@@ -1831,6 +1884,11 @@ class VideoFeedController extends ChangeNotifier {
     _diagStaleRecoveries.remove(index);
     _diagStaleEscalations.remove(index);
     _diagStuckFailovers.remove(index);
+    // Reset the user-visited tracking so a fresh preload after a release
+    // is treated as a new "first transition from preload to current" by
+    // [_resume]. Without this, scrolling far past a video and back would
+    // skip the force-seek-zero and reproduce the original bug.
+    _userVisitedIndices.remove(index);
     _notifyIndex(index);
   }
 
@@ -1953,6 +2011,7 @@ class VideoFeedController extends ChangeNotifier {
     _diagStaleRecoveries.clear();
     _diagStaleEscalations.clear();
     _diagStuckFailovers.clear();
+    _userVisitedIndices.clear();
 
     // Notify all index listeners that their video is gone.  This causes
     // ValueListenableBuilder to rebuild with videoController == null,

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -2970,11 +2970,19 @@ void main() {
       );
 
       test(
-        'preloaded video is still at position zero when it becomes current',
+        'preloaded video gets a defensive seek to zero when it first '
+        'becomes current, even if state.position already reads zero',
         () async {
-          // preloadAhead=1 loads video 1 as a preload and seeks it to zero
-          // via _onBufferReady. When the user navigates to video 1 it should
-          // play from the start without an additional seek.
+          // Background: this test used to assert that no seek fires when
+          // state.position == 0 (the assumption that preloaded videos are
+          // already rewound). That assumption was falsified by the iOS
+          // bug documented in the journal entry
+          // 2026-04-10-flutter-pooled-player-preload-rewind-silent-failure.md
+          // — on iOS via media_kit/mpv, _pauseAndRewindPreloaded's seek
+          // can silently fail and state.position is unreliable. The fix
+          // forces an unconditional seek to zero on the first transition
+          // from preload to current, regardless of what state.position
+          // reports. This test pins that behavior so it cannot regress.
           final videos = createTestVideos(count: 3);
           final controller = VideoFeedController(
             videos: videos,
@@ -2986,20 +2994,23 @@ void main() {
           await Future<void>.delayed(const Duration(milliseconds: 100));
 
           final setup1 = playerSetups[videos[1].url]!;
-          // Preloaded video is at position zero and duration is non-zero.
+          // Even when position correctly reads zero, the controller
+          // does not trust it.
           when(() => setup1.state.position).thenReturn(Duration.zero);
-          when(() => setup1.state.duration).thenReturn(
-            const Duration(seconds: 30),
-          );
+          when(
+            () => setup1.state.duration,
+          ).thenReturn(const Duration(seconds: 30));
 
           clearInteractions(setup1.player);
 
-          // Navigate to video 1.
           controller.onPageChanged(1);
           await Future<void>.delayed(const Duration(milliseconds: 50));
 
-          // Position (0) < duration (30s) — no seek needed.
-          verifyNever(() => setup1.player.seek(Duration.zero));
+          // Defensive seek MUST fire so we don't depend on
+          // _pauseAndRewindPreloaded having succeeded.
+          verify(() => setup1.player.seek(Duration.zero)).called(
+            greaterThanOrEqualTo(1),
+          );
           verify(setup1.player.play).called(greaterThanOrEqualTo(1));
 
           controller.dispose();
@@ -3909,13 +3920,20 @@ void main() {
           setup.bufferingController.add(false);
           await Future<void>.delayed(const Duration(milliseconds: 50));
 
+          // Clear out any seeks from the initial setup path (e.g. the
+          // resume_force_seek_zero defensive seek that fires once on the
+          // first transition from preload→current). This test only cares
+          // about whether STALE-recovery seeks fire later.
+          clearInteractions(setup.player);
+          when(() => setup.player.seek(any())).thenAnswer((_) async {});
+
           // Wait well past grace + threshold — recovery should NOT fire
           // because position has never advanced from initial value
           await Future<void>.delayed(
             const Duration(milliseconds: 2000),
           );
 
-          // Recovery seek should NOT be called
+          // Stale-recovery seek should NOT be called
           verifyNever(() => setup.player.seek(Duration.zero));
 
           controller.dispose();
@@ -4381,11 +4399,17 @@ void main() {
         setup.bufferingController.add(false);
         await Future<void>.delayed(const Duration(milliseconds: 50));
 
+        // Clear seeks from the initial setup (specifically the
+        // resume_force_seek_zero defensive seek). This test only cares
+        // about whether STALE-recovery seeks fire later.
+        clearInteractions(setup.player);
+        when(() => setup.player.seek(any())).thenAnswer((_) async {});
+
         // Wait well past grace + threshold — recovery should NOT fire
         // because position has never advanced from initial value
         await Future<void>.delayed(const Duration(milliseconds: 2000));
 
-        // Recovery seek should NOT be called
+        // Stale-recovery seek should NOT be called
         verifyNever(
           () => setup.player.seek(Duration.zero),
         );
@@ -5110,6 +5134,247 @@ void main() {
         },
       );
     });
+  });
+
+  group('preload→current resume seeks to zero', () {
+    // Regression test group for the iOS bug where preloaded videos start
+    // playback at positionMs ~400 (or worse) instead of 0.
+    //
+    // Background: _pauseAndRewindPreloaded does `pause(); seek(Duration.zero);`
+    // when a preloaded buffer fills, but on iOS via media_kit/mpv the seek
+    // silently fails — by the time the user swipes to the video,
+    // `player.state.position` still reports the muted-buffer-fill stop point.
+    // _resume previously trusted that comment ("Preloaded videos are already
+    // at position zero from _onBufferReady") and only seeked at end-of-video.
+    // Result: every clip started ~400ms in, occasionally near the end.
+    //
+    // The fix: track which indices have ever been the "current video" in
+    // their current player generation. On the FIRST transition from preload
+    // to current, _resume must explicitly seek to zero before play(),
+    // independent of what player.state.position reports.
+    late TestablePlayerPool pool;
+    late Map<String, MockPlayerSetup> playerSetups;
+
+    setUp(() {
+      playerSetups = {};
+      pool = TestablePlayerPool(
+        maxPlayers: 10,
+        mockPlayerFactory: (url) {
+          final setup = createMockPlayerSetup();
+          playerSetups[url] = setup;
+
+          final mockPooledPlayer = _MockPooledPlayer();
+          when(() => mockPooledPlayer.player).thenReturn(setup.player);
+          when(
+            () => mockPooledPlayer.videoController,
+          ).thenReturn(createMockVideoController());
+          when(() => mockPooledPlayer.isDisposed).thenReturn(false);
+          when(() => mockPooledPlayer.wasRecycled).thenReturn(false);
+          when(mockPooledPlayer.clearRecycled).thenReturn(null);
+          when(mockPooledPlayer.dispose).thenAnswer((_) async {});
+
+          return mockPooledPlayer;
+        },
+      );
+    });
+
+    tearDown(() async {
+      for (final setup in playerSetups.values) {
+        await setup.dispose();
+      }
+      await pool.dispose();
+    });
+
+    testWidgets(
+      'force-seeks to zero when a preloaded video first becomes current, '
+      'even if state.position reports non-zero',
+      (tester) async {
+        final videos = createTestVideos(count: 3);
+        final controller = VideoFeedController(
+          videos: videos,
+          pool: pool,
+          preloadBehind: 0,
+        );
+
+        // Let initial preload complete for indices 0, 1, 2.
+        await tester.pump(const Duration(milliseconds: 50));
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final setup1 = playerSetups[videos[1].url]!;
+
+        // Sanity: _pauseAndRewindPreloaded already called seek(0) once on
+        // index 1 during the preload. We don't care about that call —
+        // we're verifying the SECOND seek that should fire on resume.
+        clearInteractions(setup1.player);
+        when(() => setup1.player.seek(any())).thenAnswer((_) async {});
+        when(setup1.player.pause).thenAnswer((_) async {});
+        when(setup1.player.play).thenAnswer((_) async {});
+        when(() => setup1.player.setVolume(any())).thenAnswer((_) async {});
+
+        // Simulate the iOS bug: the prior seek-to-zero "succeeded" on the
+        // mpv side but state.position still reports a non-zero value
+        // (either mpv reordered the command queue or the Dart-side cache
+        // is stale). Make duration large so the loop-end seek path is
+        // not the one that fires.
+        when(
+          () => setup1.state.position,
+        ).thenReturn(const Duration(milliseconds: 423));
+        when(
+          () => setup1.state.duration,
+        ).thenReturn(const Duration(milliseconds: 6300));
+
+        // User swipes to index 1.
+        controller.onPageChanged(1);
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // The fix: _resume must call seek(Duration.zero) before play(),
+        // because index 1 has never been "current" before in this player
+        // generation — its non-zero state.position cannot be trusted.
+        verify(() => setup1.player.seek(Duration.zero)).called(
+          greaterThanOrEqualTo(1),
+        );
+
+        controller.dispose();
+      },
+    );
+
+    testWidgets(
+      'preserves position on swipe-back to a video the user already watched',
+      (tester) async {
+        final videos = createTestVideos(count: 3);
+        final controller = VideoFeedController(
+          videos: videos,
+          pool: pool,
+        );
+
+        await tester.pump(const Duration(milliseconds: 50));
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final setup1 = playerSetups[videos[1].url]!;
+
+        // First make index 1 current (this is where the force-seek-zero
+        // fires once — that's expected and not under test here).
+        when(
+          () => setup1.state.position,
+        ).thenReturn(const Duration(milliseconds: 423));
+        when(
+          () => setup1.state.duration,
+        ).thenReturn(const Duration(milliseconds: 6300));
+        when(() => setup1.player.seek(any())).thenAnswer((_) async {});
+        when(setup1.player.pause).thenAnswer((_) async {});
+        when(setup1.player.play).thenAnswer((_) async {});
+        when(() => setup1.player.setVolume(any())).thenAnswer((_) async {});
+
+        controller.onPageChanged(1);
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // Simulate the user watching for a while.
+        when(
+          () => setup1.state.position,
+        ).thenReturn(const Duration(milliseconds: 3000));
+
+        // User swipes away to index 2 (index 1 is paused at 3000ms by
+        // the controller's swipe-away logic).
+        controller.onPageChanged(2);
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // Now we care about what happens on the swipe BACK to index 1.
+        // Reset interaction history so we can assert specifically about
+        // the swipe-back.
+        clearInteractions(setup1.player);
+        when(() => setup1.player.seek(any())).thenAnswer((_) async {});
+        when(setup1.player.pause).thenAnswer((_) async {});
+        when(setup1.player.play).thenAnswer((_) async {});
+        when(() => setup1.player.setVolume(any())).thenAnswer((_) async {});
+        when(
+          () => setup1.state.position,
+        ).thenReturn(const Duration(milliseconds: 3000));
+
+        // Swipe back to index 1.
+        controller.onPageChanged(1);
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // Index 1 is no longer a "preload" — the user has been here
+        // before. The mid-playback position must be preserved, so
+        // seek(Duration.zero) must NOT be called by _resume.
+        verifyNever(() => setup1.player.seek(Duration.zero));
+
+        controller.dispose();
+      },
+    );
+
+    testWidgets(
+      'emits resume_force_seek_zero log when force-seeking on first resume',
+      (tester) async {
+        // Capture controller logs so we can grep for the new diagnostic
+        // line. The same line will appear in production iOS logs and is
+        // how we will verify the fix is firing in the wild.
+        final logs = <String>[];
+
+        final videos = createTestVideos(count: 3);
+        final controller = VideoFeedController(
+          videos: videos,
+          pool: pool,
+          preloadBehind: 0,
+          onLog: (level, message) => logs.add(message),
+        );
+
+        await tester.pump(const Duration(milliseconds: 50));
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final setup1 = playerSetups[videos[1].url]!;
+        when(() => setup1.player.seek(any())).thenAnswer((_) async {});
+        when(setup1.player.pause).thenAnswer((_) async {});
+        when(setup1.player.play).thenAnswer((_) async {});
+        when(() => setup1.player.setVolume(any())).thenAnswer((_) async {});
+        when(
+          () => setup1.state.position,
+        ).thenReturn(const Duration(milliseconds: 423));
+        when(
+          () => setup1.state.duration,
+        ).thenReturn(const Duration(milliseconds: 6300));
+
+        controller.onPageChanged(1);
+        await tester.pump(const Duration(milliseconds: 50));
+
+        // Both the initial current video (index 0) and the swiped-to
+        // video (index 1) should trigger force_seek_zero on their first
+        // resume. Find the index=1 line specifically.
+        final forceSeekLogs = logs
+            .where((m) => m.startsWith('resume_force_seek_zero'))
+            .toList();
+
+        expect(
+          forceSeekLogs,
+          isNotEmpty,
+          reason:
+              'Expected at least one resume_force_seek_zero log line to '
+              'be emitted on the first preload→current transition. This '
+              'is what we will grep in production iOS logs to verify the '
+              'fix is firing.',
+        );
+
+        // The log line for index 1 should include the position the
+        // controller saw before the force-seek (so we can correlate
+        // with position_first_advance in the same log).
+        final index1Log = forceSeekLogs.firstWhere(
+          (m) => m.contains('index=1'),
+          orElse: () => '',
+        );
+        expect(
+          index1Log,
+          isNotEmpty,
+          reason:
+              'Expected a resume_force_seek_zero log specifically for '
+              'index=1 (the swiped-to preloaded video). All force_seek '
+              'logs: $forceSeekLogs',
+        );
+        expect(index1Log, contains('positionBefore=423'));
+        expect(index1Log, contains('reason=preload_to_current'));
+
+        controller.dispose();
+      },
+    );
   });
 
   group('classifyPlaybackSourceKind', () {


### PR DESCRIPTION
Closes #2962

## Description

Fixes a long-standing iOS playback bug where every preloaded video started **~400ms in** (and occasionally near the *end* of the clip), because `_pauseAndRewindPreloaded`'s seek-to-zero silently fails on iOS via media_kit/mpv. `_resume` previously trusted a comment that preloaded players were "already at position zero from `_onBufferReady`" and only seeked at end-of-video, so the bad position was never corrected.

The diagnostics added in #2959 made the bug obvious. Across a single 81-second iOS session, **14 of 16 preloaded videos** reported `position_first_advance` with `initialMs` in the 350-560ms range:

| index | initialMs | should be |
|---|---|---|
| 1, 2, 3, 4, 5, 7, 8, 11, 12, 13 | 356–556 | 0 |
| 6 | 389 | 0 |
| 8 (re-load) | 456 | 0 |
| **10** | **5989** | 0 |
| 9 (second load) | 23 | ✓ correct |
| 0 | 0 | ✓ (cold start, special path) |

Index 10 is the catastrophic case: position 5989 on a 6339ms clip — basically the *end* of the video. To the user this reads as "video paused and jumped".

**Related Issue:** Closes #

## Root cause

`_pauseAndRewindPreloaded` does `pause(); seek(Duration.zero);` when a preloaded buffer fills, but on iOS via media_kit/mpv, the seek-to-zero either gets reordered against the pending pause command on mpv's command queue, or `player.state.position` doesn't update after a seek-while-paused until the next playback tick. Either way: by the time the user swipes to the video, `state.position` reports the muted-buffer-fill stop point, not 0. `_resume` reads `state.position`, sees ~400ms, doesn't seek (because position < duration), and resumes from there.

## Fix

Track which indices have ever been the user's "current video" in their current player generation (`_userVisitedIndices`). On the FIRST resume of an index — the transition from preload→current — `_resume` now unconditionally seeks to zero before `play()`, regardless of what `state.position` reports. The set entry is added on resume and cleared on `_releasePlayer` / `_onPlayerEvicted` / `dispose`, so a fresh preload after a release is treated as a new "first transition".

Subsequent resumes of the same index (swipe-back to a video the user has already watched) preserve the user's last-watched position via the existing loop-end-only seek path.

## Verification path (the part the user explicitly asked for)

A new diagnostic log line is emitted on every defensive seek:

```
resume_force_seek_zero index=N positionBefore=M reason=preload_to_current
```

After this lands, on the next iOS log capture we should see:

1. **One `resume_force_seek_zero` line on every swipe** to a fresh preloaded video.
2. **Every `position_first_advance` for a fresh preload reports `initialMs ≤ 100`** instead of the 350-560 cluster from before.
3. **No more `initialMs=5989`-style catastrophic cases.**

Grep snippets to verify:

```bash
grep "resume_force_seek_zero" openvine_full_logs_*.txt
grep "position_first_advance" openvine_full_logs_*.txt | grep -v "newMs="  # column-scan initialMs
```

## Type of Change

- [ ] ✨ New feature
- [x] 🛠️ Bug fix
- [ ] ❌ Breaking change
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Test plan

- [x] Three new TDD tests in `preload→current resume seeks to zero` group:
  - **force-seeks to zero on first transition** even when `state.position` reports a non-zero value (the regression test for the iOS bug — fails without the fix, passes with it)
  - **preserves position on swipe-back** to a previously-watched video
  - **emits `resume_force_seek_zero` log line** with the expected fields (so grepping production logs is reliable)
- [x] Two existing stale-recovery tests updated with `clearInteractions` to ignore the new defensive seek (their assertion is about STALE-recovery seeks, not the first-resume defensive seek)
- [x] One existing test rewritten to assert the new defensive behavior instead of the falsified "preloaded video is at position zero" assumption
- [x] **432/432 pooled_video_player tests pass**
- [x] `flutter analyze` clean
- [x] `dart format` clean
- [x] Pre-commit hook (full-repo `flutter analyze`) clean
- [ ] On-device iOS verification: capture a fresh log, grep `resume_force_seek_zero`, confirm `initialMs ≤ 100` across every preload

## Background

Full root-cause investigation writeup is in `~/.claude/journal/2026-04-10-flutter-pooled-player-preload-rewind-silent-failure.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)