### PR TITLE
fix(divine_video_player): implement disposal of zombie players on hot-restart

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -425,6 +425,13 @@ Future<void> _startOpenVineApp() async {
     configureCache: DivineVideoPlayerController.configureCache,
   );
 
+  // Dispose any zombie native players from a previous Dart VM
+  // (e.g. hot restart). Must happen after configureCache so the
+  // global method channel is already registered.
+  if (!kIsWeb) {
+    await DivineVideoPlayerController.disposeAll();
+  }
+
   StartupPerformanceService.instance.completePhase('bindings');
 
   // Initialize crash reporting ASAP so we can use it for logging

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerPlugin.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerPlugin.kt
@@ -28,6 +28,11 @@ class DivineVideoPlayerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         binding = flutterPluginBinding
 
+        // Hot restart re-calls onAttachedToEngine without a preceding
+        // onDetachedFromEngine. Dispose any leftover players so zombie
+        // timers and event channels are cleaned up.
+        PlayerRegistry.disposeAll()
+
         globalChannel = MethodChannel(
             flutterPluginBinding.binaryMessenger,
             "divine_video_player",
@@ -78,6 +83,12 @@ class DivineVideoPlayerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, 
         when (call.method) {
             "create" -> {
                 val id = call.argument<Int>("id")!!
+                // Dispose any existing player with the same ID BEFORE
+                // creating the new one. The new instance registers
+                // MethodChannel/EventChannel handlers under the same
+                // channel name, so the old instance must release them
+                // first to avoid nullifying the new handlers.
+                PlayerRegistry.remove(id)?.dispose()
                 val instance = DivineVideoPlayerInstance(
                     binding.binaryMessenger,
                     binding.applicationContext,
@@ -107,6 +118,10 @@ class DivineVideoPlayerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, 
                 val maxSizeBytes = (call.argument<Number>("maxSizeBytes"))?.toLong()
                     ?: (500L * 1024 * 1024)
                 VideoCache.configure(binding.applicationContext, maxSizeBytes)
+                result.success(null)
+            }
+            "disposeAll" -> {
+                PlayerRegistry.disposeAll()
                 result.success(null)
             }
             else -> result.notImplemented()

--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerPlugin.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerPlugin.swift
@@ -80,6 +80,10 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
                 )
                 return
             }
+            // Dispose any existing player with the same ID before
+            // creating the new one to avoid leaking zombie players.
+            PlayerRegistry.shared.remove(id)?.dispose()
+
             let instance = DivineVideoPlayerInstance(
                 messenger: registrar.messenger(),
                 playerId: id

--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerPlugin.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerPlugin.swift
@@ -11,6 +11,11 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
     private static var registrar: FlutterPluginRegistrar?
 
     public static func register(with registrar: FlutterPluginRegistrar) {
+        // Hot restart re-calls register(with:) without disposing the
+        // previous engine's players. Clean up zombie players so timers
+        // and observers are released.
+        PlayerRegistry.shared.disposeAll()
+
         self.registrar = registrar
 
         let globalChannel = FlutterMethodChannel(
@@ -49,6 +54,14 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        // Methods that require no arguments are handled before the
+        // args guard to avoid returning FlutterMethodNotImplemented.
+        if call.method == "disposeAll" {
+            PlayerRegistry.shared.disposeAll()
+            result(nil)
+            return
+        }
+
         guard let args = call.arguments as? [String: Any] else {
             result(FlutterMethodNotImplemented)
             return

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -39,7 +39,14 @@ class DivineVideoPlayerController {
   final bool useTexture;
 
   static const _globalChannel = MethodChannel('divine_video_player');
-  static int _nextId = 0;
+
+  /// Seeded from the current time so that IDs are unique across hot
+  /// restarts. Without this, Dart's static reset would reuse id 0
+  /// while the native side still holds a zombie player with that ID.
+  ///
+  /// The modulo keeps the value within int32 range because platform
+  /// channels transmit integers as 32-bit on the native side.
+  static int _nextId = DateTime.now().microsecondsSinceEpoch % 1000000;
 
   /// The next player ID that will be assigned by [initialize].
   ///
@@ -54,6 +61,17 @@ class DivineVideoPlayerController {
   /// test ordering.
   @visibleForTesting
   static void resetIdCounterForTesting() => _nextId = 0;
+
+  /// Disposes all native player instances that may still be alive.
+  ///
+  /// Call at app startup to clean up zombie players from a previous
+  /// Dart VM (e.g. after hot restart). The native plugin keeps its
+  /// process-level state across hot restarts, so old ExoPlayer /
+  /// AVPlayer instances and their timers survive unless explicitly
+  /// released.
+  static Future<void> disposeAll() {
+    return _globalChannel.invokeMethod<void>('disposeAll');
+  }
 
   /// Configures the native video cache.
   ///

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerPlugin.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerPlugin.swift
@@ -80,6 +80,10 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
                 )
                 return
             }
+            // Dispose any existing player with the same ID before
+            // creating the new one to avoid leaking zombie players.
+            MacPlayerRegistry.shared.remove(id)?.dispose()
+
             let instance = DivineVideoPlayerInstance(
                 messenger: registrar.messenger,
                 playerId: id

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerPlugin.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerPlugin.swift
@@ -11,6 +11,11 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
     private static var registrar: FlutterPluginRegistrar?
 
     public static func register(with registrar: FlutterPluginRegistrar) {
+        // Hot restart re-calls register(with:) without disposing the
+        // previous engine's players. Clean up zombie players so timers
+        // and observers are released.
+        MacPlayerRegistry.shared.disposeAll()
+
         self.registrar = registrar
 
         let globalChannel = FlutterMethodChannel(
@@ -49,6 +54,14 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        // Methods that require no arguments are handled before the
+        // args guard to avoid returning FlutterMethodNotImplemented.
+        if call.method == "disposeAll" {
+            MacPlayerRegistry.shared.disposeAll()
+            result(nil)
+            return
+        }
+
         guard let args = call.arguments as? [String: Any] else {
             result(FlutterMethodNotImplemented)
             return

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -670,6 +670,22 @@ void main() {
             (globalCalls.first.arguments as Map)['clips'] as List<dynamic>;
         expect(clips, hasLength(1));
       });
+
+      test('disposeAll invokes global channel', () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('divine_video_player'),
+              (call) async {
+                globalCalls.add(call);
+                return null;
+              },
+            );
+
+        await DivineVideoPlayerController.disposeAll();
+
+        expect(globalCalls, hasLength(1));
+        expect(globalCalls.first.method, equals('disposeAll'));
+      });
     });
   });
 }


### PR DESCRIPTION
Closes #3061

## Description

Ensure that the video players dispose correctly with every hot restart to prevent zombie video players.

**Related Issue:** 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore