### PR TITLE
fix(feed): improve empty feed messages

### DIFF
--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1725,14 +1725,6 @@
     "feedFailedToLoadVideos": "تعذر تحميل مقاطع الفيديو",
     "feedRetry": "إعادة المحاولة",
     "feedNoFollowedUsers": "لا يوجد مستخدمون متابَعون.\nتابِع شخصًا ما لترى مقاطع الفيديو هنا.",
-    "feedNoVideosForMode": "لم يُعثر على مقاطع فيديو لتغذية {mode}.",
-    "@feedNoVideosForMode": {
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
     "feedExploreVideos": "استكشاف مقاطع الفيديو",
     "feedExternalVideoSlow": "الفيديو الخارجي يُحمَّل ببطء",
     "feedSkip": "تخطي",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1725,14 +1725,6 @@
     "feedFailedToLoadVideos": "Videos konnten nicht geladen werden",
     "feedRetry": "Erneut versuchen",
     "feedNoFollowedUsers": "Keine abonnierten Nutzer.\nFolge jemandem, um hier seine Videos zu sehen.",
-    "feedNoVideosForMode": "Keine Videos für den {mode}-Feed gefunden.",
-    "@feedNoVideosForMode": {
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
     "feedExploreVideos": "Videos entdecken",
     "feedExternalVideoSlow": "Externes Video lädt langsam",
     "feedSkip": "Überspringen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1725,14 +1725,9 @@
   "feedFailedToLoadVideos": "Failed to load videos",
   "feedRetry": "Retry",
   "feedNoFollowedUsers": "No followed users.\nFollow someone to see their videos here.",
-  "feedNoVideosForMode": "No videos found for {mode} feed.",
-  "@feedNoVideosForMode": {
-    "placeholders": {
-      "mode": {
-        "type": "String"
-      }
-    }
-  },
+  "feedForYouEmpty": "Your For You feed is empty.\nExplore videos and follow creators to shape it.",
+  "feedFollowingEmpty": "No videos from people you follow yet.\nFind creators you like and follow them.",
+  "feedLatestEmpty": "No new videos yet.\nCheck back soon.",
   "feedExploreVideos": "Explore Videos",
   "feedExternalVideoSlow": "External video loading slowly",
   "feedSkip": "Skip",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1725,14 +1725,6 @@
     "feedFailedToLoadVideos": "No se pudieron cargar los videos",
     "feedRetry": "Reintentar",
     "feedNoFollowedUsers": "Todavía no seguís a nadie.\nSeguí a alguien para ver sus videos acá.",
-    "feedNoVideosForMode": "No hay videos para el feed {mode}.",
-    "@feedNoVideosForMode": {
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
     "feedExploreVideos": "Explorar videos",
     "feedExternalVideoSlow": "Un video externo se carga lento",
     "feedSkip": "Saltar",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1725,14 +1725,6 @@
     "feedFailedToLoadVideos": "Échec du chargement des vidéos",
     "feedRetry": "Réessayer",
     "feedNoFollowedUsers": "Personne suivie.\nSuis quelqu'un pour voir ses vidéos ici.",
-    "feedNoVideosForMode": "Aucune vidéo trouvée pour le fil {mode}.",
-    "@feedNoVideosForMode": {
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
     "feedExploreVideos": "Explorer les vidéos",
     "feedExternalVideoSlow": "Vidéo externe lente à charger",
     "feedSkip": "Passer",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1725,14 +1725,6 @@
     "feedFailedToLoadVideos": "Gagal memuat video",
     "feedRetry": "Coba Lagi",
     "feedNoFollowedUsers": "Tidak ada pengguna yang diikuti.\nIkuti seseorang untuk melihat video mereka di sini.",
-    "feedNoVideosForMode": "Tidak ada video ditemukan untuk feed {mode}.",
-    "@feedNoVideosForMode": {
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
     "feedExploreVideos": "Jelajahi Video",
     "feedExternalVideoSlow": "Video eksternal memuat lambat",
     "feedSkip": "Lewati",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1725,14 +1725,6 @@
     "feedFailedToLoadVideos": "Impossibile caricare i video",
     "feedRetry": "Riprova",
     "feedNoFollowedUsers": "Nessun utente seguito.\nSegui qualcuno per vedere i suoi video qui.",
-    "feedNoVideosForMode": "Nessun video trovato per il feed {mode}.",
-    "@feedNoVideosForMode": {
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
     "feedExploreVideos": "Esplora video",
     "feedExternalVideoSlow": "Video esterno in caricamento lento",
     "feedSkip": "Salta",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1725,14 +1725,6 @@
     "feedFailedToLoadVideos": "動画の読み込みがうまくいかなかった",
     "feedRetry": "もう一回",
     "feedNoFollowedUsers": "まだ誰もフォローしてないよ。\n誰かをフォローすると、ここに動画が出るよ。",
-    "feedNoVideosForMode": "{mode}フィードの動画が見つからない。",
-    "@feedNoVideosForMode": {
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
     "feedExploreVideos": "動画を探しに行こう",
     "feedExternalVideoSlow": "外部動画の読み込みに時間がかかってる",
     "feedSkip": "スキップ",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1014,14 +1014,6 @@
     "feedFailedToLoadVideos": "영상을 불러오지 못했어요",
     "feedRetry": "다시 시도",
     "feedNoFollowedUsers": "팔로우한 사용자가 없어요.\n누군가를 팔로우하면 여기에 영상이 표시돼요.",
-    "feedNoVideosForMode": "{mode} 피드에 영상이 없어요.",
-    "@feedNoVideosForMode": {
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
     "feedExploreVideos": "영상 둘러보기",
     "feedExternalVideoSlow": "외부 영상 로딩이 느려요",
     "feedSkip": "건너뛰기",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1725,14 +1725,6 @@
     "feedFailedToLoadVideos": "Video's laden mislukt",
     "feedRetry": "Opnieuw",
     "feedNoFollowedUsers": "Geen gevolgde gebruikers.\nVolg iemand om hun video's hier te zien.",
-    "feedNoVideosForMode": "Geen video's gevonden voor {mode}-feed.",
-    "@feedNoVideosForMode": {
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
     "feedExploreVideos": "Video's verkennen",
     "feedExternalVideoSlow": "Externe video laadt traag",
     "feedSkip": "Overslaan",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1725,14 +1725,6 @@
     "feedFailedToLoadVideos": "Nie udało się wczytać filmów",
     "feedRetry": "Spróbuj ponownie",
     "feedNoFollowedUsers": "Nie obserwujesz nikogo.\nZacznij obserwować, żeby zobaczyć ich filmy tutaj.",
-    "feedNoVideosForMode": "Nie znaleziono filmów dla kanału {mode}.",
-    "@feedNoVideosForMode": {
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
     "feedExploreVideos": "Odkrywaj filmy",
     "feedExternalVideoSlow": "Zewnętrzny film wczytuje się powoli",
     "feedSkip": "Pomiń",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1725,14 +1725,6 @@
     "feedFailedToLoadVideos": "Falha ao carregar vídeos",
     "feedRetry": "Tentar novamente",
     "feedNoFollowedUsers": "Nenhum usuário seguido.\nSiga alguém para ver os vídeos dessa pessoa aqui.",
-    "feedNoVideosForMode": "Nenhum vídeo encontrado para o feed {mode}.",
-    "@feedNoVideosForMode": {
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
     "feedExploreVideos": "Explorar vídeos",
     "feedExternalVideoSlow": "Vídeo externo carregando devagar",
     "feedSkip": "Pular",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1725,14 +1725,6 @@
     "feedFailedToLoadVideos": "N-am putut încărca videoclipurile",
     "feedRetry": "Reîncearcă",
     "feedNoFollowedUsers": "Niciun utilizator urmărit.\nUrmărește pe cineva ca să-i vezi videoclipurile aici.",
-    "feedNoVideosForMode": "Niciun videoclip găsit pentru feedul {mode}.",
-    "@feedNoVideosForMode": {
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
     "feedExploreVideos": "Explorează videoclipuri",
     "feedExternalVideoSlow": "Videoclipul extern se încarcă încet",
     "feedSkip": "Sari peste",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1725,14 +1725,6 @@
     "feedFailedToLoadVideos": "Kunde inte läsa in videor",
     "feedRetry": "Försök igen",
     "feedNoFollowedUsers": "Inga följda användare.\nFölj någon för att se deras videor här.",
-    "feedNoVideosForMode": "Inga videor hittades för flödet {mode}.",
-    "@feedNoVideosForMode": {
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
     "feedExploreVideos": "Upptäck videor",
     "feedExternalVideoSlow": "Extern video laddar långsamt",
     "feedSkip": "Hoppa över",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1725,14 +1725,6 @@
     "feedFailedToLoadVideos": "Videolar yüklenemedi",
     "feedRetry": "Tekrar Dene",
     "feedNoFollowedUsers": "Takip edilen kullanıcı yok.\nVideolarını burada görmek için birini takip et.",
-    "feedNoVideosForMode": "{mode} akışı için video bulunamadı.",
-    "@feedNoVideosForMode": {
-        "placeholders": {
-            "mode": {
-                "type": "String"
-            }
-        }
-    },
     "feedExploreVideos": "Videoları Keşfet",
     "feedExternalVideoSlow": "Harici video yavaş yükleniyor",
     "feedSkip": "Atla",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -5876,11 +5876,23 @@ abstract class AppLocalizations {
   /// **'No followed users.\nFollow someone to see their videos here.'**
   String get feedNoFollowedUsers;
 
-  /// No description provided for @feedNoVideosForMode.
+  /// No description provided for @feedForYouEmpty.
   ///
   /// In en, this message translates to:
-  /// **'No videos found for {mode} feed.'**
-  String feedNoVideosForMode(String mode);
+  /// **'Your For You feed is empty.\nExplore videos and follow creators to shape it.'**
+  String get feedForYouEmpty;
+
+  /// No description provided for @feedFollowingEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No videos from people you follow yet.\nFind creators you like and follow them.'**
+  String get feedFollowingEmpty;
+
+  /// No description provided for @feedLatestEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No new videos yet.\nCheck back soon.'**
+  String get feedLatestEmpty;
 
   /// No description provided for @feedExploreVideos.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3300,9 +3300,15 @@ class AppLocalizationsAr extends AppLocalizations {
       'لا يوجد مستخدمون متابَعون.\nتابِع شخصًا ما لترى مقاطع الفيديو هنا.';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return 'لم يُعثر على مقاطع فيديو لتغذية $mode.';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => 'استكشاف مقاطع الفيديو';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3377,9 +3377,15 @@ class AppLocalizationsDe extends AppLocalizations {
       'Keine abonnierten Nutzer.\nFolge jemandem, um hier seine Videos zu sehen.';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return 'Keine Videos für den $mode-Feed gefunden.';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => 'Videos entdecken';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3328,9 +3328,15 @@ class AppLocalizationsEn extends AppLocalizations {
       'No followed users.\nFollow someone to see their videos here.';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return 'No videos found for $mode feed.';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => 'Explore Videos';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3379,9 +3379,15 @@ class AppLocalizationsEs extends AppLocalizations {
       'Todavía no seguís a nadie.\nSeguí a alguien para ver sus videos acá.';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return 'No hay videos para el feed $mode.';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => 'Explorar videos';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3386,9 +3386,15 @@ class AppLocalizationsFr extends AppLocalizations {
       'Personne suivie.\nSuis quelqu\'un pour voir ses vidéos ici.';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return 'Aucune vidéo trouvée pour le fil $mode.';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => 'Explorer les vidéos';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3309,9 +3309,15 @@ class AppLocalizationsId extends AppLocalizations {
       'Tidak ada pengguna yang diikuti.\nIkuti seseorang untuk melihat video mereka di sini.';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return 'Tidak ada video ditemukan untuk feed $mode.';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => 'Jelajahi Video';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3375,9 +3375,15 @@ class AppLocalizationsIt extends AppLocalizations {
       'Nessun utente seguito.\nSegui qualcuno per vedere i suoi video qui.';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return 'Nessun video trovato per il feed $mode.';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => 'Esplora video';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3170,9 +3170,15 @@ class AppLocalizationsJa extends AppLocalizations {
   String get feedNoFollowedUsers => 'まだ誰もフォローしてないよ。\n誰かをフォローすると、ここに動画が出るよ。';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return '$modeフィードの動画が見つからない。';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => '動画を探しに行こう';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3183,9 +3183,15 @@ class AppLocalizationsKo extends AppLocalizations {
   String get feedNoFollowedUsers => '팔로우한 사용자가 없어요.\n누군가를 팔로우하면 여기에 영상이 표시돼요.';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return '$mode 피드에 영상이 없어요.';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => '영상 둘러보기';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3349,9 +3349,15 @@ class AppLocalizationsNl extends AppLocalizations {
       'Geen gevolgde gebruikers.\nVolg iemand om hun video\'s hier te zien.';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return 'Geen video\'s gevonden voor $mode-feed.';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => 'Video\'s verkennen';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3436,9 +3436,15 @@ class AppLocalizationsPl extends AppLocalizations {
       'Nie obserwujesz nikogo.\nZacznij obserwować, żeby zobaczyć ich filmy tutaj.';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return 'Nie znaleziono filmów dla kanału $mode.';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => 'Odkrywaj filmy';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3361,9 +3361,15 @@ class AppLocalizationsPt extends AppLocalizations {
       'Nenhum usuário seguido.\nSiga alguém para ver os vídeos dessa pessoa aqui.';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return 'Nenhum vídeo encontrado para o feed $mode.';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => 'Explorar vídeos';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3444,9 +3444,15 @@ class AppLocalizationsRo extends AppLocalizations {
       'Niciun utilizator urmărit.\nUrmărește pe cineva ca să-i vezi videoclipurile aici.';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return 'Niciun videoclip găsit pentru feedul $mode.';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => 'Explorează videoclipuri';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3331,9 +3331,15 @@ class AppLocalizationsSv extends AppLocalizations {
       'Inga följda användare.\nFölj någon för att se deras videor här.';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return 'Inga videor hittades för flödet $mode.';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => 'Upptäck videor';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3319,9 +3319,15 @@ class AppLocalizationsTr extends AppLocalizations {
       'Takip edilen kullanıcı yok.\nVideolarını burada görmek için birini takip et.';
 
   @override
-  String feedNoVideosForMode(String mode) {
-    return '$mode akışı için video bulunamadı.';
-  }
+  String get feedForYouEmpty =>
+      'Your For You feed is empty.\nExplore videos and follow creators to shape it.';
+
+  @override
+  String get feedFollowingEmpty =>
+      'No videos from people you follow yet.\nFind creators you like and follow them.';
+
+  @override
+  String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => 'Videoları Keşfet';

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -561,10 +561,7 @@ class _FeedErrorWidget extends StatelessWidget {
           const SizedBox(height: 16),
           Text(
             context.l10n.feedFailedToLoadVideos,
-            style: const TextStyle(
-              color: VineTheme.whiteText,
-              fontSize: 18,
-            ),
+            style: const TextStyle(color: VineTheme.whiteText, fontSize: 18),
           ),
           if (error != null) ...[
             const SizedBox(height: 8),
@@ -594,7 +591,7 @@ class FeedEmptyWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isNoFollowedUsers =
-        state.mode == FeedMode.following &&
+        (state.mode == FeedMode.following || state.mode == FeedMode.forYou) &&
         state.error == VideoFeedError.noFollowedUsers;
 
     return Center(
@@ -630,11 +627,16 @@ class FeedEmptyWidget extends StatelessWidget {
   }
 
   String _getEmptyMessage(BuildContext context, VideoFeedState state) {
-    if (state.mode == FeedMode.following &&
+    if ((state.mode == FeedMode.following || state.mode == FeedMode.forYou) &&
         state.error == VideoFeedError.noFollowedUsers) {
       return context.l10n.feedNoFollowedUsers;
     }
-    return context.l10n.feedNoVideosForMode(state.mode.name);
+
+    return switch (state.mode) {
+      FeedMode.forYou => context.l10n.feedForYouEmpty,
+      FeedMode.following => context.l10n.feedFollowingEmpty,
+      FeedMode.latest => context.l10n.feedLatestEmpty,
+    };
   }
 }
 
@@ -831,11 +833,7 @@ class _FittedVideoPlayer extends StatelessWidget {
     // Do not set filterQuality to high — on Android the bicubic
     // interpolation causes visible blur on the Texture widget when
     // the video resolution doesn't match the display size exactly.
-    return Video(
-      controller: videoController,
-      fit: boxFit,
-      controls: null,
-    );
+    return Video(controller: videoController, fit: boxFit, controls: null);
   }
 }
 

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -26,7 +26,122 @@ class _MockVideoFeedBloc extends MockBloc<VideoFeedEvent, VideoFeedState>
 
 class _MockVideoFeedController extends Mock implements VideoFeedController {}
 
+Widget _buildEmptyFeedSubject(VideoFeedState state) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(body: FeedEmptyWidget(state: state)),
+  );
+}
+
 void main() {
+  group(FeedEmptyWidget, () {
+    testWidgets('uses no-follow guidance for an empty For You feed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildEmptyFeedSubject(
+          const VideoFeedState(
+            status: VideoFeedStatus.success,
+            error: VideoFeedError.noFollowedUsers,
+          ),
+        ),
+      );
+
+      expect(
+        find.text(
+          'No followed users.\nFollow someone to see their videos here.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Explore Videos'), findsOneWidget);
+      expect(find.textContaining('forYou'), findsNothing);
+      expect(find.textContaining('ForYou'), findsNothing);
+    });
+
+    testWidgets('keeps no-follow guidance for an empty Following feed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildEmptyFeedSubject(
+          const VideoFeedState(
+            status: VideoFeedStatus.success,
+            mode: FeedMode.following,
+            error: VideoFeedError.noFollowedUsers,
+          ),
+        ),
+      );
+
+      expect(
+        find.text(
+          'No followed users.\nFollow someone to see their videos here.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Explore Videos'), findsOneWidget);
+    });
+
+    testWidgets('uses For You copy instead of the raw enum name', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildEmptyFeedSubject(
+          const VideoFeedState(
+            status: VideoFeedStatus.success,
+          ),
+        ),
+      );
+
+      expect(
+        find.text(
+          'Your For You feed is empty.\n'
+          'Explore videos and follow creators to shape it.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.textContaining('forYou'), findsNothing);
+      expect(find.textContaining('ForYou'), findsNothing);
+    });
+
+    testWidgets('uses mode-specific copy for an empty Following feed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildEmptyFeedSubject(
+          const VideoFeedState(
+            status: VideoFeedStatus.success,
+            mode: FeedMode.following,
+          ),
+        ),
+      );
+
+      expect(
+        find.text(
+          'No videos from people you follow yet.\n'
+          'Find creators you like and follow them.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.textContaining('following feed'), findsNothing);
+    });
+
+    testWidgets('uses mode-specific copy for an empty New feed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _buildEmptyFeedSubject(
+          const VideoFeedState(
+            status: VideoFeedStatus.success,
+            mode: FeedMode.latest,
+          ),
+        ),
+      );
+
+      expect(find.text('No new videos yet.\nCheck back soon.'), findsOneWidget);
+      expect(find.textContaining('latest'), findsNothing);
+    });
+  });
+
   group('VideoFeedView overlay integration', () {
     late VideoFeedBloc videoFeedBloc;
     late VideoFeedController videoFeedController;
@@ -180,41 +295,36 @@ void main() {
       verify(() => videoFeedController.setActive(active: true)).called(1);
     });
 
-    testWidgets(
-      'does not resume when videos load while overlay is open',
-      (tester) async {
-        // Start with loading state
-        whenListen(
-          videoFeedBloc,
-          Stream<VideoFeedState>.fromIterable([
-            const VideoFeedState(
-              status: VideoFeedStatus.success,
-            ),
-          ]),
-          initialState: const VideoFeedState(),
-        );
+    testWidgets('does not resume when videos load while overlay is open', (
+      tester,
+    ) async {
+      // Start with loading state
+      whenListen(
+        videoFeedBloc,
+        Stream<VideoFeedState>.fromIterable([
+          const VideoFeedState(status: VideoFeedStatus.success),
+        ]),
+        initialState: const VideoFeedState(),
+      );
 
-        await tester.pumpWidget(buildSubject());
-        await tester.pump();
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
 
-        final element = tester.element(find.byType(VideoFeedView));
-        final container = ProviderScope.containerOf(element);
+      final element = tester.element(find.byType(VideoFeedView));
+      final container = ProviderScope.containerOf(element);
 
-        // Open overlay while BLoC is still loading
-        container.read(overlayVisibilityProvider.notifier).setPageOpen(true);
-        await tester.pump();
+      // Open overlay while BLoC is still loading
+      container.read(overlayVisibilityProvider.notifier).setPageOpen(true);
+      await tester.pump();
 
-        clearInteractions(videoFeedController);
+      clearInteractions(videoFeedController);
 
-        // BLoC transitions to success (videos arrive)
-        await tester.pump();
+      // BLoC transitions to success (videos arrive)
+      await tester.pump();
 
-        // Controller must NOT be re-activated — overlay is still open
-        verifyNever(
-          () => videoFeedController.setActive(active: true),
-        );
-      },
-    );
+      // Controller must NOT be re-activated — overlay is still open
+      verifyNever(() => videoFeedController.setActive(active: true));
+    });
   });
 
   group('VideoFeedView tab switch integration', () {
@@ -250,9 +360,7 @@ void main() {
     });
 
     Widget buildSubject() {
-      when(
-        () => videoFeedBloc.state,
-      ).thenReturn(const VideoFeedState());
+      when(() => videoFeedBloc.state).thenReturn(const VideoFeedState());
 
       return testMaterialApp(
         additionalOverrides: [
@@ -273,9 +381,7 @@ void main() {
     }
 
     Widget buildSubjectWithInitialLocation(String location) {
-      when(
-        () => videoFeedBloc.state,
-      ).thenReturn(const VideoFeedState());
+      when(() => videoFeedBloc.state).thenReturn(const VideoFeedState());
 
       return testMaterialApp(
         additionalOverrides: [
@@ -295,17 +401,14 @@ void main() {
       );
     }
 
-    testWidgets(
-      'syncs controller to a non-home route on initial mount',
-      (tester) async {
-        await tester.pumpWidget(buildSubjectWithInitialLocation('/search'));
-        await tester.pump();
+    testWidgets('syncs controller to a non-home route on initial mount', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubjectWithInitialLocation('/search'));
+      await tester.pump();
 
-        verify(
-          () => videoFeedController.setActive(active: false),
-        ).called(1);
-      },
-    );
+      verify(() => videoFeedController.setActive(active: false)).called(1);
+    });
 
     testWidgets(
       'syncs controller to an already-open page overlay on initial mount',
@@ -322,9 +425,7 @@ void main() {
 
         container.read(overlayVisibilityProvider.notifier).setPageOpen(true);
 
-        when(
-          () => videoFeedBloc.state,
-        ).thenReturn(const VideoFeedState());
+        when(() => videoFeedBloc.state).thenReturn(const VideoFeedState());
 
         await tester.pumpWidget(
           UncontrolledProviderScope(
@@ -373,69 +474,61 @@ void main() {
         locationController.add('/search');
         await tester.pump();
 
-        verify(
-          () => videoFeedController.setActive(active: false),
-        ).called(1);
+        verify(() => videoFeedController.setActive(active: false)).called(1);
       },
     );
 
-    testWidgets(
-      'calls setActive(active: true) when returning to home',
-      (tester) async {
-        await tester.pumpWidget(buildSubject());
-        await tester.pump();
+    testWidgets('calls setActive(active: true) when returning to home', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
 
-        // Start on home, navigate away
-        locationController.add('/home/0');
-        await tester.pump();
-        locationController.add('/search');
-        await tester.pump();
+      // Start on home, navigate away
+      locationController.add('/home/0');
+      await tester.pump();
+      locationController.add('/search');
+      await tester.pump();
 
-        clearInteractions(videoFeedController);
+      clearInteractions(videoFeedController);
 
-        // Return to home
-        locationController.add('/home/0');
-        await tester.pump();
+      // Return to home
+      locationController.add('/home/0');
+      await tester.pump();
 
-        verify(
-          () => videoFeedController.setActive(active: true),
-        ).called(1);
-      },
-    );
+      verify(() => videoFeedController.setActive(active: true)).called(1);
+    });
 
-    testWidgets(
-      'does not resume when overlay closes while on non-home tab',
-      (tester) async {
-        await tester.pumpWidget(buildSubject());
-        await tester.pump();
+    testWidgets('does not resume when overlay closes while on non-home tab', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
 
-        final element = tester.element(find.byType(VideoFeedView));
-        final container = ProviderScope.containerOf(element);
+      final element = tester.element(find.byType(VideoFeedView));
+      final container = ProviderScope.containerOf(element);
 
-        // Start on home, navigate away
-        locationController.add('/home/0');
-        await tester.pump();
-        locationController.add('/search');
-        await tester.pump();
+      // Start on home, navigate away
+      locationController.add('/home/0');
+      await tester.pump();
+      locationController.add('/search');
+      await tester.pump();
 
-        clearInteractions(videoFeedController);
+      clearInteractions(videoFeedController);
 
-        // Open and close overlay while on search tab
-        container
-            .read(overlayVisibilityProvider.notifier)
-            .setBottomSheetOpen(true);
-        await tester.pump();
-        container
-            .read(overlayVisibilityProvider.notifier)
-            .setBottomSheetOpen(false);
-        await tester.pump();
+      // Open and close overlay while on search tab
+      container
+          .read(overlayVisibilityProvider.notifier)
+          .setBottomSheetOpen(true);
+      await tester.pump();
+      container
+          .read(overlayVisibilityProvider.notifier)
+          .setBottomSheetOpen(false);
+      await tester.pump();
 
-        // setActive(active: true) should NOT have been called
-        verifyNever(
-          () => videoFeedController.setActive(active: true),
-        );
-      },
-    );
+      // setActive(active: true) should NOT have been called
+      verifyNever(() => videoFeedController.setActive(active: true));
+    });
 
     testWidgets(
       'does not resume when router reports home while page overlay is open',
@@ -465,9 +558,7 @@ void main() {
 
         // setActive(active: true) must NOT be called — the overlay is
         // still open, so the overlay listener handles resume later.
-        verifyNever(
-          () => videoFeedController.setActive(active: true),
-        );
+        verifyNever(() => videoFeedController.setActive(active: true));
       },
     );
 
@@ -500,9 +591,7 @@ void main() {
         await tester.pump();
 
         // Now the overlay listener should resume playback
-        verify(
-          () => videoFeedController.setActive(active: true),
-        ).called(1);
+        verify(() => videoFeedController.setActive(active: true)).called(1);
       },
     );
   });
@@ -517,9 +606,7 @@ void main() {
       videoFeedController = _MockVideoFeedController();
 
       when(() => videoFeedController.videoCount).thenReturn(1);
-      when(
-        () => videoFeedController.videos,
-      ).thenReturn([
+      when(() => videoFeedController.videos).thenReturn([
         const VideoItem(id: 'video-1', url: 'https://example.com/video.mp4'),
       ]);
       when(() => videoFeedController.addListener(any())).thenReturn(null);
@@ -572,9 +659,9 @@ void main() {
         );
 
         when(() => videoFeedController.videoCount).thenReturn(1);
-        when(() => videoFeedController.videos).thenReturn([
-          VideoItem(id: testVideo.id, url: testVideo.videoUrl!),
-        ]);
+        when(
+          () => videoFeedController.videos,
+        ).thenReturn([VideoItem(id: testVideo.id, url: testVideo.videoUrl!)]);
         when(() => videoFeedController.currentIndex).thenReturn(0);
         when(() => videoFeedController.onPageChanged(any())).thenReturn(null);
         when(
@@ -588,10 +675,7 @@ void main() {
           find.byType(PooledVideoFeed),
         );
 
-        expect(
-          pooledVideoFeed.key,
-          isA<GlobalKey<PooledVideoFeedState>>(),
-        );
+        expect(pooledVideoFeed.key, isA<GlobalKey<PooledVideoFeedState>>());
       },
     );
   });


### PR DESCRIPTION
## Summary
- Replace the generic `feedNoVideosForMode(state.mode.name)` empty-state fallback with explicit per-mode l10n copy
- Treat `noFollowedUsers` as actionable for both `For You` and `Following`, matching the BLoC state
- Remove the obsolete generic l10n key and regenerate localization files
- Add widget coverage to prevent raw enum names like `forYou` from reaching feed empty states

Fixes #3040

## Test plan
- [x] `flutter gen-l10n` from `mobile/`
- [x] `dart format --set-exit-if-changed lib/screens/feed/video_feed_page.dart test/screens/feed/video_feed_page_test.dart` from `mobile/`
- [x] `flutter test test/screens/feed/video_feed_page_test.dart` from `mobile/`
- [x] `flutter analyze lib/screens/feed/video_feed_page.dart test/screens/feed/video_feed_page_test.dart` from `mobile/`