### PR TITLE
feat: feature flag for new search and explore app bar flash fix

### DIFF
--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -37,6 +37,10 @@ enum FeatureFlag {
   integratedApps(
     'Integrated Apps',
     'Enable the integrated Nostr apps directory and sandbox',
+  ),
+  newSearch(
+    'New Search',
+    'Unified search bar on Explore',
   )
   ;
 

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -37,6 +37,8 @@ class BuildConfiguration {
         return const bool.fromEnvironment('FF_BLUESKY_PUBLISHING');
       case FeatureFlag.integratedApps:
         return const bool.fromEnvironment('FF_INTEGRATED_APPS');
+      case FeatureFlag.newSearch:
+        return const bool.fromEnvironment('FF_NEW_SEARCH');
     }
   }
 
@@ -73,6 +75,8 @@ class BuildConfiguration {
         return 'FF_BLUESKY_PUBLISHING';
       case FeatureFlag.integratedApps:
         return 'FF_INTEGRATED_APPS';
+      case FeatureFlag.newSearch:
+        return 'FF_NEW_SEARCH';
     }
   }
 }

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -2,7 +2,7 @@
 // ABOUTME: Header title uses Bricolage Grotesque font, camera button in bottom nav
 
 import 'package:divine_ui/divine_ui.dart';
-import 'package:flutter/foundation.dart' show kDebugMode, kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,6 +11,8 @@ import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:openvine/app_update/app_update.dart';
 import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/providers/active_video_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -310,11 +312,15 @@ class _AppShellState extends ConsumerState<AppShell> {
       orElse: () => false,
     );
 
+    // Watch the newSearch feature flag
+    final isNewSearchEnabled = ref.watch(
+      isFeatureEnabledProvider(FeatureFlag.newSearch),
+    );
+
     // Explore grid mode manages its own header (search bar + tabs)
-    // Only in debug builds until #2470 is complete; production keeps the
-    // standard title + search-icon app bar.
+    // when the newSearch feature flag is enabled.
     final isExploreGrid =
