### PR TITLE
test(mobile): cover getDocumentsPath on web; document manual Chrome run

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -108,6 +108,35 @@ jobs:
           done
           echo "Shard ${{ matrix.shard_index }}/8: ${#selected[@]} of ${#all[@]} test files"
           flutter test --exclude-tags integration "${selected[@]}"
+  tests-chrome-path-resolver:
+    name: Tests (Chrome, path_resolver)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile/
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.4"
+          channel: "stable"
+          cache: true
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Install Chromium
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y chromium xvfb
+      - name: Run path_resolver tests on Chrome
+        run: |
+          chrome="$(command -v chromium || command -v chromium-browser || command -v google-chrome)"
+          if [ -z "${chrome}" ]; then
+            echo "No Chrome/Chromium binary found after apt install."
+            exit 1
+          fi
+          export CHROME_EXECUTABLE="${chrome}"
+          xvfb-run -a flutter test test/utils/path_resolver_test.dart --platform chrome
   mobile-ci:
     name: Mobile CI
     if: ${{ always() }}
@@ -116,6 +145,7 @@ jobs:
       - format
       - analyze
       - tests
+      - tests-chrome-path-resolver
     runs-on: ubuntu-latest
     steps:
       - name: Verify upstream jobs
@@ -124,16 +154,19 @@ jobs:
           FORMAT_RESULT: ${{ needs.format.result }}
           ANALYZE_RESULT: ${{ needs.analyze.result }}
           TESTS_RESULT: ${{ needs.tests.result }}
+          TESTS_CHROME_PATH_RESOLVER_RESULT: ${{ needs.tests-chrome-path-resolver.result }}
         run: |
           echo "generated-files: ${GENERATED_FILES_RESULT}"
           echo "format: ${FORMAT_RESULT}"
           echo "analyze: ${ANALYZE_RESULT}"
           echo "tests: ${TESTS_RESULT}"
+          echo "tests-chrome-path-resolver: ${TESTS_CHROME_PATH_RESOLVER_RESULT}"
 
           if [[ "${GENERATED_FILES_RESULT}" != "success" || \
                 "${FORMAT_RESULT}" != "success" || \
                 "${ANALYZE_RESULT}" != "success" || \
-                "${TESTS_RESULT}" != "success" ]]; then
+                "${TESTS_RESULT}" != "success" || \
+                "${TESTS_CHROME_PATH_RESOLVER_RESULT}" != "success" ]]; then
             echo "One or more Mobile CI jobs failed."
             exit 1
           fi

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -108,35 +108,6 @@ jobs:
           done
           echo "Shard ${{ matrix.shard_index }}/8: ${#selected[@]} of ${#all[@]} test files"
           flutter test --exclude-tags integration "${selected[@]}"
-  tests-chrome-path-resolver:
-    name: Tests (Chrome, path_resolver)
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: mobile/
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: "3.41.4"
-          channel: "stable"
-          cache: true
-      - name: Install dependencies
-        run: flutter pub get
-      - name: Install Chromium
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y chromium xvfb
-      - name: Run path_resolver tests on Chrome
-        run: |
-          chrome="$(command -v chromium || command -v chromium-browser || command -v google-chrome)"
-          if [ -z "${chrome}" ]; then
-            echo "No Chrome/Chromium binary found after apt install."
-            exit 1
-          fi
-          export CHROME_EXECUTABLE="${chrome}"
-          xvfb-run -a flutter test test/utils/path_resolver_test.dart --platform chrome
   mobile-ci:
     name: Mobile CI
     if: ${{ always() }}
@@ -145,7 +116,6 @@ jobs:
       - format
       - analyze
       - tests
-      - tests-chrome-path-resolver
     runs-on: ubuntu-latest
     steps:
       - name: Verify upstream jobs
@@ -154,19 +124,16 @@ jobs:
           FORMAT_RESULT: ${{ needs.format.result }}
           ANALYZE_RESULT: ${{ needs.analyze.result }}
           TESTS_RESULT: ${{ needs.tests.result }}
-          TESTS_CHROME_PATH_RESOLVER_RESULT: ${{ needs.tests-chrome-path-resolver.result }}
         run: |
           echo "generated-files: ${GENERATED_FILES_RESULT}"
           echo "format: ${FORMAT_RESULT}"
           echo "analyze: ${ANALYZE_RESULT}"
           echo "tests: ${TESTS_RESULT}"
-          echo "tests-chrome-path-resolver: ${TESTS_CHROME_PATH_RESOLVER_RESULT}"
 
           if [[ "${GENERATED_FILES_RESULT}" != "success" || \
                 "${FORMAT_RESULT}" != "success" || \
                 "${ANALYZE_RESULT}" != "success" || \
-                "${TESTS_RESULT}" != "success" || \
-                "${TESTS_CHROME_PATH_RESOLVER_RESULT}" != "success" ]]; then
+                "${TESTS_RESULT}" != "success" ]]; then
             echo "One or more Mobile CI jobs failed."
             exit 1
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Additional expectations:
 - Run `mobile/scripts/golden.sh verify` for visual changes.
 - If you touch `mobile/packages/videos_repository`, run `flutter test --coverage` from that package.
 - Add or update tests next to the changed feature or package.
-- Web-only branches: a few tests are skipped on the default VM and need Chrome, for example `flutter test test/utils/path_resolver_test.dart --platform chrome` to exercise `getDocumentsPath` when `kIsWeb` is true.
+- Web-only branches: VM shards skip tests guarded with `kIsWeb`. Mobile CI runs `test/utils/path_resolver_test.dart` on Chrome in a dedicated job; locally use `flutter test test/utils/path_resolver_test.dart --platform chrome` for the same runtime check.
 
 ## Engineering Guardrails
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Additional expectations:
 - Run `mobile/scripts/golden.sh verify` for visual changes.
 - If you touch `mobile/packages/videos_repository`, run `flutter test --coverage` from that package.
 - Add or update tests next to the changed feature or package.
-- Web-only branches: VM shards skip tests guarded with `kIsWeb`. Mobile CI runs `test/utils/path_resolver_test.dart` on Chrome in a dedicated job; locally use `flutter test test/utils/path_resolver_test.dart --platform chrome` for the same runtime check.
+- Web-only branches: VM shards skip tests guarded with `kIsWeb`. Mobile CI does **not** run browser tests; before merging changes that touch `getDocumentsPath` / web document paths, run manually from `mobile/`: `flutter test test/utils/path_resolver_test.dart --platform chrome` (headless setups may need `CHROME_EXECUTABLE` and `xvfb-run -a`).
 
 ## Engineering Guardrails
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,7 @@ Additional expectations:
 - Run `mobile/scripts/golden.sh verify` for visual changes.
 - If you touch `mobile/packages/videos_repository`, run `flutter test --coverage` from that package.
 - Add or update tests next to the changed feature or package.
+- Web-only branches: a few tests are skipped on the default VM and need Chrome, for example `flutter test test/utils/path_resolver_test.dart --platform chrome` to exercise `getDocumentsPath` when `kIsWeb` is true.
 
 ## Engineering Guardrails
 

--- a/mobile/lib/utils/path_resolver.dart
+++ b/mobile/lib/utils/path_resolver.dart
@@ -9,6 +9,9 @@ import 'package:path_provider/path_provider.dart' as path_provider;
 ///
 /// On web, path_provider has no documents directory; returns `''` so callers
 /// can join basenames without calling the plugin (avoids MissingPluginException).
+///
+/// The web branch is covered by `test/utils/path_resolver_test.dart` when run as
+/// `flutter test test/utils/path_resolver_test.dart --platform chrome`.
 Future<String> getDocumentsPath() async {
   if (kIsWeb) {
     return '';

--- a/mobile/lib/utils/path_resolver.dart
+++ b/mobile/lib/utils/path_resolver.dart
@@ -10,8 +10,9 @@ import 'package:path_provider/path_provider.dart' as path_provider;
 /// On web, path_provider has no documents directory; returns `''` so callers
 /// can join basenames without calling the plugin (avoids MissingPluginException).
 ///
-/// The web branch is covered by `test/utils/path_resolver_test.dart` when run as
-/// `flutter test test/utils/path_resolver_test.dart --platform chrome`.
+/// The web branch is covered by `test/utils/path_resolver_test.dart` when run
+/// locally as `flutter test test/utils/path_resolver_test.dart --platform chrome`
+/// (not run in CI).
 Future<String> getDocumentsPath() async {
   if (kIsWeb) {
     return '';

--- a/mobile/test/flutter_test_config.dart
+++ b/mobile/test/flutter_test_config.dart
@@ -4,12 +4,19 @@
 import 'dart:async';
 
 import 'package:alchemist/alchemist.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:golden_toolkit/golden_toolkit.dart';
 import 'test_setup.dart';
 
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   // Set up test environment with plugin mocks (secure_storage, path_provider, etc.)
   setupTestEnvironment();
+
+  // Web / `flutter test --platform chrome`: skip golden font loading and Alchemist.
+  // Those paths can stall headless Chrome with almost no CPU while `loading …` is shown.
+  if (kIsWeb) {
+    return testMain();
+  }
 
   // Load app fonts for golden tests
   await loadAppFonts();

--- a/mobile/test/utils/path_resolver_test.dart
+++ b/mobile/test/utils/path_resolver_test.dart
@@ -1,8 +1,9 @@
 // ABOUTME: Tests for path_resolver — web-safe document root joining
 //
 // `getDocumentsPath` on web is covered by the web-only test below; run it with
-// `flutter test test/utils/path_resolver_test.dart --platform chrome`.
-// `flutter build web` only checks compilation, not this runtime branch.
+// `flutter test test/utils/path_resolver_test.dart --platform chrome` (manual /
+// local — not executed in CI). `flutter build web` only checks compilation, not
+// this runtime branch.
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile/test/utils/path_resolver_test.dart
+++ b/mobile/test/utils/path_resolver_test.dart
@@ -1,14 +1,26 @@
 // ABOUTME: Tests for path_resolver — web-safe document root joining
 //
-// On web, getDocumentsPath returns '' without calling path_provider; that
-// branch is exercised by `flutter build web` (compile-time). Optional:
-// `flutter test test/utils/path_resolver_test.dart --platform chrome` plus a
-// kIsWeb-only test if the environment has a working Chrome test runner.
+// `getDocumentsPath` on web is covered by the web-only test below; run it with
+// `flutter test test/utils/path_resolver_test.dart --platform chrome`.
+// `flutter build web` only checks compilation, not this runtime branch.
 
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/utils/path_resolver.dart';
 
 void main() {
+  group('getDocumentsPath', () {
+    test(
+      'returns empty string on web without using path_provider',
+      () async {
+        expect(await getDocumentsPath(), '');
+      },
+      skip: !kIsWeb
+          ? 'Web-only: run `flutter test test/utils/path_resolver_test.dart --platform chrome`'
+          : null,
+    );
+  });
+
   group('resolvePath', () {
     test('joins basename when documents root is empty (web)', () {
       expect(resolvePath('folder/clip.mp4', ''), 'clip.mp4');


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Follow-up to the web-safe `getDocumentsPath()` work (#3029 / #2994).

**Problem:** VM `flutter test` shards skip assertions guarded with `kIsWeb`, so CI never executes a runtime check that `getDocumentsPath()` returns `''` on web. Earlier wording also suggested that `flutter build web` was enough; it only validates compilation, not that branch at runtime.

**What this branch does (net vs `main`):**

- Adds a **`getDocumentsPath`** test in `mobile/test/utils/path_resolver_test.dart` that asserts an empty string on web, with **`skip` when `!kIsWeb`** so normal CI keeps using VM-only shards.
- Replaces misleading comments: **`flutter build web` ≠ proof of the web runtime path**; documents that the web assertion is exercised with  
  `cd mobile && flutter test test/utils/path_resolver_test.dart --platform chrome` (manual, not part of Mobile CI).
- Extends **`CONTRIBUTING.md`** with the same manual Chrome expectation when changing `getDocumentsPath` / web document paths (including **`CHROME_EXECUTABLE`** / **`xvfb-run -a`** on headless Linux where needed).
- Updates **`mobile/lib/utils/path_resolver.dart`** dartdoc to point at the test and the manual Chrome command.
- Adjusts **`mobile/test/flutter_test_config.dart`** so that on **`kIsWeb`** it skips **`loadAppFonts()`** and **Alchemist** and runs **`testMain()`** directly—otherwise headless Chrome can sit on `loading …` with almost no CPU during global golden setup.

**Verification:** From `mobile/`, run `flutter test test/utils/path_resolver_test.dart` on the VM (expect the web test skipped) and again with `--platform chrome` (expect it not skipped and green).

**Related Issue:** Relates to #3076

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore
