### PR TITLE
fix(ci): move checkout before artifact download in preview deploy

### DIFF
--- a/.github/workflows/mobile_pr_preview_deploy.yml
+++ b/.github/workflows/mobile_pr_preview_deploy.yml
@@ -24,6 +24,9 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Download preview artifact
         uses: actions/download-artifact@v5
         with:
@@ -76,10 +79,6 @@ jobs:
           echo "PR state: ${{ steps.freshness.outputs.pr_state }}"
           echo "Artifact SHA: ${{ steps.metadata.outputs.head_sha }}"
           echo "Current PR SHA: ${{ steps.freshness.outputs.current_sha }}"
-
-      - name: Check out repository
-        if: ${{ steps.freshness.outputs.deployable == 'true' }}
-        uses: actions/checkout@v4
 
       - name: Extract preview site
         if: ${{ steps.freshness.outputs.deployable == 'true' }}


### PR DESCRIPTION
Closes #3064

## Summary

- Fixes the `Deploy PR Preview To Cloudflare` workflow failing at the **Extract preview site** step with `No such file or directory`
- Root cause: `actions/checkout@v4` deletes the workspace contents (`Deleting the contents of '...'`), and it was positioned **after** the artifact download but **before** the tar extraction — wiping the downloaded `artifact/` directory
- Fix: move checkout to the first step so the artifact download writes into an already-checked-out workspace

**Failed run:** https://github.com/divinevideo/divine-mobile/actions/runs/24394799604/job/71249788947

## Test plan

- [ ] Merge and verify the next PR preview deploy succeeds (workflow_run trigger)
- [ ] Confirm the preview URL comment is posted on the PR