### PR TITLE
feat(pooled_video_player): add slow_playback_detected + player_state_snapshot diagnostics

### DIFF
--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -316,6 +316,34 @@ class VideoFeedController extends ChangeNotifier {
   /// real position change.
   int? _initialPositionMs;
 
+  /// Wall-clock time (ms since epoch) when the slow-playback rate check
+  /// window started for the current video. See [_checkPlaybackRate].
+  int? _rateCheckWallStartMs;
+
+  /// Position (ms) at the start of the current slow-playback rate window.
+  int? _rateCheckPositionStartMs;
+
+  /// Wall-clock time (ms since epoch) of the last `player_state_snapshot`
+  /// log line. Used to throttle snapshots to roughly one per interval.
+  int? _lastStateSnapshotWallMs;
+
+  /// Rate check window duration in ms. Playback rate is evaluated over
+  /// windows of this length; see [_checkPlaybackRate].
+  static const _playbackRateWindowMs = 2000;
+
+  /// Minimum `positionDelta / wallDelta` ratio (as a percentage) below
+  /// which playback is considered slow. 50% = half real-time.
+  static const _slowPlaybackRateThresholdPct = 50;
+
+  /// Minimum position advance (in ms) before a rate check is allowed
+  /// to flag the window as slow. If position didn't advance at all,
+  /// the existing stale-position watchdog handles it; the slow-playback
+  /// check is specifically for the "crawling forward" case.
+  static const _slowPlaybackMinAdvanceMs = 50;
+
+  /// Minimum interval between `player_state_snapshot` log lines, in ms.
+  static const _stateSnapshotIntervalMs = 2000;
+
   /// Number of consecutive stale heartbeats before triggering recovery.
   /// With a 100ms heartbeat interval, this means ~800ms of confirmed
   /// frozen video before recovery kicks in.
@@ -1621,6 +1649,11 @@ class VideoFeedController extends ChangeNotifier {
     _staleGraceHeartbeats = _staleGraceAfterPlay;
     _positionHasAdvanced = false;
     _initialPositionMs = null;
+    // Reset slow-playback rate check and state-snapshot windows. The
+    // next timer tick will establish new start values.
+    _rateCheckWallStartMs = null;
+    _rateCheckPositionStartMs = null;
+    _lastStateSnapshotWallMs = null;
 
     // Use the shorter of the caller's interval and the stale-detection
     // interval so both position callbacks and recovery work correctly.
@@ -1634,14 +1667,24 @@ class VideoFeedController extends ChangeNotifier {
       final player = _loadedPlayers[index]?.player;
       if (player == null) return;
 
+      // Read position ONCE per tick and share it across all the
+      // diagnostics + stale watchdog. Reading it multiple times via
+      // `player.state.position` would waste cycles in production AND
+      // burn through test mocks whose `thenAnswer` callbacks advance
+      // state on each call.
+      final positionMs = player.state.position.inMilliseconds;
+
+      // Playback diagnostics for the current video. These run on
+      // every heartbeat but throttle their log output internally.
+      if (kPlaybackDiagnosticsEnabled && index == _currentIndex) {
+        _emitStateSnapshotIfDue(index, player, positionMs);
+        _checkPlaybackRate(index, player, positionMs);
+      }
+
       // Stale-position watchdog: detect and recover from mpv decoder
       // stalls caused by B-frame encoded videos.
       if (index == _currentIndex) {
-        _checkStalePosition(
-          index,
-          player,
-          player.state.position.inMilliseconds,
-        );
+        _checkStalePosition(index, player, positionMs);
       }
 
       // Loop enforcement: seek back to zero when position exceeds
@@ -1662,6 +1705,111 @@ class VideoFeedController extends ChangeNotifier {
         positionCallback?.call(index, player.state.position);
       }
     });
+  }
+
+  /// Detects slowly-advancing playback — the "crawling forward" case
+  /// that the existing [_checkStalePosition] watchdog misses because
+  /// it only flags fully-frozen positions (`positionMs ==
+  /// _lastHeartbeatPositionMs` at exact equality).
+  ///
+  /// Motivation: on iOS via media_kit/mpv a video can enter a state
+  /// where it reports `playing=true buffering=false` but position
+  /// advances at a fraction of wall-clock rate — e.g. 533ms of
+  /// position over 13 seconds of wall time (~4% real-time). The
+  /// stale-position watchdog silently misses this because position
+  /// *is* technically changing between heartbeats, so
+  /// `_staleHeartbeatCount` never increments. To the user it looks
+  /// like the video is frozen.
+  ///
+  /// This method evaluates the position-advance rate over
+  /// [_playbackRateWindowMs] wall-clock windows and logs
+  /// `slow_playback_detected` when the rate drops below
+  /// [_slowPlaybackRateThresholdPct]. The window resets after every
+  /// evaluation so recurring slowness keeps being reported.
+  ///
+  /// Only runs when [kPlaybackDiagnosticsEnabled] is true. Only runs
+  /// for the current video; preloaded background players are
+  /// expected to be paused so their position does not advance.
+  ///
+  /// [positionMs] is the already-read position for this heartbeat
+  /// tick, passed in so we don't read `player.state.position` a
+  /// second time.
+  void _checkPlaybackRate(int index, Player player, int positionMs) {
+    // Don't evaluate rate while buffering or while paused — those are
+    // expected to have zero position advance and would always look
+    // "slow".
+    if (!player.state.playing || player.state.buffering) {
+      _rateCheckWallStartMs = null;
+      _rateCheckPositionStartMs = null;
+      return;
+    }
+
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+
+    if (_rateCheckWallStartMs == null) {
+      _rateCheckWallStartMs = nowMs;
+      _rateCheckPositionStartMs = positionMs;
+      return;
+    }
+
+    final wallDelta = nowMs - _rateCheckWallStartMs!;
+    if (wallDelta < _playbackRateWindowMs) return;
+
+    final positionDelta = positionMs - _rateCheckPositionStartMs!;
+
+    // If position hasn't advanced at all, that's the stale watchdog's
+    // job. Only log here for the "slow but advancing" case.
+    if (positionDelta > _slowPlaybackMinAdvanceMs) {
+      final ratePct = wallDelta > 0 ? (positionDelta * 100) ~/ wallDelta : 0;
+      if (ratePct < _slowPlaybackRateThresholdPct) {
+        _logWarning(
+          'slow_playback_detected ${_videoDebugDetails(index)} '
+          'positionDeltaMs=$positionDelta '
+          'wallDeltaMs=$wallDelta '
+          'ratePct=$ratePct '
+          'currentPositionMs=$positionMs '
+          'sourceKind=${_sourceKindLabelOrNone(_openedSources[index])}',
+        );
+      }
+    }
+
+    // Start a new window whether we logged or not, so the next window
+    // measures fresh deltas.
+    _rateCheckWallStartMs = nowMs;
+    _rateCheckPositionStartMs = positionMs;
+  }
+
+  /// Emits a periodic `player_state_snapshot` log line that dumps the
+  /// raw `player.state` values regardless of whether the stream
+  /// listeners have fired. Lets us see divergence between what the
+  /// stream last reported (which drives the Dart-side cached state)
+  /// and what mpv actually believes now — e.g. mpv setting
+  /// `core-idle` without emitting a matching `buffering=true` event.
+  ///
+  /// Throttled to [_stateSnapshotIntervalMs] to keep production log
+  /// volume reasonable (~1 line every 2 seconds per active video).
+  ///
+  /// Only runs when [kPlaybackDiagnosticsEnabled] is true.
+  ///
+  /// [positionMs] is the already-read position for this heartbeat
+  /// tick, passed in so we don't read `player.state.position` a
+  /// second time.
+  void _emitStateSnapshotIfDue(int index, Player player, int positionMs) {
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    if (_lastStateSnapshotWallMs != null &&
+        nowMs - _lastStateSnapshotWallMs! < _stateSnapshotIntervalMs) {
+      return;
+    }
+    _lastStateSnapshotWallMs = nowMs;
+
+    _logDebug(
+      'player_state_snapshot ${_videoDebugDetails(index)} '
+      'playing=${player.state.playing} '
+      'buffering=${player.state.buffering} '
+      'positionMs=$positionMs '
+      'completed=${player.state.completed} '
+      'sourceKind=${_sourceKindLabelOrNone(_openedSources[index])}',
+    );
   }
 
   /// Checks whether the current video's position has stalled. If the position

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -5377,6 +5377,203 @@ void main() {
     );
   });
 
+  group('slow_playback_detected and player_state_snapshot', () {
+    // Diagnostic instruments added after the iOS repro showed a video
+    // whose position advanced at ~4% real-time for 13.5 seconds with
+    // zero existing log events — the stale watchdog only catches
+    // *frozen* position, not *slowly-advancing* position. These new
+    // logs close that gap. See journal entry:
+    // 2026-04-10-flutter-mpv-silent-slow-playback-invisible-to-freeze
+    // -watchdog.md
+    late TestablePlayerPool pool;
+    late Map<String, MockPlayerSetup> playerSetups;
+
+    setUp(() {
+      playerSetups = {};
+      pool = TestablePlayerPool(
+        maxPlayers: 10,
+        mockPlayerFactory: (url) {
+          final setup = createMockPlayerSetup();
+          playerSetups[url] = setup;
+          final mockPooledPlayer = _MockPooledPlayer();
+          when(() => mockPooledPlayer.player).thenReturn(setup.player);
+          when(
+            () => mockPooledPlayer.videoController,
+          ).thenReturn(createMockVideoController());
+          when(() => mockPooledPlayer.isDisposed).thenReturn(false);
+          when(() => mockPooledPlayer.wasRecycled).thenReturn(false);
+          when(mockPooledPlayer.clearRecycled).thenReturn(null);
+          when(mockPooledPlayer.dispose).thenAnswer((_) async {});
+          return mockPooledPlayer;
+        },
+      );
+    });
+
+    tearDown(() async {
+      for (final setup in playerSetups.values) {
+        await setup.dispose();
+      }
+      await pool.dispose();
+    });
+
+    test(
+      'slow_playback_detected fires when position advances at '
+      'well below real-time rate',
+      () async {
+        final logs = <String>[];
+        final controller = VideoFeedController(
+          videos: createTestVideos(count: 1),
+          pool: pool,
+          onLog: (level, message) => logs.add(message),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        final url = createTestVideos()[0].url;
+        final setup = playerSetups[url]!;
+
+        when(() => setup.state.playing).thenReturn(true);
+        when(() => setup.state.buffering).thenReturn(false);
+        when(
+          () => setup.state.position,
+        ).thenReturn(const Duration(milliseconds: 1000));
+
+        // Trigger buffer ready to start the heartbeat timer. The first
+        // rate-check tick will anchor the window at positionStart=1000,
+        // wallStart=now.
+        setup.bufferingController.add(false);
+
+        // After ~1s of wall time with the same position (1000), nudge
+        // position forward by only 100ms. This means the 2s rate-check
+        // window that fires around T+2.2s will see:
+        //   positionDelta ≈ 100ms over wallDelta ≈ 2100ms
+        //   ratePct ≈ 4–5 (well under the 50% threshold)
+        // Simulates the iOS "position crawls at ~4% real-time" bug.
+        await Future<void>.delayed(const Duration(milliseconds: 1000));
+        when(
+          () => setup.state.position,
+        ).thenReturn(const Duration(milliseconds: 1100));
+
+        // Wait past the 2s rate-check window boundary so the heartbeat
+        // tick that evaluates the window sees position=1100.
+        await Future<void>.delayed(const Duration(milliseconds: 1400));
+
+        final slowLogs = logs
+            .where((m) => m.startsWith('slow_playback_detected'))
+            .toList();
+
+        expect(
+          slowLogs,
+          isNotEmpty,
+          reason:
+              'Expected slow_playback_detected when position advanced '
+              'only ~100ms over ~2.4s of wall time (~4% real-time). '
+              'All logs: $logs',
+        );
+        // Sanity: the log line should include the rate so we can grep
+        // for it in production and filter by severity.
+        expect(slowLogs.first, contains('ratePct='));
+        expect(slowLogs.first, contains('positionDeltaMs='));
+        expect(slowLogs.first, contains('wallDeltaMs='));
+
+        controller.dispose();
+      },
+    );
+
+    test(
+      'slow_playback_detected does NOT fire at normal real-time rate',
+      () async {
+        final logs = <String>[];
+        final controller = VideoFeedController(
+          videos: createTestVideos(count: 1),
+          pool: pool,
+          onLog: (level, message) => logs.add(message),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        final url = createTestVideos()[0].url;
+        final setup = playerSetups[url]!;
+
+        when(() => setup.state.playing).thenReturn(true);
+        when(() => setup.state.buffering).thenReturn(false);
+        when(
+          () => setup.state.position,
+        ).thenReturn(const Duration(milliseconds: 1000));
+        setup.bufferingController.add(false);
+
+        // Advance position by 2000ms in ~1.5s of wall time (~133%
+        // real-time — a bit fast but comfortably above the 50%
+        // slow-playback threshold).
+        await Future<void>.delayed(const Duration(milliseconds: 1500));
+        when(
+          () => setup.state.position,
+        ).thenReturn(const Duration(milliseconds: 3000));
+
+        // Wait past the 2s rate-check window boundary so the check
+        // evaluates with positionDelta ≈ 2000, wallDelta ≈ 2100,
+        // ratePct ≈ 95.
+        await Future<void>.delayed(const Duration(milliseconds: 800));
+
+        expect(
+          logs.where((m) => m.startsWith('slow_playback_detected')),
+          isEmpty,
+          reason:
+              'slow_playback_detected should only fire when playback is '
+              'measurably slower than real-time, not for normal speed. '
+              'All logs: $logs',
+        );
+
+        controller.dispose();
+      },
+    );
+
+    test(
+      'player_state_snapshot fires periodically for current video',
+      () async {
+        final logs = <String>[];
+        final controller = VideoFeedController(
+          videos: createTestVideos(count: 1),
+          pool: pool,
+          onLog: (level, message) => logs.add(message),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        final url = createTestVideos()[0].url;
+        final setup = playerSetups[url]!;
+
+        when(() => setup.state.playing).thenReturn(true);
+        when(() => setup.state.buffering).thenReturn(false);
+        when(
+          () => setup.state.position,
+        ).thenReturn(const Duration(milliseconds: 500));
+        setup.bufferingController.add(false);
+
+        // Wait longer than the snapshot interval (2s) to guarantee at
+        // least one snapshot fires.
+        await Future<void>.delayed(const Duration(milliseconds: 2300));
+
+        final snapshotLogs = logs
+            .where((m) => m.startsWith('player_state_snapshot'))
+            .toList();
+
+        expect(
+          snapshotLogs,
+          isNotEmpty,
+          reason:
+              'Expected player_state_snapshot to fire at least once '
+              'within ~2.3s. All logs: $logs',
+        );
+        // The snapshot should include enough fields to diagnose mpv
+        // state divergence in production logs.
+        expect(snapshotLogs.first, contains('playing='));
+        expect(snapshotLogs.first, contains('buffering='));
+        expect(snapshotLogs.first, contains('positionMs='));
+        expect(snapshotLogs.first, contains('index=0'));
+
+        controller.dispose();
+      },
+    );
+  });
+
   group('classifyPlaybackSourceKind', () {
     const hash =
         'a1b2c3d4e5f6071828394a5b6c7d8e9f0a1b2c3d4e5f6071828394a5b6c7d8e9';

--- a/mobile/packages/pooled_video_player/test/helpers/test_helpers.dart
+++ b/mobile/packages/pooled_video_player/test/helpers/test_helpers.dart
@@ -133,6 +133,10 @@ MockPlayerSetup createMockPlayerSetup({
   when(() => mockState.buffering).thenReturn(isBuffering);
   when(() => mockState.position).thenReturn(position);
   when(() => mockState.duration).thenReturn(duration);
+  // `completed` is read by the playback diagnostics (player_state_snapshot)
+  // added in the preload-rewind fix. Stub a default so tests that don't
+  // override it don't hit a null-safety error from mocktail.
+  when(() => mockState.completed).thenReturn(false);
   when(() => mockPlayer.state).thenReturn(mockState);
 
   // Configure streams


### PR DESCRIPTION
Closes #2965

## Description

Follow-up to #2961. Adds two new **gated** diagnostic log lines to catch the second class of iOS playback bug the recent repros surfaced. The existing stale-position watchdog only detects position **frozen** (exact equality between heartbeats), not position **advancing below real-time**. The iOS repro at `2026-04-10T16:56:21` captured a video (index 19) whose position crawled at ~4% real-time for 13.5 seconds with zero existing events in the log — the stale watchdog was blind to it, and then mpv spontaneously cycled pause/play on its own without emitting any `buffering=true` event. Root cause writeup in `~/.claude/journal/2026-04-10-flutter-mpv-silent-slow-playback-invisible-to-freeze-watchdog.md`.

**Related Issue:** Closes #

## New diagnostics (behind `kPlaybackDiagnosticsEnabled`)

### `slow_playback_detected`

Fires when position advances at **below 50% real-time rate** over a 2-second wall-clock window for the current video. Includes every field a production investigation needs:

```
slow_playback_detected index=N videoId=<id> url=<url>
  positionDeltaMs=100 wallDeltaMs=2100 ratePct=4
  currentPositionMs=1100 sourceKind=progressive
```

A minimum of 50ms of position advance is required before flagging the window — if position didn't advance at all, the existing `stale_position_detected` watchdog already handles it. This new diagnostic is specifically for the "crawling forward" case that the exact-equality watchdog misses.

### `player_state_snapshot`

Emitted periodically (~2s per current video) to dump `player.state` directly, regardless of whether media_kit's stream listeners have fired:

```
player_state_snapshot index=N videoId=<id> url=<url>
  playing=true buffering=false positionMs=1100
  completed=false sourceKind=progressive
```

Lets us see divergence between what the Dart-side stream listeners last reported (which drives the controller's cached state) and what mpv actually believes now — e.g. mpv setting `core-idle=true` (→ `playing=false` on the snapshot) without emitting a matching `buffering=true` event, which is the leading hypothesis for the index-19 cycling pattern.

## Refactor: cache position per heartbeat tick

The heartbeat timer callback now reads `player.state.position` **once per tick** and passes the value to `_emitStateSnapshotIfDue`, `_checkPlaybackRate`, and `_checkStalePosition`. Previously each function would have read `player.state.position` independently, which triples the number of `position` getter calls per tick — bad for production performance, AND it burns through test mocks whose `thenAnswer` callbacks advance state on each call. This refactor was the reason 3 previously-passing tests didn't regress when the new diagnostics landed.

## Verification

On the next iOS log capture:

```bash
# Confirm the new diagnostics are firing
grep "slow_playback_detected" openvine_full_logs_*.txt
grep "player_state_snapshot" openvine_full_logs_*.txt | head -20

# Grep snapshots around any "video paused by itself" moment to see
# what mpv's actual state was at the time
awk '/13:56:0/' openvine_full_logs_*.txt | grep "player_state_snapshot"
```

After this lands, the "played but paused all together" kind of repro should produce either:

1. One or more `slow_playback_detected` lines immediately before the visible pause — meaning mpv was degrading decode performance
2. `player_state_snapshot` lines showing `playing=false buffering=false` while the controller still thought the video was playing — meaning mpv dropped into `core-idle` without a matching `buffering=true`, and the Dart side never knew

Either of those is actionable. Right now the same symptom shows as 13 seconds of complete log silence and then a pause we can't explain.

## Type of Change

- [ ] ✨ New feature
- [ ] 🛠️ Bug fix
- [ ] ❌ Breaking change
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore (temporary diagnostics — to be removed with the rest of the `kPlaybackDiagnosticsEnabled` gate once iOS playback investigation closes)

## Test plan

- [x] 3 new TDD tests in the `slow_playback_detected and player_state_snapshot` group:
  - `slow_playback_detected fires when position advances at well below real-time rate` — regression test for the bug (confirmed RED before the implementation landed)
  - `slow_playback_detected does NOT fire at normal real-time rate` — prevents a noisy false-positive regression
  - `player_state_snapshot fires periodically for current video` — pins the 2s interval + the field set
- [x] `createMockPlayerSetup` in `test_helpers.dart` gained a default stub for `mockState.completed = false` because the new snapshot reads it. Previously-unstubbed mocks would have thrown `type 'Null' is not a subtype of type 'bool'`.
- [x] **Existing stale-position recovery tests still pass** — the cached-position refactor was specifically needed to prevent my extra reads from burning through test mocks whose `thenAnswer` callbacks advance state per call.
- [x] **435/435 pooled_video_player tests pass** (432 previously + 3 new)
- [x] `flutter analyze` clean, `dart format` clean, pre-commit hook (full repo analyze) clean
- [ ] On-device iOS verification: capture a fresh log after this + #2961 are built, confirm both new diagnostics fire, grep for the slow-playback pattern next time the "played but paused" symptom reproduces

🤖 Generated with [Claude Code](https://claude.com/claude-code)