### PR TITLE
fix(profile): show follower count instantly from profile data

### DIFF
--- a/mobile/lib/widgets/profile/profile_followers_stat.dart
+++ b/mobile/lib/widgets/profile/profile_followers_stat.dart
@@ -18,6 +18,7 @@ class ProfileFollowersStat extends ConsumerWidget {
     required this.pubkey,
     required this.displayName,
     required this.isOwnProfile,
+    this.initialCount,
     super.key,
   });
 
@@ -30,6 +31,9 @@ class ProfileFollowersStat extends ConsumerWidget {
   /// Whether this is the current user's own profile.
   final bool isOwnProfile;
 
+  /// Initial count from profile data, shown while the BLoC loads.
+  final int? initialCount;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final followRepository = ref.watch(followRepositoryProvider);
@@ -41,22 +45,36 @@ class ProfileFollowersStat extends ConsumerWidget {
           followRepository: followRepository,
           contentBlocklistService: blocklistService,
         )..add(const MyFollowersListLoadRequested()),
-        child: _MyFollowersStatView(pubkey: pubkey, displayName: displayName),
+        child: _MyFollowersStatView(
+          pubkey: pubkey,
+          displayName: displayName,
+          initialCount: initialCount,
+        ),
       );
     } else {
-      // Use the OthersFollowersBloc from parent context (provided by ProfileGridView)
-      // This allows the follow button to update the count optimistically
-      return _OthersFollowersStatView(pubkey: pubkey, displayName: displayName);
+      // Use the OthersFollowersBloc from parent context (provided by
+      // ProfileGridView). This allows the follow button to update the
+      // count optimistically.
+      return _OthersFollowersStatView(
+        pubkey: pubkey,
+        displayName: displayName,
+        initialCount: initialCount,
+      );
     }
   }
 }
 
 /// View widget for current user's followers stat.
 class _MyFollowersStatView extends ConsumerWidget {
-  const _MyFollowersStatView({required this.pubkey, required this.displayName});
+  const _MyFollowersStatView({
+    required this.pubkey,
+    required this.displayName,
+    this.initialCount,
+  });
 
   final String pubkey;
   final String? displayName;
+  final int? initialCount;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -71,9 +89,9 @@ class _MyFollowersStatView extends ConsumerWidget {
             state.status == MyFollowersStatus.loading;
 
         return ProfileStatColumn(
-          count: isLoading ? null : state.followerCount,
+          count: isLoading ? initialCount : state.followerCount,
           label: context.l10n.profileFollowersLabel,
-          isLoading: isLoading,
+          isLoading: isLoading && initialCount == null,
           onTap: () => context.push(
             FollowersScreenRouter.pathForPubkey(pubkey),
             extra: displayName,
@@ -89,10 +107,12 @@ class _OthersFollowersStatView extends ConsumerWidget {
   const _OthersFollowersStatView({
     required this.pubkey,
     required this.displayName,
+    this.initialCount,
   });
 
   final String pubkey;
   final String? displayName;
+  final int? initialCount;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -109,9 +129,9 @@ class _OthersFollowersStatView extends ConsumerWidget {
             state.status == OthersFollowersStatus.loading;
 
         return ProfileStatColumn(
-          count: isLoading ? null : state.followerCount,
+          count: isLoading ? initialCount : state.followerCount,
           label: context.l10n.profileFollowersLabel,
-          isLoading: isLoading,
+          isLoading: isLoading && initialCount == null,
           onTap: () => context.push(
             FollowersScreenRouter.pathForPubkey(pubkey),
             extra: displayName,

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -198,6 +198,8 @@ class ProfileHeaderWidget extends ConsumerWidget {
                                     pubkey: userIdHex,
                                     displayName: displayName,
                                     isOwnProfile: isOwnProfile,
+                                    initialCount:
+                                        effectiveProfile?.followerCount,
                                   ),
                                   ProfileFollowingStat(
                                     pubkey: userIdHex,


### PR DESCRIPTION
## Summary
- Profile's `followerCount` from the REST API was already available on `UserProfile` but the header widget ignored it
- `ProfileFollowersStat` now accepts `initialCount` and shows it immediately instead of "—" while the authoritative BLoC count loads in the background
- When the BLoC finishes, it seamlessly replaces the initial count

## Test plan
- [x] All 131 profile widget tests pass
- [ ] Manual: open any profile, verify follower count appears immediately (no "—" flash)
- [ ] Manual: verify count still updates if the authoritative count differs

🤖 Generated with [Claude Code](https://claude.com/claude-code)