### PR TITLE
fix(sounds): make original sound display-only, detect bundled sounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Git worktrees
 .worktrees/
+worktrees/
 
 # Flutter repo-specific
 /bin/cache/

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -801,6 +801,11 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         name: LibraryScreen.clipsRouteName,
         builder: (_, _) => const LibraryScreen(initialTabIndex: 1),
       ),
+      GoRoute(
+        path: LibraryScreen.soundsPath,
+        name: LibraryScreen.soundsRouteName,
+        builder: (_, _) => const LibraryScreen(initialTabIndex: 2),
+      ),
       // Followers screen - routes to My or Others based on pubkey
       GoRoute(
         path: FollowersScreenRouter.path,

--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -33,6 +33,12 @@ class LibraryScreen extends ConsumerStatefulWidget {
   /// Path for clips route.
   static const clipsPath = '/clips';
 
+  /// Route name for sounds path.
+  static const soundsRouteName = 'sounds';
+
+  /// Path for sounds route.
+  static const soundsPath = '/sounds';
+
   const LibraryScreen({
     super.key,
     this.initialTabIndex = 0,
@@ -42,7 +48,7 @@ class LibraryScreen extends ConsumerStatefulWidget {
 
   /// Index of the tab to show when the screen opens.
   ///
-  /// `0` = Drafts, `1` = Clips.
+  /// `0` = Drafts, `1` = Clips, `2` = Sounds.
   final int initialTabIndex;
 
   /// When true, enables multi-select mode for adding clips to the editor.
@@ -70,7 +76,7 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen>
   void initState() {
     super.initState();
     _tabController = TabController(
-      length: 2,
+      length: 3,
       initialIndex: widget.initialTabIndex,
       vsync: this,
     );
@@ -455,6 +461,7 @@ class _LibraryAppBar extends StatelessWidget implements PreferredSizeWidget {
             tabs: const [
               Tab(text: 'Drafts'),
               Tab(text: 'Clips'),
+              Tab(text: 'Sounds'),
             ],
           ),
         );
@@ -516,6 +523,7 @@ class _TabBody extends StatelessWidget {
           targetAspectRatio: targetAspectRatio,
           isSelectionMode: false,
         ),
+        const SoundsTab(),
       ],
     );
   }

--- a/mobile/lib/widgets/library/library.dart
+++ b/mobile/lib/widgets/library/library.dart
@@ -4,3 +4,4 @@
 export 'clips_tab.dart';
 export 'drafts_tab.dart';
 export 'empty_library_state.dart';
+export 'sounds_tab.dart';

--- a/mobile/lib/widgets/library/sounds_tab.dart
+++ b/mobile/lib/widgets/library/sounds_tab.dart
@@ -1,0 +1,527 @@
+// ABOUTME: Sounds tab for the Library screen.
+// ABOUTME: Browse bundled and trending Nostr sounds with search and preview.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/models/audio_event.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/sound_library_service_provider.dart';
+import 'package:openvine/providers/sounds_providers.dart';
+import 'package:openvine/screens/sound_detail_screen.dart';
+import 'package:openvine/utils/unified_logger.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
+import 'package:openvine/widgets/sound_tile.dart';
+import 'package:sound_service/sound_service.dart';
+
+/// Sounds browsing tab for the Library screen.
+///
+/// Shows bundled and trending Nostr sounds with search, preview
+/// playback, and navigation to [SoundDetailScreen].
+class SoundsTab extends ConsumerStatefulWidget {
+  const SoundsTab({super.key});
+
+  @override
+  ConsumerState<SoundsTab> createState() => _SoundsTabState();
+}
+
+class _SoundsTabState extends ConsumerState<SoundsTab> {
+  final TextEditingController _searchController = TextEditingController();
+  String _searchQuery = '';
+  String? _previewingSoundId;
+
+  /// Cached reference to audio service for safe disposal.
+  AudioPlaybackService? _audioService;
+
+  @override
+  void dispose() {
+    if (_previewingSoundId != null && _audioService != null) {
+      _audioService!.stop();
+    }
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _onSearchChanged(String query) {
+    setState(() {
+      _searchQuery = query.toLowerCase().trim();
+    });
+  }
+
+  Future<void> _stopPreview() async {
+    if (_previewingSoundId != null) {
+      _audioService ??= ref.read(audioPlaybackServiceProvider);
+      await _audioService!.stop();
+      if (mounted) {
+        setState(() {
+          _previewingSoundId = null;
+        });
+      }
+    }
+  }
+
+  Future<void> _onPreviewTap(AudioEvent sound) async {
+    _audioService ??= ref.read(audioPlaybackServiceProvider);
+    final audioService = _audioService!;
+
+    // Toggle off if already playing this sound
+    if (_previewingSoundId == sound.id) {
+      await _stopPreview();
+      return;
+    }
+
+    if (sound.url == null || sound.url!.isEmpty) return;
+
+    try {
+      await audioService.stop();
+      await audioService.loadAudio(sound.url!);
+      if (mounted) {
+        setState(() => _previewingSoundId = sound.id);
+      }
+      await audioService.play();
+    } catch (e) {
+      Log.error(
+        'Failed to preview sound: $e',
+        name: 'SoundsTab',
+        category: LogCategory.ui,
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _previewingSoundId = null);
+      }
+    }
+  }
+
+  Future<void> _onSoundTap(AudioEvent sound) async {
+    await _stopPreview();
+    if (!mounted) return;
+    context.push(SoundDetailScreen.pathForId(sound.id), extra: sound);
+  }
+
+  Future<void> _onDetailTap(AudioEvent sound) async {
+    if (sound.isBundled) return;
+    await _stopPreview();
+    if (!mounted) return;
+    context.push(SoundDetailScreen.pathForId(sound.id), extra: sound);
+  }
+
+  List<AudioEvent> _filterSounds(List<AudioEvent> sounds) {
+    if (_searchQuery.isEmpty) return sounds;
+    return sounds.where((sound) {
+      final title = sound.title?.toLowerCase() ?? '';
+      return title.contains(_searchQuery);
+    }).toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _SearchInput(
+          controller: _searchController,
+          onChanged: _onSearchChanged,
+        ),
+        Expanded(child: _buildContent()),
+      ],
+    );
+  }
+
+  Widget _buildContent() {
+    final bundledSoundsAsync = ref.watch(soundLibraryServiceProvider);
+    final nostrSoundsAsync = ref.watch(trendingSoundsProvider);
+
+    final bundledSounds =
+        bundledSoundsAsync.whenOrNull(
+          data: (service) {
+            return service.sounds.indexed
+                .map(
+                  (e) => AudioEvent.fromBundledSound(e.$2, index: e.$1),
+                )
+                .toList();
+          },
+        ) ??
+        <AudioEvent>[];
+
+    return nostrSoundsAsync.when(
+      data: (nostrSounds) => _buildSoundsContent(
+        bundledSounds: bundledSounds,
+        nostrSounds: nostrSounds,
+      ),
+      loading: () => bundledSounds.isNotEmpty
+          ? _buildSoundsContent(
+              bundledSounds: bundledSounds,
+              nostrSounds: [],
+            )
+          : const Center(child: BrandedLoadingIndicator()),
+      error: (error, stack) => bundledSounds.isNotEmpty
+          ? _buildSoundsContent(
+              bundledSounds: bundledSounds,
+              nostrSounds: [],
+            )
+          : _buildEmptyState(),
+    );
+  }
+
+  Widget _buildSoundsContent({
+    required List<AudioEvent> bundledSounds,
+    required List<AudioEvent> nostrSounds,
+  }) {
+    final allSounds = [...bundledSounds, ...nostrSounds];
+
+    if (allSounds.isEmpty) return _buildEmptyState();
+
+    final filteredBundled = _filterSounds(bundledSounds);
+    final filteredNostr = _filterSounds(nostrSounds);
+    final filteredAll = [...filteredBundled, ...filteredNostr];
+
+    if (_searchQuery.isNotEmpty && filteredAll.isEmpty) {
+      return _buildNoResultsState();
+    }
+
+    return RefreshIndicator(
+      color: VineTheme.onPrimary,
+      backgroundColor: VineTheme.vineGreen,
+      onRefresh: () async {
+        await ref.read(trendingSoundsProvider.notifier).refresh();
+      },
+      child: ListView(
+        children: [
+          if (_searchQuery.isEmpty && bundledSounds.isNotEmpty) ...[
+            _FeaturedSoundsSection(
+              sounds: bundledSounds,
+              previewingSoundId: _previewingSoundId,
+              onTap: _onSoundTap,
+              onPreview: _onPreviewTap,
+            ),
+            const SizedBox(height: 16),
+          ],
+          if (_searchQuery.isEmpty && nostrSounds.isNotEmpty) ...[
+            _TrendingSoundsSection(
+              sounds: nostrSounds,
+              previewingSoundId: _previewingSoundId,
+              onTap: _onSoundTap,
+              onPreview: _onPreviewTap,
+              onDetail: _onDetailTap,
+            ),
+            const SizedBox(height: 16),
+          ],
+          _AllSoundsSection(
+            sounds: _searchQuery.isNotEmpty ? filteredAll : allSounds,
+            searchQuery: _searchQuery,
+            previewingSoundId: _previewingSoundId,
+            onTap: _onSoundTap,
+            onPreview: _onPreviewTap,
+            onDetail: _onDetailTap,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return const Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.music_off, size: 64, color: VineTheme.lightText),
+          SizedBox(height: 16),
+          Text(
+            'No sounds available',
+            style: TextStyle(
+              color: VineTheme.whiteText,
+              fontSize: 18,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          SizedBox(height: 8),
+          Text(
+            'Sounds will appear here when creators share audio',
+            style: TextStyle(
+              color: VineTheme.onSurfaceMuted,
+              fontSize: 14,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNoResultsState() {
+    return const Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.search_off,
+            size: 64,
+            color: VineTheme.lightText,
+          ),
+          SizedBox(height: 16),
+          Text(
+            'No sounds found',
+            style: TextStyle(
+              color: VineTheme.whiteText,
+              fontSize: 18,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SearchInput extends StatelessWidget {
+  const _SearchInput({
+    required this.controller,
+    required this.onChanged,
+  });
+
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      color: VineTheme.onPrimary,
+      child: TextField(
+        controller: controller,
+        onChanged: onChanged,
+        style: const TextStyle(color: VineTheme.whiteText),
+        decoration: InputDecoration(
+          hintText: 'Search sounds...',
+          hintStyle: const TextStyle(
+            color: VineTheme.onSurfaceMuted,
+          ),
+          prefixIcon: const Icon(
+            Icons.search,
+            color: VineTheme.onSurfaceMuted,
+          ),
+          filled: true,
+          fillColor: VineTheme.backgroundColor,
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide: BorderSide.none,
+          ),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 12,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FeaturedSoundsSection extends StatelessWidget {
+  const _FeaturedSoundsSection({
+    required this.sounds,
+    required this.previewingSoundId,
+    required this.onTap,
+    required this.onPreview,
+  });
+
+  final List<AudioEvent> sounds;
+  final String? previewingSoundId;
+  final ValueChanged<AudioEvent> onTap;
+  final ValueChanged<AudioEvent> onPreview;
+
+  @override
+  Widget build(BuildContext context) {
+    final featured = sounds.take(10).toList();
+    if (featured.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            children: [
+              Icon(Icons.star, color: VineTheme.vineGreen, size: 20),
+              SizedBox(width: 8),
+              Text(
+                'Featured Sounds',
+                style: TextStyle(
+                  color: VineTheme.whiteText,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+        SizedBox(
+          height: 100,
+          child: ListView.builder(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            itemCount: featured.length,
+            itemBuilder: (context, index) {
+              final sound = featured[index];
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4),
+                child: SoundTile(
+                  sound: sound,
+                  compact: true,
+                  isPlaying: previewingSoundId == sound.id,
+                  onTap: () => onTap(sound),
+                  onPlayPreview: () => onPreview(sound),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TrendingSoundsSection extends StatelessWidget {
+  const _TrendingSoundsSection({
+    required this.sounds,
+    required this.previewingSoundId,
+    required this.onTap,
+    required this.onPreview,
+    required this.onDetail,
+  });
+
+  final List<AudioEvent> sounds;
+  final String? previewingSoundId;
+  final ValueChanged<AudioEvent> onTap;
+  final ValueChanged<AudioEvent> onPreview;
+  final ValueChanged<AudioEvent> onDetail;
+
+  @override
+  Widget build(BuildContext context) {
+    final trending = sounds.take(10).toList();
+    if (trending.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: Row(
+            children: [
+              Icon(
+                Icons.local_fire_department,
+                color: VineTheme.vineGreen,
+                size: 20,
+              ),
+              SizedBox(width: 8),
+              Text(
+                'Trending Sounds',
+                style: TextStyle(
+                  color: VineTheme.whiteText,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+        SizedBox(
+          height: 100,
+          child: ListView.builder(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            itemCount: trending.length,
+            itemBuilder: (context, index) {
+              final sound = trending[index];
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4),
+                child: SoundTile(
+                  sound: sound,
+                  compact: true,
+                  isPlaying: previewingSoundId == sound.id,
+                  onTap: () => onTap(sound),
+                  onPlayPreview: () => onPreview(sound),
+                  onDetailTap: () => onDetail(sound),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _AllSoundsSection extends StatelessWidget {
+  const _AllSoundsSection({
+    required this.sounds,
+    required this.searchQuery,
+    required this.previewingSoundId,
+    required this.onTap,
+    required this.onPreview,
+    required this.onDetail,
+  });
+
+  final List<AudioEvent> sounds;
+  final String searchQuery;
+  final String? previewingSoundId;
+  final ValueChanged<AudioEvent> onTap;
+  final ValueChanged<AudioEvent> onPreview;
+  final ValueChanged<AudioEvent> onDetail;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 12,
+          ),
+          child: Row(
+            children: [
+              const Icon(
+                Icons.music_note,
+                color: VineTheme.vineGreen,
+                size: 20,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                searchQuery.isEmpty ? 'All Sounds' : 'Search Results',
+                style: const TextStyle(
+                  color: VineTheme.whiteText,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '(${sounds.length})',
+                style: const TextStyle(
+                  color: VineTheme.onSurfaceMuted,
+                  fontSize: 14,
+                ),
+              ),
+            ],
+          ),
+        ),
+        ListView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          itemCount: sounds.length,
+          itemBuilder: (context, index) {
+            final sound = sounds[index];
+            return SoundTile(
+              sound: sound,
+              isPlaying: previewingSoundId == sound.id,
+              onTap: () => onTap(sound),
+              onPlayPreview: () => onPreview(sound),
+              onDetailTap: sound.isBundled ? null : () => onDetail(sound),
+            );
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/widgets/library/sounds_tab.dart
+++ b/mobile/lib/widgets/library/sounds_tab.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Sounds tab for the Library screen.
 // ABOUTME: Browse bundled and trending Nostr sounds with search and preview.
 
+import 'dart:developer' as developer;
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -10,7 +12,6 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/sound_library_service_provider.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/screens/sound_detail_screen.dart';
-import 'package:openvine/utils/unified_logger.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/sound_tile.dart';
 import 'package:sound_service/sound_service.dart';
@@ -81,10 +82,10 @@ class _SoundsTabState extends ConsumerState<SoundsTab> {
       }
       await audioService.play();
     } catch (e) {
-      Log.error(
+      developer.log(
         'Failed to preview sound: $e',
         name: 'SoundsTab',
-        category: LogCategory.ui,
+        level: 1000,
       );
     } finally {
       if (mounted) {

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -72,9 +72,9 @@ class _SharedAudioSection extends ConsumerWidget {
   }
 }
 
-/// Display-only section showing "Original sound - @creator" for videos
-/// without shared audio. Not tappable — original sounds don't have a
-/// separate detail page.
+/// Section showing "Original sound - @creator" for videos without shared
+/// audio. Tapping navigates to [SoundDetailScreen] where the user can
+/// preview and select the sound for recording.
 class _OriginalSoundSection extends ConsumerWidget {
   const _OriginalSoundSection({required this.video});
 
@@ -93,39 +93,76 @@ class _OriginalSoundSection extends ConsumerWidget {
     return MetadataSection(
       label: 'Sounds',
       child: Semantics(
-        label: 'Original sound by $creatorName.',
-        child: Row(
-          spacing: 16,
-          children: [
-            const DivineIcon(
-              icon: DivineIconName.waveform,
-              color: VineTheme.onSurfaceVariant,
-            ),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    'Original sound',
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: VineTheme.titleMediumFont(),
-                  ),
-                  Text(
-                    creatorName,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: VineTheme.bodyMediumFont(
-                      color: VineTheme.onSurfaceVariant,
-                    ),
-                  ),
-                ],
+        button: true,
+        label: 'Original sound by $creatorName. Tap to use this sound.',
+        child: GestureDetector(
+          onTap: () => _navigateToSoundDetail(context, creatorName),
+          child: Row(
+            spacing: 16,
+            children: [
+              const DivineIcon(
+                icon: DivineIconName.waveform,
+                color: VineTheme.onSurfaceVariant,
               ),
-            ),
-          ],
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Original sound',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: VineTheme.titleMediumFont(),
+                    ),
+                    Text(
+                      creatorName,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: VineTheme.bodyMediumFont(
+                        color: VineTheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const Icon(
+                Icons.chevron_right,
+                color: VineTheme.onSurfaceVariant,
+                size: 20,
+              ),
+            ],
+          ),
         ),
       ),
     );
+  }
+
+  void _navigateToSoundDetail(BuildContext context, String creatorName) {
+    Log.info(
+      'Navigating to original sound detail for video: ${video.id}',
+      name: 'MetadataSoundsSection',
+      category: LogCategory.ui,
+    );
+
+    final syntheticAudio = AudioEvent.fromVideoOriginalSound(
+      video,
+      creatorName: creatorName,
+    );
+
+    // Dismiss the sheet first, then navigate from the root navigator
+    // context.
+    final hostContext = Navigator.of(context, rootNavigator: true).context;
+    Navigator.of(context).pop();
+    Future<void>.delayed(Duration.zero).then((_) {
+      if (!hostContext.mounted) return;
+      hostContext.pushWithVideoPause(
+        SoundDetailScreen.pathForId(syntheticAudio.id),
+        extra: <String, dynamic>{
+          'sound': syntheticAudio,
+          'sourceVideo': video,
+        },
+      );
+    });
   }
 }
 

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_sounds_section.dart
@@ -58,10 +58,8 @@ class _SharedAudioSection extends ConsumerWidget {
           child: _SoundListItem(audio: audio),
         );
       },
-      loading: () => const MetadataSection(
-        label: 'Sounds',
-        child: _SoundSkeleton(),
-      ),
+      loading: () =>
+          const MetadataSection(label: 'Sounds', child: _SoundSkeleton()),
       error: (error, stack) {
         Log.error(
           'Failed to load audio for metadata sheet: $error',
@@ -74,11 +72,9 @@ class _SharedAudioSection extends ConsumerWidget {
   }
 }
 
-/// Section showing "Original sound - @creator" for videos without shared audio.
-///
-/// Tapping creates a synthetic [AudioEvent] from the video's audio track
-/// and navigates to [SoundDetailScreen] where the user can preview and
-/// select the sound for recording.
+/// Display-only section showing "Original sound - @creator" for videos
+/// without shared audio. Not tappable — original sounds don't have a
+/// separate detail page.
 class _OriginalSoundSection extends ConsumerWidget {
   const _OriginalSoundSection({required this.video});
 
@@ -97,75 +93,39 @@ class _OriginalSoundSection extends ConsumerWidget {
     return MetadataSection(
       label: 'Sounds',
       child: Semantics(
-        button: true,
-        label: 'Original sound by $creatorName. Tap to use this sound.',
-        child: GestureDetector(
-          onTap: () => _navigateToSoundDetail(context, creatorName),
-          child: Row(
-            spacing: 16,
-            children: [
-              const DivineIcon(
-                icon: DivineIconName.waveform,
-                color: VineTheme.onSurfaceVariant,
-              ),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      'Original sound',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: VineTheme.titleMediumFont(),
+        label: 'Original sound by $creatorName.',
+        child: Row(
+          spacing: 16,
+          children: [
+            const DivineIcon(
+              icon: DivineIconName.waveform,
+              color: VineTheme.onSurfaceVariant,
+            ),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Original sound',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: VineTheme.titleMediumFont(),
+                  ),
+                  Text(
+                    creatorName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: VineTheme.bodyMediumFont(
+                      color: VineTheme.onSurfaceVariant,
                     ),
-                    Text(
-                      creatorName,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: VineTheme.bodyMediumFont(
-                        color: VineTheme.onSurfaceVariant,
-                      ),
-                    ),
-                  ],
-                ),
+                  ),
+                ],
               ),
-              const Icon(
-                Icons.chevron_right,
-                color: VineTheme.onSurfaceVariant,
-                size: 20,
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );
-  }
-
-  void _navigateToSoundDetail(BuildContext context, String creatorName) {
-    Log.info(
-      'Navigating to original sound detail for video: ${video.id}',
-      name: 'MetadataSoundsSection',
-      category: LogCategory.ui,
-    );
-
-    final syntheticAudio = AudioEvent.fromVideoOriginalSound(
-      video,
-      creatorName: creatorName,
-    );
-
-    // Dismiss the sheet first, then navigate from the root navigator context.
-    final hostContext = Navigator.of(context, rootNavigator: true).context;
-    Navigator.of(context).pop();
-    Future<void>.delayed(Duration.zero).then((_) {
-      if (!hostContext.mounted) return;
-      hostContext.pushWithVideoPause(
-        SoundDetailScreen.pathForId(syntheticAudio.id),
-        extra: <String, dynamic>{
-          'sound': syntheticAudio,
-          'sourceVideo': video,
-        },
-      );
-    });
   }
 }
 

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -388,18 +388,32 @@ class VideoEvent {
           // Event reference - check for audio reference marker
           // Format: ["e", "<audio-event-id>", "<relay>", "audio"]
           // The marker can be at index 2 (no relay) or index 3 (with relay)
+          // Also recognize bundled sound IDs (prefixed "bundled_") even
+          // without the "audio" marker for backward compatibility.
           // Only use the first audio reference found
-          if (tag.length >= 3 && audioEventId == null) {
-            final marker = tag.length >= 4 ? tag[3] : tag[2];
-            if (marker == 'audio' && tagValue.isNotEmpty) {
+          if (audioEventId == null && tagValue.isNotEmpty) {
+            if (tag.length >= 3) {
+              final marker = tag.length >= 4 ? tag[3] : tag[2];
+              if (marker == 'audio') {
+                audioEventId = tagValue;
+                if (tag.length >= 4 && tag[2].isNotEmpty) {
+                  audioEventRelay = tag[2];
+                }
+                developer.log(
+                  '🎵 Found audio reference: $audioEventId '
+                  '(relay: $audioEventRelay)',
+                  name: 'VideoEvent',
+                );
+              }
+            }
+            // Bundled sounds may lack the "audio" marker
+            if (audioEventId == null && tagValue.startsWith('bundled_')) {
               audioEventId = tagValue;
-              // Relay hint is at index 2 if marker is at index 3
-              if (tag.length >= 4 && tag[2].isNotEmpty) {
+              if (tag.length >= 3 && tag[2].isNotEmpty) {
                 audioEventRelay = tag[2];
               }
               developer.log(
-                '🎵 Found audio reference: $audioEventId '
-                '(relay: $audioEventRelay)',
+                '🎵 Found bundled audio reference: $audioEventId',
                 name: 'VideoEvent',
               );
             }

--- a/mobile/test/unit/models/video_event_audio_reference_test.dart
+++ b/mobile/test/unit/models/video_event_audio_reference_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Tests for VideoEvent audio reference parsing from e-tags with "audio" marker
-// ABOUTME: Verifies support for Kind 1063 audio event references in Kind 34236 video events
+// ABOUTME: Tests for VideoEvent audio reference parsing from e-tags.
+// ABOUTME: Covers "audio" marker, bundled sound prefix detection, and edge cases.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
@@ -267,5 +267,103 @@ void main() {
       expect(videoEvent.audioEventId, isNull);
       expect(videoEvent.hasAudioReference, isFalse);
     });
+
+    test(
+      'should detect bundled sound from e-tag without audio marker',
+      () {
+        // Arrange - bundled sound ID in e-tag without "audio" marker
+        // (backward compat for events published before the marker
+        // was added)
+        final nostrEvent = Event(
+          testPubkey,
+          34236,
+          [
+            ['d', 'test-vine-id'],
+            ['url', 'https://example.com/video.mp4'],
+            ['e', 'bundled_freesound_vibrant_energy'],
+          ],
+          'Video with bundled sound',
+          createdAt: 1757385263,
+        );
+
+        // Act
+        final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+        // Assert
+        expect(
+          videoEvent.audioEventId,
+          equals('bundled_freesound_vibrant_energy'),
+        );
+        expect(videoEvent.hasAudioReference, isTrue);
+      },
+    );
+
+    test(
+      'should detect bundled sound from e-tag with relay but no marker',
+      () {
+        final nostrEvent = Event(
+          testPubkey,
+          34236,
+          [
+            ['d', 'test-vine-id'],
+            ['url', 'https://example.com/video.mp4'],
+            [
+              'e',
+              'bundled_classic_vine_beat',
+              'wss://relay.divine.video',
+            ],
+          ],
+          'Video with bundled sound and relay',
+          createdAt: 1757385263,
+        );
+
+        final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+        expect(
+          videoEvent.audioEventId,
+          equals('bundled_classic_vine_beat'),
+        );
+        expect(
+          videoEvent.audioEventRelay,
+          equals('wss://relay.divine.video'),
+        );
+        expect(videoEvent.hasAudioReference, isTrue);
+      },
+    );
+
+    test(
+      'should prefer audio marker over bundled prefix detection',
+      () {
+        // If the tag has the "audio" marker, that path should win
+        final nostrEvent = Event(
+          testPubkey,
+          34236,
+          [
+            ['d', 'test-vine-id'],
+            ['url', 'https://example.com/video.mp4'],
+            [
+              'e',
+              'bundled_freesound_vibrant_energy',
+              'wss://relay.divine.video',
+              'audio',
+            ],
+          ],
+          'Video with properly tagged bundled sound',
+          createdAt: 1757385263,
+        );
+
+        final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+        expect(
+          videoEvent.audioEventId,
+          equals('bundled_freesound_vibrant_energy'),
+        );
+        expect(
+          videoEvent.audioEventRelay,
+          equals('wss://relay.divine.video'),
+        );
+        expect(videoEvent.hasAudioReference, isTrue);
+      },
+    );
   });
 }

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -142,13 +142,13 @@ void main() {
         expect(find.text('Jake Lara'), findsOneWidget);
       });
 
-      testWidgets('shows chevron (tappable to use sound)', (tester) async {
+      testWidgets('does not show chevron (display-only)', (tester) async {
         final video = createVideoWithoutAudio();
 
         await tester.pumpWidget(buildTestWidget(video: video));
         await tester.pumpAndSettle();
 
-        expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+        expect(find.byIcon(Icons.chevron_right), findsNothing);
       });
 
       testWidgets('falls back to original sound when audio event is null', (

--- a/mobile/test/widgets/metadata_sounds_section_test.dart
+++ b/mobile/test/widgets/metadata_sounds_section_test.dart
@@ -142,13 +142,13 @@ void main() {
         expect(find.text('Jake Lara'), findsOneWidget);
       });
 
-      testWidgets('does not show chevron (display-only)', (tester) async {
+      testWidgets('shows chevron (tappable to use sound)', (tester) async {
         final video = createVideoWithoutAudio();
 
         await tester.pumpWidget(buildTestWidget(video: video));
         await tester.pumpAndSettle();
 
-        expect(find.byIcon(Icons.chevron_right), findsNothing);
+        expect(find.byIcon(Icons.chevron_right), findsOneWidget);
       });
 
       testWidgets('falls back to original sound when audio event is null', (


### PR DESCRIPTION
Closes #2992

## Summary
- **Original sounds** in the metadata sheet are now display-only (no chevron, no navigation to a separate Sound detail page)
- **Bundled sounds** (e.g. `bundled_freesound_vibrant_energy`) in `"e"` tags are now detected even without the `"audio"` marker, fixing backward compatibility for older published events
- Videos using bundled sounds will now correctly show the audio attribution overlay and sound info

## Test plan
- [x] `metadata_sounds_section_test.dart` — 8 tests pass (updated chevron test)
- [x] `video_event_audio_reference_test.dart` — 13 tests pass (3 new bundled sound tests)
- [ ] Manual: verify original sound section in metadata sheet shows no chevron and is not tappable
- [ ] Manual: verify video with bundled sound shows audio attribution row on the video overlay
- [ ] Manual: verify tapping audio attribution on bundled sound navigates to Sound detail with correct info

🤖 Generated with [Claude Code](https://claude.com/claude-code)