### PR TITLE
fix: avoid overwriting newer profiles with stale data

### DIFF
--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -277,18 +277,26 @@ class ProfileRepository {
         final result = await _funnelcakeApiClient!.getUserProfile(pubkey);
         switch (result) {
           case UserProfileFound():
-            final profile = UserProfile.fromUserProfileFound(result);
-            // Funnelcake profiles use DateTime.now() as a synthetic createdAt
-            // (the REST API does not expose the Nostr event timestamp), so
-            // _cacheProfileIfNewer cannot reliably guard against overwriting a
-            // freshly-saved bio. Only cache when no local profile exists yet.
+            final funnelcakeProfile = UserProfile.fromUserProfileFound(result);
+            // Funnelcake profiles use DateTime.now() as a synthetic
+            // createdAt (the REST API does not expose the Nostr event
+            // timestamp), so _cacheProfileIfNewer cannot reliably guard
+            // against overwriting a freshly-saved bio. Only write to
+            // cache when no local profile exists yet; otherwise fall
+            // through to the relay/indexer path so a newer Kind 0 on
+            // relays can still upgrade the cache.
             final existing = await _userProfilesDao.getProfile(pubkey);
             if (existing == null) {
               _knownCached.add(pubkey);
-              await _userProfilesDao.upsertProfile(profile);
+              await _userProfilesDao.upsertProfile(funnelcakeProfile);
             }
             await _cacheProfileStatsFromResult(pubkey, result);
-            return existing ?? profile;
+            if (existing != null) {
+              // Local profile exists — skip the early return and let
+              // the relay/indexer path run so a newer Kind 0 can win.
+              break;
+            }
+            return funnelcakeProfile;
           case UserProfileNotPublished():
             // User exists but has no Kind 0. Cache stats and skip relay
             // fallback — the profile genuinely does not exist yet.
@@ -310,11 +318,17 @@ class ProfileRepository {
     // Step 2: Fire connected relays and indexer relays concurrently.
     // Return the first valid profile immediately, then let slower
     // sources upgrade the cache if they have a newer kind 0 event.
-    final profile = await _fetchFromRelaysParallel(pubkey);
-    if (profile != null) {
-      await _cacheProfileIfNewer(profile);
-      return profile;
+    final relayProfile = await _fetchFromRelaysParallel(pubkey);
+    if (relayProfile != null) {
+      await _cacheProfileIfNewer(relayProfile);
+      return relayProfile;
     }
+
+    // Relay/indexer found nothing. If a local profile already exists
+    // (e.g. Funnelcake had a hit but we skipped its upsert to protect
+    // a freshly-saved bio), return it as a fallback rather than null.
+    final fallback = await _userProfilesDao.getProfile(pubkey);
+    if (fallback != null) return fallback;
 
     // All sources exhausted — mark as confirmed missing.
     _confirmedMissing.add(pubkey);

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -278,10 +278,17 @@ class ProfileRepository {
         switch (result) {
           case UserProfileFound():
             final profile = UserProfile.fromUserProfileFound(result);
-            _knownCached.add(pubkey);
-            await _userProfilesDao.upsertProfile(profile);
+            // Funnelcake profiles use DateTime.now() as a synthetic createdAt
+            // (the REST API does not expose the Nostr event timestamp), so
+            // _cacheProfileIfNewer cannot reliably guard against overwriting a
+            // freshly-saved bio. Only cache when no local profile exists yet.
+            final existing = await _userProfilesDao.getProfile(pubkey);
+            if (existing == null) {
+              _knownCached.add(pubkey);
+              await _userProfilesDao.upsertProfile(profile);
+            }
             await _cacheProfileStatsFromResult(pubkey, result);
-            return profile;
+            return existing ?? profile;
           case UserProfileNotPublished():
             // User exists but has no Kind 0. Cache stats and skip relay
             // fallback — the profile genuinely does not exist yet.
@@ -396,15 +403,22 @@ class ProfileRepository {
       final events = await _nostrClient
           .queryEvents(
             [
-              Filter(kinds: [0], authors: [pubkey], limit: 1),
+              Filter(kinds: [0], authors: [pubkey], limit: 5),
             ],
             tempRelays: _indexerRelays,
             useCache: false,
           )
           .timeout(const Duration(seconds: 5), onTimeout: () => <Event>[]);
 
-      if (events.isNotEmpty && events.first.kind == 0) {
-        final profile = UserProfile.fromNostrEvent(events.first);
+      // Relays do not guarantee newest-first ordering, so pick the event
+      // with the highest createdAt to avoid overwriting a freshly saved
+      // profile with stale metadata.
+      final kind0Events = events.where((e) => e.kind == 0).toList();
+      if (kind0Events.isNotEmpty) {
+        final newest = kind0Events.reduce(
+          (a, b) => b.createdAt > a.createdAt ? b : a,
+        );
+        final profile = UserProfile.fromNostrEvent(newest);
         developer.log(
           'Fetched from indexer relay: ${profile.bestDisplayName}',
           name: 'ProfileRepository.fetchFreshProfile',

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -680,12 +680,16 @@ void main() {
             // the freshly-published profile (createdAt = 1704153600, newer).
             // Funnelcake returns a stale cached profile
             // (createdAt = 1704067200, older). The bio must NOT be
-            // overwritten.
+            // overwritten, the relay path must still run (so a newer Kind 0
+            // on relays can win), and the return value must be the locally
+            // cached profile when relays find nothing newer.
             const newerTimestamp = 1704153600; // newer — just saved
             const olderTimestamp = 1704067200; // older — stale Funnelcake cache
 
             final freshlySavedProfile = UserProfile(
               pubkey: testPubkey,
+              displayName: 'Test User',
+              about: 'My new bio',
               rawData: const {
                 'display_name': 'Test User',
                 'about': 'My new bio',
@@ -697,10 +701,23 @@ void main() {
               eventId: testEventId,
             );
 
-            // Local cache already holds the freshly-saved profile.
+            // Use a fresh DAO mock so we can control getProfile return values
+            // without stub-ordering issues from the outer setUp.
+            final freshDao = MockUserProfilesDao();
             when(
-              () => mockUserProfilesDao.getProfile(testPubkey),
+              () => freshDao.getProfile(any()),
             ).thenAnswer((_) async => freshlySavedProfile);
+            when(
+              () => freshDao.upsertProfile(any()),
+            ).thenAnswer((_) async {});
+
+            final repo = ProfileRepository(
+              nostrClient: mockNostrClient,
+              userProfilesDao: freshDao,
+              httpClient: mockHttpClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+              profileStatsDao: mockProfileStatsDao,
+            );
 
             when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
             when(
@@ -715,11 +732,16 @@ void main() {
               ),
             );
 
-            await repoWithFunnelcake.fetchFreshProfile(pubkey: testPubkey);
+            // Relays find nothing newer — the local cache is the fallback.
+            when(
+              () => mockNostrClient.fetchProfile(testPubkey),
+            ).thenAnswer((_) async => null);
+
+            final result = await repo.fetchFreshProfile(pubkey: testPubkey);
 
             // The stale Funnelcake profile must NOT overwrite the newer cache.
             verifyNever(
-              () => mockUserProfilesDao.upsertProfile(
+              () => freshDao.upsertProfile(
                 any(
                   that: isA<UserProfile>().having(
                     (p) => p.about,
@@ -729,6 +751,19 @@ void main() {
                 ),
               ),
             );
+
+            // The relay path must have been invoked so a newer Kind 0 can
+            // still win — a future refactor cannot safely turn the Funnelcake
+            // break into an early return while keeping this assertion green.
+            verify(
+              () => mockNostrClient.fetchProfile(testPubkey),
+            ).called(1);
+
+            // The return value must be the freshly-saved local profile,
+            // not null (the break path falls back to the cache when relays
+            // find nothing).
+            expect(result, isNotNull);
+            expect(result!.about, equals('My new bio'));
           },
         );
       });

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -671,6 +671,66 @@ void main() {
           verifyNever(() => mockFunnelcakeClient.getUserProfile(any()));
           verify(() => mockNostrClient.fetchProfile(testPubkey)).called(1);
         });
+
+        test(
+          'does not overwrite a newer locally-cached bio with stale '
+          'Funnelcake data (regression: bio appears not to save)',
+          () async {
+            // Simulate: user just saved their bio. The local cache holds
+            // the freshly-published profile (createdAt = 1704153600, newer).
+            // Funnelcake returns a stale cached profile
+            // (createdAt = 1704067200, older). The bio must NOT be
+            // overwritten.
+            const newerTimestamp = 1704153600; // newer — just saved
+            const olderTimestamp = 1704067200; // older — stale Funnelcake cache
+
+            final freshlySavedProfile = UserProfile(
+              pubkey: testPubkey,
+              rawData: const {
+                'display_name': 'Test User',
+                'about': 'My new bio',
+              },
+              createdAt: DateTime.fromMillisecondsSinceEpoch(
+                newerTimestamp * 1000,
+                isUtc: true,
+              ),
+              eventId: testEventId,
+            );
+
+            // Local cache already holds the freshly-saved profile.
+            when(
+              () => mockUserProfilesDao.getProfile(testPubkey),
+            ).thenAnswer((_) async => freshlySavedProfile);
+
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getUserProfile(testPubkey),
+            ).thenAnswer(
+              (_) async => UserProfileFound(
+                profile: UserProfileData.fromJson(testPubkey, const {
+                  'display_name': 'Test User',
+                  'about': '', // stale — bio not yet indexed by Funnelcake
+                  'created_at': olderTimestamp,
+                }),
+              ),
+            );
+
+            await repoWithFunnelcake.fetchFreshProfile(pubkey: testPubkey);
+
+            // The stale Funnelcake profile must NOT overwrite the newer cache.
+            verifyNever(
+              () => mockUserProfilesDao.upsertProfile(
+                any(
+                  that: isA<UserProfile>().having(
+                    (p) => p.about,
+                    'about',
+                    equals(''),
+                  ),
+                ),
+              ),
+            );
+          },
+        );
       });
 
       group('indexer relay fallback', () {
@@ -757,6 +817,68 @@ void main() {
           expect(result, isNull);
           expect(profileRepository.isConfirmedMissing(testPubkey), isTrue);
         });
+
+        test(
+          'picks newest kind-0 event when indexer returns multiple events '
+          'with older event first (regression: bio appears not to save)',
+          () async {
+            // Simulate: relay returns nothing, but indexer returns two kind-0
+            // events for the same pubkey. The older event (stale, no bio) comes
+            // first in the list. The fix must select the newest by createdAt.
+            when(
+              () => mockNostrClient.fetchProfile(testPubkey),
+            ).thenAnswer((_) async => null);
+
+            final olderEvent = MockEvent();
+            when(() => olderEvent.kind).thenReturn(0);
+            when(() => olderEvent.pubkey).thenReturn(testPubkey);
+            when(() => olderEvent.createdAt).thenReturn(1704067200); // older
+            when(() => olderEvent.id).thenReturn('old_$testEventId');
+            when(() => olderEvent.content).thenReturn(
+              jsonEncode({'display_name': 'Test User', 'about': ''}),
+            );
+
+            final newerEvent = MockEvent();
+            when(() => newerEvent.kind).thenReturn(0);
+            when(() => newerEvent.pubkey).thenReturn(testPubkey);
+            when(() => newerEvent.createdAt).thenReturn(1704153600); // newer
+            when(() => newerEvent.id).thenReturn('new_$testEventId');
+            when(() => newerEvent.content).thenReturn(
+              jsonEncode({
+                'display_name': 'Test User',
+                'about': 'My saved bio',
+              }),
+            );
+
+            // Indexer returns older event first, then newer — relay ordering
+            // is not guaranteed, so the repository must not trust list order.
+            when(
+              () => mockNostrClient.queryEvents(
+                any(),
+                tempRelays: any(named: 'tempRelays'),
+                useCache: any(named: 'useCache'),
+              ),
+            ).thenAnswer((_) async => [olderEvent, newerEvent]);
+
+            final result = await profileRepository.fetchFreshProfile(
+              pubkey: testPubkey,
+            );
+
+            expect(result, isNotNull);
+            expect(result!.about, equals('My saved bio'));
+            verify(
+              () => mockUserProfilesDao.upsertProfile(
+                any(
+                  that: isA<UserProfile>().having(
+                    (p) => p.about,
+                    'about',
+                    equals('My saved bio'),
+                  ),
+                ),
+              ),
+            ).called(1);
+          },
+        );
       });
 
       group('parallel relay + indexer fetch', () {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Prevent Funnelcake-cached profiles from overwriting a newer locally-saved profile by checking the local DAO first and only caching when no local profile exists. Improve indexer relay fallback: request up to 5 kind-0 events and pick the event with the highest createdAt timestamp (relays may not return newest-first). Add tests covering the regression where a stale Funnelcake or older indexer event could overwrite a freshly saved bio.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #2929 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore