### PR TITLE
fix(user_picker_sheet): add assertion for null profileRepository

### DIFF
--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -95,6 +95,7 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   void initState() {
     super.initState();
     final profileRepo = ref.read(profileRepositoryProvider);
+    assert(profileRepo != null, 'UserPickerSheet requires authentication');
     _searchBloc = UserSearchBloc(profileRepository: profileRepo!);
 
     if (_useLocalSearch) {


### PR DESCRIPTION
Closes #3001

## Summary
- Adds a debug-mode `assert` in `UserPickerSheet.initState()` to surface a clear error message when `profileRepositoryProvider` returns null

## Context

`profileRepositoryProvider` is typed `ProfileRepository?` (nullable), but `UserSearchBloc` requires a non-nullable `ProfileRepository`. The existing code uses `profileRepo!` which would crash with an unhelpful "Null check operator used on a null value" if ever hit.

**This cannot happen in normal use** — `UserPickerSheet` is only reachable through:
- "Inspired By" picker (`video_metadata_inspired_by_input.dart`)
- "Add Collaborator" picker (`video_metadata_collaborators_input.dart`)

Both live inside the video editor, which is an **auth-gated route**. When authenticated, `profileRepositoryProvider` is always non-null.

The assertion provides a clear message in debug mode if the widget is ever reused outside an authenticated context, without adding runtime complexity (nullable BLoCs, error widgets, flags) for a state that can't occur in practice.

## How to reproduce the original issue
1. This is a defensive fix — the crash requires `profileRepositoryProvider` to be null
2. Under normal app flow this cannot happen because video creation routes are auth-gated
3. It *would* crash if `UserPickerSheet` were ever mounted outside an authenticated context

## How to verify the fix
1. Run existing tests: `cd mobile && flutter test test/widgets/user_picker_sheet_test.dart` — all 14 pass
2. On device: open video editor → tap "Inspired By" → search works normally
3. On device: open video editor → tap "Add Collaborator" → search works normally
4. The `assert` is stripped in release builds, so zero runtime cost

## Test plan
- [x] All 14 existing `user_picker_sheet_test.dart` tests pass
- [x] `flutter analyze` clean
- [x] Pre-commit hooks pass