### PR TITLE
fix(auth): clear per-user data on signOut to prevent cross-account data leaks (#2999)

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -1303,16 +1303,72 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
   // Wire database cleanup callback so signOut() clears DM and notification data.
   // Stop DM listening FIRST to prevent in-flight event handlers from writing
   // to tables that are being cleared (H3 race condition fix).
-  service.onDatabaseCleanup = () async {
-    try {
-      await ref.read(dmRepositoryProvider).stopListening();
-    } catch (_) {
-      // DmRepository may not exist yet (e.g., first launch).
-    }
-    await db.directMessagesDao.clearAll();
-    await db.conversationsDao.clearAll();
-    await db.notificationsDao.clearAll();
-    await NotificationServiceEnhanced.instance.clearAllData();
+  //
+  // When [deleteUserData] is true (destructive sign-out or identity change),
+  // also deletes per-user DAO rows scoped by [userPubkey].
+  // Non-destructive sign-out (account switch) skips per-user deletion since
+  // those rows are already scoped by ownerPubkey.
+  service.onDatabaseCleanup =
+      ({String? userPubkey, bool deleteUserData = false}) async {
+        try {
+          await ref.read(dmRepositoryProvider).stopListening();
+        } catch (_) {
+          // DmRepository may not exist yet (e.g., first launch).
+        }
+        await db.directMessagesDao.clearAll();
+        await db.conversationsDao.clearAll();
+        await db.notificationsDao.clearAll();
+        await NotificationServiceEnhanced.instance.clearAllData();
+
+        // Per-user data cleanup (#2999): only on destructive paths
+        if (deleteUserData && userPubkey != null) {
+          Future<void> safeDelete(
+            String name,
+            Future<int> Function() fn,
+          ) async {
+            try {
+              await fn();
+            } catch (e) {
+              Log.warning(
+                'Failed to clean $name for $userPubkey: $e',
+                name: 'UserDataCleanup',
+                category: LogCategory.auth,
+              );
+            }
+          }
+
+          await safeDelete(
+            'drafts',
+            () => db.draftsDao.deleteAllForUser(userPubkey),
+          );
+          await safeDelete(
+            'clips',
+            () => db.clipsDao.deleteAllForUser(userPubkey),
+          );
+          await safeDelete(
+            'pendingUploads',
+            () => db.pendingUploadsDao.deleteAllForUser(userPubkey),
+          );
+          await safeDelete(
+            'personalReactions',
+            () => db.personalReactionsDao.deleteAllForUser(userPubkey),
+          );
+          await safeDelete(
+            'personalReposts',
+            () => db.personalRepostsDao.deleteAllForUser(userPubkey),
+          );
+          await safeDelete(
+            'pendingActions',
+            () => db.pendingActionsDao.clearAll(userPubkey),
+          );
+        }
+      };
+
+  // Wire legacy row claim callback so session setup can attribute
+  // pre-multi-account drafts/clips to the current user.
+  service.onClaimLegacyRows = (String userPubkey) async {
+    await db.draftsDao.claimLegacyRows(userPubkey);
+    await db.clipsDao.claimLegacyRows(userPubkey);
   };
 
   return service;

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -2673,7 +2673,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'3c3497cc89997f9995bdee112182fb36a35cc198';
+    r'17d88162a6353d7e8bf7081fccad8b23266b2734';
 
 /// Subscription manager for centralized subscription management
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -482,9 +482,7 @@ class AuthService implements BackgroundAwareService {
   /// On success: rebuilds identity to [KeycastNostrIdentity] and sets
   /// [AuthRpcCapability.rpcReady]. On failure: preserves the local identity
   /// and sets capability back to [AuthRpcCapability.unavailable].
-  Future<void> _upgradeDivineRpcInBackground(
-    KeycastSession? session,
-  ) async {
+  Future<void> _upgradeDivineRpcInBackground(KeycastSession? session) async {
     Log.info(
       'initialize: starting background RPC refresh...',
       name: 'AuthService',
@@ -558,9 +556,7 @@ class AuthService implements BackgroundAwareService {
       category: LogCategory.auth,
     );
     if (_oauthClient != null) {
-      final refreshed = await _tryRefreshOAuthSession(
-        caller: 'initialize',
-      );
+      final refreshed = await _tryRefreshOAuthSession(caller: 'initialize');
       if (refreshed) return;
     }
 
@@ -2894,9 +2890,14 @@ class AuthService implements BackgroundAwareService {
       await prefs.remove('age_verified_16_plus');
       await prefs.remove('terms_accepted_at');
 
-      // Clear user-specific cached data on explicit logout
+      // Clear user-specific cached data on explicit logout.
+      // Per-user DAO rows (drafts, clips, uploads, etc.) are only deleted
+      // on destructive sign-out (deleteKeys=true). Non-destructive sign-out
+      // (account switch) preserves them since they're scoped by ownerPubkey.
       await _userDataCleanupService.clearUserSpecificData(
         reason: 'explicit_logout',
+        userPubkey: _currentKeyContainer?.publicKeyHex,
+        deleteUserData: deleteKeys,
       );
 
       // Clear configured relays so next login re-discovers from NIP-65
@@ -2904,9 +2905,7 @@ class AuthService implements BackgroundAwareService {
 
       // Clear relay discovery cache so next login re-queries indexers
       // (even for same-user re-login, relays may have changed)
-      await _relayDiscoveryService.clearCache(
-        _currentKeyContainer?.npub ?? '',
-      );
+      await _relayDiscoveryService.clearCache(_currentKeyContainer?.npub ?? '');
 
       // Clear the stored pubkey tracking so next login is treated as new
       await prefs.remove('current_user_pubkey_hex');
@@ -3259,10 +3258,7 @@ class AuthService implements BackgroundAwareService {
 
       // 3. Post-Signing Validation
       if (signedEvent == null) {
-        Log.error(
-          'Signing failed: Signer returned null',
-          name: 'AuthService',
-        );
+        Log.error('Signing failed: Signer returned null', name: 'AuthService');
         return null;
       }
 
@@ -3385,9 +3381,7 @@ class AuthService implements BackgroundAwareService {
   /// key containers; for OAuth/bunker/amber it delegates to [signInForAccount]
   /// which restores archived signer info and triggers the appropriate flow.
   /// Returns true if an account was restored, false otherwise.
-  Future<bool> _tryRestoreFromKnownAccounts(
-    AuthenticationSource source,
-  ) async {
+  Future<bool> _tryRestoreFromKnownAccounts(AuthenticationSource source) async {
     try {
       final accounts = await getKnownAccounts();
       if (accounts.isEmpty) return false;
@@ -3742,15 +3736,19 @@ class AuthService implements BackgroundAwareService {
       );
 
       if (shouldClean) {
+        final oldPubkey = prefs.getString('current_user_pubkey_hex');
         Log.info(
           '_setupUserSession: identity change detected — '
-          'clearing user-specific data',
+          'clearing user-specific data for old pubkey '
+          '${oldPubkey ?? "unknown"}',
           name: 'AuthService',
           category: LogCategory.auth,
         );
         await _userDataCleanupService.clearUserSpecificData(
           reason: 'identity_change',
           isIdentityChange: true,
+          userPubkey: oldPubkey,
+          deleteUserData: true,
         );
         // restore the TOS acceptance since we wouldn't be here otherwise
         await acceptTerms();
@@ -3765,6 +3763,11 @@ class AuthService implements BackgroundAwareService {
         'current_user_pubkey_hex',
         keyContainer.publicKeyHex,
       );
+
+      // Claim legacy database rows (NULL ownerPubkey) for this user so
+      // pre-multi-account drafts/clips are attributed and no longer
+      // visible to other accounts.
+      await _userDataCleanupService.claimLegacyRows(keyContainer.publicKeyHex);
 
       await prefs.setString(_kAuthSourceKey, source.code);
 

--- a/mobile/lib/services/user_data_cleanup_service.dart
+++ b/mobile/lib/services/user_data_cleanup_service.dart
@@ -16,9 +16,22 @@ class UserDataCleanupService {
   final SharedPreferences _prefs;
 
   /// Optional callback invoked during cleanup to clear user-specific
-  /// database tables (DMs, conversations, notifications, etc.).
+  /// database tables (DMs, conversations, notifications, per-user DAOs).
   /// Set by the provider layer which has access to DAOs.
-  Future<void> Function()? onDatabaseCleanup;
+  ///
+  /// Parameters:
+  /// - [userPubkey]: the signing-out user's pubkey for scoped deletion.
+  /// - [deleteUserData]: when true, per-user DAO rows (drafts, clips,
+  ///   uploads, reactions, reposts, pending actions) are deleted.
+  ///   False on non-destructive sign-out (account switch) to preserve data.
+  Future<void> Function({String? userPubkey, bool deleteUserData})?
+  onDatabaseCleanup;
+
+  /// Optional callback invoked during session setup to claim legacy
+  /// database rows (NULL ownerPubkey) for the current user.
+  /// This prevents pre-multi-account rows from leaking across accounts.
+  /// Set by the provider layer which has access to DAOs.
+  Future<void> Function(String userPubkey)? onClaimLegacyRows;
 
   /// Keys that store user-specific data and should be cleared on identity change.
   /// Device/app settings like relay URLs, analytics preferences are NOT included.
@@ -113,11 +126,15 @@ class UserDataCleanupService {
   Future<int> clearUserSpecificData({
     String? reason,
     bool isIdentityChange = false,
+    String? userPubkey,
+    bool deleteUserData = false,
   }) async {
     final cleanupReason = reason ?? 'unspecified';
     Log.info(
       'Starting user data cleanup (reason: $cleanupReason, '
       'identityChange: $isIdentityChange, '
+      'deleteUserData: $deleteUserData, '
+      'userPubkey: ${userPubkey ?? "null"}, '
       'checking ${userSpecificKeys.length} keys'
       '${isIdentityChange ? ' + ${identityChangePrefixes.length} prefixes' : ''})',
       name: 'UserDataCleanupService',
@@ -136,10 +153,14 @@ class UserDataCleanupService {
       }
     }
 
-    // Clear user-specific database tables (DMs, conversations, notifications)
+    // Clear user-specific database tables (DMs, conversations, notifications,
+    // and optionally per-user DAO rows when deleteUserData is true)
     if (onDatabaseCleanup != null) {
       try {
-        await onDatabaseCleanup!();
+        await onDatabaseCleanup!(
+          userPubkey: userPubkey,
+          deleteUserData: deleteUserData,
+        );
         Log.info(
           'Database cleanup complete',
           name: 'UserDataCleanupService',
@@ -192,5 +213,27 @@ class UserDataCleanupService {
     }
 
     return clearedCount;
+  }
+
+  /// Claims legacy database rows (NULL ownerPubkey) for [userPubkey].
+  ///
+  /// Should be called during session setup so pre-multi-account data is
+  /// attributed to the current user and no longer visible to other accounts.
+  Future<void> claimLegacyRows(String userPubkey) async {
+    if (onClaimLegacyRows == null) return;
+    try {
+      await onClaimLegacyRows!(userPubkey);
+      Log.info(
+        'Legacy row claim complete for $userPubkey',
+        name: 'UserDataCleanupService',
+        category: LogCategory.auth,
+      );
+    } catch (e) {
+      Log.error(
+        'Legacy row claim failed: $e',
+        name: 'UserDataCleanupService',
+        category: LogCategory.auth,
+      );
+    }
   }
 }

--- a/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
@@ -52,11 +52,7 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
   Future<List<ClipRow>> getClipsByDraftId(String draftId) {
     final query = select(clips)
       ..where((t) => t.draftId.equals(draftId))
-      ..orderBy([
-        (t) => OrderingTerm(
-          expression: t.orderIndex,
-        ),
-      ]);
+      ..orderBy([(t) => OrderingTerm(expression: t.orderIndex)]);
     return query.get();
   }
 
@@ -72,10 +68,7 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
     final query = select(clips)
       ..where((t) => _ownedOrLegacy(t.ownerPubkey, ownerPubkey))
       ..orderBy([
-        (t) => OrderingTerm(
-          expression: t.recordedAt,
-          mode: OrderingMode.desc,
-        ),
+        (t) => OrderingTerm(expression: t.recordedAt, mode: OrderingMode.desc),
       ]);
     if (limit != null) {
       query.limit(limit);
@@ -107,11 +100,7 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
   Stream<List<ClipRow>> watchClipsByDraftId(String draftId) {
     final query = select(clips)
       ..where((t) => t.draftId.equals(draftId))
-      ..orderBy([
-        (t) => OrderingTerm(
-          expression: t.orderIndex,
-        ),
-      ]);
+      ..orderBy([(t) => OrderingTerm(expression: t.orderIndex)]);
     return query.watch();
   }
 
@@ -134,19 +123,13 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
   /// Get all library clips (no draft association), newest first.
   /// When [ownerPubkey] is provided, returns only clips owned by that
   /// account **plus** legacy clips with no owner.
-  Future<List<ClipRow>> getLibraryClips({
-    int? limit,
-    String? ownerPubkey,
-  }) {
+  Future<List<ClipRow>> getLibraryClips({int? limit, String? ownerPubkey}) {
     final query = select(clips)
       ..where(
         (t) => t.draftId.isNull() & _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
       )
       ..orderBy([
-        (t) => OrderingTerm(
-          expression: t.recordedAt,
-          mode: OrderingMode.desc,
-        ),
+        (t) => OrderingTerm(expression: t.recordedAt, mode: OrderingMode.desc),
       ]);
     if (limit != null) {
       query.limit(limit);
@@ -163,10 +146,7 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
         (t) => t.draftId.isNull() & _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
       )
       ..orderBy([
-        (t) => OrderingTerm(
-          expression: t.recordedAt,
-          mode: OrderingMode.desc,
-        ),
+        (t) => OrderingTerm(expression: t.recordedAt, mode: OrderingMode.desc),
       ]);
     return query.watch();
   }
@@ -179,6 +159,26 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
   /// Clear all clips
   Future<int> clearAll() {
     return delete(clips).go();
+  }
+
+  /// Delete all clips owned by [userPubkey].
+  ///
+  /// Legacy clips with NULL ownerPubkey are preserved because they
+  /// cannot be attributed to any specific account.
+  /// Used on destructive sign-out to prevent cross-account data leaks.
+  Future<int> deleteAllForUser(String userPubkey) {
+    return (delete(clips)..where((t) => t.ownerPubkey.equals(userPubkey))).go();
+  }
+
+  /// Claim legacy clips (NULL ownerPubkey) for [ownerPubkey].
+  ///
+  /// Called during session setup so that pre-multi-account clips are
+  /// attributed to the user who created them and stop being visible
+  /// to other accounts via the `_ownedOrLegacy` filter.
+  Future<int> claimLegacyRows(String ownerPubkey) {
+    return (update(clips)..where((t) => t.ownerPubkey.isNull())).write(
+      ClipsCompanion(ownerPubkey: Value(ownerPubkey)),
+    );
   }
 
   /// Check if a filename is referenced by any clip's file_path

--- a/mobile/packages/db_client/lib/src/database/daos/drafts_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/drafts_dao.dart
@@ -78,17 +78,12 @@ class DraftsDao extends DatabaseAccessor<AppDatabase> with _$DraftsDaoMixin {
   /// Get all drafts sorted by last modified (newest first).
   /// When [ownerPubkey] is provided, returns only drafts owned by that
   /// account **plus** legacy drafts with no owner.
-  Future<List<DraftRow>> getAllDrafts({
-    int? limit,
-    String? ownerPubkey,
-  }) {
+  Future<List<DraftRow>> getAllDrafts({int? limit, String? ownerPubkey}) {
     final query = select(drafts)
       ..where((t) => _ownedOrLegacy(t.ownerPubkey, ownerPubkey))
       ..orderBy([
-        (t) => OrderingTerm(
-          expression: t.lastModified,
-          mode: OrderingMode.desc,
-        ),
+        (t) =>
+            OrderingTerm(expression: t.lastModified, mode: OrderingMode.desc),
       ]);
     if (limit != null) {
       query.limit(limit);
@@ -116,10 +111,8 @@ class DraftsDao extends DatabaseAccessor<AppDatabase> with _$DraftsDaoMixin {
             _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
       )
       ..orderBy([
-        (t) => OrderingTerm(
-          expression: t.lastModified,
-          mode: OrderingMode.desc,
-        ),
+        (t) =>
+            OrderingTerm(expression: t.lastModified, mode: OrderingMode.desc),
       ]);
     if (limit != null) {
       query.limit(limit);
@@ -163,17 +156,12 @@ class DraftsDao extends DatabaseAccessor<AppDatabase> with _$DraftsDaoMixin {
   /// Watch all drafts (reactive stream).
   /// When [ownerPubkey] is provided, returns only drafts owned by that
   /// account **plus** legacy drafts with no owner.
-  Stream<List<DraftRow>> watchAllDrafts({
-    int? limit,
-    String? ownerPubkey,
-  }) {
+  Stream<List<DraftRow>> watchAllDrafts({int? limit, String? ownerPubkey}) {
     final query = select(drafts)
       ..where((t) => _ownedOrLegacy(t.ownerPubkey, ownerPubkey))
       ..orderBy([
-        (t) => OrderingTerm(
-          expression: t.lastModified,
-          mode: OrderingMode.desc,
-        ),
+        (t) =>
+            OrderingTerm(expression: t.lastModified, mode: OrderingMode.desc),
       ]);
     if (limit != null) {
       query.limit(limit);
@@ -201,10 +189,8 @@ class DraftsDao extends DatabaseAccessor<AppDatabase> with _$DraftsDaoMixin {
             _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
       )
       ..orderBy([
-        (t) => OrderingTerm(
-          expression: t.lastModified,
-          mode: OrderingMode.desc,
-        ),
+        (t) =>
+            OrderingTerm(expression: t.lastModified, mode: OrderingMode.desc),
       ]);
     if (limit != null) {
       query.limit(limit);
@@ -215,10 +201,7 @@ class DraftsDao extends DatabaseAccessor<AppDatabase> with _$DraftsDaoMixin {
   /// Get count of drafts by publish status.
   /// When [ownerPubkey] is provided, counts only drafts owned by that
   /// account **plus** legacy drafts with no owner.
-  Future<int> getCountByStatus(
-    String status, {
-    String? ownerPubkey,
-  }) async {
+  Future<int> getCountByStatus(String status, {String? ownerPubkey}) async {
     final query = selectOnly(drafts)
       ..where(
         drafts.publishStatus.equals(status) &
@@ -243,6 +226,28 @@ class DraftsDao extends DatabaseAccessor<AppDatabase> with _$DraftsDaoMixin {
   /// Clear all drafts
   Future<int> clearAll() {
     return delete(drafts).go();
+  }
+
+  /// Delete all drafts owned by [userPubkey].
+  ///
+  /// Legacy drafts with NULL ownerPubkey are preserved because they
+  /// cannot be attributed to any specific account.
+  /// Used on destructive sign-out to prevent cross-account data leaks.
+  Future<int> deleteAllForUser(String userPubkey) {
+    return (delete(
+      drafts,
+    )..where((t) => t.ownerPubkey.equals(userPubkey))).go();
+  }
+
+  /// Claim legacy drafts (NULL ownerPubkey) for [ownerPubkey].
+  ///
+  /// Called during session setup so that pre-multi-account drafts are
+  /// attributed to the user who created them and stop being visible
+  /// to other accounts via the `_ownedOrLegacy` filter.
+  Future<int> claimLegacyRows(String ownerPubkey) {
+    return (update(drafts)..where((t) => t.ownerPubkey.isNull())).write(
+      DraftsCompanion(ownerPubkey: Value(ownerPubkey)),
+    );
   }
 
   /// Check if a filename is referenced by any draft's

--- a/mobile/packages/db_client/lib/src/database/daos/pending_uploads_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_uploads_dao.dart
@@ -94,9 +94,7 @@ class PendingUploadsDao extends DatabaseAccessor<AppDatabase>
   Future<List<PendingUpload>> getPendingUploads() async {
     final query = select(pendingUploads)
       ..where((t) => t.status.isNotIn(['published', 'failed']))
-      ..orderBy([
-        (t) => OrderingTerm(expression: t.createdAt),
-      ]);
+      ..orderBy([(t) => OrderingTerm(expression: t.createdAt)]);
     final rows = await query.get();
     return rows.map(_rowToModel).toList();
   }
@@ -169,14 +167,21 @@ class PendingUploadsDao extends DatabaseAccessor<AppDatabase>
   Stream<List<PendingUpload>> watchPendingUploads() {
     final query = select(pendingUploads)
       ..where((t) => t.status.isNotIn(['published', 'failed']))
-      ..orderBy([
-        (t) => OrderingTerm(expression: t.createdAt),
-      ]);
+      ..orderBy([(t) => OrderingTerm(expression: t.createdAt)]);
     return query.watch().map((rows) => rows.map(_rowToModel).toList());
   }
 
   /// Clear all uploads
   Future<int> clearAll() {
     return delete(pendingUploads).go();
+  }
+
+  /// Delete all uploads for [userPubkey].
+  ///
+  /// Used on destructive sign-out to prevent cross-account data leaks.
+  Future<int> deleteAllForUser(String userPubkey) {
+    return (delete(
+      pendingUploads,
+    )..where((t) => t.nostrPubkey.equals(userPubkey))).go();
   }
 }

--- a/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
@@ -339,10 +339,7 @@ void main() {
           data: '{}',
         );
 
-        final result = await dao.updateOrderIndex(
-          id: 'clip_1',
-          orderIndex: 5,
-        );
+        final result = await dao.updateOrderIndex(id: 'clip_1', orderIndex: 5);
 
         expect(result, isTrue);
         final clip = await dao.getClipById('clip_1');
@@ -983,86 +980,80 @@ void main() {
         expect(idsB, isNot(contains('clip_a')));
       });
 
-      test(
-        'getLibraryClips without ownerPubkey returns all clips',
-        () async {
-          await dao.upsertClip(
-            id: 'clip_a',
-            orderIndex: 0,
-            durationMs: 1000,
-            recordedAt: DateTime(2023, 11, 14, 10),
-            filePath: 'a.mp4',
-            thumbnailPath: 'a.jpeg',
-            data: '{}',
-            ownerPubkey: pubkeyA,
-          );
-          await dao.upsertClip(
-            id: 'clip_b',
-            orderIndex: 0,
-            durationMs: 2000,
-            recordedAt: DateTime(2023, 11, 14, 11),
-            filePath: 'b.mp4',
-            thumbnailPath: 'b.jpeg',
-            data: '{}',
-            ownerPubkey: pubkeyB,
-          );
-          await dao.upsertClip(
-            id: 'clip_legacy',
-            orderIndex: 0,
-            durationMs: 3000,
-            recordedAt: DateTime(2023, 11, 14, 12),
-            filePath: 'legacy.mp4',
-            thumbnailPath: 'legacy.jpeg',
-            data: '{}',
-          );
+      test('getLibraryClips without ownerPubkey returns all clips', () async {
+        await dao.upsertClip(
+          id: 'clip_a',
+          orderIndex: 0,
+          durationMs: 1000,
+          recordedAt: DateTime(2023, 11, 14, 10),
+          filePath: 'a.mp4',
+          thumbnailPath: 'a.jpeg',
+          data: '{}',
+          ownerPubkey: pubkeyA,
+        );
+        await dao.upsertClip(
+          id: 'clip_b',
+          orderIndex: 0,
+          durationMs: 2000,
+          recordedAt: DateTime(2023, 11, 14, 11),
+          filePath: 'b.mp4',
+          thumbnailPath: 'b.jpeg',
+          data: '{}',
+          ownerPubkey: pubkeyB,
+        );
+        await dao.upsertClip(
+          id: 'clip_legacy',
+          orderIndex: 0,
+          durationMs: 3000,
+          recordedAt: DateTime(2023, 11, 14, 12),
+          filePath: 'legacy.mp4',
+          thumbnailPath: 'legacy.jpeg',
+          data: '{}',
+        );
 
-          final allClips = await dao.getLibraryClips();
-          expect(allClips, hasLength(3));
-        },
-      );
+        final allClips = await dao.getLibraryClips();
+        expect(allClips, hasLength(3));
+      });
 
-      test(
-        'watchLibraryClips filters by ownerPubkey',
-        () async {
-          await dao.upsertClip(
-            id: 'clip_a',
-            orderIndex: 0,
-            durationMs: 1000,
-            recordedAt: DateTime(2023, 11, 14, 10),
-            filePath: 'a.mp4',
-            thumbnailPath: 'a.jpeg',
-            data: '{}',
-            ownerPubkey: pubkeyA,
-          );
-          await dao.upsertClip(
-            id: 'clip_b',
-            orderIndex: 0,
-            durationMs: 2000,
-            recordedAt: DateTime(2023, 11, 14, 11),
-            filePath: 'b.mp4',
-            thumbnailPath: 'b.jpeg',
-            data: '{}',
-            ownerPubkey: pubkeyB,
-          );
-          await dao.upsertClip(
-            id: 'clip_legacy',
-            orderIndex: 0,
-            durationMs: 3000,
-            recordedAt: DateTime(2023, 11, 14, 12),
-            filePath: 'legacy.mp4',
-            thumbnailPath: 'legacy.jpeg',
-            data: '{}',
-          );
+      test('watchLibraryClips filters by ownerPubkey', () async {
+        await dao.upsertClip(
+          id: 'clip_a',
+          orderIndex: 0,
+          durationMs: 1000,
+          recordedAt: DateTime(2023, 11, 14, 10),
+          filePath: 'a.mp4',
+          thumbnailPath: 'a.jpeg',
+          data: '{}',
+          ownerPubkey: pubkeyA,
+        );
+        await dao.upsertClip(
+          id: 'clip_b',
+          orderIndex: 0,
+          durationMs: 2000,
+          recordedAt: DateTime(2023, 11, 14, 11),
+          filePath: 'b.mp4',
+          thumbnailPath: 'b.jpeg',
+          data: '{}',
+          ownerPubkey: pubkeyB,
+        );
+        await dao.upsertClip(
+          id: 'clip_legacy',
+          orderIndex: 0,
+          durationMs: 3000,
+          recordedAt: DateTime(2023, 11, 14, 12),
+          filePath: 'legacy.mp4',
+          thumbnailPath: 'legacy.jpeg',
+          data: '{}',
+        );
 
-          final stream = dao.watchLibraryClips(ownerPubkey: pubkeyA);
-          final results = await stream.first;
+        final stream = dao.watchLibraryClips(ownerPubkey: pubkeyA);
+        final results = await stream.first;
 
-          expect(results, hasLength(2));
-          final ids = results.map((c) => c.id).toSet();
-          expect(ids, containsAll(['clip_a', 'clip_legacy']));
-          expect(ids, isNot(contains('clip_b')));
-        },
-      );
+        expect(results, hasLength(2));
+        final ids = results.map((c) => c.id).toSet();
+        expect(ids, containsAll(['clip_a', 'clip_legacy']));
+        expect(ids, isNot(contains('clip_b')));
+      });
 
       test('clips of user A are invisible to user B', () async {
         await dao.upsertClip(
@@ -1078,6 +1069,207 @@ void main() {
 
         final clipsB = await dao.getLibraryClips(ownerPubkey: pubkeyB);
         expect(clipsB, isEmpty);
+      });
+    });
+
+    group('deleteAllForUser', () {
+      const pubkeyA =
+          'aaaa1111aaaa1111aaaa1111aaaa1111'
+          'aaaa1111aaaa1111aaaa1111aaaa1111';
+      const pubkeyB =
+          'bbbb2222bbbb2222bbbb2222bbbb2222'
+          'bbbb2222bbbb2222bbbb2222bbbb2222';
+
+      test('deletes all clips for user', () async {
+        await dao.upsertClip(
+          id: 'clip_a1',
+          orderIndex: 0,
+          durationMs: 1000,
+          recordedAt: DateTime(2023, 11, 14, 10),
+          filePath: 'a1.mp4',
+          thumbnailPath: 'a1.jpeg',
+          data: '{}',
+          ownerPubkey: pubkeyA,
+        );
+        await dao.upsertClip(
+          id: 'clip_a2',
+          orderIndex: 1,
+          durationMs: 2000,
+          recordedAt: DateTime(2023, 11, 14, 11),
+          filePath: 'a2.mp4',
+          thumbnailPath: 'a2.jpeg',
+          data: '{}',
+          ownerPubkey: pubkeyA,
+        );
+
+        final deleted = await dao.deleteAllForUser(pubkeyA);
+
+        expect(deleted, equals(2));
+        final remaining = await dao.getAllClips();
+        expect(remaining, isEmpty);
+      });
+
+      test('does not delete clips for other users', () async {
+        await dao.upsertClip(
+          id: 'clip_a',
+          orderIndex: 0,
+          durationMs: 1000,
+          recordedAt: DateTime(2023, 11, 14, 10),
+          filePath: 'a.mp4',
+          thumbnailPath: 'a.jpeg',
+          data: '{}',
+          ownerPubkey: pubkeyA,
+        );
+        await dao.upsertClip(
+          id: 'clip_b',
+          orderIndex: 0,
+          durationMs: 2000,
+          recordedAt: DateTime(2023, 11, 14, 11),
+          filePath: 'b.mp4',
+          thumbnailPath: 'b.jpeg',
+          data: '{}',
+          ownerPubkey: pubkeyB,
+        );
+
+        await dao.deleteAllForUser(pubkeyA);
+
+        final remaining = await dao.getAllClips();
+        expect(remaining, hasLength(1));
+        expect(remaining.first.id, equals('clip_b'));
+      });
+
+      test('does not delete legacy clips with null ownerPubkey', () async {
+        await dao.upsertClip(
+          id: 'clip_a',
+          orderIndex: 0,
+          durationMs: 1000,
+          recordedAt: DateTime(2023, 11, 14, 10),
+          filePath: 'a.mp4',
+          thumbnailPath: 'a.jpeg',
+          data: '{}',
+          ownerPubkey: pubkeyA,
+        );
+        await dao.upsertClip(
+          id: 'clip_legacy',
+          orderIndex: 0,
+          durationMs: 2000,
+          recordedAt: DateTime(2023, 11, 14, 11),
+          filePath: 'legacy.mp4',
+          thumbnailPath: 'legacy.jpeg',
+          data: '{}',
+        );
+
+        await dao.deleteAllForUser(pubkeyA);
+
+        final remaining = await dao.getAllClips();
+        expect(remaining, hasLength(1));
+        expect(remaining.first.id, equals('clip_legacy'));
+      });
+
+      test('returns 0 when no clips exist', () async {
+        final deleted = await dao.deleteAllForUser(pubkeyA);
+
+        expect(deleted, equals(0));
+      });
+    });
+
+    group('claimLegacyRows', () {
+      const pubkeyA =
+          'aaaa1111aaaa1111aaaa1111aaaa1111'
+          'aaaa1111aaaa1111aaaa1111aaaa1111';
+      const pubkeyB =
+          'bbbb2222bbbb2222bbbb2222bbbb2222'
+          'bbbb2222bbbb2222bbbb2222bbbb2222';
+
+      test('claims NULL-owner rows for the given pubkey', () async {
+        await dao.upsertClip(
+          id: 'clip_legacy1',
+          orderIndex: 0,
+          durationMs: 1000,
+          recordedAt: DateTime(2023, 11, 14, 10),
+          filePath: 'l1.mp4',
+          thumbnailPath: 'l1.jpeg',
+          data: '{}',
+        );
+        await dao.upsertClip(
+          id: 'clip_legacy2',
+          orderIndex: 1,
+          durationMs: 2000,
+          recordedAt: DateTime(2023, 11, 14, 11),
+          filePath: 'l2.mp4',
+          thumbnailPath: 'l2.jpeg',
+          data: '{}',
+        );
+
+        final claimed = await dao.claimLegacyRows(pubkeyA);
+
+        expect(claimed, equals(2));
+        final all = await dao.getAllClips(ownerPubkey: pubkeyA);
+        expect(all, hasLength(2));
+        for (final clip in all) {
+          expect(clip.ownerPubkey, equals(pubkeyA));
+        }
+      });
+
+      test('does not modify already-owned rows', () async {
+        await dao.upsertClip(
+          id: 'clip_b',
+          orderIndex: 0,
+          durationMs: 1000,
+          recordedAt: DateTime(2023, 11, 14, 10),
+          filePath: 'b.mp4',
+          thumbnailPath: 'b.jpeg',
+          data: '{}',
+          ownerPubkey: pubkeyB,
+        );
+        await dao.upsertClip(
+          id: 'clip_legacy',
+          orderIndex: 0,
+          durationMs: 2000,
+          recordedAt: DateTime(2023, 11, 14, 11),
+          filePath: 'legacy.mp4',
+          thumbnailPath: 'legacy.jpeg',
+          data: '{}',
+        );
+
+        await dao.claimLegacyRows(pubkeyA);
+
+        final clipB = await dao.getClipById('clip_b');
+        expect(clipB!.ownerPubkey, equals(pubkeyB));
+      });
+
+      test('claimed rows are no longer visible to other users', () async {
+        await dao.upsertClip(
+          id: 'clip_legacy',
+          orderIndex: 0,
+          durationMs: 1000,
+          recordedAt: DateTime(2023, 11, 14, 10),
+          filePath: 'legacy.mp4',
+          thumbnailPath: 'legacy.jpeg',
+          data: '{}',
+        );
+
+        await dao.claimLegacyRows(pubkeyA);
+
+        final clipsB = await dao.getAllClips(ownerPubkey: pubkeyB);
+        expect(clipsB, isEmpty);
+      });
+
+      test('returns 0 when no legacy rows exist', () async {
+        await dao.upsertClip(
+          id: 'clip_a',
+          orderIndex: 0,
+          durationMs: 1000,
+          recordedAt: DateTime(2023, 11, 14, 10),
+          filePath: 'a.mp4',
+          thumbnailPath: 'a.jpeg',
+          data: '{}',
+          ownerPubkey: pubkeyA,
+        );
+
+        final claimed = await dao.claimLegacyRows(pubkeyA);
+
+        expect(claimed, equals(0));
       });
     });
   });

--- a/mobile/packages/db_client/test/src/database/daos/drafts_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/drafts_dao_test.dart
@@ -13,9 +13,7 @@ void main() {
   late String tempDbPath;
 
   setUp(() async {
-    final tempDir = Directory.systemTemp.createTempSync(
-      'drafts_dao_test_',
-    );
+    final tempDir = Directory.systemTemp.createTempSync('drafts_dao_test_');
     tempDbPath = '${tempDir.path}/test.db';
 
     database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
@@ -49,9 +47,7 @@ void main() {
           data: '{}',
         );
 
-        final result = await dao.isRenderedFileReferenced(
-          'rendered_video.mp4',
-        );
+        final result = await dao.isRenderedFileReferenced('rendered_video.mp4');
         expect(result, isTrue);
       });
 
@@ -90,16 +86,12 @@ void main() {
           data: '{}',
         );
 
-        final result = await dao.isRenderedFileReferenced(
-          'nonexistent.mp4',
-        );
+        final result = await dao.isRenderedFileReferenced('nonexistent.mp4');
         expect(result, isFalse);
       });
 
       test('returns false when no drafts exist', () async {
-        final result = await dao.isRenderedFileReferenced(
-          'anything.mp4',
-        );
+        final result = await dao.isRenderedFileReferenced('anything.mp4');
         expect(result, isFalse);
       });
 
@@ -117,9 +109,7 @@ void main() {
           data: '{}',
         );
 
-        final result = await dao.isRenderedFileReferenced(
-          'something.mp4',
-        );
+        final result = await dao.isRenderedFileReferenced('something.mp4');
         expect(result, isFalse);
       });
 
@@ -148,14 +138,8 @@ void main() {
           data: '{}',
         );
 
-        expect(
-          await dao.isRenderedFileReferenced('video_b.mp4'),
-          isTrue,
-        );
-        expect(
-          await dao.isRenderedFileReferenced('video_c.mp4'),
-          isFalse,
-        );
+        expect(await dao.isRenderedFileReferenced('video_b.mp4'), isTrue);
+        expect(await dao.isRenderedFileReferenced('video_c.mp4'), isFalse);
       });
     });
 
@@ -221,17 +205,14 @@ void main() {
         expect(idsB, isNot(contains('draft_a')));
       });
 
-      test(
-        'getAllDrafts without ownerPubkey returns all drafts',
-        () async {
-          await insertDraft(id: 'draft_a', ownerPubkey: pubkeyA);
-          await insertDraft(id: 'draft_b', ownerPubkey: pubkeyB);
-          await insertDraft(id: 'draft_legacy');
+      test('getAllDrafts without ownerPubkey returns all drafts', () async {
+        await insertDraft(id: 'draft_a', ownerPubkey: pubkeyA);
+        await insertDraft(id: 'draft_b', ownerPubkey: pubkeyB);
+        await insertDraft(id: 'draft_legacy');
 
-          final all = await dao.getAllDrafts();
-          expect(all, hasLength(3));
-        },
-      );
+        final all = await dao.getAllDrafts();
+        expect(all, hasLength(3));
+      });
 
       test('getDraftsByStatus filters by owner', () async {
         await insertDraft(
@@ -271,20 +252,11 @@ void main() {
       });
 
       test('watchDraftsByStatus filters by ownerPubkey', () async {
-        await insertDraft(
-          id: 'draft_a',
-          ownerPubkey: pubkeyA,
-        );
-        await insertDraft(
-          id: 'draft_b',
-          ownerPubkey: pubkeyB,
-        );
+        await insertDraft(id: 'draft_a', ownerPubkey: pubkeyA);
+        await insertDraft(id: 'draft_b', ownerPubkey: pubkeyB);
         await insertDraft(id: 'draft_legacy');
 
-        final stream = dao.watchDraftsByStatus(
-          'draft',
-          ownerPubkey: pubkeyA,
-        );
+        final stream = dao.watchDraftsByStatus('draft', ownerPubkey: pubkeyA);
         final results = await stream.first;
 
         expect(results, hasLength(2));
@@ -293,14 +265,8 @@ void main() {
       });
 
       test('getCountByStatus filters by owner', () async {
-        await insertDraft(
-          id: 'draft_a',
-          ownerPubkey: pubkeyA,
-        );
-        await insertDraft(
-          id: 'draft_b',
-          ownerPubkey: pubkeyB,
-        );
+        await insertDraft(id: 'draft_a', ownerPubkey: pubkeyA);
+        await insertDraft(id: 'draft_b', ownerPubkey: pubkeyB);
         await insertDraft(id: 'draft_legacy');
 
         final countA = await dao.getCountByStatus(
@@ -356,6 +322,140 @@ void main() {
         final draft = await dao.getDraftById('draft_txn');
         expect(draft, isNotNull);
         expect(draft!.ownerPubkey, equals(pubkeyA));
+      });
+    });
+
+    group('deleteAllForUser', () {
+      const pubkeyA =
+          'aaaa1111aaaa1111aaaa1111aaaa1111'
+          'aaaa1111aaaa1111aaaa1111aaaa1111';
+      const pubkeyB =
+          'bbbb2222bbbb2222bbbb2222bbbb2222'
+          'bbbb2222bbbb2222bbbb2222bbbb2222';
+
+      Future<void> insertDraft({
+        required String id,
+        String? ownerPubkey,
+      }) async {
+        await dao.upsertDraft(
+          id: id,
+          title: 'Draft $id',
+          description: '',
+          publishStatus: 'draft',
+          createdAt: DateTime(2023, 11, 14),
+          lastModified: DateTime(2023, 11, 14),
+          renderedFilePath: null,
+          renderedThumbnailPath: null,
+          data: '{}',
+          ownerPubkey: ownerPubkey,
+        );
+      }
+
+      test('deletes all drafts for user', () async {
+        await insertDraft(id: 'draft_a1', ownerPubkey: pubkeyA);
+        await insertDraft(id: 'draft_a2', ownerPubkey: pubkeyA);
+
+        final deleted = await dao.deleteAllForUser(pubkeyA);
+
+        expect(deleted, equals(2));
+        final remaining = await dao.getAllDrafts();
+        expect(remaining, isEmpty);
+      });
+
+      test('does not delete drafts for other users', () async {
+        await insertDraft(id: 'draft_a', ownerPubkey: pubkeyA);
+        await insertDraft(id: 'draft_b', ownerPubkey: pubkeyB);
+
+        await dao.deleteAllForUser(pubkeyA);
+
+        final remaining = await dao.getAllDrafts();
+        expect(remaining, hasLength(1));
+        expect(remaining.first.id, equals('draft_b'));
+      });
+
+      test('does not delete legacy drafts with null ownerPubkey', () async {
+        await insertDraft(id: 'draft_a', ownerPubkey: pubkeyA);
+        await insertDraft(id: 'draft_legacy');
+
+        await dao.deleteAllForUser(pubkeyA);
+
+        final remaining = await dao.getAllDrafts();
+        expect(remaining, hasLength(1));
+        expect(remaining.first.id, equals('draft_legacy'));
+      });
+
+      test('returns 0 when no drafts exist', () async {
+        final deleted = await dao.deleteAllForUser(pubkeyA);
+
+        expect(deleted, equals(0));
+      });
+    });
+
+    group('claimLegacyRows', () {
+      const pubkeyA =
+          'aaaa1111aaaa1111aaaa1111aaaa1111'
+          'aaaa1111aaaa1111aaaa1111aaaa1111';
+      const pubkeyB =
+          'bbbb2222bbbb2222bbbb2222bbbb2222'
+          'bbbb2222bbbb2222bbbb2222bbbb2222';
+
+      Future<void> insertDraft({
+        required String id,
+        String? ownerPubkey,
+      }) async {
+        await dao.upsertDraft(
+          id: id,
+          title: 'Draft $id',
+          description: '',
+          publishStatus: 'draft',
+          createdAt: DateTime(2023, 11, 14),
+          lastModified: DateTime(2023, 11, 14),
+          renderedFilePath: null,
+          renderedThumbnailPath: null,
+          data: '{}',
+          ownerPubkey: ownerPubkey,
+        );
+      }
+
+      test('claims NULL-owner rows for the given pubkey', () async {
+        await insertDraft(id: 'draft_legacy1');
+        await insertDraft(id: 'draft_legacy2');
+
+        final claimed = await dao.claimLegacyRows(pubkeyA);
+
+        expect(claimed, equals(2));
+        final all = await dao.getAllDrafts(ownerPubkey: pubkeyA);
+        expect(all, hasLength(2));
+        for (final draft in all) {
+          expect(draft.ownerPubkey, equals(pubkeyA));
+        }
+      });
+
+      test('does not modify already-owned rows', () async {
+        await insertDraft(id: 'draft_b', ownerPubkey: pubkeyB);
+        await insertDraft(id: 'draft_legacy');
+
+        await dao.claimLegacyRows(pubkeyA);
+
+        final draftB = await dao.getDraftById('draft_b');
+        expect(draftB!.ownerPubkey, equals(pubkeyB));
+      });
+
+      test('claimed rows are no longer visible to other users', () async {
+        await insertDraft(id: 'draft_legacy');
+
+        await dao.claimLegacyRows(pubkeyA);
+
+        final draftsB = await dao.getAllDrafts(ownerPubkey: pubkeyB);
+        expect(draftsB, isEmpty);
+      });
+
+      test('returns 0 when no legacy rows exist', () async {
+        await insertDraft(id: 'draft_a', ownerPubkey: pubkeyA);
+
+        final claimed = await dao.claimLegacyRows(pubkeyA);
+
+        expect(claimed, equals(0));
       });
     });
   });

--- a/mobile/packages/db_client/test/src/database/daos/pending_uploads_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/pending_uploads_dao_test.dart
@@ -92,9 +92,7 @@ void main() {
       });
 
       test('updates existing upload with same ID', () async {
-        final upload1 = createTestUpload(
-          uploadProgress: 0,
-        );
+        final upload1 = createTestUpload(uploadProgress: 0);
         await dao.upsertUpload(upload1);
 
         final upload2 = createTestUpload(
@@ -185,9 +183,7 @@ void main() {
 
     group('getPendingUploads', () {
       test('returns only uploads not published or failed', () async {
-        await dao.upsertUpload(
-          createTestUpload(id: 'pending'),
-        );
+        await dao.upsertUpload(createTestUpload(id: 'pending'));
         await dao.upsertUpload(
           createTestUpload(id: 'uploading', status: UploadStatus.uploading),
         );
@@ -214,22 +210,13 @@ void main() {
 
       test('returns uploads sorted by createdAt ascending', () async {
         await dao.upsertUpload(
-          createTestUpload(
-            id: 'first',
-            createdAt: DateTime(2024),
-          ),
+          createTestUpload(id: 'first', createdAt: DateTime(2024)),
         );
         await dao.upsertUpload(
-          createTestUpload(
-            id: 'third',
-            createdAt: DateTime(2024, 1, 3),
-          ),
+          createTestUpload(id: 'third', createdAt: DateTime(2024, 1, 3)),
         );
         await dao.upsertUpload(
-          createTestUpload(
-            id: 'second',
-            createdAt: DateTime(2024, 1, 2),
-          ),
+          createTestUpload(id: 'second', createdAt: DateTime(2024, 1, 2)),
         );
 
         final results = await dao.getPendingUploads();
@@ -252,22 +239,13 @@ void main() {
     group('getAllUploads', () {
       test('returns all uploads sorted by createdAt descending', () async {
         await dao.upsertUpload(
-          createTestUpload(
-            id: 'first',
-            createdAt: DateTime(2024),
-          ),
+          createTestUpload(id: 'first', createdAt: DateTime(2024)),
         );
         await dao.upsertUpload(
-          createTestUpload(
-            id: 'third',
-            createdAt: DateTime(2024, 1, 3),
-          ),
+          createTestUpload(id: 'third', createdAt: DateTime(2024, 1, 3)),
         );
         await dao.upsertUpload(
-          createTestUpload(
-            id: 'second',
-            createdAt: DateTime(2024, 1, 2),
-          ),
+          createTestUpload(id: 'second', createdAt: DateTime(2024, 1, 2)),
         );
 
         final results = await dao.getAllUploads();
@@ -286,12 +264,8 @@ void main() {
 
     group('getUploadsByStatus', () {
       test('filters by status', () async {
-        await dao.upsertUpload(
-          createTestUpload(id: 'pending1'),
-        );
-        await dao.upsertUpload(
-          createTestUpload(id: 'pending2'),
-        );
+        await dao.upsertUpload(createTestUpload(id: 'pending1'));
+        await dao.upsertUpload(createTestUpload(id: 'pending2'));
         await dao.upsertUpload(
           createTestUpload(id: 'uploading', status: UploadStatus.uploading),
         );
@@ -303,9 +277,7 @@ void main() {
       });
 
       test('returns empty list when no uploads match status', () async {
-        await dao.upsertUpload(
-          createTestUpload(id: 'pending'),
-        );
+        await dao.upsertUpload(createTestUpload(id: 'pending'));
 
         final results = await dao.getUploadsByStatus(UploadStatus.failed);
         expect(results, isEmpty);
@@ -314,9 +286,7 @@ void main() {
 
     group('updateStatus', () {
       test('updates status for existing upload', () async {
-        await dao.upsertUpload(
-          createTestUpload(),
-        );
+        await dao.upsertUpload(createTestUpload());
 
         final result = await dao.updateStatus(
           'upload_1',
@@ -376,9 +346,7 @@ void main() {
 
     group('deleteCompleted', () {
       test('deletes only published and failed uploads', () async {
-        await dao.upsertUpload(
-          createTestUpload(id: 'pending'),
-        );
+        await dao.upsertUpload(createTestUpload(id: 'pending'));
         await dao.upsertUpload(
           createTestUpload(id: 'published', status: UploadStatus.published),
         );
@@ -395,9 +363,7 @@ void main() {
       });
 
       test('returns 0 when no completed uploads', () async {
-        await dao.upsertUpload(
-          createTestUpload(),
-        );
+        await dao.upsertUpload(createTestUpload());
 
         final deleted = await dao.deleteCompleted();
         expect(deleted, equals(0));
@@ -433,9 +399,7 @@ void main() {
 
     group('watchPendingUploads', () {
       test('emits only pending uploads', () async {
-        await dao.upsertUpload(
-          createTestUpload(id: 'pending'),
-        );
+        await dao.upsertUpload(createTestUpload(id: 'pending'));
         await dao.upsertUpload(
           createTestUpload(id: 'published', status: UploadStatus.published),
         );
@@ -449,16 +413,10 @@ void main() {
 
       test('emits sorted by createdAt ascending', () async {
         await dao.upsertUpload(
-          createTestUpload(
-            id: 'second',
-            createdAt: DateTime(2024, 1, 2),
-          ),
+          createTestUpload(id: 'second', createdAt: DateTime(2024, 1, 2)),
         );
         await dao.upsertUpload(
-          createTestUpload(
-            id: 'first',
-            createdAt: DateTime(2024),
-          ),
+          createTestUpload(id: 'first', createdAt: DateTime(2024)),
         );
 
         final stream = dao.watchPendingUploads();
@@ -483,6 +441,42 @@ void main() {
 
       test('returns 0 when table is empty', () async {
         final deleted = await dao.clearAll();
+        expect(deleted, equals(0));
+      });
+    });
+
+    group('deleteAllForUser', () {
+      const testPubkey2 =
+          'fedcba9876543210fedcba9876543210'
+          'fedcba9876543210fedcba9876543210';
+
+      test('deletes all uploads for user', () async {
+        await dao.upsertUpload(createTestUpload(id: 'u1'));
+        await dao.upsertUpload(createTestUpload(id: 'u2'));
+
+        final deleted = await dao.deleteAllForUser(testPubkey);
+
+        expect(deleted, equals(2));
+        final remaining = await dao.getAllUploads();
+        expect(remaining, isEmpty);
+      });
+
+      test('does not delete uploads for other users', () async {
+        await dao.upsertUpload(createTestUpload(id: 'u_a'));
+        await dao.upsertUpload(
+          createTestUpload(id: 'u_b', nostrPubkey: testPubkey2),
+        );
+
+        await dao.deleteAllForUser(testPubkey);
+
+        final remaining = await dao.getAllUploads();
+        expect(remaining, hasLength(1));
+        expect(remaining.first.id, equals('u_b'));
+      });
+
+      test('returns 0 when no uploads exist', () async {
+        final deleted = await dao.deleteAllForUser(testPubkey);
+
         expect(deleted, equals(0));
       });
     });

--- a/mobile/test/services/auth_service_delete_keycast_account_test.dart
+++ b/mobile/test/services/auth_service_delete_keycast_account_test.dart
@@ -38,8 +38,13 @@ void main() {
       when(
         () => mockCleanupService.clearUserSpecificData(
           reason: any(named: 'reason'),
+          userPubkey: any(named: 'userPubkey'),
+          deleteUserData: any(named: 'deleteUserData'),
         ),
       ).thenAnswer((_) async => 0);
+      when(
+        () => mockCleanupService.claimLegacyRows(any()),
+      ).thenAnswer((_) async {});
     });
 
     test('returns success when no OAuth client is configured', () async {
@@ -57,31 +62,28 @@ void main() {
       expect(error, isNull);
     });
 
-    test(
-      'returns failure when session is unavailable after refresh',
-      () async {
-        // Create AuthService with OAuth client
-        authService = AuthService(
-          userDataCleanupService: mockCleanupService,
-          keyStorage: mockKeyStorage,
-          oauthClient: mockOAuthClient,
-        );
+    test('returns failure when session is unavailable after refresh', () async {
+      // Create AuthService with OAuth client
+      authService = AuthService(
+        userDataCleanupService: mockCleanupService,
+        keyStorage: mockKeyStorage,
+        oauthClient: mockOAuthClient,
+      );
 
-        // Mock: no session even after refresh attempt
-        when(
-          () => mockOAuthClient.getSessionOrRefresh(),
-        ).thenAnswer((_) async => null);
+      // Mock: no session even after refresh attempt
+      when(
+        () => mockOAuthClient.getSessionOrRefresh(),
+      ).thenAnswer((_) async => null);
 
-        // Act
-        final (success, error) = await authService.deleteKeycastAccount();
+      // Act
+      final (success, error) = await authService.deleteKeycastAccount();
 
-        // Assert — now correctly reports failure
-        expect(success, isFalse);
-        expect(error, contains('Session expired'));
-        verify(() => mockOAuthClient.getSessionOrRefresh()).called(1);
-        verifyNever(() => mockOAuthClient.deleteAccount(any()));
-      },
-    );
+      // Assert — now correctly reports failure
+      expect(success, isFalse);
+      expect(error, contains('Session expired'));
+      verify(() => mockOAuthClient.getSessionOrRefresh()).called(1);
+      verifyNever(() => mockOAuthClient.deleteAccount(any()));
+    });
 
     test(
       'returns failure when session has no access token after refresh',

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -37,8 +37,13 @@ void main() {
       when(
         () => mockCleanupService.clearUserSpecificData(
           reason: any(named: 'reason'),
+          userPubkey: any(named: 'userPubkey'),
+          deleteUserData: any(named: 'deleteUserData'),
         ),
       ).thenAnswer((_) async => 0);
+      when(
+        () => mockCleanupService.claimLegacyRows(any()),
+      ).thenAnswer((_) async {});
 
       // In-memory secure storage backing
       secureStorage = {};

--- a/mobile/test/services/auth_service_local_first_startup_test.dart
+++ b/mobile/test/services/auth_service_local_first_startup_test.dart
@@ -38,8 +38,13 @@ void main() {
       when(
         () => mockCleanupService.clearUserSpecificData(
           reason: any(named: 'reason'),
+          userPubkey: any(named: 'userPubkey'),
+          deleteUserData: any(named: 'deleteUserData'),
         ),
       ).thenAnswer((_) async => 0);
+      when(
+        () => mockCleanupService.claimLegacyRows(any()),
+      ).thenAnswer((_) async {});
 
       secureStorage = {};
 
@@ -128,45 +133,42 @@ void main() {
       );
     }
 
-    test(
-      'divineOAuth local restore starts in upgrading state '
-      'before RPC is ready',
-      () async {
-        SharedPreferences.setMockInitialValues({
-          'authentication_source': 'divineOAuth',
-          'tos_accepted': true,
-        });
+    test('divineOAuth local restore starts in upgrading state '
+        'before RPC is ready', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
 
-        arrangeExpiredSessionWithMatchingLocalKeys();
+      arrangeExpiredSessionWithMatchingLocalKeys();
 
-        // refreshSession returns null (failed)
-        when(
-          () => mockOAuthClient.refreshSession(),
-        ).thenAnswer((_) async => null);
+      // refreshSession returns null (failed)
+      when(
+        () => mockOAuthClient.refreshSession(),
+      ).thenAnswer((_) async => null);
 
-        final authService = createAuthService();
+      final authService = createAuthService();
 
-        await runZonedGuarded(
-          () async {
-            await authService.initialize();
+      await runZonedGuarded(
+        () async {
+          await authService.initialize();
 
-            expect(authService.isAuthenticated, isTrue);
-            expect(
-              authService.authenticationSource,
-              equals(AuthenticationSource.divineOAuth),
-            );
-            // RPC capability should not be rpcReady since refresh failed
-            expect(
-              authService.authRpcCapability,
-              isNot(equals(AuthRpcCapability.rpcReady)),
-            );
-          },
-          (error, stack) {
-            // Ignore background relay discovery errors
-          },
-        );
-      },
-    );
+          expect(authService.isAuthenticated, isTrue);
+          expect(
+            authService.authenticationSource,
+            equals(AuthenticationSource.divineOAuth),
+          );
+          // RPC capability should not be rpcReady since refresh failed
+          expect(
+            authService.authRpcCapability,
+            isNot(equals(AuthRpcCapability.rpcReady)),
+          );
+        },
+        (error, stack) {
+          // Ignore background relay discovery errors
+        },
+      );
+    });
 
     test(
       'authRpcCapability defaults to unavailable for non-oauth sources',
@@ -233,54 +235,48 @@ void main() {
       },
     );
 
-    test(
-      'canPublishNostrWritesNow is false when not authenticated',
-      () {
-        final authService = createAuthService();
-        expect(authService.canPublishNostrWritesNow, isFalse);
-      },
-    );
+    test('canPublishNostrWritesNow is false when not authenticated', () {
+      final authService = createAuthService();
+      expect(authService.canPublishNostrWritesNow, isFalse);
+    });
 
-    test(
-      'matching local key authenticates before refresh completes',
-      () async {
-        SharedPreferences.setMockInitialValues({
-          'authentication_source': 'divineOAuth',
-          'tos_accepted': true,
-        });
+    test('matching local key authenticates before refresh completes', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
 
-        final pubkey = arrangeExpiredSessionWithMatchingLocalKeys();
+      final pubkey = arrangeExpiredSessionWithMatchingLocalKeys();
 
-        // refreshSession hangs forever (simulates slow network)
-        when(
-          () => mockOAuthClient.refreshSession(),
-        ).thenAnswer((_) => Completer<KeycastSession?>().future);
+      // refreshSession hangs forever (simulates slow network)
+      when(
+        () => mockOAuthClient.refreshSession(),
+      ).thenAnswer((_) => Completer<KeycastSession?>().future);
 
-        final authService = createAuthService();
+      final authService = createAuthService();
 
-        await runZonedGuarded(
-          () async {
-            await authService.initialize();
+      await runZonedGuarded(
+        () async {
+          await authService.initialize();
 
-            // Should be authenticated immediately from local keys
-            expect(authService.isAuthenticated, isTrue);
-            expect(authService.currentPublicKeyHex, equals(pubkey));
-            expect(
-              authService.authenticationSource,
-              equals(AuthenticationSource.divineOAuth),
-            );
-            // RPC is upgrading (refresh is still in-flight)
-            expect(
-              authService.authRpcCapability,
-              equals(AuthRpcCapability.upgrading),
-            );
-          },
-          (error, stack) {
-            // Ignore background errors
-          },
-        );
-      },
-    );
+          // Should be authenticated immediately from local keys
+          expect(authService.isAuthenticated, isTrue);
+          expect(authService.currentPublicKeyHex, equals(pubkey));
+          expect(
+            authService.authenticationSource,
+            equals(AuthenticationSource.divineOAuth),
+          );
+          // RPC is upgrading (refresh is still in-flight)
+          expect(
+            authService.authRpcCapability,
+            equals(AuthRpcCapability.upgrading),
+          );
+        },
+        (error, stack) {
+          // Ignore background errors
+        },
+      );
+    });
 
     test(
       'refresh timeout does not block local authenticated startup',
@@ -313,43 +309,37 @@ void main() {
       },
     );
 
-    test(
-      'no local key + no valid session → unauthenticated',
-      () async {
-        SharedPreferences.setMockInitialValues({
-          'authentication_source': 'divineOAuth',
-          'tos_accepted': true,
-        });
+    test('no local key + no valid session → unauthenticated', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
 
-        // Expired session, no local keys
-        final expiredSession = KeycastSession(
-          bunkerUrl: 'https://login.divine.video/api/nostr',
-          accessToken: 'expired_token',
-          expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
-        );
-        secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
+      // Expired session, no local keys
+      final expiredSession = KeycastSession(
+        bunkerUrl: 'https://login.divine.video/api/nostr',
+        accessToken: 'expired_token',
+        expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+      );
+      secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
 
-        when(
-          () => mockOAuthClient.refreshSession(),
-        ).thenAnswer((_) async => null);
+      when(
+        () => mockOAuthClient.refreshSession(),
+      ).thenAnswer((_) async => null);
 
-        final authService = createAuthService();
+      final authService = createAuthService();
 
-        await runZonedGuarded(
-          () async {
-            await authService.initialize();
+      await runZonedGuarded(
+        () async {
+          await authService.initialize();
 
-            expect(
-              authService.authState,
-              equals(AuthState.unauthenticated),
-            );
-            expect(authService.hasExpiredOAuthSession, isTrue);
-          },
-          (error, stack) {
-            // Ignore background errors
-          },
-        );
-      },
-    );
+          expect(authService.authState, equals(AuthState.unauthenticated));
+          expect(authService.hasExpiredOAuthSession, isTrue);
+        },
+        (error, stack) {
+          // Ignore background errors
+        },
+      );
+    });
   });
 }

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -114,8 +114,13 @@ void main() {
       () => mockCleanupService.clearUserSpecificData(
         reason: any(named: 'reason'),
         isIdentityChange: any(named: 'isIdentityChange'),
+        userPubkey: any(named: 'userPubkey'),
+        deleteUserData: any(named: 'deleteUserData'),
       ),
     ).thenAnswer((_) async => 0);
+    when(
+      () => mockCleanupService.claimLegacyRows(any()),
+    ).thenAnswer((_) async {});
 
     // Default flutter secure storage stubs
     when(
@@ -1857,6 +1862,55 @@ void main() {
       expect(prefs.getString('last_used_npub'), isNotNull);
     });
 
+    test(
+      'destructive sign-out passes the signed-in pubkey to cleanup',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+          kKnownAccountsKey: '[]',
+        });
+
+        await _ignoringDiscoveryErrors(authService.createNewIdentity);
+        // Capture the pubkey hex before signOut disposes the container.
+        final expectedPubkey = testKeyContainer.publicKeyHex;
+        await authService.signOut(deleteKeys: true);
+
+        verify(
+          () => mockCleanupService.clearUserSpecificData(
+            reason: 'explicit_logout',
+            userPubkey: expectedPubkey,
+            deleteUserData: true,
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'non-destructive sign-out passes the signed-in pubkey to cleanup '
+      'with deleteUserData: false so account-local DAO rows survive '
+      'an account switch',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+          kKnownAccountsKey: '[]',
+        });
+
+        await _ignoringDiscoveryErrors(authService.createNewIdentity);
+        // Capture the pubkey hex before signOut disposes the container.
+        final expectedPubkey = testKeyContainer.publicKeyHex;
+        await authService.signOut();
+
+        verify(
+          () => mockCleanupService.clearUserSpecificData(
+            reason: 'explicit_logout',
+            userPubkey: expectedPubkey,
+            // ignore: avoid_redundant_argument_values
+            deleteUserData: false,
+          ),
+        ).called(1);
+      },
+    );
+
     test('_setupUserSession persists last_used_npub', () async {
       await _ignoringDiscoveryErrors(authService.createNewIdentity);
 
@@ -1965,60 +2019,48 @@ void main() {
 
         // Recovery should point to A (the remaining account)
         final prefs = await SharedPreferences.getInstance();
-        expect(
-          prefs.getString('last_used_npub'),
-          equals(accountA.npub),
-        );
-        expect(
-          prefs.getString('authentication_source'),
-          equals('automatic'),
-        );
+        expect(prefs.getString('last_used_npub'), equals(accountA.npub));
+        expect(prefs.getString('authentication_source'), equals('automatic'));
       },
     );
 
-    test(
-      'initialize restores remaining account after destructive sign-out '
-      'via known accounts scan',
-      () async {
-        // Scenario: last_used_npub is absent, PRIMARY is wiped,
-        // but account A still has per-identity keys
-        final accountA = SecureKeyContainer.fromNsec(
-          'nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsmhltgl',
-        );
+    test('initialize restores remaining account after destructive sign-out '
+        'via known accounts scan', () async {
+      // Scenario: last_used_npub is absent, PRIMARY is wiped,
+      // but account A still has per-identity keys
+      final accountA = SecureKeyContainer.fromNsec(
+        'nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsmhltgl',
+      );
 
-        final knownAccounts = jsonEncode([
-          KnownAccount(
-            pubkeyHex: accountA.publicKeyHex,
-            authSource: AuthenticationSource.automatic,
-            addedAt: DateTime.now().subtract(const Duration(hours: 2)),
-            lastUsedAt: DateTime.now().subtract(const Duration(hours: 1)),
-          ).toJson(),
-        ]);
+      final knownAccounts = jsonEncode([
+        KnownAccount(
+          pubkeyHex: accountA.publicKeyHex,
+          authSource: AuthenticationSource.automatic,
+          addedAt: DateTime.now().subtract(const Duration(hours: 2)),
+          lastUsedAt: DateTime.now().subtract(const Duration(hours: 1)),
+        ).toJson(),
+      ]);
 
-        // No last_used_npub, simulating edge case where pref was lost
-        SharedPreferences.setMockInitialValues({
-          'authentication_source': 'automatic',
-          kKnownAccountsKey: knownAccounts,
-        });
+      // No last_used_npub, simulating edge case where pref was lost
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'automatic',
+        kKnownAccountsKey: knownAccounts,
+      });
 
-        // PRIMARY is empty (wiped by deleteKeys)
-        when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
-        // But account A has per-identity keys
-        when(
-          () => mockKeyStorage.getIdentityKeyContainer(
-            accountA.npub,
-            biometricPrompt: any(named: 'biometricPrompt'),
-          ),
-        ).thenAnswer((_) async => accountA);
+      // PRIMARY is empty (wiped by deleteKeys)
+      when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+      // But account A has per-identity keys
+      when(
+        () => mockKeyStorage.getIdentityKeyContainer(
+          accountA.npub,
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      ).thenAnswer((_) async => accountA);
 
-        await _ignoringDiscoveryErrors(authService.initialize);
+      await _ignoringDiscoveryErrors(authService.initialize);
 
-        expect(authService.authState, equals(AuthState.authenticated));
-        expect(
-          authService.currentPublicKeyHex,
-          equals(accountA.publicKeyHex),
-        );
-      },
-    );
+      expect(authService.authState, equals(AuthState.authenticated));
+      expect(authService.currentPublicKeyHex, equals(accountA.publicKeyHex));
+    });
   });
 }

--- a/mobile/test/services/auth_service_oauth_recovery_test.dart
+++ b/mobile/test/services/auth_service_oauth_recovery_test.dart
@@ -173,8 +173,13 @@ void main() {
       () => mockCleanupService.clearUserSpecificData(
         reason: any(named: 'reason'),
         isIdentityChange: any(named: 'isIdentityChange'),
+        userPubkey: any(named: 'userPubkey'),
+        deleteUserData: any(named: 'deleteUserData'),
       ),
     ).thenAnswer((_) async => 0);
+    when(
+      () => mockCleanupService.claimLegacyRows(any()),
+    ).thenAnswer((_) async {});
 
     // Mock OAuth client: logout clears the same keys that the real
     // KeycastOAuth.logout() would clear via SecureKeycastStorage.
@@ -243,10 +248,7 @@ void main() {
       // Verify recovery prefs point to A
       final prefs = await SharedPreferences.getInstance();
       expect(prefs.getString('last_used_npub'), equals(accountA.npub));
-      expect(
-        prefs.getString('authentication_source'),
-        equals('divineOAuth'),
-      );
+      expect(prefs.getString('authentication_source'), equals('divineOAuth'));
 
       // Verify A's OAuth session was restored to the active slot
       final restoredSessionJson = fakeSecureStorage.data['keycast_session'];
@@ -300,9 +302,9 @@ void main() {
           refreshToken: 'new_refresh_token_A',
           userPubkey: accountA.publicKeyHex,
         );
-        when(() => mockOAuthClient.refreshSession()).thenAnswer(
-          (_) async => refreshedSession,
-        );
+        when(
+          () => mockOAuthClient.refreshSession(),
+        ).thenAnswer((_) async => refreshedSession);
 
         // Create fresh AuthService (simulates app restart)
         authService = createAuthService();

--- a/mobile/test/services/auth_service_signing_mismatch_test.dart
+++ b/mobile/test/services/auth_service_signing_mismatch_test.dart
@@ -83,9 +83,7 @@ void main() {
     when(
       () => mockKeyStorage.storeIdentityKeyContainer(any(), any()),
     ).thenAnswer((_) async {});
-    when(
-      () => mockKeyStorage.getKeyContainer(),
-    ).thenAnswer((_) async => null);
+    when(() => mockKeyStorage.getKeyContainer()).thenAnswer((_) async => null);
     when(
       () => mockKeyStorage.switchToIdentity(
         any(),
@@ -100,8 +98,13 @@ void main() {
       () => mockCleanupService.clearUserSpecificData(
         reason: any(named: 'reason'),
         isIdentityChange: any(named: 'isIdentityChange'),
+        userPubkey: any(named: 'userPubkey'),
+        deleteUserData: any(named: 'deleteUserData'),
       ),
     ).thenAnswer((_) async => 0);
+    when(
+      () => mockCleanupService.claimLegacyRows(any()),
+    ).thenAnswer((_) async {});
 
     when(
       () => mockSecureStorage.read(key: any(named: 'key')),
@@ -128,139 +131,130 @@ void main() {
   });
 
   group('Bug #2233: signing after account switch', () {
-    test(
-      'createAndSignEvent fails when PRIMARY key slot has different nsec '
-      'than _currentKeyContainer',
-      () async {
-        // ── Setup: simulate the state AFTER the corruption ──
-        //
-        // 1. signInForAccount(pubkeyA, automatic) loaded identity[npubA]
-        //    into _currentKeyContainer (has pubkey_A).
-        // 2. PRIMARY key slot still has nsec_B from a previous import.
-        //
-        // We mock getIdentityKeyContainer to return containerA (pubkey_A)
-        // and withPrivateKey to return nsec_B (simulating corrupted PRIMARY).
+    test('createAndSignEvent fails when PRIMARY key slot has different nsec '
+        'than _currentKeyContainer', () async {
+      // ── Setup: simulate the state AFTER the corruption ──
+      //
+      // 1. signInForAccount(pubkeyA, automatic) loaded identity[npubA]
+      //    into _currentKeyContainer (has pubkey_A).
+      // 2. PRIMARY key slot still has nsec_B from a previous import.
+      //
+      // We mock getIdentityKeyContainer to return containerA (pubkey_A)
+      // and withPrivateKey to return nsec_B (simulating corrupted PRIMARY).
 
-        final npubA = containerA.npub;
+      final npubA = containerA.npub;
 
-        // getIdentityKeyContainer returns A's container
-        when(
-          () => mockKeyStorage.getIdentityKeyContainer(
-            npubA,
-            biometricPrompt: any(named: 'biometricPrompt'),
-          ),
-        ).thenAnswer((_) async => containerA);
+      // getIdentityKeyContainer returns A's container
+      when(
+        () => mockKeyStorage.getIdentityKeyContainer(
+          npubA,
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      ).thenAnswer((_) async => containerA);
 
-        // Track which private key the PRIMARY slot holds.
-        // Starts with nsec_B (simulating corrupted state from previous import).
-        String? privateKeyBHex;
-        containerB.withPrivateKey<void>((pk) => privateKeyBHex = pk);
-        String? privateKeyAHex;
-        containerA.withPrivateKey<void>((pk) => privateKeyAHex = pk);
-        var primaryPrivateKey = privateKeyBHex!;
+      // Track which private key the PRIMARY slot holds.
+      // Starts with nsec_B (simulating corrupted state from previous import).
+      String? privateKeyBHex;
+      containerB.withPrivateKey<void>((pk) => privateKeyBHex = pk);
+      String? privateKeyAHex;
+      containerA.withPrivateKey<void>((pk) => privateKeyAHex = pk);
+      var primaryPrivateKey = privateKeyBHex!;
 
-        // switchToIdentity syncs PRIMARY — the fix calls this before signing
-        when(
-          () => mockKeyStorage.switchToIdentity(
-            any(),
-            biometricPrompt: any(named: 'biometricPrompt'),
-          ),
-        ).thenAnswer((_) async {
-          primaryPrivateKey = privateKeyAHex!;
-          return true;
-        });
+      // switchToIdentity syncs PRIMARY — the fix calls this before signing
+      when(
+        () => mockKeyStorage.switchToIdentity(
+          any(),
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      ).thenAnswer((_) async {
+        primaryPrivateKey = privateKeyAHex!;
+        return true;
+      });
 
-        when(
-          () => mockKeyStorage.withPrivateKey<Event?>(
-            any(),
-            biometricPrompt: any(named: 'biometricPrompt'),
-          ),
-        ).thenAnswer((invocation) async {
-          final operation =
-              invocation.positionalArguments[0] as Event? Function(String);
-          // Returns whatever PRIMARY currently holds
-          return operation(primaryPrivateKey);
-        });
+      when(
+        () => mockKeyStorage.withPrivateKey<Event?>(
+          any(),
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      ).thenAnswer((invocation) async {
+        final operation =
+            invocation.positionalArguments[0] as Event? Function(String);
+        // Returns whatever PRIMARY currently holds
+        return operation(primaryPrivateKey);
+      });
 
-        // Sign in as account A
-        await _ignoringDiscoveryErrors(
-          () => authService.signInForAccount(
-            containerA.publicKeyHex,
-            AuthenticationSource.automatic,
-          ),
-        );
+      // Sign in as account A
+      await _ignoringDiscoveryErrors(
+        () => authService.signInForAccount(
+          containerA.publicKeyHex,
+          AuthenticationSource.automatic,
+        ),
+      );
 
-        expect(authService.isAuthenticated, isTrue);
-        expect(
-          authService.currentPublicKeyHex,
-          equals(containerA.publicKeyHex),
-        );
+      expect(authService.isAuthenticated, isTrue);
+      expect(authService.currentPublicKeyHex, equals(containerA.publicKeyHex));
 
-        // ── Act: try to sign an event ──
-        final signedEvent = await authService.createAndSignEvent(
-          kind: 1,
-          content: 'test after account switch',
-        );
+      // ── Act: try to sign an event ──
+      final signedEvent = await authService.createAndSignEvent(
+        kind: 1,
+        content: 'test after account switch',
+      );
 
-        // ── Assert: signing should succeed (fails with bug #2233) ──
-        expect(
-          signedEvent,
-          isNotNull,
-          reason:
-              'BUG #2233: createAndSignEvent returns null because '
-              '_keyStorage.withPrivateKey reads nsec_B from PRIMARY but '
-              'the event was created with pubkey_A from '
-              '_currentKeyContainer.',
-        );
-      },
-    );
+      // ── Assert: signing should succeed (fails with bug #2233) ──
+      expect(
+        signedEvent,
+        isNotNull,
+        reason:
+            'BUG #2233: createAndSignEvent returns null because '
+            '_keyStorage.withPrivateKey reads nsec_B from PRIMARY but '
+            'the event was created with pubkey_A from '
+            '_currentKeyContainer.',
+      );
+    });
 
-    test(
-      'createAndSignEvent succeeds when PRIMARY key slot matches '
-      '_currentKeyContainer',
-      () async {
-        // Control case: when PRIMARY has the correct nsec, signing works.
+    test('createAndSignEvent succeeds when PRIMARY key slot matches '
+        '_currentKeyContainer', () async {
+      // Control case: when PRIMARY has the correct nsec, signing works.
 
-        final npubA = containerA.npub;
+      final npubA = containerA.npub;
 
-        when(
-          () => mockKeyStorage.getIdentityKeyContainer(
-            npubA,
-            biometricPrompt: any(named: 'biometricPrompt'),
-          ),
-        ).thenAnswer((_) async => containerA);
+      when(
+        () => mockKeyStorage.getIdentityKeyContainer(
+          npubA,
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      ).thenAnswer((_) async => containerA);
 
-        // withPrivateKey returns nsec_A (correct key)
-        String? privateKeyAHex;
-        containerA.withPrivateKey<void>((pk) => privateKeyAHex = pk);
+      // withPrivateKey returns nsec_A (correct key)
+      String? privateKeyAHex;
+      containerA.withPrivateKey<void>((pk) => privateKeyAHex = pk);
 
-        when(
-          () => mockKeyStorage.withPrivateKey<Event?>(
-            any(),
-            biometricPrompt: any(named: 'biometricPrompt'),
-          ),
-        ).thenAnswer((invocation) async {
-          final operation =
-              invocation.positionalArguments[0] as Event? Function(String);
-          return operation(privateKeyAHex!);
-        });
+      when(
+        () => mockKeyStorage.withPrivateKey<Event?>(
+          any(),
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      ).thenAnswer((invocation) async {
+        final operation =
+            invocation.positionalArguments[0] as Event? Function(String);
+        return operation(privateKeyAHex!);
+      });
 
-        await _ignoringDiscoveryErrors(
-          () => authService.signInForAccount(
-            containerA.publicKeyHex,
-            AuthenticationSource.automatic,
-          ),
-        );
+      await _ignoringDiscoveryErrors(
+        () => authService.signInForAccount(
+          containerA.publicKeyHex,
+          AuthenticationSource.automatic,
+        ),
+      );
 
-        final signedEvent = await authService.createAndSignEvent(
-          kind: 1,
-          content: 'test with matching keys',
-        );
+      final signedEvent = await authService.createAndSignEvent(
+        kind: 1,
+        content: 'test with matching keys',
+      );
 
-        expect(signedEvent, isNotNull);
-        expect(signedEvent!.pubkey, equals(containerA.publicKeyHex));
-      },
-    );
+      expect(signedEvent, isNotNull);
+      expect(signedEvent!.pubkey, equals(containerA.publicKeyHex));
+    });
 
     test(
       'createAndSignEvent fails when PRIMARY key slot was wiped by deleteKeys '

--- a/mobile/test/services/auth_service_signout_cleanup_test.dart
+++ b/mobile/test/services/auth_service_signout_cleanup_test.dart
@@ -51,8 +51,13 @@ void main() {
       when(
         () => mockCleanupService.clearUserSpecificData(
           reason: any(named: 'reason'),
+          userPubkey: any(named: 'userPubkey'),
+          deleteUserData: any(named: 'deleteUserData'),
         ),
       ).thenAnswer((_) async => 0);
+      when(
+        () => mockCleanupService.claimLegacyRows(any()),
+      ).thenAnswer((_) async {});
     });
 
     test('signOut should clear current_user_pubkey_hex', () async {
@@ -85,58 +90,58 @@ void main() {
       expect(prefs.getString('terms_accepted_at'), isNull);
     });
 
-    test(
-      'signOut should call cleanup service to clear user-specific data',
-      () async {
-        // Setup mock
-        when(() => mockKeyStorage.clearCache()).thenReturn(null);
+    test('non-destructive signOut passes deleteUserData: false', () async {
+      // Setup mock
+      when(() => mockKeyStorage.clearCache()).thenReturn(null);
 
-        // Act: Sign out
-        await authService.signOut();
+      // Act: Sign out without deleting keys (account switch)
+      await authService.signOut();
 
-        // Assert: Cleanup service should be called with explicit_logout reason
-        verify(
-          () => mockCleanupService.clearUserSpecificData(
-            reason: 'explicit_logout',
-          ),
-        ).called(1);
-      },
-    );
+      // Assert: Cleanup called with deleteUserData=false (preserves
+      // per-user DAO data since it's scoped by ownerPubkey)
+      verify(
+        () => mockCleanupService.clearUserSpecificData(
+          reason: 'explicit_logout',
+          userPubkey: any(named: 'userPubkey'),
+          // ignore: avoid_redundant_argument_values
+          deleteUserData: false,
+        ),
+      ).called(1);
+    });
 
-    test(
-      'signOut with deleteKeys should delete keys and call cleanup',
-      () async {
-        // Arrange
-        when(() => mockKeyStorage.deleteKeys()).thenAnswer((_) async => {});
-        when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
-        when(() => mockKeyStorage.initialize()).thenAnswer((_) async => {});
+    test('destructive signOut passes deleteUserData: true', () async {
+      // Arrange
+      when(() => mockKeyStorage.deleteKeys()).thenAnswer((_) async => {});
+      when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+      when(() => mockKeyStorage.initialize()).thenAnswer((_) async => {});
 
-        // Auto-create new identity after deletion
-        final newKeyContainer = SecureKeyContainer.fromNsec(testNsec);
-        when(
-          () => mockKeyStorage.generateAndStoreKeys(
-            biometricPrompt: any(named: 'biometricPrompt'),
-          ),
-        ).thenAnswer((_) async => newKeyContainer);
+      // Auto-create new identity after deletion
+      final newKeyContainer = SecureKeyContainer.fromNsec(testNsec);
+      when(
+        () => mockKeyStorage.generateAndStoreKeys(
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      ).thenAnswer((_) async => newKeyContainer);
 
-        // Act: Sign out with key deletion
-        await authService.signOut(deleteKeys: true);
+      // Act: Sign out with key deletion
+      await authService.signOut(deleteKeys: true);
 
-        // Assert: Keys should be deleted
-        verify(() => mockKeyStorage.deleteKeys()).called(1);
+      // Assert: Keys should be deleted
+      verify(() => mockKeyStorage.deleteKeys()).called(1);
 
-        // Assert: Cleanup service should be called with explicit_logout reason
-        verify(
-          () => mockCleanupService.clearUserSpecificData(
-            reason: 'explicit_logout',
-          ),
-        ).called(1);
+      // Assert: Cleanup called with deleteUserData=true (destructive)
+      verify(
+        () => mockCleanupService.clearUserSpecificData(
+          reason: 'explicit_logout',
+          userPubkey: any(named: 'userPubkey'),
+          deleteUserData: true,
+        ),
+      ).called(1);
 
-        // Note: After deleteKeys=true, a new identity is auto-created,
-        // which sets a new pubkey. So we verify cleanup was called,
-        // not that pubkey is null (since new identity sets it).
-      },
-    );
+      // Note: After deleteKeys=true, a new identity is auto-created,
+      // which sets a new pubkey. So we verify cleanup was called,
+      // not that pubkey is null (since new identity sets it).
+    });
 
     test('signOut should set auth state to unauthenticated', () async {
       // Setup mock
@@ -150,113 +155,91 @@ void main() {
     });
 
     group('key deletion error propagation', () {
-      test(
-        'signOut with deleteKeys rethrows SecureKeyStorageException '
-        'after completing cleanup',
-        () async {
-          // Arrange: deleteKeys() throws
-          when(() => mockKeyStorage.deleteKeys()).thenThrow(
-            const SecureKeyStorageException(
-              'Platform key deletion failed',
-              code: 'platform_deletion_failed',
-            ),
-          );
-          when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+      test('signOut with deleteKeys rethrows SecureKeyStorageException '
+          'after completing cleanup', () async {
+        // Arrange: deleteKeys() throws
+        when(() => mockKeyStorage.deleteKeys()).thenThrow(
+          const SecureKeyStorageException(
+            'Platform key deletion failed',
+            code: 'platform_deletion_failed',
+          ),
+        );
+        when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
 
-          // Act & Assert: signOut completes cleanup then rethrows
-          await expectLater(
-            authService.signOut(deleteKeys: true),
-            throwsA(isA<SecureKeyStorageException>()),
-          );
+        // Act & Assert: signOut completes cleanup then rethrows
+        await expectLater(
+          authService.signOut(deleteKeys: true),
+          throwsA(isA<SecureKeyStorageException>()),
+        );
 
-          // Auth state should still be unauthenticated — cleanup completed
-          expect(
-            authService.authState,
-            equals(AuthState.unauthenticated),
-          );
-        },
-      );
+        // Auth state should still be unauthenticated — cleanup completed
+        expect(authService.authState, equals(AuthState.unauthenticated));
+      });
 
-      test(
-        'signOut with deleteKeys succeeds normally when keys delete '
-        'successfully',
-        () async {
-          // Arrange: deleteKeys() succeeds
-          when(() => mockKeyStorage.deleteKeys()).thenAnswer((_) async => {});
-          when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+      test('signOut with deleteKeys succeeds normally when keys delete '
+          'successfully', () async {
+        // Arrange: deleteKeys() succeeds
+        when(() => mockKeyStorage.deleteKeys()).thenAnswer((_) async => {});
+        when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
 
-          // Act: should not throw
-          await authService.signOut(deleteKeys: true);
+        // Act: should not throw
+        await authService.signOut(deleteKeys: true);
 
-          // Assert: completed normally
-          expect(
-            authService.authState,
-            equals(AuthState.unauthenticated),
-          );
-          verify(() => mockKeyStorage.deleteKeys()).called(1);
-        },
-      );
+        // Assert: completed normally
+        expect(authService.authState, equals(AuthState.unauthenticated));
+        verify(() => mockKeyStorage.deleteKeys()).called(1);
+      });
 
-      test(
-        'signOut with abortOnKeyDeletionFailure throws before cleanup '
-        'when key deletion fails',
-        () async {
-          // Arrange: deleteKeys() throws
-          when(() => mockKeyStorage.deleteKeys()).thenThrow(
-            const SecureKeyStorageException(
-              'Platform key deletion failed',
-              code: 'platform_deletion_failed',
-            ),
-          );
+      test('signOut with abortOnKeyDeletionFailure throws before cleanup '
+          'when key deletion fails', () async {
+        // Arrange: deleteKeys() throws
+        when(() => mockKeyStorage.deleteKeys()).thenThrow(
+          const SecureKeyStorageException(
+            'Platform key deletion failed',
+            code: 'platform_deletion_failed',
+          ),
+        );
 
-          // Act & Assert: signOut throws immediately
-          await expectLater(
-            authService.signOut(
-              deleteKeys: true,
-              abortOnKeyDeletionFailure: true,
-            ),
-            throwsA(isA<SecureKeyStorageException>()),
-          );
-
-          // Auth state should still be initial — no cleanup happened
-          expect(
-            authService.authState,
-            isNot(equals(AuthState.unauthenticated)),
-          );
-
-          // Cleanup service should NOT have been called
-          verifyNever(
-            () => mockCleanupService.clearUserSpecificData(
-              reason: any(named: 'reason'),
-            ),
-          );
-        },
-      );
-
-      test(
-        'signOut with abortOnKeyDeletionFailure completes normally '
-        'when key deletion succeeds',
-        () async {
-          // Arrange: deleteKeys() succeeds
-          when(() => mockKeyStorage.deleteKeys()).thenAnswer((_) async => {});
-          when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
-
-          // Act: should not throw
-          await authService.signOut(
+        // Act & Assert: signOut throws immediately
+        await expectLater(
+          authService.signOut(
             deleteKeys: true,
             abortOnKeyDeletionFailure: true,
-          );
+          ),
+          throwsA(isA<SecureKeyStorageException>()),
+        );
 
-          // Assert: completed normally, auth state unauthenticated
-          expect(
-            authService.authState,
-            equals(AuthState.unauthenticated),
-          );
+        // Auth state should still be initial — no cleanup happened
+        expect(authService.authState, isNot(equals(AuthState.unauthenticated)));
 
-          // deleteKeys() called only once (pre-flight), not twice
-          verify(() => mockKeyStorage.deleteKeys()).called(1);
-        },
-      );
+        // Cleanup service should NOT have been called
+        verifyNever(
+          () => mockCleanupService.clearUserSpecificData(
+            reason: any(named: 'reason'),
+            userPubkey: any(named: 'userPubkey'),
+            deleteUserData: any(named: 'deleteUserData'),
+          ),
+        );
+      });
+
+      test('signOut with abortOnKeyDeletionFailure completes normally '
+          'when key deletion succeeds', () async {
+        // Arrange: deleteKeys() succeeds
+        when(() => mockKeyStorage.deleteKeys()).thenAnswer((_) async => {});
+        when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+
+        // Act: should not throw
+        await authService.signOut(
+          deleteKeys: true,
+          abortOnKeyDeletionFailure: true,
+        );
+
+        // Assert: completed normally, auth state unauthenticated
+        expect(authService.authState, equals(AuthState.unauthenticated));
+
+        // deleteKeys() called only once (pre-flight), not twice
+        verify(() => mockKeyStorage.deleteKeys()).called(1);
+      });
     });
   });
 }

--- a/mobile/test/services/user_data_cleanup_service_test.dart
+++ b/mobile/test/services/user_data_cleanup_service_test.dart
@@ -232,6 +232,59 @@ void main() {
         // Matching prefix should be cleared
         expect(prefs.containsKey('following_list_abc123'), isFalse);
       });
+
+      test(
+        'passes userPubkey and deleteUserData to onDatabaseCleanup',
+        () async {
+          String? receivedPubkey;
+          var receivedDeleteUserData = false;
+          service.onDatabaseCleanup =
+              ({String? userPubkey, bool deleteUserData = false}) async {
+                receivedPubkey = userPubkey;
+                receivedDeleteUserData = deleteUserData;
+              };
+
+          await service.clearUserSpecificData(
+            reason: 'explicit_logout',
+            userPubkey: 'abc123',
+            deleteUserData: true,
+          );
+
+          expect(receivedPubkey, equals('abc123'));
+          expect(receivedDeleteUserData, isTrue);
+        },
+      );
+
+      test(
+        'passes deleteUserData=false by default to onDatabaseCleanup',
+        () async {
+          var receivedDeleteUserData = true;
+          service.onDatabaseCleanup =
+              ({String? userPubkey, bool deleteUserData = false}) async {
+                receivedDeleteUserData = deleteUserData;
+              };
+
+          await service.clearUserSpecificData(reason: 'explicit_logout');
+
+          expect(receivedDeleteUserData, isFalse);
+        },
+      );
+
+      test('claimLegacyRows calls onClaimLegacyRows callback', () async {
+        String? receivedPubkey;
+        service.onClaimLegacyRows = (String pubkey) async {
+          receivedPubkey = pubkey;
+        };
+
+        await service.claimLegacyRows('abc123');
+
+        expect(receivedPubkey, equals('abc123'));
+      });
+
+      test('claimLegacyRows is safe when callback not set', () async {
+        // Should not throw
+        await service.claimLegacyRows('abc123');
+      });
     });
 
     group('userSpecificKeys', () {


### PR DESCRIPTION
Closes #3006

Addresses PR #3006 review. Gates per-user DAO cleanup (drafts, clips, pending uploads, personal reactions/reposts, pending actions) behind destructive sign-out (deleteKeys=true) via a new `deleteUserData` flag on UserDataCleanupService; non-destructive sign-out (account switch) now preserves account-local state. Closes the cross-account legacy leak by adding `claimLegacyRows` to DraftsDao and ClipsDao, called during `_setupUserSession` so NULL-owner rows are attributed to the current user and no longer visible to other accounts through `_ownedOrLegacy`. Adds a `safeDelete` helper so one failing DAO call doesn't skip the rest, and strengthens test coverage with exact-pubkey assertions in auth_service_multi_account_test for both destructive and non-destructive sign-out paths.