### PR TITLE
fix(sounds): hide original sound from video overlay

### DIFF
--- a/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
+++ b/mobile/lib/widgets/video_feed_item/audio_attribution_row.dart
@@ -29,9 +29,10 @@ class AudioAttributionRow extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Videos without a shared audio event show "Original sound - @creator"
+    // Only show for videos with shared/bundled audio, not original sounds.
+    // Original sound info is available in the metadata "more info" sheet.
     if (!video.hasAudioReference || video.audioEventId == null) {
-      return _OriginalSoundContent(video: video);
+      return const SizedBox.shrink();
     }
 
     // Watch the shared audio event asynchronously
@@ -46,8 +47,7 @@ class AudioAttributionRow extends ConsumerWidget {
             name: 'AudioAttributionRow',
             category: LogCategory.ui,
           );
-          // Fall back to original sound when the referenced audio is missing
-          return _OriginalSoundContent(video: video);
+          return const SizedBox.shrink();
         }
 
         return _AudioAttributionContent(audio: audio);
@@ -59,8 +59,7 @@ class AudioAttributionRow extends ConsumerWidget {
           name: 'AudioAttributionRow',
           category: LogCategory.ui,
         );
-        // Fall back to original sound on error
-        return _OriginalSoundContent(video: video);
+        return const SizedBox.shrink();
       },
     );
   }
@@ -143,80 +142,6 @@ class _AudioAttributionContent extends ConsumerWidget {
     context.pushWithVideoPause(
       SoundDetailScreen.pathForId(audio.id),
       extra: audio,
-    );
-  }
-}
-
-/// Original sound attribution for videos without a shared audio event.
-///
-/// Shows `♪ Original sound - @creator_display_name` and navigates to
-/// [OriginalSoundDetailScreen] on tap.
-class _OriginalSoundContent extends ConsumerWidget {
-  const _OriginalSoundContent({required this.video});
-
-  final VideoEvent video;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final creatorProfile = ref
-        .watch(userProfileReactiveProvider(video.pubkey))
-        .value;
-    final creatorName =
-        creatorProfile?.bestDisplayName ??
-        UserProfile.defaultDisplayNameFor(video.pubkey);
-
-    final label = 'Original sound - $creatorName';
-
-    return Semantics(
-      identifier: 'audio_attribution_row',
-      button: true,
-      label: 'Sound: $label. Tap to view sound details.',
-      child: GestureDetector(
-        onTap: () {
-          Log.info(
-            'Navigating to original sound detail: pubkey=${video.pubkey}',
-            name: 'AudioAttributionRow',
-            category: LogCategory.ui,
-          );
-          context.pushWithVideoPause(
-            OriginalSoundDetailScreen.pathForPubkey(video.pubkey),
-            extra: video,
-          );
-        },
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-          decoration: BoxDecoration(
-            color: VineTheme.backgroundColor.withValues(alpha: 0.3),
-            borderRadius: BorderRadius.circular(4),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            spacing: 4,
-            children: [
-              const DivineIcon(
-                icon: DivineIconName.musicNote,
-                size: 14,
-                color: VineTheme.vineGreen,
-              ),
-              Flexible(
-                child: Text(
-                  label,
-                  style: VineTheme.labelMediumFont().copyWith(
-                    shadows: [const Shadow(blurRadius: 4)],
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              const DivineIcon(
-                icon: DivineIconName.caretRight,
-                size: 14,
-                color: VineTheme.onSurfaceVariant,
-              ),
-            ],
-          ),
-        ),
-      ),
     );
   }
 }

--- a/mobile/test/widgets/audio_attribution_row_test.dart
+++ b/mobile/test/widgets/audio_attribution_row_test.dart
@@ -9,7 +9,6 @@ import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/audio_event.dart';
 import 'package:openvine/providers/sounds_providers.dart';
-import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/widgets/video_feed_item/audio_attribution_row.dart';
 
 void main() {
@@ -89,38 +88,7 @@ void main() {
     }
 
     group('Original sound (no audio reference)', () {
-      testWidgets('shows Original sound with creator display name', (
-        tester,
-      ) async {
-        final video = createVideoWithoutAudio();
-        final profile = UserProfile(
-          pubkey: testPubkey,
-          rawData: const <String, dynamic>{},
-          createdAt: DateTime(2024),
-          eventId:
-              'event0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab',
-          displayName: 'TestCreator',
-        );
-
-        await tester.pumpWidget(
-          buildTestWidget(
-            video: video,
-            additionalOverrides: [
-              userProfileReactiveProvider(testPubkey).overrideWith(
-                (ref) => Stream.value(profile),
-              ),
-            ],
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        expect(
-          find.textContaining('Original sound - TestCreator'),
-          findsOneWidget,
-        );
-      });
-
-      testWidgets('shows music note icon with vineGreen color', (
+      testWidgets('renders nothing for videos without audio reference', (
         tester,
       ) async {
         final video = createVideoWithoutAudio();
@@ -128,87 +96,17 @@ void main() {
         await tester.pumpWidget(buildTestWidget(video: video));
         await tester.pumpAndSettle();
 
-        final divineIcons = tester.widgetList<DivineIcon>(
+        // Should render SizedBox.shrink - no visible content
+        expect(
           find.descendant(
             of: find.byType(AudioAttributionRow),
-            matching: find.byType(DivineIcon),
+            matching: find.byType(SizedBox),
           ),
-        );
-        final musicNoteIcon = divineIcons.firstWhere(
-          (icon) => icon.icon == DivineIconName.musicNote,
-        );
-        expect(musicNoteIcon.color, equals(VineTheme.vineGreen));
-      });
-
-      testWidgets('shows caret right icon', (tester) async {
-        final video = createVideoWithoutAudio();
-
-        await tester.pumpWidget(buildTestWidget(video: video));
-        await tester.pumpAndSettle();
-
-        final divineIcons = tester.widgetList<DivineIcon>(
-          find.descendant(
-            of: find.byType(AudioAttributionRow),
-            matching: find.byType(DivineIcon),
-          ),
-        );
-        expect(
-          divineIcons.any((icon) => icon.icon == DivineIconName.caretRight),
-          isTrue,
-        );
-      });
-
-      testWidgets('has correct semantics identifier', (tester) async {
-        final video = createVideoWithoutAudio();
-
-        await tester.pumpWidget(buildTestWidget(video: video));
-        await tester.pumpAndSettle();
-
-        final semantics = tester.widget<Semantics>(
-          find
-              .descendant(
-                of: find.byType(AudioAttributionRow),
-                matching: find.byType(Semantics),
-              )
-              .first,
-        );
-
-        expect(
-          semantics.properties.identifier,
-          equals('audio_attribution_row'),
-        );
-      });
-
-      testWidgets('has semantic label with Original sound', (tester) async {
-        final video = createVideoWithoutAudio();
-
-        await tester.pumpWidget(buildTestWidget(video: video));
-        await tester.pumpAndSettle();
-
-        final semantics = tester.widget<Semantics>(
-          find
-              .descendant(
-                of: find.byType(AudioAttributionRow),
-                matching: find.byType(Semantics),
-              )
-              .first,
-        );
-
-        expect(semantics.properties.label, contains('Original sound'));
-      });
-
-      testWidgets('falls back to generated name when no profile', (
-        tester,
-      ) async {
-        final video = createVideoWithoutAudio();
-        final generatedName = UserProfile.defaultDisplayNameFor(testPubkey);
-
-        await tester.pumpWidget(buildTestWidget(video: video));
-        await tester.pumpAndSettle();
-
-        expect(
-          find.textContaining('Original sound - $generatedName'),
           findsOneWidget,
+        );
+        expect(
+          find.textContaining('Original sound'),
+          findsNothing,
         );
       });
     });
@@ -295,7 +193,7 @@ void main() {
       });
 
       testWidgets(
-        'falls back to Original sound when audio event is null',
+        'renders nothing when audio event is null',
         (tester) async {
           final video = createVideoWithAudio();
 
@@ -318,8 +216,8 @@ void main() {
 
           await tester.pumpAndSettle();
 
-          // Should fall back to original sound, not hide
-          expect(find.textContaining('Original sound'), findsOneWidget);
+          // Should render nothing when audio can't be found
+          expect(find.textContaining('Original sound'), findsNothing);
         },
       );
     });


### PR DESCRIPTION
Closes #3014

## Summary
- Original sound attribution ("Original sound - @creator") no longer appears on the video player overlay
- Only videos with shared or bundled audio show the audio attribution row
- Original sound info remains in the metadata "more info" sheet (unchanged)

## Test plan
- [x] All 14 audio attribution row tests pass (updated for new behavior)
- [ ] Manual: verify videos with original sound no longer show "Original sound - @creator" on the overlay
- [ ] Manual: verify videos with shared/bundled audio still show the attribution row
- [ ] Manual: verify original sound info still appears in the "more info" metadata sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)