### PR TITLE
fix(dm): restore DMs orphaned by database path change

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -1313,6 +1313,9 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
     await db.conversationsDao.clearAll();
     await db.notificationsDao.clearAll();
     await NotificationServiceEnhanced.instance.clearAllData();
+    // Clear DM sync cursors so the next login triggers a full re-fetch
+    // from relays instead of using stale `since:` boundaries.
+    await DmSyncState(prefs).clearAll();
   };
 
   return service;

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -2673,7 +2673,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'3c3497cc89997f9995bdee112182fb36a35cc198';
+    r'56d99094bba86b89b54ababd0ab82604bc95cc4e';
 
 /// Subscription manager for centralized subscription management
 

--- a/mobile/lib/services/user_data_cleanup_service.dart
+++ b/mobile/lib/services/user_data_cleanup_service.dart
@@ -62,6 +62,8 @@ class UserDataCleanupService {
   static const List<String> identityChangePrefixes = [
     'following_list_', // follow cache per pubkey
     'relay_discovery_', // relay discovery cache per npub
+    'dm.newestSyncedAt.', // DM sync cursor per pubkey
+    'dm.oldestSyncedAt.', // DM sync cursor per pubkey
   ];
 
   /// Checks if user-specific data should be cleared for the given pubkey.

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -7,7 +7,6 @@ import 'package:drift/native.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
-import 'package:sqlite3/sqlite3.dart' as raw_sqlite;
 
 /// Open a database connection for native platforms
 /// Uses file-based SQLite through drift's native implementation
@@ -35,6 +34,9 @@ Future<String> getSharedDatabasePath() async {
   final appSupportDir = await getApplicationSupportDirectory();
   final newPath = buildSharedDatabasePath(appSupportDir.path);
 
+  // Check cache version and wipe stale database if needed.
+  applyDbCacheVersionReset(newPath);
+
   final docDir = await getApplicationDocumentsDirectory();
   final legacyPath = p.join(
     docDir.path,
@@ -47,21 +49,71 @@ Future<String> getSharedDatabasePath() async {
   return newPath;
 }
 
-/// If the new DB has at most this many conversations it is considered an
-/// artifact of the relay re-fetch (`limit: 50`) and is safe to replace
-/// with the legacy database that contains the user's real history.
+/// Bump this version to force a full database reset on next app launch.
+///
+/// All local data is re-fetchable from Nostr relays, so the database is
+/// effectively a cache. When a schema change, path migration, or data
+/// corruption requires a clean slate, increment this constant.
+///
+/// Version history:
+///   1 — initial (implicit, no version file exists yet)
+///   2 — force reset to recover from PR #2840 path-change data loss
 @visibleForTesting
-const int maxConversationsForReplacement = 5;
+const int dbCacheVersion = 2;
+
+/// File name written next to the database to track [dbCacheVersion].
+@visibleForTesting
+const String dbVersionFileName = 'divine_db.version';
+
+/// Reads the stored cache version from a file next to the database.
+/// Returns `null` when the version file does not exist (first run with
+/// this mechanism).
+@visibleForTesting
+int? readDbCacheVersion(String dbDir) {
+  final file = File(p.join(dbDir, dbVersionFileName));
+  if (!file.existsSync()) return null;
+  return int.tryParse(file.readAsStringSync().trim());
+}
+
+/// Writes [version] to the version file next to the database.
+@visibleForTesting
+void writeDbCacheVersion(String dbDir, int version) {
+  final dir = Directory(dbDir);
+  if (!dir.existsSync()) dir.createSync(recursive: true);
+  File(p.join(dbDir, dbVersionFileName)).writeAsStringSync('$version');
+}
+
+/// Deletes the database and its `-wal` / `-shm` sidecars when the stored
+/// cache version is stale. Writes the current [dbCacheVersion] afterwards.
+///
+/// On first run (no version file), writes the current version without
+/// deleting anything — existing users are not wiped by the mechanism's
+/// introduction.
+@visibleForTesting
+void applyDbCacheVersionReset(String dbPath) {
+  final dbDir = p.dirname(dbPath);
+  final stored = readDbCacheVersion(dbDir);
+
+  if (stored == null) {
+    // First run with version tracking — adopt current version, no wipe.
+    writeDbCacheVersion(dbDir, dbCacheVersion);
+    return;
+  }
+
+  if (stored < dbCacheVersion) {
+    _deleteDatabaseAndSidecars(dbPath);
+    writeDbCacheVersion(dbDir, dbCacheVersion);
+  }
+}
 
 /// One-time migration from the pre-PR #2840 Documents-directory location
 /// to the current Application Support location.
 ///
 /// Handles three cases:
-/// 1. New DB does not exist, legacy exists → rename legacy to new.
-/// 2. Both exist but new DB is near-empty (≤ [maxConversationsForReplacement]
-///    conversations) → replace new with legacy. This covers users who went
-///    through the intermediate build that created an empty DB at the new path.
-/// 3. Both exist and new DB has data → keep new, delete legacy as cleanup.
+/// 1. Legacy does not exist → no-op (fresh install or already migrated).
+/// 2. Legacy exists, new does not → rename legacy to new.
+/// 3. Both exist → the legacy DB predates the path change and contains the
+///    user's real history. Replace the new DB with the legacy one.
 ///
 /// Also migrates the SQLite `-wal` and `-shm` sidecar files if present, so
 /// any unsynced writes in the write-ahead log are preserved.
@@ -75,15 +127,9 @@ Future<void> migrateLegacyDatabase({
 
   final newFile = File(newPath);
   if (newFile.existsSync()) {
-    // Both databases exist. Check whether the new DB is near-empty
-    // (artifact of the intermediate build) or has real user data.
-    if (_isNearEmptyDatabase(newPath)) {
-      _deleteDatabaseAndSidecars(newPath);
-    } else {
-      // New DB has real data — keep it, discard orphaned legacy.
-      _deleteDatabaseAndSidecars(legacyPath);
-      return;
-    }
+    // Both databases exist. The legacy DB predates the path change and
+    // has more history — always prefer it.
+    _deleteDatabaseAndSidecars(newPath);
   }
 
   Directory(p.dirname(newPath)).createSync(recursive: true);
@@ -94,34 +140,6 @@ Future<void> migrateLegacyDatabase({
     if (legacySidecar.existsSync()) {
       legacySidecar.renameSync('$newPath$suffix');
     }
-  }
-}
-
-/// Returns `true` when the database at [dbPath] has at most
-/// [maxConversationsForReplacement] conversations, meaning it was likely
-/// created by the relay re-fetch and does not contain meaningful user data.
-///
-/// Returns `true` (treat as empty) when the conversations table does not
-/// exist or the database cannot be opened — both indicate an incomplete
-/// or corrupt database that is safe to replace.
-bool _isNearEmptyDatabase(String dbPath) {
-  try {
-    final db = raw_sqlite.sqlite3.open(dbPath);
-    try {
-      final result = db.select(
-        'SELECT COUNT(*) AS cnt FROM conversations',
-      );
-      final count = result.first['cnt'] as int;
-      return count <= maxConversationsForReplacement;
-    } on raw_sqlite.SqliteException {
-      // Table does not exist or DB is corrupt — treat as empty.
-      return true;
-    } finally {
-      db.dispose();
-    }
-  } on raw_sqlite.SqliteException {
-    // Cannot open the database — treat as empty.
-    return true;
   }
 }
 

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -7,6 +7,7 @@ import 'package:drift/native.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
+import 'package:sqlite3/sqlite3.dart' as raw_sqlite;
 
 /// Open a database connection for native platforms
 /// Uses file-based SQLite through drift's native implementation
@@ -46,12 +47,21 @@ Future<String> getSharedDatabasePath() async {
   return newPath;
 }
 
+/// If the new DB has at most this many conversations it is considered an
+/// artifact of the relay re-fetch (`limit: 50`) and is safe to replace
+/// with the legacy database that contains the user's real history.
+@visibleForTesting
+const int maxConversationsForReplacement = 5;
+
 /// One-time migration from the pre-PR #2840 Documents-directory location
 /// to the current Application Support location.
 ///
-/// No-op when:
-/// * the new location already has a database (never clobber existing data),
-/// * or the legacy file does not exist (fresh install / post-migration run).
+/// Handles three cases:
+/// 1. New DB does not exist, legacy exists → rename legacy to new.
+/// 2. Both exist but new DB is near-empty (≤ [maxConversationsForReplacement]
+///    conversations) → replace new with legacy. This covers users who went
+///    through the intermediate build that created an empty DB at the new path.
+/// 3. Both exist and new DB has data → keep new, delete legacy as cleanup.
 ///
 /// Also migrates the SQLite `-wal` and `-shm` sidecar files if present, so
 /// any unsynced writes in the write-ahead log are preserved.
@@ -60,14 +70,20 @@ Future<void> migrateLegacyDatabase({
   required String legacyPath,
   required String newPath,
 }) async {
+  final legacyFile = File(legacyPath);
+  if (!legacyFile.existsSync()) return;
+
   final newFile = File(newPath);
   if (newFile.existsSync()) {
-    return;
-  }
-
-  final legacyFile = File(legacyPath);
-  if (!legacyFile.existsSync()) {
-    return;
+    // Both databases exist. Check whether the new DB is near-empty
+    // (artifact of the intermediate build) or has real user data.
+    if (_isNearEmptyDatabase(newPath)) {
+      _deleteDatabaseAndSidecars(newPath);
+    } else {
+      // New DB has real data — keep it, discard orphaned legacy.
+      _deleteDatabaseAndSidecars(legacyPath);
+      return;
+    }
   }
 
   Directory(p.dirname(newPath)).createSync(recursive: true);
@@ -78,6 +94,42 @@ Future<void> migrateLegacyDatabase({
     if (legacySidecar.existsSync()) {
       legacySidecar.renameSync('$newPath$suffix');
     }
+  }
+}
+
+/// Returns `true` when the database at [dbPath] has at most
+/// [maxConversationsForReplacement] conversations, meaning it was likely
+/// created by the relay re-fetch and does not contain meaningful user data.
+///
+/// Returns `true` (treat as empty) when the conversations table does not
+/// exist or the database cannot be opened — both indicate an incomplete
+/// or corrupt database that is safe to replace.
+bool _isNearEmptyDatabase(String dbPath) {
+  try {
+    final db = raw_sqlite.sqlite3.open(dbPath);
+    try {
+      final result = db.select(
+        'SELECT COUNT(*) AS cnt FROM conversations',
+      );
+      final count = result.first['cnt'] as int;
+      return count <= maxConversationsForReplacement;
+    } on raw_sqlite.SqliteException {
+      // Table does not exist or DB is corrupt — treat as empty.
+      return true;
+    } finally {
+      db.dispose();
+    }
+  } on raw_sqlite.SqliteException {
+    // Cannot open the database — treat as empty.
+    return true;
+  }
+}
+
+/// Deletes a database file and its `-wal` / `-shm` sidecars.
+void _deleteDatabaseAndSidecars(String dbPath) {
+  for (final suffix in const ['', '-wal', '-shm']) {
+    final file = File('$dbPath$suffix');
+    if (file.existsSync()) file.deleteSync();
   }
 }
 

--- a/mobile/packages/db_client/pubspec.yaml
+++ b/mobile/packages/db_client/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
     path: ../nostr_sdk
   path: ^1.9.1
   path_provider: ^2.1.5
-  sqlite3: ^2.7.6
 
 dev_dependencies:
   build_runner: ^2.7.1
@@ -28,4 +27,5 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4
+  sqlite3: ^2.7.6
   very_good_analysis: ^10.2.0

--- a/mobile/packages/db_client/pubspec.yaml
+++ b/mobile/packages/db_client/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
     path: ../nostr_sdk
   path: ^1.9.1
   path_provider: ^2.1.5
+  sqlite3: ^2.7.6
 
 dev_dependencies:
   build_runner: ^2.7.1
@@ -27,5 +28,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4
-  sqlite3: ^2.7.6
-  very_good_analysis: ^10.0.0
+  very_good_analysis: ^10.2.0

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:db_client/src/database/connection/connection_native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
+import 'package:sqlite3/sqlite3.dart' as raw_sqlite;
 
 void main() {
   group('prepareDatabaseFile', () {
@@ -102,22 +103,126 @@ void main() {
       expect(File(newPath).existsSync(), isTrue);
     });
 
-    test('never clobbers an existing database at the new location', () async {
-      final legacyFile = File(legacyPath);
-      legacyFile.parent.createSync(recursive: true);
-      legacyFile.writeAsBytesSync(const [1, 2, 3]);
+    test(
+      'replaces near-empty new DB with legacy when both exist',
+      () async {
+        // Legacy DB with conversations (the user's real data).
+        final legacyDb = _createDatabaseWithConversations(legacyPath, 20);
+        legacyDb.dispose();
 
-      final newFile = File(newPath);
-      newFile.parent.createSync(recursive: true);
-      newFile.writeAsBytesSync(const [9, 9, 9]);
+        // New DB with 0 conversations (artifact of relay re-fetch).
+        final newDb = _createDatabaseWithConversations(newPath, 0);
+        newDb.dispose();
 
-      await migrateLegacyDatabase(legacyPath: legacyPath, newPath: newPath);
+        await migrateLegacyDatabase(
+          legacyPath: legacyPath,
+          newPath: newPath,
+        );
 
-      // New location untouched, legacy left in place.
-      expect(newFile.readAsBytesSync(), equals(const [9, 9, 9]));
-      expect(legacyFile.existsSync(), isTrue);
-      expect(legacyFile.readAsBytesSync(), equals(const [1, 2, 3]));
-    });
+        // Legacy replaced the new DB.
+        expect(File(legacyPath).existsSync(), isFalse);
+        final resultDb = raw_sqlite.sqlite3.open(newPath);
+        final count =
+            resultDb
+                    .select(
+                      'SELECT COUNT(*) AS cnt FROM conversations',
+                    )
+                    .first['cnt']
+                as int;
+        resultDb.dispose();
+        expect(count, equals(20));
+      },
+    );
+
+    test(
+      'keeps new DB and deletes legacy when new has data above threshold',
+      () async {
+        final legacyDb = _createDatabaseWithConversations(legacyPath, 50);
+        legacyDb.dispose();
+
+        // New DB with conversations above threshold — real user data.
+        final newDb = _createDatabaseWithConversations(
+          newPath,
+          maxConversationsForReplacement + 1,
+        );
+        newDb.dispose();
+
+        await migrateLegacyDatabase(
+          legacyPath: legacyPath,
+          newPath: newPath,
+        );
+
+        // New DB kept, legacy cleaned up.
+        expect(File(newPath).existsSync(), isTrue);
+        expect(File(legacyPath).existsSync(), isFalse);
+        final resultDb = raw_sqlite.sqlite3.open(newPath);
+        final count =
+            resultDb
+                    .select(
+                      'SELECT COUNT(*) AS cnt FROM conversations',
+                    )
+                    .first['cnt']
+                as int;
+        resultDb.dispose();
+        expect(count, equals(maxConversationsForReplacement + 1));
+      },
+    );
+
+    test(
+      'treats new DB without conversations table as empty and replaces it',
+      () async {
+        final legacyDb = _createDatabaseWithConversations(legacyPath, 10);
+        legacyDb.dispose();
+
+        // New DB exists but has no conversations table (incomplete init).
+        final newFile = File(newPath);
+        newFile.parent.createSync(recursive: true);
+        final newDb = raw_sqlite.sqlite3.open(newPath);
+        newDb.execute('CREATE TABLE other_table (id TEXT PRIMARY KEY)');
+        newDb.dispose();
+
+        await migrateLegacyDatabase(
+          legacyPath: legacyPath,
+          newPath: newPath,
+        );
+
+        expect(File(legacyPath).existsSync(), isFalse);
+        final resultDb = raw_sqlite.sqlite3.open(newPath);
+        final count =
+            resultDb
+                    .select(
+                      'SELECT COUNT(*) AS cnt FROM conversations',
+                    )
+                    .first['cnt']
+                as int;
+        resultDb.dispose();
+        expect(count, equals(10));
+      },
+    );
+
+    test(
+      'cleans up sidecars of the replaced new DB before renaming legacy',
+      () async {
+        final legacyDb = _createDatabaseWithConversations(legacyPath, 15);
+        legacyDb.dispose();
+
+        final newDb = _createDatabaseWithConversations(newPath, 0);
+        newDb.dispose();
+        // Simulate stale sidecars on the new DB.
+        File('$newPath-wal').writeAsBytesSync(const [1]);
+        File('$newPath-shm').writeAsBytesSync(const [2]);
+
+        await migrateLegacyDatabase(
+          legacyPath: legacyPath,
+          newPath: newPath,
+        );
+
+        expect(File(newPath).existsSync(), isTrue);
+        // Stale sidecars from the replaced new DB should be gone.
+        // (Legacy sidecars are migrated by the existing logic if present.)
+        expect(File(legacyPath).existsSync(), isFalse);
+      },
+    );
 
     test('no-op when no legacy database exists (fresh install)', () async {
       expect(File(legacyPath).existsSync(), isFalse);
@@ -157,4 +262,34 @@ void main() {
       expect(File('$newPath-shm').existsSync(), isFalse);
     });
   });
+}
+
+/// Creates a real SQLite database at [path] with a conversations table
+/// containing [count] rows. Returns the open database handle so the
+/// caller can dispose it after setup.
+raw_sqlite.Database _createDatabaseWithConversations(String path, int count) {
+  File(path).parent.createSync(recursive: true);
+  final db = raw_sqlite.sqlite3.open(path);
+  db.execute('''
+    CREATE TABLE conversations (
+      id TEXT PRIMARY KEY,
+      participant_pubkeys TEXT NOT NULL DEFAULT '[]',
+      is_group INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL DEFAULT 0,
+      last_message_content TEXT,
+      last_message_timestamp INTEGER,
+      last_message_sender_pubkey TEXT,
+      subject TEXT,
+      is_read INTEGER NOT NULL DEFAULT 1,
+      current_user_has_sent INTEGER NOT NULL DEFAULT 0,
+      owner_pubkey TEXT,
+      dm_protocol TEXT
+    )
+  ''');
+  for (var i = 0; i < count; i++) {
+    db.execute(
+      "INSERT INTO conversations (id, created_at) VALUES ('conv_$i', $i)",
+    );
+  }
+  return db;
 }

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -107,12 +107,10 @@ void main() {
       'replaces near-empty new DB with legacy when both exist',
       () async {
         // Legacy DB with conversations (the user's real data).
-        final legacyDb = _createDatabaseWithConversations(legacyPath, 20);
-        legacyDb.dispose();
+        _createDatabaseWithConversations(legacyPath, 20).dispose();
 
         // New DB with 0 conversations (artifact of relay re-fetch).
-        final newDb = _createDatabaseWithConversations(newPath, 0);
-        newDb.dispose();
+        _createDatabaseWithConversations(newPath, 0).dispose();
 
         await migrateLegacyDatabase(
           legacyPath: legacyPath,
@@ -137,15 +135,13 @@ void main() {
     test(
       'keeps new DB and deletes legacy when new has data above threshold',
       () async {
-        final legacyDb = _createDatabaseWithConversations(legacyPath, 50);
-        legacyDb.dispose();
+        _createDatabaseWithConversations(legacyPath, 50).dispose();
 
         // New DB with conversations above threshold — real user data.
-        final newDb = _createDatabaseWithConversations(
+        _createDatabaseWithConversations(
           newPath,
           maxConversationsForReplacement + 1,
-        );
-        newDb.dispose();
+        ).dispose();
 
         await migrateLegacyDatabase(
           legacyPath: legacyPath,
@@ -171,15 +167,14 @@ void main() {
     test(
       'treats new DB without conversations table as empty and replaces it',
       () async {
-        final legacyDb = _createDatabaseWithConversations(legacyPath, 10);
-        legacyDb.dispose();
+        _createDatabaseWithConversations(legacyPath, 10).dispose();
 
         // New DB exists but has no conversations table (incomplete init).
         final newFile = File(newPath);
         newFile.parent.createSync(recursive: true);
-        final newDb = raw_sqlite.sqlite3.open(newPath);
-        newDb.execute('CREATE TABLE other_table (id TEXT PRIMARY KEY)');
-        newDb.dispose();
+        raw_sqlite.sqlite3.open(newPath)
+          ..execute('CREATE TABLE other_table (id TEXT PRIMARY KEY)')
+          ..dispose();
 
         await migrateLegacyDatabase(
           legacyPath: legacyPath,
@@ -203,11 +198,9 @@ void main() {
     test(
       'cleans up sidecars of the replaced new DB before renaming legacy',
       () async {
-        final legacyDb = _createDatabaseWithConversations(legacyPath, 15);
-        legacyDb.dispose();
+        _createDatabaseWithConversations(legacyPath, 15).dispose();
 
-        final newDb = _createDatabaseWithConversations(newPath, 0);
-        newDb.dispose();
+        _createDatabaseWithConversations(newPath, 0).dispose();
         // Simulate stale sidecars on the new DB.
         File('$newPath-wal').writeAsBytesSync(const [1]);
         File('$newPath-shm').writeAsBytesSync(const [2]);
@@ -269,8 +262,8 @@ void main() {
 /// caller can dispose it after setup.
 raw_sqlite.Database _createDatabaseWithConversations(String path, int count) {
   File(path).parent.createSync(recursive: true);
-  final db = raw_sqlite.sqlite3.open(path);
-  db.execute('''
+  final db = raw_sqlite.sqlite3.open(path)
+    ..execute('''
     CREATE TABLE conversations (
       id TEXT PRIMARY KEY,
       participant_pubkeys TEXT NOT NULL DEFAULT '[]',

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:db_client/src/database/connection/connection_native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
-import 'package:sqlite3/sqlite3.dart' as raw_sqlite;
 
 void main() {
   group('prepareDatabaseFile', () {
@@ -44,6 +43,110 @@ void main() {
         path,
         equals('/tmp/app-support/openvine/database/divine_db.db'),
       );
+    });
+  });
+
+  group('applyDbCacheVersionReset', () {
+    late Directory tempRoot;
+    late String dbPath;
+    late String dbDir;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_cache_version_test_',
+      );
+      dbDir = p.join(tempRoot.path, 'openvine', 'database');
+      dbPath = p.join(dbDir, 'divine_db.db');
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) {
+        tempRoot.deleteSync(recursive: true);
+      }
+    });
+
+    test('writes current version on first run without deleting DB', () {
+      Directory(dbDir).createSync(recursive: true);
+      File(dbPath).writeAsBytesSync(const [1, 2, 3]);
+
+      applyDbCacheVersionReset(dbPath);
+
+      expect(File(dbPath).existsSync(), isTrue);
+      expect(
+        File(dbPath).readAsBytesSync(),
+        equals(const [1, 2, 3]),
+      );
+      expect(readDbCacheVersion(dbDir), equals(dbCacheVersion));
+    });
+
+    test('deletes DB and sidecars when stored version is stale', () {
+      Directory(dbDir).createSync(recursive: true);
+      File(dbPath).writeAsBytesSync(const [1]);
+      File('$dbPath-wal').writeAsBytesSync(const [2]);
+      File('$dbPath-shm').writeAsBytesSync(const [3]);
+      writeDbCacheVersion(dbDir, 1);
+
+      applyDbCacheVersionReset(dbPath);
+
+      expect(File(dbPath).existsSync(), isFalse);
+      expect(File('$dbPath-wal').existsSync(), isFalse);
+      expect(File('$dbPath-shm').existsSync(), isFalse);
+      expect(readDbCacheVersion(dbDir), equals(dbCacheVersion));
+    });
+
+    test('no-op when stored version matches current', () {
+      Directory(dbDir).createSync(recursive: true);
+      File(dbPath).writeAsBytesSync(const [9, 9]);
+      writeDbCacheVersion(dbDir, dbCacheVersion);
+
+      applyDbCacheVersionReset(dbPath);
+
+      expect(File(dbPath).existsSync(), isTrue);
+      expect(
+        File(dbPath).readAsBytesSync(),
+        equals(const [9, 9]),
+      );
+    });
+
+    test('no-op when DB does not exist and no version file', () {
+      applyDbCacheVersionReset(dbPath);
+
+      expect(readDbCacheVersion(dbDir), equals(dbCacheVersion));
+    });
+  });
+
+  group('readDbCacheVersion / writeDbCacheVersion', () {
+    late Directory tempRoot;
+    late String dbDir;
+
+    setUp(() {
+      tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_version_rw_test_',
+      );
+      dbDir = p.join(tempRoot.path, 'openvine', 'database');
+    });
+
+    tearDown(() {
+      if (tempRoot.existsSync()) {
+        tempRoot.deleteSync(recursive: true);
+      }
+    });
+
+    test('returns null when version file does not exist', () {
+      expect(readDbCacheVersion(dbDir), isNull);
+    });
+
+    test('round-trips a version number', () {
+      writeDbCacheVersion(dbDir, 42);
+
+      expect(readDbCacheVersion(dbDir), equals(42));
+    });
+
+    test('returns null for corrupt version file content', () {
+      Directory(dbDir).createSync(recursive: true);
+      File(p.join(dbDir, dbVersionFileName)).writeAsStringSync('not-a-number');
+
+      expect(readDbCacheVersion(dbDir), isNull);
     });
   });
 
@@ -104,106 +207,39 @@ void main() {
     });
 
     test(
-      'replaces near-empty new DB with legacy when both exist',
+      'replaces new DB with legacy when both exist',
       () async {
-        // Legacy DB with conversations (the user's real data).
-        _createDatabaseWithConversations(legacyPath, 20).dispose();
+        final legacyFile = File(legacyPath);
+        legacyFile.parent.createSync(recursive: true);
+        legacyFile.writeAsBytesSync(const [1, 2, 3]);
 
-        // New DB with 0 conversations (artifact of relay re-fetch).
-        _createDatabaseWithConversations(newPath, 0).dispose();
-
-        await migrateLegacyDatabase(
-          legacyPath: legacyPath,
-          newPath: newPath,
-        );
-
-        // Legacy replaced the new DB.
-        expect(File(legacyPath).existsSync(), isFalse);
-        final resultDb = raw_sqlite.sqlite3.open(newPath);
-        final count =
-            resultDb
-                    .select(
-                      'SELECT COUNT(*) AS cnt FROM conversations',
-                    )
-                    .first['cnt']
-                as int;
-        resultDb.dispose();
-        expect(count, equals(20));
-      },
-    );
-
-    test(
-      'keeps new DB and deletes legacy when new has data above threshold',
-      () async {
-        _createDatabaseWithConversations(legacyPath, 50).dispose();
-
-        // New DB with conversations above threshold — real user data.
-        _createDatabaseWithConversations(
-          newPath,
-          maxConversationsForReplacement + 1,
-        ).dispose();
-
-        await migrateLegacyDatabase(
-          legacyPath: legacyPath,
-          newPath: newPath,
-        );
-
-        // New DB kept, legacy cleaned up.
-        expect(File(newPath).existsSync(), isTrue);
-        expect(File(legacyPath).existsSync(), isFalse);
-        final resultDb = raw_sqlite.sqlite3.open(newPath);
-        final count =
-            resultDb
-                    .select(
-                      'SELECT COUNT(*) AS cnt FROM conversations',
-                    )
-                    .first['cnt']
-                as int;
-        resultDb.dispose();
-        expect(count, equals(maxConversationsForReplacement + 1));
-      },
-    );
-
-    test(
-      'treats new DB without conversations table as empty and replaces it',
-      () async {
-        _createDatabaseWithConversations(legacyPath, 10).dispose();
-
-        // New DB exists but has no conversations table (incomplete init).
         final newFile = File(newPath);
         newFile.parent.createSync(recursive: true);
-        raw_sqlite.sqlite3.open(newPath)
-          ..execute('CREATE TABLE other_table (id TEXT PRIMARY KEY)')
-          ..dispose();
+        newFile.writeAsBytesSync(const [9, 9, 9]);
 
         await migrateLegacyDatabase(
           legacyPath: legacyPath,
           newPath: newPath,
         );
 
+        // Legacy always wins — it predates the path change.
         expect(File(legacyPath).existsSync(), isFalse);
-        final resultDb = raw_sqlite.sqlite3.open(newPath);
-        final count =
-            resultDb
-                    .select(
-                      'SELECT COUNT(*) AS cnt FROM conversations',
-                    )
-                    .first['cnt']
-                as int;
-        resultDb.dispose();
-        expect(count, equals(10));
+        expect(File(newPath).readAsBytesSync(), equals(const [1, 2, 3]));
       },
     );
 
     test(
-      'cleans up sidecars of the replaced new DB before renaming legacy',
+      'cleans up new DB sidecars before replacing with legacy',
       () async {
-        _createDatabaseWithConversations(legacyPath, 15).dispose();
+        final legacyFile = File(legacyPath);
+        legacyFile.parent.createSync(recursive: true);
+        legacyFile.writeAsBytesSync(const [1]);
 
-        _createDatabaseWithConversations(newPath, 0).dispose();
-        // Simulate stale sidecars on the new DB.
-        File('$newPath-wal').writeAsBytesSync(const [1]);
-        File('$newPath-shm').writeAsBytesSync(const [2]);
+        final newFile = File(newPath);
+        newFile.parent.createSync(recursive: true);
+        newFile.writeAsBytesSync(const [9]);
+        File('$newPath-wal').writeAsBytesSync(const [2]);
+        File('$newPath-shm').writeAsBytesSync(const [3]);
 
         await migrateLegacyDatabase(
           legacyPath: legacyPath,
@@ -211,9 +247,9 @@ void main() {
         );
 
         expect(File(newPath).existsSync(), isTrue);
-        // Stale sidecars from the replaced new DB should be gone.
-        // (Legacy sidecars are migrated by the existing logic if present.)
-        expect(File(legacyPath).existsSync(), isFalse);
+        expect(File(newPath).readAsBytesSync(), equals(const [1]));
+        expect(File('$newPath-wal').existsSync(), isFalse);
+        expect(File('$newPath-shm').existsSync(), isFalse);
       },
     );
 
@@ -255,34 +291,4 @@ void main() {
       expect(File('$newPath-shm').existsSync(), isFalse);
     });
   });
-}
-
-/// Creates a real SQLite database at [path] with a conversations table
-/// containing [count] rows. Returns the open database handle so the
-/// caller can dispose it after setup.
-raw_sqlite.Database _createDatabaseWithConversations(String path, int count) {
-  File(path).parent.createSync(recursive: true);
-  final db = raw_sqlite.sqlite3.open(path)
-    ..execute('''
-    CREATE TABLE conversations (
-      id TEXT PRIMARY KEY,
-      participant_pubkeys TEXT NOT NULL DEFAULT '[]',
-      is_group INTEGER NOT NULL DEFAULT 0,
-      created_at INTEGER NOT NULL DEFAULT 0,
-      last_message_content TEXT,
-      last_message_timestamp INTEGER,
-      last_message_sender_pubkey TEXT,
-      subject TEXT,
-      is_read INTEGER NOT NULL DEFAULT 1,
-      current_user_has_sent INTEGER NOT NULL DEFAULT 0,
-      owner_pubkey TEXT,
-      dm_protocol TEXT
-    )
-  ''');
-  for (var i = 0; i < count; i++) {
-    db.execute(
-      "INSERT INTO conversations (id, created_at) VALUES ('conv_$i', $i)",
-    );
-  }
-  return db;
 }

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -51,4 +51,21 @@ class DmSyncState {
     await _prefs.remove('$_newestPrefix$pubkey');
     await _prefs.remove('$_oldestPrefix$pubkey');
   }
+
+  /// Removes all DM sync state entries for every pubkey.
+  ///
+  /// Called during database cleanup to ensure the next login triggers a
+  /// full re-sync from relays instead of using stale `since:` cursors.
+  Future<void> clearAll() async {
+    final keysToRemove = _prefs
+        .getKeys()
+        .where(
+          (key) =>
+              key.startsWith(_newestPrefix) || key.startsWith(_oldestPrefix),
+        )
+        .toList();
+    for (final key in keysToRemove) {
+      await _prefs.remove(key);
+    }
+  }
 }

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -60,6 +60,13 @@ class _FakeDmSyncState implements DmSyncState {
     newestOverride = null;
     oldestOverride = null;
   }
+
+  @override
+  Future<void> clearAll() async {
+    newestOverride = null;
+    oldestOverride = null;
+    recorded.clear();
+  }
 }
 
 // Valid 64-character hex pubkeys for testing

--- a/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
@@ -96,5 +96,24 @@ void main() {
         expect(state.oldestSyncedAt(pkB), equals(3000));
       },
     );
+
+    test(
+      'clearAll removes sync state for every pubkey and leaves '
+      'non-dm keys intact',
+      () async {
+        await state.recordSeen(pkA, createdAt: 1000);
+        await state.recordSeen(pkA, createdAt: 2000);
+        await state.recordSeen(pkB, createdAt: 3000);
+        await prefs.setString('unrelated_key', 'keep_me');
+
+        await state.clearAll();
+
+        expect(state.newestSyncedAt(pkA), isNull);
+        expect(state.oldestSyncedAt(pkA), isNull);
+        expect(state.newestSyncedAt(pkB), isNull);
+        expect(state.oldestSyncedAt(pkB), isNull);
+        expect(prefs.getString('unrelated_key'), equals('keep_me'));
+      },
+    );
   });
 }

--- a/mobile/test/services/user_data_cleanup_service_test.dart
+++ b/mobile/test/services/user_data_cleanup_service_test.dart
@@ -278,6 +278,8 @@ void main() {
 
         expect(prefixes, contains('following_list_'));
         expect(prefixes, contains('relay_discovery_'));
+        expect(prefixes, contains('dm.newestSyncedAt.'));
+        expect(prefixes, contains('dm.oldestSyncedAt.'));
       });
 
       test('does NOT contain non-dynamic prefixes', () {
@@ -287,6 +289,41 @@ void main() {
         expect(prefixes, isNot(contains('curated_lists')));
         expect(prefixes, isNot(contains('seen_video_ids')));
       });
+    });
+
+    group('DM sync state cleanup', () {
+      test(
+        'clears dm sync cursor keys on identity change',
+        () async {
+          await prefs.setInt('dm.newestSyncedAt.pubkeyA', 1000);
+          await prefs.setInt('dm.oldestSyncedAt.pubkeyA', 500);
+          await prefs.setInt('dm.newestSyncedAt.pubkeyB', 2000);
+          await prefs.setInt('dm.oldestSyncedAt.pubkeyB', 1500);
+
+          await service.clearUserSpecificData(
+            reason: 'identity_change',
+            isIdentityChange: true,
+          );
+
+          expect(prefs.containsKey('dm.newestSyncedAt.pubkeyA'), isFalse);
+          expect(prefs.containsKey('dm.oldestSyncedAt.pubkeyA'), isFalse);
+          expect(prefs.containsKey('dm.newestSyncedAt.pubkeyB'), isFalse);
+          expect(prefs.containsKey('dm.oldestSyncedAt.pubkeyB'), isFalse);
+        },
+      );
+
+      test(
+        'preserves dm sync cursor keys on non-identity-change cleanup',
+        () async {
+          await prefs.setInt('dm.newestSyncedAt.pubkeyA', 1000);
+          await prefs.setInt('dm.oldestSyncedAt.pubkeyA', 500);
+
+          await service.clearUserSpecificData(reason: 'explicit_logout');
+
+          expect(prefs.containsKey('dm.newestSyncedAt.pubkeyA'), isTrue);
+          expect(prefs.containsKey('dm.oldestSyncedAt.pubkeyA'), isTrue);
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
Closes #2834

PR #2840 moved the SQLite database from `getApplicationDocumentsDirectory()` to `getApplicationSupportDirectory()` without a data migration. Users who updated via TestFlight got a fresh empty DB at the new path while their real DMs stayed at the old path. The migration added in PR #2887 skips the move when the new DB already exists, leaving intermediate-build users stuck with missing DMs.

### Root Cause
- **Primary**: DB path change in #2840 orphaned all local data (DMs, conversations, notifications, etc.)
- **Secondary**: `DmSyncState` SharedPreferences keys were never cleared alongside DB table wipes, so stale sync cursors prevented a full relay re-fetch after data loss

### Changes

1. **`dbCacheVersion` reset mechanism** — A file-based cache version constant (`divine_db.version`) next to the database. Bumping `dbCacheVersion` forces a full DB reset on next app launch. Since all local data is re-fetchable from Nostr relays, the database is effectively a cache. This gives us a deterministic, general-purpose reset lever for future schema changes, path migrations, or data corruption — no heuristics tied to user data.

2. **Simplified `migrateLegacyDatabase()`** — When both old-path and new-path databases exist, always prefer the legacy (old-path) DB. It predates the path change and has more history by definition. Removed the conversation-count heuristic and the `sqlite3` runtime dependency.

3. **Added `DmSyncState.clearAll()`** — Wired into `onDatabaseCleanup` callback so stale sync cursors are cleared alongside table wipes, forcing a full `limit: 50` relay re-fetch on next login.

4. **Added DM sync cursor prefixes to `identityChangePrefixes`** — Identity-change cleanup now also clears `dm.newestSyncedAt.*` and `dm.oldestSyncedAt.*` keys.

### Risk Assessment

| Risk | Likelihood | Mitigation |
|------|-----------|-----------|
| Future version bump wipes all users' local data | By design — Nostr data is re-fetchable from relays | Version history is documented in the constant's docstring. Local-only data (drafts, pending uploads) is lost on reset — acceptable trade-off for a clean-slate recovery |
| First deployment doesn't fix "both DBs" users | Low — the "prefer legacy when both exist" rule handles this regardless of version state | Tested with both-DBs scenario in `connection_native_test.dart` |
| Version file deleted by user/OS cleanup | Low | Falls back to "no version = treat as current" — writes the current version without wiping, so the mechanism re-initializes safely |

## Steps to Reproduce (original bug)
1. Install a build from before PR #2840 (database at Documents path)
2. Seed DM conversations
3. Update to a build containing #2840 but before #2887 (database path changes to Application Support, no migration)
4. Open app → all prior DMs are missing
5. Update to a build with #2887 → DMs still missing (migration is a no-op because new DB already exists)

## Test Plan
- [x] `connection_native_test.dart`: 16 tests covering `applyDbCacheVersionReset` (first run, stale version, current version, missing DB), `readDbCacheVersion`/`writeDbCacheVersion` (round-trip, missing file, corrupt file), and `migrateLegacyDatabase` (move, both-exist replacement, sidecar cleanup, fresh install, sidecar migration)
- [x] `dm_sync_state_test.dart`: `clearAll()` removes all sync cursor keys while preserving unrelated keys
- [x] `dm_repository_test.dart`: `_FakeDmSyncState.clearAll()` implemented for test coverage
- [x] `user_data_cleanup_service_test.dart`: DM sync cursor prefixes present in `identityChangePrefixes`, cleared on identity change, preserved on non-identity cleanup