### PR TITLE
fix(social): stabilize follower/following counts for small accounts and stale cache

### DIFF
--- a/mobile/lib/repositories/follow_repository.dart
+++ b/mobile/lib/repositories/follow_repository.dart
@@ -1363,6 +1363,22 @@ class FollowRepository {
             .toList();
 
         if (pubkeys.isNotEmpty) {
+          // Guard: only accept the cached event when it is at least as large
+          // as the list already loaded from LocalStorage. A stale
+          // PersonalEventCache entry with fewer pubkeys should not overwrite
+          // a fresher LocalStorage value — the network steps will fetch the
+          // authoritative event later.
+          if (pubkeys.length < _followingPubkeys.length) {
+            Log.debug(
+              'PersonalEventCache has fewer follows '
+              '(${pubkeys.length}) than LocalStorage '
+              '(${_followingPubkeys.length}), skipping',
+              name: 'FollowRepository',
+              category: LogCategory.system,
+            );
+            return;
+          }
+
           _followingPubkeys = pubkeys;
           _currentUserContactListEvent = latestContactList;
           _emitFollowingList();
@@ -1724,15 +1740,47 @@ class FollowRepository {
     );
   }
 
-  /// Minimum number of follows the local list must have before the
-  /// catastrophic-reduction heuristic kicks in. Below this threshold every
-  /// remote event is accepted as-is, because small lists change drastically
-  /// during normal use.
-  static const _mergeMinFollows = 10;
+  // ── Catastrophic-reduction merge guard ──────────────────────────────
+  //
+  // Protects against buggy external Nostr clients that publish a Kind 3
+  // event without first fetching the existing contact list, effectively
+  // overwriting hundreds of follows with a single entry.
+  //
+  // The guard uses a two-condition AND gate:
+  //   1. Drastic reduction — the remote list lost more than
+  //      [_mergeMaxLossFraction] (50 %) of the local list.
+  //   2. New-pubkey fingerprint — the remote list contains at least one
+  //      pubkey absent from the local list (the hallmark of a "follow one
+  //      user, replace the whole list" bug).
+  //
+  // When BOTH conditions are true the lists are union-merged and the
+  // corrected list is re-broadcast so relays converge on the right state.
+  //
+  // A legitimate mass-unfollow produces a strict *subset* of the local
+  // list, so condition 2 filters it out and the replacement is accepted.
+  //
+  // The guard is only active when the local list has at least
+  // [_mergeMinFollows] entries. With only 1 follow the list can only
+  // drop to zero, which is either a legitimate unfollow or a fresh
+  // account state — no merge is needed.
+  //
+  // Edge cases:
+  //   • Exactly 50 % loss (equals the ceil threshold) → accepted, not
+  //     merged, because the loss is within tolerance.
+  //   • Remote list is entirely new pubkeys but same size → accepted,
+  //     because condition 1 fails (no size reduction).
+  //   • Re-broadcast failure after merge → local list is already
+  //     correct; relays will converge on the next publish.
+  // ───────────────────────────────────────────────────────────────────
 
-  /// Maximum fraction of the local list that a remote event may remove
-  /// before we treat the reduction as suspicious and merge instead of replace.
-  /// 0.5 means "if more than half the list would be lost, merge."
+  /// Minimum local-list size for the merge guard to activate. A user with
+  /// only 1 follow cannot trigger a "catastrophic reduction" — the list
+  /// can only go to zero.
+  static const _mergeMinFollows = 2;
+
+  /// Maximum fraction of the local list that may be removed before the
+  /// reduction is treated as suspicious. 0.5 → more than half lost
+  /// triggers a merge instead of a replace.
   static const _mergeMaxLossFraction = 0.5;
 
   /// Process a NIP-02 contact list event (Kind 3)

--- a/mobile/test/repositories/follow_repository_test.dart
+++ b/mobile/test/repositories/follow_repository_test.dart
@@ -202,6 +202,97 @@ void main() {
         expect(repository.followingCount, 0);
       });
 
