### PR TITLE
fix(comments): restore clickable profile labels and links

### DIFF
--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -19,6 +19,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/comments/widgets/comment_options_modal.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/widgets/clickable_hashtag_text.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_name.dart';
 
@@ -358,78 +359,23 @@ class _CommentContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isEmoji = _isEmojiOnly(content);
+    final baseStyle = TextStyle(
+      color: VineTheme.onSurface,
+      fontSize: isEmoji ? _emojiOnlyFontSize : 14,
+      height: isEmoji ? null : 20 / 14,
+    );
     return TapRegion(
       onTapOutside: (_) => FocusScope.of(context).unfocus(),
-      child: Text.rich(
-        _buildContentSpans(context),
-        style: TextStyle(
-          color: VineTheme.onSurface,
-          fontSize: isEmoji ? _emojiOnlyFontSize : null,
+      child: ClickableHashtagText(
+        text: content,
+        style: baseStyle,
+        hashtagStyle: baseStyle.copyWith(
+          color: VineTheme.info,
+          fontWeight: FontWeight.w500,
         ),
-      ),
-    );
-  }
-
-  TextSpan _buildContentSpans(BuildContext context) {
-    // Match nostr:npub1... pattern
-    final mentionPattern = RegExp('nostr:(npub1[a-zA-Z0-9]{58,})');
-    final spans = <InlineSpan>[];
-    var lastEnd = 0;
-
-    for (final match in mentionPattern.allMatches(content)) {
-      // Text before mention
-      if (match.start > lastEnd) {
-        spans.add(TextSpan(text: content.substring(lastEnd, match.start)));
-      }
-
-      // Mention span
-      final npub = match.group(1)!;
-      spans.add(
-        WidgetSpan(
-          alignment: PlaceholderAlignment.baseline,
-          baseline: TextBaseline.alphabetic,
-          child: _MentionLink(npub: npub),
-        ),
-      );
-      lastEnd = match.end;
-    }
-
-    // Remaining text
-    if (lastEnd < content.length) {
-      spans.add(TextSpan(text: content.substring(lastEnd)));
-    }
-
-    if (spans.isEmpty) {
-      return TextSpan(text: content);
-    }
-
-    return TextSpan(children: spans);
-  }
-}
-
-/// Inline mention link that resolves profile name and navigates to profile.
-class _MentionLink extends ConsumerWidget {
-  const _MentionLink({required this.npub});
-
-  final String npub;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    String displayText;
-    try {
-      final hexPubkey = NostrKeyUtils.decode(npub);
-      final profile = ref.watch(userProfileReactiveProvider(hexPubkey)).value;
-      displayText = profile?.displayName ?? profile?.name ?? npub;
-    } catch (_) {
-      displayText = npub;
-    }
-
-    return GestureDetector(
-      onTap: () => context.push(OtherProfileScreen.pathForNpub(npub)),
-      child: Text(
-        '@$displayText',
-        style: VineTheme.labelLargeFont(
+        mentionStyle: baseStyle.copyWith(
           color: VineTheme.tabIndicatorGreen,
+          fontWeight: FontWeight.w600,
         ),
       ),
     );

--- a/mobile/lib/utils/public_identifier_normalizer.dart
+++ b/mobile/lib/utils/public_identifier_normalizer.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Normalizes all public identifier formats to hex pubkey
 // ABOUTME: Handles npub, nprofile, hex, and special 'me' identifier universally
 
+import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 
 /// Normalized result containing hex pubkey and optional relay hints
@@ -57,19 +58,13 @@ NormalizedPublicIdentifier? normalizePublicIdentifier(
 
   // Try nprofile format
   if (identifier.startsWith('nprofile1')) {
-    try {
-      // Use NostrKeyUtils.decode which handles nprofile
-      final decoded = NostrKeyUtils.decode(identifier);
-
-      // For nprofile, the decoded value is the hex pubkey
-      // (relay hints are lost in basic decode, but we could parse TLV if needed)
-      if (decoded.isNotEmpty && decoded.length == 64) {
-        return NormalizedPublicIdentifier(hexPubkey: decoded);
-      }
-      return null;
-    } catch (e) {
-      return null;
-    }
+    final decoded = NIP19Tlv.decodeNprofile(identifier);
+    final pubkey = decoded?.pubkey;
+    if (pubkey == null || pubkey.isEmpty || pubkey.length != 64) return null;
+    return NormalizedPublicIdentifier(
+      hexPubkey: pubkey,
+      relayHints: decoded?.relays ?? const [],
+    );
   }
 
   return null;

--- a/mobile/lib/widgets/clickable_hashtag_text.dart
+++ b/mobile/lib/widgets/clickable_hashtag_text.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hashtag_repository/hashtag_repository.dart';
+import 'package:models/models.dart' show UserProfile;
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/nav_extensions.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
@@ -185,13 +186,16 @@ class ClickableHashtagText extends ConsumerWidget {
     }
 
     // Try to get cached profile (reactive provider handles background fetch)
-    final profile = ref.read(userProfileReactiveProvider(hexPubkey)).value;
+    final profile = ref.watch(userProfileReactiveProvider(hexPubkey)).value;
 
-    // Display name: @username if available, otherwise @truncated_npub
-    final displayName = profile?.bestDisplayName;
-    final displayText = displayName != null
-        ? '@$displayName'
-        : '@${NostrKeyUtils.truncateNpub(hexPubkey)}';
+    final displayText = switch (profile) {
+      UserProfile(:final displayName?) when displayName.isNotEmpty =>
+        '@$displayName',
+      UserProfile(:final name?) when name.isNotEmpty => '@$name',
+      UserProfile(:final displayNip05?) when displayNip05.isNotEmpty =>
+        displayNip05,
+      _ => '@${NostrKeyUtils.truncateNpub(hexPubkey)}',
+    };
 
     return TextSpan(
       text: displayText,

--- a/mobile/lib/widgets/clickable_hashtag_text.dart
+++ b/mobile/lib/widgets/clickable_hashtag_text.dart
@@ -39,9 +39,9 @@ class ClickableHashtagText extends ConsumerWidget {
   final TextOverflow? overflow;
   final Function()? onVideoStateChange;
 
-  /// Regex to detect nostr: URIs (npub and nprofile)
-  static final _nostrUriRegex = RegExp(
-    'nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+)',
+  /// Regex to detect bare or `nostr:`-prefixed npub/nprofile mentions.
+  static final _nostrMentionRegex = RegExp(
+    r'(?<![A-Za-z0-9])(?:nostr:)?(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+)\b',
     caseSensitive: false,
   );
 
@@ -63,12 +63,12 @@ class ClickableHashtagText extends ConsumerWidget {
 
     // Check if text contains any clickable/stylable elements
     final hasHashtags = HashtagExtractor.extractHashtags(text).isNotEmpty;
-    final hasNostrUris = _nostrUriRegex.hasMatch(text);
+    final hasNostrMentions = _nostrMentionRegex.hasMatch(text);
     final hasPlainMentions = _plainMentionRegex.hasMatch(text);
     final hasUrls = _urlRegex.hasMatch(text);
 
     // If no clickable elements, return simple text
-    if (!hasHashtags && !hasNostrUris && !hasPlainMentions && !hasUrls) {
+    if (!hasHashtags && !hasNostrMentions && !hasPlainMentions && !hasUrls) {
       return Text(text, style: style, maxLines: maxLines, overflow: overflow);
     }
 
@@ -97,11 +97,12 @@ class ClickableHashtagText extends ConsumerWidget {
     final profileStyle =
         mentionStyle ?? tagStyle.copyWith(fontWeight: FontWeight.w600);
 
-    // Combined regex to find URLs, hashtags, nostr: URIs, and plain @mentions
+    // Combined regex to find URLs, hashtags, npub/nprofile mentions,
+    // and plain @mentions.
     // Group 1: URL, Group 2: hashtag, Group 3: nostr ID,
     // Group 4: plain mention username
     final combinedRegex = RegExp(
-      r'(https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?)|#(\w+)|nostr:(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+)|@([a-zA-Z][a-zA-Z0-9_]{0,30})',
+      r'(https?:\/\/[^\s]+|www\.[^\s]+|(?<![@\w])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?)|#(\w+)|(?<![A-Za-z0-9])(?:nostr:)?(npub1[a-z0-9]{58}|nprofile1[a-z0-9]+)\b|@([a-zA-Z][a-zA-Z0-9_]{0,30})',
       caseSensitive: false,
     );
 
@@ -117,29 +118,31 @@ class ClickableHashtagText extends ConsumerWidget {
         );
       }
 
-      final fullMatch = match.group(0)!;
+      final matchedUrl = match.group(1);
+      final hashtag = match.group(2);
+      final nostrId = match.group(3);
+      final plainMention = match.group(4);
 
-      if (_urlRegex.hasMatch(fullMatch)) {
-        spans.add(_buildUrlSpan(fullMatch, tagStyle));
-      } else if (fullMatch.startsWith('#')) {
+      if (matchedUrl != null) {
+        spans.add(_buildUrlSpan(matchedUrl, tagStyle));
+      } else if (hashtag != null) {
         // Handle hashtag
-        final hashtag = match.group(2)!;
         spans.add(
           TextSpan(
-            text: fullMatch,
+            text: '#$hashtag',
             style: tagStyle,
             recognizer: TapGestureRecognizer()
               ..onTap = () => _navigateToHashtagFeed(context, hashtag),
           ),
         );
-      } else if (fullMatch.startsWith('nostr:')) {
-        // Handle nostr: URI
-        final nostrId = match.group(3)!;
+      } else if (nostrId != null) {
+        // Handle bare or `nostr:`-prefixed npub/nprofile mention.
         spans.add(_buildNostrMentionSpan(context, ref, nostrId, profileStyle));
-      } else if (fullMatch.startsWith('@')) {
+      } else if (plainMention != null) {
         // Handle plain @mention (legacy Vine format)
-        final username = match.group(4)!;
-        spans.add(_buildPlainMentionSpan(context, ref, username, profileStyle));
+        spans.add(
+          _buildPlainMentionSpan(context, ref, plainMention, profileStyle),
+        );
       }
 
       lastEnd = match.end;

--- a/mobile/test/screens/comments/comment_item_test.dart
+++ b/mobile/test/screens/comments/comment_item_test.dart
@@ -1,0 +1,127 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/blocs/comments/comments_bloc.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/screens/comments/widgets/comment_item.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/widgets/clickable_hashtag_text.dart';
+
+import '../../builders/comment_builder.dart';
+
+class _FakeNostrClient implements NostrClient {
+  const _FakeNostrClient();
+
+  @override
+  String get publicKey => '';
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _MockCommentsBloc extends MockBloc<CommentsEvent, CommentsState>
+    implements CommentsBloc {}
+
+const _testHexPubkey =
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+const _testRootEventId =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _testRootAuthorPubkey =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(const CommentsLoadRequested());
+  });
+
+  Widget buildTestWidget(
+    String content,
+    _MockCommentsBloc mockCommentsBloc,
+  ) {
+    final comment = CommentBuilder()
+        .withAuthorPubkey(_testHexPubkey)
+        .withRootEventId(_testRootEventId)
+        .withRootAuthorPubkey(_testRootAuthorPubkey)
+        .withContent(content)
+        .build();
+
+    return ProviderScope(
+      overrides: [
+        nostrServiceProvider.overrideWithValue(const _FakeNostrClient()),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: BlocProvider<CommentsBloc>.value(
+            value: mockCommentsBloc,
+            child: SingleChildScrollView(child: CommentItem(comment: comment)),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Text contentText(WidgetTester tester) {
+    return tester.widget<Text>(
+      find.descendant(
+        of: find.byType(ClickableHashtagText),
+        matching: find.byType(Text),
+      ),
+    );
+  }
+
+  testWidgets('renders bare npub mentions as interactive profile links', (
+    tester,
+  ) async {
+    final mockCommentsBloc = _MockCommentsBloc();
+    when(() => mockCommentsBloc.state).thenReturn(
+      const CommentsState(
+        rootEventId: _testRootEventId,
+        rootAuthorPubkey: _testRootAuthorPubkey,
+        status: CommentsStatus.success,
+      ),
+    );
+    final npub = NostrKeyUtils.encodePubKey(_testHexPubkey);
+
+    await tester.pumpWidget(
+      buildTestWidget('My account is $npub', mockCommentsBloc),
+    );
+    await tester.pump();
+
+    expect(find.byType(ClickableHashtagText), findsOneWidget);
+    expect(find.textContaining('@npub1'), findsOneWidget);
+  });
+
+  testWidgets('renders comment urls with tappable spans', (tester) async {
+    final mockCommentsBloc = _MockCommentsBloc();
+    when(() => mockCommentsBloc.state).thenReturn(
+      const CommentsState(
+        rootEventId: _testRootEventId,
+        rootAuthorPubkey: _testRootAuthorPubkey,
+        status: CommentsStatus.success,
+      ),
+    );
+    await tester.pumpWidget(
+      buildTestWidget(
+        'checkout https://divine.video/leaderboard',
+        mockCommentsBloc,
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byType(ClickableHashtagText), findsOneWidget);
+
+    final text = contentText(tester);
+    final textSpan = text.textSpan! as TextSpan;
+    final spans = textSpan.children!.cast<TextSpan>();
+    final linkSpan = spans.firstWhere(
+      (span) => span.text == 'https://divine.video/leaderboard',
+    );
+
+    expect(linkSpan.recognizer, isA<TapGestureRecognizer>());
+  });
+}

--- a/mobile/test/widgets/clickable_hashtag_text_test.dart
+++ b/mobile/test/widgets/clickable_hashtag_text_test.dart
@@ -2,8 +2,10 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
 import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/clickable_hashtag_text.dart';
 import 'package:url_launcher_platform_interface/link.dart';
@@ -300,6 +302,48 @@ void main() {
       final spans = textSpan.children!.cast<TextSpan>();
       final mentionSpan = spans.firstWhere(
         (span) => span.text != null && span.text!.startsWith('@npub1'),
+      );
+
+      expect(mentionSpan.recognizer, isA<TapGestureRecognizer>());
+    });
+
+    testWidgets('uses display nip05 when no profile name is available', (
+      tester,
+    ) async {
+      final npub = NostrKeyUtils.encodePubKey(_testHexPubkey);
+      final textWithMention = 'Find me at $npub';
+      final profile = UserProfile(
+        pubkey: _testHexPubkey,
+        nip05: '_@alice.divine.video',
+        rawData: const {},
+        createdAt: DateTime.utc(2026, 4, 16),
+        eventId:
+            'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            userProfileReactiveProvider(_testHexPubkey).overrideWith(
+              (ref) => Stream.value(profile),
+            ),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: ClickableHashtagText(text: textWithMention)),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final text = tester.widget<Text>(find.byType(Text));
+      expect(text.textSpan, isNotNull);
+
+      final textSpan = text.textSpan! as TextSpan;
+      final spans = textSpan.children!.cast<TextSpan>();
+      final mentionSpan = spans.firstWhere(
+        (span) => span.text == '@alice.divine.video',
       );
 
       expect(mentionSpan.recognizer, isA<TapGestureRecognizer>());

--- a/mobile/test/widgets/clickable_hashtag_text_test.dart
+++ b/mobile/test/widgets/clickable_hashtag_text_test.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/clickable_hashtag_text.dart';
 import 'package:url_launcher_platform_interface/link.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
@@ -30,6 +33,9 @@ class _FakeUrlLauncherPlatform extends UrlLauncherPlatform {
   @override
   LinkDelegate? get linkDelegate => null;
 }
+
+const _testHexPubkey =
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
 void main() {
   group('ClickableHashtagText', () {
@@ -216,10 +222,12 @@ void main() {
       const textWithLink = 'Read more at example.com/docs';
 
       await tester.pumpWidget(
-        const MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(body: ClickableHashtagText(text: textWithLink)),
+        const ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: ClickableHashtagText(text: textWithLink)),
+          ),
         ),
       );
 
@@ -237,6 +245,64 @@ void main() {
       await tester.pump();
 
       expect(fakeUrlLauncherPlatform.launchedUrl, 'https://example.com/docs');
+    });
+
+    testWidgets('parses bare npub mentions as tappable profile spans', (
+      tester,
+    ) async {
+      final npub = NostrKeyUtils.encodePubKey(_testHexPubkey);
+      final textWithMention = 'Find me at $npub';
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: ClickableHashtagText(text: textWithMention)),
+          ),
+        ),
+      );
+
+      final text = tester.widget<Text>(find.byType(Text));
+      expect(text.textSpan, isNotNull);
+
+      final textSpan = text.textSpan! as TextSpan;
+      final spans = textSpan.children!.cast<TextSpan>();
+      final mentionSpan = spans.firstWhere(
+        (span) => span.text != null && span.text!.startsWith('@npub1'),
+      );
+
+      expect(mentionSpan.recognizer, isA<TapGestureRecognizer>());
+    });
+
+    testWidgets('parses bare nprofile mentions as tappable profile spans', (
+      tester,
+    ) async {
+      final nprofile = NIP19Tlv.encodeNprofile(
+        Nprofile(pubkey: _testHexPubkey),
+      );
+      final textWithMention = 'Find me at $nprofile';
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: ClickableHashtagText(text: textWithMention)),
+          ),
+        ),
+      );
+
+      final text = tester.widget<Text>(find.byType(Text));
+      expect(text.textSpan, isNotNull);
+
+      final textSpan = text.textSpan! as TextSpan;
+      final spans = textSpan.children!.cast<TextSpan>();
+      final mentionSpan = spans.firstWhere(
+        (span) => span.text != null && span.text!.startsWith('@npub1'),
+      );
+
+      expect(mentionSpan.recognizer, isA<TapGestureRecognizer>());
     });
 
     // Note: Testing tap functionality and navigation requires integration testing


### PR DESCRIPTION
Closes #3110

## Summary
- restore clickable comment/profile mention rendering for bare or `nostr:`-prefixed `npub` and `nprofile` identifiers
- route comment text through the shared interactive text parser so URLs are clickable again
- prefer mention labels in this order: display name, name, display NIP-05, then truncated `npub`

## Test Plan
- [x] `cd mobile && flutter test test/widgets/clickable_hashtag_text_test.dart`
- [x] `cd mobile && flutter test test/screens/comments/comment_item_test.dart`
- [x] pre-push hook re-ran the changed-file test set successfully
