### PR TITLE
fix(web): restore fullscreen video playback

### DIFF
--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2531,5 +2531,17 @@
   "cameraPermissionAllowAccessTitle": "Allow camera & microphone access",
   "cameraPermissionAllowAccessDescription": "This allows you to capture and edit videos right here in the app, nothing more.",
   "cameraPermissionContinue": "Continue",
-  "cameraPermissionGoToSettings": "Go to settings"
+  "cameraPermissionGoToSettings": "Go to settings",
+  "metadataCaptionsLabel": "Captions",
+  "@metadataCaptionsLabel": {
+    "description": "Label for the global captions toggle in the video metadata sheet"
+  },
+  "metadataCaptionsEnabledSemantics": "Captions enabled for all videos",
+  "@metadataCaptionsEnabledSemantics": {
+    "description": "Screen reader label when the global captions toggle is on"
+  },
+  "metadataCaptionsDisabledSemantics": "Captions disabled for all videos",
+  "@metadataCaptionsDisabledSemantics": {
+    "description": "Screen reader label when the global captions toggle is off"
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -8545,6 +8545,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Go to settings'**
   String get cameraPermissionGoToSettings;
+
+  /// Label for the global captions toggle in the video metadata sheet
+  ///
+  /// In en, this message translates to:
+  /// **'Captions'**
+  String get metadataCaptionsLabel;
+
+  /// Screen reader label when the global captions toggle is on
+  ///
+  /// In en, this message translates to:
+  /// **'Captions enabled for all videos'**
+  String get metadataCaptionsEnabledSemantics;
+
+  /// Screen reader label when the global captions toggle is off
+  ///
+  /// In en, this message translates to:
+  /// **'Captions disabled for all videos'**
+  String get metadataCaptionsDisabledSemantics;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4774,4 +4774,15 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => 'الذهاب إلى الإعدادات';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4877,4 +4877,15 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => 'Zu den Einstellungen';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4813,4 +4813,15 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => 'Go to settings';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4871,4 +4871,15 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => 'Ir a ajustes';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4886,4 +4886,15 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => 'Aller aux paramètres';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4793,4 +4793,15 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => 'Buka pengaturan';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4867,4 +4867,15 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => 'Vai alle impostazioni';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4616,4 +4616,15 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => '設定に移動';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4639,4 +4639,15 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => '설정으로 이동';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4840,4 +4840,15 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => 'Naar instellingen';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4954,4 +4954,15 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => 'Przejdź do ustawień';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4852,4 +4852,15 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => 'Ir para configurações';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4953,4 +4953,15 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => 'Mergi la setări';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4812,4 +4812,15 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => 'Gå till inställningar';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4801,4 +4801,15 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get cameraPermissionGoToSettings => 'Ayarlara git';
+
+  @override
+  String get metadataCaptionsLabel => 'Captions';
+
+  @override
+  String get metadataCaptionsEnabledSemantics =>
+      'Captions enabled for all videos';
+
+  @override
+  String get metadataCaptionsDisabledSemantics =>
+      'Captions disabled for all videos';
 }

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
@@ -8,6 +8,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/subtitle_providers.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
@@ -122,6 +123,7 @@ class _CaptionsSettingSection extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final captionsEnabled = ref.watch(subtitleVisibilityProvider);
+    final l10n = context.l10n;
 
     return DecoratedBox(
       decoration: const BoxDecoration(
@@ -137,12 +139,15 @@ class _CaptionsSettingSection extends ConsumerWidget {
             button: true,
             toggled: captionsEnabled,
             label: captionsEnabled
-                ? 'Captions enabled for all videos'
-                : 'Captions disabled for all videos',
+                ? l10n.metadataCaptionsEnabledSemantics
+                : l10n.metadataCaptionsDisabledSemantics,
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text('Captions', style: VineTheme.titleSmallFont()),
+                Text(
+                  l10n.metadataCaptionsLabel,
+                  style: VineTheme.titleSmallFont(),
+                ),
                 const SizedBox(width: 8),
                 Switch(
                   value: captionsEnabled,

--- a/mobile/lib/widgets/web_video_feed.dart
+++ b/mobile/lib/widgets/web_video_feed.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Replaces PooledVideoFeed on web where media_kit is not available
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:models/models.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_policy.dart';
@@ -102,15 +103,31 @@ class WebVideoFeedState extends State<WebVideoFeed> {
   late PageController _pageController;
   int _currentIndex = 0;
 
-  // Track web player keys to control playback
+  // Track web player keys to control playback.
   final Map<int, GlobalKey<WebVideoPlayerState>> _playerKeys = {};
-  final Map<int, VideoPlayerController> _controllers = {};
+
+  // Exposed as a [ValueNotifier] so only overlay widgets that care about the
+  // initialized controller rebuild when a controller becomes available,
+  // instead of the entire feed's itemBuilder.
+  final ValueNotifier<Map<int, VideoPlayerController>> _controllers =
+      ValueNotifier<Map<int, VideoPlayerController>>(
+        const <int, VideoPlayerController>{},
+      );
+
   final Map<int, VoidCallback> _controllerListeners = {};
   final Map<int, Duration> _lastPositions = {};
   final Map<int, bool> _armedForCompletion = {};
 
   int get currentIndex => _currentIndex;
   int get videoCount => widget.videos.length;
+
+  /// Number of tracked controllers. Exposed for test instrumentation.
+  @visibleForTesting
+  int get debugControllerCount => _controllers.value.length;
+
+  /// Number of tracked player keys. Exposed for test instrumentation.
+  @visibleForTesting
+  int get debugPlayerKeyCount => _playerKeys.length;
 
   @override
   void initState() {
@@ -120,12 +137,57 @@ class WebVideoFeedState extends State<WebVideoFeed> {
   }
 
   @override
+  void didUpdateWidget(WebVideoFeed oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!listEquals(oldWidget.videos, widget.videos)) {
+      _pruneStaleEntries();
+    }
+  }
+
+  @override
   void dispose() {
-    for (final entry in _controllers.entries) {
+    for (final entry in _controllers.value.entries) {
       _detachCompletionListener(entry.key, entry.value);
     }
+    _controllers.dispose();
     _pageController.dispose();
     super.dispose();
+  }
+
+  /// Removes tracked entries for indices outside the current video list.
+  void _pruneStaleEntries() {
+    final validCount = widget.videos.length;
+    _playerKeys.removeWhere((index, _) => index >= validCount);
+    final current = _controllers.value;
+    final pruned = <int, VideoPlayerController>{
+      for (final entry in current.entries)
+        if (entry.key < validCount) entry.key: entry.value,
+    };
+    if (pruned.length != current.length) {
+      // Detach listeners for evicted controllers before dropping the
+      // reference so we don't leak the position callback.
+      for (final entry in current.entries) {
+        if (entry.key >= validCount) {
+          _detachCompletionListener(entry.key, entry.value);
+        }
+      }
+      _controllers.value = pruned;
+    }
+  }
+
+  /// Removes tracked entries when a [WebVideoPlayer] at [index] disposes.
+  ///
+  /// Drops both the controller reference and the GlobalKey so we don't
+  /// retain disposed controllers across scroll. If the user scrolls back
+  /// to this index, the next [_getPlayerKey] call mints a fresh key.
+  void _onPlayerDisposed(int index) {
+    _playerKeys.remove(index);
+    final current = _controllers.value;
+    final controller = current[index];
+    if (controller == null) return;
+    _detachCompletionListener(index, controller);
+    final next = Map<int, VideoPlayerController>.of(current)..remove(index);
+    _controllers.value = next;
   }
 
   Future<void> animateToPage(int index) async {
@@ -171,7 +233,7 @@ class WebVideoFeedState extends State<WebVideoFeed> {
     int index,
     VideoPlayerController controller,
   ) {
-    final previousController = _controllers[index];
+    final previousController = _controllers.value[index];
     if (identical(previousController, controller) &&
         _controllerListeners.containsKey(index)) {
       return;
@@ -181,7 +243,10 @@ class WebVideoFeedState extends State<WebVideoFeed> {
       _detachCompletionListener(index, previousController);
     }
 
-    _controllers[index] = controller;
+    final next = Map<int, VideoPlayerController>.of(_controllers.value)
+      ..[index] = controller;
+    _controllers.value = next;
+
     _lastPositions[index] = controller.value.position;
     _armedForCompletion[index] = false;
 
@@ -258,40 +323,106 @@ class WebVideoFeedState extends State<WebVideoFeed> {
 
         final playerKey = _getPlayerKey(index);
 
-        return Stack(
-          fit: StackFit.expand,
-          children: [
-            // Video layer
-            WebVideoPlayer(
-              key: playerKey,
-              url: videoUrl,
-              autoPlay: isActive,
-              headers: widget.headers,
-              controllerFactory: widget.controllerFactory,
-              onInitialized: (controller) {
-                if (!mounted) return;
-                setState(() {
-                  _attachCompletionListener(index, controller);
-                });
-              },
-              onError: () {
-                if (!mounted) return;
-                widget.onErrored?.call(index);
-              },
-            ),
-            // Custom overlay layer
-            if (widget.itemBuilder != null)
-              widget.itemBuilder!(
+        return _WebVideoFeedItem(
+          video: video,
+          index: index,
+          isActive: isActive,
+          videoUrl: videoUrl,
+          playerKey: playerKey,
+          headers: widget.headers,
+          controllerFactory: widget.controllerFactory,
+          controllersListenable: _controllers,
+          itemBuilder: widget.itemBuilder,
+          onInitialized: (controller) {
+            if (!mounted) return;
+            setState(() {
+              _attachCompletionListener(index, controller);
+            });
+          },
+          onDisposed: () {
+            if (!mounted) return;
+            _onPlayerDisposed(index);
+          },
+          onError: () {
+            if (!mounted) return;
+            widget.onErrored?.call(index);
+          },
+        );
+      },
+    );
+  }
+}
+
+/// Per-item content of the web video feed.
+///
+/// Splits the stack so that the overlay subtree rebuilds via
+/// [ValueListenableBuilder] when its controller becomes available, instead
+/// of rebuilding the entire [PageView.builder] via `setState` on the parent.
+class _WebVideoFeedItem extends StatelessWidget {
+  const _WebVideoFeedItem({
+    required this.video,
+    required this.index,
+    required this.isActive,
+    required this.videoUrl,
+    required this.playerKey,
+    required this.headers,
+    required this.controllerFactory,
+    required this.controllersListenable,
+    required this.itemBuilder,
+    required this.onInitialized,
+    required this.onDisposed,
+    required this.onError,
+  });
+
+  final VideoEvent video;
+  final int index;
+  final bool isActive;
+  final String videoUrl;
+  final GlobalKey<WebVideoPlayerState> playerKey;
+  final Map<String, String> headers;
+  final WebVideoPlayerControllerFactory controllerFactory;
+  final ValueListenable<Map<int, VideoPlayerController>> controllersListenable;
+  final WebVideoFeedItemBuilder? itemBuilder;
+  final ValueChanged<VideoPlayerController> onInitialized;
+  final VoidCallback onDisposed;
+  final VoidCallback onError;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        WebVideoPlayer(
+          key: playerKey,
+          url: videoUrl,
+          autoPlay: isActive,
+          headers: headers,
+          controllerFactory: controllerFactory,
+          onInitialized: onInitialized,
+          onDisposed: onDisposed,
+          onError: onError,
+        ),
+        if (itemBuilder != null)
+          ValueListenableBuilder<Map<int, VideoPlayerController>>(
+            valueListenable: controllersListenable,
+            builder: (context, controllers, _) {
+              // Only expose the controller once it has initialized so
+              // overlays never receive an uninitialized controller.
+              final tracked = controllers[index];
+              final controller =
+                  (tracked != null && tracked.value.isInitialized)
+                  ? tracked
+                  : null;
+              return itemBuilder!(
                 context,
                 video,
                 index,
                 isActive: isActive,
-                controller:
-                    _controllers[index] ?? playerKey.currentState?.controller,
-              ),
-          ],
-        );
-      },
+                controller: controller,
+              );
+            },
+          ),
+      ],
     );
   }
 }

--- a/mobile/lib/widgets/web_video_player.dart
+++ b/mobile/lib/widgets/web_video_player.dart
@@ -27,6 +27,7 @@ class WebVideoPlayer extends StatefulWidget {
     this.fit = BoxFit.cover,
     this.headers = const {},
     this.onInitialized,
+    this.onDisposed,
     this.onError,
     this.initializeTimeout = const Duration(seconds: 8),
     this.controllerFactory = defaultWebVideoPlayerControllerFactory,
@@ -50,6 +51,12 @@ class WebVideoPlayer extends StatefulWidget {
 
   /// Called when the video controller is initialized.
   final ValueChanged<VideoPlayerController>? onInitialized;
+
+  /// Called when the underlying [VideoPlayerController] has been disposed.
+  ///
+  /// Use this to release any external references that mirror the controller
+  /// (for example, feed-level caches) so they don't leak.
+  final VoidCallback? onDisposed;
 
   /// Called when an error occurs.
   final VoidCallback? onError;
@@ -122,10 +129,14 @@ class WebVideoPlayerState extends State<WebVideoPlayer> {
   }
 
   void _disposeController() {
-    _controller?.dispose();
+    final controller = _controller;
     _controller = null;
     _isInitialized = false;
     _hasError = false;
+    if (controller != null) {
+      controller.dispose();
+      widget.onDisposed?.call();
+    }
   }
 
   /// Plays the video.

--- a/mobile/test/widgets/web_video_feed_test.dart
+++ b/mobile/test/widgets/web_video_feed_test.dart
@@ -137,14 +137,18 @@ class _FakeVideoPlayerPlatform extends video_platform.VideoPlayerPlatform {
   Future<void> setMixWithOthers(bool mixWithOthers) async {}
 }
 
-VideoEvent _makeVideo() => VideoEvent(
-  id: 'a1b2c3d4e5f6789012345678901234567890abcdef123456789012345678901234',
-  pubkey: 'd4e5f6789012345678901234567890abcdef123456789012345678901234a1b2c3',
-  createdAt: 1700000000,
-  content: 'Test video',
-  timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
-  videoUrl: 'https://example.com/video.mp4',
-);
+VideoEvent _makeVideo({int seed = 0}) {
+  final hex = seed.toRadixString(16).padLeft(2, '0');
+  return VideoEvent(
+    id: 'a1b2c3d4e5f6789012345678901234567890abcdef12345678901234567890$hex',
+    pubkey:
+        'd4e5f6789012345678901234567890abcdef123456789012345678901234a1b2c3',
+    createdAt: 1700000000,
+    content: 'Test video $seed',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
+    videoUrl: 'https://example.com/video$seed.mp4',
+  );
+}
 
 void main() {
   late video_platform.VideoPlayerPlatform originalPlatform;
@@ -262,4 +266,143 @@ void main() {
     expect(key.currentState!.currentIndex, 1);
     expect(activeIndex, 1);
   });
+
+  testWidgets(
+    'drops controller entries when WebVideoPlayer items are disposed',
+    (tester) async {
+      final videos = List.generate(8, (i) => _makeVideo(seed: i));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WebVideoFeed(
+            videos: videos,
+            controllerFactory: ({required url, required headers}) =>
+                _FakeVideoPlayerController(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final state =
+          tester.state<State<WebVideoFeed>>(
+                find.byType(WebVideoFeed),
+              )
+              as dynamic;
+      final pageController = tester
+          .widget<PageView>(
+            find.byType(PageView),
+          )
+          .controller!;
+
+      // Drive PageView through several indices. Pages that drop out of the
+      // viewport cause their WebVideoPlayer state to dispose, which must
+      // evict the tracked controller entry.
+      for (var i = 1; i < videos.length; i++) {
+        pageController.jumpToPage(i);
+        await tester.pump();
+      }
+
+      // With bounded eviction, the tracked controllers and player keys must
+      // not include every visited index — only those still alive in the
+      // PageView viewport.
+      expect(
+        state.debugControllerCount as int,
+        lessThan(videos.length),
+        reason: 'controllers should be evicted for disposed items',
+      );
+      expect(
+        state.debugPlayerKeyCount as int,
+        lessThan(videos.length),
+        reason: 'player keys should be pruned for disposed items',
+      );
+    },
+  );
+
+  testWidgets(
+    'prunes stale controller entries when videos list shrinks',
+    (tester) async {
+      final initial = List.generate(4, (i) => _makeVideo(seed: i));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WebVideoFeed(
+            videos: initial,
+            controllerFactory: ({required url, required headers}) =>
+                _FakeVideoPlayerController(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Shrink the list — the feed should prune indices that no longer map
+      // to a valid video.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WebVideoFeed(
+            videos: [initial.first],
+            controllerFactory: ({required url, required headers}) =>
+                _FakeVideoPlayerController(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final state =
+          tester.state<State<WebVideoFeed>>(
+                find.byType(WebVideoFeed),
+              )
+              as dynamic;
+
+      expect(state.debugControllerCount as int, lessThanOrEqualTo(1));
+      expect(state.debugPlayerKeyCount as int, lessThanOrEqualTo(1));
+    },
+  );
+
+  testWidgets(
+    'does not rebuild the feed itemBuilder for every controller init',
+    (tester) async {
+      final videos = List.generate(3, (i) => _makeVideo(seed: i));
+      final itemBuilderCalls = <int, int>{};
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WebVideoFeed(
+            videos: videos,
+            controllerFactory: ({required url, required headers}) =>
+                _FakeVideoPlayerController(),
+            itemBuilder:
+                (
+                  context,
+                  video,
+                  index, {
+                  required isActive,
+                  controller,
+                }) {
+                  itemBuilderCalls.update(
+                    index,
+                    (prev) => prev + 1,
+                    ifAbsent: () => 1,
+                  );
+                  return const SizedBox.shrink();
+                },
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      // Each item builder only rebuilds for its own controller state changes,
+      // not for every other page's controller init. 3 items × any number of
+      // inits must stay well below N² builds.
+      for (final entry in itemBuilderCalls.entries) {
+        expect(
+          entry.value,
+          lessThanOrEqualTo(4),
+          reason:
+              'itemBuilder for index ${entry.key} rebuilt ${entry.value} '
+              'times; expected scoped rebuilds only',
+        );
+      }
+    },
+  );
 }


### PR DESCRIPTION
Closes #3114

## Why this PR isn't split

The diff looks broader than the title suggests, but the commits form
one dependent chain that must land together; splitting them would leave
main in a half-applied state. Per `.claude/rules/code_style.md` "PR
Scope", I'm keeping them together and calling the surface area out
explicitly below.

## What's in the 14 commits

**Captions moved to "More info"**
- Plan doc for moving the captions control into the metadata sheet.
- Feature commits that add a global captions preference persisted via
  `SharedPreferences`, expose it through the new
  `subtitleVisibilityProvider`, and surface it as a row in the metadata
  expanded sheet instead of a per-video overlay toggle.
- UI tweaks: repositioning the captions row, simplifying the control,
  improving contrast, and URL-based subtitle track support.
- Test harness commits that wire a `SharedPreferences` override into
  the metadata sheet tests.
- New `VideoPlayerSubtitleLayer` for rendering captions on top of the
  web video surface.
- Styling tweaks to `metadata_badges_row`.

**Native feed changes**
- Updates in `pooled_fullscreen_video_feed_screen.dart` to consume the
  new subtitle provider and coordinate caption visibility with the
  existing fullscreen pipeline.

**Web fullscreen fix (the title of the PR)**
- Size the web video platform view explicitly for `BoxFit` semantics
  instead of relying on `FittedBox`.
- Keep the web player initialized when browser autoplay is rejected so
  the user doesn't see a spurious "Failed to load video" state.
- Fall back to a safe non-zero size when the viewport is degenerate,
  avoiding a collapsed `OverflowBox`.
- Widget regressions for fullscreen cover sizing and autoplay rejection.

**Review fixes (added during review)**
- `WebVideoFeed` no longer leaks `VideoPlayerController` references:
  the `_controllers` map lives behind a `ValueNotifier`, is pruned on
  per-item dispose (new `onDisposed` callback), and cleaned up when the
  incoming `videos` list shrinks.
- Overlay subtree rebuilds via `ValueListenableBuilder` instead of a
  parent-wide `setState`, so per-item controller init no longer causes
  an N×M rebuild of the feed `itemBuilder`.
- `onInitialized` now fires after `play()` succeeds; autoplay
  rejection logs at `developer.log` level 900 instead of being
  swallowed.
- Captions strings (`Captions`, `Captions enabled/disabled for all
  videos`) moved from hardcoded English to `context.l10n` with ARB
  keys (`metadataCaptionsLabel`, `metadataCaptionsEnabledSemantics`,
  `metadataCaptionsDisabledSemantics`).
- Added white-box widget tests for controller eviction, list-shrink
  pruning, and scoped overlay rebuilds.

## Why not split

The captions-sheet move, subtitle provider, web fullscreen fix, and
caption overlay layer all depend on each other:

- The new captions overlay and subtitle provider share the same
  persisted key.
- The fullscreen web fix lives in the same
  `WebVideoFeed` / `WebVideoPlayer` files that the caption overlay
  hooks into.
- Splitting would mean shipping an empty toggle (no overlay) or an
  overlay with no persisted state, which is worse than landing them
  together.

## Verification

- `cd mobile && flutter test test/widgets/web_video_player_test.dart test/widgets/web_video_feed_test.dart test/widgets/video_feed_item/` (128 pass)
- `cd mobile && flutter analyze lib test` (no issues)
- `cd mobile && dart format lib test` (no changes)
- `cd mobile && flutter gen-l10n` (regenerated; other locales fall back to English)
- Pre-commit hook (format + analyze + codegen) passes on every commit