### PR TITLE
fix(video-editor): hide camera button on web platform

### DIFF
--- a/mobile/lib/widgets/vine_bottom_nav.dart
+++ b/mobile/lib/widgets/vine_bottom_nav.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Provides consistent bottom nav across screens with/without shell
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -150,17 +151,18 @@ class VineBottomNav extends ConsumerWidget {
               1,
               'explore_tab',
             ),
-            // Camera button in center of bottom nav
-            _CameraButton(
-              onTap: () {
-                Log.info(
-                  '👆 User tapped camera button',
-                  name: 'Navigation',
-                  category: LogCategory.ui,
-                );
-                context.pushToCameraWithPermission();
-              },
-            ),
+            // Camera button in center of bottom nav (hidden on web)
+            if (!kIsWeb)
+              _CameraButton(
+                onTap: () {
+                  Log.info(
+                    '👆 User tapped camera button',
+                    name: 'Navigation',
+                    category: LogCategory.ui,
+                  );
+                  context.pushToCameraWithPermission();
+                },
+              ),
             NotificationBadge(
               count: _inboxUnreadCount(context, ref),
               child: _buildTabButton(


### PR DESCRIPTION
Closes #3035

## Description

Ensure that users cannot access the video editor in the web app. Until now, the camera button has been hidden except when the user navigates to their profile.


**Related Issue:** 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore