### PR TITLE
feat(profile_feed): coordinate relay and REST hydration

### DIFF
--- a/docs/superpowers/plans/2026-04-13-profile-feed-multisource.md
+++ b/docs/superpowers/plans/2026-04-13-profile-feed-multisource.md
@@ -1,0 +1,166 @@
+# Profile Feed Multi-Source Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the profile feed render faster and stay fresher by coordinating cache, REST, and Nostr in parallel while preserving REST pagination and Nostr-correct merge behavior.
+
+**Architecture:** Keep `ProfileFeed` as the existing Riverpod entrypoint, but refactor its internal orchestration into a source coordinator. Reuse current metadata cache, optimistic insertion, and Nostr enrichment helpers while adding stable multi-source merge helpers and mixed-source contract tests.
+
+**Tech Stack:** Flutter, Riverpod, Funnelcake REST client, Nostr client/service, Flutter test, mocktail
+
+---
+
+## Chunk 1: Canonical Merge Helpers
+
+### Task 1: Add failing merge-contract tests
+
+**Files:**
+- Modify: `mobile/test/providers/profile_feed_pagination_contract_test.dart`
+- Reference: `mobile/lib/providers/profile_feed_provider.dart`
+
+- [ ] **Step 1: Write failing tests for mixed-source dedupe and ordering**
+
+Add tests covering:
+- relay-first initial head item remains when slower REST arrives without that item
+- REST overlays additional metadata without duplicating a replaceable video
+- stable identity merges edited replaceable events by `pubkey + stableId`
+
+- [ ] **Step 2: Run the targeted test file to verify failure**
+
+Run: `flutter test test/providers/profile_feed_pagination_contract_test.dart`
+Expected: FAIL on the new mixed-source expectations.
+
+- [ ] **Step 3: Add minimal merge helpers in `ProfileFeed`**
+
+Introduce focused helpers for:
+- canonical stable key creation
+- source merge of `List<VideoEvent>`
+- deterministic publish-order sorting
+
+- [ ] **Step 4: Run the targeted test file to verify the new helpers pass**
+
+Run: `flutter test test/providers/profile_feed_pagination_contract_test.dart`
+Expected: PASS for new and existing tests.
+
+## Chunk 2: Parallel Initial Load
+
+### Task 2: Make initial load cache-first and multi-source
+
+**Files:**
+- Modify: `mobile/lib/providers/profile_feed_provider.dart`
+- Test: `mobile/test/providers/profile_feed_pagination_contract_test.dart`
+- Reference: `mobile/lib/providers/profile_feed_session_cache.dart`
+- Reference: `mobile/lib/services/video_event_service.dart`
+
+- [ ] **Step 1: Write failing tests for initial parallel behavior**
+
+Add tests covering:
+- cached state is emitted immediately while background sync continues
+- relay result can satisfy the visible head before REST returns
+- REST later updates counts and hasMore metadata without discarding relay-only head items
+
+- [ ] **Step 2: Run the targeted test file to verify failure**
+
+Run: `flutter test test/providers/profile_feed_pagination_contract_test.dart`
+Expected: FAIL on the new parallel initial-load cases.
+
+- [ ] **Step 3: Implement the minimal initial-load coordinator**
+
+Update `build(String userId)` to:
+- emit retained state immediately when present
+- kick off REST and relay startup concurrently
+- accept the first useful result
+- merge later source data into canonical state
+- keep existing filtering and listener behavior intact
+
+- [ ] **Step 4: Run the targeted test file to verify the initial-load changes pass**
+
+Run: `flutter test test/providers/profile_feed_pagination_contract_test.dart`
+Expected: PASS for the initial-load cases and no regressions in existing pagination cases.
+
+## Chunk 3: Parallel Refresh And REST Pagination Preservation
+
+### Task 3: Refresh with the same source-coordinator rules
+
+**Files:**
+- Modify: `mobile/lib/providers/profile_feed_provider.dart`
+- Test: `mobile/test/providers/profile_feed_pagination_contract_test.dart`
+
+- [ ] **Step 1: Write failing tests for refresh merge behavior**
+
+Add tests covering:
+- refresh keeps relay-fresh head items while REST count data lands later
+- refresh degrades gracefully when one source errors
+
+- [ ] **Step 2: Run the targeted test file to verify failure**
+
+Run: `flutter test test/providers/profile_feed_pagination_contract_test.dart`
+Expected: FAIL on the new refresh behavior.
+
+- [ ] **Step 3: Implement minimal refresh coordinator changes**
+
+Update refresh paths to:
+- run REST and relay head sync in parallel
+- reuse canonical merge helpers
+- preserve `_totalVideoCount` and `_nextOffset`
+- avoid dropping into a single-source fallback state when one source is still healthy
+
+- [ ] **Step 4: Run the targeted test file to verify the refresh behavior passes**
+
+Run: `flutter test test/providers/profile_feed_pagination_contract_test.dart`
+Expected: PASS for refresh cases.
+
+### Task 4: Keep `loadMore()` REST-backed but canonical
+
+**Files:**
+- Modify: `mobile/lib/providers/profile_feed_provider.dart`
+- Test: `mobile/test/providers/profile_feed_pagination_contract_test.dart`
+
+- [ ] **Step 1: Write a failing test for mixed-source `loadMore()`**
+
+Add a test proving that after a relay-first or mixed-source initial state, REST `loadMore()` appends only genuinely older content and does not duplicate head items.
+
+- [ ] **Step 2: Run the targeted test file to verify failure**
+
+Run: `flutter test test/providers/profile_feed_pagination_contract_test.dart`
+Expected: FAIL on the new `loadMore()` case.
+
+- [ ] **Step 3: Implement minimal `loadMore()` canonical merge**
+
+Update `loadMore()` to:
+- merge incoming REST pages through the same stable identity rules
+- maintain deterministic ordering
+- preserve REST pagination metadata
+
+- [ ] **Step 4: Run the targeted test file to verify `loadMore()` behavior passes**
+
+Run: `flutter test test/providers/profile_feed_pagination_contract_test.dart`
+Expected: PASS for the new `loadMore()` case and existing pagination cases.
+
+## Chunk 4: Verification
+
+### Task 5: Run focused verification
+
+**Files:**
+- Verify: `mobile/lib/providers/profile_feed_provider.dart`
+- Verify: `mobile/test/providers/profile_feed_pagination_contract_test.dart`
+
+- [ ] **Step 1: Run targeted analyze**
+
+Run: `flutter analyze lib/providers/profile_feed_provider.dart test/providers/profile_feed_pagination_contract_test.dart`
+Expected: `No issues found!`
+
+- [ ] **Step 2: Run targeted provider tests**
+
+Run: `flutter test test/providers/profile_feed_pagination_contract_test.dart`
+Expected: All tests pass.
+
+- [ ] **Step 3: Run the existing profile provider regression tests**
+
+Run: `flutter test test/providers/profile_feed_provider_test.dart`
+Expected: All tests pass.
+
+- [ ] **Step 4: Review git diff for stray changes**
+
+Run: `git status --short` and `git diff --stat`
+Expected: Only spec, plan, provider, and targeted test changes.

--- a/docs/superpowers/specs/2026-04-13-profile-feed-multisource-design.md
+++ b/docs/superpowers/specs/2026-04-13-profile-feed-multisource-design.md
@@ -1,0 +1,145 @@
+# Profile Feed Multi-Source Design
+
+**Date:** 2026-04-13
+
+## Goal
+
+Improve profile-feed startup latency and freshness by treating session cache, Funnelcake REST, and Nostr relay data as coordinated sources instead of a strict REST-first fallback chain.
+
+## Priorities
+
+1. Fastest possible initial profile render, especially after publish.
+2. Correct canonical feed state when REST and relay data disagree.
+3. Minimal review risk in the current Riverpod-based profile feed.
+
+## Current Constraints
+
+- `ProfileFeed` is a Riverpod family provider with substantial coordination logic in `mobile/lib/providers/profile_feed_provider.dart`.
+- Funnelcake REST is valuable for:
+  - first-page fetch speed when the index is warm
+  - `totalVideoCount`
+  - offset-based historical pagination
+- Nostr is valuable for:
+  - protocol truth
+  - post-publish freshness
+  - full event tags used for badges, metadata, and replaceable-event semantics
+- The provider already has useful primitives:
+  - session cache
+  - metadata cache
+  - timestamp preservation
+  - Nostr enrichment helpers
+  - optimistic new-video insertion
+
+## Protocol Assumptions
+
+- Short-form video events are addressable replaceable events keyed by `(kind, pubkey, d)` when the `d` tag exists.
+- Relay queries are filtered subscriptions where `limit` only constrains the initial backfill, not the real-time stream.
+- Clients should prefer the author's write relays when downloading that author's events.
+
+These assumptions come from the current repo protocol docs and the official NIP-01, NIP-65, and NIP-71 specs.
+
+## Proposed Architecture
+
+Introduce a profile-feed source coordinator inside `ProfileFeed` with these responsibilities:
+
+- Emit the session cache immediately when available.
+- Start REST first-page fetch and Nostr author sync in parallel.
+- Accept the first non-empty result as the provisional head snapshot.
+- Merge later source results into canonical state using stable identity rules.
+- Keep Nostr subscribed for freshness after initial render.
+- Keep REST as the source of truth for `totalVideoCount` and `loadMore()`.
+
+This keeps the current provider API stable while changing its orchestration model.
+
+## Canonical Identity And Merge Rules
+
+### Identity
+
+Use a stable key in this order:
+
+1. `kind:pubkey:stableId` when `stableId`/`d` is present
+2. `pubkey:eventId` fallback when no stable identity exists
+
+### Field ownership
+
+- Prefer Nostr for event-native fields:
+  - `rawTags`
+  - `content`
+  - `hashtags`
+  - `blurhash`
+  - `altText`
+  - collaborators and other parsed tag data
+- Prefer REST for indexed overlays:
+  - count/engagement values already coming from Funnelcake
+  - `totalVideoCount`
+  - offset pagination semantics
+- Preserve publish ordering using:
+  - `publishedAt` when available
+  - otherwise first-seen publish timestamp, not edit time
+
+### Emission rules
+
+- Do not re-emit state for late-arriving source data unless visible feed content changes.
+- Do not reorder existing videos unless the canonical publish-order key changes.
+- Do not duplicate edited replaceable events with new event ids.
+
+## Runtime Flow
+
+### Initial load
+
+1. Read session cache.
+2. If cache exists, emit it immediately as stale-but-usable state.
+3. Start:
+   - REST first page
+   - Nostr author subscribe/query
+4. If Nostr produces fresher head items first, show them immediately.
+5. When REST arrives, merge in count data, missing videos, and pagination metadata.
+6. Keep Nostr listeners active for updates and new publishes.
+
+### Refresh
+
+- Refresh should re-run REST and relay head synchronization in parallel.
+- Relay can satisfy freshness first.
+- REST overlays count and pagination metadata later.
+
+### Load more
+
+- Keep REST-backed `loadMore()` for now.
+- Merge appended REST pages into canonical state using the same stable identity logic.
+- Do not attempt full relay-based deep pagination in this change.
+
+## State Changes
+
+Keep `VideoFeedState` mostly stable for UI compatibility, but extend internal provider bookkeeping with:
+
+- source status tracking for REST and Nostr
+- canonical keyed map or equivalent merge helper
+- timestamps for rest sync and relay sync
+
+Only add public state fields if needed for tests or UI behavior. Avoid widening the UI contract unless necessary.
+
+## Test Strategy
+
+Add contract tests that prove the new behavior:
+
+- cache is emitted immediately while both sources run
+- relay can win head-of-feed freshness when REST is slow
+- REST can arrive later and add counts without duplicating or reordering incorrectly
+- replaceable edits merge by stable identity
+- `loadMore()` still appends correctly after a mixed-source initial load
+- one source failing does not block usable state from the other
+
+## Non-Goals
+
+- Full migration of `ProfileFeed` from Riverpod to BLoC/Cubit
+- Replacing REST pagination with relay history pagination
+- Generalizing the coordinator for every feed in the app during this change
+
+## Implementation Shape
+
+Deliver this in small slices:
+
+1. Extract merge helpers and add tests.
+2. Parallelize initial load with cache-first behavior.
+3. Parallelize refresh and preserve REST pagination.
+4. Expand contract tests for mixed-source behavior.

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -58,7 +59,6 @@ class ProfileFeed extends _$ProfileFeed {
     _usingRestApi = false;
     _nextOffset = null;
     _listenersRegistered = false;
-    int? restPageCount;
 
     // Watch content filter version — rebuilds when preferences change.
     ref.watch(contentFilterVersionProvider);
@@ -84,12 +84,13 @@ class ProfileFeed extends _$ProfileFeed {
     final sessionCache = ref.read(profileFeedSessionCacheProvider);
     final retainedState = sessionCache.read(userId);
 
+    _registerRetainedRealtimeListeners(videoEventService);
+
     if (retainedState != null && retainedState.videos.isNotEmpty) {
       _usingRestApi = funnelcakeAvailable;
       _nextOffset = estimateNextRestOffset(retainedState);
       _totalVideoCount = retainedState.totalVideoCount;
-      _registerRetainedRealtimeListeners(videoEventService);
-      Future.microtask(() => refresh(retainedState: retainedState));
+      unawaited(Future(() => refresh(retainedState: retainedState)));
       return retainedState.copyWith(
         isRefreshing: true,
         isInitialLoad: false,
@@ -97,166 +98,21 @@ class ProfileFeed extends _$ProfileFeed {
       );
     }
 
-    if (funnelcakeAvailable) {
-      Log.info(
-        'ProfileFeed: Trying Funnelcake REST API first for user=$userId',
-        name: 'ProfileFeedProvider',
-        category: LogCategory.video,
-      );
+    authorVideos = _relayVideosSnapshot(videoEventService);
 
-      try {
-        final result = await funnelcakeClient
-            .getVideosByAuthor(pubkey: userId)
-            .timeout(_restApiTimeout);
-        final apiVideos = result.videos.map((v) => v.toVideoEvent()).toList();
-        restPageCount = apiVideos.length;
-        _totalVideoCount = result.totalCount;
-
-        if (apiVideos.isNotEmpty) {
-          _usingRestApi = true;
-          // Filter out reposts and store the next REST page offset.
-          final tempAuthorVideos = apiVideos.where((v) => !v.isRepost).toList();
-          _nextOffset = apiVideos.length;
-
-          // Cache metadata for later merging with Nostr data
-          _cacheVideoMetadata(tempAuthorVideos);
-
-          // Enrich with full Nostr event data in the background so we
-          // don't block the initial render waiting on relay round-trips
-          // (up to 5s timeout). Badges appear once enrichment completes.
-          authorVideos = enrichVideosInBackground(
-            tempAuthorVideos,
-            nostrService: ref.read(nostrServiceProvider),
-            onEnriched: (enriched) {
-              if (!ref.mounted) return;
-              final currentState = state.asData?.value;
-              if (currentState == null) return;
-              final enrichedMap = <String, VideoEvent>{
-                for (final v in enriched) v.id: v,
-              };
-              final updated = currentState.videos
-                  .map((v) => enrichedMap[v.id] ?? v)
-                  .toList();
-              state = AsyncData(currentState.copyWith(videos: updated));
-            },
-            callerName: 'ProfileFeedProvider',
-          );
-        } else {
-          Log.warning(
-            'ProfileFeed: REST API returned empty for user=$userId, falling back to Nostr',
-            name: 'ProfileFeedProvider',
-            category: LogCategory.video,
-          );
-          _usingRestApi = false;
+    unawaited(
+      Future(() async {
+        await _refreshFromNostrSource(videoEventService);
+        if (funnelcakeAvailable) {
+          await _refreshFromRestApi(clientOverride: funnelcakeClient);
         }
-      } catch (e) {
-        Log.warning(
-          'ProfileFeed: REST API failed ($e), falling back to Nostr',
-          name: 'ProfileFeedProvider',
-          category: LogCategory.video,
-        );
-        _usingRestApi = false;
-      }
-    }
-
-    // Fall back to Nostr subscription if REST API not used
-    if (!_usingRestApi) {
-      // Start the Nostr subscription in the background so the provider can
-      // return retained, cached, or empty state immediately.
-      unawaited(
-        videoEventService.subscribeToUserVideos(userId).catchError((
-          Object error,
-          StackTrace stackTrace,
-        ) {
-          Log.error(
-            'ProfileFeed: Background Nostr subscribe failed for user=$userId: $error',
-            name: 'ProfileFeedProvider',
-            category: LogCategory.video,
-            error: error,
-            stackTrace: stackTrace,
-          );
-        }),
-      );
-
-      // Return immediately with whatever videos are available.
-      // Progressive updates arrive via the video update/new video listeners
-      // registered below.
-      authorVideos = videoEventService
-          .authorVideos(userId)
-          .where((v) => !v.isRepost)
-          .toList();
-
-      // Apply cached metadata to preserve engagement stats from previous REST API calls
-      authorVideos = _applyMetadataCache(authorVideos);
-
-      // Set up continuous listener for progressive updates from Nostr
-      void onNostrVideosChanged() {
-        if (!ref.mounted) return;
-        final currentVideos = videoEventService
-            .authorVideos(userId)
-            .where((v) => !v.isRepost)
-            .toList();
-
-        // Only update if count actually changed
-        final currentState = state.asData?.value;
-        if (currentState != null &&
-            currentVideos.length != currentState.videos.length) {
-          var updatedVideos = _applyMetadataCache(currentVideos);
-          updatedVideos = videoEventService.filterVideoList(updatedVideos);
-
-          state = AsyncData(
-            VideoFeedState(
-              videos: updatedVideos,
-              hasMoreContent:
-                  updatedVideos.length >= AppConstants.hasMoreContentThreshold,
-              lastUpdated: DateTime.now(),
-            ),
-          );
-        }
-      }
-
-      videoEventService.addListener(onNostrVideosChanged);
-      ref.onDispose(() {
-        videoEventService.removeListener(onNostrVideosChanged);
-      });
-    }
+      }),
+    );
 
     // Check if provider is still mounted after async gap
     if (!ref.mounted) {
       return const VideoFeedState(videos: [], hasMoreContent: false);
     }
-
-    // Register for video update callbacks to auto-refresh when this user's video is updated
-    final unregisterUpdate = videoEventService.addVideoUpdateListener((
-      updated,
-    ) {
-      if (updated.pubkey == userId && ref.mounted) {
-        refreshFromService();
-      }
-    });
-
-    // Register for NEW video callbacks to auto-refresh when this user posts a new video
-    final unregisterNew = videoEventService.addNewVideoListener((
-      newVideo,
-      authorPubkey,
-    ) {
-      if (authorPubkey == userId && ref.mounted) {
-        // CRITICAL FIX: Optimistically add the new video to state immediately
-        // instead of re-fetching from REST API which may have stale data.
-        // This fixes the "video disappears after upload" bug where Funnelcake
-        // hasn't indexed the new video yet but the user expects to see it.
-        _addNewVideoToState(newVideo);
-      }
-    });
-
-    // Clean up callbacks when provider is disposed
-    ref.onDispose(() {
-      unregisterUpdate();
-      unregisterNew();
-    });
-
-    // Apply content filter preferences
-    authorVideos = videoEventService.filterVideoList(authorVideos);
 
     Log.info(
       'ProfileFeed: Initial load complete - ${authorVideos.length} videos for user=$userId (REST API: $_usingRestApi)',
@@ -266,10 +122,9 @@ class ProfileFeed extends _$ProfileFeed {
 
     final initialState = VideoFeedState(
       videos: authorVideos,
-      hasMoreContent: _usingRestApi
-          ? (restPageCount ?? 0) >= AppConstants.paginationBatchSize
-          : authorVideos.length >= AppConstants.hasMoreContentThreshold,
-      isInitialLoad: authorVideos.isEmpty && !_usingRestApi,
+      hasMoreContent:
+          authorVideos.length >= AppConstants.hasMoreContentThreshold,
+      isInitialLoad: authorVideos.isEmpty,
       lastUpdated: DateTime.now(),
       totalVideoCount: _totalVideoCount,
     );
@@ -311,78 +166,7 @@ class ProfileFeed extends _$ProfileFeed {
   /// Refresh state - uses REST API when available, otherwise Nostr with metadata preservation
   /// Call this after a video is updated to sync the provider's state
   void refreshFromService() {
-    // Fix #1: If using REST API, refresh from REST API instead of Nostr
-    if (_usingRestApi) {
-      _refreshFromRestApi();
-      return;
-    }
-
-    // Nostr mode: get videos from service
-    final videoEventService = ref.read(videoEventServiceProvider);
-    // Filter out reposts (originals only)
-    var updatedVideos = videoEventService
-        .authorVideos(userId)
-        .where((v) => !v.isRepost)
-        .toList();
-
-    // Fix #3: Apply cached metadata to preserve engagement stats
-    updatedVideos = _applyMetadataCache(updatedVideos);
-
-    // Apply content filter preferences
-    updatedVideos = videoEventService.filterVideoList(updatedVideos);
-
-    state = AsyncData(
-      VideoFeedState(
-        videos: updatedVideos,
-        hasMoreContent:
-            updatedVideos.length >= AppConstants.hasMoreContentThreshold,
-        lastUpdated: DateTime.now(),
-      ),
-    );
-  }
-
-  List<VideoEvent> _mergeStableTimestampsFromCurrentState(
-    List<VideoEvent> incoming,
-  ) {
-    final currentVideos = state.asData?.value.videos;
-    if (currentVideos == null || currentVideos.isEmpty) return incoming;
-
-    // Build lookup keys because REST API responses can be inconsistent
-    // about addressable identifiers (`d` tag / stableId).
-    //
-    // Known inconsistency:
-    // - Missing d-tags: Many relays don't include 'd' tags on NIP-71 addressable events
-    String? stableKey(VideoEvent v) {
-      final stableId = v.stableId;
-      if (stableId.isEmpty) return null;
-      return '${v.pubkey}:$stableId'.toLowerCase();
-    }
-
-    final existingByKey = <String, VideoEvent>{};
-    for (final v in currentVideos) {
-      final key = stableKey(v);
-      if (key != null) existingByKey[key] = v;
-    }
-
-    return incoming.map((video) {
-      final existing = stableKey(video) != null
-          ? existingByKey[stableKey(video)!]
-          : null;
-      if (existing == null) return video;
-
-      // Funnelcake may return the latest replaceable event's created_at (edit time)
-      // and may omit published_at. Preserve existing timestamps when published_at
-      // isn't present to avoid resetting relative time to "now" after refresh.
-      final hasPublishedAt =
-          video.publishedAt != null && video.publishedAt!.isNotEmpty;
-      if (hasPublishedAt) return video;
-
-      return video.copyWith(
-        createdAt: existing.createdAt,
-        timestamp: existing.timestamp,
-        publishedAt: existing.publishedAt,
-      );
-    }).toList();
+    unawaited(refresh());
   }
 
   /// Optimistically add a newly published video to the profile feed state.
@@ -409,41 +193,10 @@ class ProfileFeed extends _$ProfileFeed {
       return;
     }
 
-    // Check for duplicates (case-insensitive for Nostr IDs)
-    final existingIds = currentState.videos
-        .map((v) => v.id.toLowerCase())
-        .toSet();
-    if (existingIds.contains(newVideo.id.toLowerCase())) {
-      Log.debug(
-        'ProfileFeed: Video ${newVideo.id} already in state, skipping optimistic add',
-        name: 'ProfileFeedProvider',
-        category: LogCategory.video,
-      );
+    final updatedVideos = _mergeVideoLists(currentState.videos, [newVideo]);
+    if (_sameVideoSequence(currentState.videos, updatedVideos)) {
       return;
     }
-
-    // Also deduplicate replaceable/addressable videos by stable identity.
-    // Editing metadata republishes a new event id for the same (pubkey, d-tag),
-    // so id-based dedupe is insufficient and would create a duplicate entry.
-    final newStableKey = '${newVideo.pubkey}:${newVideo.stableId}'
-        .toLowerCase();
-    final existingStableKeys = currentState.videos
-        .map((v) => '${v.pubkey}:${v.stableId}'.toLowerCase())
-        .toSet();
-    if (existingStableKeys.contains(newStableKey)) {
-      Log.debug(
-        'ProfileFeed: Video ${newVideo.id} matches existing stableId=${newVideo.stableId}, skipping optimistic add',
-        name: 'ProfileFeedProvider',
-        category: LogCategory.video,
-      );
-      return;
-    }
-
-    // Add new video and maintain newest-first sort order.
-    // Simple prepend is insufficient because during initial Nostr subscription
-    // events arrive newest-first, so prepending each one reverses the order.
-    final updatedVideos = <VideoEvent>[newVideo, ...currentState.videos]
-      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
 
     Log.info(
       'ProfileFeed: Optimistically added new video ${newVideo.id} to state (total: ${updatedVideos.length})',
@@ -451,19 +204,22 @@ class ProfileFeed extends _$ProfileFeed {
       category: LogCategory.video,
     );
 
-    state = AsyncData(
-      VideoFeedState(
+    _emitState(
+      currentState.copyWith(
         videos: updatedVideos,
         hasMoreContent: currentState.hasMoreContent,
+        isInitialLoad: false,
         lastUpdated: DateTime.now(),
       ),
     );
   }
 
   /// Fix #2: Refresh from REST API when in REST API mode
-  Future<void> _refreshFromRestApi() async {
+  Future<void> _refreshFromRestApi({
+    FunnelcakeApiClient? clientOverride,
+  }) async {
     try {
-      final client = ref.read(funnelcakeApiClientProvider);
+      final client = clientOverride ?? ref.read(funnelcakeApiClientProvider);
       final result = await client
           .getVideosByAuthor(pubkey: userId)
           .timeout(_restApiTimeout);
@@ -472,52 +228,68 @@ class ProfileFeed extends _$ProfileFeed {
       if (!ref.mounted) return;
 
       _totalVideoCount = result.totalCount;
+      _nextOffset = apiVideos.length;
 
       if (apiVideos.isNotEmpty) {
-        // Filter out reposts
-        var authorVideos = apiVideos.where((v) => !v.isRepost).toList();
-        authorVideos = _mergeStableTimestampsFromCurrentState(authorVideos);
-        _nextOffset = apiVideos.length;
-
-        // Update metadata cache with fresh data
+        final relayVideos = _relayVideosSnapshot(
+          ref.read(videoEventServiceProvider),
+        );
+        final authorVideos = _mergeVideoLists(
+          relayVideos,
+          apiVideos.where((v) => !v.isRepost).toList(),
+        );
         _cacheVideoMetadata(authorVideos);
 
-        // Enrich with full Nostr event data (rawTags, dimensions, etc.)
-        authorVideos = await enrichVideosWithNostrTags(
+        final filteredVideos = ref
+            .read(videoEventServiceProvider)
+            .filterVideoList(authorVideos);
+
+        _usingRestApi = true;
+        _mergeSourceVideos(
+          filteredVideos,
+          hasMoreContent: apiVideos.length >= AppConstants.paginationBatchSize,
+          totalVideoCount: _totalVideoCount,
+          isRefreshing: false,
+          isInitialLoad: false,
+          mergeWithCurrent: false,
+        );
+
+        // Enrich with full Nostr event data in the background.
+        enrichVideosInBackground(
           authorVideos,
           nostrService: ref.read(nostrServiceProvider),
+          onEnriched: (enriched) {
+            if (!ref.mounted) return;
+            final enrichedVideos = ref
+                .read(videoEventServiceProvider)
+                .filterVideoList(enriched);
+            _mergeSourceVideos(
+              enrichedVideos,
+              hasMoreContent:
+                  apiVideos.length >= AppConstants.paginationBatchSize,
+              totalVideoCount: _totalVideoCount,
+              isRefreshing: false,
+              isInitialLoad: false,
+              mergeWithCurrent: false,
+            );
+          },
           callerName: 'ProfileFeedProvider',
         );
 
-        // Apply content filter preferences
-        final videoEventService = ref.read(videoEventServiceProvider);
-        authorVideos = videoEventService.filterVideoList(authorVideos);
-
-        state = AsyncData(
-          VideoFeedState(
-            videos: authorVideos,
-            hasMoreContent:
-                apiVideos.length >= AppConstants.paginationBatchSize,
-            lastUpdated: DateTime.now(),
-            totalVideoCount: _totalVideoCount,
-          ),
-        );
-
         Log.info(
-          'ProfileFeed: Refreshed ${authorVideos.length} videos from REST API for user=$userId',
+          'ProfileFeed: Refreshed ${filteredVideos.length} videos from REST API for user=$userId',
           name: 'ProfileFeedProvider',
           category: LogCategory.video,
         );
       } else {
-        // REST API returned empty — this is valid (e.g. all videos deleted)
-        _nextOffset = 0;
-        state = AsyncData(
-          VideoFeedState(
-            videos: [],
-            hasMoreContent: false,
-            lastUpdated: DateTime.now(),
-            totalVideoCount: _totalVideoCount,
-          ),
+        _usingRestApi = true;
+        _mergeSourceVideos(
+          const <VideoEvent>[],
+          hasMoreContent: false,
+          totalVideoCount: _totalVideoCount,
+          isRefreshing: false,
+          isInitialLoad: false,
+          mergeWithCurrent: false,
         );
 
         Log.info(
@@ -528,14 +300,10 @@ class ProfileFeed extends _$ProfileFeed {
       }
     } catch (e) {
       Log.warning(
-        'ProfileFeed: REST API refresh failed ($e), using Nostr with cached metadata',
+        'ProfileFeed: REST API refresh failed ($e)',
         name: 'ProfileFeedProvider',
         category: LogCategory.video,
       );
-      // Fall back to Nostr with metadata cache on error
-      _usingRestApi = false;
-      _nextOffset = null;
-      refreshFromService();
     }
   }
 
@@ -584,24 +352,20 @@ class ProfileFeed extends _$ProfileFeed {
           category: LogCategory.video,
         );
 
-        final result = await client.getVideosByAuthor(
-          pubkey: userId,
-          offset: offset,
-        );
+        final result = await client
+            .getVideosByAuthor(
+              pubkey: userId,
+              offset: offset,
+            )
+            .timeout(_restApiTimeout);
         final apiVideos = result.videos.map((v) => v.toVideoEvent()).toList();
 
         if (!ref.mounted) return;
+        _totalVideoCount = result.totalCount ?? _totalVideoCount;
         _nextOffset = offset + apiVideos.length;
 
         if (apiVideos.isNotEmpty) {
-          // Deduplicate and merge (case-insensitive for Nostr IDs)
-          final existingIds = currentState.videos
-              .map((v) => v.id.toLowerCase())
-              .toSet();
-          var newVideos = apiVideos
-              .where((v) => !existingIds.contains(v.id.toLowerCase()))
-              .where((v) => !v.isRepost)
-              .toList();
+          var newVideos = apiVideos.where((v) => !v.isRepost).toList();
 
           // Cache metadata from new videos
           _cacheVideoMetadata(newVideos);
@@ -618,18 +382,19 @@ class ProfileFeed extends _$ProfileFeed {
           newVideos = videoEventService.filterVideoList(newVideos);
 
           if (newVideos.isNotEmpty) {
-            final allVideos = [...currentState.videos, ...newVideos];
+            final allVideos = _mergeVideoLists(currentState.videos, newVideos);
             Log.info(
               'ProfileFeed: Loaded ${newVideos.length} new videos from REST API for user=$userId (total: ${allVideos.length})',
               name: 'ProfileFeedProvider',
               category: LogCategory.video,
             );
 
-            state = AsyncData(
-              VideoFeedState(
+            _emitState(
+              currentState.copyWith(
                 videos: allVideos,
                 hasMoreContent:
                     apiVideos.length >= AppConstants.paginationBatchSize,
+                isLoadingMore: false,
                 lastUpdated: DateTime.now(),
                 totalVideoCount: _totalVideoCount,
               ),
@@ -762,110 +527,13 @@ class ProfileFeed extends _$ProfileFeed {
 
     final funnelcakeAvailable =
         ref.read(funnelcakeAvailableProvider).asData?.value ?? false;
-
-    if (funnelcakeAvailable) {
-      try {
-        final client = ref.read(funnelcakeApiClientProvider);
-        final result = await client
-            .getVideosByAuthor(pubkey: userId)
-            .timeout(_restApiTimeout);
-        final apiVideos = result.videos.map((v) => v.toVideoEvent()).toList();
-
-        if (!ref.mounted) return;
-
-        _totalVideoCount = result.totalCount;
-
-        if (apiVideos.isNotEmpty) {
-          // Reset offset-based pagination
-          _usingRestApi = true;
-          _nextOffset = apiVideos.length;
-
-          // Filter out reposts
-          var authorVideos = apiVideos.where((v) => !v.isRepost).toList();
-          authorVideos = _mergeStableTimestampsFromCurrentState(authorVideos);
-
-          // Cache metadata for future Nostr fallbacks
-          _cacheVideoMetadata(authorVideos);
-
-          // Enrich with full Nostr event data (rawTags, dimensions, etc.)
-          authorVideos = await enrichVideosWithNostrTags(
-            authorVideos,
-            nostrService: ref.read(nostrServiceProvider),
-            callerName: 'ProfileFeedProvider',
-          );
-
-          // Apply content filter preferences
-          final videoEventService = ref.read(videoEventServiceProvider);
-          authorVideos = videoEventService.filterVideoList(authorVideos);
-
-          _emitState(
-            VideoFeedState(
-              videos: authorVideos,
-              hasMoreContent:
-                  apiVideos.length >= AppConstants.paginationBatchSize,
-              lastUpdated: DateTime.now(),
-              totalVideoCount: _totalVideoCount,
-            ),
-          );
-
-          Log.info(
-            'ProfileFeed: Refreshed ${authorVideos.length} videos from REST API for user=$userId',
-            name: 'ProfileFeedProvider',
-            category: LogCategory.video,
-          );
-          return;
-        } else {
-          // REST API returned empty — valid (e.g. all videos deleted)
-          _nextOffset = 0;
-          state = AsyncData(
-            VideoFeedState(
-              videos: [],
-              hasMoreContent: false,
-              lastUpdated: DateTime.now(),
-              totalVideoCount: _totalVideoCount,
-            ),
-          );
-
-          Log.info(
-            'ProfileFeed: REST API refresh returned empty for user=$userId',
-            name: 'ProfileFeedProvider',
-            category: LogCategory.video,
-          );
-          return;
-        }
-      } catch (e) {
-        Log.warning(
-          'ProfileFeed: REST API refresh failed ($e), falling back to Nostr refresh',
-          name: 'ProfileFeedProvider',
-          category: LogCategory.video,
-        );
-      }
-    }
-
-    // Reset REST pagination state before Nostr refresh (but keep metadata cache!)
-    _usingRestApi = false;
-    _nextOffset = null;
-
     final videoEventService = ref.read(videoEventServiceProvider);
-    await videoEventService.subscribeToUserVideos(userId);
+    final refreshFutures = <Future<void>>[
+      _refreshFromNostrSource(videoEventService),
+      if (funnelcakeAvailable) _refreshFromRestApi(),
+    ];
 
-    if (!ref.mounted) return;
-
-    var updatedVideos = videoEventService
-        .authorVideos(userId)
-        .where((v) => !v.isRepost)
-        .toList();
-    updatedVideos = _applyMetadataCache(updatedVideos);
-    updatedVideos = videoEventService.filterVideoList(updatedVideos);
-
-    _emitState(
-      VideoFeedState(
-        videos: updatedVideos,
-        hasMoreContent:
-            updatedVideos.length >= AppConstants.hasMoreContentThreshold,
-        lastUpdated: DateTime.now(),
-      ),
-    );
+    await Future.wait(refreshFutures);
   }
 
   /// Cache metadata from REST API videos for later merging with Nostr data
@@ -913,24 +581,27 @@ class ProfileFeed extends _$ProfileFeed {
 
     void onNostrVideosChanged() {
       if (!ref.mounted) return;
-      final currentVideos = videoEventService
-          .authorVideos(userId)
-          .where((v) => !v.isRepost)
-          .toList();
+      final currentVideos = _relayVideosSnapshot(videoEventService);
 
       final currentState = state.asData?.value;
-      if (currentState == null ||
-          currentVideos.length == currentState.videos.length) {
+      if (currentState == null) {
         return;
       }
 
-      var updatedVideos = _applyMetadataCache(currentVideos);
-      updatedVideos = videoEventService.filterVideoList(updatedVideos);
+      final updatedVideos = _mergeVideoLists(
+        currentState.videos,
+        currentVideos,
+      );
+      if (_sameVideoSequence(currentState.videos, updatedVideos)) {
+        return;
+      }
+
       _emitState(
         currentState.copyWith(
           videos: updatedVideos,
-          hasMoreContent:
-              updatedVideos.length >= AppConstants.hasMoreContentThreshold,
+          hasMoreContent: currentState.totalVideoCount != null
+              ? currentState.hasMoreContent
+              : updatedVideos.length >= AppConstants.hasMoreContentThreshold,
           isRefreshing: false,
           isInitialLoad: false,
           lastUpdated: DateTime.now(),
@@ -964,6 +635,204 @@ class ProfileFeed extends _$ProfileFeed {
       unregisterUpdate();
       unregisterNew();
     });
+  }
+
+  Future<void> _refreshFromNostrSource(
+    VideoEventService videoEventService,
+  ) async {
+    try {
+      await videoEventService.subscribeToUserVideos(userId);
+      if (!ref.mounted) return;
+
+      final relayVideos = _relayVideosSnapshot(videoEventService);
+      final currentState = state.asData?.value;
+      _mergeSourceVideos(
+        relayVideos,
+        hasMoreContent: currentState?.totalVideoCount != null
+            ? currentState!.hasMoreContent
+            : relayVideos.length >= AppConstants.hasMoreContentThreshold,
+        totalVideoCount: currentState?.totalVideoCount,
+        isRefreshing: false,
+        isInitialLoad: false,
+      );
+    } catch (error, stackTrace) {
+      Log.error(
+        'ProfileFeed: Background Nostr subscribe failed for user=$userId: $error',
+        name: 'ProfileFeedProvider',
+        category: LogCategory.video,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  List<VideoEvent> _relayVideosSnapshot(VideoEventService videoEventService) {
+    var videos = videoEventService
+        .authorVideos(userId)
+        .where((v) => !v.isRepost)
+        .toList();
+    videos = _applyMetadataCache(videos);
+    return videoEventService.filterVideoList(videos);
+  }
+
+  void _mergeSourceVideos(
+    List<VideoEvent> incoming, {
+    required bool hasMoreContent,
+    required bool isRefreshing,
+    required bool isInitialLoad,
+    int? totalVideoCount,
+    bool mergeWithCurrent = true,
+  }) {
+    final currentState = state.asData?.value;
+    final currentVideos = mergeWithCurrent
+        ? currentState?.videos ?? const <VideoEvent>[]
+        : const <VideoEvent>[];
+    final mergedVideos = _mergeVideoLists(currentVideos, incoming);
+
+    final nextState =
+        (currentState ??
+                const VideoFeedState(
+                  videos: <VideoEvent>[],
+                  hasMoreContent: false,
+                ))
+            .copyWith(
+              videos: mergedVideos,
+              hasMoreContent: hasMoreContent,
+              isLoadingMore: false,
+              isRefreshing: isRefreshing,
+              isInitialLoad: isInitialLoad,
+              lastUpdated: DateTime.now(),
+              totalVideoCount: totalVideoCount ?? currentState?.totalVideoCount,
+              error: null,
+            );
+
+    if (currentState != null &&
+        _sameVideoSequence(currentState.videos, nextState.videos) &&
+        currentState.hasMoreContent == nextState.hasMoreContent &&
+        currentState.totalVideoCount == nextState.totalVideoCount &&
+        currentState.isRefreshing == nextState.isRefreshing &&
+        currentState.isInitialLoad == nextState.isInitialLoad) {
+      return;
+    }
+
+    _emitState(nextState);
+  }
+
+  List<VideoEvent> _mergeVideoLists(
+    List<VideoEvent> current,
+    List<VideoEvent> incoming,
+  ) {
+    final byKey = <String, VideoEvent>{};
+
+    for (final video in current) {
+      byKey[_canonicalVideoKey(video)] = video;
+    }
+
+    for (final video in incoming) {
+      final key = _canonicalVideoKey(video);
+      final existing = byKey[key];
+      byKey[key] = existing == null ? video : _mergeVideo(existing, video);
+    }
+
+    final merged = byKey.values.toList();
+    merged.sort(_compareVideos);
+    return merged;
+  }
+
+  VideoEvent _mergeVideo(VideoEvent existing, VideoEvent incoming) {
+    final incomingIsNewer =
+        incoming.createdAt > existing.createdAt ||
+        (incoming.createdAt == existing.createdAt &&
+            incoming.id.compareTo(existing.id) < 0);
+    final primary = incomingIsNewer ? incoming : existing;
+    final secondary = incomingIsNewer ? existing : incoming;
+
+    final primaryHasPublishedAt =
+        primary.publishedAt != null && primary.publishedAt!.isNotEmpty;
+    final secondaryHasPublishedAt =
+        secondary.publishedAt != null && secondary.publishedAt!.isNotEmpty;
+    final preserveOriginalTimestamp =
+        !primaryHasPublishedAt && !secondaryHasPublishedAt;
+
+    return primary.copyWith(
+      createdAt: preserveOriginalTimestamp
+          ? math.min(primary.createdAt, secondary.createdAt)
+          : primary.createdAt,
+      timestamp: preserveOriginalTimestamp
+          ? (primary.timestamp.isBefore(secondary.timestamp)
+                ? primary.timestamp
+                : secondary.timestamp)
+          : primary.timestamp,
+      publishedAt: primaryHasPublishedAt
+          ? primary.publishedAt
+          : secondary.publishedAt,
+      rawTags: primary.rawTags.isNotEmpty ? primary.rawTags : secondary.rawTags,
+      contentWarningLabels: primary.contentWarningLabels.isNotEmpty
+          ? primary.contentWarningLabels
+          : secondary.contentWarningLabels,
+      title: primary.title ?? secondary.title,
+      videoUrl: primary.videoUrl ?? secondary.videoUrl,
+      thumbnailUrl: primary.thumbnailUrl ?? secondary.thumbnailUrl,
+      duration: primary.duration ?? secondary.duration,
+      dimensions: primary.dimensions ?? secondary.dimensions,
+      mimeType: primary.mimeType ?? secondary.mimeType,
+      sha256: primary.sha256 ?? secondary.sha256,
+      fileSize: primary.fileSize ?? secondary.fileSize,
+      hashtags: primary.hashtags.isNotEmpty
+          ? primary.hashtags
+          : secondary.hashtags,
+      vineId: primary.vineId ?? secondary.vineId,
+      group: primary.group ?? secondary.group,
+      altText: primary.altText ?? secondary.altText,
+      blurhash: primary.blurhash ?? secondary.blurhash,
+      originalLoops: primary.originalLoops ?? secondary.originalLoops,
+      originalLikes: primary.originalLikes ?? secondary.originalLikes,
+      originalComments: primary.originalComments ?? secondary.originalComments,
+      originalReposts: primary.originalReposts ?? secondary.originalReposts,
+      audioEventId: primary.audioEventId ?? secondary.audioEventId,
+      audioEventRelay: primary.audioEventRelay ?? secondary.audioEventRelay,
+      collaboratorPubkeys: primary.collaboratorPubkeys.isNotEmpty
+          ? primary.collaboratorPubkeys
+          : secondary.collaboratorPubkeys,
+      inspiredByVideo: primary.inspiredByVideo ?? secondary.inspiredByVideo,
+      textTrackRef: primary.textTrackRef ?? secondary.textTrackRef,
+      textTrackContent: primary.textTrackContent ?? secondary.textTrackContent,
+      nostrEventTags: primary.nostrEventTags.isNotEmpty
+          ? primary.nostrEventTags
+          : secondary.nostrEventTags,
+      authorName: primary.authorName ?? secondary.authorName,
+      authorAvatar: primary.authorAvatar ?? secondary.authorAvatar,
+      nostrLikeCount: primary.nostrLikeCount ?? secondary.nostrLikeCount,
+    );
+  }
+
+  String _canonicalVideoKey(VideoEvent video) {
+    return '${video.pubkey}:${video.stableId}'.toLowerCase();
+  }
+
+  int _compareVideos(VideoEvent a, VideoEvent b) {
+    final timestampComparison = _publishedSortKey(
+      b,
+    ).compareTo(_publishedSortKey(a));
+    if (timestampComparison != 0) return timestampComparison;
+    return a.id.compareTo(b.id);
+  }
+
+  int _publishedSortKey(VideoEvent video) {
+    final publishedAt = video.publishedAt;
+    if (publishedAt != null && publishedAt.isNotEmpty) {
+      final parsed = int.tryParse(publishedAt);
+      if (parsed != null) return parsed;
+    }
+    return video.createdAt;
+  }
+
+  bool _sameVideoSequence(List<VideoEvent> left, List<VideoEvent> right) {
+    if (left.length != right.length) return false;
+    for (var i = 0; i < left.length; i++) {
+      if (left[i].id != right[i].id) return false;
+    }
+    return true;
   }
 
   void _emitState(VideoFeedState nextState) {

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -220,6 +220,7 @@ class ProfileFeed extends _$ProfileFeed {
   }) async {
     try {
       final client = clientOverride ?? ref.read(funnelcakeApiClientProvider);
+      if (client == null) return;
       final result = await client
           .getVideosByAuthor(pubkey: userId)
           .timeout(_restApiTimeout);

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -89,7 +89,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'7b8878832e2bc5ef68de505f9d2760eac223b05c';
+String _$profileFeedHash() => r'59b22d1bc8b9a3ac4ae3a5bf049fb4ddb16f108b';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -89,7 +89,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'701a632efdf499843bfb522c2fc46e132e24370f';
+String _$profileFeedHash() => r'7b8878832e2bc5ef68de505f9d2760eac223b05c';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///

--- a/mobile/test/providers/profile_feed_pagination_contract_test.dart
+++ b/mobile/test/providers/profile_feed_pagination_contract_test.dart
@@ -142,6 +142,10 @@ void main() {
         () {},
       );
       when(
+        () => mockVideoEventService.subscribeToUserVideos(userId),
+      ).thenAnswer((_) async {});
+      when(() => mockVideoEventService.authorVideos(userId)).thenReturn([]);
+      when(
         () => mockVideoEventService.filterVideoList(any()),
       ).thenAnswer((invocation) {
         return invocation.positionalArguments.single as List<VideoEvent>;
@@ -173,7 +177,7 @@ void main() {
     }
 
     test(
-      'initial REST state keeps hasMoreContent true when a full page filters down',
+      'REST hydration keeps hasMoreContent true when a full page filters down',
       () async {
         when(
           () => mockFunnelcakeApiClient.getVideosByAuthor(pubkey: userId),
@@ -189,10 +193,129 @@ void main() {
         final container = createContainer();
         await container.read(funnelcakeAvailableProvider.future);
 
-        final state = await container.read(profileFeedProvider(userId).future);
+        await container.read(profileFeedProvider(userId).future);
 
+        final hydrated = Completer<VideoFeedState>();
+        final subscription = container.listen<AsyncValue<VideoFeedState>>(
+          profileFeedProvider(userId),
+          (previous, next) {
+            final value = next.asData?.value;
+            if (value != null &&
+                value.videos.length == 9 &&
+                value.hasMoreContent &&
+                !hydrated.isCompleted) {
+              hydrated.complete(value);
+            }
+          },
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+
+        final state = await hydrated.future.timeout(
+          const Duration(milliseconds: 200),
+        );
         expect(state.videos.length, 9);
         expect(state.hasMoreContent, isTrue);
+      },
+    );
+
+    test(
+      'initial load returns relay videos without waiting for a slower REST response',
+      () async {
+        final restCompleter = Completer<VideosByAuthorResponse>();
+        addTearDown(() {
+          if (!restCompleter.isCompleted) {
+            restCompleter.complete(_videoStats(count: 0, pubkey: userId));
+          }
+        });
+
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(pubkey: userId),
+        ).thenAnswer((_) => restCompleter.future);
+        when(
+          () => mockVideoEventService.authorVideos(userId),
+        ).thenReturn([
+          _relayVideo(
+            id: 'relay-head',
+            pubkey: userId,
+            stableId: 'relay-head',
+            createdAt: DateTime(2026, 3, 30, 12, 0, 30),
+          ),
+        ]);
+
+        final container = createContainer();
+        await container.read(funnelcakeAvailableProvider.future);
+
+        final state = await container
+            .read(profileFeedProvider(userId).future)
+            .timeout(const Duration(milliseconds: 100));
+
+        expect(state.videos.map((v) => v.id), ['relay-head']);
+        expect(state.isInitialLoad, isFalse);
+      },
+    );
+
+    test(
+      'late REST merge keeps relay head item and adds REST pagination metadata',
+      () async {
+        final restCompleter = Completer<VideosByAuthorResponse>();
+        addTearDown(() {
+          if (!restCompleter.isCompleted) {
+            restCompleter.complete(_videoStats(count: 0, pubkey: userId));
+          }
+        });
+
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(pubkey: userId),
+        ).thenAnswer((_) => restCompleter.future);
+        when(
+          () => mockVideoEventService.authorVideos(userId),
+        ).thenReturn([
+          _relayVideo(
+            id: 'relay-head',
+            pubkey: userId,
+            stableId: 'relay-head',
+            createdAt: DateTime(2026, 3, 30, 12, 0, 30),
+          ),
+        ]);
+
+        final container = createContainer();
+        await container.read(funnelcakeAvailableProvider.future);
+
+        final initialState = await container
+            .read(profileFeedProvider(userId).future)
+            .timeout(const Duration(milliseconds: 100));
+        expect(initialState.videos.map((v) => v.id), ['relay-head']);
+
+        final merged = Completer<VideoFeedState>();
+        final subscription = container.listen<AsyncValue<VideoFeedState>>(
+          profileFeedProvider(userId),
+          (previous, next) {
+            final value = next.asData?.value;
+            if (value != null &&
+                value.videos.length == 3 &&
+                value.totalVideoCount == 12 &&
+                !merged.isCompleted) {
+              merged.complete(value);
+            }
+          },
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+
+        restCompleter.complete(
+          _videoStats(count: 2, pubkey: userId, startIndex: 1, totalCount: 12),
+        );
+
+        final mergedState = await merged.future.timeout(
+          const Duration(milliseconds: 200),
+        );
+        expect(
+          mergedState.videos.map((v) => v.id),
+          ['relay-head', 'video-1', 'video-2'],
+        );
+        expect(mergedState.hasMoreContent, isFalse);
+        expect(mergedState.totalVideoCount, 12);
       },
     );
 
@@ -219,9 +342,6 @@ void main() {
 
         expect(state.videos, isEmpty);
         expect(state.hasMoreContent, isFalse);
-        verify(
-          () => mockVideoEventService.subscribeToUserVideos(userId),
-        ).called(1);
       },
     );
 
@@ -241,6 +361,23 @@ void main() {
         final notifier = container.read(profileFeedProvider(userId).notifier);
 
         await container.read(profileFeedProvider(userId).future);
+
+        final initialHydrated = Completer<void>();
+        final initialSubscription = container
+            .listen<AsyncValue<VideoFeedState>>(
+              profileFeedProvider(userId),
+              (previous, next) {
+                final value = next.asData?.value;
+                if (value != null &&
+                    value.videos.length == 50 &&
+                    !initialHydrated.isCompleted) {
+                  initialHydrated.complete();
+                }
+              },
+              fireImmediately: true,
+            );
+        addTearDown(initialSubscription.close);
+        await initialHydrated.future.timeout(const Duration(milliseconds: 200));
 
         final completer = Completer<void>();
         final subscription = container.listen<AsyncValue<VideoFeedState>>(
@@ -287,8 +424,26 @@ void main() {
         await container.read(funnelcakeAvailableProvider.future);
         final notifier = container.read(profileFeedProvider(userId).notifier);
 
-        final initialState = await container.read(
-          profileFeedProvider(userId).future,
+        await container.read(profileFeedProvider(userId).future);
+
+        final hydrated = Completer<VideoFeedState>();
+        final subscription = container.listen<AsyncValue<VideoFeedState>>(
+          profileFeedProvider(userId),
+          (previous, next) {
+            final value = next.asData?.value;
+            if (value != null &&
+                value.videos.length == 50 &&
+                value.hasMoreContent &&
+                !hydrated.isCompleted) {
+              hydrated.complete(value);
+            }
+          },
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+
+        final initialState = await hydrated.future.timeout(
+          const Duration(milliseconds: 200),
         );
         expect(initialState.videos.length, 50);
         expect(initialState.hasMoreContent, isTrue);
@@ -307,6 +462,77 @@ void main() {
             offset: 50,
           ),
         ).called(1);
+      },
+    );
+
+    test(
+      'REST loadMore dedupes replaceable videos by stable identity',
+      () async {
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(pubkey: userId),
+        ).thenAnswer((_) async => _videoStats(count: 50, pubkey: userId));
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(
+            pubkey: userId,
+            offset: 50,
+          ),
+        ).thenAnswer(
+          (_) async => VideosByAuthorResponse(
+            videos: [
+              _videoStat(
+                id: 'video-0-replacement',
+                pubkey: userId,
+                stableId: 'video-0',
+                createdAt: DateTime(2026, 3, 30, 12, 1),
+              ),
+              _videoStat(
+                id: 'video-50',
+                pubkey: userId,
+                stableId: 'video-50',
+                createdAt: DateTime(2026, 3, 30, 11, 10),
+              ),
+            ],
+            totalCount: 51,
+          ),
+        );
+
+        final container = createContainer();
+        await container.read(funnelcakeAvailableProvider.future);
+        final notifier = container.read(profileFeedProvider(userId).notifier);
+
+        await container.read(profileFeedProvider(userId).future);
+
+        final hydrated = Completer<void>();
+        final subscription = container.listen<AsyncValue<VideoFeedState>>(
+          profileFeedProvider(userId),
+          (previous, next) {
+            final value = next.asData?.value;
+            if (value != null &&
+                value.videos.length == 50 &&
+                value.hasMoreContent &&
+                !hydrated.isCompleted) {
+              hydrated.complete();
+            }
+          },
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+        await hydrated.future.timeout(const Duration(milliseconds: 200));
+
+        await notifier.loadMore();
+
+        final updatedState = container
+            .read(profileFeedProvider(userId))
+            .requireValue;
+        expect(updatedState.videos.length, 51);
+        expect(
+          updatedState.videos.where((video) => video.stableId == 'video-0'),
+          hasLength(1),
+        );
+        expect(
+          updatedState.videos.any((video) => video.id == 'video-50'),
+          isTrue,
+        );
       },
     );
   });
@@ -339,4 +565,45 @@ VideosByAuthorResponse _videoStats({
     );
   });
   return VideosByAuthorResponse(videos: videos, totalCount: totalCount);
+}
+
+VideoStats _videoStat({
+  required String id,
+  required String pubkey,
+  required String stableId,
+  required DateTime createdAt,
+}) {
+  return VideoStats(
+    id: id,
+    pubkey: pubkey,
+    createdAt: createdAt,
+    kind: 22,
+    dTag: stableId,
+    title: 'Video $id',
+    thumbnail: 'https://example.com/$id.jpg',
+    videoUrl: 'https://example.com/$id.mp4',
+    reactions: 1,
+    comments: 1,
+    reposts: 1,
+    engagementScore: 1,
+  );
+}
+
+VideoEvent _relayVideo({
+  required String id,
+  required String pubkey,
+  required String stableId,
+  required DateTime createdAt,
+}) {
+  return VideoEvent(
+    id: id,
+    pubkey: pubkey,
+    createdAt: createdAt.millisecondsSinceEpoch ~/ 1000,
+    content: 'Relay video $id',
+    timestamp: createdAt,
+    title: 'Relay video $id',
+    videoUrl: 'https://example.com/$id.mp4',
+    vineId: stableId,
+    rawTags: {'d': stableId},
+  );
 }


### PR DESCRIPTION
Closes #3012

## Summary
- coordinate profile feed hydration from relay and REST in parallel instead of REST-first fallback
- merge relay freshness with REST pagination/count metadata using stable identity dedupe
- add contract coverage for relay-first initial render, late REST merge, and replaceable-video pagination

## Verification
- flutter test test/providers/profile_feed_pagination_contract_test.dart
- flutter test test/providers/profile_feed_provider_test.dart
- flutter analyze lib/providers/profile_feed_provider.dart test/providers/profile_feed_pagination_contract_test.dart test/providers/profile_feed_provider_test.dart