### PR TITLE
fix(video_stop_observer): eliminate navigator null race condition

### DIFF
--- a/mobile/lib/services/video_stop_navigator_observer.dart
+++ b/mobile/lib/services/video_stop_navigator_observer.dart
@@ -28,9 +28,6 @@ class VideoStopNavigatorObserver extends NavigatorObserver {
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
-    print(
-      '🟪 NAV OBSERVER: didPush - route=${route.settings.name}, previousRoute=${previousRoute?.settings.name}',
-    );
 
     // Skip disposal for popup routes (modals, bottom sheets, dialogs)
     // The overlayVisibilityProvider already handles pausing via activeVideoIdProvider
@@ -47,35 +44,13 @@ class VideoStopNavigatorObserver extends NavigatorObserver {
     _stopAllVideos('didPush', route.settings.name);
   }
 
-  @override
-  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    super.didPop(route, previousRoute);
-    print(
-      '🟪 NAV OBSERVER: didPop - route=${route.settings.name}, previousRoute=${previousRoute?.settings.name}',
-    );
-  }
-
-  @override
-  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    super.didRemove(route, previousRoute);
-    print(
-      '🟪 NAV OBSERVER: didRemove - route=${route.settings.name}, previousRoute=${previousRoute?.settings.name}',
-    );
-  }
-
-  @override
-  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
-    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
-    print(
-      '🟪 NAV OBSERVER: didReplace - newRoute=${newRoute?.settings.name}, oldRoute=${oldRoute?.settings.name}',
-    );
-  }
-
   void _stopAllVideos(String action, String? routeName) {
     try {
-      // Access container from navigator context
-      if (navigator?.context != null) {
-        final container = ProviderScope.containerOf(navigator!.context);
+      // Capture navigator in a local variable to avoid race condition
+      // where navigator becomes null between the null check and usage.
+      final nav = navigator;
+      if (nav?.context != null) {
+        final container = ProviderScope.containerOf(nav!.context);
 
         // Stop videos immediately - no delay
         // This ensures videos stop BEFORE the new route builds

--- a/mobile/test/services/video_stop_navigator_observer_test.dart
+++ b/mobile/test/services/video_stop_navigator_observer_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/video_stop_navigator_observer.dart';
+
+void main() {
+  group(VideoStopNavigatorObserver, () {
+    late VideoStopNavigatorObserver observer;
+
+    setUp(() {
+      observer = VideoStopNavigatorObserver();
+    });
+
+    test('can be instantiated', () {
+      expect(observer, isA<NavigatorObserver>());
+    });
+
+    test('handles null navigator gracefully in didPush', () {
+      // navigator is null when observer is not attached to a Navigator.
+      // This should not throw.
+      final route = _FakeRoute(name: 'test-route');
+      expect(
+        () => observer.didPush(route, null),
+        returnsNormally,
+      );
+    });
+
+    test('handles null navigator gracefully in didStartUserGesture', () {
+      final route = _FakeRoute(name: 'test-route');
+      expect(
+        () => observer.didStartUserGesture(route, null),
+        returnsNormally,
+      );
+    });
+
+    test('skips video disposal for PopupRoute in didPush', () {
+      final route = _FakePopupRoute();
+      // Should return early without attempting to access navigator.
+      expect(
+        () => observer.didPush(route, null),
+        returnsNormally,
+      );
+    });
+
+    test('skips video disposal for PopupRoute in didStartUserGesture', () {
+      final route = _FakePopupRoute();
+      expect(
+        () => observer.didStartUserGesture(route, null),
+        returnsNormally,
+      );
+    });
+  });
+}
+
+class _FakeRoute extends Fake implements Route<dynamic> {
+  _FakeRoute({this.name});
+
+  final String? name;
+
+  @override
+  RouteSettings get settings => RouteSettings(name: name);
+
+  @override
+  bool get isActive => true;
+}
+
+class _FakePopupRoute extends Fake implements PopupRoute<dynamic> {
+  @override
+  RouteSettings get settings => const RouteSettings(name: 'popup');
+
+  @override
+  bool get isActive => true;
+}


### PR DESCRIPTION
Closes #3003

## Summary
- Fixes a race condition in `VideoStopNavigatorObserver._stopAllVideos()` where `navigator` could become null between the null check and the null assertion on the next line. The navigator reference is now captured in a local variable first.
- Removes four leftover debug `print()` statements and their now-empty method overrides (`didPop`, `didRemove`, `didReplace`) that only existed to host those prints.
- Adds a new test file covering the observer's behavior with null navigator and PopupRoute skipping.

## Test plan
- [x] `flutter analyze lib/services/video_stop_navigator_observer.dart` passes with no issues
- [x] `flutter test test/services/video_stop_navigator_observer_test.dart` passes (5 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)