+      test(
+        'skips PersonalEventCache when it has fewer follows than '
+        'LocalStorage',
+        () async {
+          // Seed LocalStorage with 10 follows
+          final localPubkeys = List.generate(
+            10,
+            (i) => i.toRadixString(16).padLeft(64, '0'),
+          );
+          SharedPreferences.setMockInitialValues({
+            'following_list_$testCurrentUserPubkey':
+                '[${localPubkeys.map((p) => '"$p"').join(',')}]',
+          });
+
+          // PersonalEventCache returns a stale event with only 3 pubkeys
+          final stalePubkeys = localPubkeys.take(3).toList();
+          final staleEvent = Event(
+            testCurrentUserPubkey,
+            3,
+            stalePubkeys.map((p) => ['p', p]).toList(),
+            '',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 - 100,
+          );
+          when(() => mockPersonalEventCache.isInitialized).thenReturn(true);
+          when(
+            () => mockPersonalEventCache.getEventsByKind(3),
+          ).thenReturn([staleEvent]);
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            personalEventCache: mockPersonalEventCache,
+            indexerRelayUrls: const [],
+          );
+
+          await repository.initialize();
+
+          // Should keep the 10 from LocalStorage, not the 3 from cache
+          expect(repository.followingCount, 10);
+          for (final pk in localPubkeys) {
+            expect(repository.followingPubkeys, contains(pk));
+          }
+        },
+      );
+
+      test(
+        'accepts PersonalEventCache when it has more follows than '
+        'LocalStorage',
+        () async {
+          // Seed LocalStorage with 3 follows
+          final localPubkeys = List.generate(
+            3,
+            (i) => i.toRadixString(16).padLeft(64, '0'),
+          );
+          SharedPreferences.setMockInitialValues({
+            'following_list_$testCurrentUserPubkey':
+                '[${localPubkeys.map((p) => '"$p"').join(',')}]',
+          });
+
+          // PersonalEventCache returns a newer event with 5 pubkeys
+          final cachePubkeys = List.generate(
+            5,
+            (i) => (i + 10).toRadixString(16).padLeft(64, '0'),
+          );
+          final cacheEvent = Event(
+            testCurrentUserPubkey,
+            3,
+            cachePubkeys.map((p) => ['p', p]).toList(),
+            '',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 100,
+          );
+          when(() => mockPersonalEventCache.isInitialized).thenReturn(true);
+          when(
+            () => mockPersonalEventCache.getEventsByKind(3),
+          ).thenReturn([cacheEvent]);
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            personalEventCache: mockPersonalEventCache,
+            indexerRelayUrls: const [],
+          );
+
+          await repository.initialize();
+
+          // Should use the 5 from PersonalEventCache
+          expect(repository.followingCount, 5);
+          for (final pk in cachePubkeys) {
+            expect(repository.followingPubkeys, contains(pk));
+          }
+        },
+      );
+
       test('does not reinitialize if already initialized', () async {
         await repository.initialize();
         expect(repository.isInitialized, isTrue);
@@ -1347,11 +1438,10 @@ void main() {
       test(
         'skips merge protection when local list is below threshold',
         () async {
-          // Seed with 5 follows (below _mergeMinFollows of 10)
-          final seededPubkeys = List.generate(
-            5,
-            (i) => i.toRadixString(16).padLeft(64, '0'),
-          );
+          // Seed with 1 follow (below _mergeMinFollows of 2)
+          final seededPubkeys = [
+            '0'.padLeft(64, '0'),
+          ];
           SharedPreferences.setMockInitialValues({
             'following_list_$testCurrentUserPubkey':
                 '[${seededPubkeys.map((p) => '"$p"').join(',')}]',
@@ -1364,9 +1454,9 @@ void main() {
           );
 
           await repository.initialize();
-          expect(repository.followingCount, 5);
+          expect(repository.followingCount, 1);
 
-          // Remote event with only 1 follow — drastic but below threshold
+          // Remote event with a different follow — drastic but below threshold
           final remoteEvent = Event(
             testCurrentUserPubkey,
             3,
@@ -1383,6 +1473,110 @@ void main() {
           // Should replace (not merge) because local list is below threshold
           expect(repository.followingCount, 1);
           expect(repository.followingPubkeys, equals([testTargetPubkey]));
+        },
+      );
+
+      test(
+        'merges when small list (above threshold) receives buggy event with '
+        'new pubkey',
+        () async {
+          // Seed with 3 follows (above _mergeMinFollows of 2)
+          final seededPubkeys = List.generate(
+            3,
+            (i) => i.toRadixString(16).padLeft(64, '0'),
+          );
+          SharedPreferences.setMockInitialValues({
+            'following_list_$testCurrentUserPubkey':
+                '[${seededPubkeys.map((p) => '"$p"').join(',')}]',
+          });
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            personalEventCache: mockPersonalEventCache,
+            indexerRelayUrls: const [],
+          );
+
+          // Mock sendContactList for the merge re-broadcast
+          when(
+            () => mockNostrClient.sendContactList(any(), any()),
+          ).thenAnswer(
+            (_) async => Event(
+              testCurrentUserPubkey,
+              3,
+              [],
+              '',
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 200,
+            ),
+          );
+
+          await repository.initialize();
+          expect(repository.followingCount, 3);
+
+          // Remote event with 1 new follow — drastic reduction + new pubkey
+          final remoteEvent = Event(
+            testCurrentUserPubkey,
+            3,
+            [
+              ['p', testTargetPubkey],
+            ],
+            '',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 100,
+          );
+
+          realTimeStreamController.add(remoteEvent);
+          await Future<void>.delayed(Duration.zero);
+
+          // Should merge: all 3 original + 1 new = 4
+          expect(repository.followingCount, 4);
+          expect(repository.followingPubkeys, contains(testTargetPubkey));
+          for (final pk in seededPubkeys) {
+            expect(repository.followingPubkeys, contains(pk));
+          }
+
+          // Verify re-broadcast was triggered
+          verify(() => mockNostrClient.sendContactList(any(), any())).called(1);
+        },
+      );
+
+      test(
+        'accepts legitimate unfollow on small list (subset, no new pubkeys)',
+        () async {
+          // Seed with 3 follows (above _mergeMinFollows of 2)
+          final seededPubkeys = List.generate(
+            3,
+            (i) => i.toRadixString(16).padLeft(64, '0'),
+          );
+          SharedPreferences.setMockInitialValues({
+            'following_list_$testCurrentUserPubkey':
+                '[${seededPubkeys.map((p) => '"$p"').join(',')}]',
+          });
+
+          repository = FollowRepository(
+            nostrClient: mockNostrClient,
+            personalEventCache: mockPersonalEventCache,
+            indexerRelayUrls: const [],
+          );
+
+          await repository.initialize();
+          expect(repository.followingCount, 3);
+
+          // Remote event with 1 of the original 3 — legitimate unfollow
+          final remoteEvent = Event(
+            testCurrentUserPubkey,
+            3,
+            [
+              ['p', seededPubkeys.first],
+            ],
+            '',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 100,
+          );
+
+          realTimeStreamController.add(remoteEvent);
+          await Future<void>.delayed(Duration.zero);
+
+          // Should accept as-is: no new pubkeys → legitimate mass unfollow
+          expect(repository.followingCount, 1);
+          expect(repository.followingPubkeys, equals([seededPubkeys.first]));
         },
       );
 


### PR DESCRIPTION
## Summary

Closes #2838

Addresses two of the four audit areas identified in the parent issue:

- **Small-account protection** — Lowered `_mergeMinFollows` from 10 to 2 so users with 2–9 follows are protected by the catastrophic-reduction merge guard. Previously, a buggy external Nostr client could wipe a new user's entire following list with a single malformed Kind 3 event.
- **Stale PersonalEventCache guard** — Added a size check to `_loadFromPersonalEventCache()` so a stale cached Kind 3 event with fewer follows cannot overwrite a fresher LocalStorage value during the 4-step initialization bootstrap.
- **Merge guard documentation** — Added inline documentation explaining the two-condition gate design, thresholds, edge cases, and re-broadcast behavior.

## Reproduction (before fix)

### Small-account vulnerability
1. Create/use an account with 2–9 follows
2. From an external Nostr client (e.g. web app), publish a Kind 3 event containing only 1 new pubkey without fetching the existing contact list first
3. **Before fix**: Mobile app silently replaces the full following list with just 1 entry — all original follows are lost
4. **After fix**: Mobile app detects the catastrophic reduction (>50% loss + new pubkey fingerprint) and union-merges instead

### Stale PersonalEventCache
1. User has 500 follows persisted in LocalStorage
2. PersonalEventCache holds an older Kind 3 event with only 50 pubkeys (e.g. app crashed before caching a newer event)
3. On app restart, `initialize()` loads 500 from LocalStorage (step 1), then `_loadFromPersonalEventCache()` runs (step 2)
4. **Before fix**: Step 2 overwrites 500 with 50 — user sees a massive count drop
5. **After fix**: Step 2 detects the cached event has fewer follows and skips it

## Changes

| File | Change |
|------|--------|
| `follow_repository.dart` | `_mergeMinFollows`: 10 → 2 |
| `follow_repository.dart` | `_loadFromPersonalEventCache()`: skip when cached event has fewer pubkeys than already loaded |
| `follow_repository.dart` | Added block comment documenting merge guard design |
| `follow_repository_test.dart` | Updated threshold test for new value |
| `follow_repository_test.dart` | Added: small list (3 follows) merge protection test |
| `follow_repository_test.dart` | Added: small list legitimate unfollow (subset) accepted |
| `follow_repository_test.dart` | Added: stale PersonalEventCache skipped |
| `follow_repository_test.dart` | Added: larger PersonalEventCache accepted |

## Out of scope

- **External client interop** (audit area 1) — web app concern, not a mobile code change
- **OthersFollowingBloc NostrClient bypass** — tracked in #571
- **Count display consistency for analytics/message-requests** — these intentionally use separate REST API data sources

## Test plan

- [x] All 74 `follow_repository_test.dart` tests pass
- [x] `flutter analyze` clean
- [x] Pre-commit hooks pass
- [ ] Manual: verify a user with 3 follows is protected from a malformed Kind 3 event
- [ ] Manual: verify app restart with stale PersonalEventCache does not drop follow count