### PR TITLE
fix(mobile): add viewer auth parity for age-gated playback

### DIFF
--- a/docs/superpowers/specs/2026-04-05-moderated-content-filter-design.md
+++ b/docs/superpowers/specs/2026-04-05-moderated-content-filter-design.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-When the relay serves moderated content (age-restricted or removed), the app shows video metadata — author, title, description, like/comment/share buttons — but the video player is broken. No content warning overlay appears, no NIP-98 auth is attempted, and there is no mechanism to skip the video.
+When the relay serves moderated content (age-restricted or removed), the app shows video metadata — author, title, description, like/comment/share buttons — but the video player is broken. No content warning overlay appears, no viewer auth is attempted, and there is no mechanism to skip the video.
 
 ## Root Causes
 
@@ -17,7 +17,7 @@ Investigation revealed three specific gaps that let moderated content reach the 
 `_normalizeModerationLabel()` in `packages/models/lib/src/video_stats.dart:511` compares against a hardcoded `_recognizedModerationLabels` set (19 entries). Any label outside that set — e.g. `"sexual content"` (with a space), `"adult"`, `"restricted"`, new labels added server-side — returns `null` and is discarded in `_parseModerationLabels`. A video whose only signal was an unknown label arrives at the UI with `moderationLabels: []` and passes through the filter as if unmoderated.
 
 **3. No fallback when videos fail with 401/403 but weren't pre-filtered.**
-When a video slips past the content filter (missing labels, unknown labels, race conditions) but the Blossom media server returns 401/403, `PooledVideoErrorOverlay` renders a small icon and a "Content restricted" or "Age-restricted content" message inside the player area. The metadata overlay (`FeedVideoOverlay`) continues to render author info, description, and action buttons on top of that broken player. The user sees a mostly-normal video card with an error icon where the video should be. There is no auto-advance, no blur overlay, and no NIP-98 auth prompt for age-restricted content.
+When a video slips past the content filter (missing labels, unknown labels, race conditions) but the Blossom media server returns 401/403, `PooledVideoErrorOverlay` renders a small icon and a "Content restricted" or "Age-restricted content" message inside the player area. The metadata overlay (`FeedVideoOverlay`) continues to render author info, description, and action buttons on top of that broken player. The user sees a mostly-normal video card with an error icon where the video should be. There is no auto-advance, no blur overlay, and no viewer-auth retry for age-restricted content.
 
 ## Goals
 
@@ -132,7 +132,7 @@ if (status == PlaybackStatus.forbidden ||
 `_ModeratedContentOverlay` is a new full-screen overlay that:
 - Shows a shield/lock icon and a clear explanation ("This video was restricted by the relay" / "This video requires age verification").
 - Hides the author info, description, and interaction buttons (no likes/comments/shares on content the user cannot watch).
-- For `ageRestricted`, shows a "Verify age" button that triggers the existing `MediaAuthInterceptor` flow.
+- For `ageRestricted`, shows a "Verify age" button that triggers the existing `MediaAuthInterceptor` flow and retries playback with refreshed viewer auth headers.
 - For `forbidden`, shows a "Skip" button that advances `PooledVideoFeedController` to the next video.
 
 **Why not auto-skip:** Silent skipping breaks the user's mental model ("did I scroll?") and makes debugging impossible. A single tap to skip is low friction and preserves observability.
@@ -140,6 +140,30 @@ if (status == PlaybackStatus.forbidden ||
 **Why a new cubit instead of extending `VideoFeedBloc`:** Per the state-management rules, BLoCs should have a single responsibility. `VideoFeedBloc` owns "which videos are in the feed and in what order." Playback status is a different axis — per-item, frequently changing, scoped to the active viewport. Mixing it into `VideoFeedBloc` state would cause feed-wide rebuilds on per-video status changes.
 
 **Testing:** `blocTest` on `VideoPlaybackStatusCubit` for status transitions. Widget tests on `_ModeratedContentOverlay` for each status variant. Integration test in `integration_test/` covering: feed loads → video fails with 403 → overlay appears → skip button advances.
+
+### Part D — Shared viewer auth contract
+
+Age-gated media GET requests against `divine-blossom` accept two viewer-auth
+shapes:
+
+- Blossom/BUD-01 when the client knows the blob SHA-256 hash.
+- NIP-98 when the client only knows the media URL.
+
+`MediaViewerAuthService` is the selector for that contract. It chooses
+Blossom/BUD-01 when a SHA-256 hash is available, otherwise it falls back to
+NIP-98 for the exact media URL. Both playback stacks now use that same policy:
+
+- Legacy individual-controller playback calls `MediaViewerAuthService` through
+  `MediaAuthInterceptor` and `individual_video_providers.dart`.
+- Pooled playback passes viewer auth through `VideoItem.requestHeaders`,
+  forwards those headers into `media_kit` via `Media(..., httpHeaders: ...)`,
+  and retries the active item after age verification succeeds.
+
+This keeps the protocol boundary explicit:
+
+- Viewer media GETs: Blossom/BUD-01 or NIP-98, depending on request shape.
+- Backend API auth: NIP-98 only.
+- Upload/delete blob management: Blossom auth where required.
 
 ## Architecture Diagram
 
@@ -203,6 +227,13 @@ UI (PooledVideoFeed)
 | `test/widgets/video_feed_item/moderated_content_overlay_test.dart` | NEW: widget tests |
 | `lib/screens/feed/feed_video_overlay.dart` | Swap in `_ModeratedContentOverlay` when status is restricted |
 | `lib/screens/feed/pooled_fullscreen_video_feed_screen.dart` | Same, for fullscreen feed |
+| `lib/screens/feed/pooled_age_restricted_retry.dart` | NEW: shared pooled age-verification retry helper |
+| `lib/services/media_viewer_auth_service.dart` | NEW: shared viewer auth contract selector |
+| `lib/services/media_auth_interceptor.dart` | Reuse shared viewer auth contract + preference gating |
+| `lib/providers/individual_video_providers.dart` | Legacy playback now shares viewer auth contract |
+| `packages/pooled_video_player/lib/src/models/video_item.dart` | Carry request headers on pooled items |
+| `packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart` | Forward viewer auth headers into `media_kit` and retry current item |
+| `packages/pooled_video_player/test/controllers/video_feed_controller_test.dart` | Verify authenticated pooled retries |
 | `lib/screens/feed/video_feed_page.dart` | Provide `VideoPlaybackStatusCubit` |
 | `integration_test/moderated_content_test.dart` | NEW: end-to-end |
 

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -71,6 +71,7 @@ import 'package:openvine/services/hashtag_service.dart';
 import 'package:openvine/services/immediate_completion_helper.dart';
 import 'package:openvine/services/language_preference_service.dart';
 import 'package:openvine/services/media_auth_interceptor.dart';
+import 'package:openvine/services/media_viewer_auth_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/mute_service.dart';
 import 'package:openvine/services/nip98_auth_service.dart';
@@ -1720,6 +1721,18 @@ BlossomAuthService blossomAuthService(Ref ref) {
     authProvider: _BlossomAuthAdapter(authService),
   );
 }
+
+/// Shared viewer auth service for media GET requests.
+final mediaViewerAuthServiceProvider = Provider<MediaViewerAuthService>((ref) {
+  final authService = ref.watch(authServiceProvider);
+  final blossomAuthService = ref.watch(blossomAuthServiceProvider);
+  final nip98AuthService = ref.watch(nip98AuthServiceProvider);
+  return MediaViewerAuthService(
+    authService: authService,
+    blossomAuthService: blossomAuthService,
+    nip98AuthService: nip98AuthService,
+  );
+});
 
 /// Media authentication interceptor for handling 401 unauthorized responses
 @riverpod

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -1738,10 +1738,10 @@ final mediaViewerAuthServiceProvider = Provider<MediaViewerAuthService>((ref) {
 @riverpod
 MediaAuthInterceptor mediaAuthInterceptor(Ref ref) {
   final ageVerificationService = ref.watch(ageVerificationServiceProvider);
-  final blossomAuthService = ref.watch(blossomAuthServiceProvider);
+  final mediaViewerAuthService = ref.watch(mediaViewerAuthServiceProvider);
   return MediaAuthInterceptor(
     ageVerificationService: ageVerificationService,
-    blossomAuthService: blossomAuthService,
+    mediaViewerAuthService: mediaViewerAuthService,
   );
 }
 

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -3479,7 +3479,7 @@ final class MediaAuthInterceptorProvider
 }
 
 String _$mediaAuthInterceptorHash() =>
-    r'adae18db875674843f6ced55608bb65a5ef7f445';
+    r'214d6a37de9072814c52d22cf97a2c8c643664a8';
 
 /// Blossom upload service (uses user-configured Blossom server)
 

--- a/mobile/lib/providers/individual_video_providers.dart
+++ b/mobile/lib/providers/individual_video_providers.dart
@@ -13,6 +13,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/bandwidth_tracker_service.dart';
 import 'package:openvine/services/broken_video_tracker.dart'
     show BrokenVideoTracker;
+import 'package:openvine/services/media_viewer_auth_service.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -1060,12 +1061,12 @@ String? _extractSha256FromUrl(String url) {
     final uri = Uri.parse(url);
     final pathSegments = uri.pathSegments;
 
-    // The last path segment is often the sha256 hash
-    if (pathSegments.isNotEmpty) {
-      final lastSegment = pathSegments.last;
+    // Check from the end because Divine derivative URLs can be
+    // /<sha256>/720p.mp4 or a bare /<sha256>.
+    for (final segment in pathSegments.reversed) {
       // SHA256 hashes are 64 hex characters
       // Also handle filenames like "hash.mp4" by stripping extension
-      final cleanSegment = lastSegment.split('.').first;
+      final cleanSegment = segment.split('.').first;
       if (cleanSegment.length == 64 &&
           RegExp(r'^[a-fA-F0-9]+$').hasMatch(cleanSegment)) {
         return cleanSegment.toLowerCase();
@@ -1089,10 +1090,10 @@ Map<String, String>? _computeAuthHeadersSync(
     category: LogCategory.video,
   );
 
-  final blossomAuthService = ref.read(blossomAuthServiceProvider);
+  final mediaViewerAuthService = ref.read(mediaViewerAuthServiceProvider);
 
   // If we can't create headers (not authenticated), return null
-  if (!blossomAuthService.canCreateHeaders) {
+  if (!mediaViewerAuthService.canCreateHeaders) {
     Log.debug(
       '🔐 [AUTH-SYNC] Cannot create headers (not authenticated) - returning null',
       name: 'IndividualVideoController',
@@ -1133,67 +1134,36 @@ Map<String, String>? _computeAuthHeadersSync(
   return null;
 }
 
+/// Builds viewer auth headers for a legacy video playback request.
+Future<Map<String, String>?> createViewerAuthHeadersForVideo({
+  required MediaViewerAuthService mediaViewerAuthService,
+  required VideoControllerParams params,
+}) {
+  final sha256 = _resolveSha256ForParams(params);
+  final serverUrl = _extractServerUrl(params.videoUrl);
+  return mediaViewerAuthService.createAuthHeaders(
+    sha256Hash: sha256,
+    url: params.videoUrl,
+    serverUrl: serverUrl,
+  );
+}
+
 /// Generate auth headers asynchronously and cache them for future use
 Future<void> _generateAuthHeadersAsync(
   Ref ref,
   VideoControllerParams params,
 ) async {
   try {
-    final blossomAuthService = ref.read(blossomAuthServiceProvider);
-
-    // Try to get sha256 from video event first
-    String? sha256;
-    if (params.videoEvent != null) {
-      final videoEvent = params.videoEvent as dynamic;
-      sha256 = videoEvent.sha256 as String?;
-    }
-
-    // If no sha256 in event, try to extract from URL
-    // CDN URLs often have format: https://cdn.domain.com/{sha256hash}
-    if (sha256 == null || sha256.isEmpty) {
-      sha256 = _extractSha256FromUrl(params.videoUrl);
-      if (sha256 != null) {
-        Log.debug(
-          '🔐 Extracted sha256 from URL: ${sha256.substring(0, 8)}...',
-          name: 'IndividualVideoController',
-          category: LogCategory.video,
-        );
-      }
-    }
-
-    if (sha256 == null || sha256.isEmpty) {
-      Log.debug(
-        '🔐 No sha256 available for video ${params.videoId} - cannot generate auth header',
-        name: 'IndividualVideoController',
-        category: LogCategory.video,
-      );
-      return;
-    }
-
-    // Extract server URL from video URL
-    String? serverUrl;
-    try {
-      final uri = Uri.parse(params.videoUrl);
-      serverUrl = '${uri.scheme}://${uri.host}';
-    } catch (e) {
-      Log.warning(
-        'Failed to parse video URL for server: $e',
-        name: 'IndividualVideoController',
-        category: LogCategory.video,
-      );
-      return;
-    }
-
-    // Generate auth header
-    final authHeader = await blossomAuthService.createGetAuthHeader(
-      sha256Hash: sha256,
-      serverUrl: serverUrl,
+    final mediaViewerAuthService = ref.read(mediaViewerAuthServiceProvider);
+    final authHeaders = await createViewerAuthHeadersForVideo(
+      mediaViewerAuthService: mediaViewerAuthService,
+      params: params,
     );
 
-    if (authHeader != null) {
+    if (authHeaders != null) {
       // Cache the header for future use
       final cache = {...ref.read(authHeadersCacheProvider)};
-      cache[params.videoId] = {'Authorization': authHeader};
+      cache[params.videoId] = authHeaders;
       ref.read(authHeadersCacheProvider.notifier).state = cache;
 
       Log.info(
@@ -1232,67 +1202,27 @@ Future<dynamic> _cacheVideoWithAuth(
   // Check if we should add auth headers
   Map<String, String>? authHeaders;
 
-  final blossomAuthService = ref.read(blossomAuthServiceProvider);
+  final mediaViewerAuthService = ref.read(mediaViewerAuthServiceProvider);
 
   Log.debug(
-    '🔐 Auth check: canCreate=${blossomAuthService.canCreateHeaders}',
+    '🔐 Auth check: canCreate=${mediaViewerAuthService.canCreateHeaders}',
     name: 'IndividualVideoController',
     category: LogCategory.video,
   );
 
   // If user is authenticated, create auth header for all CDN requests
-  if (blossomAuthService.canCreateHeaders) {
-    // Try to get sha256 from video event first
-    String? sha256;
-    if (params.videoEvent != null) {
-      final videoEvent = params.videoEvent as dynamic;
-      sha256 = videoEvent.sha256 as String?;
-    }
-
-    // If no sha256 in event, try to extract from URL
-    if (sha256 == null || sha256.isEmpty) {
-      sha256 = _extractSha256FromUrl(params.videoUrl);
-    }
-
-    Log.debug(
-      '🔐 Video sha256: ${sha256 != null ? '${sha256.substring(0, 8)}...' : 'null'}',
-      name: 'IndividualVideoController',
-      category: LogCategory.video,
+  if (mediaViewerAuthService.canCreateHeaders) {
+    authHeaders = await createViewerAuthHeadersForVideo(
+      mediaViewerAuthService: mediaViewerAuthService,
+      params: params,
     );
 
-    if (sha256 != null && sha256.isNotEmpty) {
-      Log.debug(
-        '🔐 Creating Blossom auth header for video cache request',
+    if (authHeaders != null) {
+      Log.info(
+        '✅ Added viewer auth header for video cache',
         name: 'IndividualVideoController',
         category: LogCategory.video,
       );
-
-      // Extract server URL from video URL for auth
-      String? serverUrl;
-      try {
-        final uri = Uri.parse(params.videoUrl);
-        serverUrl = '${uri.scheme}://${uri.host}';
-      } catch (e) {
-        Log.warning(
-          'Failed to parse video URL for server: $e',
-          name: 'IndividualVideoController',
-          category: LogCategory.video,
-        );
-      }
-
-      final authHeader = await blossomAuthService.createGetAuthHeader(
-        sha256Hash: sha256,
-        serverUrl: serverUrl,
-      );
-
-      if (authHeader != null) {
-        authHeaders = {'Authorization': authHeader};
-        Log.info(
-          '✅ Added Blossom auth header for video cache',
-          name: 'IndividualVideoController',
-          category: LogCategory.video,
-        );
-      }
     }
   }
 
@@ -1310,6 +1240,50 @@ Future<dynamic> _cacheVideoWithAuth(
       tracker.markVideoBroken(params.videoId, 'Cache download failed: $e');
     }
     rethrow;
+  }
+}
+
+String? _resolveSha256ForParams(VideoControllerParams params) {
+  String? sha256;
+  if (params.videoEvent != null) {
+    final videoEvent = params.videoEvent as dynamic;
+    sha256 = videoEvent.sha256 as String?;
+  }
+
+  if (sha256 == null || sha256.isEmpty) {
+    sha256 = _extractSha256FromUrl(params.videoUrl);
+    if (sha256 != null) {
+      Log.debug(
+        '🔐 Extracted sha256 from URL: ${sha256.substring(0, 8)}...',
+        name: 'IndividualVideoController',
+        category: LogCategory.video,
+      );
+    }
+  }
+
+  if (sha256 == null || sha256.isEmpty) {
+    Log.debug(
+      '🔐 No sha256 available for video ${params.videoId} - falling back to URL-only viewer auth',
+      name: 'IndividualVideoController',
+      category: LogCategory.video,
+    );
+    return null;
+  }
+
+  return sha256;
+}
+
+String? _extractServerUrl(String videoUrl) {
+  try {
+    final uri = Uri.parse(videoUrl);
+    return '${uri.scheme}://${uri.host}';
+  } catch (e) {
+    Log.warning(
+      'Failed to parse video URL for server: $e',
+      name: 'IndividualVideoController',
+      category: LogCategory.video,
+    );
+    return null;
   }
 }
 

--- a/mobile/lib/screens/feed/feed_video_overlay.dart
+++ b/mobile/lib/screens/feed/feed_video_overlay.dart
@@ -18,6 +18,7 @@ import 'package:openvine/providers/subtitle_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/routes/route_extras.dart';
 import 'package:openvine/screens/curated_list_feed_screen.dart';
+import 'package:openvine/screens/feed/pooled_age_restricted_retry.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
@@ -107,18 +108,13 @@ class _FeedVideoOverlayState extends ConsumerState<FeedVideoOverlay> {
     unawaited(feedState.animateToPage(widget.index + 1));
   }
 
-  /// Triggers the existing age-verification flow via the Riverpod service.
-  /// On success, clears the cached moderated status so a retry can
-  /// re-classify the video using the newly unlocked auth cookie.
+  /// Triggers age verification and retries pooled playback with viewer auth.
   Future<void> _verifyAge(BuildContext context, VideoEvent video) async {
-    final ageVerificationService = ref.read(ageVerificationServiceProvider);
-    final verified = await ageVerificationService.verifyAdultContentAccess(
-      context,
-    );
-    if (!verified || !context.mounted) return;
-    context.read<VideoPlaybackStatusCubit>().report(
-      video.id,
-      PlaybackStatus.ready,
+    await retryAgeRestrictedPooledVideo(
+      context: context,
+      ref: ref,
+      video: video,
+      index: widget.index,
     );
   }
 

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
+import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:pooled_video_player/pooled_video_player.dart';
+
+/// Verifies access to an age-restricted pooled video, then retries playback
+/// with viewer auth headers on the active pooled controller item.
+Future<void> retryAgeRestrictedPooledVideo({
+  required BuildContext context,
+  required WidgetRef ref,
+  required VideoEvent video,
+  required int index,
+}) async {
+  final videoUrl = video.videoUrl;
+  if (videoUrl == null || videoUrl.isEmpty) {
+    return;
+  }
+
+  final headers = await ref
+      .read(mediaAuthInterceptorProvider)
+      .handleUnauthorizedMedia(
+        context: context,
+        sha256Hash: _resolveSha256(video),
+        url: videoUrl,
+        serverUrl: _extractServerUrl(videoUrl),
+        category: 'video',
+      );
+  if (headers == null || !context.mounted) {
+    return;
+  }
+
+  final feedController = VideoPoolProvider.maybeFeedOf(context);
+  if (feedController == null) {
+    return;
+  }
+
+  context.read<VideoPlaybackStatusCubit>().report(
+    video.id,
+    PlaybackStatus.ready,
+  );
+  feedController.updateRequestHeadersAndRetry(index, headers);
+}
+
+String? _resolveSha256(VideoEvent video) {
+  final sha256 = video.sha256;
+  if (sha256 != null && sha256.isNotEmpty) {
+    return sha256;
+  }
+
+  final videoUrl = video.videoUrl;
+  if (videoUrl == null || videoUrl.isEmpty) {
+    return null;
+  }
+
+  return _extractSha256FromUrl(videoUrl);
+}
+
+String? _extractSha256FromUrl(String url) {
+  try {
+    final uri = Uri.parse(url);
+    for (final segment in uri.pathSegments.reversed) {
+      final cleanSegment = segment.split('.').first;
+      if (cleanSegment.length == 64 &&
+          RegExp(r'^[a-fA-F0-9]+$').hasMatch(cleanSegment)) {
+        return cleanSegment.toLowerCase();
+      }
+    }
+  } catch (_) {
+    return null;
+  }
+
+  return null;
+}
+
+String? _extractServerUrl(String videoUrl) {
+  try {
+    final uri = Uri.parse(videoUrl);
+    final portSuffix = uri.hasPort ? ':${uri.port}' : '';
+    return '${uri.scheme}://${uri.host}$portSuffix';
+  } catch (_) {
+    return null;
+  }
+}

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -6,6 +6,9 @@ import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:pooled_video_player/pooled_video_player.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+const _logName = 'PooledAgeRestrictedRetry';
 
 /// Verifies access to an age-restricted pooled video, then retries playback
 /// with viewer auth headers on the active pooled controller item.
@@ -17,6 +20,12 @@ Future<void> retryAgeRestrictedPooledVideo({
 }) async {
   final videoUrl = video.videoUrl;
   if (videoUrl == null || videoUrl.isEmpty) {
+    Log.warning(
+      'Skipping age-restricted retry: missing videoUrl for event '
+      '${video.id}',
+      name: _logName,
+      category: LogCategory.video,
+    );
     return;
   }
 
@@ -35,6 +44,12 @@ Future<void> retryAgeRestrictedPooledVideo({
 
   final feedController = VideoPoolProvider.maybeFeedOf(context);
   if (feedController == null) {
+    Log.warning(
+      'Skipping age-restricted retry: no VideoPoolProvider feed controller '
+      'in context for event ${video.id}',
+      name: _logName,
+      category: LogCategory.video,
+    );
     return;
   }
 

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -27,6 +27,7 @@ import 'package:openvine/screens/feed/feed_auto_advance_completion_listener.dart
 import 'package:openvine/screens/feed/feed_auto_advance_coordinator.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_error_listener.dart';
+import 'package:openvine/screens/feed/pooled_age_restricted_retry.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/view_event_publisher.dart';
@@ -971,22 +972,16 @@ class _PooledFullscreenItemContentState
     unawaited(feedState.animateToPage(widget.index + 1));
   }
 
-  /// Triggers the existing age verification flow. Matches the pattern used
-  /// by the legacy [VideoErrorOverlay].
+  /// Triggers age verification and retries pooled playback with viewer auth.
   Future<void> _verifyAgeForVideo(
     BuildContext context,
     VideoEvent video,
   ) async {
-    final ageVerificationService = ref.read(ageVerificationServiceProvider);
-    final verified = await ageVerificationService.verifyAdultContentAccess(
-      context,
-    );
-    if (!verified || !context.mounted) return;
-    // Clear the cached moderated status so a retry can re-classify the
-    // video if the auth cookie now unlocks it.
-    context.read<VideoPlaybackStatusCubit>().report(
-      video.id,
-      PlaybackStatus.ready,
+    await retryAgeRestrictedPooledVideo(
+      context: context,
+      ref: ref,
+      video: video,
+      index: widget.index,
     );
   }
 

--- a/mobile/lib/services/media_auth_interceptor.dart
+++ b/mobile/lib/services/media_auth_interceptor.dart
@@ -1,27 +1,28 @@
-// ABOUTME: Intercepts 401 unauthorized media requests and handles Blossom authentication
+// ABOUTME: Intercepts 401 unauthorized media requests and handles viewer authentication
 // ABOUTME: Coordinates age verification and signed auth header creation for age-restricted content
 
-import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/services/age_verification_service.dart';
+import 'package:openvine/services/media_viewer_auth_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Service for intercepting unauthorized media requests and handling authentication flow
 class MediaAuthInterceptor {
   MediaAuthInterceptor({
     required AgeVerificationService ageVerificationService,
-    required BlossomAuthService blossomAuthService,
+    required MediaViewerAuthService mediaViewerAuthService,
   }) : _ageVerificationService = ageVerificationService,
-       _blossomAuthService = blossomAuthService;
+       _mediaViewerAuthService = mediaViewerAuthService;
 
   final AgeVerificationService _ageVerificationService;
-  final BlossomAuthService _blossomAuthService;
+  final MediaViewerAuthService _mediaViewerAuthService;
 
   /// Handle 401 unauthorized response from Blossom media server
-  /// Returns auth header if user verifies adult content access, null otherwise
-  Future<String?> handleUnauthorizedMedia({
+  /// Returns request headers if user verifies adult content access, null otherwise
+  Future<Map<String, String>?> handleUnauthorizedMedia({
     required BuildContext context,
-    required String sha256Hash,
+    String? sha256Hash,
+    String? url,
     String? serverUrl,
     String? category,
   }) async {
@@ -49,8 +50,9 @@ class MediaAuthInterceptor {
           name: 'MediaAuthInterceptor',
           category: LogCategory.system,
         );
-        return await _blossomAuthService.createGetAuthHeader(
+        return await _mediaViewerAuthService.createAuthHeaders(
           sha256Hash: sha256Hash,
+          url: url,
           serverUrl: serverUrl,
         );
       }
@@ -91,8 +93,9 @@ class MediaAuthInterceptor {
       );
 
       // Create auth header after verification
-      return await _blossomAuthService.createGetAuthHeader(
+      return await _mediaViewerAuthService.createAuthHeaders(
         sha256Hash: sha256Hash,
+        url: url,
         serverUrl: serverUrl,
       );
     } catch (e) {
@@ -106,7 +109,7 @@ class MediaAuthInterceptor {
   }
 
   /// Check if we can create auth headers (user is authenticated with Nostr)
-  bool get canCreateAuthHeaders => _blossomAuthService.canCreateHeaders;
+  bool get canCreateAuthHeaders => _mediaViewerAuthService.canCreateHeaders;
 
   /// Returns true if adult content should be filtered from feeds entirely
   bool get shouldFilterContent =>

--- a/mobile/lib/services/media_viewer_auth_service.dart
+++ b/mobile/lib/services/media_viewer_auth_service.dart
@@ -1,0 +1,59 @@
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/nip98_auth_service.dart';
+
+/// Creates viewer auth headers for media GET requests.
+class MediaViewerAuthService {
+  MediaViewerAuthService({
+    required AuthService authService,
+    required BlossomAuthService blossomAuthService,
+    required Nip98AuthService nip98AuthService,
+  }) : _authService = authService,
+       _blossomAuthService = blossomAuthService,
+       _nip98AuthService = nip98AuthService;
+
+  final AuthService _authService;
+  final BlossomAuthService _blossomAuthService;
+  final Nip98AuthService _nip98AuthService;
+
+  bool get canCreateHeaders => _authService.isAuthenticated;
+
+  /// Returns request headers for a media GET, or null when no viewer auth can
+  /// be created for the current user/request shape.
+  Future<Map<String, String>?> createAuthHeaders({
+    String? sha256Hash,
+    String? url,
+    String? serverUrl,
+    HttpMethod method = HttpMethod.get,
+  }) async {
+    if (!_authService.isAuthenticated) {
+      return null;
+    }
+
+    if (sha256Hash != null && sha256Hash.isNotEmpty) {
+      final header = await _blossomAuthService.createGetAuthHeader(
+        sha256Hash: sha256Hash,
+        serverUrl: serverUrl,
+      );
+      return _authorizationHeaders(header);
+    }
+
+    if (url != null && url.isNotEmpty) {
+      final token = await _nip98AuthService.createAuthToken(
+        url: url,
+        method: method,
+      );
+      return _authorizationHeaders(token?.authorizationHeader);
+    }
+
+    return null;
+  }
+
+  Map<String, String>? _authorizationHeaders(String? authorizationHeader) {
+    if (authorizationHeader == null || authorizationHeader.isEmpty) {
+      return null;
+    }
+
+    return {'Authorization': authorizationHeader};
+  }
+}

--- a/mobile/lib/services/media_viewer_auth_service.dart
+++ b/mobile/lib/services/media_viewer_auth_service.dart
@@ -24,7 +24,6 @@ class MediaViewerAuthService {
     String? sha256Hash,
     String? url,
     String? serverUrl,
-    HttpMethod method = HttpMethod.get,
   }) async {
     if (!_authService.isAuthenticated) {
       return null;
@@ -41,7 +40,7 @@ class MediaViewerAuthService {
     if (url != null && url.isNotEmpty) {
       final token = await _nip98AuthService.createAuthToken(
         url: url,
-        method: method,
+        method: HttpMethod.get,
       );
       return _authorizationHeaders(token?.authorizationHeader);
     }

--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -592,6 +592,7 @@ class VideoFeedController extends ChangeNotifier {
     required int startIndex,
     required Stopwatch? loadStopwatch,
     required String retryLogLabel,
+    Map<String, String>? requestHeaders,
     String diagnosticsReason = 'load_error',
   }) async {
     var attemptIndex = startIndex;
@@ -600,7 +601,10 @@ class VideoFeedController extends ChangeNotifier {
       final source = playbackSources[attemptIndex];
 
       try {
-        await player.open(Media(source), play: false);
+        await player.open(
+          Media(source, httpHeaders: requestHeaders),
+          play: false,
+        );
         return (openedSource: source, sourceIndex: attemptIndex);
       } on Exception catch (error) {
         final nextAttempt = attemptIndex + 1;
@@ -763,6 +767,7 @@ class VideoFeedController extends ChangeNotifier {
         player: player,
         playbackSources: playbackSources,
         startIndex: nextSourceIndex,
+        requestHeaders: _videos[index].requestHeaders,
         loadStopwatch: _loadStopwatches[index],
         retryLogLabel: 'stuck_retry',
         diagnosticsReason: 'stuck_playback',
@@ -798,6 +803,16 @@ class VideoFeedController extends ChangeNotifier {
     _logDebug('retry_load ${_videoDebugDetails(index)}');
     _releasePlayer(index);
     _updatePreloadWindow(_currentIndex);
+  }
+
+  /// Updates request headers for the video at [index] and retries loading it.
+  void updateRequestHeadersAndRetry(
+    int index,
+    Map<String, String>? requestHeaders,
+  ) {
+    if (_isDisposed || index < 0 || index >= _videos.length) return;
+    _videos[index] = _videos[index].copyWith(requestHeaders: requestHeaders);
+    retryLoad(index);
   }
 
   /// Called when the visible page changes.
@@ -1174,6 +1189,7 @@ class VideoFeedController extends ChangeNotifier {
         player: pooledPlayer.player,
         playbackSources: playbackSources,
         startIndex: sourceIndex,
+        requestHeaders: video.requestHeaders,
         loadStopwatch: loadStopwatch,
         retryLogLabel: 'open_retry',
       );

--- a/mobile/packages/pooled_video_player/lib/src/models/video_item.dart
+++ b/mobile/packages/pooled_video_player/lib/src/models/video_item.dart
@@ -11,6 +11,7 @@ class VideoItem extends Equatable {
     required this.id,
     required this.url,
     this.originalUrl,
+    this.requestHeaders,
   });
 
   /// Unique identifier for this video.
@@ -22,6 +23,27 @@ class VideoItem extends Equatable {
   /// Original source URL from the event, used as a last-resort fallback
   /// when all derived URLs fail.
   final String? originalUrl;
+
+  /// Request headers applied when opening this media source.
+  ///
+  /// These headers are forwarded to `media_kit` for the current source and
+  /// any derived fallback sources loaded for this item.
+  final Map<String, String>? requestHeaders;
+
+  /// Creates a copy with updated properties.
+  VideoItem copyWith({
+    String? id,
+    String? url,
+    String? originalUrl,
+    Map<String, String>? requestHeaders,
+  }) {
+    return VideoItem(
+      id: id ?? this.id,
+      url: url ?? this.url,
+      originalUrl: originalUrl ?? this.originalUrl,
+      requestHeaders: requestHeaders ?? this.requestHeaders,
+    );
+  }
 
   @override
   List<Object?> get props => [id];

--- a/mobile/packages/pooled_video_player/lib/src/models/video_item.dart
+++ b/mobile/packages/pooled_video_player/lib/src/models/video_item.dart
@@ -1,5 +1,9 @@
 import 'package:equatable/equatable.dart';
 
+/// Sentinel used by [VideoItem.copyWith] to distinguish "argument omitted"
+/// from "argument explicitly set to `null`".
+const Object _sentinel = Object();
+
 /// Represents a video item with metadata for playback.
 ///
 /// Each video item has a unique [id] and a [url] pointing to the video source.
@@ -31,17 +35,26 @@ class VideoItem extends Equatable {
   final Map<String, String>? requestHeaders;
 
   /// Creates a copy with updated properties.
+  ///
+  /// Passing `requestHeaders: null` explicitly clears the headers on the
+  /// returned item. Omitting [requestHeaders] preserves the current value.
+  /// This distinction matters when auth state changes (logout, expired
+  /// session) and the caller needs to drop previously attached headers.
   VideoItem copyWith({
     String? id,
     String? url,
-    String? originalUrl,
-    Map<String, String>? requestHeaders,
+    Object? originalUrl = _sentinel,
+    Object? requestHeaders = _sentinel,
   }) {
     return VideoItem(
       id: id ?? this.id,
       url: url ?? this.url,
-      originalUrl: originalUrl ?? this.originalUrl,
-      requestHeaders: requestHeaders ?? this.requestHeaders,
+      originalUrl: identical(originalUrl, _sentinel)
+          ? this.originalUrl
+          : originalUrl as String?,
+      requestHeaders: identical(requestHeaders, _sentinel)
+          ? this.requestHeaders
+          : requestHeaders as Map<String, String>?,
     );
   }
 

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -4873,6 +4873,38 @@ void main() {
     });
 
     group('retryLoad', () {
+      test('passes request headers into Media when opening a video', () async {
+        const headers = {'Authorization': 'Nostr token'};
+        const video = VideoItem(
+          id: 'auth-video',
+          url: 'https://example.com/auth-video.mp4',
+          requestHeaders: headers,
+        );
+        final controller = VideoFeedController(
+          videos: [video],
+          pool: pool,
+          preloadAhead: 0,
+          preloadBehind: 0,
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final setup = playerSetups[video.url]!;
+        final capturedMedia =
+            verify(
+                  () => setup.player.open(
+                    captureAny(),
+                    play: any(named: 'play'),
+                  ),
+                ).captured.single
+                as Media;
+
+        expect(capturedMedia.uri, equals(video.url));
+        expect(capturedMedia.httpHeaders, equals(headers));
+
+        controller.dispose();
+      });
+
       test('releases player and re-triggers preload', () async {
         final videos = createTestVideos(count: 3);
 
@@ -4964,6 +4996,79 @@ void main() {
         controller.dispose();
         await retryPool.dispose();
       });
+
+      test(
+        'retries an age-restricted load after request headers are updated',
+        () async {
+          var shouldRequireAuth = true;
+          Media? lastOpenedMedia;
+          final retryPool = TestablePlayerPool(
+            maxPlayers: 10,
+            mockPlayerFactory: (url) {
+              final setup = createMockPlayerSetup();
+              final mock = _MockPooledPlayer();
+              when(() => mock.player).thenReturn(setup.player);
+              when(
+                () => mock.videoController,
+              ).thenReturn(createMockVideoController());
+              when(() => mock.isDisposed).thenReturn(false);
+              when(() => mock.wasRecycled).thenReturn(false);
+              when(mock.clearRecycled).thenReturn(null);
+              when(mock.dispose).thenAnswer((_) async {});
+              when(
+                () => setup.player.open(
+                  any(),
+                  play: any(named: 'play'),
+                ),
+              ).thenAnswer((invocation) async {
+                lastOpenedMedia = invocation.positionalArguments.first as Media;
+                if (shouldRequireAuth &&
+                    lastOpenedMedia!.httpHeaders?['Authorization'] !=
+                        'Nostr allowed') {
+                  throw Exception('401 Unauthorized');
+                }
+              });
+              return mock;
+            },
+          );
+
+          final controller = VideoFeedController(
+            videos: const [
+              VideoItem(
+                id: 'protected-video',
+                url: 'https://example.com/protected-video.mp4',
+              ),
+            ],
+            pool: retryPool,
+            preloadAhead: 0,
+            preloadBehind: 0,
+          );
+
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          expect(controller.getLoadState(0), equals(LoadState.error));
+          expect(
+            controller.getIndexNotifier(0).value.errorType,
+            equals(VideoErrorType.ageRestricted),
+          );
+          expect(lastOpenedMedia?.httpHeaders, isNull);
+
+          shouldRequireAuth = false;
+          controller.updateRequestHeadersAndRetry(0, const {
+            'Authorization': 'Nostr allowed',
+          });
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          expect(controller.getLoadState(0), isNot(LoadState.error));
+          expect(
+            lastOpenedMedia?.httpHeaders,
+            equals(const {'Authorization': 'Nostr allowed'}),
+          );
+
+          controller.dispose();
+          await retryPool.dispose();
+        },
+      );
     });
 
     group('error type classification', () {

--- a/mobile/packages/pooled_video_player/test/models/video_item_test.dart
+++ b/mobile/packages/pooled_video_player/test/models/video_item_test.dart
@@ -88,6 +88,50 @@ void main() {
       });
     });
 
+    group('copyWith', () {
+      test('preserves requestHeaders when not specified', () {
+        const headers = {'Authorization': 'Nostr token'};
+        const item = VideoItem(
+          id: 'id',
+          url: 'https://example.com/video.mp4',
+          requestHeaders: headers,
+        );
+
+        final copy = item.copyWith(url: 'https://example.com/new.mp4');
+
+        expect(copy.requestHeaders, equals(headers));
+        expect(copy.url, equals('https://example.com/new.mp4'));
+      });
+
+      test('clears requestHeaders when explicitly passed null', () {
+        const item = VideoItem(
+          id: 'id',
+          url: 'https://example.com/video.mp4',
+          requestHeaders: {'Authorization': 'Nostr token'},
+        );
+
+        final copy = item.copyWith(requestHeaders: null);
+
+        expect(copy.requestHeaders, isNull);
+        expect(copy.id, equals('id'));
+        expect(copy.url, equals('https://example.com/video.mp4'));
+      });
+
+      test('replaces requestHeaders with new map when provided', () {
+        const item = VideoItem(
+          id: 'id',
+          url: 'https://example.com/video.mp4',
+          requestHeaders: {'Authorization': 'Nostr old'},
+        );
+
+        final copy = item.copyWith(
+          requestHeaders: const {'Authorization': 'Nostr new'},
+        );
+
+        expect(copy.requestHeaders, equals({'Authorization': 'Nostr new'}));
+      });
+    });
+
     group('edge cases', () {
       test('handles empty strings', () {
         const item = VideoItem(id: '', url: '');

--- a/mobile/test/providers/individual_video_providers_test.dart
+++ b/mobile/test/providers/individual_video_providers_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/providers/individual_video_providers.dart';
+import 'package:openvine/services/media_viewer_auth_service.dart';
+
+class MockMediaViewerAuthService extends Mock
+    implements MediaViewerAuthService {}
+
+void main() {
+  late MockMediaViewerAuthService mockMediaViewerAuthService;
+
+  setUp(() {
+    mockMediaViewerAuthService = MockMediaViewerAuthService();
+  });
+
+  group('createViewerAuthHeadersForVideo', () {
+    test('prefers the event sha256 when it is present', () async {
+      final params = VideoControllerParams(
+        videoId: 'video-1',
+        videoUrl:
+            'https://media.divine.video/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/720p.mp4',
+        videoEvent: _videoEvent(
+          sha256:
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        ),
+      );
+      when(
+        () => mockMediaViewerAuthService.createAuthHeaders(
+          sha256Hash: any(named: 'sha256Hash'),
+          url: any(named: 'url'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      ).thenAnswer((_) async => {'Authorization': 'Nostr blossom'});
+
+      final headers = await createViewerAuthHeadersForVideo(
+        mediaViewerAuthService: mockMediaViewerAuthService,
+        params: params,
+      );
+
+      expect(headers, equals({'Authorization': 'Nostr blossom'}));
+      verify(
+        () => mockMediaViewerAuthService.createAuthHeaders(
+          sha256Hash:
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          url:
+              'https://media.divine.video/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/720p.mp4',
+          serverUrl: 'https://media.divine.video',
+        ),
+      ).called(1);
+    });
+
+    test('falls back to the sha256 embedded in the media URL', () async {
+      const params = VideoControllerParams(
+        videoId: 'video-2',
+        videoUrl:
+            'https://media.divine.video/cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc/720p.mp4',
+      );
+      when(
+        () => mockMediaViewerAuthService.createAuthHeaders(
+          sha256Hash: any(named: 'sha256Hash'),
+          url: any(named: 'url'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      ).thenAnswer((_) async => {'Authorization': 'Nostr extracted'});
+
+      final headers = await createViewerAuthHeadersForVideo(
+        mediaViewerAuthService: mockMediaViewerAuthService,
+        params: params,
+      );
+
+      expect(headers, equals({'Authorization': 'Nostr extracted'}));
+      verify(
+        () => mockMediaViewerAuthService.createAuthHeaders(
+          sha256Hash:
+              'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+          url:
+              'https://media.divine.video/cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc/720p.mp4',
+          serverUrl: 'https://media.divine.video',
+        ),
+      ).called(1);
+    });
+
+    test(
+      'falls back to URL-only auth when no sha256 can be resolved',
+      () async {
+        const params = VideoControllerParams(
+          videoId: 'video-3',
+          videoUrl: 'https://cdn.example.com/protected/video/master.m3u8',
+        );
+        when(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        ).thenAnswer((_) async => {'Authorization': 'Nostr nip98'});
+
+        final headers = await createViewerAuthHeadersForVideo(
+          mediaViewerAuthService: mockMediaViewerAuthService,
+          params: params,
+        );
+
+        expect(headers, equals({'Authorization': 'Nostr nip98'}));
+        verify(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            url: 'https://cdn.example.com/protected/video/master.m3u8',
+            serverUrl: 'https://cdn.example.com',
+          ),
+        ).called(1);
+      },
+    );
+  });
+}
+
+VideoEvent _videoEvent({String? sha256}) {
+  return VideoEvent(
+    id: 'event-id',
+    pubkey: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    createdAt: 1,
+    content: 'content',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1000),
+    sha256: sha256,
+  );
+}

--- a/mobile/test/screens/feed/feed_video_overlay_test.dart
+++ b/mobile/test/screens/feed/feed_video_overlay_test.dart
@@ -13,14 +13,19 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
+import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/feed_video_overlay.dart';
+import 'package:openvine/services/media_auth_interceptor.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/utils/scroll_driven_opacity.dart';
 import 'package:openvine/widgets/proofmode_badge_row.dart';
 import 'package:openvine/widgets/video_feed_item/list_attribution_chip.dart';
+import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
+import 'package:pooled_video_player/pooled_video_player.dart';
 
 import '../../helpers/test_provider_overrides.dart';
+import '../../test_data/video_test_data.dart';
 
 class _MockVideoInteractionsBloc
     extends MockBloc<VideoInteractionsEvent, VideoInteractionsState>
@@ -36,6 +41,12 @@ class _MockCuratedListRepository extends Mock
     implements CuratedListRepository {}
 
 class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockMediaAuthInterceptor extends Mock implements MediaAuthInterceptor {}
+
+class _MockVideoFeedController extends Mock implements VideoFeedController {}
+
+class _FakeBuildContext extends Fake implements BuildContext {}
 
 // Full 64-character test IDs (never truncate Nostr IDs)
 const _testVideoId =
@@ -60,6 +71,8 @@ void main() {
 
     setUpAll(() {
       registerFallbackValue(const VideoInteractionsSubscriptionRequested());
+      registerFallbackValue(_FakeBuildContext());
+      registerFallbackValue(<String, String>{});
     });
 
     setUp(() {
@@ -125,13 +138,29 @@ void main() {
       bool showAutoButton = false,
       bool isAutoEnabled = false,
       VoidCallback? onAutoPressed,
+      VideoFeedController? feedController,
+      List<dynamic>? additionalOverrides,
     }) {
+      final overlay = FeedVideoOverlay(
+        video: testVideo,
+        isActive: isActive,
+        pagePosition: pagePositionOverride ?? pagePosition,
+        index: index,
+        player: includePlayer ? (player ?? mockPlayer) : null,
+        firstFrameFuture: firstFrameFuture,
+        listSources: listSources,
+        showAutoButton: showAutoButton,
+        isAutoEnabled: isAutoEnabled,
+        onAutoPressed: onAutoPressed,
+      );
+
       return testMaterialApp(
         additionalOverrides: [
           curatedListRepositoryProvider.overrideWithValue(
             mockCuratedListRepository,
           ),
           videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          ...?additionalOverrides,
         ],
         mockProfileRepository: mockProfileRepository,
         mockNip05VerificationService: mockNip05VerificationService,
@@ -145,18 +174,12 @@ void main() {
                 create: (_) => VideoPlaybackStatusCubit(),
               ),
             ],
-            child: FeedVideoOverlay(
-              video: testVideo,
-              isActive: isActive,
-              pagePosition: pagePositionOverride ?? pagePosition,
-              index: index,
-              player: includePlayer ? (player ?? mockPlayer) : null,
-              firstFrameFuture: firstFrameFuture,
-              listSources: listSources,
-              showAutoButton: showAutoButton,
-              isAutoEnabled: isAutoEnabled,
-              onAutoPressed: onAutoPressed,
-            ),
+            child: feedController == null
+                ? overlay
+                : VideoPoolProvider(
+                    feedController: feedController,
+                    child: overlay,
+                  ),
           ),
         ),
       );
@@ -242,6 +265,81 @@ void main() {
 
         expect(find.byType(ProofModeBadgeRow), findsOneWidget);
       });
+
+      testWidgets(
+        'verify age retries pooled playback with viewer auth headers',
+        (tester) async {
+          const sha256 =
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+          const videoUrl = 'https://media.divine.video/$sha256/720p.mp4';
+          const headers = {'Authorization': 'Nostr viewer-token'};
+          final mockMediaAuthInterceptor = _MockMediaAuthInterceptor();
+          final mockFeedController = _MockVideoFeedController();
+
+          testVideo = createTestVideoEvent(
+            id: _testVideoId,
+            pubkey: _testPubkey,
+            videoUrl: videoUrl,
+            sha256: sha256,
+          );
+
+          when(
+            () => mockMediaAuthInterceptor.handleUnauthorizedMedia(
+              context: any(named: 'context'),
+              sha256Hash: sha256,
+              url: videoUrl,
+              serverUrl: 'https://media.divine.video',
+              category: 'video',
+            ),
+          ).thenAnswer((_) async => headers);
+          when(
+            () => mockFeedController.updateRequestHeadersAndRetry(0, headers),
+          ).thenReturn(null);
+
+          await tester.pumpWidget(
+            buildSubject(
+              feedController: mockFeedController,
+              additionalOverrides: [
+                mediaAuthInterceptorProvider.overrideWithValue(
+                  mockMediaAuthInterceptor,
+                ),
+              ],
+            ),
+          );
+          await tester.pump();
+
+          final cubit = BlocProvider.of<VideoPlaybackStatusCubit>(
+            tester.element(find.byType(FeedVideoOverlay)),
+          );
+          cubit.report(testVideo.id, PlaybackStatus.ageRestricted);
+          await tester.pump();
+
+          expect(find.byType(ModeratedContentOverlay), findsOneWidget);
+          expect(
+            find.text(ModeratedContentOverlayStrings.verifyAgeLabel),
+            findsOneWidget,
+          );
+
+          await tester.tap(
+            find.text(ModeratedContentOverlayStrings.verifyAgeLabel),
+          );
+          await tester.pump();
+
+          verify(
+            () => mockMediaAuthInterceptor.handleUnauthorizedMedia(
+              context: any(named: 'context'),
+              sha256Hash: sha256,
+              url: videoUrl,
+              serverUrl: 'https://media.divine.video',
+              category: 'video',
+            ),
+          ).called(1);
+          verify(
+            () => mockFeedController.updateRequestHeadersAndRetry(0, headers),
+          ).called(1);
+          expect(cubit.state.statusFor(testVideo.id), PlaybackStatus.ready);
+        },
+      );
 
       testWidgets('renders $ListAttributionChip when listSources is provided', (
         tester,

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -14,9 +14,13 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
+import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/services/media_auth_interceptor.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_feed_item/actions/actions.dart';
+import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
 import 'package:pooled_video_player/pooled_video_player.dart';
@@ -35,6 +39,10 @@ class MockPlayer extends Mock implements Player {}
 class MockPlayerStream extends Mock implements PlayerStream {}
 
 class MockPlayerState extends Mock implements PlayerState {}
+
+class MockMediaAuthInterceptor extends Mock implements MediaAuthInterceptor {}
+
+class _FakeBuildContext extends Fake implements BuildContext {}
 
 // Full 64-character test IDs
 const testVideoId1 =
@@ -70,6 +78,9 @@ void stubVideoFeedController(
     () => controller.setActive(active: any(named: 'active')),
   ).thenReturn(null);
   when(() => controller.addVideos(any())).thenReturn(null);
+  when(
+    () => controller.updateRequestHeadersAndRetry(any(), any()),
+  ).thenReturn(null);
   when(() => controller.addListener(any())).thenReturn(null);
   when(() => controller.removeListener(any())).thenReturn(null);
   when(controller.dispose).thenReturn(null);
@@ -120,6 +131,8 @@ void main() {
       registerFallbackValue(const FullscreenFeedVideoCacheStarted(index: 0));
       registerFallbackValue(Duration.zero);
       registerFallbackValue(LoadState.none);
+      registerFallbackValue(_FakeBuildContext());
+      registerFallbackValue(<String, String>{});
     });
 
     setUp(() async {
@@ -503,6 +516,79 @@ void main() {
           );
 
           expect(find.byType(PooledVideoFeed), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'verify age retries pooled playback with viewer auth headers',
+        (tester) async {
+          const sha256 =
+              'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+          const videoUrl = 'https://media.divine.video/$sha256/720p.mp4';
+          const headers = {'Authorization': 'Nostr fullscreen-token'};
+          final mockMediaAuthInterceptor = MockMediaAuthInterceptor();
+          final video = createTestVideoEvent(
+            id: testVideoId1,
+            pubkey: testPubkey,
+            videoUrl: videoUrl,
+            sha256: sha256,
+          );
+
+          when(
+            () => mockMediaAuthInterceptor.handleUnauthorizedMedia(
+              context: any(named: 'context'),
+              sha256Hash: sha256,
+              url: videoUrl,
+              serverUrl: 'https://media.divine.video',
+              category: 'video',
+            ),
+          ).thenAnswer((_) async => headers);
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: [video],
+              ),
+              additionalOverrides: [
+                mediaAuthInterceptorProvider.overrideWithValue(
+                  mockMediaAuthInterceptor,
+                ),
+              ],
+            ),
+          );
+          await tester.pump();
+
+          final cubit = BlocProvider.of<VideoPlaybackStatusCubit>(
+            tester.element(find.byType(FullscreenFeedContent)),
+          );
+          cubit.report(video.id, PlaybackStatus.ageRestricted);
+          await tester.pump();
+
+          expect(find.byType(ModeratedContentOverlay), findsOneWidget);
+          expect(
+            find.text(ModeratedContentOverlayStrings.verifyAgeLabel),
+            findsOneWidget,
+          );
+
+          await tester.tap(
+            find.text(ModeratedContentOverlayStrings.verifyAgeLabel),
+          );
+          await tester.pump();
+
+          verify(
+            () => mockMediaAuthInterceptor.handleUnauthorizedMedia(
+              context: any(named: 'context'),
+              sha256Hash: sha256,
+              url: videoUrl,
+              serverUrl: 'https://media.divine.video',
+              category: 'video',
+            ),
+          ).called(1);
+          verify(
+            () => defaultController.updateRequestHeadersAndRetry(0, headers),
+          ).called(1);
+          expect(cubit.state.statusFor(video.id), PlaybackStatus.ready);
         },
       );
     });

--- a/mobile/test/services/media_auth_interceptor_preference_test.dart
+++ b/mobile/test/services/media_auth_interceptor_preference_test.dart
@@ -1,17 +1,18 @@
 // ABOUTME: TDD tests for MediaAuthInterceptor respecting AdultContentPreference
 // ABOUTME: Tests neverShow filtering, alwaysShow auto-auth, and askEachTime dialog flow
 
-import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/services/age_verification_service.dart';
 import 'package:openvine/services/media_auth_interceptor.dart';
+import 'package:openvine/services/media_viewer_auth_service.dart';
 
 class MockAgeVerificationService extends Mock
     implements AgeVerificationService {}
 
-class MockBlossomAuthService extends Mock implements BlossomAuthService {}
+class MockMediaViewerAuthService extends Mock
+    implements MediaViewerAuthService {}
 
 class MockBuildContext extends Mock implements BuildContext {}
 
@@ -19,7 +20,7 @@ class FakeBuildContext extends Fake implements BuildContext {}
 
 void main() {
   late MockAgeVerificationService mockAgeVerificationService;
-  late MockBlossomAuthService mockBlossomAuthService;
+  late MockMediaViewerAuthService mockMediaViewerAuthService;
   late MediaAuthInterceptor interceptor;
   late MockBuildContext mockContext;
 
@@ -29,11 +30,11 @@ void main() {
 
   setUp(() {
     mockAgeVerificationService = MockAgeVerificationService();
-    mockBlossomAuthService = MockBlossomAuthService();
+    mockMediaViewerAuthService = MockMediaViewerAuthService();
     mockContext = MockBuildContext();
     interceptor = MediaAuthInterceptor(
       ageVerificationService: mockAgeVerificationService,
-      blossomAuthService: mockBlossomAuthService,
+      mediaViewerAuthService: mockMediaViewerAuthService,
     );
   });
 
@@ -75,8 +76,9 @@ void main() {
         // Assert - returns null immediately, no auth attempt
         expect(result, isNull);
         verifyNever(
-          () => mockBlossomAuthService.createGetAuthHeader(
+          () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
             serverUrl: any(named: 'serverUrl'),
           ),
         );
@@ -97,11 +99,12 @@ void main() {
           () => mockAgeVerificationService.shouldAutoShowAdultContent,
         ).thenReturn(true);
         when(
-          () => mockBlossomAuthService.createGetAuthHeader(
+          () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
             serverUrl: any(named: 'serverUrl'),
           ),
-        ).thenAnswer((_) async => 'Nostr autoToken');
+        ).thenAnswer((_) async => {'Authorization': 'Nostr autoToken'});
 
         // Act
         final result = await interceptor.handleUnauthorizedMedia(
@@ -111,13 +114,14 @@ void main() {
         );
 
         // Assert - auto auth header created, no dialog shown
-        expect(result, equals('Nostr autoToken'));
+        expect(result, equals({'Authorization': 'Nostr autoToken'}));
         verifyNever(
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
         );
         verify(
-          () =>
-              mockBlossomAuthService.createGetAuthHeader(sha256Hash: 'abc123'),
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: 'abc123',
+          ),
         ).called(1);
       },
     );
@@ -140,11 +144,12 @@ void main() {
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
         ).thenAnswer((_) async => true);
         when(
-          () => mockBlossomAuthService.createGetAuthHeader(
+          () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
             serverUrl: any(named: 'serverUrl'),
           ),
-        ).thenAnswer((_) async => 'Nostr dialogToken');
+        ).thenAnswer((_) async => {'Authorization': 'Nostr dialogToken'});
 
         // Act
         final result = await interceptor.handleUnauthorizedMedia(
@@ -154,13 +159,14 @@ void main() {
         );
 
         // Assert - dialog was shown, auth header created after confirmation
-        expect(result, equals('Nostr dialogToken'));
+        expect(result, equals({'Authorization': 'Nostr dialogToken'}));
         verify(
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
         ).called(1);
         verify(
-          () =>
-              mockBlossomAuthService.createGetAuthHeader(sha256Hash: 'abc123'),
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: 'abc123',
+          ),
         ).called(1);
       },
     );
@@ -196,8 +202,9 @@ void main() {
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
         ).called(1);
         verifyNever(
-          () => mockBlossomAuthService.createGetAuthHeader(
+          () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
             serverUrl: any(named: 'serverUrl'),
           ),
         );

--- a/mobile/test/services/media_auth_interceptor_test.dart
+++ b/mobile/test/services/media_auth_interceptor_test.dart
@@ -1,17 +1,18 @@
 // ABOUTME: Tests for media authentication interceptor handling 401 errors
 // ABOUTME: Validates privacy-first auth flow for age-restricted Blossom content
 
-import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/services/age_verification_service.dart';
 import 'package:openvine/services/media_auth_interceptor.dart';
+import 'package:openvine/services/media_viewer_auth_service.dart';
 
 class MockAgeVerificationService extends Mock
     implements AgeVerificationService {}
 
-class MockBlossomAuthService extends Mock implements BlossomAuthService {}
+class MockMediaViewerAuthService extends Mock
+    implements MediaViewerAuthService {}
 
 class MockBuildContext extends Mock implements BuildContext {}
 
@@ -19,7 +20,7 @@ class FakeBuildContext extends Fake implements BuildContext {}
 
 void main() {
   late MockAgeVerificationService mockAgeVerificationService;
-  late MockBlossomAuthService mockBlossomAuthService;
+  late MockMediaViewerAuthService mockMediaViewerAuthService;
   late MediaAuthInterceptor interceptor;
   late MockBuildContext mockContext;
 
@@ -29,11 +30,11 @@ void main() {
 
   setUp(() {
     mockAgeVerificationService = MockAgeVerificationService();
-    mockBlossomAuthService = MockBlossomAuthService();
+    mockMediaViewerAuthService = MockMediaViewerAuthService();
     mockContext = MockBuildContext();
     interceptor = MediaAuthInterceptor(
       ageVerificationService: mockAgeVerificationService,
-      blossomAuthService: mockBlossomAuthService,
+      mediaViewerAuthService: mockMediaViewerAuthService,
     );
 
     // Default mock behavior for preference checks
@@ -71,8 +72,9 @@ void main() {
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
         ).called(1);
         verifyNever(
-          () => mockBlossomAuthService.createGetAuthHeader(
+          () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
             serverUrl: any(named: 'serverUrl'),
           ),
         );
@@ -87,11 +89,14 @@ void main() {
           () => mockAgeVerificationService.shouldAutoShowAdultContent,
         ).thenReturn(true);
         when(
-          () => mockBlossomAuthService.createGetAuthHeader(
+          () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
             serverUrl: any(named: 'serverUrl'),
           ),
-        ).thenAnswer((_) async => 'Nostr abc123token');
+        ).thenAnswer(
+          (_) async => {'Authorization': 'Nostr abc123token'},
+        );
 
         // Act
         final result = await interceptor.handleUnauthorizedMedia(
@@ -101,13 +106,14 @@ void main() {
         );
 
         // Assert
-        expect(result, equals('Nostr abc123token'));
+        expect(result, equals({'Authorization': 'Nostr abc123token'}));
         verifyNever(
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
         );
         verify(
-          () =>
-              mockBlossomAuthService.createGetAuthHeader(sha256Hash: 'abc123'),
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: 'abc123',
+          ),
         ).called(1);
       },
     );
@@ -121,11 +127,14 @@ void main() {
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
         ).thenAnswer((_) async => true);
         when(
-          () => mockBlossomAuthService.createGetAuthHeader(
+          () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
             serverUrl: any(named: 'serverUrl'),
           ),
-        ).thenAnswer((_) async => 'Nostr abc123token');
+        ).thenAnswer(
+          (_) async => {'Authorization': 'Nostr abc123token'},
+        );
 
         // Act
         final result = await interceptor.handleUnauthorizedMedia(
@@ -135,13 +144,14 @@ void main() {
         );
 
         // Assert
-        expect(result, equals('Nostr abc123token'));
+        expect(result, equals({'Authorization': 'Nostr abc123token'}));
         verify(
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
         ).called(1);
         verify(
-          () =>
-              mockBlossomAuthService.createGetAuthHeader(sha256Hash: 'abc123'),
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: 'abc123',
+          ),
         ).called(1);
       },
     );
@@ -152,11 +162,14 @@ void main() {
         () => mockAgeVerificationService.shouldAutoShowAdultContent,
       ).thenReturn(true);
       when(
-        () => mockBlossomAuthService.createGetAuthHeader(
+        () => mockMediaViewerAuthService.createAuthHeaders(
           sha256Hash: any(named: 'sha256Hash'),
+          url: any(named: 'url'),
           serverUrl: any(named: 'serverUrl'),
         ),
-      ).thenAnswer((_) async => 'Nostr tokenWithServer');
+      ).thenAnswer(
+        (_) async => {'Authorization': 'Nostr tokenWithServer'},
+      );
 
       // Act
       final result = await interceptor.handleUnauthorizedMedia(
@@ -167,9 +180,9 @@ void main() {
       );
 
       // Assert
-      expect(result, equals('Nostr tokenWithServer'));
+      expect(result, equals({'Authorization': 'Nostr tokenWithServer'}));
       verify(
-        () => mockBlossomAuthService.createGetAuthHeader(
+        () => mockMediaViewerAuthService.createAuthHeaders(
           sha256Hash: 'xyz789',
           serverUrl: 'https://blossom.example.com',
         ),
@@ -182,11 +195,12 @@ void main() {
         () => mockAgeVerificationService.shouldAutoShowAdultContent,
       ).thenReturn(true);
       when(
-        () => mockBlossomAuthService.createGetAuthHeader(
+        () => mockMediaViewerAuthService.createAuthHeaders(
           sha256Hash: any(named: 'sha256Hash'),
+          url: any(named: 'url'),
           serverUrl: any(named: 'serverUrl'),
         ),
-      ).thenAnswer((_) async => 'Nostr token');
+      ).thenAnswer((_) async => {'Authorization': 'Nostr token'});
 
       // Act - Test with different category (future-proofing for violence, etc.)
       await interceptor.handleUnauthorizedMedia(
@@ -197,7 +211,9 @@ void main() {
 
       // Assert - Should still work (currently only handles nudity/adult content)
       verify(
-        () => mockBlossomAuthService.createGetAuthHeader(sha256Hash: 'abc123'),
+        () => mockMediaViewerAuthService.createAuthHeaders(
+          sha256Hash: 'abc123',
+        ),
       ).called(1);
     });
 
@@ -209,8 +225,9 @@ void main() {
           () => mockAgeVerificationService.shouldAutoShowAdultContent,
         ).thenReturn(true);
         when(
-          () => mockBlossomAuthService.createGetAuthHeader(
+          () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
             serverUrl: any(named: 'serverUrl'),
           ),
         ).thenAnswer((_) async => null);
@@ -229,16 +246,16 @@ void main() {
   });
 
   group('MediaAuthInterceptor - helper methods', () {
-    test('canCreateAuthHeaders delegates to BlossomAuthService', () {
+    test('canCreateAuthHeaders delegates to MediaViewerAuthService', () {
       // Arrange
-      when(() => mockBlossomAuthService.canCreateHeaders).thenReturn(true);
+      when(() => mockMediaViewerAuthService.canCreateHeaders).thenReturn(true);
 
       // Act
       final result = interceptor.canCreateAuthHeaders;
 
       // Assert
       expect(result, isTrue);
-      verify(() => mockBlossomAuthService.canCreateHeaders).called(1);
+      verify(() => mockMediaViewerAuthService.canCreateHeaders).called(1);
     });
   });
 }

--- a/mobile/test/services/media_viewer_auth_service_test.dart
+++ b/mobile/test/services/media_viewer_auth_service_test.dart
@@ -140,7 +140,6 @@ void main() {
       verify(
         () => mockBlossomAuthService.createGetAuthHeader(
           sha256Hash: 'abc123',
-          serverUrl: null,
         ),
       ).called(1);
       verifyNever(

--- a/mobile/test/services/media_viewer_auth_service_test.dart
+++ b/mobile/test/services/media_viewer_auth_service_test.dart
@@ -1,0 +1,174 @@
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/media_viewer_auth_service.dart';
+import 'package:openvine/services/nip98_auth_service.dart';
+
+class MockAuthService extends Mock implements AuthService {}
+
+class MockBlossomAuthService extends Mock implements BlossomAuthService {}
+
+class MockNip98AuthService extends Mock implements Nip98AuthService {}
+
+void main() {
+  late MockAuthService mockAuthService;
+  late MockBlossomAuthService mockBlossomAuthService;
+  late MockNip98AuthService mockNip98AuthService;
+  late MediaViewerAuthService service;
+
+  setUpAll(() {
+    registerFallbackValue(HttpMethod.get);
+  });
+
+  setUp(() {
+    mockAuthService = MockAuthService();
+    mockBlossomAuthService = MockBlossomAuthService();
+    mockNip98AuthService = MockNip98AuthService();
+    service = MediaViewerAuthService(
+      authService: mockAuthService,
+      blossomAuthService: mockBlossomAuthService,
+      nip98AuthService: mockNip98AuthService,
+    );
+  });
+
+  group('MediaViewerAuthService', () {
+    test('prefers Blossom auth when a SHA-256 hash is known', () async {
+      when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(
+        () => mockBlossomAuthService.createGetAuthHeader(
+          sha256Hash: any(named: 'sha256Hash'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      ).thenAnswer((_) async => 'Nostr blossom-token');
+
+      final headers = await service.createAuthHeaders(
+        sha256Hash: 'abc123',
+        url: 'https://media.divine.video/abc123/720p.mp4',
+        serverUrl: 'https://media.divine.video',
+      );
+
+      expect(headers, equals({'Authorization': 'Nostr blossom-token'}));
+      verify(
+        () => mockBlossomAuthService.createGetAuthHeader(
+          sha256Hash: 'abc123',
+          serverUrl: 'https://media.divine.video',
+        ),
+      ).called(1);
+      verifyNever(
+        () => mockNip98AuthService.createAuthToken(
+          url: any(named: 'url'),
+          method: any(named: 'method'),
+        ),
+      );
+    });
+
+    test('falls back to NIP-98 auth when only a URL is available', () async {
+      when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(
+        () => mockNip98AuthService.createAuthToken(
+          url: any(named: 'url'),
+          method: any(named: 'method'),
+        ),
+      ).thenAnswer(
+        (_) async => Nip98Token(
+          token: 'nip98-token',
+          signedEvent: _createMockEvent(),
+          createdAt: DateTime.now(),
+          expiresAt: DateTime.now().add(const Duration(minutes: 10)),
+        ),
+      );
+
+      final headers = await service.createAuthHeaders(
+        url: 'https://media.divine.video/no-hash/playlist.m3u8',
+      );
+
+      expect(headers, equals({'Authorization': 'Nostr nip98-token'}));
+      verify(
+        () => mockNip98AuthService.createAuthToken(
+          url: 'https://media.divine.video/no-hash/playlist.m3u8',
+          method: HttpMethod.get,
+        ),
+      ).called(1);
+      verifyNever(
+        () => mockBlossomAuthService.createGetAuthHeader(
+          sha256Hash: any(named: 'sha256Hash'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      );
+    });
+
+    test('returns null when the user is unauthenticated', () async {
+      when(() => mockAuthService.isAuthenticated).thenReturn(false);
+
+      final headers = await service.createAuthHeaders(
+        sha256Hash: 'abc123',
+        url: 'https://media.divine.video/abc123/720p.mp4',
+      );
+
+      expect(headers, isNull);
+      verifyNever(
+        () => mockBlossomAuthService.createGetAuthHeader(
+          sha256Hash: any(named: 'sha256Hash'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      );
+      verifyNever(
+        () => mockNip98AuthService.createAuthToken(
+          url: any(named: 'url'),
+          method: any(named: 'method'),
+        ),
+      );
+    });
+
+    test('never returns both protocols for a single request', () async {
+      when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(
+        () => mockBlossomAuthService.createGetAuthHeader(
+          sha256Hash: any(named: 'sha256Hash'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      ).thenAnswer((_) async => 'Nostr blossom-token');
+
+      final headers = await service.createAuthHeaders(
+        sha256Hash: 'abc123',
+        url: 'https://media.divine.video/abc123/720p.mp4',
+      );
+
+      expect(headers, equals({'Authorization': 'Nostr blossom-token'}));
+      verify(
+        () => mockBlossomAuthService.createGetAuthHeader(
+          sha256Hash: 'abc123',
+          serverUrl: null,
+        ),
+      ).called(1);
+      verifyNever(
+        () => mockNip98AuthService.createAuthToken(
+          url: any(named: 'url'),
+          method: any(named: 'method'),
+        ),
+      );
+    });
+  });
+}
+
+Event _createMockEvent() {
+  final timestamp = (DateTime.now().millisecondsSinceEpoch / 1000).round();
+  return Event.fromJson({
+    'id': 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+    'kind': 27235,
+    'pubkey':
+        'aabbccdd0123456789abcdef0123456789abcdef0123456789abcdef01234567',
+    'created_at': timestamp,
+    'content': '',
+    'tags': const <List<String>>[
+      ['u', 'https://media.divine.video/no-hash/playlist.m3u8'],
+      ['method', 'GET'],
+    ],
+    'sig':
+        'deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567'
+        '89abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234567'
+        '89ab',
+  });
+}


### PR DESCRIPTION
Closes #3128

## Summary
- add a shared media viewer auth service that selects Blossom/BUD-01 when a blob hash is known and NIP-98 when only a URL is available
- route both legacy playback and pooled playback through that shared viewer-auth contract, including authenticated pooled media sources and retry support
- wire Verify Age into a real pooled playback retry and document the accepted viewer-auth contract for age-gated Blossom media

## Test Plan
- [x] cd mobile && flutter test test/services/media_viewer_auth_service_test.dart test/services/media_auth_interceptor_test.dart test/services/media_auth_interceptor_preference_test.dart test/providers/individual_video_providers_test.dart test/screens/feed/feed_video_overlay_test.dart test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
- [x] cd mobile/packages/pooled_video_player && flutter test test/controllers/video_feed_controller_test.dart
- [x] cd mobile && flutter analyze lib/services lib/screens/feed lib/providers
- [x] cd mobile/packages/pooled_video_player && flutter analyze lib
- [x] repo pre-push hook
