### PR TITLE
feat(feed): open metadata sheet from descriptions

### DIFF
--- a/docs/superpowers/plans/2026-04-14-feed-description-metadata-sheet.md
+++ b/docs/superpowers/plans/2026-04-14-feed-description-metadata-sheet.md
@@ -1,0 +1,216 @@
+# Feed Description Metadata Sheet Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let any non-empty feed description open the existing metadata sheet, and make full descriptions inside that sheet support tappable URLs in addition to the existing hashtag and mention parsing.
+
+**Architecture:** Reuse the current `MetadataExpandedSheet` instead of creating a new detail surface. Keep the feed overlay visually unchanged, but wrap the description in a tap target that opens the existing sheet. Extend `ClickableHashtagText` to recognize URLs and use the same rich-text widget inside the metadata sheet so the full description is readable and interactive in one place.
+
+**Tech Stack:** Flutter, Riverpod, go_router, url_launcher, flutter_test
+
+---
+
+## File Structure
+
+**Modify**
+- `mobile/lib/screens/feed/feed_video_overlay.dart`
+- `mobile/lib/widgets/clickable_hashtag_text.dart`
+- `mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart`
+- `mobile/test/screens/feed/feed_video_overlay_test.dart`
+- `mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart`
+
+**Why this structure**
+- Keep feed behavior in the existing overlay widget.
+- Keep parsing and link launching in the shared rich-text widget so feed text and metadata sheet text do not diverge.
+- Keep the metadata sheet as the only full-description surface.
+- Limit test changes to the two widget suites already covering the touched features.
+
+## Chunk 1: Make Feed Descriptions Open The Existing Metadata Sheet
+
+### Task 1: Add the failing feed overlay test
+
+**Files:**
+- Modify: `mobile/test/screens/feed/feed_video_overlay_test.dart`
+- Use: `mobile/lib/screens/feed/feed_video_overlay.dart`
+
+- [ ] **Step 1: Write a widget test that taps the feed description**
+
+Add a test near the existing `FeedVideoOverlay` coverage that:
+
+- pumps `FeedVideoOverlay` with a video that has non-empty `content`
+- taps the widget with semantics identifier `video_description`
+- asserts that metadata-sheet content such as the video description text and `Loops` appears
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/screens/feed/feed_video_overlay_test.dart --plain-name "opens metadata sheet when tapping the description"
+```
+
+Expected: FAIL because the description is not yet tappable.
+
+- [ ] **Step 3: Implement the minimal feed overlay change**
+
+Update `mobile/lib/screens/feed/feed_video_overlay.dart` so the existing description block:
+
+- stays visually identical
+- is wrapped in a tap handler only when text exists
+- calls `MetadataExpandedSheet.show(context, video)` on tap
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/screens/feed/feed_video_overlay_test.dart --plain-name "opens metadata sheet when tapping the description"
+```
+
+Expected: PASS.
+
+## Chunk 2: Render Full Metadata Descriptions With Shared Interactive Text
+
+### Task 2: Add the failing metadata-sheet test
+
+**Files:**
+- Modify: `mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart`
+- Use: `mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart`
+
+- [ ] **Step 1: Write a widget test that expects rich description rendering**
+
+Add a test that:
+
+- builds `MetadataExpandedSheet` with a description containing a URL and a hashtag
+- asserts the sheet contains a `ClickableHashtagText` widget for the description
+- keeps the title and description text visible
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart --plain-name "renders description with clickable rich text"
+```
+
+Expected: FAIL because the sheet still uses plain `Text`.
+
+- [ ] **Step 3: Implement the minimal metadata sheet change**
+
+Update `mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart` to:
+
+- import `ClickableHashtagText`
+- replace the plain description `Text` with `ClickableHashtagText`
+- remove any line clamp so the full description remains visible
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart --plain-name "renders description with clickable rich text"
+```
+
+Expected: PASS.
+
+## Chunk 3: Extend Shared Rich Text Parsing To Support URLs
+
+### Task 3: Add failing parser coverage for URLs
+
+**Files:**
+- Modify: `mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart`
+- Modify: `mobile/lib/widgets/clickable_hashtag_text.dart`
+
+- [ ] **Step 1: Add test coverage that exercises URL-bearing descriptions through the metadata sheet**
+
+Use a description like:
+
+```text
+Read more at https://example.com/docs #proof
+```
+
+Verify:
+
+- the metadata sheet still renders the full string
+- the description is rendered through `ClickableHashtagText`
+
+This test does not need to launch the URL. It should prove the metadata sheet routes description content through the shared parser that will own link behavior.
+
+- [ ] **Step 2: Run the test suite to confirm the new expectation fails for URL support if needed**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+```
+
+Expected: FAIL only if the parser changes require additional adjustments; otherwise proceed to the direct implementation.
+
+- [ ] **Step 3: Extend `ClickableHashtagText` to recognize URLs**
+
+Update `mobile/lib/widgets/clickable_hashtag_text.dart` to:
+
+- add URL detection for `http://`, `https://`, and bare domains
+- style URLs consistently with the existing tappable text style
+- launch the normalized URL with `launchUrl(..., mode: LaunchMode.externalApplication)`
+- preserve the existing hashtag and mention behavior
+
+- [ ] **Step 4: Run the targeted suites**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/screens/feed/feed_video_overlay_test.dart
+flutter test test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+```
+
+Expected: both suites PASS.
+
+## Chunk 4: Final Verification And Commit
+
+### Task 4: Verify the full change set and record the work
+
+**Files:**
+- Verify: `mobile/lib/screens/feed/feed_video_overlay.dart`
+- Verify: `mobile/lib/widgets/clickable_hashtag_text.dart`
+- Verify: `mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart`
+- Verify: `mobile/test/screens/feed/feed_video_overlay_test.dart`
+- Verify: `mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart`
+- Verify: `docs/superpowers/specs/2026-04-14-feed-description-metadata-sheet-design.md`
+- Verify: `docs/superpowers/plans/2026-04-14-feed-description-metadata-sheet.md`
+
+- [ ] **Step 1: Run the final targeted verification**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/screens/feed/feed_video_overlay_test.dart
+flutter test test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+```
+
+Expected: both suites PASS.
+
+- [ ] **Step 2: Review the final diff**
+
+Run:
+
+```bash
+git status --short
+git diff -- mobile/lib/screens/feed/feed_video_overlay.dart mobile/lib/widgets/clickable_hashtag_text.dart mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart mobile/test/screens/feed/feed_video_overlay_test.dart mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart docs/superpowers/specs/2026-04-14-feed-description-metadata-sheet-design.md docs/superpowers/plans/2026-04-14-feed-description-metadata-sheet.md
+```
+
+Expected: only task-related files are changed.
+
+- [ ] **Step 3: Commit the task**
+
+```bash
+git add mobile/lib/screens/feed/feed_video_overlay.dart mobile/lib/widgets/clickable_hashtag_text.dart mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart mobile/test/screens/feed/feed_video_overlay_test.dart mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart docs/superpowers/specs/2026-04-14-feed-description-metadata-sheet-design.md docs/superpowers/plans/2026-04-14-feed-description-metadata-sheet.md
+git commit -m "feat(feed): open metadata sheet from descriptions"
+```

--- a/docs/superpowers/specs/2026-04-14-feed-description-metadata-sheet-design.md
+++ b/docs/superpowers/specs/2026-04-14-feed-description-metadata-sheet-design.md
@@ -1,0 +1,77 @@
+# Feed Description Metadata Sheet Design
+
+**Date:** 2026-04-14
+**Status:** Approved
+
+## Problem
+
+Feed descriptions are truncated to three lines in the video overlay. When a description is longer than that, people cannot read the full text from the video surface. The expanded metadata sheet already exists, but the inline description does not open it.
+
+The metadata sheet also renders the full description as plain text, which means URLs inside the description are not tappable even though the feed already supports clickable hashtags and mentions.
+
+## Decision
+
+Use the existing metadata sheet as the canonical "full description" surface.
+
+- Tapping any non-empty inline description in the feed opens the existing `MetadataExpandedSheet`.
+- The inline description remains visually unchanged: three-line clamp with ellipsis.
+- The metadata sheet shows the full description with rich text behavior instead of plain text.
+- URLs in the full description are tappable and open externally.
+
+This keeps the interaction model simple: the feed stays compact, and the existing more-info surface becomes the place to read and interact with the full description.
+
+## UI Behavior
+
+### Feed overlay description
+
+For any video with non-empty title/content text:
+
+- Keep the current truncated text styling and layout.
+- Make the description area tappable.
+- Open `MetadataExpandedSheet.show(context, video)` on tap.
+
+This applies even when the text would fit within three lines. Always-open behavior is more predictable than trying to detect truncation per layout pass.
+
+### Metadata sheet description
+
+In the sheet title section:
+
+- Keep the title rendering as-is.
+- Replace the plain description `Text` widget with the shared rich-text renderer used in feed text.
+- Render the full description without line limits.
+
+### Interactive text support
+
+The rich-text renderer should support:
+
+- hashtags
+- nostr mentions
+- plain `@mentions`
+- plain URLs like `example.com/path`
+- full URLs like `https://example.com/path`
+
+URL taps should launch the link externally with `url_launcher`, matching other external link patterns already used in the app.
+
+## Files In Scope
+
+| File | Change |
+|------|--------|
+| `mobile/lib/screens/feed/feed_video_overlay.dart` | Make the inline description tappable and open the metadata sheet |
+| `mobile/lib/widgets/clickable_hashtag_text.dart` | Add plain URL detection and external launch behavior |
+| `mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart` | Render the full description with `ClickableHashtagText` |
+| `mobile/test/screens/feed/feed_video_overlay_test.dart` | Add coverage for tapping description to open the metadata sheet |
+| `mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart` | Add coverage for rich description rendering in the sheet |
+
+## Out Of Scope
+
+- Changing the visual layout of the feed overlay
+- Adding a separate "Read more" affordance
+- Building a second full-description modal or route
+- Adding domain warnings or custom in-app browser behavior for description URLs
+
+## Testing
+
+- Widget test: tapping a feed description opens the metadata sheet
+- Widget test: the metadata sheet still renders full title and description
+- Widget test: the metadata sheet uses the rich-text widget for descriptions so linkable content is rendered through the shared parser
+- Regression test: existing feed overlay and metadata sheet tests stay green

--- a/mobile/lib/screens/feed/feed_video_overlay.dart
+++ b/mobile/lib/screens/feed/feed_video_overlay.dart
@@ -32,6 +32,7 @@ import 'package:openvine/widgets/video_feed_item/collaborator_avatar_row.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/inspired_by_attribution_row.dart';
 import 'package:openvine/widgets/video_feed_item/list_attribution_chip.dart';
+import 'package:openvine/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/paused_video_play_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
@@ -339,20 +340,26 @@ class _AuthorInfoSection extends ConsumerWidget {
         // Video description
         if (hasTextContent) ...[
           const SizedBox(height: 2),
-          Semantics(
-            identifier: 'video_description',
-            container: true,
-            explicitChildNodes: true,
-            label:
-                'Video description: ${(video.content.isNotEmpty ? video.content : video.title ?? '').trim()}',
-            child: ClickableHashtagText(
-              text:
-                  (video.content.isNotEmpty ? video.content : video.title ?? '')
-                      .trim(),
-              style: VineTheme.bodyMediumFont(),
-              hashtagStyle: VineTheme.bodySmallFont(),
-              maxLines: 3,
-              overflow: TextOverflow.ellipsis,
+          GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () => MetadataExpandedSheet.show(context, video),
+            child: Semantics(
+              identifier: 'video_description',
+              container: true,
+              explicitChildNodes: true,
+              label:
+                  'Video description: ${(video.content.isNotEmpty ? video.content : video.title ?? '').trim()}',
+              child: ClickableHashtagText(
+                text:
+                    (video.content.isNotEmpty
+                            ? video.content
+                            : video.title ?? '')
+                        .trim(),
+                style: VineTheme.bodyMediumFont(),
+                hashtagStyle: VineTheme.bodySmallFont(),
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
           ),
           // Collaborator avatars

--- a/mobile/lib/widgets/clickable_hashtag_text.dart
+++ b/mobile/lib/widgets/clickable_hashtag_text.dart
@@ -13,6 +13,7 @@ import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/npub_hex.dart';
 import 'package:unified_logger/unified_logger.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// A widget that displays text with clickable hashtags and nostr: mentions
 ///
@@ -48,6 +49,12 @@ class ClickableHashtagText extends ConsumerWidget {
   /// Matches @username where username is alphanumeric with underscores
   static final _plainMentionRegex = RegExp('@([a-zA-Z][a-zA-Z0-9_]{0,30})');
 
+  /// Regex to detect plain URLs and bare domains.
+  static final _urlRegex = RegExp(
+    r'(https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?)',
+    caseSensitive: false,
+  );
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     if (text.isEmpty) {
@@ -58,9 +65,10 @@ class ClickableHashtagText extends ConsumerWidget {
     final hasHashtags = HashtagExtractor.extractHashtags(text).isNotEmpty;
     final hasNostrUris = _nostrUriRegex.hasMatch(text);
     final hasPlainMentions = _plainMentionRegex.hasMatch(text);
+    final hasUrls = _urlRegex.hasMatch(text);
 
     // If no clickable elements, return simple text
-    if (!hasHashtags && !hasNostrUris && !hasPlainMentions) {
+    if (!hasHashtags && !hasNostrUris && !hasPlainMentions && !hasUrls) {
       return Text(text, style: style, maxLines: maxLines, overflow: overflow);
     }
 
@@ -89,10 +97,11 @@ class ClickableHashtagText extends ConsumerWidget {
     final profileStyle =
         mentionStyle ?? tagStyle.copyWith(fontWeight: FontWeight.w600);
 
-    // Combined regex to find hashtags, nostr: URIs, and plain @mentions
-    // Group 1: hashtag, Group 2: nostr ID, Group 3: plain mention username
+    // Combined regex to find URLs, hashtags, nostr: URIs, and plain @mentions
+    // Group 1: URL, Group 2: hashtag, Group 3: nostr ID,
+    // Group 4: plain mention username
     final combinedRegex = RegExp(
-      r'#(\w+)|nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+)|@([a-zA-Z][a-zA-Z0-9_]{0,30})',
+      r'(https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?)|#(\w+)|nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+)|@([a-zA-Z][a-zA-Z0-9_]{0,30})',
       caseSensitive: false,
     );
 
@@ -110,9 +119,11 @@ class ClickableHashtagText extends ConsumerWidget {
 
       final fullMatch = match.group(0)!;
 
-      if (fullMatch.startsWith('#')) {
+      if (_urlRegex.hasMatch(fullMatch)) {
+        spans.add(_buildUrlSpan(fullMatch, tagStyle));
+      } else if (fullMatch.startsWith('#')) {
         // Handle hashtag
-        final hashtag = match.group(1)!;
+        final hashtag = match.group(2)!;
         spans.add(
           TextSpan(
             text: fullMatch,
@@ -123,11 +134,11 @@ class ClickableHashtagText extends ConsumerWidget {
         );
       } else if (fullMatch.startsWith('nostr:')) {
         // Handle nostr: URI
-        final nostrId = match.group(2)!;
+        final nostrId = match.group(3)!;
         spans.add(_buildNostrMentionSpan(context, ref, nostrId, profileStyle));
       } else if (fullMatch.startsWith('@')) {
         // Handle plain @mention (legacy Vine format)
-        final username = match.group(3)!;
+        final username = match.group(4)!;
         spans.add(_buildPlainMentionSpan(context, ref, username, profileStyle));
       }
 
@@ -140,6 +151,18 @@ class ClickableHashtagText extends ConsumerWidget {
     }
 
     return spans;
+  }
+
+  TextSpan _buildUrlSpan(String matchedUrl, TextStyle style) {
+    return TextSpan(
+      text: matchedUrl,
+      style: style,
+      recognizer: TapGestureRecognizer()
+        ..onTap = () {
+          onVideoStateChange?.call();
+          _launchUrl(matchedUrl);
+        },
+    );
   }
 
   /// Build a TextSpan for a nostr mention (npub or nprofile)
@@ -234,5 +257,18 @@ class ClickableHashtagText extends ConsumerWidget {
 
     // Navigate to search with the username pre-filled
     context.goSearch(searchTerm);
+  }
+
+  Future<void> _launchUrl(String rawUrl) async {
+    final normalizedUrl =
+        rawUrl.startsWith(
+          RegExp('https?://', caseSensitive: false),
+        )
+        ? rawUrl
+        : 'https://$rawUrl';
+    final uri = Uri.tryParse(normalizedUrl);
+    if (uri == null) return;
+
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
   }
 }

--- a/mobile/lib/widgets/video_feed_item/actions/video_description_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/video_description_overlay.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:models/models.dart';
 import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/widgets/clickable_hashtag_text.dart';
+import 'package:openvine/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart';
 
 /// Video description overlay showing title/content and loop count.
 ///
@@ -29,37 +30,41 @@ class VideoDescriptionOverlay extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           // Video title with clickable hashtags
-          Semantics(
-            identifier: 'video_description',
-            container: true,
-            explicitChildNodes: true,
-            label: 'Video description',
-            child: ClickableHashtagText(
-              text: video.content.isNotEmpty
-                  ? video.content
-                  : video.title ?? '',
-              style: const TextStyle(
-                color: VineTheme.whiteText,
-                fontSize: 16,
-                fontWeight: FontWeight.bold,
-                height: 1.3,
-                shadows: [
-                  Shadow(blurRadius: 8),
-                  Shadow(offset: Offset(2, 2), blurRadius: 4),
-                ],
+          GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () => MetadataExpandedSheet.show(context, video),
+            child: Semantics(
+              identifier: 'video_description',
+              container: true,
+              explicitChildNodes: true,
+              label: 'Video description',
+              child: ClickableHashtagText(
+                text: video.content.isNotEmpty
+                    ? video.content
+                    : video.title ?? '',
+                style: const TextStyle(
+                  color: VineTheme.whiteText,
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                  height: 1.3,
+                  shadows: [
+                    Shadow(blurRadius: 8),
+                    Shadow(offset: Offset(2, 2), blurRadius: 4),
+                  ],
+                ),
+                hashtagStyle: const TextStyle(
+                  color: VineTheme.vineGreen,
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                  height: 1.3,
+                  shadows: [
+                    Shadow(blurRadius: 8),
+                    Shadow(offset: Offset(2, 2), blurRadius: 4),
+                  ],
+                ),
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
               ),
-              hashtagStyle: const TextStyle(
-                color: VineTheme.vineGreen,
-                fontSize: 16,
-                fontWeight: FontWeight.bold,
-                height: 1.3,
-                shadows: [
-                  Shadow(blurRadius: 8),
-                  Shadow(offset: Offset(2, 2), blurRadius: 4),
-                ],
-              ),
-              maxLines: 3,
-              overflow: TextOverflow.ellipsis,
             ),
           ),
           const SizedBox(height: 4),

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
@@ -10,6 +10,7 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
+import 'package:openvine/widgets/clickable_hashtag_text.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_badges_row.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_sounds_section.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_stats_row.dart';
@@ -142,8 +143,8 @@ class _TitleSection extends StatelessWidget {
             if (title != null && title.isNotEmpty)
               Text(title, style: VineTheme.titleMediumFont()),
             if (description.isNotEmpty)
-              Text(
-                description,
+              ClickableHashtagText(
+                text: description,
                 style: VineTheme.bodyLargeFont(
                   color: VineTheme.onSurfaceVariant,
                 ),

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -54,6 +54,7 @@ import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_heart_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/inspired_by_attribution_row.dart';
 import 'package:openvine/widgets/video_feed_item/list_attribution_chip.dart';
+import 'package:openvine/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart';
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_error_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_follow_button.dart';
@@ -1641,34 +1642,38 @@ class VideoOverlayActions extends ConsumerWidget {
                       const SizedBox(
                         height: 2,
                       ), // 2px + 10px from avatar container = 12px total
-                      Semantics(
-                        identifier: 'video_description',
-                        container: true,
-                        explicitChildNodes: true,
-                        label:
-                            'Video description: ${(video.content.isNotEmpty ? video.content : video.title ?? '').trim()}',
-                        child: ClickableHashtagText(
-                          text:
-                              (video.content.isNotEmpty
-                                      ? video.content
-                                      : video.title ?? '')
-                                  .trim(),
-                          style: const TextStyle(
-                            fontFamily: 'Inter',
-                            color: VineTheme.whiteText,
-                            fontSize: 14,
-                            height: 20 / 14,
-                            letterSpacing: 0.25,
+                      GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: () => MetadataExpandedSheet.show(context, video),
+                        child: Semantics(
+                          identifier: 'video_description',
+                          container: true,
+                          explicitChildNodes: true,
+                          label:
+                              'Video description: ${(video.content.isNotEmpty ? video.content : video.title ?? '').trim()}',
+                          child: ClickableHashtagText(
+                            text:
+                                (video.content.isNotEmpty
+                                        ? video.content
+                                        : video.title ?? '')
+                                    .trim(),
+                            style: const TextStyle(
+                              fontFamily: 'Inter',
+                              color: VineTheme.whiteText,
+                              fontSize: 14,
+                              height: 20 / 14,
+                              letterSpacing: 0.25,
+                            ),
+                            hashtagStyle: const TextStyle(
+                              fontFamily: 'Inter',
+                              color: VineTheme.vineGreen,
+                              fontSize: 14,
+                              height: 20 / 14,
+                              letterSpacing: 0.25,
+                            ),
+                            maxLines: 3,
+                            overflow: TextOverflow.ellipsis,
                           ),
-                          hashtagStyle: const TextStyle(
-                            fontFamily: 'Inter',
-                            color: VineTheme.vineGreen,
-                            fontSize: 14,
-                            height: 20 / 14,
-                            letterSpacing: 0.25,
-                          ),
-                          maxLines: 3,
-                          overflow: TextOverflow.ellipsis,
                         ),
                       ),
                       // Collaborator avatar row (if video has collaborators)

--- a/mobile/test/screens/feed/feed_video_overlay_test.dart
+++ b/mobile/test/screens/feed/feed_video_overlay_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/feed_video_overlay.dart';
+import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/utils/scroll_driven_opacity.dart';
 import 'package:openvine/widgets/proofmode_badge_row.dart';
 import 'package:openvine/widgets/video_feed_item/list_attribution_chip.dart';
@@ -34,6 +35,8 @@ class _MockPlayerState extends Mock implements PlayerState {}
 class _MockCuratedListRepository extends Mock
     implements CuratedListRepository {}
 
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
 // Full 64-character test IDs (never truncate Nostr IDs)
 const _testVideoId =
     'a1b2c3d4e5f6789012345678901234567890abcdef123456789012345678901234';
@@ -47,6 +50,7 @@ void main() {
     late PlayerStream mockStream;
     late PlayerState mockPlayerState;
     late CuratedListRepository mockCuratedListRepository;
+    late VideoEventService mockVideoEventService;
     late MockProfileRepository mockProfileRepository;
     late MockNip05VerificationService mockNip05VerificationService;
     late VideoEvent testVideo;
@@ -64,6 +68,7 @@ void main() {
       mockStream = _MockPlayerStream();
       mockPlayerState = _MockPlayerState();
       mockCuratedListRepository = _MockCuratedListRepository();
+      mockVideoEventService = _MockVideoEventService();
       mockProfileRepository = createMockProfileRepository();
       mockNip05VerificationService = createMockNip05VerificationService();
       playingController = StreamController<bool>.broadcast();
@@ -84,6 +89,9 @@ void main() {
       ).thenAnswer((_) => bufferingController.stream);
       when(() => mockPlayerState.playing).thenReturn(false);
       when(() => mockPlayerState.buffering).thenReturn(false);
+      when(
+        () => mockVideoEventService.getRepostersForVideo(any()),
+      ).thenAnswer((_) async => const <String>[]);
 
       // Stub interactions bloc state
       when(
@@ -120,6 +128,7 @@ void main() {
           curatedListRepositoryProvider.overrideWithValue(
             mockCuratedListRepository,
           ),
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
         ],
         mockProfileRepository: mockProfileRepository,
         mockNip05VerificationService: mockNip05VerificationService,
@@ -303,6 +312,19 @@ void main() {
 
         expect(find.byType(ListAttributionChip), findsOneWidget);
         expect(find.byIcon(Icons.playlist_play), findsNWidgets(2));
+      });
+
+      testWidgets('opens metadata sheet when tapping the description', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        await tester.tap(find.text('Test video content'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Loops'), findsOneWidget);
+        expect(find.text('Likes'), findsOneWidget);
       });
     });
 

--- a/mobile/test/widgets/clickable_hashtag_text_test.dart
+++ b/mobile/test/widgets/clickable_hashtag_text_test.dart
@@ -1,10 +1,51 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/clickable_hashtag_text.dart';
+import 'package:url_launcher_platform_interface/link.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+class _FakeUrlLauncherPlatform extends UrlLauncherPlatform {
+  String? launchedUrl;
+
+  @override
+  Future<bool> canLaunch(String url) async => true;
+
+  @override
+  Future<bool> launch(
+    String url, {
+    required bool useSafariVC,
+    required bool useWebView,
+    required bool enableJavaScript,
+    required bool enableDomStorage,
+    required bool universalLinksOnly,
+    required Map<String, String> headers,
+    String? webOnlyWindowName,
+  }) async {
+    launchedUrl = url;
+    return true;
+  }
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+}
 
 void main() {
   group('ClickableHashtagText', () {
+    late UrlLauncherPlatform originalUrlLauncherPlatform;
+    late _FakeUrlLauncherPlatform fakeUrlLauncherPlatform;
+
+    setUp(() {
+      originalUrlLauncherPlatform = UrlLauncherPlatform.instance;
+      fakeUrlLauncherPlatform = _FakeUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fakeUrlLauncherPlatform;
+    });
+
+    tearDown(() {
+      UrlLauncherPlatform.instance = originalUrlLauncherPlatform;
+    });
+
     testWidgets('displays plain text without hashtags correctly', (
       tester,
     ) async {
@@ -169,6 +210,33 @@ void main() {
         // Clear the widget tree before next test
         await tester.pumpWidget(Container());
       }
+    });
+
+    testWidgets('launches bare domains as external links', (tester) async {
+      const textWithLink = 'Read more at example.com/docs';
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: ClickableHashtagText(text: textWithLink)),
+        ),
+      );
+
+      final text = tester.widget<Text>(find.byType(Text));
+      final textSpan = text.textSpan! as TextSpan;
+      final spans = textSpan.children!.cast<TextSpan>();
+      final linkSpan = spans.firstWhere(
+        (span) => span.text == 'example.com/docs',
+      );
+
+      expect(linkSpan.recognizer, isNotNull);
+
+      final recognizer = linkSpan.recognizer! as TapGestureRecognizer;
+      recognizer.onTap!();
+      await tester.pump();
+
+      expect(fakeUrlLauncherPlatform.launchedUrl, 'https://example.com/docs');
     });
 
     // Note: Testing tap functionality and navigation requires integration testing

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/audio_event.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/widgets/clickable_hashtag_text.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_badges_row.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_sounds_section.dart';
@@ -165,6 +166,22 @@ void main() {
 
       expect(find.text('Who knew?'), findsOneWidget);
       expect(find.text('A description'), findsOneWidget);
+    });
+
+    testWidgets('renders description with clickable rich text', (
+      tester,
+    ) async {
+      final video = _makeVideo(
+        title: 'Who knew?',
+        content: 'Read more at https://example.com/docs #proof',
+      );
+
+      await tester.pumpWidget(
+        buildSubject(child: MetadataExpandedSheet(video: video)),
+      );
+
+      expect(find.text('Who knew?'), findsOneWidget);
+      expect(find.byType(ClickableHashtagText), findsOneWidget);
     });
 
     testWidgets('hides title section when both are empty', (tester) async {

--- a/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
@@ -1,0 +1,84 @@
+// ABOUTME: Regression test for tapping descriptions in VideoOverlayActions.
+// ABOUTME: Verifies the inline description opens the metadata sheet.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockVideoInteractionsBloc extends Mock
+    implements VideoInteractionsBloc {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+void main() {
+  late _MockVideoInteractionsBloc mockInteractionsBloc;
+  late _MockVideoEventService mockVideoEventService;
+  late VideoEvent testVideo;
+
+  setUp(() {
+    mockInteractionsBloc = _MockVideoInteractionsBloc();
+    mockVideoEventService = _MockVideoEventService();
+
+    when(
+      () => mockInteractionsBloc.stream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(
+      () => mockInteractionsBloc.state,
+    ).thenReturn(const VideoInteractionsState());
+    when(
+      () => mockVideoEventService.getRepostersForVideo(any()),
+    ).thenAnswer((_) async => const <String>[]);
+
+    testVideo = VideoEvent(
+      id: 'video-overlay-actions-test-0123456789abcdef0123456789abcdef012345',
+      pubkey:
+          'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+      createdAt: 1757385263,
+      content: 'Tap this description',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+      videoUrl: 'https://example.com/video.mp4',
+      title: 'Test Video',
+    );
+  });
+
+  testWidgets('opens metadata sheet when tapping description', (tester) async {
+    await tester.pumpWidget(
+      testProviderScope(
+        additionalOverrides: [
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: BlocProvider<VideoInteractionsBloc>.value(
+              value: mockInteractionsBloc,
+              child: VideoOverlayActions(
+                video: testVideo,
+                isVisible: true,
+                isActive: true,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Tap this description'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Loops'), findsOneWidget);
+    expect(find.text('Likes'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- open the existing metadata sheet when a feed description is tapped
- render full metadata descriptions with the shared rich-text widget
- add URL parsing and launch coverage for description text

## Test Plan
- [x] 00:00 +0: loading /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart
00:00 +0: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +1: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +2: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +3: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +5: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +6: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +7: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +7: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not show the content warning overlay for creator labels without warn labels
[14:04:21.703] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
[14:04:21.705] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:00 +8: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +9: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +10: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +11: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +12: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +13: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +14: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +14 ~1: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +15 ~1: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +15 ~2: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +15 ~3: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +15 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +16 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +17 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: _TitleSection (via MetadataExpandedSheet) renders title and description when present
00:00 +18 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not show the content warning overlay for creator labels without warn labels
00:00 +19 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not show the content warning overlay for creator labels without warn labels
00:00 +20 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not show the content warning overlay for creator labels without warn labels
00:00 +21 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not show the content warning overlay for creator labels without warn labels
00:00 +22 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not show the content warning overlay for creator labels without warn labels
00:00 +23 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not show the content warning overlay for creator labels without warn labels
00:00 +24 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not show the content warning overlay for creator labels without warn labels
00:00 +25 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not show the content warning overlay for creator labels without warn labels
00:00 +26 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not show the content warning overlay for creator labels without warn labels
00:00 +27 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not show the content warning overlay for creator labels without warn labels
00:00 +28 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not show the content warning overlay for creator labels without warn labels
00:00 +29 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not show the content warning overlay for creator labels without warn labels
00:00 +30 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: MetadataCreatorSection renders creator chip with profile name
00:00 +30 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution renders a centered play affordance when paused
[14:04:21.938] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
[14:04:21.939] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:00 +31 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution renders a centered play affordance when paused
00:00 +32 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution renders a centered play affordance when paused
00:00 +33 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: MetadataBadgesRow renders Not Divine badge for external videos
00:00 +34 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution hides the centered play affordance while playing
[14:04:21.989] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
00:00 +35 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution hides the centered play affordance while playing
[14:04:21.990] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:00 +36 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution hides the centered play affordance while playing
00:00 +37 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution hides the centered play affordance while playing
00:00 +38 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: MetadataTagsSection prepends classic hashtag for original Vine
00:00 +39 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution waits for the first frame before showing play after playback starts
[14:04:22.024] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
[14:04:22.025] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:00 +40 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution waits for the first frame before showing play after playback starts
00:00 +41 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution waits for the first frame before showing play after playback starts
00:00 +42 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: MetadataTagsSection renders category chips with accent colors
00:00 +42 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution still renders badges when inactive and player is missing
[14:04:22.066] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
[14:04:22.066] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:00 +43 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution still renders badges when inactive and player is missing
00:00 +44 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution still renders badges when inactive and player is missing
00:00 +45 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: MetadataCollaboratorsSection renders collaborator chips when present
00:00 +46 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution renders ListAttributionChip when listSources is provided
[14:04:22.100] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
[14:04:22.100] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:00 +47 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution renders ListAttributionChip when listSources is provided
00:00 +48 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution renders ListAttributionChip when listSources is provided
00:00 +49 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: MetadataInspiredBySection hides when no inspired-by
00:00 +50 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not render ListAttributionChip when listSources is null
[14:04:22.139] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
[14:04:22.139] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:00 +51 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not render ListAttributionChip when listSources is null
00:00 +52 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not render ListAttributionChip when listSources is null
00:00 +53 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: MetadataRepostedBySection hides when relay returns empty and no pre-populated data
00:00 +54 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not render ListAttributionChip when listSources is empty
[14:04:22.173] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
[14:04:22.174] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:00 +55 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution does not render ListAttributionChip when listSources is empty
00:00 +56 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: MetadataVerificationSection hides when no proof data
00:00 +57 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution renders multiple list chips for multiple sources
[14:04:22.208] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
[14:04:22.209] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:00 +58 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution renders multiple list chips for multiple sources
00:00 +59 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution renders multiple list chips for multiple sources
00:00 +60 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart: MetadataExpandedSheet full integration renders all sections for fully populated video
00:00 +60 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution opens metadata sheet when tapping the description
[14:04:22.243] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
[14:04:22.243] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:01 +61 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution opens metadata sheet when tapping the description
00:01 +62 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay list attribution opens metadata sheet when tapping the description
00:01 +63 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay scroll-driven opacity overlay is fully opaque when pagePosition matches index
[14:04:22.380] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
[14:04:22.380] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:01 +64 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay scroll-driven opacity overlay is fully hidden when scrolled a full page away
[14:04:22.408] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
[14:04:22.408] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:01 +65 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay scroll-driven opacity overlay uses dimmed opacity in the middle of the scroll band
[14:04:22.441] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
[14:04:22.441] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:01 +66 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay scroll-driven opacity overlay opacity updates when pagePosition changes
[14:04:22.466] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
[14:04:22.466] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:01 +67 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay scroll-driven opacity overlay is fully opaque for a non-zero index when pagePosition matches
[14:04:22.492] [SYSTEM] FollowRepository.initialize() skipped - no keys yet
[14:04:22.493] [SYSTEM] ContentBlocklistService initialized with 0 blocked accounts
00:01 +68 ~4: /Users/rabble/code/divine/divine-mobile/.worktrees/codex-feed-description-metadata/mobile/test/screens/feed/feed_video_overlay_test.dart: FeedVideoOverlay (tearDownAll)
00:01 +68 ~4: All tests passed!
- [x] pre-commit analyzer passed
