### PR TITLE
feat(video-recorder): allow users on the web to open the video-recorder

### DIFF
--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1960,6 +1960,7 @@
     "saveOriginalPhotosAccessMessage": "لحفظ مقاطع الفيديو، اسمح بالوصول إلى الصور في الإعدادات.",
     "saveOriginalOpenSettings": "فتح الإعدادات",
     "saveOriginalNotNow": "ليس الآن",
+    "cameraPermissionNotNow": "ليس الآن",
     "saveOriginalDownloadFailed": "فشل التنزيل",
     "saveOriginalDismiss": "إخفاء",
     "saveOriginalDownloadingVideo": "جارٍ تنزيل الفيديو",
@@ -2422,5 +2423,15 @@
     "timeYesterday": "أمس",
     "@timeYesterday": {
         "description": "Date label for yesterday"
-    }
+    },
+    "cameraPermissionWebUnsupportedTitle": "الكاميرا غير مدعومة على الويب بعد",
+    "cameraPermissionWebUnsupportedDescription": "التقاط الكاميرا وتسجيلها غير متاحين في إصدار الويب بعد.",
+    "cameraPermissionBackToFeed": "العودة إلى الخلاصة",
+    "cameraPermissionErrorTitle": "خطأ في الأذونات",
+    "cameraPermissionErrorDescription": "حدث خطأ أثناء التحقق من الأذونات.",
+    "cameraPermissionRetry": "إعادة المحاولة",
+    "cameraPermissionAllowAccessTitle": "السماح بالوصول إلى الكاميرا والميكروفون",
+    "cameraPermissionAllowAccessDescription": "يتيح لك هذا التقاط الفيديوهات وتعديلها مباشرة داخل التطبيق، ولا شيء أكثر.",
+    "cameraPermissionContinue": "متابعة",
+    "cameraPermissionGoToSettings": "الذهاب إلى الإعدادات"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1960,6 +1960,7 @@
     "saveOriginalPhotosAccessMessage": "Um Videos zu speichern, erlaube den Fotozugriff in den Einstellungen.",
     "saveOriginalOpenSettings": "Einstellungen öffnen",
     "saveOriginalNotNow": "Nicht jetzt",
+    "cameraPermissionNotNow": "Nicht jetzt",
     "saveOriginalDownloadFailed": "Download fehlgeschlagen",
     "saveOriginalDismiss": "Schließen",
     "saveOriginalDownloadingVideo": "Video wird heruntergeladen",
@@ -2422,5 +2423,15 @@
     "timeYesterday": "Gestern",
     "@timeYesterday": {
         "description": "Date label for yesterday"
-    }
+    },
+    "cameraPermissionWebUnsupportedTitle": "Kamera wird im Web noch nicht unterstützt",
+    "cameraPermissionWebUnsupportedDescription": "Kameraaufnahme und -aufzeichnung sind in der Webversion noch nicht verfügbar.",
+    "cameraPermissionBackToFeed": "Zurück zum Feed",
+    "cameraPermissionErrorTitle": "Berechtigungsfehler",
+    "cameraPermissionErrorDescription": "Beim Prüfen der Berechtigungen ist etwas schiefgelaufen.",
+    "cameraPermissionRetry": "Erneut versuchen",
+    "cameraPermissionAllowAccessTitle": "Kamera- und Mikrofonzugriff erlauben",
+    "cameraPermissionAllowAccessDescription": "Damit kannst du Videos direkt hier in der App aufnehmen und bearbeiten, sonst nichts.",
+    "cameraPermissionContinue": "Weiter",
+    "cameraPermissionGoToSettings": "Zu den Einstellungen"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1963,6 +1963,7 @@
   "saveOriginalPhotosAccessMessage": "To save videos, allow Photos access in Settings.",
   "saveOriginalOpenSettings": "Open Settings",
   "saveOriginalNotNow": "Not Now",
+  "cameraPermissionNotNow": "Not Now",
   "saveOriginalDownloadFailed": "Download Failed",
   "saveOriginalDismiss": "Dismiss",
   "saveOriginalDownloadingVideo": "Downloading Video",
@@ -2428,5 +2429,15 @@
   "textBackgroundTransparent": "Transparent",
   "textAlignLeft": "Left",
   "textAlignRight": "Right",
-  "textAlignCenter": "Center"
+  "textAlignCenter": "Center",
+  "cameraPermissionWebUnsupportedTitle": "Camera not supported on web yet",
+  "cameraPermissionWebUnsupportedDescription": "Camera capture and recording are not available in the web version yet.",
+  "cameraPermissionBackToFeed": "Back to feed",
+  "cameraPermissionErrorTitle": "Permission Error",
+  "cameraPermissionErrorDescription": "Something went wrong while checking permissions.",
+  "cameraPermissionRetry": "Retry",
+  "cameraPermissionAllowAccessTitle": "Allow camera & microphone access",
+  "cameraPermissionAllowAccessDescription": "This allows you to capture and edit videos right here in the app, nothing more.",
+  "cameraPermissionContinue": "Continue",
+  "cameraPermissionGoToSettings": "Go to settings"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1963,7 +1963,7 @@
   "saveOriginalPhotosAccessMessage": "To save videos, allow Photos access in Settings.",
   "saveOriginalOpenSettings": "Open Settings",
   "saveOriginalNotNow": "Not Now",
-  "cameraPermissionNotNow": "Not Now",
+  "cameraPermissionNotNow": "Not now",
   "saveOriginalDownloadFailed": "Download Failed",
   "saveOriginalDismiss": "Dismiss",
   "saveOriginalDownloadingVideo": "Downloading Video",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1960,6 +1960,7 @@
     "saveOriginalPhotosAccessMessage": "Para guardar videos, permití el acceso a Fotos en Ajustes.",
     "saveOriginalOpenSettings": "Abrir Ajustes",
     "saveOriginalNotNow": "Ahora no",
+    "cameraPermissionNotNow": "Ahora no",
     "saveOriginalDownloadFailed": "Falló la descarga",
     "saveOriginalDismiss": "Descartar",
     "saveOriginalDownloadingVideo": "Descargando video",
@@ -2422,5 +2423,15 @@
     "timeYesterday": "Ayer",
     "@timeYesterday": {
         "description": "Date label for yesterday"
-    }
+    },
+    "cameraPermissionWebUnsupportedTitle": "La cámara todavía no es compatible en la web",
+    "cameraPermissionWebUnsupportedDescription": "La captura y grabación con cámara todavía no están disponibles en la versión web.",
+    "cameraPermissionBackToFeed": "Volver al feed",
+    "cameraPermissionErrorTitle": "Error de permisos",
+    "cameraPermissionErrorDescription": "Algo salió mal al verificar los permisos.",
+    "cameraPermissionRetry": "Reintentar",
+    "cameraPermissionAllowAccessTitle": "Permitir acceso a cámara y micrófono",
+    "cameraPermissionAllowAccessDescription": "Esto te permite capturar y editar videos aquí mismo en la app, nada más.",
+    "cameraPermissionContinue": "Continuar",
+    "cameraPermissionGoToSettings": "Ir a ajustes"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1960,6 +1960,7 @@
     "saveOriginalPhotosAccessMessage": "Pour enregistrer les vidéos, autorise l'accès aux Photos dans les Réglages.",
     "saveOriginalOpenSettings": "Ouvrir les Réglages",
     "saveOriginalNotNow": "Pas maintenant",
+    "cameraPermissionNotNow": "Pas maintenant",
     "saveOriginalDownloadFailed": "Téléchargement échoué",
     "saveOriginalDismiss": "Ignorer",
     "saveOriginalDownloadingVideo": "Téléchargement de la vidéo",
@@ -2422,5 +2423,15 @@
     "timeYesterday": "Hier",
     "@timeYesterday": {
         "description": "Date label for yesterday"
-    }
+    },
+    "cameraPermissionWebUnsupportedTitle": "La caméra n'est pas encore prise en charge sur le web",
+    "cameraPermissionWebUnsupportedDescription": "La capture et l'enregistrement vidéo avec la caméra ne sont pas encore disponibles dans la version web.",
+    "cameraPermissionBackToFeed": "Retour au fil",
+    "cameraPermissionErrorTitle": "Erreur d'autorisation",
+    "cameraPermissionErrorDescription": "Une erreur s'est produite lors de la vérification des autorisations.",
+    "cameraPermissionRetry": "Réessayer",
+    "cameraPermissionAllowAccessTitle": "Autoriser l'accès à la caméra et au micro",
+    "cameraPermissionAllowAccessDescription": "Cela vous permet de capturer et de modifier des vidéos directement dans l'application, rien de plus.",
+    "cameraPermissionContinue": "Continuer",
+    "cameraPermissionGoToSettings": "Aller aux paramètres"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1960,6 +1960,7 @@
     "saveOriginalPhotosAccessMessage": "Untuk menyimpan video, izinkan akses Foto di Pengaturan.",
     "saveOriginalOpenSettings": "Buka Pengaturan",
     "saveOriginalNotNow": "Nanti Saja",
+    "cameraPermissionNotNow": "Nanti Saja",
     "saveOriginalDownloadFailed": "Unduhan Gagal",
     "saveOriginalDismiss": "Tutup",
     "saveOriginalDownloadingVideo": "Mengunduh Video",
@@ -2422,5 +2423,15 @@
     "timeYesterday": "Kemarin",
     "@timeYesterday": {
         "description": "Date label for yesterday"
-    }
+    },
+    "cameraPermissionWebUnsupportedTitle": "Kamera belum didukung di web",
+    "cameraPermissionWebUnsupportedDescription": "Pengambilan gambar dan perekaman kamera belum tersedia di versi web.",
+    "cameraPermissionBackToFeed": "Kembali ke feed",
+    "cameraPermissionErrorTitle": "Kesalahan izin",
+    "cameraPermissionErrorDescription": "Terjadi kesalahan saat memeriksa izin.",
+    "cameraPermissionRetry": "Coba lagi",
+    "cameraPermissionAllowAccessTitle": "Izinkan akses kamera & mikrofon",
+    "cameraPermissionAllowAccessDescription": "Ini memungkinkan Anda merekam dan mengedit video langsung di aplikasi, tidak lebih.",
+    "cameraPermissionContinue": "Lanjutkan",
+    "cameraPermissionGoToSettings": "Buka pengaturan"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1960,6 +1960,7 @@
     "saveOriginalPhotosAccessMessage": "Per salvare i video, consenti l'accesso a Foto nelle Impostazioni.",
     "saveOriginalOpenSettings": "Apri impostazioni",
     "saveOriginalNotNow": "Non ora",
+    "cameraPermissionNotNow": "Non ora",
     "saveOriginalDownloadFailed": "Download fallito",
     "saveOriginalDismiss": "Ignora",
     "saveOriginalDownloadingVideo": "Download video",
@@ -2422,5 +2423,15 @@
     "timeYesterday": "Ieri",
     "@timeYesterday": {
         "description": "Date label for yesterday"
-    }
+    },
+    "cameraPermissionWebUnsupportedTitle": "La fotocamera non è ancora supportata sul web",
+    "cameraPermissionWebUnsupportedDescription": "L'acquisizione e la registrazione con fotocamera non sono ancora disponibili nella versione web.",
+    "cameraPermissionBackToFeed": "Torna al feed",
+    "cameraPermissionErrorTitle": "Errore di autorizzazione",
+    "cameraPermissionErrorDescription": "Si è verificato un errore durante il controllo delle autorizzazioni.",
+    "cameraPermissionRetry": "Riprova",
+    "cameraPermissionAllowAccessTitle": "Consenti accesso a fotocamera e microfono",
+    "cameraPermissionAllowAccessDescription": "Questo ti consente di registrare e modificare video direttamente nell'app, niente di più.",
+    "cameraPermissionContinue": "Continua",
+    "cameraPermissionGoToSettings": "Vai alle impostazioni"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1960,6 +1960,7 @@
     "saveOriginalPhotosAccessMessage": "動画を保存するには、設定で写真へのアクセスを許可してね。",
     "saveOriginalOpenSettings": "設定を開く",
     "saveOriginalNotNow": "今はいい",
+    "cameraPermissionNotNow": "今はいい",
     "saveOriginalDownloadFailed": "ダウンロードがうまくいかなかった",
     "saveOriginalDismiss": "閉じる",
     "saveOriginalDownloadingVideo": "動画をダウンロード中",
@@ -2422,5 +2423,15 @@
     "timeYesterday": "昨日",
     "@timeYesterday": {
         "description": "Date label for yesterday"
-    }
+    },
+    "cameraPermissionWebUnsupportedTitle": "カメラはまだWebでサポートされていません",
+    "cameraPermissionWebUnsupportedDescription": "カメラでの撮影と録画は、Web版ではまだ利用できません。",
+    "cameraPermissionBackToFeed": "フィードに戻る",
+    "cameraPermissionErrorTitle": "権限エラー",
+    "cameraPermissionErrorDescription": "権限の確認中に問題が発生しました。",
+    "cameraPermissionRetry": "再試行",
+    "cameraPermissionAllowAccessTitle": "カメラとマイクへのアクセスを許可",
+    "cameraPermissionAllowAccessDescription": "これにより、アプリ内で動画の撮影と編集ができるようになります。それ以外の用途はありません。",
+    "cameraPermissionContinue": "続行",
+    "cameraPermissionGoToSettings": "設定に移動"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1249,6 +1249,7 @@
     "saveOriginalPhotosAccessMessage": "영상을 저장하려면 설정에서 사진 접근을 허용해 주세요.",
     "saveOriginalOpenSettings": "설정 열기",
     "saveOriginalNotNow": "나중에",
+    "cameraPermissionNotNow": "나중에",
     "saveOriginalDownloadFailed": "다운로드 실패",
     "saveOriginalDismiss": "닫기",
     "saveOriginalDownloadingVideo": "영상 다운로드 중",
@@ -1711,5 +1712,15 @@
     "timeYesterday": "어제",
     "@timeYesterday": {
         "description": "Date label for yesterday"
-    }
+    },
+    "cameraPermissionWebUnsupportedTitle": "카메라는 아직 웹에서 지원되지 않습니다",
+    "cameraPermissionWebUnsupportedDescription": "카메라 촬영 및 녹화는 웹 버전에서 아직 사용할 수 없습니다.",
+    "cameraPermissionBackToFeed": "피드로 돌아가기",
+    "cameraPermissionErrorTitle": "권한 오류",
+    "cameraPermissionErrorDescription": "권한을 확인하는 중 문제가 발생했습니다.",
+    "cameraPermissionRetry": "다시 시도",
+    "cameraPermissionAllowAccessTitle": "카메라 및 마이크 접근 허용",
+    "cameraPermissionAllowAccessDescription": "이렇게 하면 앱에서 바로 동영상을 촬영하고 편집할 수 있으며, 그 외 용도는 없습니다.",
+    "cameraPermissionContinue": "계속",
+    "cameraPermissionGoToSettings": "설정으로 이동"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1960,6 +1960,7 @@
     "saveOriginalPhotosAccessMessage": "Om video's op te slaan, geef je in Instellingen toegang tot Foto's.",
     "saveOriginalOpenSettings": "Instellingen openen",
     "saveOriginalNotNow": "Niet nu",
+    "cameraPermissionNotNow": "Niet nu",
     "saveOriginalDownloadFailed": "Download mislukt",
     "saveOriginalDismiss": "Sluiten",
     "saveOriginalDownloadingVideo": "Video downloaden",
@@ -2422,5 +2423,15 @@
     "timeYesterday": "Gisteren",
     "@timeYesterday": {
         "description": "Date label for yesterday"
-    }
+    },
+    "cameraPermissionWebUnsupportedTitle": "Camera wordt nog niet ondersteund op het web",
+    "cameraPermissionWebUnsupportedDescription": "Camerabeelden opnemen en video opnemen zijn nog niet beschikbaar in de webversie.",
+    "cameraPermissionBackToFeed": "Terug naar feed",
+    "cameraPermissionErrorTitle": "Machtigingsfout",
+    "cameraPermissionErrorDescription": "Er is iets misgegaan bij het controleren van machtigingen.",
+    "cameraPermissionRetry": "Opnieuw proberen",
+    "cameraPermissionAllowAccessTitle": "Toegang tot camera en microfoon toestaan",
+    "cameraPermissionAllowAccessDescription": "Hiermee kun je video's rechtstreeks in de app opnemen en bewerken, verder niets.",
+    "cameraPermissionContinue": "Doorgaan",
+    "cameraPermissionGoToSettings": "Naar instellingen"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1960,6 +1960,7 @@
     "saveOriginalPhotosAccessMessage": "Aby zapisać filmy, zezwól na dostęp do Zdjęć w Ustawieniach.",
     "saveOriginalOpenSettings": "Otwórz Ustawienia",
     "saveOriginalNotNow": "Nie teraz",
+    "cameraPermissionNotNow": "Nie teraz",
     "saveOriginalDownloadFailed": "Pobieranie nieudane",
     "saveOriginalDismiss": "Odrzuć",
     "saveOriginalDownloadingVideo": "Pobieranie filmu",
@@ -2422,5 +2423,15 @@
     "timeYesterday": "Wczoraj",
     "@timeYesterday": {
         "description": "Date label for yesterday"
-    }
+    },
+    "cameraPermissionWebUnsupportedTitle": "Aparat nie jest jeszcze obsługiwany w wersji webowej",
+    "cameraPermissionWebUnsupportedDescription": "Robienie zdjęć i nagrywanie kamerą nie są jeszcze dostępne w wersji webowej.",
+    "cameraPermissionBackToFeed": "Wróć do feedu",
+    "cameraPermissionErrorTitle": "Błąd uprawnień",
+    "cameraPermissionErrorDescription": "Wystąpił błąd podczas sprawdzania uprawnień.",
+    "cameraPermissionRetry": "Spróbuj ponownie",
+    "cameraPermissionAllowAccessTitle": "Zezwól na dostęp do aparatu i mikrofonu",
+    "cameraPermissionAllowAccessDescription": "To pozwala nagrywać i edytować filmy bezpośrednio w aplikacji i nic więcej.",
+    "cameraPermissionContinue": "Kontynuuj",
+    "cameraPermissionGoToSettings": "Przejdź do ustawień"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1960,6 +1960,7 @@
     "saveOriginalPhotosAccessMessage": "Para salvar vídeos, permita o acesso a Fotos nas Configurações.",
     "saveOriginalOpenSettings": "Abrir Configurações",
     "saveOriginalNotNow": "Agora não",
+    "cameraPermissionNotNow": "Agora não",
     "saveOriginalDownloadFailed": "Download falhou",
     "saveOriginalDismiss": "Dispensar",
     "saveOriginalDownloadingVideo": "Baixando vídeo",
@@ -2422,5 +2423,15 @@
     "timeYesterday": "Ontem",
     "@timeYesterday": {
         "description": "Date label for yesterday"
-    }
+    },
+    "cameraPermissionWebUnsupportedTitle": "A câmera ainda não é compatível na web",
+    "cameraPermissionWebUnsupportedDescription": "A captura e a gravação com câmera ainda não estão disponíveis na versão web.",
+    "cameraPermissionBackToFeed": "Voltar ao feed",
+    "cameraPermissionErrorTitle": "Erro de permissão",
+    "cameraPermissionErrorDescription": "Ocorreu um erro ao verificar as permissões.",
+    "cameraPermissionRetry": "Tentar novamente",
+    "cameraPermissionAllowAccessTitle": "Permitir acesso à câmera e ao microfone",
+    "cameraPermissionAllowAccessDescription": "Isso permite capturar e editar vídeos direto no app, nada além disso.",
+    "cameraPermissionContinue": "Continuar",
+    "cameraPermissionGoToSettings": "Ir para configurações"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1960,6 +1960,7 @@
     "saveOriginalPhotosAccessMessage": "Pentru a salva videoclipuri, permite accesul la Poze în Setări.",
     "saveOriginalOpenSettings": "Deschide setările",
     "saveOriginalNotNow": "Nu acum",
+    "cameraPermissionNotNow": "Nu acum",
     "saveOriginalDownloadFailed": "Descărcare eșuată",
     "saveOriginalDismiss": "Respinge",
     "saveOriginalDownloadingVideo": "Se descarcă videoclipul",
@@ -2422,5 +2423,15 @@
     "timeYesterday": "Ieri",
     "@timeYesterday": {
         "description": "Date label for yesterday"
-    }
+    },
+    "cameraPermissionWebUnsupportedTitle": "Camera nu este încă acceptată pe web",
+    "cameraPermissionWebUnsupportedDescription": "Captura și înregistrarea cu camera nu sunt încă disponibile în versiunea web.",
+    "cameraPermissionBackToFeed": "Înapoi la feed",
+    "cameraPermissionErrorTitle": "Eroare de permisiuni",
+    "cameraPermissionErrorDescription": "A apărut o eroare la verificarea permisiunilor.",
+    "cameraPermissionRetry": "Încearcă din nou",
+    "cameraPermissionAllowAccessTitle": "Permite accesul la cameră și microfon",
+    "cameraPermissionAllowAccessDescription": "Aceasta îți permite să capturezi și să editezi videoclipuri direct în aplicație, nimic mai mult.",
+    "cameraPermissionContinue": "Continuă",
+    "cameraPermissionGoToSettings": "Mergi la setări"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1960,6 +1960,7 @@
     "saveOriginalPhotosAccessMessage": "För att spara videor, tillåt fotoåtkomst i Inställningar.",
     "saveOriginalOpenSettings": "Öppna inställningar",
     "saveOriginalNotNow": "Inte nu",
+    "cameraPermissionNotNow": "Inte nu",
     "saveOriginalDownloadFailed": "Nedladdning misslyckades",
     "saveOriginalDismiss": "Avfärda",
     "saveOriginalDownloadingVideo": "Laddar ner video",
@@ -2422,5 +2423,15 @@
     "timeYesterday": "Igår",
     "@timeYesterday": {
         "description": "Date label for yesterday"
-    }
+    },
+    "cameraPermissionWebUnsupportedTitle": "Kameran stöds inte på webben än",
+    "cameraPermissionWebUnsupportedDescription": "Kamerainspelning och videoinspelning är ännu inte tillgängliga i webbversionen.",
+    "cameraPermissionBackToFeed": "Tillbaka till flödet",
+    "cameraPermissionErrorTitle": "Behörighetsfel",
+    "cameraPermissionErrorDescription": "Något gick fel när behörigheterna kontrollerades.",
+    "cameraPermissionRetry": "Försök igen",
+    "cameraPermissionAllowAccessTitle": "Tillåt åtkomst till kamera och mikrofon",
+    "cameraPermissionAllowAccessDescription": "Detta låter dig spela in och redigera videor direkt i appen, inget mer.",
+    "cameraPermissionContinue": "Fortsätt",
+    "cameraPermissionGoToSettings": "Gå till inställningar"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1960,6 +1960,7 @@
     "saveOriginalPhotosAccessMessage": "Videoları kaydetmek için Ayarlar'dan Fotoğraf erişimine izin ver.",
     "saveOriginalOpenSettings": "Ayarları Aç",
     "saveOriginalNotNow": "Şimdi Değil",
+    "cameraPermissionNotNow": "Şimdi Değil",
     "saveOriginalDownloadFailed": "İndirme Başarısız",
     "saveOriginalDismiss": "Kapat",
     "saveOriginalDownloadingVideo": "Video İndiriliyor",
@@ -2422,5 +2423,15 @@
     "timeYesterday": "Dün",
     "@timeYesterday": {
         "description": "Date label for yesterday"
-    }
+    },
+    "cameraPermissionWebUnsupportedTitle": "Kamera henüz web'de desteklenmiyor",
+    "cameraPermissionWebUnsupportedDescription": "Kamera ile çekim ve kayıt henüz web sürümünde kullanılamıyor.",
+    "cameraPermissionBackToFeed": "Akışa geri dön",
+    "cameraPermissionErrorTitle": "İzin hatası",
+    "cameraPermissionErrorDescription": "İzinler kontrol edilirken bir sorun oluştu.",
+    "cameraPermissionRetry": "Tekrar dene",
+    "cameraPermissionAllowAccessTitle": "Kamera ve mikrofona erişime izin ver",
+    "cameraPermissionAllowAccessDescription": "Bu, videoları doğrudan uygulama içinde çekip düzenlemeni sağlar, daha fazlasını değil.",
+    "cameraPermissionContinue": "Devam et",
+    "cameraPermissionGoToSettings": "Ayarlara git"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -6866,6 +6866,12 @@ abstract class AppLocalizations {
   /// **'Not Now'**
   String get saveOriginalNotNow;
 
+  /// No description provided for @cameraPermissionNotNow.
+  ///
+  /// In en, this message translates to:
+  /// **'Not Now'**
+  String get cameraPermissionNotNow;
+
   /// No description provided for @saveOriginalDownloadFailed.
   ///
   /// In en, this message translates to:
@@ -8263,6 +8269,66 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Center'**
   String get textAlignCenter;
+
+  /// No description provided for @cameraPermissionWebUnsupportedTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Camera not supported on web yet'**
+  String get cameraPermissionWebUnsupportedTitle;
+
+  /// No description provided for @cameraPermissionWebUnsupportedDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Camera capture and recording are not available in the web version yet.'**
+  String get cameraPermissionWebUnsupportedDescription;
+
+  /// No description provided for @cameraPermissionBackToFeed.
+  ///
+  /// In en, this message translates to:
+  /// **'Back to feed'**
+  String get cameraPermissionBackToFeed;
+
+  /// No description provided for @cameraPermissionErrorTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Permission Error'**
+  String get cameraPermissionErrorTitle;
+
+  /// No description provided for @cameraPermissionErrorDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong while checking permissions.'**
+  String get cameraPermissionErrorDescription;
+
+  /// No description provided for @cameraPermissionRetry.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get cameraPermissionRetry;
+
+  /// No description provided for @cameraPermissionAllowAccessTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Allow camera & microphone access'**
+  String get cameraPermissionAllowAccessTitle;
+
+  /// No description provided for @cameraPermissionAllowAccessDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'This allows you to capture and edit videos right here in the app, nothing more.'**
+  String get cameraPermissionAllowAccessDescription;
+
+  /// No description provided for @cameraPermissionContinue.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue'**
+  String get cameraPermissionContinue;
+
+  /// No description provided for @cameraPermissionGoToSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Go to settings'**
+  String get cameraPermissionGoToSettings;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -6869,7 +6869,7 @@ abstract class AppLocalizations {
   /// No description provided for @cameraPermissionNotNow.
   ///
   /// In en, this message translates to:
-  /// **'Not Now'**
+  /// **'Not now'**
   String get cameraPermissionNotNow;
 
   /// No description provided for @saveOriginalDownloadFailed.

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3834,6 +3834,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get saveOriginalNotNow => 'ليس الآن';
 
   @override
+  String get cameraPermissionNotNow => 'ليس الآن';
+
+  @override
   String get saveOriginalDownloadFailed => 'فشل التنزيل';
 
   @override
@@ -4590,4 +4593,39 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get textAlignCenter => 'وسط';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle =>
+      'الكاميرا غير مدعومة على الويب بعد';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      'التقاط الكاميرا وتسجيلها غير متاحين في إصدار الويب بعد.';
+
+  @override
+  String get cameraPermissionBackToFeed => 'العودة إلى الخلاصة';
+
+  @override
+  String get cameraPermissionErrorTitle => 'خطأ في الأذونات';
+
+  @override
+  String get cameraPermissionErrorDescription =>
+      'حدث خطأ أثناء التحقق من الأذونات.';
+
+  @override
+  String get cameraPermissionRetry => 'إعادة المحاولة';
+
+  @override
+  String get cameraPermissionAllowAccessTitle =>
+      'السماح بالوصول إلى الكاميرا والميكروفون';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      'يتيح لك هذا التقاط الفيديوهات وتعديلها مباشرة داخل التطبيق، ولا شيء أكثر.';
+
+  @override
+  String get cameraPermissionContinue => 'متابعة';
+
+  @override
+  String get cameraPermissionGoToSettings => 'الذهاب إلى الإعدادات';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3922,6 +3922,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get saveOriginalNotNow => 'Nicht jetzt';
 
   @override
+  String get cameraPermissionNotNow => 'Nicht jetzt';
+
+  @override
   String get saveOriginalDownloadFailed => 'Download fehlgeschlagen';
 
   @override
@@ -4688,4 +4691,39 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get textAlignCenter => 'Zentriert';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle =>
+      'Kamera wird im Web noch nicht unterstützt';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      'Kameraaufnahme und -aufzeichnung sind in der Webversion noch nicht verfügbar.';
+
+  @override
+  String get cameraPermissionBackToFeed => 'Zurück zum Feed';
+
+  @override
+  String get cameraPermissionErrorTitle => 'Berechtigungsfehler';
+
+  @override
+  String get cameraPermissionErrorDescription =>
+      'Beim Prüfen der Berechtigungen ist etwas schiefgelaufen.';
+
+  @override
+  String get cameraPermissionRetry => 'Erneut versuchen';
+
+  @override
+  String get cameraPermissionAllowAccessTitle =>
+      'Kamera- und Mikrofonzugriff erlauben';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      'Damit kannst du Videos direkt hier in der App aufnehmen und bearbeiten, sonst nichts.';
+
+  @override
+  String get cameraPermissionContinue => 'Weiter';
+
+  @override
+  String get cameraPermissionGoToSettings => 'Zu den Einstellungen';
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3868,7 +3868,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get saveOriginalNotNow => 'Not Now';
 
   @override
-  String get cameraPermissionNotNow => 'Not Now';
+  String get cameraPermissionNotNow => 'Not now';
 
   @override
   String get saveOriginalDownloadFailed => 'Download Failed';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3868,6 +3868,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get saveOriginalNotNow => 'Not Now';
 
   @override
+  String get cameraPermissionNotNow => 'Not Now';
+
+  @override
   String get saveOriginalDownloadFailed => 'Download Failed';
 
   @override
@@ -4628,4 +4631,39 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get textAlignCenter => 'Center';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle =>
+      'Camera not supported on web yet';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      'Camera capture and recording are not available in the web version yet.';
+
+  @override
+  String get cameraPermissionBackToFeed => 'Back to feed';
+
+  @override
+  String get cameraPermissionErrorTitle => 'Permission Error';
+
+  @override
+  String get cameraPermissionErrorDescription =>
+      'Something went wrong while checking permissions.';
+
+  @override
+  String get cameraPermissionRetry => 'Retry';
+
+  @override
+  String get cameraPermissionAllowAccessTitle =>
+      'Allow camera & microphone access';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      'This allows you to capture and edit videos right here in the app, nothing more.';
+
+  @override
+  String get cameraPermissionContinue => 'Continue';
+
+  @override
+  String get cameraPermissionGoToSettings => 'Go to settings';
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3919,6 +3919,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get saveOriginalNotNow => 'Ahora no';
 
   @override
+  String get cameraPermissionNotNow => 'Ahora no';
+
+  @override
   String get saveOriginalDownloadFailed => 'Falló la descarga';
 
   @override
@@ -4683,4 +4686,39 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get textAlignCenter => 'Centro';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle =>
+      'La cámara todavía no es compatible en la web';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      'La captura y grabación con cámara todavía no están disponibles en la versión web.';
+
+  @override
+  String get cameraPermissionBackToFeed => 'Volver al feed';
+
+  @override
+  String get cameraPermissionErrorTitle => 'Error de permisos';
+
+  @override
+  String get cameraPermissionErrorDescription =>
+      'Algo salió mal al verificar los permisos.';
+
+  @override
+  String get cameraPermissionRetry => 'Reintentar';
+
+  @override
+  String get cameraPermissionAllowAccessTitle =>
+      'Permitir acceso a cámara y micrófono';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      'Esto te permite capturar y editar videos aquí mismo en la app, nada más.';
+
+  @override
+  String get cameraPermissionContinue => 'Continuar';
+
+  @override
+  String get cameraPermissionGoToSettings => 'Ir a ajustes';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3928,6 +3928,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get saveOriginalNotNow => 'Pas maintenant';
 
   @override
+  String get cameraPermissionNotNow => 'Pas maintenant';
+
+  @override
   String get saveOriginalDownloadFailed => 'Téléchargement échoué';
 
   @override
@@ -4697,4 +4700,39 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get textAlignCenter => 'Centré';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle =>
+      'La caméra n\'est pas encore prise en charge sur le web';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      'La capture et l\'enregistrement vidéo avec la caméra ne sont pas encore disponibles dans la version web.';
+
+  @override
+  String get cameraPermissionBackToFeed => 'Retour au fil';
+
+  @override
+  String get cameraPermissionErrorTitle => 'Erreur d\'autorisation';
+
+  @override
+  String get cameraPermissionErrorDescription =>
+      'Une erreur s\'est produite lors de la vérification des autorisations.';
+
+  @override
+  String get cameraPermissionRetry => 'Réessayer';
+
+  @override
+  String get cameraPermissionAllowAccessTitle =>
+      'Autoriser l\'accès à la caméra et au micro';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      'Cela vous permet de capturer et de modifier des vidéos directement dans l\'application, rien de plus.';
+
+  @override
+  String get cameraPermissionContinue => 'Continuer';
+
+  @override
+  String get cameraPermissionGoToSettings => 'Aller aux paramètres';
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3852,6 +3852,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get saveOriginalNotNow => 'Nanti Saja';
 
   @override
+  String get cameraPermissionNotNow => 'Nanti Saja';
+
+  @override
   String get saveOriginalDownloadFailed => 'Unduhan Gagal';
 
   @override
@@ -4609,4 +4612,39 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get textAlignCenter => 'Tengah';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle =>
+      'Kamera belum didukung di web';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      'Pengambilan gambar dan perekaman kamera belum tersedia di versi web.';
+
+  @override
+  String get cameraPermissionBackToFeed => 'Kembali ke feed';
+
+  @override
+  String get cameraPermissionErrorTitle => 'Kesalahan izin';
+
+  @override
+  String get cameraPermissionErrorDescription =>
+      'Terjadi kesalahan saat memeriksa izin.';
+
+  @override
+  String get cameraPermissionRetry => 'Coba lagi';
+
+  @override
+  String get cameraPermissionAllowAccessTitle =>
+      'Izinkan akses kamera & mikrofon';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      'Ini memungkinkan Anda merekam dan mengedit video langsung di aplikasi, tidak lebih.';
+
+  @override
+  String get cameraPermissionContinue => 'Lanjutkan';
+
+  @override
+  String get cameraPermissionGoToSettings => 'Buka pengaturan';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3918,6 +3918,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get saveOriginalNotNow => 'Non ora';
 
   @override
+  String get cameraPermissionNotNow => 'Non ora';
+
+  @override
   String get saveOriginalDownloadFailed => 'Download fallito';
 
   @override
@@ -4682,4 +4685,39 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get textAlignCenter => 'Centro';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle =>
+      'La fotocamera non è ancora supportata sul web';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      'L\'acquisizione e la registrazione con fotocamera non sono ancora disponibili nella versione web.';
+
+  @override
+  String get cameraPermissionBackToFeed => 'Torna al feed';
+
+  @override
+  String get cameraPermissionErrorTitle => 'Errore di autorizzazione';
+
+  @override
+  String get cameraPermissionErrorDescription =>
+      'Si è verificato un errore durante il controllo delle autorizzazioni.';
+
+  @override
+  String get cameraPermissionRetry => 'Riprova';
+
+  @override
+  String get cameraPermissionAllowAccessTitle =>
+      'Consenti accesso a fotocamera e microfono';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      'Questo ti consente di registrare e modificare video direttamente nell\'app, niente di più.';
+
+  @override
+  String get cameraPermissionContinue => 'Continua';
+
+  @override
+  String get cameraPermissionGoToSettings => 'Vai alle impostazioni';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3695,6 +3695,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get saveOriginalNotNow => '今はいい';
 
   @override
+  String get cameraPermissionNotNow => '今はいい';
+
+  @override
   String get saveOriginalDownloadFailed => 'ダウンロードがうまくいかなかった';
 
   @override
@@ -4448,4 +4451,36 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get textAlignCenter => '中央';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle => 'カメラはまだWebでサポートされていません';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      'カメラでの撮影と録画は、Web版ではまだ利用できません。';
+
+  @override
+  String get cameraPermissionBackToFeed => 'フィードに戻る';
+
+  @override
+  String get cameraPermissionErrorTitle => '権限エラー';
+
+  @override
+  String get cameraPermissionErrorDescription => '権限の確認中に問題が発生しました。';
+
+  @override
+  String get cameraPermissionRetry => '再試行';
+
+  @override
+  String get cameraPermissionAllowAccessTitle => 'カメラとマイクへのアクセスを許可';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      'これにより、アプリ内で動画の撮影と編集ができるようになります。それ以外の用途はありません。';
+
+  @override
+  String get cameraPermissionContinue => '続行';
+
+  @override
+  String get cameraPermissionGoToSettings => '設定に移動';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3710,6 +3710,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get saveOriginalNotNow => '나중에';
 
   @override
+  String get cameraPermissionNotNow => '나중에';
+
+  @override
   String get saveOriginalDownloadFailed => '다운로드 실패';
 
   @override
@@ -4463,4 +4466,36 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get textAlignCenter => '가운데';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle => '카메라는 아직 웹에서 지원되지 않습니다';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      '카메라 촬영 및 녹화는 웹 버전에서 아직 사용할 수 없습니다.';
+
+  @override
+  String get cameraPermissionBackToFeed => '피드로 돌아가기';
+
+  @override
+  String get cameraPermissionErrorTitle => '권한 오류';
+
+  @override
+  String get cameraPermissionErrorDescription => '권한을 확인하는 중 문제가 발생했습니다.';
+
+  @override
+  String get cameraPermissionRetry => '다시 시도';
+
+  @override
+  String get cameraPermissionAllowAccessTitle => '카메라 및 마이크 접근 허용';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      '이렇게 하면 앱에서 바로 동영상을 촬영하고 편집할 수 있으며, 그 외 용도는 없습니다.';
+
+  @override
+  String get cameraPermissionContinue => '계속';
+
+  @override
+  String get cameraPermissionGoToSettings => '설정으로 이동';
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3890,6 +3890,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get saveOriginalNotNow => 'Niet nu';
 
   @override
+  String get cameraPermissionNotNow => 'Niet nu';
+
+  @override
   String get saveOriginalDownloadFailed => 'Download mislukt';
 
   @override
@@ -4651,4 +4654,39 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get textAlignCenter => 'Gecentreerd';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle =>
+      'Camera wordt nog niet ondersteund op het web';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      'Camerabeelden opnemen en video opnemen zijn nog niet beschikbaar in de webversie.';
+
+  @override
+  String get cameraPermissionBackToFeed => 'Terug naar feed';
+
+  @override
+  String get cameraPermissionErrorTitle => 'Machtigingsfout';
+
+  @override
+  String get cameraPermissionErrorDescription =>
+      'Er is iets misgegaan bij het controleren van machtigingen.';
+
+  @override
+  String get cameraPermissionRetry => 'Opnieuw proberen';
+
+  @override
+  String get cameraPermissionAllowAccessTitle =>
+      'Toegang tot camera en microfoon toestaan';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      'Hiermee kun je video\'s rechtstreeks in de app opnemen en bewerken, verder niets.';
+
+  @override
+  String get cameraPermissionContinue => 'Doorgaan';
+
+  @override
+  String get cameraPermissionGoToSettings => 'Naar instellingen';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3987,6 +3987,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get saveOriginalNotNow => 'Nie teraz';
 
   @override
+  String get cameraPermissionNotNow => 'Nie teraz';
+
+  @override
   String get saveOriginalDownloadFailed => 'Pobieranie nieudane';
 
   @override
@@ -4760,4 +4763,39 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get textAlignCenter => 'Środek';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle =>
+      'Aparat nie jest jeszcze obsługiwany w wersji webowej';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      'Robienie zdjęć i nagrywanie kamerą nie są jeszcze dostępne w wersji webowej.';
+
+  @override
+  String get cameraPermissionBackToFeed => 'Wróć do feedu';
+
+  @override
+  String get cameraPermissionErrorTitle => 'Błąd uprawnień';
+
+  @override
+  String get cameraPermissionErrorDescription =>
+      'Wystąpił błąd podczas sprawdzania uprawnień.';
+
+  @override
+  String get cameraPermissionRetry => 'Spróbuj ponownie';
+
+  @override
+  String get cameraPermissionAllowAccessTitle =>
+      'Zezwól na dostęp do aparatu i mikrofonu';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      'To pozwala nagrywać i edytować filmy bezpośrednio w aplikacji i nic więcej.';
+
+  @override
+  String get cameraPermissionContinue => 'Kontynuuj';
+
+  @override
+  String get cameraPermissionGoToSettings => 'Przejdź do ustawień';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3904,6 +3904,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get saveOriginalNotNow => 'Agora não';
 
   @override
+  String get cameraPermissionNotNow => 'Agora não';
+
+  @override
   String get saveOriginalDownloadFailed => 'Download falhou';
 
   @override
@@ -4668,4 +4671,39 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get textAlignCenter => 'Centro';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle =>
+      'A câmera ainda não é compatível na web';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      'A captura e a gravação com câmera ainda não estão disponíveis na versão web.';
+
+  @override
+  String get cameraPermissionBackToFeed => 'Voltar ao feed';
+
+  @override
+  String get cameraPermissionErrorTitle => 'Erro de permissão';
+
+  @override
+  String get cameraPermissionErrorDescription =>
+      'Ocorreu um erro ao verificar as permissões.';
+
+  @override
+  String get cameraPermissionRetry => 'Tentar novamente';
+
+  @override
+  String get cameraPermissionAllowAccessTitle =>
+      'Permitir acesso à câmera e ao microfone';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      'Isso permite capturar e editar vídeos direto no app, nada além disso.';
+
+  @override
+  String get cameraPermissionContinue => 'Continuar';
+
+  @override
+  String get cameraPermissionGoToSettings => 'Ir para configurações';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3995,6 +3995,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get saveOriginalNotNow => 'Nu acum';
 
   @override
+  String get cameraPermissionNotNow => 'Nu acum';
+
+  @override
   String get saveOriginalDownloadFailed => 'Descărcare eșuată';
 
   @override
@@ -4769,4 +4772,39 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get textAlignCenter => 'Centru';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle =>
+      'Camera nu este încă acceptată pe web';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      'Captura și înregistrarea cu camera nu sunt încă disponibile în versiunea web.';
+
+  @override
+  String get cameraPermissionBackToFeed => 'Înapoi la feed';
+
+  @override
+  String get cameraPermissionErrorTitle => 'Eroare de permisiuni';
+
+  @override
+  String get cameraPermissionErrorDescription =>
+      'A apărut o eroare la verificarea permisiunilor.';
+
+  @override
+  String get cameraPermissionRetry => 'Încearcă din nou';
+
+  @override
+  String get cameraPermissionAllowAccessTitle =>
+      'Permite accesul la cameră și microfon';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      'Aceasta îți permite să capturezi și să editezi videoclipuri direct în aplicație, nimic mai mult.';
+
+  @override
+  String get cameraPermissionContinue => 'Continuă';
+
+  @override
+  String get cameraPermissionGoToSettings => 'Mergi la setări';
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3870,6 +3870,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get saveOriginalNotNow => 'Inte nu';
 
   @override
+  String get cameraPermissionNotNow => 'Inte nu';
+
+  @override
   String get saveOriginalDownloadFailed => 'Nedladdning misslyckades';
 
   @override
@@ -4628,4 +4631,39 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get textAlignCenter => 'Centrera';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle =>
+      'Kameran stöds inte på webben än';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      'Kamerainspelning och videoinspelning är ännu inte tillgängliga i webbversionen.';
+
+  @override
+  String get cameraPermissionBackToFeed => 'Tillbaka till flödet';
+
+  @override
+  String get cameraPermissionErrorTitle => 'Behörighetsfel';
+
+  @override
+  String get cameraPermissionErrorDescription =>
+      'Något gick fel när behörigheterna kontrollerades.';
+
+  @override
+  String get cameraPermissionRetry => 'Försök igen';
+
+  @override
+  String get cameraPermissionAllowAccessTitle =>
+      'Tillåt åtkomst till kamera och mikrofon';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      'Detta låter dig spela in och redigera videor direkt i appen, inget mer.';
+
+  @override
+  String get cameraPermissionContinue => 'Fortsätt';
+
+  @override
+  String get cameraPermissionGoToSettings => 'Gå till inställningar';
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3860,6 +3860,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get saveOriginalNotNow => 'Şimdi Değil';
 
   @override
+  String get cameraPermissionNotNow => 'Şimdi Değil';
+
+  @override
   String get saveOriginalDownloadFailed => 'İndirme Başarısız';
 
   @override
@@ -4618,4 +4621,39 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get textAlignCenter => 'Ortala';
+
+  @override
+  String get cameraPermissionWebUnsupportedTitle =>
+      'Kamera henüz web\'de desteklenmiyor';
+
+  @override
+  String get cameraPermissionWebUnsupportedDescription =>
+      'Kamera ile çekim ve kayıt henüz web sürümünde kullanılamıyor.';
+
+  @override
+  String get cameraPermissionBackToFeed => 'Akışa geri dön';
+
+  @override
+  String get cameraPermissionErrorTitle => 'İzin hatası';
+
+  @override
+  String get cameraPermissionErrorDescription =>
+      'İzinler kontrol edilirken bir sorun oluştu.';
+
+  @override
+  String get cameraPermissionRetry => 'Tekrar dene';
+
+  @override
+  String get cameraPermissionAllowAccessTitle =>
+      'Kamera ve mikrofona erişime izin ver';
+
+  @override
+  String get cameraPermissionAllowAccessDescription =>
+      'Bu, videoları doğrudan uygulama içinde çekip düzenlemeni sağlar, daha fazlasını değil.';
+
+  @override
+  String get cameraPermissionContinue => 'Devam et';
+
+  @override
+  String get cameraPermissionGoToSettings => 'Ayarlara git';
 }

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -552,40 +552,39 @@ class _AppShellState extends ConsumerState<AppShell> {
                   currentIndex,
                   'explore_tab',
                 ),
-                // Camera button in center of bottom nav (hidden on web)
-                if (!kIsWeb)
-                  Semantics(
-                    identifier: 'camera_button',
-                    button: true,
-                    label: context.l10n.navOpenCamera,
-                    child: GestureDetector(
-                      onTap: () {
-                        Log.info(
-                          '👆 User tapped camera button',
-                          name: 'Navigation',
-                          category: LogCategory.ui,
-                        );
-                        context.pushToCameraWithPermission();
-                      },
-                      child: Container(
-                        width: 72,
-                        height: 48,
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 20,
-                          vertical: 8,
-                        ),
-                        decoration: BoxDecoration(
-                          color: VineTheme.cameraButtonGreen,
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                        child: SvgPicture.asset(
-                          DivineIconName.cameraRetro.assetPath,
-                          width: 32,
-                          height: 32,
-                        ),
+                // Camera button in center of bottom nav
+                Semantics(
+                  identifier: 'camera_button',
+                  button: true,
+                  label: context.l10n.navOpenCamera,
+                  child: GestureDetector(
+                    onTap: () {
+                      Log.info(
+                        '👆 User tapped camera button',
+                        name: 'Navigation',
+                        category: LogCategory.ui,
+                      );
+                      context.pushToCameraWithPermission();
+                    },
+                    child: Container(
+                      width: 72,
+                      height: 48,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 20,
+                        vertical: 8,
+                      ),
+                      decoration: BoxDecoration(
+                        color: VineTheme.cameraButtonGreen,
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: SvgPicture.asset(
+                        DivineIconName.cameraRetro.assetPath,
+                        width: 32,
+                        height: 32,
                       ),
                     ),
                   ),
+                ),
                 NotificationBadge(
                   count:
                       context.watch<DmUnreadCountCubit>().state +

--- a/mobile/lib/utils/camera_permission_check.dart
+++ b/mobile/lib/utils/camera_permission_check.dart
@@ -4,9 +4,11 @@
 import 'dart:async';
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/camera_permission/camera_permission_bloc.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 
@@ -19,6 +21,11 @@ extension CameraPermissionNavigation on BuildContext {
   /// Returns `true` if navigation occurred.
   Future<bool> pushToCameraWithPermission() async {
     final bloc = read<CameraPermissionBloc>();
+
+    if (kIsWeb) {
+      await pushWithVideoPause(VideoRecorderScreen.path);
+      return true;
+    }
 
     final status = await _resolvePermissionStatus(bloc);
     if (!mounted) return false;
@@ -37,16 +44,14 @@ extension CameraPermissionNavigation on BuildContext {
     await VineBottomSheetPrompt.show<void>(
       context: this,
       sticker: DivineStickerName.skeletonKey,
-      title: 'Allow camera & microphone access',
-      subtitle:
-          'This allows you to capture and edit videos '
-          'right here in the app, nothing more.',
-      primaryButtonText: 'Continue',
+      title: l10n.cameraPermissionAllowAccessTitle,
+      subtitle: l10n.cameraPermissionAllowAccessDescription,
+      primaryButtonText: l10n.cameraPermissionContinue,
       onPrimaryPressed: () {
         permissionRequested = true;
         Navigator.of(this).pop();
       },
-      secondaryButtonText: 'Not now',
+      secondaryButtonText: l10n.cameraPermissionNotNow,
       onSecondaryPressed: () => Navigator.of(this).pop(),
     );
 

--- a/mobile/lib/widgets/camera_permission_gate.dart
+++ b/mobile/lib/widgets/camera_permission_gate.dart
@@ -2,12 +2,14 @@
 // ABOUTME: Renders permission UI or camera based on CameraPermissionBloc state
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/camera_permission/camera_permission_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_bottom_bar.dart';
 import 'package:tv_static_effect/tv_static_effect.dart';
@@ -126,13 +128,24 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
           name: 'CameraPermissionGate',
           category: LogCategory.video,
         );
+
+        if (kIsWeb) {
+          return _PermissionScreen(
+            title: context.l10n.cameraPermissionWebUnsupportedTitle,
+            description: context.l10n.cameraPermissionWebUnsupportedDescription,
+            buttonLabel: context.l10n.cameraPermissionBackToFeed,
+            onAction: _popBack,
+            onClose: _popBack,
+          );
+        }
+
         return switch (state) {
           CameraPermissionInitial() => const _LoadingIndicator(),
           CameraPermissionLoading() => const _LoadingIndicator(),
           CameraPermissionError() => _PermissionScreen(
-            title: 'Permission Error',
-            description: 'Something went wrong while checking permissions.',
-            buttonLabel: 'Retry',
+            title: context.l10n.cameraPermissionErrorTitle,
+            description: context.l10n.cameraPermissionErrorDescription,
+            buttonLabel: context.l10n.cameraPermissionRetry,
             onAction: () {
               context.read<CameraPermissionBloc>().add(
                 const CameraPermissionRefresh(),
@@ -144,11 +157,9 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
           CameraPermissionLoaded(:final status) => switch (status) {
             CameraPermissionStatus.authorized => widget.child,
             CameraPermissionStatus.canRequest => _PermissionScreen(
-              title: 'Allow camera & microphone access',
-              description:
-                  'This allows you to capture and edit videos '
-                  'right here in the app, nothing more.',
-              buttonLabel: 'Continue',
+              title: context.l10n.cameraPermissionAllowAccessTitle,
+              description: context.l10n.cameraPermissionAllowAccessDescription,
+              buttonLabel: context.l10n.cameraPermissionContinue,
               onAction: () {
                 context.read<CameraPermissionBloc>().add(
                   const CameraPermissionRequest(),
@@ -157,11 +168,9 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
               onClose: _popBack,
             ),
             CameraPermissionStatus.requiresSettings => _PermissionScreen(
-              title: 'Allow camera & microphone access',
-              description:
-                  'This allows you to capture and edit videos '
-                  'right here in the app, nothing more.',
-              buttonLabel: 'Go to settings',
+              title: context.l10n.cameraPermissionAllowAccessTitle,
+              description: context.l10n.cameraPermissionAllowAccessDescription,
+              buttonLabel: context.l10n.cameraPermissionGoToSettings,
               onAction: () {
                 context.read<CameraPermissionBloc>().add(
                   const CameraPermissionOpenSettings(),

--- a/mobile/lib/widgets/vine_bottom_nav.dart
+++ b/mobile/lib/widgets/vine_bottom_nav.dart
@@ -2,7 +2,6 @@
 // ABOUTME: Provides consistent bottom nav across screens with/without shell
 
 import 'package:divine_ui/divine_ui.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -151,18 +150,17 @@ class VineBottomNav extends ConsumerWidget {
               1,
               'explore_tab',
             ),
-            // Camera button in center of bottom nav (hidden on web)
-            if (!kIsWeb)
-              _CameraButton(
-                onTap: () {
-                  Log.info(
-                    '👆 User tapped camera button',
-                    name: 'Navigation',
-                    category: LogCategory.ui,
-                  );
-                  context.pushToCameraWithPermission();
-                },
-              ),
+            // Camera button in center of bottom nav
+            _CameraButton(
+              onTap: () {
+                Log.info(
+                  '👆 User tapped camera button',
+                  name: 'Navigation',
+                  category: LogCategory.ui,
+                );
+                context.pushToCameraWithPermission();
+              },
+            ),
             NotificationBadge(
               count: _inboxUnreadCount(context, ref),
               child: _buildTabButton(


### PR DESCRIPTION

## Description

Allows users to navigate to the video recorder and displays a message there indicating that the feature is not supported. Additionally, it directly adds all missing localization files from the permission screen.


**Related Issue:** Closes #3077

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore