### PR TITLE
fix(profile): guard pagination against multi-position controllers

### DIFF
--- a/mobile/lib/mixins/scroll_pagination_mixin.dart
+++ b/mobile/lib/mixins/scroll_pagination_mixin.dart
@@ -79,8 +79,10 @@ mixin ScrollPaginationMixin<T extends StatefulWidget> on State<T> {
     if (_pendingPaginationLoad != null) return;
     if (!canLoadMore()) return;
 
-    final position = paginationScrollController.position;
-    if (position.pixels < position.maxScrollExtent - _threshold) {
+    final isNearBottom = paginationScrollController.positions.any(
+      (position) => position.pixels >= position.maxScrollExtent - _threshold,
+    );
+    if (!isNearBottom) {
       return;
     }
 

--- a/mobile/test/mixins/scroll_pagination_mixin_test.dart
+++ b/mobile/test/mixins/scroll_pagination_mixin_test.dart
@@ -98,6 +98,38 @@ void main() {
         expect(loadMoreCalls, 1);
       },
     );
+
+    testWidgets(
+      'does not throw when the scroll controller has multiple positions',
+      (tester) async {
+        var loadMoreCalls = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: _MultiPositionTestWidget(
+              onLoadMore: () async {
+                loadMoreCalls++;
+              },
+            ),
+          ),
+        );
+
+        final state = tester.state<_MultiPositionTestWidgetState>(
+          find.byType(_MultiPositionTestWidget),
+        );
+        final scrollController = state.paginationScrollController;
+
+        expect(scrollController.positions.length, 2);
+
+        scrollController.jumpTo(
+          scrollController.positions.first.maxScrollExtent,
+        );
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+        expect(loadMoreCalls, 1);
+      },
+    );
   });
 }
 
@@ -147,6 +179,64 @@ class _TestWidgetState extends State<_TestWidget> with ScrollPaginationMixin {
       itemCount: 100,
       itemBuilder: (context, index) => SizedBox(
         height: 80,
+        child: Text('Item $index'),
+      ),
+    );
+  }
+}
+
+class _MultiPositionTestWidget extends StatefulWidget {
+  const _MultiPositionTestWidget({required this.onLoadMore});
+
+  final FutureOr<void> Function() onLoadMore;
+
+  @override
+  State<_MultiPositionTestWidget> createState() =>
+      _MultiPositionTestWidgetState();
+}
+
+class _MultiPositionTestWidgetState extends State<_MultiPositionTestWidget>
+    with ScrollPaginationMixin {
+  final _scrollController = ScrollController();
+
+  @override
+  ScrollController get paginationScrollController => _scrollController;
+
+  @override
+  bool canLoadMore() => true;
+
+  @override
+  FutureOr<void> onLoadMore() => widget.onLoadMore();
+
+  @override
+  void initState() {
+    super.initState();
+    initPagination();
+  }
+
+  @override
+  void dispose() {
+    disposePagination();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(child: _buildList()),
+        Expanded(child: _buildList()),
+      ],
+    );
+  }
+
+  Widget _buildList() {
+    return ListView.builder(
+      controller: _scrollController,
+      itemCount: 100,
+      itemBuilder: (context, index) => SizedBox(
+        height: 40,
         child: Text('Item $index'),
       ),
     );


### PR DESCRIPTION
Closes #3085

## Summary
- avoid calling  in the pagination mixin when a controller is attached to multiple scroll views
- trigger pagination when any attached scroll position crosses the near-bottom threshold
- add a widget regression test that reproduces the multi-position controller crash path

## Test Plan
- [x] cd mobile && flutter test test/mixins/scroll_pagination_mixin_test.dart
- [x] cd mobile && flutter analyze lib/mixins/scroll_pagination_mixin.dart test/mixins/scroll_pagination_mixin_test.dart
