### PR TITLE
chore(ci): assign internal TestFlight beta groups

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -380,8 +380,13 @@ workflows:
         auth: integration
         submit_to_testflight: true
         submit_to_app_store: false
-        # Don't auto-distribute to any groups - we'll manually add builds to external testers
-        beta_groups: []
+        # Auto-distribute internal builds to the existing internal TestFlight groups.
+        beta_groups:
+          - "AOS"
+          - "GW"
+          - "rabblelabs"
+          - "RL Devs"
+          - "VGV"
 
   ios-simulator-build:
     name: iOS Simulator Build


### PR DESCRIPTION
Closes #3008

## Summary
- configure iOS Codemagic publishing to assign uploaded builds to the internal TestFlight groups
- quote the group names explicitly, including `RL Devs`, to avoid YAML ambiguity
- keep the rest of the iOS publishing flow unchanged

## Test Plan
- [x] `ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml'); puts 'YAML OK'"`
- [x] `git push -u origin chore/codemagic-beta-groups` pre-push checks
