### PR TITLE
fix(user_picker_sheet): handle null profileRepository gracefully

### DIFF
--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -80,13 +80,16 @@ class UserPickerSheet extends ConsumerStatefulWidget {
 }
 
 class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
-  late final UserSearchBloc _searchBloc;
+  UserSearchBloc? _searchBloc;
   final _searchController = TextEditingController();
 
   // For mutualFollowsOnly: local follow list search
   List<UserProfile> _followProfiles = [];
   List<UserProfile> _filteredFollowProfiles = [];
   bool _followListLoaded = false;
+
+  /// Whether the profile repository was unavailable at init time.
+  bool _profileRepoMissing = false;
 
   bool get _useLocalSearch =>
       widget.filterMode == UserPickerFilterMode.mutualFollowsOnly;
@@ -95,7 +98,11 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   void initState() {
     super.initState();
     final profileRepo = ref.read(profileRepositoryProvider);
-    _searchBloc = UserSearchBloc(profileRepository: profileRepo!);
+    if (profileRepo == null) {
+      _profileRepoMissing = true;
+      return;
+    }
+    _searchBloc = UserSearchBloc(profileRepository: profileRepo);
 
     if (_useLocalSearch) {
       _loadFollowProfiles();
@@ -142,7 +149,7 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   @override
   void dispose() {
     _searchController.dispose();
-    _searchBloc.close();
+    _searchBloc?.close();
     super.dispose();
   }
 
@@ -151,9 +158,9 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
       _filterFollowProfiles(query);
     } else {
       if (query.trim().isEmpty) {
-        _searchBloc.add(const UserSearchCleared());
+        _searchBloc?.add(const UserSearchCleared());
       } else {
-        _searchBloc.add(UserSearchQueryChanged(query));
+        _searchBloc?.add(UserSearchQueryChanged(query));
       }
     }
   }
@@ -180,6 +187,10 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
 
   @override
   Widget build(BuildContext context) {
+    if (_profileRepoMissing) {
+      return const _ProfileRepoUnavailable();
+    }
+
     final hintText = _useLocalSearch
         ? 'Filter by name...'
         : 'Search by name...';
@@ -242,7 +253,7 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
                   excludePubkeys: widget.excludePubkeys,
                 )
               : _NetworkResults(
-                  searchBloc: _searchBloc,
+                  searchBloc: _searchBloc!,
                   scrollController: widget.scrollController,
                   onUserSelected: _onUserSelected,
                   excludePubkeys: widget.excludePubkeys,
@@ -407,6 +418,26 @@ class _EmptyHint extends StatelessWidget {
           style: VineTheme.bodyMediumFont(
             color: VineTheme.onSurfaceMuted,
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ProfileRepoUnavailable extends StatelessWidget {
+  const _ProfileRepoUnavailable();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Text(
+          'User search is unavailable. Please try again later.',
+          style: VineTheme.bodyMediumFont(
+            color: VineTheme.onSurfaceMuted,
+          ),
+          textAlign: TextAlign.center,
         ),
       ),
     );

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -534,6 +534,81 @@ void main() {
         expect(find.byType(SvgPicture), findsNWidgets(2));
       });
     });
+
+    group('null profileRepository', () {
+      testWidgets(
+        'shows error state for allUsers mode when profileRepository is null',
+        (tester) async {
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                profileRepositoryProvider.overrideWithValue(null),
+                followRepositoryProvider.overrideWithValue(
+                  _createMockFollowRepository(),
+                ),
+              ],
+              child: const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: Scaffold(
+                  body: UserPickerSheet(
+                    filterMode: UserPickerFilterMode.allUsers,
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.pumpAndSettle();
+
+          expect(
+            find.text(
+              'User search is unavailable. Please try again later.',
+            ),
+            findsOneWidget,
+          );
+          // Should not show the search field
+          expect(find.byType(TextField), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'shows error state for mutualFollowsOnly mode '
+        'when profileRepository is null',
+        (tester) async {
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                profileRepositoryProvider.overrideWithValue(null),
+                followRepositoryProvider.overrideWithValue(
+                  _createMockFollowRepository(),
+                ),
+              ],
+              child: const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: Scaffold(
+                  body: UserPickerSheet(
+                    filterMode: UserPickerFilterMode.mutualFollowsOnly,
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.pumpAndSettle();
+
+          expect(
+            find.text(
+              'User search is unavailable. Please try again later.',
+            ),
+            findsOneWidget,
+          );
+          // Should not show the search field
+          expect(find.byType(TextField), findsNothing);
+        },
+      );
+    });
   });
 
   group(UserPickerFilterMode, () {


### PR DESCRIPTION
Closes #3001

## Summary
- Fix crash ("Null check operator used on a null value") in `UserPickerSheet` when `profileRepositoryProvider` returns null
- Both "Inspired By" and "Add Collaborator" picker sheets now show a user-friendly error message instead of crashing with "Oops, something went wrong"
- Changed `_searchBloc` from `late final` to nullable, added `_profileRepoMissing` flag, and added a `_ProfileRepoUnavailable` error widget

## Test plan
- [x] Added test: allUsers mode shows error state when profileRepository is null
- [x] Added test: mutualFollowsOnly mode shows error state when profileRepository is null
- [x] All 16 existing + new tests pass
- [x] `flutter analyze` clean


Generated with [Claude Code](https://claude.com/claude-code)