### PR TITLE
fix(routing): return to originating tab when navigating back from search

### DIFF
--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -125,6 +125,34 @@ class _AppShellState extends ConsumerState<AppShell> {
     };
   }
 
+  /// Navigates to the given tab at its last known position.
+  void _navigateToTab(BuildContext context, WidgetRef ref, int tabIndex) {
+    final routeType = _routeTypeForTab(tabIndex);
+    final lastIndex = ref
+        .read(lastTabPositionProvider.notifier)
+        .getPosition(routeType);
+
+    switch (tabIndex) {
+      case 0:
+        context.go(VideoFeedPage.pathForIndex(lastIndex ?? 0));
+      case 1:
+        if (lastIndex != null) {
+          context.go(ExploreScreen.pathForIndex(lastIndex));
+        } else {
+          context.go(ExploreScreen.path);
+        }
+      case 2:
+        context.go(NotificationsPage.pathForIndex(lastIndex ?? 0));
+      case 3:
+        final authService = ref.read(authServiceProvider);
+        final currentUserHex = authService.currentPublicKeyHex;
+        if (currentUserHex != null) {
+          final npub = NostrKeyUtils.encodePubKey(currentUserHex);
+          context.go(ProfileScreenRouter.pathForNpub(npub));
+        }
+    }
+  }
+
   /// Handles tab tap - navigates to last known position in that tab
   void _handleTabTap(BuildContext context, WidgetRef ref, int tabIndex) {
     final routeType = _routeTypeForTab(tabIndex);
@@ -384,12 +412,26 @@ class _AppShellState extends ConsumerState<AppShell> {
                       final ctx = ref.read(pageContextProvider).asData?.value;
                       if (ctx == null) return;
 
-                      // Check if we're in a sub-route (hashtag, search, etc.)
-                      // If so, navigate back to parent route
+                      // Check if we're in a sub-route (search, etc.)
+                      // If so, navigate back appropriately
                       switch (ctx.type) {
                         case RouteType.search:
-                          // Go back to explore
-                          return context.go(ExploreScreen.path);
+                          if (ctx.videoIndex != null) {
+                            // Feed mode → go back to search grid
+                            return context.go(
+                              SearchScreenPure.pathForTerm(
+                                term: ctx.searchTerm,
+                              ),
+                            );
+                          }
+                          // Grid mode → return to the originating tab
+                          final lastTab =
+                              ref
+                                  .read(tabHistoryProvider.notifier)
+                                  .getCurrentTab() ??
+                              0;
+                          _navigateToTab(context, ref, lastTab);
+                          return;
                         default:
                           break;
                       }
@@ -425,46 +467,10 @@ class _AppShellState extends ConsumerState<AppShell> {
 
                       // If there's a previous tab in history, navigate to it
                       if (previousTab != null) {
-                        // Navigate to previous tab
-                        final previousRouteType = _routeTypeForTab(previousTab);
-                        final lastIndex = ref
-                            .read(lastTabPositionProvider.notifier)
-                            .getPosition(previousRouteType);
-
                         // Remove current tab from history before navigating
                         tabHistory.navigateBack();
 
-                        // Navigate to previous tab
-                        switch (previousTab) {
-                          case 0:
-                            context.go(
-                              VideoFeedPage.pathForIndex(lastIndex ?? 0),
-                            );
-                          case 1:
-                            if (lastIndex != null) {
-                              return context.go(
-                                ExploreScreen.pathForIndex(lastIndex),
-                              );
-                            } else {
-                              return context.go(ExploreScreen.path);
-                            }
-                          case 2:
-                            return context.go(
-                              NotificationsPage.pathForIndex(lastIndex ?? 0),
-                            );
-                          case 3:
-                            final authService = ref.read(authServiceProvider);
-                            final currentUserHex =
-                                authService.currentPublicKeyHex;
-                            if (currentUserHex != null) {
-                              final npub = NostrKeyUtils.encodePubKey(
-                                currentUserHex,
-                              );
-                              return context.go(
-                                ProfileScreenRouter.pathForNpub(npub),
-                              );
-                            }
-                        }
+                        _navigateToTab(context, ref, previousTab);
                         return;
                       }
 

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -415,6 +415,8 @@ class _AppShellState extends ConsumerState<AppShell> {
                       // Check if we're in a sub-route (search, etc.)
                       // If so, navigate back appropriately
                       switch (ctx.type) {
+                        // TODO(#2470): Remove search case when unified
+                        // search/explore replaces the old search path.
                         case RouteType.search:
                           if (ctx.videoIndex != null) {
                             // Feed mode → go back to search grid

--- a/mobile/lib/services/back_button_handler.dart
+++ b/mobile/lib/services/back_button_handler.dart
@@ -11,6 +11,7 @@ import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/screens/pure/search_screen_pure.dart';
 
 class BackButtonHandler {
   static const MethodChannel _channel = MethodChannel(
@@ -57,9 +58,21 @@ class BackButtonHandler {
         }
         return true; // Handled
       case RouteType.hashtag:
-      case RouteType.search:
-        // Go back to explore
+        // Hashtag is part of the Explore tab
         _router!.go(ExploreScreen.path);
+        return true; // Handled
+      case RouteType.search:
+        if (ctx.videoIndex != null) {
+          // Feed mode → go back to search grid
+          _router!.go(
+            SearchScreenPure.pathForTerm(term: ctx.searchTerm),
+          );
+        } else {
+          // Grid mode → return to the originating tab
+          final lastTab =
+              _ref!.read(tabHistoryProvider.notifier).getCurrentTab() ?? 0;
+          _navigateToTab(lastTab);
+        }
         return true; // Handled
       case RouteType.videoRecorder:
       case RouteType.videoEditor:
@@ -96,37 +109,10 @@ class BackButtonHandler {
 
     // If there's a previous tab in history, navigate to it
     if (previousTab != null) {
-      // Navigate to previous tab
-      final previousRouteType = _routeTypeForTab(previousTab);
-      final lastIndex = _ref!
-          .read(lastTabPositionProvider.notifier)
-          .getPosition(previousRouteType);
-
       // Remove current tab from history before navigating
       tabHistory.navigateBack();
 
-      // Navigate to previous tab
-      switch (previousTab) {
-        case 0:
-          _router!.go(VideoFeedPage.pathForIndex(lastIndex ?? 0));
-        case 1:
-          if (lastIndex != null) {
-            _router!.go(ExploreScreen.pathForIndex(lastIndex));
-          } else {
-            _router!.go(ExploreScreen.path);
-          }
-        case 2:
-          _router!.go(NotificationsPage.pathForIndex(lastIndex ?? 0));
-        case 3:
-          // Get current user's npub for profile
-          final authService = _ref!.read(authServiceProvider);
-          final currentNpub = authService.currentNpub;
-          if (currentNpub != null) {
-            _router!.go(ProfileScreenRouter.pathForNpub(currentNpub));
-          } else {
-            _router!.go(VideoFeedPage.pathForIndex(0));
-          }
-      }
+      _navigateToTab(previousTab);
       return true; // Handled
     }
 
@@ -141,6 +127,35 @@ class BackButtonHandler {
 
     // Already at home with no history - let system exit app
     return false; // Not handled - let Android exit app
+  }
+
+  /// Navigates to the given tab at its last known position.
+  static void _navigateToTab(int tabIndex) {
+    final routeType = _routeTypeForTab(tabIndex);
+    final lastIndex = _ref!
+        .read(lastTabPositionProvider.notifier)
+        .getPosition(routeType);
+
+    switch (tabIndex) {
+      case 0:
+        _router!.go(VideoFeedPage.pathForIndex(lastIndex ?? 0));
+      case 1:
+        if (lastIndex != null) {
+          _router!.go(ExploreScreen.pathForIndex(lastIndex));
+        } else {
+          _router!.go(ExploreScreen.path);
+        }
+      case 2:
+        _router!.go(NotificationsPage.pathForIndex(lastIndex ?? 0));
+      case 3:
+        final authService = _ref!.read(authServiceProvider);
+        final currentNpub = authService.currentNpub;
+        if (currentNpub != null) {
+          _router!.go(ProfileScreenRouter.pathForNpub(currentNpub));
+        } else {
+          _router!.go(VideoFeedPage.pathForIndex(0));
+        }
+    }
   }
 
   /// Maps tab index to RouteType

--- a/mobile/lib/services/back_button_handler.dart
+++ b/mobile/lib/services/back_button_handler.dart
@@ -61,6 +61,8 @@ class BackButtonHandler {
         // Hashtag is part of the Explore tab
         _router!.go(ExploreScreen.path);
         return true; // Handled
+      // TODO(#2470): Remove search case when unified
+      // search/explore replaces the old search path.
       case RouteType.search:
         if (ctx.videoIndex != null) {
           // Feed mode → go back to search grid

--- a/mobile/test/router/tab_history_search_back_nav_test.dart
+++ b/mobile/test/router/tab_history_search_back_nav_test.dart
@@ -1,0 +1,194 @@
+// ABOUTME: Tests that tab history correctly preserves the originating tab
+// ABOUTME: when navigating to search, so back-nav returns to the right tab
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/router/providers/providers.dart';
+
+void main() {
+  group('TabHistory search back-navigation', () {
+    late StreamController<RouteContext> contextController;
+    late ProviderContainer container;
+
+    setUp(() {
+      contextController = StreamController<RouteContext>();
+      container = ProviderContainer(
+        overrides: [
+          pageContextProvider.overrideWith(
+            (ref) => contextController.stream,
+          ),
+        ],
+      );
+      // Force the provider to start listening
+      container.listen(tabHistoryProvider, (_, _) {});
+    });
+
+    tearDown(() {
+      container.dispose();
+      contextController.close();
+    });
+
+    test('getCurrentTab returns Home after navigating Home → Search', () async {
+      // Start on Home
+      contextController.add(const RouteContext(type: RouteType.home));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        container.read(tabHistoryProvider.notifier).getCurrentTab(),
+        equals(0),
+      );
+
+      // Navigate to Search
+      contextController.add(const RouteContext(type: RouteType.search));
+      await Future<void>.delayed(Duration.zero);
+
+      // Tab history should still report Home as the current tab
+      // (search is not a main tab and should not be tracked)
+      expect(
+        container.read(tabHistoryProvider.notifier).getCurrentTab(),
+        equals(0),
+      );
+    });
+
+    test(
+      'getCurrentTab returns Explore after navigating Explore → Search',
+      () async {
+        // Start on Home
+        contextController.add(const RouteContext(type: RouteType.home));
+        await Future<void>.delayed(Duration.zero);
+
+        // Navigate to Explore
+        contextController.add(const RouteContext(type: RouteType.explore));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          container.read(tabHistoryProvider.notifier).getCurrentTab(),
+          equals(1),
+        );
+
+        // Navigate to Search
+        contextController.add(const RouteContext(type: RouteType.search));
+        await Future<void>.delayed(Duration.zero);
+
+        // Tab history should still report Explore as the current tab
+        expect(
+          container.read(tabHistoryProvider.notifier).getCurrentTab(),
+          equals(1),
+        );
+      },
+    );
+
+    test(
+      'getCurrentTab returns Profile after navigating Profile → Search',
+      () async {
+        // Start on Home
+        contextController.add(const RouteContext(type: RouteType.home));
+        await Future<void>.delayed(Duration.zero);
+
+        // Navigate to Profile
+        contextController.add(const RouteContext(type: RouteType.profile));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          container.read(tabHistoryProvider.notifier).getCurrentTab(),
+          equals(3),
+        );
+
+        // Navigate to Search
+        contextController.add(const RouteContext(type: RouteType.search));
+        await Future<void>.delayed(Duration.zero);
+
+        // Tab history should still report Profile as the current tab
+        expect(
+          container.read(tabHistoryProvider.notifier).getCurrentTab(),
+          equals(3),
+        );
+      },
+    );
+
+    test(
+      'getCurrentTab returns Notifications after navigating Notifications → Search',
+      () async {
+        // Start on Home
+        contextController.add(const RouteContext(type: RouteType.home));
+        await Future<void>.delayed(Duration.zero);
+
+        // Navigate to Notifications
+        contextController.add(
+          const RouteContext(type: RouteType.notifications),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          container.read(tabHistoryProvider.notifier).getCurrentTab(),
+          equals(2),
+        );
+
+        // Navigate to Search
+        contextController.add(const RouteContext(type: RouteType.search));
+        await Future<void>.delayed(Duration.zero);
+
+        // Tab history should still report Notifications as the current tab
+        expect(
+          container.read(tabHistoryProvider.notifier).getCurrentTab(),
+          equals(2),
+        );
+      },
+    );
+
+    test('tab history is unchanged by search navigation', () async {
+      // Start on Home
+      contextController.add(const RouteContext(type: RouteType.home));
+      await Future<void>.delayed(Duration.zero);
+
+      // Navigate to Explore
+      contextController.add(const RouteContext(type: RouteType.explore));
+      await Future<void>.delayed(Duration.zero);
+
+      final historyBeforeSearch = List<int>.from(
+        container.read(tabHistoryProvider),
+      );
+
+      // Navigate to Search
+      contextController.add(const RouteContext(type: RouteType.search));
+      await Future<void>.delayed(Duration.zero);
+
+      // History should be identical — search is not tracked
+      expect(container.read(tabHistoryProvider), equals(historyBeforeSearch));
+    });
+
+    test(
+      'search with videoIndex does not affect tab history',
+      () async {
+        // Start on Home
+        contextController.add(const RouteContext(type: RouteType.home));
+        await Future<void>.delayed(Duration.zero);
+
+        final historyBeforeSearch = List<int>.from(
+          container.read(tabHistoryProvider),
+        );
+
+        // Navigate to Search feed mode (with videoIndex)
+        contextController.add(
+          const RouteContext(
+            type: RouteType.search,
+            searchTerm: 'bitcoin',
+            videoIndex: 3,
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        // History should be identical
+        expect(container.read(tabHistoryProvider), equals(historyBeforeSearch));
+
+        // getCurrentTab should still report Home
+        expect(
+          container.read(tabHistoryProvider.notifier).getCurrentTab(),
+          equals(0),
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes #1670

Back-from-search was hardcoded to always land on Explore, regardless of which tab the user came from. This PR fixes both `app_shell.dart` (iOS back button) and `back_button_handler.dart` (Android back button) to return to the correct originating tab.

- **Search feed mode** (`/search/bitcoin/3`) → back goes to search grid (`/search/bitcoin`)
- **Search grid mode** (`/search` or `/search/bitcoin`) → back returns to the tab the user was on before opening search

## Root cause

`app_shell.dart:390` and `back_button_handler.dart:60` both hardcoded `ExploreScreen.path` for `RouteType.search` back-navigation. Since `tabHistoryProvider` intentionally excludes search (it's a sub-route, not a main tab), the last tracked tab is always the correct originating tab — it just wasn't being consulted.

## Changes

- **`app_shell.dart`** — Search back-nav now uses `tabHistoryProvider.getCurrentTab()` to return to the originating tab. Extracted `_navigateToTab()` helper to eliminate duplicated tab-switch logic.
- **`back_button_handler.dart`** — Same fix for Android back button. Separated search from hashtag case (hashtag correctly belongs to Explore).
- **New test file** — 6 unit tests verifying tab history preserves the originating tab when navigating to search from any tab.

## Steps to reproduce (before fix)

1. Tap the **Home** icon (bottom left)
2. Tap the **Search** icon (top right)
3. Type a search term and tap a video result
4. Tap the **back button** (top left)

**Before:** Explore tab is displayed
**After:** Home tab is displayed (the tab you came from)

Also verify with other originating tabs:
- Explore → Search → Back → should return to Explore
- Profile → Search → Back → should return to Profile
- Notifications → Search → Back → should return to Notifications

## Test plan

- [x] `flutter analyze` — no issues
- [x] `dart format` — no changes needed
- [x] 6 new unit tests pass (`test/router/tab_history_search_back_nav_test.dart`)
- [x] 110 existing router tests pass, 0 regressions
- [ ] Manual: Home → Search → video → back → lands on Home
- [ ] Manual: Explore → Search → video → back → lands on search grid → back → lands on Explore
- [ ] Manual: Profile → Search → back → lands on Profile
- [ ] Manual: Android back button same scenarios