### PR TITLE
fix(divine_ui): add SliverBottomSafeArea and fix search results bottom padding

### DIFF
--- a/mobile/lib/screens/search_results/view/search_results_view.dart
+++ b/mobile/lib/screens/search_results/view/search_results_view.dart
@@ -40,19 +40,20 @@ class SearchResultsView extends StatelessWidget {
                   .read<SearchResultsFilterCubit>()
                   .filterChanged(.videos),
             ),
+            const SliverBottomSafeArea(),
           ],
         ),
         SearchResultsFilter.people => const CustomScrollView(
-          slivers: [PeopleSection(showAll: true)],
+          slivers: [PeopleSection(showAll: true), SliverBottomSafeArea()],
         ),
         SearchResultsFilter.tags => const CustomScrollView(
-          slivers: [TagsSection(showAll: true)],
+          slivers: [TagsSection(showAll: true), SliverBottomSafeArea()],
         ),
         SearchResultsFilter.lists => const CustomScrollView(
-          slivers: [ListsSection(showAll: true)],
+          slivers: [ListsSection(showAll: true), SliverBottomSafeArea()],
         ),
         SearchResultsFilter.videos => const CustomScrollView(
-          slivers: [VideosSection(showAll: true)],
+          slivers: [VideosSection(showAll: true), SliverBottomSafeArea()],
         ),
       },
     );

--- a/mobile/packages/divine_ui/lib/divine_ui.dart
+++ b/mobile/packages/divine_ui/lib/divine_ui.dart
@@ -8,6 +8,7 @@ export 'src/partial_circle_spinner.dart';
 export 'src/search_bar/search_bar.dart';
 export 'src/skeleton/vine_skeleton_effect.dart';
 export 'src/slider/slider.dart';
+export 'src/sliver_bottom_safe_area.dart';
 export 'src/sliver_pagination_trigger.dart';
 export 'src/sticker/sticker.dart';
 export 'src/text_field/text_field.dart';

--- a/mobile/packages/divine_ui/lib/src/sliver_bottom_safe_area.dart
+++ b/mobile/packages/divine_ui/lib/src/sliver_bottom_safe_area.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+/// A sliver that adds bottom padding equal to the system navigation bar
+/// height, ensuring scroll content is not obscured on devices with gesture
+/// navigation or a translucent nav bar.
+///
+/// Drop this as the **last sliver** in a [CustomScrollView]. Content still
+/// scrolls *behind* the system UI (the modern Android/iOS effect), but the
+/// final scroll position keeps everything visible above it.
+class SliverBottomSafeArea extends StatelessWidget {
+  /// Creates a [SliverBottomSafeArea].
+  const SliverBottomSafeArea({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final bottom = MediaQuery.viewPaddingOf(context).bottom;
+    return SliverToBoxAdapter(child: SizedBox(height: bottom));
+  }
+}

--- a/mobile/packages/divine_ui/test/src/sliver_bottom_safe_area_test.dart
+++ b/mobile/packages/divine_ui/test/src/sliver_bottom_safe_area_test.dart
@@ -1,0 +1,37 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(SliverBottomSafeArea, () {
+    testWidgets(
+      'renders $SizedBox with system bottom padding',
+      (tester) async {
+        await tester.pumpWidget(
+          const MediaQuery(
+            data: MediaQueryData(
+              viewPadding: EdgeInsets.only(bottom: 34),
+            ),
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: CustomScrollView(
+                slivers: [
+                  SliverToBoxAdapter(child: SizedBox(height: 100)),
+                  SliverBottomSafeArea(),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        final sizedBox = tester.widget<SizedBox>(
+          find.descendant(
+            of: find.byType(SliverBottomSafeArea),
+            matching: find.byType(SizedBox),
+          ),
+        );
+        expect(sizedBox.height, equals(34));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description

Add a reusable `SliverBottomSafeArea` widget to `divine_ui` that applies system navigation bar padding to `CustomScrollView` slivers, and use it in the search results screen to prevent content from being obscured on newer Android devices with gesture navigation.

**Related Issue:** Closes #3022

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore