### PR TITLE
ci(mobile): post new preview comment for each refresh

### DIFF
--- a/.github/scripts/mobile_pr_preview_comment.py
+++ b/.github/scripts/mobile_pr_preview_comment.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Render PR preview comments for the mobile preview deploy workflow."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from textwrap import dedent
+
+
+def short_sha(sha: str) -> str:
+    return sha[:7]
+
+
+def render_deployed_comment(args: argparse.Namespace) -> str:
+    sha = short_sha(args.sha)
+    return dedent(
+        f"""\
+        ## Mobile PR Preview
+
+        Preview refreshed for `{sha}`
+
+        Last refresh: `{sha}` at {args.updated_at} ([preview run]({args.run_url}))
+
+        | Property | Value |
+        | --- | --- |
+        | Preview URL | {args.deployment_url} |
+        | Pages project | `openvine-app` |
+        | Preview branch | `{args.preview_branch}` |
+        | PR branch | `{args.head_ref}` |
+        | Commit | `{sha}` |
+        """
+    )
+
+
+def render_blocked_comment(args: argparse.Namespace) -> str:
+    sha = short_sha(args.sha)
+    return dedent(
+        f"""\
+        ## Mobile PR Preview
+
+        Preview refresh blocked for `{sha}`
+
+        Last refresh: `{sha}` at {args.updated_at} ([preview run]({args.run_url}))
+
+        Preview deployment is not configured for this repository yet.
+
+        Missing GitHub Actions secrets:
+        - `CLOUDFLARE_API_TOKEN`
+        - `CLOUDFLARE_ACCOUNT_ID`
+
+        Once those are added, this workflow will deploy this PR to the existing `openvine-app` Pages project on branch `{args.preview_branch}`.
+
+        | Property | Value |
+        | --- | --- |
+        | Preview branch | `{args.preview_branch}` |
+        | PR branch | `{args.head_ref}` |
+        | Commit | `{sha}` |
+        """
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("deployed", "blocked"), required=True)
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--updated-at", required=True)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--preview-branch", required=True)
+    parser.add_argument("--head-ref", required=True)
+    parser.add_argument("--deployment-url")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.mode == "deployed":
+        if not args.deployment_url:
+            raise SystemExit("--deployment-url is required for deployed mode")
+        comment = render_deployed_comment(args)
+    else:
+        comment = render_blocked_comment(args)
+
+    sys.stdout.write(comment)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_mobile_pr_preview_comment.py
+++ b/.github/scripts/tests/test_mobile_pr_preview_comment.py
@@ -1,0 +1,76 @@
+import subprocess
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "mobile_pr_preview_comment.py"
+
+
+class MobilePrPreviewCommentTest(unittest.TestCase):
+    def run_renderer(self, *args: str) -> str:
+        result = subprocess.run(
+            ["python3", str(SCRIPT_PATH), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"renderer exited with {result.returncode}: {result.stderr}",
+        )
+        return result.stdout
+
+    def test_renders_deployed_comment_with_refresh_line(self) -> None:
+        output = self.run_renderer(
+            "--mode",
+            "deployed",
+            "--sha",
+            "212fe3360",
+            "--updated-at",
+            "2026-04-14 04:38:43 UTC",
+            "--run-url",
+            "https://github.com/divinevideo/divine-mobile/actions/runs/24381216336",
+            "--preview-branch",
+            "pr-3042",
+            "--head-ref",
+            "codex/feed-description-metadata",
+            "--deployment-url",
+            "https://b38b5fb6.openvine-app.pages.dev",
+        )
+
+        self.assertIn("Preview refreshed for `212fe33`", output)
+        self.assertIn("https://b38b5fb6.openvine-app.pages.dev", output)
+        self.assertIn(
+            "https://github.com/divinevideo/divine-mobile/actions/runs/24381216336",
+            output,
+        )
+        self.assertIn("`pr-3042`", output)
+        self.assertIn("`codex/feed-description-metadata`", output)
+
+    def test_renders_blocked_comment_with_refresh_line(self) -> None:
+        output = self.run_renderer(
+            "--mode",
+            "blocked",
+            "--sha",
+            "212fe3360",
+            "--updated-at",
+            "2026-04-14 04:38:43 UTC",
+            "--run-url",
+            "https://github.com/divinevideo/divine-mobile/actions/runs/24381216336",
+            "--preview-branch",
+            "pr-3042",
+            "--head-ref",
+            "codex/feed-description-metadata",
+        )
+
+        self.assertIn("Preview refresh blocked for `212fe33`", output)
+        self.assertIn("`CLOUDFLARE_API_TOKEN`", output)
+        self.assertIn("`CLOUDFLARE_ACCOUNT_ID`", output)
+        self.assertIn("`pr-3042`", output)
+        self.assertIn("`codex/feed-description-metadata`", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/mobile_pr_preview_deploy.yml
+++ b/.github/workflows/mobile_pr_preview_deploy.yml
@@ -77,6 +77,10 @@ jobs:
           echo "Artifact SHA: ${{ steps.metadata.outputs.head_sha }}"
           echo "Current PR SHA: ${{ steps.freshness.outputs.current_sha }}"
 
+      - name: Check out repository
+        if: ${{ steps.freshness.outputs.deployable == 'true' }}
+        uses: actions/checkout@v4
+
       - name: Extract preview site
         if: ${{ steps.freshness.outputs.deployable == 'true' }}
         run: tar -xzf artifact/pr-web-preview-site.tar.gz -C artifact
@@ -94,67 +98,46 @@ jobs:
             echo "configured=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Render blocked preview comment
+        if: ${{ steps.freshness.outputs.deployable == 'true' && steps.secrets.outputs.configured != 'true' }}
+        id: blocked_comment
+        env:
+          HEAD_REF: ${{ steps.metadata.outputs.head_ref }}
+          HEAD_SHA: ${{ steps.metadata.outputs.head_sha }}
+          PREVIEW_BRANCH: ${{ steps.metadata.outputs.preview_branch }}
+        run: |
+          updated_at="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          comment_file="${RUNNER_TEMP}/mobile-pr-preview-blocked.md"
+
+          python3 .github/scripts/mobile_pr_preview_comment.py \
+            --mode blocked \
+            --sha "${HEAD_SHA}" \
+            --updated-at "${updated_at}" \
+            --run-url "${run_url}" \
+            --preview-branch "${PREVIEW_BRANCH}" \
+            --head-ref "${HEAD_REF}" \
+            > "${comment_file}"
+
+          echo "comment_file=${comment_file}" >> "$GITHUB_OUTPUT"
+
       - name: Comment missing preview configuration
         if: ${{ steps.freshness.outputs.deployable == 'true' && steps.secrets.outputs.configured != 'true' }}
         uses: actions/github-script@v7
+        env:
+          PREVIEW_COMMENT_FILE: ${{ steps.blocked_comment.outputs.comment_file }}
         with:
           script: |
             const prNumber = Number('${{ steps.metadata.outputs.pr_number }}');
-            const previewBranch = '${{ steps.metadata.outputs.preview_branch }}';
-            const headRef = '${{ steps.metadata.outputs.head_ref }}';
-            const sha = '${{ steps.metadata.outputs.head_sha }}'.slice(0, 7);
-            const runUrl =
-              `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}` +
-              `/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const updatedAt = new Date()
-              .toISOString()
-              .replace('T', ' ')
-              .replace(/\.\d+Z$/, ' UTC');
+            const fs = require('fs');
+            const body = fs.readFileSync(process.env.PREVIEW_COMMENT_FILE, 'utf8');
 
-            const body = `## Mobile PR Preview
-
-            Last refresh: \`${sha}\` at ${updatedAt} ([preview run](${runUrl}))
-
-            Preview deployment is not configured for this repository yet.
-
-            Missing GitHub Actions secrets:
-            - \`CLOUDFLARE_API_TOKEN\`
-            - \`CLOUDFLARE_ACCOUNT_ID\`
-
-            Once those are added, this workflow will deploy this PR to the existing \`openvine-app\` Pages project on branch \`${previewBranch}\`.
-
-            | Property | Value |
-            | --- | --- |
-            | Preview branch | \`${previewBranch}\` |
-            | PR branch | \`${headRef}\` |
-            | Commit | \`${sha}\` |`;
-
-            const { data: comments } = await github.rest.issues.listComments({
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
+              body,
             });
-
-            const existing = comments.find((comment) =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('## Mobile PR Preview')
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body,
-              });
-            }
 
       - name: Deploy preview to Cloudflare Pages
         if: ${{ steps.freshness.outputs.deployable == 'true' && steps.secrets.outputs.configured == 'true' }}
@@ -168,59 +151,45 @@ jobs:
             --project-name=openvine-app
             --branch=${{ steps.metadata.outputs.preview_branch }}
 
+      - name: Render deployed preview comment
+        if: ${{ steps.freshness.outputs.deployable == 'true' && steps.secrets.outputs.configured == 'true' }}
+        id: deployed_comment
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+          HEAD_REF: ${{ steps.metadata.outputs.head_ref }}
+          HEAD_SHA: ${{ steps.metadata.outputs.head_sha }}
+          PREVIEW_BRANCH: ${{ steps.metadata.outputs.preview_branch }}
+        run: |
+          updated_at="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          comment_file="${RUNNER_TEMP}/mobile-pr-preview-deployed.md"
+
+          python3 .github/scripts/mobile_pr_preview_comment.py \
+            --mode deployed \
+            --sha "${HEAD_SHA}" \
+            --updated-at "${updated_at}" \
+            --run-url "${run_url}" \
+            --preview-branch "${PREVIEW_BRANCH}" \
+            --head-ref "${HEAD_REF}" \
+            --deployment-url "${DEPLOYMENT_URL}" \
+            > "${comment_file}"
+
+          echo "comment_file=${comment_file}" >> "$GITHUB_OUTPUT"
+
       - name: Comment preview URL on PR
         if: ${{ steps.freshness.outputs.deployable == 'true' && steps.secrets.outputs.configured == 'true' }}
         uses: actions/github-script@v7
+        env:
+          PREVIEW_COMMENT_FILE: ${{ steps.deployed_comment.outputs.comment_file }}
         with:
           script: |
             const prNumber = Number('${{ steps.metadata.outputs.pr_number }}');
-            const headRef = '${{ steps.metadata.outputs.head_ref }}';
-            const previewBranch = '${{ steps.metadata.outputs.preview_branch }}';
-            const sha = '${{ steps.metadata.outputs.head_sha }}'.slice(0, 7);
-            const deploymentUrl = '${{ steps.deploy.outputs.deployment-url }}';
-            const runUrl =
-              `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}` +
-              `/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const updatedAt = new Date()
-              .toISOString()
-              .replace('T', ' ')
-              .replace(/\.\d+Z$/, ' UTC');
+            const fs = require('fs');
+            const body = fs.readFileSync(process.env.PREVIEW_COMMENT_FILE, 'utf8');
 
-            const body = `## Mobile PR Preview
-
-            Last refresh: \`${sha}\` at ${updatedAt} ([preview run](${runUrl}))
-
-            | Property | Value |
-            | --- | --- |
-            | Preview URL | ${deploymentUrl} |
-            | Pages project | \`openvine-app\` |
-            | Preview branch | \`${previewBranch}\` |
-            | PR branch | \`${headRef}\` |
-            | Commit | \`${sha}\` |`;
-
-            const { data: comments } = await github.rest.issues.listComments({
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
+              body,
             });
-
-            const existing = comments.find((comment) =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('## Mobile PR Preview')
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body,
-              });
-            }

--- a/docs/superpowers/plans/2026-04-14-feed-description-metadata-sheet.md
+++ b/docs/superpowers/plans/2026-04-14-feed-description-metadata-sheet.md
@@ -1,0 +1,216 @@
+# Feed Description Metadata Sheet Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let any non-empty feed description open the existing metadata sheet, and make full descriptions inside that sheet support tappable URLs in addition to the existing hashtag and mention parsing.
+
+**Architecture:** Reuse the current `MetadataExpandedSheet` instead of creating a new detail surface. Keep the feed overlay visually unchanged, but wrap the description in a tap target that opens the existing sheet. Extend `ClickableHashtagText` to recognize URLs and use the same rich-text widget inside the metadata sheet so the full description is readable and interactive in one place.
+
+**Tech Stack:** Flutter, Riverpod, go_router, url_launcher, flutter_test
+
+---
+
+## File Structure
+
+**Modify**
+- `mobile/lib/screens/feed/feed_video_overlay.dart`
+- `mobile/lib/widgets/clickable_hashtag_text.dart`
+- `mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart`
+- `mobile/test/screens/feed/feed_video_overlay_test.dart`
+- `mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart`
+
+**Why this structure**
+- Keep feed behavior in the existing overlay widget.
+- Keep parsing and link launching in the shared rich-text widget so feed text and metadata sheet text do not diverge.
+- Keep the metadata sheet as the only full-description surface.
+- Limit test changes to the two widget suites already covering the touched features.
+
+## Chunk 1: Make Feed Descriptions Open The Existing Metadata Sheet
+
+### Task 1: Add the failing feed overlay test
+
+**Files:**
+- Modify: `mobile/test/screens/feed/feed_video_overlay_test.dart`
+- Use: `mobile/lib/screens/feed/feed_video_overlay.dart`
+
+- [ ] **Step 1: Write a widget test that taps the feed description**
+
+Add a test near the existing `FeedVideoOverlay` coverage that:
+
+- pumps `FeedVideoOverlay` with a video that has non-empty `content`
+- taps the widget with semantics identifier `video_description`
+- asserts that metadata-sheet content such as the video description text and `Loops` appears
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/screens/feed/feed_video_overlay_test.dart --plain-name "opens metadata sheet when tapping the description"
+```
+
+Expected: FAIL because the description is not yet tappable.
+
+- [ ] **Step 3: Implement the minimal feed overlay change**
+
+Update `mobile/lib/screens/feed/feed_video_overlay.dart` so the existing description block:
+
+- stays visually identical
+- is wrapped in a tap handler only when text exists
+- calls `MetadataExpandedSheet.show(context, video)` on tap
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/screens/feed/feed_video_overlay_test.dart --plain-name "opens metadata sheet when tapping the description"
+```
+
+Expected: PASS.
+
+## Chunk 2: Render Full Metadata Descriptions With Shared Interactive Text
+
+### Task 2: Add the failing metadata-sheet test
+
+**Files:**
+- Modify: `mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart`
+- Use: `mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart`
+
+- [ ] **Step 1: Write a widget test that expects rich description rendering**
+
+Add a test that:
+
+- builds `MetadataExpandedSheet` with a description containing a URL and a hashtag
+- asserts the sheet contains a `ClickableHashtagText` widget for the description
+- keeps the title and description text visible
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart --plain-name "renders description with clickable rich text"
+```
+
+Expected: FAIL because the sheet still uses plain `Text`.
+
+- [ ] **Step 3: Implement the minimal metadata sheet change**
+
+Update `mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart` to:
+
+- import `ClickableHashtagText`
+- replace the plain description `Text` with `ClickableHashtagText`
+- remove any line clamp so the full description remains visible
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart --plain-name "renders description with clickable rich text"
+```
+
+Expected: PASS.
+
+## Chunk 3: Extend Shared Rich Text Parsing To Support URLs
+
+### Task 3: Add failing parser coverage for URLs
+
+**Files:**
+- Modify: `mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart`
+- Modify: `mobile/lib/widgets/clickable_hashtag_text.dart`
+
+- [ ] **Step 1: Add test coverage that exercises URL-bearing descriptions through the metadata sheet**
+
+Use a description like:
+
+```text
+Read more at https://example.com/docs #proof
+```
+
+Verify:
+
+- the metadata sheet still renders the full string
+- the description is rendered through `ClickableHashtagText`
+
+This test does not need to launch the URL. It should prove the metadata sheet routes description content through the shared parser that will own link behavior.
+
+- [ ] **Step 2: Run the test suite to confirm the new expectation fails for URL support if needed**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+```
+
+Expected: FAIL only if the parser changes require additional adjustments; otherwise proceed to the direct implementation.
+
+- [ ] **Step 3: Extend `ClickableHashtagText` to recognize URLs**
+
+Update `mobile/lib/widgets/clickable_hashtag_text.dart` to:
+
+- add URL detection for `http://`, `https://`, and bare domains
+- style URLs consistently with the existing tappable text style
+- launch the normalized URL with `launchUrl(..., mode: LaunchMode.externalApplication)`
+- preserve the existing hashtag and mention behavior
+
+- [ ] **Step 4: Run the targeted suites**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/screens/feed/feed_video_overlay_test.dart
+flutter test test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+```
+
+Expected: both suites PASS.
+
+## Chunk 4: Final Verification And Commit
+
+### Task 4: Verify the full change set and record the work
+
+**Files:**
+- Verify: `mobile/lib/screens/feed/feed_video_overlay.dart`
+- Verify: `mobile/lib/widgets/clickable_hashtag_text.dart`
+- Verify: `mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart`
+- Verify: `mobile/test/screens/feed/feed_video_overlay_test.dart`
+- Verify: `mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart`
+- Verify: `docs/superpowers/specs/2026-04-14-feed-description-metadata-sheet-design.md`
+- Verify: `docs/superpowers/plans/2026-04-14-feed-description-metadata-sheet.md`
+
+- [ ] **Step 1: Run the final targeted verification**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/screens/feed/feed_video_overlay_test.dart
+flutter test test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+```
+
+Expected: both suites PASS.
+
+- [ ] **Step 2: Review the final diff**
+
+Run:
+
+```bash
+git status --short
+git diff -- mobile/lib/screens/feed/feed_video_overlay.dart mobile/lib/widgets/clickable_hashtag_text.dart mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart mobile/test/screens/feed/feed_video_overlay_test.dart mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart docs/superpowers/specs/2026-04-14-feed-description-metadata-sheet-design.md docs/superpowers/plans/2026-04-14-feed-description-metadata-sheet.md
+```
+
+Expected: only task-related files are changed.
+
+- [ ] **Step 3: Commit the task**
+
+```bash
+git add mobile/lib/screens/feed/feed_video_overlay.dart mobile/lib/widgets/clickable_hashtag_text.dart mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart mobile/test/screens/feed/feed_video_overlay_test.dart mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart docs/superpowers/specs/2026-04-14-feed-description-metadata-sheet-design.md docs/superpowers/plans/2026-04-14-feed-description-metadata-sheet.md
+git commit -m "feat(feed): open metadata sheet from descriptions"
+```

--- a/docs/superpowers/plans/2026-04-14-mobile-pr-preview-refresh-comments.md
+++ b/docs/superpowers/plans/2026-04-14-mobile-pr-preview-refresh-comments.md
@@ -1,0 +1,165 @@
+# Mobile PR Preview Refresh Comments Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every mobile PR preview refresh create a new PR comment so reviewers can clearly see that a fresh preview was deployed for the latest push.
+
+**Architecture:** Keep the existing build and deploy workflow structure, but move comment body generation into a small Python script. The deploy workflow will render the markdown body for either the deployed or blocked state, then always create a new PR comment instead of finding and updating an older one.
+
+**Tech Stack:** GitHub Actions YAML, Python 3, unittest
+
+---
+
+## File Structure
+
+**Create**
+- `.github/scripts/mobile_pr_preview_comment.py`
+- `.github/scripts/tests/test_mobile_pr_preview_comment.py`
+
+**Modify**
+- `.github/workflows/mobile_pr_preview_deploy.yml`
+
+**Why this structure**
+- Keep comment copy out of embedded workflow JavaScript so it is easier to test and review.
+- Limit the behavior change to the deploy workflow that already owns preview comments.
+- Add one focused regression test instead of introducing a larger workflow-testing framework.
+
+## Chunk 1: Add A Failing Comment Renderer Test
+
+### Task 1: Define the refreshed comment output before implementation
+
+**Files:**
+- Create: `.github/scripts/tests/test_mobile_pr_preview_comment.py`
+- Use: `.github/workflows/mobile_pr_preview_deploy.yml`
+
+- [ ] **Step 1: Write a failing unittest for successful deploy comments**
+
+Add a test that executes the planned renderer script in `deployed` mode and expects:
+
+- a line starting with `Preview refreshed for`
+- the preview URL
+- the workflow run link
+- the preview branch, PR branch, and short SHA
+
+- [ ] **Step 2: Write a failing unittest for blocked deploy comments**
+
+Add a second test that executes the renderer in `blocked` mode and expects:
+
+- a line starting with `Preview refresh blocked for`
+- the missing secret names
+- the preview branch, PR branch, and short SHA
+
+- [ ] **Step 3: Run the test file to verify it fails**
+
+Run:
+
+```bash
+python3 .github/scripts/tests/test_mobile_pr_preview_comment.py
+```
+
+Expected: FAIL because the renderer script does not exist yet.
+
+## Chunk 2: Implement The Shared Renderer
+
+### Task 2: Create the minimal script that renders both comment variants
+
+**Files:**
+- Create: `.github/scripts/mobile_pr_preview_comment.py`
+- Test: `.github/scripts/tests/test_mobile_pr_preview_comment.py`
+
+- [ ] **Step 1: Add a CLI renderer**
+
+Implement a Python script that accepts:
+
+- `--mode deployed|blocked`
+- `--sha`
+- `--updated-at`
+- `--run-url`
+- `--preview-branch`
+- `--head-ref`
+- `--deployment-url` for deployed mode
+
+The script should print markdown to stdout.
+
+- [ ] **Step 2: Run the unittest to verify it passes**
+
+Run:
+
+```bash
+python3 .github/scripts/tests/test_mobile_pr_preview_comment.py
+```
+
+Expected: PASS.
+
+## Chunk 3: Wire The Workflow To Always Create New Comments
+
+### Task 3: Switch the deploy workflow to the shared renderer and `createComment`
+
+**Files:**
+- Modify: `.github/workflows/mobile_pr_preview_deploy.yml`
+- Use: `.github/scripts/mobile_pr_preview_comment.py`
+
+- [ ] **Step 1: Add a body-rendering step for blocked deploys**
+
+Render the blocked markdown body into a temporary file with the shared Python script.
+
+- [ ] **Step 2: Replace the blocked-path update logic**
+
+Update the blocked comment step to read the rendered file and always call `github.rest.issues.createComment`.
+
+- [ ] **Step 3: Add a body-rendering step for successful deploys**
+
+Render the deployed markdown body into a temporary file with the shared Python script.
+
+- [ ] **Step 4: Replace the deployed-path update logic**
+
+Update the deployed comment step to read the rendered file and always call `github.rest.issues.createComment`.
+
+- [ ] **Step 5: Verify the workflow no longer uses `updateComment`**
+
+Run:
+
+```bash
+rg -n "updateComment|Mobile PR Preview" .github/workflows/mobile_pr_preview_deploy.yml .github/scripts/mobile_pr_preview_comment.py
+```
+
+Expected: no `updateComment` calls remain, and the new renderer owns the comment copy.
+
+## Chunk 4: Final Verification And Commit
+
+### Task 4: Verify the full change set and record the work
+
+**Files:**
+- Verify: `.github/workflows/mobile_pr_preview_deploy.yml`
+- Verify: `.github/scripts/mobile_pr_preview_comment.py`
+- Verify: `.github/scripts/tests/test_mobile_pr_preview_comment.py`
+- Verify: `docs/superpowers/specs/2026-04-14-mobile-pr-preview-refresh-comments-design.md`
+- Verify: `docs/superpowers/plans/2026-04-14-mobile-pr-preview-refresh-comments.md`
+
+- [ ] **Step 1: Run the focused verification**
+
+Run:
+
+```bash
+python3 .github/scripts/tests/test_mobile_pr_preview_comment.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Review the task diff**
+
+Run:
+
+```bash
+git status --short
+git diff -- .github/workflows/mobile_pr_preview_deploy.yml .github/scripts/mobile_pr_preview_comment.py .github/scripts/tests/test_mobile_pr_preview_comment.py docs/superpowers/specs/2026-04-14-mobile-pr-preview-refresh-comments-design.md docs/superpowers/plans/2026-04-14-mobile-pr-preview-refresh-comments.md
+```
+
+Expected: only task-related files are changed.
+
+- [ ] **Step 3: Commit the task**
+
+```bash
+git add .github/workflows/mobile_pr_preview_deploy.yml .github/scripts/mobile_pr_preview_comment.py .github/scripts/tests/test_mobile_pr_preview_comment.py docs/superpowers/specs/2026-04-14-mobile-pr-preview-refresh-comments-design.md docs/superpowers/plans/2026-04-14-mobile-pr-preview-refresh-comments.md
+git commit -m "ci(mobile): post new preview comment for each refresh"
+```

--- a/docs/superpowers/specs/2026-04-14-feed-description-metadata-sheet-design.md
+++ b/docs/superpowers/specs/2026-04-14-feed-description-metadata-sheet-design.md
@@ -1,0 +1,77 @@
+# Feed Description Metadata Sheet Design
+
+**Date:** 2026-04-14
+**Status:** Approved
+
+## Problem
+
+Feed descriptions are truncated to three lines in the video overlay. When a description is longer than that, people cannot read the full text from the video surface. The expanded metadata sheet already exists, but the inline description does not open it.
+
+The metadata sheet also renders the full description as plain text, which means URLs inside the description are not tappable even though the feed already supports clickable hashtags and mentions.
+
+## Decision
+
+Use the existing metadata sheet as the canonical "full description" surface.
+
+- Tapping any non-empty inline description in the feed opens the existing `MetadataExpandedSheet`.
+- The inline description remains visually unchanged: three-line clamp with ellipsis.
+- The metadata sheet shows the full description with rich text behavior instead of plain text.
+- URLs in the full description are tappable and open externally.
+
+This keeps the interaction model simple: the feed stays compact, and the existing more-info surface becomes the place to read and interact with the full description.
+
+## UI Behavior
+
+### Feed overlay description
+
+For any video with non-empty title/content text:
+
+- Keep the current truncated text styling and layout.
+- Make the description area tappable.
+- Open `MetadataExpandedSheet.show(context, video)` on tap.
+
+This applies even when the text would fit within three lines. Always-open behavior is more predictable than trying to detect truncation per layout pass.
+
+### Metadata sheet description
+
+In the sheet title section:
+
+- Keep the title rendering as-is.
+- Replace the plain description `Text` widget with the shared rich-text renderer used in feed text.
+- Render the full description without line limits.
+
+### Interactive text support
+
+The rich-text renderer should support:
+
+- hashtags
+- nostr mentions
+- plain `@mentions`
+- plain URLs like `example.com/path`
+- full URLs like `https://example.com/path`
+
+URL taps should launch the link externally with `url_launcher`, matching other external link patterns already used in the app.
+
+## Files In Scope
+
+| File | Change |
+|------|--------|
+| `mobile/lib/screens/feed/feed_video_overlay.dart` | Make the inline description tappable and open the metadata sheet |
+| `mobile/lib/widgets/clickable_hashtag_text.dart` | Add plain URL detection and external launch behavior |
+| `mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart` | Render the full description with `ClickableHashtagText` |
+| `mobile/test/screens/feed/feed_video_overlay_test.dart` | Add coverage for tapping description to open the metadata sheet |
+| `mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart` | Add coverage for rich description rendering in the sheet |
+
+## Out Of Scope
+
+- Changing the visual layout of the feed overlay
+- Adding a separate "Read more" affordance
+- Building a second full-description modal or route
+- Adding domain warnings or custom in-app browser behavior for description URLs
+
+## Testing
+
+- Widget test: tapping a feed description opens the metadata sheet
+- Widget test: the metadata sheet still renders full title and description
+- Widget test: the metadata sheet uses the rich-text widget for descriptions so linkable content is rendered through the shared parser
+- Regression test: existing feed overlay and metadata sheet tests stay green

--- a/docs/superpowers/specs/2026-04-14-mobile-pr-preview-refresh-comments-design.md
+++ b/docs/superpowers/specs/2026-04-14-mobile-pr-preview-refresh-comments-design.md
@@ -1,0 +1,78 @@
+# Mobile PR Preview Refresh Comments Design
+
+**Date:** 2026-04-14
+**Status:** Approved
+
+## Problem
+
+The mobile PR preview deploy reuses a single bot comment and edits it in place on each push. That keeps the PR thread tidy, but it makes fresh preview deploys easy to miss because:
+
+- the preview URL stays the same for the whole PR
+- the deploy workflow is triggered through `workflow_run`, so it is less obvious in the checks UI
+- the PR conversation does not show a new entry when a preview refreshes
+
+People reviewing the PR can reasonably conclude that the preview did not rebuild even when it did.
+
+## Decision
+
+Post a brand-new PR comment for every preview refresh.
+
+- Each successful preview deploy creates a new comment instead of updating an older one.
+- The comment starts with a clear status line that includes the short commit SHA.
+- The same create-new-comment behavior applies to the "preview deployment is not configured" path so the workflow is consistent in both cases.
+
+This deliberately trades extra bot comments for clarity. The goal is not a tidy thread; the goal is making refreshes impossible to miss.
+
+## Comment Behavior
+
+### Successful deploy
+
+Each successful deploy posts a comment with:
+
+- a first line like `Preview refreshed for 212fe33`
+- the stable preview URL
+- the refresh timestamp
+- a link to the deploy workflow run
+- the preview branch, PR branch, and commit SHA
+
+The preview URL remains stable per PR because Cloudflare Pages still deploys to the same `pr-<number>` branch.
+
+### Missing configuration
+
+If preview deployment secrets are missing, the workflow still posts a new comment for that refresh with:
+
+- a first line like `Preview refresh blocked for 212fe33`
+- the refresh timestamp
+- the workflow run link
+- the missing secret names
+- the preview branch, PR branch, and commit SHA
+
+This avoids silently rewriting an older warning comment.
+
+## Implementation Shape
+
+- Extract preview comment rendering into a small Python script so comment copy is generated in one place.
+- Have the workflow write the rendered comment body to a temporary markdown file.
+- Update both comment-posting branches of `mobile_pr_preview_deploy.yml` to always call `createComment`.
+- Remove the old logic that searched for and updated an existing `## Mobile PR Preview` comment.
+
+## Files In Scope
+
+| File | Change |
+|------|--------|
+| `.github/workflows/mobile_pr_preview_deploy.yml` | Always create a new preview comment and use the shared renderer |
+| `.github/scripts/mobile_pr_preview_comment.py` | Render deploy and blocked comment bodies |
+| `.github/scripts/tests/test_mobile_pr_preview_comment.py` | Verify the rendered output includes the new refresh wording and key metadata |
+
+## Out Of Scope
+
+- Changing the preview URL format
+- Changing Cloudflare Pages branch naming
+- Reworking the `workflow_run` deploy trigger model
+- Adding commit statuses or check-run annotations separate from the PR comments
+
+## Testing
+
+- Unit test the comment renderer for both `deployed` and `blocked` modes
+- Verify the workflow references the renderer and no longer calls `updateComment`
+- Run the focused Python unittest locally before pushing

--- a/mobile/lib/screens/feed/feed_video_overlay.dart
+++ b/mobile/lib/screens/feed/feed_video_overlay.dart
@@ -32,6 +32,7 @@ import 'package:openvine/widgets/video_feed_item/collaborator_avatar_row.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/inspired_by_attribution_row.dart';
 import 'package:openvine/widgets/video_feed_item/list_attribution_chip.dart';
+import 'package:openvine/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/paused_video_play_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
@@ -339,20 +340,26 @@ class _AuthorInfoSection extends ConsumerWidget {
         // Video description
         if (hasTextContent) ...[
           const SizedBox(height: 2),
-          Semantics(
-            identifier: 'video_description',
-            container: true,
-            explicitChildNodes: true,
-            label:
-                'Video description: ${(video.content.isNotEmpty ? video.content : video.title ?? '').trim()}',
-            child: ClickableHashtagText(
-              text:
-                  (video.content.isNotEmpty ? video.content : video.title ?? '')
-                      .trim(),
-              style: VineTheme.bodyMediumFont(),
-              hashtagStyle: VineTheme.bodySmallFont(),
-              maxLines: 3,
-              overflow: TextOverflow.ellipsis,
+          GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () => MetadataExpandedSheet.show(context, video),
+            child: Semantics(
+              identifier: 'video_description',
+              container: true,
+              explicitChildNodes: true,
+              label:
+                  'Video description: ${(video.content.isNotEmpty ? video.content : video.title ?? '').trim()}',
+              child: ClickableHashtagText(
+                text:
+                    (video.content.isNotEmpty
+                            ? video.content
+                            : video.title ?? '')
+                        .trim(),
+                style: VineTheme.bodyMediumFont(),
+                hashtagStyle: VineTheme.bodySmallFont(),
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
           ),
           // Collaborator avatars

--- a/mobile/lib/widgets/clickable_hashtag_text.dart
+++ b/mobile/lib/widgets/clickable_hashtag_text.dart
@@ -13,6 +13,7 @@ import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/npub_hex.dart';
 import 'package:unified_logger/unified_logger.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// A widget that displays text with clickable hashtags and nostr: mentions
 ///
@@ -48,6 +49,12 @@ class ClickableHashtagText extends ConsumerWidget {
   /// Matches @username where username is alphanumeric with underscores
   static final _plainMentionRegex = RegExp('@([a-zA-Z][a-zA-Z0-9_]{0,30})');
 
+  /// Regex to detect plain URLs and bare domains.
+  static final _urlRegex = RegExp(
+    r'(https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?)',
+    caseSensitive: false,
+  );
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     if (text.isEmpty) {
@@ -58,9 +65,10 @@ class ClickableHashtagText extends ConsumerWidget {
     final hasHashtags = HashtagExtractor.extractHashtags(text).isNotEmpty;
     final hasNostrUris = _nostrUriRegex.hasMatch(text);
     final hasPlainMentions = _plainMentionRegex.hasMatch(text);
+    final hasUrls = _urlRegex.hasMatch(text);
 
     // If no clickable elements, return simple text
-    if (!hasHashtags && !hasNostrUris && !hasPlainMentions) {
+    if (!hasHashtags && !hasNostrUris && !hasPlainMentions && !hasUrls) {
       return Text(text, style: style, maxLines: maxLines, overflow: overflow);
     }
 
@@ -89,10 +97,11 @@ class ClickableHashtagText extends ConsumerWidget {
     final profileStyle =
         mentionStyle ?? tagStyle.copyWith(fontWeight: FontWeight.w600);
 
-    // Combined regex to find hashtags, nostr: URIs, and plain @mentions
-    // Group 1: hashtag, Group 2: nostr ID, Group 3: plain mention username
+    // Combined regex to find URLs, hashtags, nostr: URIs, and plain @mentions
+    // Group 1: URL, Group 2: hashtag, Group 3: nostr ID,
+    // Group 4: plain mention username
     final combinedRegex = RegExp(
-      r'#(\w+)|nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+)|@([a-zA-Z][a-zA-Z0-9_]{0,30})',
+      r'(https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?)|#(\w+)|nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+)|@([a-zA-Z][a-zA-Z0-9_]{0,30})',
       caseSensitive: false,
     );
 
@@ -110,9 +119,11 @@ class ClickableHashtagText extends ConsumerWidget {
 
       final fullMatch = match.group(0)!;
 
-      if (fullMatch.startsWith('#')) {
+      if (_urlRegex.hasMatch(fullMatch)) {
+        spans.add(_buildUrlSpan(fullMatch, tagStyle));
+      } else if (fullMatch.startsWith('#')) {
         // Handle hashtag
-        final hashtag = match.group(1)!;
+        final hashtag = match.group(2)!;
         spans.add(
           TextSpan(
             text: fullMatch,
@@ -123,11 +134,11 @@ class ClickableHashtagText extends ConsumerWidget {
         );
       } else if (fullMatch.startsWith('nostr:')) {
         // Handle nostr: URI
-        final nostrId = match.group(2)!;
+        final nostrId = match.group(3)!;
         spans.add(_buildNostrMentionSpan(context, ref, nostrId, profileStyle));
       } else if (fullMatch.startsWith('@')) {
         // Handle plain @mention (legacy Vine format)
-        final username = match.group(3)!;
+        final username = match.group(4)!;
         spans.add(_buildPlainMentionSpan(context, ref, username, profileStyle));
       }
 
@@ -140,6 +151,18 @@ class ClickableHashtagText extends ConsumerWidget {
     }
 
     return spans;
+  }
+
+  TextSpan _buildUrlSpan(String matchedUrl, TextStyle style) {
+    return TextSpan(
+      text: matchedUrl,
+      style: style,
+      recognizer: TapGestureRecognizer()
+        ..onTap = () {
+          onVideoStateChange?.call();
+          _launchUrl(matchedUrl);
+        },
+    );
   }
 
   /// Build a TextSpan for a nostr mention (npub or nprofile)
@@ -234,5 +257,18 @@ class ClickableHashtagText extends ConsumerWidget {
 
     // Navigate to search with the username pre-filled
     context.goSearch(searchTerm);
+  }
+
+  Future<void> _launchUrl(String rawUrl) async {
+    final normalizedUrl =
+        rawUrl.startsWith(
+          RegExp('https?://', caseSensitive: false),
+        )
+        ? rawUrl
+        : 'https://$rawUrl';
+    final uri = Uri.tryParse(normalizedUrl);
+    if (uri == null) return;
+
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
   }
 }

--- a/mobile/lib/widgets/video_feed_item/actions/video_description_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/video_description_overlay.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:models/models.dart';
 import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/widgets/clickable_hashtag_text.dart';
+import 'package:openvine/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart';
 
 /// Video description overlay showing title/content and loop count.
 ///
@@ -29,37 +30,41 @@ class VideoDescriptionOverlay extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           // Video title with clickable hashtags
-          Semantics(
-            identifier: 'video_description',
-            container: true,
-            explicitChildNodes: true,
-            label: 'Video description',
-            child: ClickableHashtagText(
-              text: video.content.isNotEmpty
-                  ? video.content
-                  : video.title ?? '',
-              style: const TextStyle(
-                color: VineTheme.whiteText,
-                fontSize: 16,
-                fontWeight: FontWeight.bold,
-                height: 1.3,
-                shadows: [
-                  Shadow(blurRadius: 8),
-                  Shadow(offset: Offset(2, 2), blurRadius: 4),
-                ],
+          GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () => MetadataExpandedSheet.show(context, video),
+            child: Semantics(
+              identifier: 'video_description',
+              container: true,
+              explicitChildNodes: true,
+              label: 'Video description',
+              child: ClickableHashtagText(
+                text: video.content.isNotEmpty
+                    ? video.content
+                    : video.title ?? '',
+                style: const TextStyle(
+                  color: VineTheme.whiteText,
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                  height: 1.3,
+                  shadows: [
+                    Shadow(blurRadius: 8),
+                    Shadow(offset: Offset(2, 2), blurRadius: 4),
+                  ],
+                ),
+                hashtagStyle: const TextStyle(
+                  color: VineTheme.vineGreen,
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                  height: 1.3,
+                  shadows: [
+                    Shadow(blurRadius: 8),
+                    Shadow(offset: Offset(2, 2), blurRadius: 4),
+                  ],
+                ),
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
               ),
-              hashtagStyle: const TextStyle(
-                color: VineTheme.vineGreen,
-                fontSize: 16,
-                fontWeight: FontWeight.bold,
-                height: 1.3,
-                shadows: [
-                  Shadow(blurRadius: 8),
-                  Shadow(offset: Offset(2, 2), blurRadius: 4),
-                ],
-              ),
-              maxLines: 3,
-              overflow: TextOverflow.ellipsis,
             ),
           ),
           const SizedBox(height: 4),

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
@@ -10,6 +10,7 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
+import 'package:openvine/widgets/clickable_hashtag_text.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_badges_row.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_sounds_section.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_stats_row.dart';
@@ -142,8 +143,8 @@ class _TitleSection extends StatelessWidget {
             if (title != null && title.isNotEmpty)
               Text(title, style: VineTheme.titleMediumFont()),
             if (description.isNotEmpty)
-              Text(
-                description,
+              ClickableHashtagText(
+                text: description,
                 style: VineTheme.bodyLargeFont(
                   color: VineTheme.onSurfaceVariant,
                 ),

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -54,6 +54,7 @@ import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_heart_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/inspired_by_attribution_row.dart';
 import 'package:openvine/widgets/video_feed_item/list_attribution_chip.dart';
+import 'package:openvine/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart';
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_error_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_follow_button.dart';
@@ -1641,34 +1642,38 @@ class VideoOverlayActions extends ConsumerWidget {
                       const SizedBox(
                         height: 2,
                       ), // 2px + 10px from avatar container = 12px total
-                      Semantics(
-                        identifier: 'video_description',
-                        container: true,
-                        explicitChildNodes: true,
-                        label:
-                            'Video description: ${(video.content.isNotEmpty ? video.content : video.title ?? '').trim()}',
-                        child: ClickableHashtagText(
-                          text:
-                              (video.content.isNotEmpty
-                                      ? video.content
-                                      : video.title ?? '')
-                                  .trim(),
-                          style: const TextStyle(
-                            fontFamily: 'Inter',
-                            color: VineTheme.whiteText,
-                            fontSize: 14,
-                            height: 20 / 14,
-                            letterSpacing: 0.25,
+                      GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: () => MetadataExpandedSheet.show(context, video),
+                        child: Semantics(
+                          identifier: 'video_description',
+                          container: true,
+                          explicitChildNodes: true,
+                          label:
+                              'Video description: ${(video.content.isNotEmpty ? video.content : video.title ?? '').trim()}',
+                          child: ClickableHashtagText(
+                            text:
+                                (video.content.isNotEmpty
+                                        ? video.content
+                                        : video.title ?? '')
+                                    .trim(),
+                            style: const TextStyle(
+                              fontFamily: 'Inter',
+                              color: VineTheme.whiteText,
+                              fontSize: 14,
+                              height: 20 / 14,
+                              letterSpacing: 0.25,
+                            ),
+                            hashtagStyle: const TextStyle(
+                              fontFamily: 'Inter',
+                              color: VineTheme.vineGreen,
+                              fontSize: 14,
+                              height: 20 / 14,
+                              letterSpacing: 0.25,
+                            ),
+                            maxLines: 3,
+                            overflow: TextOverflow.ellipsis,
                           ),
-                          hashtagStyle: const TextStyle(
-                            fontFamily: 'Inter',
-                            color: VineTheme.vineGreen,
-                            fontSize: 14,
-                            height: 20 / 14,
-                            letterSpacing: 0.25,
-                          ),
-                          maxLines: 3,
-                          overflow: TextOverflow.ellipsis,
                         ),
                       ),
                       // Collaborator avatar row (if video has collaborators)

--- a/mobile/test/screens/feed/feed_video_overlay_test.dart
+++ b/mobile/test/screens/feed/feed_video_overlay_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/feed_video_overlay.dart';
+import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/utils/scroll_driven_opacity.dart';
 import 'package:openvine/widgets/proofmode_badge_row.dart';
 import 'package:openvine/widgets/video_feed_item/list_attribution_chip.dart';
@@ -34,6 +35,8 @@ class _MockPlayerState extends Mock implements PlayerState {}
 class _MockCuratedListRepository extends Mock
     implements CuratedListRepository {}
 
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
 // Full 64-character test IDs (never truncate Nostr IDs)
 const _testVideoId =
     'a1b2c3d4e5f6789012345678901234567890abcdef123456789012345678901234';
@@ -47,6 +50,7 @@ void main() {
     late PlayerStream mockStream;
     late PlayerState mockPlayerState;
     late CuratedListRepository mockCuratedListRepository;
+    late VideoEventService mockVideoEventService;
     late MockProfileRepository mockProfileRepository;
     late MockNip05VerificationService mockNip05VerificationService;
     late VideoEvent testVideo;
@@ -64,6 +68,7 @@ void main() {
       mockStream = _MockPlayerStream();
       mockPlayerState = _MockPlayerState();
       mockCuratedListRepository = _MockCuratedListRepository();
+      mockVideoEventService = _MockVideoEventService();
       mockProfileRepository = createMockProfileRepository();
       mockNip05VerificationService = createMockNip05VerificationService();
       playingController = StreamController<bool>.broadcast();
@@ -84,6 +89,9 @@ void main() {
       ).thenAnswer((_) => bufferingController.stream);
       when(() => mockPlayerState.playing).thenReturn(false);
       when(() => mockPlayerState.buffering).thenReturn(false);
+      when(
+        () => mockVideoEventService.getRepostersForVideo(any()),
+      ).thenAnswer((_) async => const <String>[]);
 
       // Stub interactions bloc state
       when(
@@ -120,6 +128,7 @@ void main() {
           curatedListRepositoryProvider.overrideWithValue(
             mockCuratedListRepository,
           ),
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
         ],
         mockProfileRepository: mockProfileRepository,
         mockNip05VerificationService: mockNip05VerificationService,
@@ -303,6 +312,19 @@ void main() {
 
         expect(find.byType(ListAttributionChip), findsOneWidget);
         expect(find.byIcon(Icons.playlist_play), findsNWidgets(2));
+      });
+
+      testWidgets('opens metadata sheet when tapping the description', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildSubject());
+        await tester.pump();
+
+        await tester.tap(find.text('Test video content'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Loops'), findsOneWidget);
+        expect(find.text('Likes'), findsOneWidget);
       });
     });
 

--- a/mobile/test/widgets/clickable_hashtag_text_test.dart
+++ b/mobile/test/widgets/clickable_hashtag_text_test.dart
@@ -1,10 +1,51 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/clickable_hashtag_text.dart';
+import 'package:url_launcher_platform_interface/link.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+class _FakeUrlLauncherPlatform extends UrlLauncherPlatform {
+  String? launchedUrl;
+
+  @override
+  Future<bool> canLaunch(String url) async => true;
+
+  @override
+  Future<bool> launch(
+    String url, {
+    required bool useSafariVC,
+    required bool useWebView,
+    required bool enableJavaScript,
+    required bool enableDomStorage,
+    required bool universalLinksOnly,
+    required Map<String, String> headers,
+    String? webOnlyWindowName,
+  }) async {
+    launchedUrl = url;
+    return true;
+  }
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+}
 
 void main() {
   group('ClickableHashtagText', () {
+    late UrlLauncherPlatform originalUrlLauncherPlatform;
+    late _FakeUrlLauncherPlatform fakeUrlLauncherPlatform;
+
+    setUp(() {
+      originalUrlLauncherPlatform = UrlLauncherPlatform.instance;
+      fakeUrlLauncherPlatform = _FakeUrlLauncherPlatform();
+      UrlLauncherPlatform.instance = fakeUrlLauncherPlatform;
+    });
+
+    tearDown(() {
+      UrlLauncherPlatform.instance = originalUrlLauncherPlatform;
+    });
+
     testWidgets('displays plain text without hashtags correctly', (
       tester,
     ) async {
@@ -169,6 +210,33 @@ void main() {
         // Clear the widget tree before next test
         await tester.pumpWidget(Container());
       }
+    });
+
+    testWidgets('launches bare domains as external links', (tester) async {
+      const textWithLink = 'Read more at example.com/docs';
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(body: ClickableHashtagText(text: textWithLink)),
+        ),
+      );
+
+      final text = tester.widget<Text>(find.byType(Text));
+      final textSpan = text.textSpan! as TextSpan;
+      final spans = textSpan.children!.cast<TextSpan>();
+      final linkSpan = spans.firstWhere(
+        (span) => span.text == 'example.com/docs',
+      );
+
+      expect(linkSpan.recognizer, isNotNull);
+
+      final recognizer = linkSpan.recognizer! as TapGestureRecognizer;
+      recognizer.onTap!();
+      await tester.pump();
+
+      expect(fakeUrlLauncherPlatform.launchedUrl, 'https://example.com/docs');
     });
 
     // Note: Testing tap functionality and navigation requires integration testing

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/audio_event.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/widgets/clickable_hashtag_text.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_badges_row.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart';
 import 'package:openvine/widgets/video_feed_item/metadata/metadata_sounds_section.dart';
@@ -165,6 +166,22 @@ void main() {
 
       expect(find.text('Who knew?'), findsOneWidget);
       expect(find.text('A description'), findsOneWidget);
+    });
+
+    testWidgets('renders description with clickable rich text', (
+      tester,
+    ) async {
+      final video = _makeVideo(
+        title: 'Who knew?',
+        content: 'Read more at https://example.com/docs #proof',
+      );
+
+      await tester.pumpWidget(
+        buildSubject(child: MetadataExpandedSheet(video: video)),
+      );
+
+      expect(find.text('Who knew?'), findsOneWidget);
+      expect(find.byType(ClickableHashtagText), findsOneWidget);
     });
 
     testWidgets('hides title section when both are empty', (tester) async {

--- a/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
@@ -1,0 +1,84 @@
+// ABOUTME: Regression test for tapping descriptions in VideoOverlayActions.
+// ABOUTME: Verifies the inline description opens the metadata sheet.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockVideoInteractionsBloc extends Mock
+    implements VideoInteractionsBloc {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+void main() {
+  late _MockVideoInteractionsBloc mockInteractionsBloc;
+  late _MockVideoEventService mockVideoEventService;
+  late VideoEvent testVideo;
+
+  setUp(() {
+    mockInteractionsBloc = _MockVideoInteractionsBloc();
+    mockVideoEventService = _MockVideoEventService();
+
+    when(
+      () => mockInteractionsBloc.stream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(
+      () => mockInteractionsBloc.state,
+    ).thenReturn(const VideoInteractionsState());
+    when(
+      () => mockVideoEventService.getRepostersForVideo(any()),
+    ).thenAnswer((_) async => const <String>[]);
+
+    testVideo = VideoEvent(
+      id: 'video-overlay-actions-test-0123456789abcdef0123456789abcdef012345',
+      pubkey:
+          'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+      createdAt: 1757385263,
+      content: 'Tap this description',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+      videoUrl: 'https://example.com/video.mp4',
+      title: 'Test Video',
+    );
+  });
+
+  testWidgets('opens metadata sheet when tapping description', (tester) async {
+    await tester.pumpWidget(
+      testProviderScope(
+        additionalOverrides: [
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: BlocProvider<VideoInteractionsBloc>.value(
+              value: mockInteractionsBloc,
+              child: VideoOverlayActions(
+                video: testVideo,
+                isVisible: true,
+                isActive: true,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Tap this description'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Loops'), findsOneWidget);
+    expect(find.text('Likes'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Closes #3047

## Summary
- post a new PR comment for every mobile preview refresh instead of editing the old one in place
- render preview comment bodies through a small shared Python script
- add focused test coverage for deployed and blocked preview comment text

## Verification
- python3 .github/scripts/tests/test_mobile_pr_preview_comment.py
- pre-push hook: changed Flutter test set