### PR TITLE
perf(feed): increase page size and preload window to reduce loading interruptions

### DIFF
--- a/mobile/lib/constants/app_constants.dart
+++ b/mobile/lib/constants/app_constants.dart
@@ -96,7 +96,7 @@ class AppConstants {
   static const int preloadBefore = 2;
 
   /// Number of videos to preload after current position
-  static const int preloadAfter = 3;
+  static const int preloadAfter = 5;
 
   /// Maximum videos to prefetch from grid views (approx 3x3 visible area)
   static const int gridPrefetchLimit = 9;

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -466,6 +466,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                       videos: pooledVideos,
                       maxLoopDuration: VideoEditorConstants.maxDuration,
                       controller: controller,
+                      nearEndThreshold: 5,
                       onScrollOffsetChanged: (page) =>
                           _pagePosition.value = page,
                       itemBuilder: (context, video, index, {required isActive}) {

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -22,8 +22,11 @@ export 'package:models/src/nip71_video_kinds.dart' show NIP71VideoKinds;
 const int _videoKind = EventKind.videoVertical;
 
 /// Default number of videos to fetch per page.
-/// Kept small to stay "a couple videos ahead" in the buffer.
-const int _defaultLimit = 5;
+///
+/// Set to 20 so that after client-side filtering (blocklists, NSFW, expired,
+/// missing URLs) the UI still has a comfortable buffer of ~8-12 videos,
+/// reducing visible loading interruptions while scrolling.
+const int _defaultLimit = 20;
 
 /// Timeout for relay search queries.
 ///

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -954,8 +954,10 @@ void main() {
 
           expect(result.videos, hasLength(1));
           verify(
-            () =>
-                mockFunnelcakeClient.getHomeFeed(pubkey: 'my-pubkey', limit: 5),
+            () => mockFunnelcakeClient.getHomeFeed(
+              pubkey: 'my-pubkey',
+              limit: 20,
+            ),
           ).called(1);
           verifyNever(() => mockNostrClient.queryEvents(any()));
         });
@@ -1843,7 +1845,7 @@ void main() {
         expect(result.last.id, equals('older'));
       });
 
-      test('uses default limit of 5 when not specified', () async {
+      test('uses default limit of 20 when not specified', () async {
         when(
           () => mockNostrClient.queryEvents(any()),
         ).thenAnswer((_) async => <Event>[]);
@@ -1855,7 +1857,7 @@ void main() {
         ).captured;
         final filters = captured.first as List<Filter>;
 
-        expect(filters.first.limit, equals(5));
+        expect(filters.first.limit, equals(20));
       });
     });
 
@@ -2162,7 +2164,7 @@ void main() {
           expect(filters.first.search, equals('sort:hot'));
           expect(
             filters.first.limit,
-            equals(5),
+            equals(20),
           ); // Default limit, not multiplied
           expect(useCache, isFalse);
           expect(result, hasLength(1));
@@ -2322,14 +2324,14 @@ void main() {
 
           // First call: NIP-50 with exact limit
           final nip50Filters = captured[0] as List<Filter>;
-          expect(nip50Filters.first.limit, equals(5));
+          expect(nip50Filters.first.limit, equals(20));
           expect(nip50Filters.first.search, equals('sort:hot'));
 
           // Second call: fallback with multiplied limit
           // captured[1] contains filters from second call
           // (only filters are captured)
           final fallbackFilters = captured[1] as List<Filter>;
-          expect(fallbackFilters.first.limit, equals(20)); // 5 * 4
+          expect(fallbackFilters.first.limit, equals(80)); // 20 * 4
           expect(fallbackFilters.first.search, isNull);
         });
 
@@ -2354,7 +2356,7 @@ void main() {
           // captured[1] contains filters from second call
           // (only filters are captured)
           final fallbackFilters = captured[1] as List<Filter>;
-          expect(fallbackFilters.first.limit, equals(10)); // 5 * 2
+          expect(fallbackFilters.first.limit, equals(40)); // 20 * 2
         });
 
         test('fallback sorts by engagement score (highest first)', () async {
@@ -4070,7 +4072,7 @@ void main() {
         expect(filters.first.until, equals(1704067200));
       });
 
-      test('uses default limit of 5', () async {
+      test('uses default limit of 20', () async {
         when(
           () => mockNostrClient.queryEvents(any()),
         ).thenAnswer((_) async => <Event>[]);
@@ -4081,7 +4083,7 @@ void main() {
           () => mockNostrClient.queryEvents(captureAny()),
         ).captured;
         final filters = captured.first as List<Filter>;
-        expect(filters.first.limit, equals(5));
+        expect(filters.first.limit, equals(20));
       });
 
       test('returns empty list when no events found', () async {

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -114,8 +114,8 @@ void main() {
       );
     }
 
-    /// Page size constant must match the one in video_feed_bloc.dart
-    const pageSize = 5;
+    /// Page size constant must match the one in videos_repository.dart
+    const pageSize = 20;
 
     test('initial state is correct', () {
       final bloc = createBloc();

--- a/mobile/test/screens/video_feed_prefetch_test.dart
+++ b/mobile/test/screens/video_feed_prefetch_test.dart
@@ -24,9 +24,9 @@ void main() {
         final videos = _createMockVideoEvents(10);
         const currentIndex = 3;
 
-        // Expected: With preloadBefore=2 and preloadAfter=3, should prefetch:
+        // Expected: With preloadBefore=2 and preloadAfter=5, should prefetch:
         // - Before: 1, 2 (preloadBefore=2)
-        // - After: 4, 5, 6 (preloadAfter=3)
+        // - After: 4, 5, 6, 7, 8 (preloadAfter=5)
         // - Skipped: 3 (current)
         final expectedVideoIds = [
           videos[1].id,
@@ -34,6 +34,8 @@ void main() {
           videos[4].id,
           videos[5].id,
           videos[6].id,
+          videos[7].id,
+          videos[8].id,
         ];
 
         // Mock preCacheFiles to verify it's called with correct params
@@ -144,8 +146,14 @@ void main() {
       final videos = _createMockVideoEvents(10);
       const currentIndex = 0;
 
-      // Expected: Only prefetch after (1, 2, 3), not before
-      final expectedVideoIds = [videos[1].id, videos[2].id, videos[3].id];
+      // Expected: Only prefetch after (1, 2, 3, 4, 5), not before
+      final expectedVideoIds = [
+        videos[1].id,
+        videos[2].id,
+        videos[3].id,
+        videos[4].id,
+        videos[5].id,
+      ];
 
       when(
         () => mockCacheManager.preCacheFiles(
@@ -218,6 +226,8 @@ void main() {
       expect(actualVideoIds, contains(videos[2].id)); // preloadBefore
       expect(actualVideoIds, contains(videos[4].id)); // preloadAfter
       expect(actualVideoIds, contains(videos[6].id)); // preloadAfter
+      expect(actualVideoIds, contains(videos[7].id)); // preloadAfter
+      expect(actualVideoIds, contains(videos[8].id)); // preloadAfter
     });
 
     test('SPEC: should handle prefetch errors gracefully', () async {


### PR DESCRIPTION
## Summary

Closes #1972

The home feed fetched only **5 videos per page**. After client-side filtering (blocklists, NSFW, expired, missing URLs), this shrank to as few as 1–2 usable videos. Combined with a `nearEndThreshold` of 3, users hit loading spinners after just 2–3 swipes.

**Changes:**
- Increase `_defaultLimit` from 5 → **20** in `VideosRepository` — the Funnelcake API already supports up to 50, so 20 is well within capacity
- Pass `nearEndThreshold: 5` to `PooledVideoFeed` (was default 3) — triggers pagination earlier, giving more time for the fetch to complete
- Increase `preloadAfter` from 3 → **5** in `AppConstants` — keeps video player preloading ahead of the pagination trigger

## Steps to reproduce (before fix)

1. Open the home feed
2. Swipe through videos at a moderate pace
3. After ~3 swipes, a loading indicator appears while the next batch loads
4. On slower connections or with aggressive server filtering, pauses are more noticeable

## Expected behavior (after fix)

- Feed starts with ~12–14 usable videos (20 requested, minus filtering)
- Pagination fires 5 items from the end instead of 3
- Users can swipe through 8–10+ videos before any background fetch is needed
- No visible loading spinners under normal network conditions

## Test plan

- [x] `flutter test test/blocs/video_feed/video_feed_bloc_test.dart` — 66 tests pass
- [x] `flutter test test/screens/video_feed_prefetch_test.dart` — 7 tests pass
- [x] `flutter test test/src/videos_repository_test.dart` (in videos_repository package) — 223 tests pass
- [x] `flutter analyze` — no issues
- [ ] Manual QA: swipe through feed on WiFi and cellular, confirm no loading spinner within first ~10 swipes
- [ ] Verify feed still paginates correctly at end of content (server returns < 20)