### PR TITLE
test: replace real Future.delayed sleeps with fakeAsync to save ~106s CI time

### DIFF
--- a/mobile/test/repositories/follow_repository_test.dart
+++ b/mobile/test/repositories/follow_repository_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
@@ -799,23 +800,25 @@ void main() {
         expect(filters.first.p, contains(testTargetPubkey));
       });
 
-      test(
-        'returns empty list on timeout',
-        () async {
+      test('returns empty list on timeout', () {
+        fakeAsync((async) {
           // Simulate a slow query that exceeds the repository's internal
-          // timeout. The delay must be longer than the repo timeout (5s) but
-          // shorter than the test timeout so cleanup completes cleanly.
+          // 8-second timeout.
           when(() => mockNostrClient.queryEvents(any())).thenAnswer((_) async {
-            await Future<void>.delayed(const Duration(seconds: 7));
+            await Future<void>.delayed(const Duration(seconds: 15));
             return [];
           });
 
-          final followers = await repository.getFollowers(testTargetPubkey);
+          List<String>? followers;
+          repository.getFollowers(testTargetPubkey).then((r) => followers = r);
+
+          // Advance past the 8s _fetchFollowersTimeout
+          async.elapse(const Duration(seconds: 9));
+          async.flushMicrotasks();
 
           expect(followers, isEmpty);
-        },
-        timeout: const Timeout(Duration(seconds: 15)),
-      );
+        });
+      });
     });
 
     group('getMyFollowers', () {
@@ -970,7 +973,10 @@ void main() {
       setUp(() {
         realTimeStreamController = StreamController<Event>.broadcast();
 
-        // Override the default subscribe mock to use the stream controller
+        // Override subscribe to distinguish initialization from real-time:
+        //   - Init relay query (no subscriptionId) → empty stream so it
+        //     completes immediately instead of waiting 5s fallback timeout
+        //   - Real-time sync (with subscriptionId) → broadcast stream
         when(
           () => mockNostrClient.subscribe(
             any(),
@@ -981,7 +987,14 @@ void main() {
             sendAfterAuth: any(named: 'sendAfterAuth'),
             onEose: any(named: 'onEose'),
           ),
-        ).thenAnswer((_) => realTimeStreamController.stream);
+        ).thenAnswer((invocation) {
+          final subscriptionId =
+              invocation.namedArguments[#subscriptionId] as String?;
+          if (subscriptionId == null) {
+            return const Stream<Event>.empty();
+          }
+          return realTimeStreamController.stream;
+        });
       });
 
       tearDown(() async {
@@ -1008,7 +1021,7 @@ void main() {
         );
 
         realTimeStreamController.add(remoteEvent);
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await Future<void>.delayed(Duration.zero);
 
         expect(repository.followingPubkeys, contains(testTargetPubkey));
         expect(repository.followingCount, 1);
@@ -1029,7 +1042,7 @@ void main() {
         );
 
         realTimeStreamController.add(remoteEvent);
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await Future<void>.delayed(Duration.zero);
 
         expect(repository.followingPubkeys, contains(testTargetPubkey));
         expect(repository.followingPubkeys, contains(testTargetPubkey2));
@@ -1050,7 +1063,7 @@ void main() {
           createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
         );
         realTimeStreamController.add(recentEvent);
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await Future<void>.delayed(Duration.zero);
 
         expect(repository.followingCount, 1);
 
@@ -1065,7 +1078,7 @@ void main() {
         );
 
         realTimeStreamController.add(oldEvent);
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await Future<void>.delayed(Duration.zero);
 
         // Should still have the original following list
         expect(repository.followingPubkeys, contains(testTargetPubkey));
@@ -1090,7 +1103,7 @@ void main() {
         );
 
         realTimeStreamController.add(otherUserEvent);
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await Future<void>.delayed(Duration.zero);
 
         // Should not update following list
         expect(repository.followingPubkeys, isEmpty);
@@ -1111,7 +1124,7 @@ void main() {
         );
 
         realTimeStreamController.add(textNoteEvent);
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await Future<void>.delayed(Duration.zero);
 
         // Should not update following list
         expect(repository.followingPubkeys, isEmpty);
@@ -1137,7 +1150,7 @@ void main() {
         );
 
         realTimeStreamController.add(remoteEvent);
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await Future<void>.delayed(Duration.zero);
 
         expect(emittedLists.length, greaterThanOrEqualTo(1));
         expect(emittedLists.last, contains(testTargetPubkey));
@@ -1195,7 +1208,7 @@ void main() {
           );
 
           realTimeStreamController.add(remoteEvent);
-          await Future<void>.delayed(const Duration(milliseconds: 50));
+          await Future<void>.delayed(Duration.zero);
 
           // Should have merged: all 12 original + 1 new = 13
           expect(repository.followingCount, 13);
@@ -1244,7 +1257,7 @@ void main() {
           );
 
           realTimeStreamController.add(remoteEvent);
-          await Future<void>.delayed(const Duration(milliseconds: 50));
+          await Future<void>.delayed(Duration.zero);
 
           // Should accept as-is (not merge) because no new pubkeys
           expect(repository.followingCount, 3);
@@ -1284,7 +1297,7 @@ void main() {
           );
 
           realTimeStreamController.add(remoteEvent);
-          await Future<void>.delayed(const Duration(milliseconds: 50));
+          await Future<void>.delayed(Duration.zero);
 
           // Should accept the remote event as-is (8 follows)
           expect(repository.followingCount, 8);
@@ -1325,7 +1338,7 @@ void main() {
         );
 
         realTimeStreamController.add(remoteEvent);
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await Future<void>.delayed(Duration.zero);
 
         // Should accept the larger list
         expect(repository.followingCount, 10);
@@ -1365,7 +1378,7 @@ void main() {
           );
 
           realTimeStreamController.add(remoteEvent);
-          await Future<void>.delayed(const Duration(milliseconds: 50));
+          await Future<void>.delayed(Duration.zero);
 
           // Should replace (not merge) because local list is below threshold
           expect(repository.followingCount, 1);
@@ -1391,7 +1404,7 @@ void main() {
 
         // This should not throw or cause any updates
         realTimeStreamController.add(remoteEvent);
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await Future<void>.delayed(Duration.zero);
 
         // Following list should remain empty (disposed before event processed)
         expect(repository.followingPubkeys, isEmpty);

--- a/mobile/test/services/curation_publish_test.dart
+++ b/mobile/test/services/curation_publish_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show CurationPublishResult;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
@@ -240,7 +241,7 @@ void main() {
             return _testEvent();
           });
 
-          dynamic result;
+          CurationPublishResult? result;
           curationService
               .publishCuration(
                 id: 'test_curation',
@@ -253,8 +254,8 @@ void main() {
           async.elapse(const Duration(seconds: 6));
           async.flushMicrotasks();
 
-          expect(result.success, isFalse);
-          expect(result.errors['timeout'], isNotNull);
+          expect(result!.success, isFalse);
+          expect(result!.errors['timeout'], isNotNull);
         });
       });
 
@@ -266,7 +267,7 @@ void main() {
           ).thenAnswer((_) => completer.future);
 
           // Start first publish (will block on completer)
-          dynamic firstResult;
+          CurationPublishResult? firstResult;
           curationService
               .publishCuration(
                 id: 'rapid_curation',
@@ -279,7 +280,7 @@ void main() {
           async.flushMicrotasks();
 
           // Second publish of the same ID should be rejected as duplicate
-          dynamic secondResult;
+          CurationPublishResult? secondResult;
           curationService
               .publishCuration(
                 id: 'rapid_curation',
@@ -290,13 +291,13 @@ void main() {
 
           async.flushMicrotasks();
 
-          expect(secondResult.success, isFalse);
-          expect(secondResult.errors.containsKey('duplicate'), isTrue);
+          expect(secondResult!.success, isFalse);
+          expect(secondResult!.errors.containsKey('duplicate'), isTrue);
 
           // Complete the first publish
           completer.complete(_testEvent());
           async.flushMicrotasks();
-          expect(firstResult.success, isTrue);
+          expect(firstResult!.success, isTrue);
         });
       });
     });
@@ -404,10 +405,12 @@ void main() {
             () => mockNostrService.publishEvent(any()),
           ).thenAnswer((_) => completer.future);
 
-          curationService.publishCuration(
-            id: 'publishing_curation',
-            title: 'Test',
-            videoIds: [],
+          unawaited(
+            curationService.publishCuration(
+              id: 'publishing_curation',
+              title: 'Test',
+              videoIds: [],
+            ),
           );
 
           // Allow async code to start

--- a/mobile/test/services/curation_publish_test.dart
+++ b/mobile/test/services/curation_publish_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:likes_repository/likes_repository.dart';
@@ -230,56 +231,73 @@ void main() {
         expect(result.errors.containsKey('publish'), isTrue);
       });
 
-      test('should timeout after 5 seconds', () async {
-        when(() => mockNostrService.publishEvent(any())).thenAnswer((_) async {
-          await Future.delayed(const Duration(seconds: 10));
-          return _testEvent();
+      test('should timeout after 5 seconds', () {
+        fakeAsync((async) {
+          when(
+            () => mockNostrService.publishEvent(any()),
+          ).thenAnswer((_) async {
+            await Future<void>.delayed(const Duration(seconds: 10));
+            return _testEvent();
+          });
+
+          dynamic result;
+          curationService
+              .publishCuration(
+                id: 'test_curation',
+                title: 'Test',
+                videoIds: [],
+              )
+              .then((r) => result = r);
+
+          // Advance past the 5-second timeout
+          async.elapse(const Duration(seconds: 6));
+          async.flushMicrotasks();
+
+          expect(result.success, isFalse);
+          expect(result.errors['timeout'], isNotNull);
         });
-
-        final stopwatch = Stopwatch()..start();
-        final result = await curationService.publishCuration(
-          id: 'test_curation',
-          title: 'Test',
-          videoIds: [],
-        );
-        stopwatch.stop();
-
-        // Allow some margin for test timing
-        expect(stopwatch.elapsed.inSeconds, lessThan(7));
-        expect(result.success, isFalse);
-        expect(result.errors['timeout'], isNotNull);
       });
 
-      test('should prevent duplicate concurrent publishes', () async {
-        final completer = Completer<Event?>();
-        when(
-          () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) => completer.future);
+      test('should prevent duplicate concurrent publishes', () {
+        fakeAsync((async) {
+          final completer = Completer<Event?>();
+          when(
+            () => mockNostrService.publishEvent(any()),
+          ).thenAnswer((_) => completer.future);
 
-        // Start first publish (will block on completer)
-        final firstPublish = curationService.publishCuration(
-          id: 'rapid_curation',
-          title: 'Test',
-          videoIds: [],
-        );
+          // Start first publish (will block on completer)
+          dynamic firstResult;
+          curationService
+              .publishCuration(
+                id: 'rapid_curation',
+                title: 'Test',
+                videoIds: [],
+              )
+              .then((r) => firstResult = r);
 
-        // Allow async code to start
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+          // Allow async code to start
+          async.flushMicrotasks();
 
-        // Second publish of the same ID should be rejected as duplicate
-        final secondResult = await curationService.publishCuration(
-          id: 'rapid_curation',
-          title: 'Test',
-          videoIds: [],
-        );
+          // Second publish of the same ID should be rejected as duplicate
+          dynamic secondResult;
+          curationService
+              .publishCuration(
+                id: 'rapid_curation',
+                title: 'Test',
+                videoIds: [],
+              )
+              .then((r) => secondResult = r);
 
-        expect(secondResult.success, isFalse);
-        expect(secondResult.errors.containsKey('duplicate'), isTrue);
+          async.flushMicrotasks();
 
-        // Complete the first publish
-        completer.complete(_testEvent());
-        final firstResult = await firstPublish;
-        expect(firstResult.success, isTrue);
+          expect(secondResult.success, isFalse);
+          expect(secondResult.errors.containsKey('duplicate'), isTrue);
+
+          // Complete the first publish
+          completer.complete(_testEvent());
+          async.flushMicrotasks();
+          expect(firstResult.success, isTrue);
+        });
       });
     });
 
@@ -379,37 +397,39 @@ void main() {
     });
 
     group('Publishing Status UI', () {
-      test('should report "Publishing..." status during publish', () async {
-        final completer = Completer<Event?>();
-        when(
-          () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) => completer.future);
+      test('should report "Publishing..." status during publish', () {
+        fakeAsync((async) {
+          final completer = Completer<Event?>();
+          when(
+            () => mockNostrService.publishEvent(any()),
+          ).thenAnswer((_) => completer.future);
 
-        final publishFuture = curationService.publishCuration(
-          id: 'publishing_curation',
-          title: 'Test',
-          videoIds: [],
-        );
+          curationService.publishCuration(
+            id: 'publishing_curation',
+            title: 'Test',
+            videoIds: [],
+          );
 
-        // Wait for async code to start
-        await Future<void>.delayed(const Duration(milliseconds: 10));
+          // Allow async code to start
+          async.flushMicrotasks();
 
-        final status = curationService.getCurationPublishStatus(
-          'publishing_curation',
-        );
-        expect(status.isPublishing, isTrue);
-        expect(status.statusText, equals('Publishing...'));
+          final status = curationService.getCurationPublishStatus(
+            'publishing_curation',
+          );
+          expect(status.isPublishing, isTrue);
+          expect(status.statusText, equals('Publishing...'));
 
-        // Complete the publish
-        completer.complete(_testEvent());
-        await publishFuture;
+          // Complete the publish
+          completer.complete(_testEvent());
+          async.flushMicrotasks();
 
-        final finalStatus = curationService.getCurationPublishStatus(
-          'publishing_curation',
-        );
-        expect(finalStatus.isPublishing, isFalse);
-        expect(finalStatus.isPublished, isTrue);
-        expect(finalStatus.statusText, contains('Published'));
+          final finalStatus = curationService.getCurationPublishStatus(
+            'publishing_curation',
+          );
+          expect(finalStatus.isPublishing, isFalse);
+          expect(finalStatus.isPublished, isTrue);
+          expect(finalStatus.statusText, contains('Published'));
+        });
       });
 
       test('should show error status for failed publishes', () async {

--- a/mobile/test/services/video_event_publisher_retry_test.dart
+++ b/mobile/test/services/video_event_publisher_retry_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for VideoEventPublisher retry logic with exponential backoff
 // ABOUTME: Verifies 3 retry attempts with 2s, 4s delays match implementation
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// Extracted retry logic from VideoEventPublisher for testability
@@ -40,149 +41,205 @@ void main() {
     group('RetryExecutor.executeWithRetry', () {
       test(
         'returns true immediately when operation succeeds on first try',
-        () async {
-          var callCount = 0;
+        () {
+          fakeAsync((async) {
+            var callCount = 0;
+            bool? result;
 
-          final result = await RetryExecutor.executeWithRetry(
+            RetryExecutor.executeWithRetry(
+              operation: () async {
+                callCount++;
+                return true; // Succeeds immediately
+              },
+            ).then((r) => result = r);
+
+            async.flushMicrotasks();
+
+            expect(result, isTrue);
+            expect(
+              callCount,
+              equals(1),
+              reason: 'Should only call once on success',
+            );
+          });
+        },
+      );
+
+      test('retries up to 3 times when operation fails', () {
+        fakeAsync((async) {
+          var callCount = 0;
+          bool? result;
+
+          RetryExecutor.executeWithRetry(
             operation: () async {
               callCount++;
-              return true; // Succeeds immediately
+              return false; // Always fails
             },
+          ).then((r) => result = r);
+
+          // Elapse past all retry delays: 2s + 4s = 6s
+          async.elapse(const Duration(seconds: 7));
+
+          expect(result, isFalse);
+          expect(
+            callCount,
+            equals(3),
+            reason: 'Should try 3 times (maxRetries)',
           );
+        });
+      });
+
+      test('returns true on second attempt when first fails', () {
+        fakeAsync((async) {
+          var callCount = 0;
+          bool? result;
+
+          RetryExecutor.executeWithRetry(
+            operation: () async {
+              callCount++;
+              return callCount >= 2; // Fails first, succeeds second
+            },
+          ).then((r) => result = r);
+
+          // Elapse past first retry delay: 2s
+          async.elapse(const Duration(seconds: 3));
 
           expect(result, isTrue);
           expect(
             callCount,
-            equals(1),
-            reason: 'Should only call once on success',
+            equals(2),
+            reason: 'Should succeed on second try',
           );
-        },
-      );
-
-      test('retries up to 3 times when operation fails', () async {
-        var callCount = 0;
-
-        final result = await RetryExecutor.executeWithRetry(
-          operation: () async {
-            callCount++;
-            return false; // Always fails
-          },
-        );
-
-        expect(result, isFalse);
-        expect(callCount, equals(3), reason: 'Should try 3 times (maxRetries)');
+        });
       });
 
-      test('returns true on second attempt when first fails', () async {
-        var callCount = 0;
-
-        final result = await RetryExecutor.executeWithRetry(
-          operation: () async {
-            callCount++;
-            return callCount >= 2; // Fails first, succeeds second
-          },
-        );
-
-        expect(result, isTrue);
-        expect(callCount, equals(2), reason: 'Should succeed on second try');
-      });
-
-      test('returns true on third attempt when first two fail', () async {
-        var callCount = 0;
-
-        final result = await RetryExecutor.executeWithRetry(
-          operation: () async {
-            callCount++;
-            return callCount >= 3; // Fails first two, succeeds third
-          },
-        );
-
-        expect(result, isTrue);
-        expect(callCount, equals(3), reason: 'Should succeed on third try');
-      });
-
-      test('calls onRetry callback with correct attempt and delay', () async {
-        final retryAttempts = <int>[];
-        final retryDelays = <int>[];
-
-        await RetryExecutor.executeWithRetry(
-          operation: () async => false,
-          onRetry: (attempt, delaySeconds) {
-            retryAttempts.add(attempt);
-            retryDelays.add(delaySeconds);
-          },
-        );
-
-        // Should have 2 retries (attempt 1 and 2, not 3 since that's the last)
-        expect(retryAttempts, equals([1, 2]));
-        expect(
-          retryDelays,
-          equals([2, 4]),
-          reason: 'Delays should be 2s, 4s (exponential backoff)',
-        );
-      });
-
-      test('calls onAllFailed callback when all attempts exhausted', () async {
-        var allFailedCalled = false;
-
-        await RetryExecutor.executeWithRetry(
-          operation: () async => false,
-          onAllFailed: () {
-            allFailedCalled = true;
-          },
-        );
-
-        expect(allFailedCalled, isTrue);
-      });
-
-      test(
-        'does not call onAllFailed when operation eventually succeeds',
-        () async {
-          var allFailedCalled = false;
+      test('returns true on third attempt when first two fail', () {
+        fakeAsync((async) {
           var callCount = 0;
+          bool? result;
 
-          await RetryExecutor.executeWithRetry(
+          RetryExecutor.executeWithRetry(
             operation: () async {
               callCount++;
-              return callCount >= 2; // Succeeds on second try
+              return callCount >= 3; // Fails first two, succeeds third
             },
+          ).then((r) => result = r);
+
+          // Elapse past all retry delays: 2s + 4s = 6s
+          async.elapse(const Duration(seconds: 7));
+
+          expect(result, isTrue);
+          expect(
+            callCount,
+            equals(3),
+            reason: 'Should succeed on third try',
+          );
+        });
+      });
+
+      test('calls onRetry callback with correct attempt and delay', () {
+        fakeAsync((async) {
+          final retryAttempts = <int>[];
+          final retryDelays = <int>[];
+
+          RetryExecutor.executeWithRetry(
+            operation: () async => false,
+            onRetry: (attempt, delaySeconds) {
+              retryAttempts.add(attempt);
+              retryDelays.add(delaySeconds);
+            },
+          );
+
+          async.elapse(const Duration(seconds: 7));
+
+          // Should have 2 retries (attempt 1 and 2, not 3 since that's last)
+          expect(retryAttempts, equals([1, 2]));
+          expect(
+            retryDelays,
+            equals([2, 4]),
+            reason: 'Delays should be 2s, 4s (exponential backoff)',
+          );
+        });
+      });
+
+      test('calls onAllFailed callback when all attempts exhausted', () {
+        fakeAsync((async) {
+          var allFailedCalled = false;
+
+          RetryExecutor.executeWithRetry(
+            operation: () async => false,
             onAllFailed: () {
               allFailedCalled = true;
             },
           );
 
-          expect(allFailedCalled, isFalse);
+          async.elapse(const Duration(seconds: 7));
+
+          expect(allFailedCalled, isTrue);
+        });
+      });
+
+      test(
+        'does not call onAllFailed when operation eventually succeeds',
+        () {
+          fakeAsync((async) {
+            var allFailedCalled = false;
+            var callCount = 0;
+
+            RetryExecutor.executeWithRetry(
+              operation: () async {
+                callCount++;
+                return callCount >= 2; // Succeeds on second try
+              },
+              onAllFailed: () {
+                allFailedCalled = true;
+              },
+            );
+
+            async.elapse(const Duration(seconds: 3));
+
+            expect(allFailedCalled, isFalse);
+          });
         },
       );
 
       test(
         'does not call onRetry when operation succeeds on first try',
-        () async {
-          var retryCalled = false;
+        () {
+          fakeAsync((async) {
+            var retryCalled = false;
 
-          await RetryExecutor.executeWithRetry(
-            operation: () async => true,
-            onRetry: (_, _) {
-              retryCalled = true;
-            },
-          );
+            RetryExecutor.executeWithRetry(
+              operation: () async => true,
+              onRetry: (_, _) {
+                retryCalled = true;
+              },
+            );
 
-          expect(retryCalled, isFalse);
+            async.flushMicrotasks();
+
+            expect(retryCalled, isFalse);
+          });
         },
       );
 
-      test('respects custom maxRetries parameter', () async {
-        var callCount = 0;
+      test('respects custom maxRetries parameter', () {
+        fakeAsync((async) {
+          var callCount = 0;
 
-        await RetryExecutor.executeWithRetry(
-          operation: () async {
-            callCount++;
-            return false;
-          },
-          maxRetries: 5,
-        );
+          RetryExecutor.executeWithRetry(
+            operation: () async {
+              callCount++;
+              return false;
+            },
+            maxRetries: 5,
+          );
 
-        expect(callCount, equals(5));
+          // 2+4+6+8 = 20s of delays for 5 attempts
+          async.elapse(const Duration(seconds: 21));
+
+          expect(callCount, equals(5));
+        });
       });
     });
 
@@ -203,7 +260,8 @@ void main() {
         const attempt = 3;
         const delaySeconds = attempt * 2;
         expect(delaySeconds, equals(6));
-        // Note: In actual implementation, delay is not applied after last attempt
+        // Note: In actual implementation, delay is not applied after last
+        // attempt
       });
 
       test('total wait time for 3 attempts is 6 seconds (2s + 4s)', () {

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -57,153 +58,173 @@ void main() {
       return container;
     }
 
-    test('does not trigger reset on initial activation', () async {
-      final container = createContainer(
-        initialStatuses: {
-          'wss://relay1.example.com': RelayConnectionStatus.connected(
-            'wss://relay1.example.com',
-          ),
-        },
-      );
+    test('does not trigger reset on initial activation', () {
+      fakeAsync((async) {
+        final container = createContainer(
+          initialStatuses: {
+            'wss://relay1.example.com': RelayConnectionStatus.connected(
+              'wss://relay1.example.com',
+            ),
+          },
+        );
 
-      // Wait for any async processing
-      await Future<void>.delayed(const Duration(seconds: 3));
+        // Elapse well past debounce to confirm nothing fires
+        async.elapse(const Duration(seconds: 3));
 
-      verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
-      container.dispose();
-    });
-
-    test('triggers reset when a new relay is added', () async {
-      final container = createContainer(
-        initialStatuses: {
-          'wss://relay1.example.com': RelayConnectionStatus.connected(
-            'wss://relay1.example.com',
-          ),
-        },
-      );
-
-      // Simulate adding a new relay
-      statusController.add({
-        'wss://relay1.example.com': RelayConnectionStatus.connected(
-          'wss://relay1.example.com',
-        ),
-        'wss://relay2.example.com': RelayConnectionStatus.connected(
-          'wss://relay2.example.com',
-        ),
+        verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
+        container.dispose();
       });
-
-      // Wait for debounce (2s) + buffer
-      await Future<void>.delayed(const Duration(milliseconds: 2500));
-
-      verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
-      container.dispose();
     });
 
-    test('triggers reset when a relay is removed', () async {
-      final container = createContainer(
-        initialStatuses: {
+    test('triggers reset when a new relay is added', () {
+      fakeAsync((async) {
+        final container = createContainer(
+          initialStatuses: {
+            'wss://relay1.example.com': RelayConnectionStatus.connected(
+              'wss://relay1.example.com',
+            ),
+          },
+        );
+
+        // Simulate adding a new relay
+        statusController.add({
           'wss://relay1.example.com': RelayConnectionStatus.connected(
             'wss://relay1.example.com',
           ),
           'wss://relay2.example.com': RelayConnectionStatus.connected(
             'wss://relay2.example.com',
           ),
-        },
-      );
+        });
 
-      // Simulate removing a relay
-      statusController.add({
-        'wss://relay1.example.com': RelayConnectionStatus.connected(
-          'wss://relay1.example.com',
-        ),
+        async.flushMicrotasks();
+        // Elapse past the 2s debounce timer
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
+        container.dispose();
       });
-
-      // Wait for debounce
-      await Future<void>.delayed(const Duration(milliseconds: 2500));
-
-      verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
-      container.dispose();
     });
 
-    test('does not trigger reset on connection state flapping', () async {
-      final container = createContainer(
-        initialStatuses: {
+    test('triggers reset when a relay is removed', () {
+      fakeAsync((async) {
+        final container = createContainer(
+          initialStatuses: {
+            'wss://relay1.example.com': RelayConnectionStatus.connected(
+              'wss://relay1.example.com',
+            ),
+            'wss://relay2.example.com': RelayConnectionStatus.connected(
+              'wss://relay2.example.com',
+            ),
+          },
+        );
+
+        // Simulate removing a relay
+        statusController.add({
           'wss://relay1.example.com': RelayConnectionStatus.connected(
             'wss://relay1.example.com',
           ),
-        },
-      );
+        });
 
-      // Simulate connection state change (same URLs, different status)
-      statusController.add({
-        'wss://relay1.example.com': RelayConnectionStatus.disconnected(
-          'wss://relay1.example.com',
-        ),
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
+        container.dispose();
       });
-
-      // Wait for debounce period
-      await Future<void>.delayed(const Duration(milliseconds: 2500));
-
-      verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
-      container.dispose();
     });
 
-    test('debounces rapid relay set changes into single reset', () async {
-      final container = createContainer(
-        initialStatuses: {
+    test('does not trigger reset on connection state flapping', () {
+      fakeAsync((async) {
+        final container = createContainer(
+          initialStatuses: {
+            'wss://relay1.example.com': RelayConnectionStatus.connected(
+              'wss://relay1.example.com',
+            ),
+          },
+        );
+
+        // Simulate connection state change (same URLs, different status)
+        statusController.add({
+          'wss://relay1.example.com': RelayConnectionStatus.disconnected(
+            'wss://relay1.example.com',
+          ),
+        });
+
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        verifyNever(() => mockVideoEventService.resetAndResubscribeAll());
+        container.dispose();
+      });
+    });
+
+    test('debounces rapid relay set changes into single reset', () {
+      fakeAsync((async) {
+        final container = createContainer(
+          initialStatuses: {
+            'wss://relay1.example.com': RelayConnectionStatus.connected(
+              'wss://relay1.example.com',
+            ),
+          },
+        );
+
+        // Rapid changes: add relay2, then add relay3 (within 2s window)
+        statusController.add({
           'wss://relay1.example.com': RelayConnectionStatus.connected(
             'wss://relay1.example.com',
           ),
-        },
-      );
+          'wss://relay2.example.com': RelayConnectionStatus.connected(
+            'wss://relay2.example.com',
+          ),
+        });
 
-      // Rapid changes: add relay2, then add relay3 (within 2s window)
-      statusController.add({
-        'wss://relay1.example.com': RelayConnectionStatus.connected(
-          'wss://relay1.example.com',
-        ),
-        'wss://relay2.example.com': RelayConnectionStatus.connected(
-          'wss://relay2.example.com',
-        ),
+        async.flushMicrotasks();
+        async.elapse(const Duration(milliseconds: 500));
+
+        statusController.add({
+          'wss://relay1.example.com': RelayConnectionStatus.connected(
+            'wss://relay1.example.com',
+          ),
+          'wss://relay2.example.com': RelayConnectionStatus.connected(
+            'wss://relay2.example.com',
+          ),
+          'wss://relay3.example.com': RelayConnectionStatus.connected(
+            'wss://relay3.example.com',
+          ),
+        });
+
+        async.flushMicrotasks();
+        // 2s from last change fires the debounce
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        // Should only have fired once despite two set changes
+        verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
+        container.dispose();
       });
-
-      await Future<void>.delayed(const Duration(milliseconds: 500));
-
-      statusController.add({
-        'wss://relay1.example.com': RelayConnectionStatus.connected(
-          'wss://relay1.example.com',
-        ),
-        'wss://relay2.example.com': RelayConnectionStatus.connected(
-          'wss://relay2.example.com',
-        ),
-        'wss://relay3.example.com': RelayConnectionStatus.connected(
-          'wss://relay3.example.com',
-        ),
-      });
-
-      // Wait for debounce to fire (2s from last change)
-      await Future<void>.delayed(const Duration(milliseconds: 2500));
-
-      // Should only have fired once despite two set changes
-      verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
-      container.dispose();
     });
 
-    test('handles empty initial relay set', () async {
-      final container = createContainer(initialStatuses: {});
+    test('handles empty initial relay set', () {
+      fakeAsync((async) {
+        final container = createContainer(initialStatuses: {});
 
-      // Add first relay
-      statusController.add({
-        'wss://relay1.example.com': RelayConnectionStatus.connected(
-          'wss://relay1.example.com',
-        ),
+        // Add first relay
+        statusController.add({
+          'wss://relay1.example.com': RelayConnectionStatus.connected(
+            'wss://relay1.example.com',
+          ),
+        });
+
+        async.flushMicrotasks();
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
+        container.dispose();
       });
-
-      // Wait for debounce
-      await Future<void>.delayed(const Duration(milliseconds: 2500));
-
-      verify(() => mockVideoEventService.resetAndResubscribeAll()).called(1);
-      container.dispose();
     });
   });
 }

--- a/mobile/test/unit/providers/relay_set_change_bridge_test.dart
+++ b/mobile/test/unit/providers/relay_set_change_bridge_test.dart
@@ -32,6 +32,9 @@ void main() {
       when(
         () => mockVideoEventService.resetAndResubscribeAll(),
       ).thenAnswer((_) async {});
+      when(
+        () => mockNostrClient.forceReconnectAll(),
+      ).thenAnswer((_) async {});
     });
 
     tearDown(() {


### PR DESCRIPTION
## Summary
Closes #2892

- **video_event_publisher_retry_test** (48s → <1s): wrap retry tests in `fakeAsync`, use `async.elapse()` to advance past exponential backoff delays
- **relay_set_change_bridge_test** (15s → <1s): wrap debounce tests in `fakeAsync`, use `async.elapse()` to fire the 2s debounce Timer instantly
- **curation_publish_test** (5.3s → <1s): wrap timeout and duplicate-publish tests in `fakeAsync`, replace 10ms event-loop yields with `flushMicrotasks()`
- **follow_repository_test** (43s → <1s): smarter subscribe mock returns `Stream.empty()` for init relay query (avoids 5s `ImmediateCompletionHelper` fallback timeout per test), `fakeAsync` for getFollowers timeout test, `Duration.zero` for stream processing delays

No production code changes — test-only.

## Test plan
- [x] `flutter test test/services/video_event_publisher_retry_test.dart` — 15 tests pass
- [x] `flutter test test/unit/providers/relay_set_change_bridge_test.dart` — 6 tests pass
- [x] `flutter test test/services/curation_publish_test.dart` — 16 tests pass
- [x] `flutter test test/repositories/follow_repository_test.dart` — 70 tests pass
- [x] All tests complete at `00:00` (previously 48s, 15s, 5s, 43s respectively)