### PR TITLE
fix: set light status bar icons app-wide for both iOS and Android

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1462,14 +1462,17 @@ class _DivineAppState extends ConsumerState<DivineApp> {
     // in the widget tree by MultiBlocProvider.
     Widget buildApp(Locale? locale) {
       if (!kIsWeb && io.Platform.isAndroid) {
-        return MaterialApp.router(
-          title: 'Divine',
-          debugShowCheckedModeBanner: false,
-          theme: VineTheme.theme,
-          routerConfig: router,
-          locale: locale,
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
+        return AnnotatedRegion<SystemUiOverlayStyle>(
+          value: SystemUiOverlayStyle.light,
+          child: MaterialApp.router(
+            title: 'Divine',
+            debugShowCheckedModeBanner: false,
+            theme: VineTheme.theme,
+            routerConfig: router,
+            locale: locale,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
         );
       }
       return PopScope(
@@ -1478,14 +1481,17 @@ class _DivineAppState extends ConsumerState<DivineApp> {
           if (didPop) return;
           await handleBackNavigation(router, ref);
         },
-        child: MaterialApp.router(
-          title: 'Divine',
-          debugShowCheckedModeBanner: false,
-          theme: VineTheme.theme,
-          routerConfig: router,
-          locale: locale,
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
+        child: AnnotatedRegion<SystemUiOverlayStyle>(
+          value: SystemUiOverlayStyle.light,
+          child: MaterialApp.router(
+            title: 'Divine',
+            debugShowCheckedModeBanner: false,
+            theme: VineTheme.theme,
+            routerConfig: router,
+            locale: locale,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
         ),
       );
     }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1463,7 +1463,7 @@ class _DivineAppState extends ConsumerState<DivineApp> {
     Widget buildApp(Locale? locale) {
       if (!kIsWeb && io.Platform.isAndroid) {
         return AnnotatedRegion<SystemUiOverlayStyle>(
-          value: SystemUiOverlayStyle.light,
+          value: VineTheme.statusBarStyle,
           child: MaterialApp.router(
             title: 'Divine',
             debugShowCheckedModeBanner: false,
@@ -1482,7 +1482,7 @@ class _DivineAppState extends ConsumerState<DivineApp> {
           await handleBackNavigation(router, ref);
         },
         child: AnnotatedRegion<SystemUiOverlayStyle>(
-          value: SystemUiOverlayStyle.light,
+          value: VineTheme.statusBarStyle,
           child: MaterialApp.router(
             title: 'Divine',
             debugShowCheckedModeBanner: false,

--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Matches the classic Vine app aesthetic with proper styling
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 /// Vine-inspired theme with characteristic green colors and clean design.
@@ -205,6 +206,17 @@ class VineTheme {
         letterSpacing: 0.5,
         color: color,
       );
+
+  /// Status bar style for dark backgrounds: light icons on both platforms.
+  ///
+  /// [SystemUiOverlayStyle.light] uses `statusBarBrightness: Brightness.light`
+  /// which causes **dark** icons on iOS. This constant sets the correct
+  /// brightness per platform so icons are always visible on dark backgrounds.
+  static const SystemUiOverlayStyle statusBarStyle = SystemUiOverlayStyle(
+    statusBarColor: transparent,
+    statusBarIconBrightness: Brightness.light, // Android
+    statusBarBrightness: Brightness.dark, // iOS
+  );
 
   // Classic Vine green color palette
 
@@ -487,6 +499,7 @@ class VineTheme {
       foregroundColor: whiteText,
       elevation: 1,
       centerTitle: true,
+      systemOverlayStyle: statusBarStyle,
       titleTextStyle: TextStyle(
         color: whiteText,
         fontSize: 20,


### PR DESCRIPTION
## Description

Set light status bar icons app-wide by wrapping `MaterialApp.router` in an `AnnotatedRegion` and adding `systemOverlayStyle` to the `AppBarTheme`. Adds `VineTheme.statusBarStyle` with explicit per-platform brightness so icons are visible on dark backgrounds on both iOS and Android — `SystemUiOverlayStyle.light` alone causes dark icons on iOS.

**Related Issue:** Closes #3021

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore