### PR TITLE
fix(auth): guard back navigation when nothing can pop

### DIFF
--- a/mobile/lib/screens/auth/invite_gate_screen.dart
+++ b/mobile/lib/screens/auth/invite_gate_screen.dart
@@ -500,7 +500,7 @@ class _InviteSheetPage extends StatelessWidget {
               child: Row(
                 children: [
                   if (showBackButton)
-                    AuthBackButton(onPressed: () => context.pop())
+                    const AuthBackButton()
                   else
                     const SizedBox(width: 48, height: 48),
                 ],

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -224,9 +224,7 @@ class _SignInContentState extends ConsumerState<_SignInContent> {
                 // Top bar: back + info
                 Row(
                   children: [
-                    AuthBackButton(
-                      onPressed: isDisabled ? null : () => context.pop(),
-                    ),
+                    AuthBackButton(enabled: !isDisabled),
                     const Spacer(),
                     RoundedIconButton(
                       onPressed: isDisabled

--- a/mobile/lib/screens/auth/reset_password.dart
+++ b/mobile/lib/screens/auth/reset_password.dart
@@ -110,9 +110,7 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
               const SizedBox(height: 8),
 
               // Back button
-              AuthBackButton(
-                onPressed: _isLoading ? null : () => context.pop(),
-              ),
+              AuthBackButton(enabled: !_isLoading),
 
               const SizedBox(height: 32),
 

--- a/mobile/lib/screens/key_import_screen.dart
+++ b/mobile/lib/screens/key_import_screen.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -80,9 +79,7 @@ class _KeyImportScreenState extends ConsumerState<KeyImportScreen> {
                         const SizedBox(height: 8),
 
                         // Back button
-                        AuthBackButton(
-                          onPressed: _isImporting ? null : () => context.pop(),
-                        ),
+                        AuthBackButton(enabled: !_isImporting),
 
                         const SizedBox(height: 32),
 

--- a/mobile/lib/widgets/auth/auth_form_scaffold.dart
+++ b/mobile/lib/widgets/auth/auth_form_scaffold.dart
@@ -8,7 +8,6 @@ import 'dart:math';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:go_router/go_router.dart';
 import 'package:openvine/widgets/auth_back_button.dart';
 
 /// A shared scaffold layout for authentication form screens.
@@ -76,7 +75,8 @@ class AuthFormScaffold extends StatelessWidget {
   /// Optional secondary action button (e.g. "Skip for now").
   final Widget? secondaryButton;
 
-  /// Custom back button callback. Defaults to `context.pop()`.
+  /// Custom back button callback. Defaults to [AuthBackButton]'s safe back
+  /// behavior.
   final VoidCallback? onBack;
 
   @override
@@ -97,7 +97,7 @@ class AuthFormScaffold extends StatelessWidget {
                     const SizedBox(height: 8),
 
                     // Back button
-                    AuthBackButton(onPressed: onBack ?? () => context.pop()),
+                    AuthBackButton(onPressed: onBack),
 
                     const SizedBox(height: 32),
 

--- a/mobile/lib/widgets/auth_back_button.dart
+++ b/mobile/lib/widgets/auth_back_button.dart
@@ -14,18 +14,34 @@ import 'package:openvine/widgets/rounded_icon_button.dart';
 class AuthBackButton extends StatelessWidget {
   /// Creates an authentication flow back button.
   ///
-  /// If [onPressed] is null, the button will call `context.pop()`.
-  const AuthBackButton({super.key, this.onPressed});
+  /// If [onPressed] is null, the button will perform a guarded back action.
+  const AuthBackButton({
+    super.key,
+    this.onPressed,
+    this.enabled = true,
+  });
 
   /// Optional custom callback when the button is pressed.
   ///
   /// If null, defaults to `context.pop()`.
   final VoidCallback? onPressed;
 
+  /// Whether the back button should respond to taps.
+  final bool enabled;
+
+  void _handleBackTap(BuildContext context) {
+    if (context.canPop()) {
+      context.pop();
+      return;
+    }
+
+    Navigator.of(context).maybePop();
+  }
+
   @override
   Widget build(BuildContext context) {
     return RoundedIconButton(
-      onPressed: onPressed ?? () => context.pop(),
+      onPressed: !enabled ? null : onPressed ?? () => _handleBackTap(context),
       icon: const Icon(
         Icons.chevron_left,
         color: VineTheme.vineGreenLight,

--- a/mobile/test/widgets/auth_back_button_test.dart
+++ b/mobile/test/widgets/auth_back_button_test.dart
@@ -4,9 +4,12 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/auth_back_button.dart';
 import 'package:openvine/widgets/rounded_icon_button.dart';
+
+import '../helpers/go_router.dart';
 
 void main() {
   group(AuthBackButton, () {
@@ -68,6 +71,32 @@ void main() {
 
         await tester.tap(find.byType(RoundedIconButton));
         expect(tapped, isTrue);
+      });
+
+      testWidgets('does not call GoRouter.pop when there is nothing to pop', (
+        tester,
+      ) async {
+        final mockGoRouter = MockGoRouter();
+        when(mockGoRouter.canPop).thenReturn(false);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            theme: VineTheme.theme,
+            home: MockGoRouterProvider(
+              goRouter: mockGoRouter,
+              child: const Scaffold(body: AuthBackButton()),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(RoundedIconButton));
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+        verify(mockGoRouter.canPop).called(1);
+        verifyNever(() => mockGoRouter.pop<dynamic>(any()));
       });
     });
   });


### PR DESCRIPTION
Closes #3088

## Summary
- route auth back-button taps through a safe default handler that checks whether navigation can pop before calling go_router
- update auth screens that were bypassing the shared back-button behavior so disabled states still work without forcing an unsafe pop
- add a regression test covering the empty-stack back-button case seen in Crashlytics

## Test Plan
- [x] dart analyze lib/widgets/auth_back_button.dart lib/widgets/auth/auth_form_scaffold.dart lib/screens/auth/invite_gate_screen.dart lib/screens/auth/login_options_screen.dart lib/screens/auth/reset_password.dart lib/screens/key_import_screen.dart test/widgets/auth_back_button_test.dart
- [x] flutter test test/widgets/auth_back_button_test.dart
- [x] flutter test test/widgets/auth/auth_form_scaffold_test.dart
- [x] flutter test test/screens/auth/login_options_screen_test.dart
- [x] pre-push targeted suite for changed files via git hook
