### PR TITLE
fix(app): downgrade recoverable media load errors

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -71,6 +71,7 @@ import 'package:openvine/services/video_format_preference.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:openvine/utils/log_message_batcher.dart';
+import 'package:openvine/utils/recoverable_flutter_error.dart';
 import 'package:openvine/widgets/app_lifecycle_handler.dart';
 import 'package:openvine/widgets/geo_blocking_gate.dart';
 import 'package:openvine/widgets/upload_failure_sheet.dart';
@@ -698,6 +699,24 @@ Future<void> _startOpenVineApp() async {
       } catch (_) {}
       // Still show the error widget (dark placeholder) but don't report
       // as fatal.
+      FlutterError.presentError(details);
+      return;
+    }
+
+    final recoverableReason = classifyRecoverableFlutterError(details);
+    if (recoverableReason != null) {
+      Log.warning(
+        'Recoverable Flutter resource load error (non-fatal): '
+        '${details.exception}',
+        name: 'Main',
+      );
+      try {
+        FirebaseCrashlytics.instance.recordError(
+          details.exception,
+          details.stack,
+          reason: recoverableReason,
+        );
+      } catch (_) {}
       FlutterError.presentError(details);
       return;
     }

--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -11,11 +11,21 @@ const _recoverableMediaHosts = <String>{
 
 /// Returns a non-fatal reporting reason when a Flutter error represents a
 /// recoverable media or image loading failure.
+///
+/// The signature checks below match against Flutter/Dart SDK-internal library
+/// paths and context descriptions (for example `_network_image_io` and
+/// `image codec`). Those strings are not part of Flutter's public API and may
+/// change silently on a major SDK upgrade — re-verify them when bumping
+/// Flutter to a new major version.
 String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
   final error = details.exception.toString();
   final library = details.library ?? '';
   final context = details.context?.toDescription() ?? '';
+  final hasRecoverableMediaHost = _containsRecoverableMediaHost(error);
 
+  // Image 404s are classified by Flutter's image-loading context rather than
+  // host, because a missing image from any source is recoverable — the app
+  // falls back to a placeholder.
   final isImage404 =
       error.contains('HTTP request failed, statusCode: 404') &&
       (library.contains('_network_image_io') ||
@@ -23,11 +33,11 @@ String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
           context.contains('image resource'));
 
   final isMediaHostLookup =
-      error.contains('SocketException') && _containsRecoverableMediaHost(error);
+      error.contains('SocketException') && hasRecoverableMediaHost;
 
   final isInterruptedMediaDownload =
       error.contains('Connection closed while receiving data') &&
-      _containsRecoverableMediaHost(error);
+      hasRecoverableMediaHost;
 
   final isInvalidImageData =
       error.contains('Invalid image data') &&

--- a/mobile/lib/utils/recoverable_flutter_error.dart
+++ b/mobile/lib/utils/recoverable_flutter_error.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+const _recoverableMediaLoadReason = 'Recoverable media load failure';
+const _recoverableMediaHosts = <String>{
+  'media.divine.video',
+  'cdn.divine.video',
+  'divine.video',
+  'v.cdn.vine.co',
+  'cdn.vine.co',
+};
+
+/// Returns a non-fatal reporting reason when a Flutter error represents a
+/// recoverable media or image loading failure.
+String? classifyRecoverableFlutterError(FlutterErrorDetails details) {
+  final error = details.exception.toString();
+  final library = details.library ?? '';
+  final context = details.context?.toDescription() ?? '';
+
+  final isImage404 =
+      error.contains('HTTP request failed, statusCode: 404') &&
+      (library.contains('_network_image_io') ||
+          context.contains('image codec') ||
+          context.contains('image resource'));
+
+  final isMediaHostLookup =
+      error.contains('SocketException') && _containsRecoverableMediaHost(error);
+
+  final isInterruptedMediaDownload =
+      error.contains('Connection closed while receiving data') &&
+      _containsRecoverableMediaHost(error);
+
+  final isInvalidImageData =
+      error.contains('Invalid image data') &&
+      (library == 'dart:ui' ||
+          context.contains('image codec') ||
+          context.contains('instantiateImageCodecWithSize'));
+
+  if (isImage404 ||
+      isMediaHostLookup ||
+      isInterruptedMediaDownload ||
+      isInvalidImageData) {
+    return _recoverableMediaLoadReason;
+  }
+
+  return null;
+}
+
+bool _containsRecoverableMediaHost(String value) {
+  for (final host in _recoverableMediaHosts) {
+    if (value.contains(host)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/mobile/test/utils/recoverable_flutter_error_test.dart
+++ b/mobile/test/utils/recoverable_flutter_error_test.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/recoverable_flutter_error.dart';
+
+void main() {
+  group('classifyRecoverableFlutterError', () {
+    test('classifies image 404 codec failures as recoverable', () {
+      final details = FlutterErrorDetails(
+        exception: Exception(
+          'HTTP request failed, statusCode: 404, '
+          'https://cdn.divine.video/test/thumbnails/thumbnail.jpg. '
+          'Error thrown resolving an image codec.',
+        ),
+        library: 'package:flutter/src/painting/_network_image_io.dart',
+      );
+
+      expect(
+        classifyRecoverableFlutterError(details),
+        'Recoverable media load failure',
+      );
+    });
+
+    test('classifies Divine media host lookup failures as recoverable', () {
+      const details = FlutterErrorDetails(
+        exception: SocketException(
+          "Failed host lookup: 'media.divine.video'",
+        ),
+        library: 'dart:_http',
+      );
+
+      expect(
+        classifyRecoverableFlutterError(details),
+        'Recoverable media load failure',
+      );
+    });
+
+    test('classifies invalid image data failures as recoverable', () {
+      const details = FlutterErrorDetails(
+        exception: FormatException('Invalid image data.'),
+        library: 'dart:ui',
+      );
+
+      expect(
+        classifyRecoverableFlutterError(details),
+        'Recoverable media load failure',
+      );
+    });
+
+    test('classifies interrupted Divine media downloads as recoverable', () {
+      const details = FlutterErrorDetails(
+        exception: HttpException(
+          'Connection closed while receiving data, '
+          'uri = https://media.divine.video/hash',
+        ),
+        library: 'dart:_http',
+      );
+
+      expect(
+        classifyRecoverableFlutterError(details),
+        'Recoverable media load failure',
+      );
+    });
+
+    test('does not classify unrelated gesture errors as recoverable', () {
+      final details = FlutterErrorDetails(
+        exception: Exception('GoError: There is nothing to pop.'),
+        library: 'package:go_router/src/delegate.dart',
+      );
+
+      expect(classifyRecoverableFlutterError(details), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Closes #3090

## Summary
- classify repeated media and image loading Flutter errors as recoverable instead of letting Crashlytics mark them fatal
- handle CDN 404s, Divine media DNS failures, interrupted media downloads, and invalid image data through the shared classifier in the global Flutter error handler
- add regression coverage for the Crashlytics signatures so future changes keep these failures non-fatal

## Test Plan
- [x] flutter test test/utils/recoverable_flutter_error_test.dart
- [x] dart analyze lib/main.dart lib/utils/recoverable_flutter_error.dart test/utils/recoverable_flutter_error_test.dart
- [x] pre-push targeted suite for changed files via git hook