-        kDebugMode &&
+        isNewSearchEnabled &&
         pageCtxAsync.maybeWhen(
           data: (ctx) =>
               ctx.type == RouteType.explore && ctx.videoIndex == null,
@@ -479,7 +485,7 @@ class _AppShellState extends ConsumerState<AppShell> {
                       // Already at home with no history - let system handle exit
                     }
                   : null,
-              actions: isSearchRoute
+              actions: isSearchRoute || isNewSearchEnabled
                   ? const []
                   : [
                       DiVineAppBarAction(

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -322,9 +322,10 @@ class _AppShellState extends ConsumerState<AppShell> {
     final isExploreGrid =
         isNewSearchEnabled &&
         pageCtxAsync.maybeWhen(
-          data: (ctx) =>
-              ctx.type == RouteType.explore && ctx.videoIndex == null,
-          orElse: () => false,
+          data: (ctx) => ctx.type == RouteType.explore
+              ? ctx.videoIndex == null
+              : currentIndex == 1,
+          orElse: () => currentIndex == 1,
         );
     final showBackButton = pageCtxAsync.maybeWhen(
       data: (ctx) {

--- a/mobile/lib/screens/explore_screen.dart
+++ b/mobile/lib/screens/explore_screen.dart
@@ -438,10 +438,10 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
       child: Column(
         children: [
           // Top area: SafeArea + search bar on surfaceBackground
-          // Search bar is debug-only until #2470 is complete
+          // Search bar shown when newSearch feature flag is enabled
           SafeArea(
             bottom: false,
-            child: kDebugMode
+            child: ref.watch(isFeatureEnabledProvider(FeatureFlag.newSearch))
                 ? Padding(
                     padding: const EdgeInsets.all(16),
                     child: DivineSearchBar(
@@ -1196,10 +1196,7 @@ class _ExploreFeedContentState extends ConsumerState<_ExploreFeedContent> {
 
     if (videos.isEmpty) {
       return Center(
-        child: Text(
-          'No videos available',
-          style: VineTheme.bodyMediumFont(),
-        ),
+        child: Text('No videos available', style: VineTheme.bodyMediumFont()),
       );
     }
 

--- a/mobile/lib/screens/feed/feed_mode_switch.dart
+++ b/mobile/lib/screens/feed/feed_mode_switch.dart
@@ -5,7 +5,6 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
@@ -56,40 +55,41 @@ class FeedModeSwitch extends StatelessWidget {
               builder: (context, state) {
                 return Row(
                   children: [
-                    GestureDetector(
-                      onTap: () =>
-                          _showFeedModeBottomSheet(context, state.mode),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text(
-                            feedModeLabels[state.mode] ?? state.mode.name,
-                            style: VineTheme.headlineSmallFont().copyWith(
-                              shadows: [
-                                const Shadow(
-                                  color: VineTheme.innerShadow,
-                                  offset: Offset(1, 1),
-                                  blurRadius: 1,
-                                ),
-                                const Shadow(
-                                  color: VineTheme.innerShadow,
-                                  offset: Offset(0.4, 0.4),
-                                  blurRadius: 0.6,
-                                ),
-                              ],
+                    Semantics(
+                      label:
+                          'Feed mode: '
+                          '${feedModeLabels[state.mode] ?? state.mode.name}',
+                      button: true,
+                      child: GestureDetector(
+                        onTap: () =>
+                            _showFeedModeBottomSheet(context, state.mode),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          spacing: 12,
+                          children: [
+                            Text(
+                              feedModeLabels[state.mode] ?? state.mode.name,
+                              style: VineTheme.headlineSmallFont().copyWith(
+                                shadows: [
+                                  const Shadow(
+                                    color: VineTheme.innerShadow,
+                                    offset: Offset(1, 1),
+                                    blurRadius: 1,
+                                  ),
+                                  const Shadow(
+                                    color: VineTheme.innerShadow,
+                                    offset: Offset(0.4, 0.4),
+                                    blurRadius: 0.6,
+                                  ),
+                                ],
+                              ),
                             ),
-                          ),
-                          const SizedBox(width: 12),
-                          SvgPicture.asset(
-                            DivineIconName.caretDown.assetPath,
-                            width: 24,
-                            height: 24,
-                            colorFilter: const ColorFilter.mode(
-                              VineTheme.whiteText,
-                              BlendMode.srcIn,
+                            const DivineIcon(
+                              icon: DivineIconName.caretDown,
+                              color: VineTheme.whiteText,
                             ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
                     const Spacer(),

--- a/mobile/lib/screens/feed/feed_mode_switch.dart
+++ b/mobile/lib/screens/feed/feed_mode_switch.dart
@@ -4,8 +4,11 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/screens/pure/search_screen_pure.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 
@@ -53,50 +56,56 @@ class FeedModeSwitch extends StatelessWidget {
               builder: (context, state) {
                 return Row(
                   children: [
-                    const SizedBox(width: 48),
-                    Expanded(
-                      child: Center(
-                        child: GestureDetector(
-                          onTap: () =>
-                              _showFeedModeBottomSheet(context, state.mode),
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Text(
-                                feedModeLabels[state.mode] ?? state.mode.name,
-                                style: VineTheme.headlineSmallFont().copyWith(
-                                  shadows: [
-                                    const Shadow(
-                                      color: VineTheme.innerShadow,
-                                      offset: Offset(1, 1),
-                                      blurRadius: 1,
-                                    ),
-                                    const Shadow(
-                                      color: VineTheme.innerShadow,
-                                      offset: Offset(0.4, 0.4),
-                                      blurRadius: 0.6,
-                                    ),
-                                  ],
+                    GestureDetector(
+                      onTap: () =>
+                          _showFeedModeBottomSheet(context, state.mode),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            feedModeLabels[state.mode] ?? state.mode.name,
+                            style: VineTheme.headlineSmallFont().copyWith(
+                              shadows: [
+                                const Shadow(
+                                  color: VineTheme.innerShadow,
+                                  offset: Offset(1, 1),
+                                  blurRadius: 1,
                                 ),
-                              ),
-                              const SizedBox(width: 12),
-                              SvgPicture.asset(
-                                DivineIconName.caretDown.assetPath,
-                                width: 24,
-                                height: 24,
-                                colorFilter: const ColorFilter.mode(
-                                  VineTheme.whiteText,
-                                  BlendMode.srcIn,
+                                const Shadow(
+                                  color: VineTheme.innerShadow,
+                                  offset: Offset(0.4, 0.4),
+                                  blurRadius: 0.6,
                                 ),
-                              ),
-                            ],
+                              ],
+                            ),
                           ),
-                        ),
+                          const SizedBox(width: 12),
+                          SvgPicture.asset(
+                            DivineIconName.caretDown.assetPath,
+                            width: 24,
+                            height: 24,
+                            colorFilter: const ColorFilter.mode(
+                              VineTheme.whiteText,
+                              BlendMode.srcIn,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                    _SearchButton(
-                      onTap: () =>
-                          context.pushWithVideoPause(SearchScreenPure.path),
+                    const Spacer(),
+                    Consumer(
+                      builder: (context, ref, _) {
+                        final isNewSearchEnabled = ref.watch(
+                          isFeatureEnabledProvider(FeatureFlag.newSearch),
+                        );
+                        if (isNewSearchEnabled) {
+                          return const SizedBox.shrink();
+                        }
+                        return _SearchButton(
+                          onTap: () =>
+                              context.pushWithVideoPause(SearchScreenPure.path),
+                        );
+                      },
                     ),
                   ],
                 );

--- a/mobile/test/core/feature_flag_test.dart
+++ b/mobile/test/core/feature_flag_test.dart
@@ -39,18 +39,13 @@ void main() {
       expect(FeatureFlag.values, contains(FeatureFlag.livestreamingBeta));
       expect(FeatureFlag.values, contains(FeatureFlag.debugTools));
       expect(FeatureFlag.values, contains(FeatureFlag.integratedApps));
+      expect(FeatureFlag.values, contains(FeatureFlag.newSearch));
     });
 
     test('integratedApps flag should have correct metadata', () {
-      expect(
-        FeatureFlag.integratedApps.displayName,
-        equals('Integrated Apps'),
-      );
+      expect(FeatureFlag.integratedApps.displayName, equals('Integrated Apps'));
       expect(FeatureFlag.integratedApps.description, isNotEmpty);
-      expect(
-        FeatureFlag.integratedApps.description.length,
-        greaterThan(10),
-      );
+      expect(FeatureFlag.integratedApps.description.length, greaterThan(10));
     });
 
     test('should provide meaningful descriptions', () {

--- a/mobile/test/router/app_shell_notification_badge_test.dart
+++ b/mobile/test/router/app_shell_notification_badge_test.dart
@@ -11,9 +11,11 @@ import 'package:openvine/providers/active_video_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/relay_notifications_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/widgets/notification_badge.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
@@ -25,6 +27,7 @@ class _MockAppUpdateBloc extends MockBloc<AppUpdateEvent, AppUpdateState>
 
 Widget _buildSubject({
   required _MockAuthService mockAuthService,
+  required SharedPreferences sharedPreferences,
   required int unreadCount,
   int dmUnreadCount = 0,
 }) {
@@ -51,6 +54,7 @@ Widget _buildSubject({
         pushNotificationSyncProvider.overrideWithValue(null),
         blocklistSyncBridgeProvider.overrideWithValue(null),
         authServiceProvider.overrideWithValue(mockAuthService),
+        sharedPreferencesProvider.overrideWithValue(sharedPreferences),
         currentEnvironmentProvider.overrideWithValue(
           EnvironmentConfig.production,
         ),
@@ -65,13 +69,17 @@ Widget _buildSubject({
 
 void main() {
   late _MockAuthService mockAuthService;
+  late SharedPreferences sharedPreferences;
 
-  setUp(() {
+  setUp(() async {
     mockAuthService = _MockAuthService();
     when(() => mockAuthService.currentPublicKeyHex).thenReturn(null);
     when(() => mockAuthService.currentNpub).thenReturn(null);
     when(() => mockAuthService.isAuthenticated).thenReturn(false);
     when(() => mockAuthService.authState).thenReturn(AuthState.unauthenticated);
+
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    sharedPreferences = await SharedPreferences.getInstance();
   });
 
   group('$AppShell notification badge', () {
@@ -79,7 +87,11 @@ void main() {
       'renders $NotificationBadge on bell tab when unread count > 0',
       (tester) async {
         await tester.pumpWidget(
-          _buildSubject(mockAuthService: mockAuthService, unreadCount: 3),
+          _buildSubject(
+            mockAuthService: mockAuthService,
+            sharedPreferences: sharedPreferences,
+            unreadCount: 3,
+          ),
         );
         await tester.pump();
 
@@ -90,7 +102,11 @@ void main() {
 
     testWidgets('renders no badge when unread count is 0', (tester) async {
       await tester.pumpWidget(
-        _buildSubject(mockAuthService: mockAuthService, unreadCount: 0),
+        _buildSubject(
+          mockAuthService: mockAuthService,
+          sharedPreferences: sharedPreferences,
+          unreadCount: 0,
+        ),
       );
       await tester.pump();
 

--- a/mobile/test/screens/feed/feed_mode_switch_test.dart
+++ b/mobile/test/screens/feed/feed_mode_switch_test.dart
@@ -5,16 +5,19 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/screens/feed/feed_mode_switch.dart';
 
 class _MockVideoFeedBloc extends MockBloc<VideoFeedEvent, VideoFeedState>
     implements VideoFeedBloc {}
 
 void main() {
-  group('FeedModeSwitch', () {
+  group(FeedModeSwitch, () {
     late _MockVideoFeedBloc mockBloc;
 
     setUp(() {
@@ -29,16 +32,23 @@ void main() {
       mockBloc.close();
     });
 
-    Widget createTestWidget() {
-      return MaterialApp(
-        home: Scaffold(
-          body: Stack(
-            children: [
-              BlocProvider<VideoFeedBloc>.value(
-                value: mockBloc,
-                child: const FeedModeSwitch(),
-              ),
-            ],
+    Widget createTestWidget({bool newSearchEnabled = false}) {
+      return ProviderScope(
+        overrides: [
+          isFeatureEnabledProvider(
+            FeatureFlag.newSearch,
+          ).overrideWith((ref) => newSearchEnabled),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: Stack(
+              children: [
+                BlocProvider<VideoFeedBloc>.value(
+                  value: mockBloc,
+                  child: const FeedModeSwitch(),
+                ),
+              ],
+            ),
           ),
         ),
       );
@@ -79,7 +89,7 @@ void main() {
         );
         await tester.pumpWidget(createTestWidget());
 
-        await tester.tap(find.byType(FeedModeSwitch));
+        await tester.tap(find.text('New'));
         await tester.pumpAndSettle();
 
         expect(find.byType(VineBottomSheet), findsOneWidget);
@@ -96,7 +106,7 @@ void main() {
         );
         await tester.pumpWidget(createTestWidget());
 
-        await tester.tap(find.byType(FeedModeSwitch));
+        await tester.tap(find.text('New'));
         await tester.pumpAndSettle();
 
         await tester.tap(find.text('Following'));
@@ -110,14 +120,12 @@ void main() {
       testWidgets('dispatches VideoFeedModeChanged when new selected', (
         tester,
       ) async {
-        when(() => mockBloc.state).thenReturn(
-          const VideoFeedState(
-            status: VideoFeedStatus.success,
-          ),
-        );
+        when(
+          () => mockBloc.state,
+        ).thenReturn(const VideoFeedState(status: VideoFeedStatus.success));
         await tester.pumpWidget(createTestWidget());
 
-        await tester.tap(find.byType(FeedModeSwitch));
+        await tester.tap(find.text('For You'));
         await tester.pumpAndSettle();
 
         await tester.tap(find.text('New'));
@@ -139,7 +147,7 @@ void main() {
         );
         await tester.pumpWidget(createTestWidget());
 
-        await tester.tap(find.byType(FeedModeSwitch));
+        await tester.tap(find.text('New'));
         await tester.pumpAndSettle();
 
         // Dismiss by tapping outside (on the barrier)
@@ -154,9 +162,7 @@ void main() {
       whenListen(
         mockBloc,
         Stream.fromIterable([
-          const VideoFeedState(
-            status: VideoFeedStatus.success,
-          ),
+          const VideoFeedState(status: VideoFeedStatus.success),
         ]),
         initialState: const VideoFeedState(
           status: VideoFeedStatus.success,
@@ -168,6 +174,26 @@ void main() {
       await tester.pump();
 
       expect(find.text('For You'), findsOneWidget);
+    });
+
+    group('newSearch feature flag', () {
+      testWidgets('hides search button when flag is enabled', (tester) async {
+        when(
+          () => mockBloc.state,
+        ).thenReturn(const VideoFeedState(status: VideoFeedStatus.success));
+        await tester.pumpWidget(createTestWidget(newSearchEnabled: true));
+
+        expect(find.byType(DiVineAppBarIconButton), findsNothing);
+      });
+
+      testWidgets('shows search button when flag is disabled', (tester) async {
+        when(
+          () => mockBloc.state,
+        ).thenReturn(const VideoFeedState(status: VideoFeedStatus.success));
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.byType(DiVineAppBarIconButton), findsOneWidget);
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

Add a `newSearch` feature flag to gate the unified search bar on Explore and the home feed switcher layout, replacing the previous `kDebugMode` guard. Also fixes a pre-existing app bar flash during Explore tab transitions caused by stale async page context by falling back to the synchronous tab index.

**Related Issue:** Closes #2980

With feature flag:
<img width="465" height="925" alt="image" src="https://github.com/user-attachments/assets/dfb40080-6908-4b63-9fc6-724deecd2c6c" />
<img width="352" height="246" alt="image" src="https://github.com/user-attachments/assets/1fc4595f-d5f3-46da-a1ae-4d0037649019" />


Without feature flag:
<img width="465" height="925" alt="image" src="https://github.com/user-attachments/assets/a236aa44-ec5d-4c0d-a822-98949a86fb7a" />
<img width="346" height="146" alt="image" src="https://github.com/user-attachments/assets/3f287e97-49db-4167-826f-035c95375912" />



## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
