### PR TITLE
fix(test): resolve test isolation for VGV parallel runner

### DIFF
--- a/mobile/lib/services/feed_performance_tracker.dart
+++ b/mobile/lib/services/feed_performance_tracker.dart
@@ -15,10 +15,19 @@ const _maxSessionAge = Duration(seconds: 60);
 
 /// Service for tracking feed performance and user engagement
 class FeedPerformanceTracker {
-  static final FeedPerformanceTracker _instance =
-      FeedPerformanceTracker._internal();
-  factory FeedPerformanceTracker() => _instance;
-  FeedPerformanceTracker._internal();
+  factory FeedPerformanceTracker() => _instance ??= FeedPerformanceTracker._();
+  FeedPerformanceTracker._();
+
+  static FeedPerformanceTracker? _instance;
+
+  /// Resets the singleton so the next [FeedPerformanceTracker()] call returns a
+  /// fresh instance. Call in test `tearDown` to prevent state leaking between
+  /// test files when tests run in a shared isolate (e.g. VGV optimized runner).
+  @visibleForTesting
+  static void resetInstance() {
+    _instance?._activeSessions.clear();
+    _instance = null;
+  }
 
   /// Creates a testable instance that does not touch [FirebaseAnalytics].
   @visibleForTesting

--- a/mobile/lib/services/notification_service_enhanced.dart
+++ b/mobile/lib/services/notification_service_enhanced.dart
@@ -35,6 +35,15 @@ class NotificationServiceEnhanced {
     return _instance!;
   }
 
+  /// Resets the singleton so the next access returns a fresh instance.
+  /// Call in test `tearDown` to prevent state leaking between test files
+  /// when tests run in a shared isolate (e.g. VGV optimized runner).
+  @visibleForTesting
+  static void resetInstance() {
+    _instance?.dispose();
+    _instance = null;
+  }
+
   final List<NotificationModel> _notifications = [];
   final Map<String, StreamSubscription> _subscriptions = {};
   final Lock _notificationLock = Lock(); // Mutex for atomic deduplication

--- a/mobile/lib/services/screen_analytics_service.dart
+++ b/mobile/lib/services/screen_analytics_service.dart
@@ -15,10 +15,21 @@ const _maxScreenSessionAge = Duration(seconds: 60);
 
 /// Service for tracking screen navigation, performance, and user engagement
 class ScreenAnalyticsService {
-  static final ScreenAnalyticsService _instance =
-      ScreenAnalyticsService._internal();
-  factory ScreenAnalyticsService() => _instance;
-  ScreenAnalyticsService._internal();
+  factory ScreenAnalyticsService() => _instance ??= ScreenAnalyticsService._();
+  ScreenAnalyticsService._();
+
+  static ScreenAnalyticsService? _instance;
+
+  /// Resets the singleton so the next [ScreenAnalyticsService()] call returns a
+  /// fresh instance. Call in test `tearDown` to prevent state leaking between
+  /// test files when tests run in a shared isolate (e.g. VGV optimized runner).
+  @visibleForTesting
+  static void resetInstance() {
+    _instance?._activeSessions.clear();
+    _instance?._currentScreen = null;
+    _instance?._currentScreenStartTime = null;
+    _instance = null;
+  }
 
   /// Creates a testable instance that does not touch [FirebaseAnalytics].
   @visibleForTesting

--- a/mobile/test/infrastructure/schema_test.dart
+++ b/mobile/test/infrastructure/schema_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for Drift table schema definitions
 // ABOUTME: Verifies NostrEvents and UserProfiles tables are properly defined
 
+@Tags(['skip_very_good_optimization'])
 import 'dart:io';
 
 import 'package:db_client/db_client.dart';

--- a/mobile/test/notifications/widgets/notification_avatar_stack_test.dart
+++ b/mobile/test/notifications/widgets/notification_avatar_stack_test.dart
@@ -1,3 +1,4 @@
+@Tags(['skip_very_good_optimization'])
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for ClipManagerProvider - Riverpod state management
 // ABOUTME: Validates state updates and provider lifecycle
 
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';

--- a/mobile/test/providers/video_recorder_provider_test.dart
+++ b/mobile/test/providers/video_recorder_provider_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Unit tests for VideoRecorderProviderState and VideoRecorderNotifier
 // ABOUTME: Tests state getters, properties, and recording lifecycle
 
+@Tags(['skip_very_good_optimization'])
 import 'dart:io';
 
 import 'package:divine_camera/divine_camera.dart' show DivineCameraLens;

--- a/mobile/test/screens/discover_lists_screen_test.dart
+++ b/mobile/test/screens/discover_lists_screen_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for DiscoverListsScreen pagination behavior
 // ABOUTME: Verifies pagination stops re-triggering when no more lists found
 
+@Tags(['skip_very_good_optimization'])
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Widget tests for PooledFullscreenVideoFeedScreen
 // ABOUTME: Tests state rendering and BLoC event dispatching
 
+@Tags(['skip_very_good_optimization'])
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies that overlay visibility and tab switches pause/resume the
 // ABOUTME: pooled video feed
 
+@Tags(['skip_very_good_optimization'])
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';

--- a/mobile/test/screens/pure/search_screen_pure_test.dart
+++ b/mobile/test/screens/pure/search_screen_pure_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for SearchScreenPure widget
 // ABOUTME: Verifies tab count formatting consistency and search behavior
 
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile/test/screens/search_results/view/search_results_page_test.dart
+++ b/mobile/test/screens/search_results/view/search_results_page_test.dart
@@ -1,3 +1,4 @@
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hashtag_repository/hashtag_repository.dart';

--- a/mobile/test/screens/search_results/widgets/videos_section_test.dart
+++ b/mobile/test/screens/search_results/widgets/videos_section_test.dart
@@ -1,3 +1,4 @@
+@Tags(['skip_very_good_optimization'])
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';

--- a/mobile/test/screens/video_recorder_screen_test.dart
+++ b/mobile/test/screens/video_recorder_screen_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for VideoRecorderScreen - main video recording UI
 // ABOUTME: Tests screen initialization, camera setup, UI elements, and lifecycle
 
+@Tags(['skip_very_good_optimization'])
 import 'dart:core';
 
 import 'package:flutter/foundation.dart';

--- a/mobile/test/services/audio_extraction_service_test.dart
+++ b/mobile/test/services/audio_extraction_service_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Tests audio extraction result model, exceptions, cleanup, and
 // ABOUTME: core extraction path with ProVideoEditor mock.
 
+@Tags(['skip_very_good_optimization'])
 import 'dart:io';
 import 'dart:ui';
 

--- a/mobile/test/services/background_activity_manager_test.dart
+++ b/mobile/test/services/background_activity_manager_test.dart
@@ -1,4 +1,5 @@
 // Test for BackgroundActivityManager functionality
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/background_activity_manager.dart';

--- a/mobile/test/services/clip_library_service_test.dart
+++ b/mobile/test/services/clip_library_service_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for ClipLibraryService - persistent storage for video clips
 // ABOUTME: Covers save, load, delete, and thumbnail generation for clips
 
+@Tags(['skip_very_good_optimization'])
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: TDD tests for DraftStorageService - persistent storage for vine drafts
 // ABOUTME: Tests save, load, delete, clear, and migration operations using Drift
 
+@Tags(['skip_very_good_optimization'])
 import 'dart:convert';
 
 import 'package:db_client/db_client.dart';
@@ -644,7 +645,10 @@ void main() {
         final mockPlatform = MockPathProviderPlatform()
           ..setApplicationDocumentsPath(documentsPath);
         PathProviderPlatform.instance = mockPlatform;
+        SharedPreferences.setMockInitialValues({});
       });
+
+      tearDown(SharedPreferences.resetStatic);
 
       Map<String, dynamic> buildClipJson({
         required String id,

--- a/mobile/test/services/feed_performance_tracker_stale_session_test.dart
+++ b/mobile/test/services/feed_performance_tracker_stale_session_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies sessions older than 60s are discarded and resetAllSessions
 // ABOUTME: clears all active sessions on app resume.
 
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 
@@ -12,6 +13,8 @@ void main() {
     setUp(() {
       tracker = FeedPerformanceTracker.testInstance();
     });
+
+    tearDown(FeedPerformanceTracker.resetInstance);
 
     group('resetAllSessions', () {
       test('clears all active sessions', () {

--- a/mobile/test/services/notification_persistence_test.dart
+++ b/mobile/test/services/notification_persistence_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for NotificationPersistence - handles Hive storage operations
 // ABOUTME: Pure persistence logic tests without service dependencies
 
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:models/models.dart';

--- a/mobile/test/services/notification_service_enhanced_test.dart
+++ b/mobile/test/services/notification_service_enhanced_test.dart
@@ -2,59 +2,25 @@
 // ABOUTME: Verifies race condition fixes and concurrent notification deduplication
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
-import 'package:nostr_client/nostr_client.dart';
-import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/services/notification_service_enhanced.dart';
-import 'package:openvine/services/video_event_service.dart';
-import 'package:profile_repository/profile_repository.dart';
-
-class _MockNostrClient extends Mock implements NostrClient {}
-
-class _MockProfileRepository extends Mock implements ProfileRepository {}
-
-class _MockVideoEventService extends Mock implements VideoEventService {}
 
 void main() {
-  setUpAll(() {
-    registerFallbackValue(<Filter>[]);
-  });
-
   group('NotificationServiceEnhanced Race Condition Tests', () {
     late NotificationServiceEnhanced service;
-    late _MockNostrClient mockNostrService;
-    late _MockProfileRepository mockProfileRepository;
-    late _MockVideoEventService mockVideoService;
 
     setUp(() {
+      // Reset to discard any stale singleton left by a previous test or test
+      // file when running in a shared isolate (VGV optimized runner).
+      NotificationServiceEnhanced.resetInstance();
       service = NotificationServiceEnhanced();
-      mockNostrService = _MockNostrClient();
-      mockProfileRepository = _MockProfileRepository();
-      mockVideoService = _MockVideoEventService();
-
-      // Setup mock responses
-      when(() => mockNostrService.hasKeys).thenReturn(true);
-      when(() => mockNostrService.publicKey).thenReturn('test-pubkey-123');
-      when(
-        () => mockNostrService.subscribe(any()),
-      ).thenAnswer((_) => const Stream.empty());
     });
 
-    tearDown(() {
-      service.dispose();
-    });
+    tearDown(NotificationServiceEnhanced.resetInstance);
 
     test(
       'concurrent addNotificationForTesting calls with same ID should only add once',
       () async {
-        // Initialize the service
-        await service.initialize(
-          nostrService: mockNostrService,
-          profileRepository: mockProfileRepository,
-          videoService: mockVideoService,
-        );
-
         // Create identical notifications (same ID)
         final notification1 = NotificationModel(
           id: 'duplicate-test-id',
@@ -94,12 +60,6 @@ void main() {
     test(
       'concurrent addNotificationForTesting calls with different IDs should add both',
       () async {
-        await service.initialize(
-          nostrService: mockNostrService,
-          profileRepository: mockProfileRepository,
-          videoService: mockVideoService,
-        );
-
         final notification1 = NotificationModel(
           id: 'notification-1',
           type: NotificationType.like,
@@ -134,12 +94,6 @@ void main() {
     );
 
     test('rapid sequential adds with same ID should only add once', () async {
-      await service.initialize(
-        nostrService: mockNostrService,
-        profileRepository: mockProfileRepository,
-        videoService: mockVideoService,
-      );
-
       final notification = NotificationModel(
         id: 'rapid-test-id',
         type: NotificationType.like,
@@ -162,12 +116,6 @@ void main() {
     });
 
     test('stress test: 100 concurrent adds with mixed IDs', () async {
-      await service.initialize(
-        nostrService: mockNostrService,
-        profileRepository: mockProfileRepository,
-        videoService: mockVideoService,
-      );
-
       // Create 10 unique notification IDs, but add each one 10 times
       final futures = <Future<void>>[];
       for (var i = 0; i < 10; i++) {
@@ -204,36 +152,19 @@ void main() {
 
   group('NotificationServiceEnhanced Chronological Order Tests', () {
     late NotificationServiceEnhanced service;
-    late _MockNostrClient mockNostrService;
-    late _MockProfileRepository mockProfileRepository;
-    late _MockVideoEventService mockVideoService;
 
     setUp(() {
+      // Reset to discard any stale singleton left by a previous test or test
+      // file when running in a shared isolate (VGV optimized runner).
+      NotificationServiceEnhanced.resetInstance();
       service = NotificationServiceEnhanced();
-      mockNostrService = _MockNostrClient();
-      mockProfileRepository = _MockProfileRepository();
-      mockVideoService = _MockVideoEventService();
-
-      when(() => mockNostrService.hasKeys).thenReturn(true);
-      when(() => mockNostrService.publicKey).thenReturn('test-pubkey-123');
-      when(
-        () => mockNostrService.subscribe(any()),
-      ).thenAnswer((_) => const Stream.empty());
     });
 
-    tearDown(() {
-      service.dispose();
-    });
+    tearDown(NotificationServiceEnhanced.resetInstance);
 
     test(
       'notifications are sorted by timestamp (newest first) regardless of insertion order',
       () async {
-        await service.initialize(
-          nostrService: mockNostrService,
-          profileRepository: mockProfileRepository,
-          videoService: mockVideoService,
-        );
-
         // Add notifications OUT OF ORDER (older first, then newer)
         final olderNotification = NotificationModel(
           id: 'older-notification',
@@ -275,12 +206,6 @@ void main() {
     test(
       'getNotificationsByType returns filtered results in chronological order',
       () async {
-        await service.initialize(
-          nostrService: mockNostrService,
-          profileRepository: mockProfileRepository,
-          videoService: mockVideoService,
-        );
-
         // Add mixed notification types out of order
         final oldLike = NotificationModel(
           id: 'old-like',
@@ -330,12 +255,6 @@ void main() {
     test(
       'follow notifications with different IDs but same actor are deduplicated',
       () async {
-        await service.initialize(
-          nostrService: mockNostrService,
-          profileRepository: mockProfileRepository,
-          videoService: mockVideoService,
-        );
-
         // Simulate two Kind 3 events from the same actor (different event IDs)
         // This happens when the actor follows someone else, republishing their
         // entire contact list with a new event ID.
@@ -372,12 +291,6 @@ void main() {
     test(
       'follow notifications from different actors are not deduplicated',
       () async {
-        await service.initialize(
-          nostrService: mockNostrService,
-          profileRepository: mockProfileRepository,
-          videoService: mockVideoService,
-        );
-
         final follow1 = NotificationModel(
           id: 'kind3-event-aaa',
           type: NotificationType.follow,
@@ -410,12 +323,6 @@ void main() {
     test(
       'non-follow notifications with same actor are not deduplicated',
       () async {
-        await service.initialize(
-          nostrService: mockNostrService,
-          profileRepository: mockProfileRepository,
-          videoService: mockVideoService,
-        );
-
         final like1 = NotificationModel(
           id: 'like-event-aaa',
           type: NotificationType.like,
@@ -448,12 +355,6 @@ void main() {
     );
 
     test('notifications with same timestamp are stable-sorted by ID', () async {
-      await service.initialize(
-        nostrService: mockNostrService,
-        profileRepository: mockProfileRepository,
-        videoService: mockVideoService,
-      );
-
       final sameTime = DateTime(2024, 1, 1, 12);
 
       // Add notifications with identical timestamps but different IDs

--- a/mobile/test/services/screen_analytics_service_test.dart
+++ b/mobile/test/services/screen_analytics_service_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies sessions older than 60s are discarded and resetAllSessions
 // ABOUTME: clears all active sessions on app resume.
 
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/screen_analytics_service.dart';
 
@@ -12,6 +13,8 @@ void main() {
     setUp(() {
       service = ScreenAnalyticsService.testInstance();
     });
+
+    tearDown(ScreenAnalyticsService.resetInstance);
 
     group('resetAllSessions', () {
       test('clears all active sessions', () {

--- a/mobile/test/services/video_event_service_deduplication_test.dart
+++ b/mobile/test/services/video_event_service_deduplication_test.dart
@@ -1,3 +1,4 @@
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';

--- a/mobile/test/services/video_thumbnail_service_test.dart
+++ b/mobile/test/services/video_thumbnail_service_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Unit tests for video thumbnail extraction service
 // ABOUTME: Tests thumbnail generation, error handling, and edge cases
 
+@Tags(['skip_very_good_optimization'])
 import 'dart:io';
 
 import 'package:flutter/services.dart';
@@ -15,36 +16,35 @@ void main() {
     late String testVideoPath;
     late Directory tempDir;
 
-    // Mock the pro_video_editor platform channel
     const channel = MethodChannel('pro_video_editor');
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-          if (methodCall.method == 'getThumbnails') {
-            // Return empty list to simulate no thumbnails generated
-            return <Uint8List>[];
-          }
-          return null;
-        });
 
     setUpAll(() async {
-      // Create a temporary directory for test files
       tempDir = await Directory.systemTemp.createTemp('video_thumbnail_test');
     });
 
     tearDownAll(() async {
-      // Clean up temporary directory
       if (tempDir.existsSync()) {
         await tempDir.delete(recursive: true);
       }
-
-      // Clean up the mock method call handler
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, null);
     });
 
     setUp(() {
-      // Create a mock video file path
       testVideoPath = '${tempDir.path}/test_video.mp4';
+
+      // Mock the pro_video_editor platform channel per-test so it does not
+      // leak into other test files when running in a shared isolate.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+            if (methodCall.method == 'getThumbnails') {
+              return <Uint8List>[];
+            }
+            return null;
+          });
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
     });
 
     group('extractThumbnail', () {
@@ -289,8 +289,6 @@ void main() {
       if (tempDir.existsSync()) {
         await tempDir.delete(recursive: true);
       }
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, null);
     });
 
     setUp(() {
@@ -326,6 +324,11 @@ void main() {
             }
             return null;
           });
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
     });
 
     test('returns path when getSingleThumbnail succeeds', () async {

--- a/mobile/test/services/web_auth_service_bunker_test.dart
+++ b/mobile/test/services/web_auth_service_bunker_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Unit tests for WebAuthService nsec bunker authentication integration
 // ABOUTME: Tests bunker authentication flow and signer functionality in WebAuthService
 
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';

--- a/mobile/test/unit/services/bug_report_service_upload_logs_test.dart
+++ b/mobile/test/unit/services/bug_report_service_upload_logs_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for BugReportService.uploadFullLogs()
 // ABOUTME: Verifies Blossom upload success, failure fallback, and null service handling
 
+@Tags(['skip_very_good_optimization'])
 import 'dart:io';
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';

--- a/mobile/test/unit/services/upload_manager_get_by_path_test.dart
+++ b/mobile/test/unit/services/upload_manager_get_by_path_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Unit tests for UploadManager.getUploadByFilePath method
 // ABOUTME: Tests file path lookup functionality using the public API
 
+@Tags(['skip_very_good_optimization'])
 import 'dart:io';
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';

--- a/mobile/test/unit/services/video_event_service_subscription_test.dart
+++ b/mobile/test/unit/services/video_event_service_subscription_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Unit tests for VideoEventService subscription duplicate checking
 // ABOUTME: Tests that different subscription parameters are properly allowed and not wrongly rejected as duplicates
 
+@Tags(['skip_very_good_optimization'])
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';

--- a/mobile/test/widgets/global_error_widget_test.dart
+++ b/mobile/test/widgets/global_error_widget_test.dart
@@ -1,3 +1,4 @@
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/widgets/global_error_widget.dart';

--- a/mobile/test/widgets/profile/profile_collabs_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_collabs_grid_test.dart
@@ -1,3 +1,4 @@
+@Tags(['skip_very_good_optimization'])
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';

--- a/mobile/test/widgets/profile/profile_comments_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_comments_grid_test.dart
@@ -1,3 +1,4 @@
+@Tags(['skip_very_good_optimization'])
 import 'package:bloc_test/bloc_test.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:divine_ui/divine_ui.dart';

--- a/mobile/test/widgets/profile/profile_liked_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_liked_grid_test.dart
@@ -1,3 +1,4 @@
+@Tags(['skip_very_good_optimization'])
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';

--- a/mobile/test/widgets/profile/profile_reposts_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_reposts_grid_test.dart
@@ -1,3 +1,4 @@
+@Tags(['skip_very_good_optimization'])
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';

--- a/mobile/test/widgets/profile_drafts_button_test.dart
+++ b/mobile/test/widgets/profile_drafts_button_test.dart
@@ -1,21 +1,28 @@
 // ABOUTME: TDD widget test for Clips button in profile action buttons
 // ABOUTME: Tests that Clips button is prominently displayed and navigates correctly
 
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/screens/library_screen.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/test_provider_overrides.dart';
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
 void main() {
   group('Profile Clips Button', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    tearDown(SharedPreferences.resetStatic);
+
     testWidgets('should render Clips button in action buttons row', (
       tester,
     ) async {
@@ -108,14 +115,11 @@ void main() {
     testWidgets(
       'should navigate to ClipLibraryScreen when Clips button tapped',
       (tester) async {
-        SharedPreferences.setMockInitialValues({});
-        final sharedPreferences = await SharedPreferences.getInstance();
         final mockDraftStorageService = _MockDraftStorageService();
 
         await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+          testProviderScope(
+            additionalOverrides: [
               draftStorageServiceProvider.overrideWithValue(
                 mockDraftStorageService,
               ),

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Covers share sheet rendering, contact row, more actions, feature
 // ABOUTME: flags, save/bookmark, copy link, share via, and error handling
 
+@Tags(['skip_very_good_optimization'])
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -30,15 +31,18 @@ class _MockProfileRepository extends Mock implements ProfileRepository {}
 
 class _FakeVideoEvent extends Fake implements VideoEvent {}
 
-/// Fake notifier that provides test data for curatedListsStateProvider
-List<CuratedList> _fakeLists = [];
-
+/// Fake notifier that provides test data for curatedListsStateProvider.
+///
+/// Uses a static field instead of a module-level variable so that state
+/// does not leak between test files when running in a shared isolate.
 class _FakeCuratedListsState extends CuratedListsState {
+  static List<CuratedList> fakeLists = [];
+
   @override
   CuratedListService? get service => null;
 
   @override
-  Future<List<CuratedList>> build() async => _fakeLists;
+  Future<List<CuratedList>> build() async => fakeLists;
 }
 
 void main() {
@@ -77,7 +81,7 @@ void main() {
 
     mockBookmarkService = _MockBookmarkService();
     mockVideoSharingService = _MockVideoSharingService();
-    _fakeLists = [];
+    _FakeCuratedListsState.fakeLists = [];
 
     when(
       () => mockBookmarkService.addVideoToGlobalBookmarks(any()),

--- a/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies share icon renders, share sheet opens with correct sections,
 // ABOUTME: and standard action items display in the unified share sheet.
 
+@Tags(['skip_very_good_optimization'])
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Regression test for tapping descriptions in VideoOverlayActions.
 // ABOUTME: Verifies the inline description opens the metadata sheet.
 
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile/test/widgets/video_metadata/video_metadata_tags_input_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_tags_input_test.dart
@@ -1,3 +1,4 @@
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile/test/widgets/video_metadata/video_metadata_user_chip_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_user_chip_test.dart
@@ -1,3 +1,4 @@
+@Tags(['skip_very_good_optimization'])
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';


### PR DESCRIPTION
## Summary
- Add `@visibleForTesting resetInstance()` to 3 singleton services: `FeedPerformanceTracker`, `ScreenAnalyticsService`, `NotificationServiceEnhanced`
- Fix test tearDown in 5 files that leaked singleton, SharedPreferences, or MethodChannel state across test files
- Tag 29 unit/widget test files with `skip_very_good_optimization` that still have cross-file contamination (fixable incrementally in follow-up PRs)

Part of #2899 (2 of 3). Independent of PR 1, prerequisite for PR 3.

### Production code changes (additive, no behavior change)
| File | Change |
|------|--------|
| `feed_performance_tracker.dart` | Lazy nullable singleton + `resetInstance()` |
| `screen_analytics_service.dart` | Lazy nullable singleton + `resetInstance()` |
| `notification_service_enhanced.dart` | `resetInstance()` |

### Test isolation fixes
| File | Fix |
|------|-----|
| `notification_service_enhanced_test` | Remove `initialize()` calls (Hive leak), add resetInstance setUp/tearDown |
| `draft_storage_service_test` | Reset SharedPreferences in tearDown |
| `profile_drafts_button_test` | Use `testProviderScope`, setUp/tearDown for SharedPreferences |
| `video_thumbnail_service_test` | Move MethodChannel mock from file-level to per-test setUp/tearDown |
| `share_video_menu_comprehensive_test` | Scope `_fakeLists` to class static field |

## Test plan
- [x] `flutter test` passes on all modified test files individually
- [x] `resetInstance()` methods are `@visibleForTesting` — no production call sites
- [x] Tagged files are inert metadata until VGV optimizer is enabled