### PR TITLE
chore(upload): add detailed logging for resumable upload process

### DIFF
--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -570,6 +570,14 @@ class BlossomUploadService {
       );
     }
 
+    Log.info(
+      '📤 Resumable init: POST $serverUrl/upload/init '
+      '(file: ${(fileSize / 1024 / 1024).toStringAsFixed(2)} MB)',
+      name: 'BlossomUploadService',
+      category: LogCategory.video,
+    );
+    final initStopwatch = Stopwatch()..start();
+
     final response = await dio.post<dynamic>(
       '$serverUrl/upload/init',
       data: {
@@ -585,6 +593,14 @@ class BlossomUploadService {
         },
         validateStatus: _validateHttpStatus,
       ),
+    );
+    initStopwatch.stop();
+
+    Log.info(
+      '📤 Resumable init response: ${response.statusCode} '
+      'in ${initStopwatch.elapsedMilliseconds}ms',
+      name: 'BlossomUploadService',
+      category: LogCategory.video,
     );
 
     final responseData = response.data;
@@ -612,6 +628,15 @@ class BlossomUploadService {
         'Resumable upload init response is missing required fields',
       );
     }
+
+    final totalChunks = (fileSize / chunkSize).ceil();
+    Log.info(
+      '📤 Resumable session created: uploadId=$uploadId, '
+      'chunkSize=${(chunkSize / 1024).toStringAsFixed(0)}KB, '
+      'totalChunks=$totalChunks, nextOffset=$nextOffset',
+      name: 'BlossomUploadService',
+      category: LogCategory.video,
+    );
 
     return BlossomResumableUploadSession(
       uploadId: uploadId,
@@ -662,6 +687,18 @@ class BlossomUploadService {
   }) async {
     var currentSession = session;
     final fileReader = await file.open();
+    final totalChunks = (fileSize / currentSession.chunkSize).ceil();
+    var chunkIndex = 0;
+    final uploadStopwatch = Stopwatch()..start();
+
+    Log.info(
+      '📤 Chunk upload starting: '
+      '${(fileSize / 1024 / 1024).toStringAsFixed(2)} MB '
+      'in ~$totalChunks chunks '
+      '(${(currentSession.chunkSize / 1024).toStringAsFixed(0)}KB each)',
+      name: 'BlossomUploadService',
+      category: LogCategory.video,
+    );
 
     try {
       while (currentSession.nextOffset < fileSize) {
@@ -671,6 +708,7 @@ class BlossomUploadService {
           fileSize,
         );
         final chunkLength = endExclusive - start;
+        chunkIndex++;
 
         await fileReader.setPosition(start);
         final chunkBytes = await fileReader.read(chunkLength);
@@ -679,6 +717,7 @@ class BlossomUploadService {
         // Chunk bytes are already in memory so retries are cheap.
         late Response<dynamic> response;
         var chunkAttempt = 0;
+        final chunkStopwatch = Stopwatch()..start();
         while (true) {
           try {
             response = await dio.put<dynamic>(
@@ -739,6 +778,20 @@ class BlossomUploadService {
           );
         }
 
+        chunkStopwatch.stop();
+        final chunkMs = chunkStopwatch.elapsedMilliseconds;
+        final chunkSpeed = chunkMs > 0
+            ? (chunkLength / 1024 / (chunkMs / 1000)).toStringAsFixed(0)
+            : '?';
+        Log.debug(
+          '📤 Chunk $chunkIndex/$totalChunks: '
+          '${(chunkLength / 1024).toStringAsFixed(0)}KB '
+          'in ${chunkMs}ms (${chunkSpeed}KB/s) '
+          '[${(endExclusive / fileSize * 100).toStringAsFixed(0)}%]',
+          name: 'BlossomUploadService',
+          category: LogCategory.video,
+        );
+
         currentSession = currentSession.copyWith(
           nextOffset: _parseUploadOffset(response.headers) ?? endExclusive,
           expiresAt:
@@ -747,6 +800,19 @@ class BlossomUploadService {
         );
         onResumableSessionUpdated?.call(currentSession);
       }
+
+      uploadStopwatch.stop();
+      final totalMs = uploadStopwatch.elapsedMilliseconds;
+      final avgSpeed = totalMs > 0
+          ? (fileSize / 1024 / 1024 / (totalMs / 1000)).toStringAsFixed(2)
+          : '?';
+      Log.info(
+        '📤 Chunk upload complete: $chunkIndex chunks, '
+        '${(totalMs / 1000).toStringAsFixed(1)}s total, '
+        '${avgSpeed}MB/s avg',
+        name: 'BlossomUploadService',
+        category: LogCategory.video,
+      );
 
       return currentSession;
     } finally {
@@ -785,6 +851,14 @@ class BlossomUploadService {
       _addProofModeHeaders(headers, proofManifestJson);
     }
 
+    Log.info(
+      '📤 Completing resumable upload: '
+      '${session.uploadId}',
+      name: 'BlossomUploadService',
+      category: LogCategory.video,
+    );
+    final completeStopwatch = Stopwatch()..start();
+
     final response = await dio.post<dynamic>(
       '$serverUrl/upload/${session.uploadId}/complete',
       data: {'sha256': fileHash},
@@ -792,6 +866,14 @@ class BlossomUploadService {
         headers: headers,
         validateStatus: _validateHttpStatus,
       ),
+    );
+    completeStopwatch.stop();
+
+    Log.info(
+      '📤 Complete response: ${response.statusCode} '
+      'in ${completeStopwatch.elapsedMilliseconds}ms',
+      name: 'BlossomUploadService',
+      category: LogCategory.video,
     );
 
     return _parseUploadResponse(

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -783,9 +783,11 @@ class BlossomUploadService {
 
         chunkStopwatch.stop();
         final chunkMs = chunkStopwatch.elapsedMilliseconds;
+        // coverage:ignore-start
         final chunkSpeed = chunkMs > 0
             ? (chunkLength / 1024 / (chunkMs / 1000)).toStringAsFixed(0)
-            : '?'; // coverage:ignore-line
+            : '?';
+        // coverage:ignore-end
         Log.debug(
           '📤 Chunk $chunkIndex/$totalChunks: '
           '${(chunkLength / 1024).toStringAsFixed(0)}KB '

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -688,6 +688,7 @@ class BlossomUploadService {
     var currentSession = session;
     final fileReader = await file.open();
     final totalChunks = (fileSize / currentSession.chunkSize).ceil();
+    final startOffset = currentSession.nextOffset;
     var chunkIndex = 0;
     final uploadStopwatch = Stopwatch()..start();
 
@@ -695,7 +696,8 @@ class BlossomUploadService {
       '📤 Chunk upload starting: '
       '${(fileSize / 1024 / 1024).toStringAsFixed(2)} MB '
       'in ~$totalChunks chunks '
-      '(${(currentSession.chunkSize / 1024).toStringAsFixed(0)}KB each)',
+      '(${(currentSession.chunkSize / 1024).toStringAsFixed(0)}KB each)'
+      '${startOffset > 0 ? ', resuming from offset $startOffset' : ''}',
       name: 'BlossomUploadService',
       category: LogCategory.video,
     );
@@ -717,8 +719,9 @@ class BlossomUploadService {
         // Chunk bytes are already in memory so retries are cheap.
         late Response<dynamic> response;
         var chunkAttempt = 0;
-        final chunkStopwatch = Stopwatch()..start();
+        late Stopwatch chunkStopwatch;
         while (true) {
+          chunkStopwatch = Stopwatch()..start();
           try {
             response = await dio.put<dynamic>(
               currentSession.uploadUrl,
@@ -803,12 +806,17 @@ class BlossomUploadService {
 
       uploadStopwatch.stop();
       final totalMs = uploadStopwatch.elapsedMilliseconds;
+      final bytesThisSession = fileSize - startOffset;
       final avgSpeed = totalMs > 0
-          ? (fileSize / 1024 / 1024 / (totalMs / 1000)).toStringAsFixed(2)
+          ? (bytesThisSession / 1024 / 1024 / (totalMs / 1000)).toStringAsFixed(
+              2,
+            )
           : '?';
       Log.info(
-        '📤 Chunk upload complete: $chunkIndex chunks, '
-        '${(totalMs / 1000).toStringAsFixed(1)}s total, '
+        '📤 Chunk upload complete: '
+        '$chunkIndex chunks this session '
+        '($totalChunks total), '
+        '${(totalMs / 1000).toStringAsFixed(1)}s, '
         '${avgSpeed}MB/s avg',
         name: 'BlossomUploadService',
         category: LogCategory.video,

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -785,7 +785,7 @@ class BlossomUploadService {
         final chunkMs = chunkStopwatch.elapsedMilliseconds;
         final chunkSpeed = chunkMs > 0
             ? (chunkLength / 1024 / (chunkMs / 1000)).toStringAsFixed(0)
-            : '?';
+            : '?'; // coverage:ignore-line
         Log.debug(
           '📤 Chunk $chunkIndex/$totalChunks: '
           '${(chunkLength / 1024).toStringAsFixed(0)}KB '


### PR DESCRIPTION
Closes #3125

## Description

### Problem

A 8.9 MB video upload took ~87 seconds despite the actual data transfer rate being ~0.8 MB/s (~11 seconds of real transfer time). The remaining ~76 seconds are unaccounted for because the resumable upload flow (`init → chunk uploads → complete`) had **zero logging** between the first and second auth events.

### Root cause (suspected)

The Blossom server determines `chunkSize` in the `/upload/init` response. A small chunk size (e.g. 256 KB) means many sequential HTTP round-trips. Each chunk PUT carries fixed overhead regardless of payload size:

- TCP round-trip latency
- TLS record framing
- Server-side offset validation, disk write, response construction

With ~2s of overhead per request, the math works out:

| Chunk size | Chunks for 8.9 MB | Overhead at ~2s/chunk | Total time |
|---|---|---|---|
| 256 KB | 35 | ~70s | ~81s |
| 1 MB | 9 | ~18s | ~29s |
| 2 MB | 5 | ~10s | ~21s |

The raw transfer time (~11s) stays the same — only the per-request overhead changes.

### What this PR does

**Adds timing logs across the entire resumable upload pipeline:**

- **`_initResumableUpload`**: Logs request duration, server-returned `chunkSize`, total expected chunks, and `nextOffset`
- **`_uploadChunks`**: Logs per-chunk index, size, duration, throughput (KB/s), and progress %. Logs total duration and average speed on completion
- **`_completeResumableUpload`**: Logs request duration for the finalization POST

### Next steps (after we have data)

1. **Enforce a minimum chunk size client-side** — clamp the server's `chunkSize` to at least 2 MB to reduce round-trips
2. **Add send/receive timeouts on chunk PUTs** — currently no Dio timeout is set, so a stalled request waits indefinitely
3. **Verify persistent connections** — ensure the Dio instance reuses the TCP+TLS connection across chunks instead of reconnecting per request

**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore