### PR TITLE
fix(feed): show loop counts under author on home feed overlay

### DIFF
--- a/mobile/lib/screens/feed/feed_video_overlay.dart
+++ b/mobile/lib/screens/feed/feed_video_overlay.dart
@@ -23,6 +23,7 @@ import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:openvine/utils/scroll_driven_opacity.dart';
+import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/widgets/badge_explanation_modal.dart';
 import 'package:openvine/widgets/clickable_hashtag_text.dart';
 import 'package:openvine/widgets/proofmode_badge_row.dart';
@@ -330,7 +331,10 @@ class _AuthorInfoSection extends ConsumerWidget {
                         _Nip05Badge(pubkey: video.pubkey),
                       ],
                     ),
-                    Text(video.relativeTime, style: VineTheme.labelSmallFont()),
+                    Text(
+                      '${StringUtils.formatCompactNumber(video.totalLoops)} ${video.totalLoops == 1 ? 'loop' : 'loops'}',
+                      style: VineTheme.labelSmallFont(),
+                    ),
                   ],
                 ),
               ),

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -1492,16 +1492,6 @@ class VideoOverlayActions extends ConsumerWidget {
                             profile?.bestDisplayName ??
                             video.authorName ??
                             UserProfile.generatedNameFor(video.pubkey);
-                        final archivedLoops = video.originalLoops ?? 0;
-                        final liveViews =
-                            int.tryParse(video.rawTags['views'] ?? '') ?? 0;
-                        // Always sum archived (original Vine) and live (new diVine)
-                        // loops so migrated videos show their full combined count.
-                        final loopCount = archivedLoops + liveViews;
-                        final hasLoopMetadata =
-                            video.originalLoops != null ||
-                            video.rawTags.containsKey('loops') ||
-                            video.rawTags.containsKey('views');
 
                         void navigateToProfile() {
                           Log.info(
@@ -1579,9 +1569,7 @@ class VideoOverlayActions extends ConsumerWidget {
                                       ],
                                     ),
                                     Text(
-                                      hasLoopMetadata
-                                          ? '${StringUtils.formatCompactNumber(loopCount)} loops'
-                                          : video.relativeTime,
+                                      '${StringUtils.formatCompactNumber(video.totalLoops)} ${video.totalLoops == 1 ? 'loop' : 'loops'}',
                                       style: const TextStyle(
                                         fontFamily: 'Inter',
                                         fontSize: 14,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

All feed views that display a video were showing dates (relative time) instead of loop counts. This was a user‑facing regression in video metadata presentation.

This change:

- Ensures that `FeedVideoOverlay` and `VideoOverlayActions` display the loop count (sum of archived Vine loops and live views) using the existing `totalLoops` getter.
- The `totalLoops` getter already safely returns `0` when no loop metadata is present, so no fallback to `relativeTime` is needed.

**Related Issue:** Closes #3048

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
