### PR TITLE
fix: fallback for unavailable list thumbnails

### DIFF
--- a/mobile/lib/widgets/list_search_card.dart
+++ b/mobile/lib/widgets/list_search_card.dart
@@ -171,7 +171,10 @@ class _ThumbnailCard extends StatelessWidget {
       child: ClipRRect(
         borderRadius: BorderRadius.circular(_cardRadius),
         child: imageUrl != null
-            ? VineCachedImage(imageUrl: imageUrl!)
+            ? VineCachedImage(
+                imageUrl: imageUrl!,
+                errorWidget: (_, _, _) => const SizedBox(),
+              )
             : const SizedBox(),
       ),
     );


### PR DESCRIPTION
Closes #2975

## Description

Add `errorWidget` fallback to `VineCachedImage` in `CuratedListSearchCard` so that broken thumbnail URLs (e.g. 404 from `media.divine.video`) silently fall back to the `containerLow` background instead of throwing an unhandled `HttpException`.

**Related Issue:** #2470

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore