### PR TITLE
fix(feed): skip confirmed missing web videos

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
 import 'package:models/models.dart';
 import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
@@ -84,6 +85,23 @@ double _scrollDrivenOpacity(double distance) {
     )!;
   }
   return 0.0;
+}
+
+Future<bool> confirmWebVideoNotFound(
+  String videoUrl, {
+  http.Client? client,
+}) async {
+  final effectiveClient = client ?? http.Client();
+  try {
+    final response = await effectiveClient.head(Uri.parse(videoUrl));
+    return response.statusCode == 404;
+  } catch (_) {
+    return false;
+  } finally {
+    if (client == null) {
+      effectiveClient.close();
+    }
+  }
 }
 
 /// Arguments for navigating to PooledFullscreenVideoFeedScreen.
@@ -234,6 +252,7 @@ class FullscreenFeedContent extends ConsumerStatefulWidget {
     this.sourceDetail,
     this.autoOpenComments = false,
     this.onPageChanged,
+    @visibleForTesting this.confirmWebNotFound = confirmWebVideoNotFound,
     @visibleForTesting this.controllerFactory,
     @visibleForTesting this.webControllerFactory,
     super.key,
@@ -257,6 +276,10 @@ class FullscreenFeedContent extends ConsumerStatefulWidget {
   ///
   /// Used by embedded surfaces to keep the URL in sync.
   final void Function(int index)? onPageChanged;
+
+  /// Confirms whether a failed web video URL is a removable 404.
+  @visibleForTesting
+  final Future<bool> Function(String videoUrl) confirmWebNotFound;
 
   /// Optional factory for creating the [VideoFeedController].
   ///
@@ -282,6 +305,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
   late final ValueNotifier<double> _pagePosition;
   final _feedKey = GlobalKey<PooledVideoFeedState>();
   final _webFeedKey = GlobalKey<WebVideoFeedState>();
+  final Set<String> _handledWebNotFoundVideoIds = <String>{};
 
   /// Feed-scoped Auto playback state; exposed to descendants via
   /// `BlocProvider.value` in [build].
@@ -428,12 +452,36 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
     );
   }
 
-  /// Treat a failed web player as "completed" so Auto skips past broken
-  /// videos. Only fires for the currently-active page to avoid advancing
-  /// when a background/preloaded player fails.
-  void _handleWebPlayerErrored(int index) {
-    if (index != context.read<FullscreenFeedBloc>().state.currentIndex) return;
-    _handleAutoAdvanceCompleted();
+  /// Confirms removable 404s on web and skips past them.
+  ///
+  /// Non-404 failures still feed into the existing auto-advance completion
+  /// flow so generic broken videos do not regress.
+  Future<bool> _handleWebPlayerErrored(VideoEvent video, int index) async {
+    final currentIndex = context.read<FullscreenFeedBloc>().state.currentIndex;
+    if (index != currentIndex) return false;
+
+    final videoUrl = video.videoUrl;
+    if (videoUrl == null || videoUrl.isEmpty) {
+      _handleAutoAdvanceCompleted();
+      return false;
+    }
+    if (!_handledWebNotFoundVideoIds.add(video.id)) return false;
+
+    final isNotFound = await widget.confirmWebNotFound(videoUrl);
+    final isStillCurrent =
+        mounted &&
+        index == context.read<FullscreenFeedBloc>().state.currentIndex;
+
+    if (!isNotFound) {
+      _handledWebNotFoundVideoIds.remove(video.id);
+      if (isStillCurrent) {
+        _handleAutoAdvanceCompleted();
+      }
+      return false;
+    }
+
+    ref.read(videoEventServiceProvider).removeVideoCompletely(video.id);
+    return isStillCurrent;
   }
 
   void _continuePendingAutoAdvance(FullscreenFeedState state) {

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -283,9 +283,10 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   /// Treat a failed web player as "completed" so Auto skips past broken
   /// videos. Only fires for the currently-active page to avoid advancing
   /// when a background/preloaded player fails.
-  void _handleWebPlayerErrored(int index) {
-    if (index != _currentFeedIndex()) return;
+  Future<bool> _handleWebPlayerErrored(VideoEvent video, int index) async {
+    if (index != _currentFeedIndex()) return false;
     _handleAutoAdvanceCompleted();
+    return false;
   }
 
   void _continuePendingAutoAdvance(VideoFeedState state) {

--- a/mobile/lib/widgets/web_video_feed.dart
+++ b/mobile/lib/widgets/web_video_feed.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Web-native video feed using Flutter's video_player package
 // ABOUTME: Replaces PooledVideoFeed on web where media_kit is not available
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -28,11 +30,12 @@ typedef WebOnActiveVideoChanged = void Function(VideoEvent video, int index);
 /// Callback fired when the active web player crosses the loop boundary.
 typedef WebOnCompleted = void Function(int index);
 
-/// Callback fired when a web player for [index] fails to load or initialise.
+/// Callback fired when a web player for the active video fails to load.
 ///
-/// Used by auto-advance to skip past broken videos instead of getting stuck
-/// on them — a failed player never emits a loop-boundary crossing.
-typedef WebOnErrored = void Function(int index);
+/// Return `true` to auto-advance to the next page after the error has been
+/// handled. This lets the caller confirm a removable 404 before the feed
+/// skips away from the broken item.
+typedef WebOnErrored = Future<bool> Function(VideoEvent video, int index);
 
 /// A vertical-scrolling video feed for web platforms.
 ///
@@ -117,6 +120,7 @@ class WebVideoFeedState extends State<WebVideoFeed> {
   final Map<int, VoidCallback> _controllerListeners = {};
   final Map<int, Duration> _lastPositions = {};
   final Map<int, bool> _armedForCompletion = {};
+  final Set<String> _handlingErrorVideoIds = <String>{};
 
   int get currentIndex => _currentIndex;
   int get videoCount => widget.videos.length;
@@ -305,6 +309,30 @@ class WebVideoFeedState extends State<WebVideoFeed> {
     _lastPositions[index] = position;
   }
 
+  Future<void> _handleActiveVideoError(VideoEvent video, int index) async {
+    if (!mounted || index != _currentIndex) return;
+
+    final handler = widget.onErrored;
+    if (handler == null) return;
+    if (!_handlingErrorVideoIds.add(video.id)) return;
+
+    try {
+      final shouldAdvance = await handler(video, index);
+      if (!mounted || index != _currentIndex || !shouldAdvance) return;
+
+      final nextIndex = index + 1;
+      if (nextIndex >= widget.videos.length) return;
+
+      await _pageController.animateToPage(
+        nextIndex,
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeOut,
+      );
+    } finally {
+      _handlingErrorVideoIds.remove(video.id);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return PageView.builder(
@@ -343,10 +371,7 @@ class WebVideoFeedState extends State<WebVideoFeed> {
             if (!mounted) return;
             _onPlayerDisposed(index);
           },
-          onError: () {
-            if (!mounted) return;
-            widget.onErrored?.call(index);
-          },
+          onError: () => unawaited(_handleActiveVideoError(video, index)),
         );
       },
     );

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_web_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_web_test.dart
@@ -6,7 +6,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/video_feed_item/actions/actions.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
@@ -21,6 +23,17 @@ class MockFullscreenFeedBloc
     extends MockBloc<FullscreenFeedEvent, FullscreenFeedState>
     implements FullscreenFeedBloc {}
 
+class MockVideoEventService extends Mock implements VideoEventService {}
+
+class _ErroringVideoPlayerController extends FakeVideoPlayerController {
+  _ErroringVideoPlayerController({required super.source});
+
+  @override
+  Future<void> initialize() async {
+    throw Exception('load failed');
+  }
+}
+
 const _testVideoId =
     'a1b2c3d4e5f6789012345678901234567890abcdef123456789012345678901234';
 const _testPubkey =
@@ -31,6 +44,7 @@ void main() {
     late MockFullscreenFeedBloc mockBloc;
     late MockAuthService mockAuthService;
     late MockProfileRepository mockProfileRepository;
+    late MockVideoEventService mockVideoEventService;
     late StreamController<FullscreenFeedState> stateController;
     late video_platform.VideoPlayerPlatform originalPlatform;
     late FakeVideoPlayerController webController;
@@ -43,6 +57,7 @@ void main() {
       mockBloc = MockFullscreenFeedBloc();
       mockAuthService = createMockAuthService();
       mockProfileRepository = createMockProfileRepository();
+      mockVideoEventService = MockVideoEventService();
       stateController = StreamController<FullscreenFeedState>.broadcast();
       originalPlatform = video_platform.VideoPlayerPlatform.instance;
       video_platform.VideoPlayerPlatform.instance = FakeVideoPlayerPlatform();
@@ -50,6 +65,9 @@ void main() {
 
       when(() => mockBloc.stream).thenAnswer((_) => stateController.stream);
       when(() => mockAuthService.currentPublicKeyHex).thenReturn(null);
+      when(
+        () => mockVideoEventService.removeVideoCompletely(any()),
+      ).thenReturn(null);
     });
 
     tearDown(() async {
@@ -126,6 +144,65 @@ void main() {
         await tester.pump();
 
         expect(find.byType(AutoActionButton), findsOneWidget);
+      },
+      skip: !kIsWeb,
+    );
+
+    testWidgets(
+      'removes and skips confirmed missing web videos',
+      (tester) async {
+        final firstVideo = createTestVideoEvent(
+          id: _testVideoId,
+          pubkey: _testPubkey,
+          videoUrl: 'https://example.com/missing.mp4',
+        );
+        final secondVideo = createTestVideoEvent(
+          id: 'b2c3d4e5f6789012345678901234567890abcdef123456789012345678901234',
+          pubkey: _testPubkey,
+          videoUrl: 'https://example.com/ok.mp4',
+        );
+        final state = FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [firstVideo, secondVideo],
+        );
+        when(() => mockBloc.state).thenReturn(state);
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            additionalOverrides: [
+              videoEventServiceProvider.overrideWithValue(
+                mockVideoEventService,
+              ),
+            ],
+            mockAuthService: mockAuthService,
+            mockProfileRepository: mockProfileRepository,
+            home: BlocProvider<FullscreenFeedBloc>.value(
+              value: mockBloc,
+              child: FullscreenFeedContent(
+                confirmWebNotFound: (_) async => true,
+                webControllerFactory:
+                    ({
+                      required url,
+                      required headers,
+                    }) => url.toString().contains('missing')
+                    ? _ErroringVideoPlayerController(
+                        source: url.toString(),
+                      )
+                    : FakeVideoPlayerController(source: url.toString()),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
+        await tester.pump(const Duration(milliseconds: 350));
+
+        verify(
+          () => mockVideoEventService.removeVideoCompletely(firstVideo.id),
+        ).called(1);
+        verify(
+          () => mockBloc.add(const FullscreenFeedIndexChanged(1)),
+        ).called(1);
       },
       skip: !kIsWeb,
     );

--- a/mobile/test/screens/feed/web_video_not_found_confirmation_test.dart
+++ b/mobile/test/screens/feed/web_video_not_found_confirmation_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+
+void main() {
+  test('confirms web video is session-missing only on HEAD 404', () async {
+    final client = MockClient((request) async {
+      expect(request.method, 'HEAD');
+      return http.Response('', 404);
+    });
+
+    expect(
+      await confirmWebVideoNotFound(
+        'https://example.com/missing.mp4',
+        client: client,
+      ),
+      isTrue,
+    );
+  });
+
+  test('does not mark web video missing on non-404 responses', () async {
+    final client = MockClient((request) async => http.Response('', 200));
+
+    expect(
+      await confirmWebVideoNotFound(
+        'https://example.com/ok.mp4',
+        client: client,
+      ),
+      isFalse,
+    );
+  });
+}

--- a/mobile/test/widgets/web_video_feed_test.dart
+++ b/mobile/test/widgets/web_video_feed_test.dart
@@ -10,8 +10,11 @@ import 'package:video_player_platform_interface/video_player_platform_interface.
 
 class _FakeVideoPlayerController extends ValueNotifier<VideoPlayerValue>
     implements VideoPlayerController {
-  _FakeVideoPlayerController()
-    : super(const VideoPlayerValue(duration: Duration.zero));
+  _FakeVideoPlayerController({
+    this.initializeError,
+  }) : super(const VideoPlayerValue(duration: Duration.zero));
+
+  final Exception? initializeError;
 
   void emitValue(VideoPlayerValue newValue) {
     value = newValue;
@@ -20,6 +23,8 @@ class _FakeVideoPlayerController extends ValueNotifier<VideoPlayerValue>
 
   @override
   Future<void> initialize() async {
+    final error = initializeError;
+    if (error != null) throw error;
     value = const VideoPlayerValue(
       duration: Duration(seconds: 6),
       isInitialized: true,
@@ -266,6 +271,42 @@ void main() {
     expect(key.currentState!.currentIndex, 1);
     expect(activeIndex, 1);
   });
+
+  testWidgets(
+    'auto-skips when the active web video error handler confirms removal',
+    (tester) async {
+      final firstController = _FakeVideoPlayerController(
+        initializeError: Exception('load failed'),
+      );
+      final secondController = _FakeVideoPlayerController();
+      final handledIndexes = <int>[];
+      final activeIndexes = <int>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WebVideoFeed(
+            videos: [_makeVideo(), _makeVideo(seed: 1)],
+            controllerFactory: ({required url, required headers}) {
+              return url.toString().contains('video0')
+                  ? firstController
+                  : secondController;
+            },
+            onActiveVideoChanged: (_, index) => activeIndexes.add(index),
+            onErrored: (video, index) async {
+              handledIndexes.add(index);
+              expect(video.id, _makeVideo().id);
+              return true;
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(handledIndexes, [0]);
+      expect(activeIndexes, contains(1));
+    },
+  );
 
   testWidgets(
     'drops controller entries when WebVideoPlayer items are disposed',


### PR DESCRIPTION
Closes #3131

## Summary
- confirm web video load failures with a  request before treating them as missing
- remove confirmed 404 videos from the feed source and auto-skip the active web player to the next item
- add regression coverage for the web feed skip path and the 404 confirmation helper

## Test Plan
- [x] Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 91.0.0 (99.0.0 available)
  _flutterfire_internals 1.3.66 (1.3.69 available)
  alchemist 0.12.1 (0.14.0 available)
  analyzer 8.4.0 (12.1.0 available)
  analyzer_buffer 0.1.11 (0.3.1 available)
  analyzer_plugin 0.13.10 (0.14.8 available)
! app_device_integrity 1.1.0 from path overrides/app_device_integrity-1.1.0 (overridden)
  app_links 6.4.1 (7.0.0 available)
  archive 4.0.7 (4.0.9 available)
  async 2.13.0 (2.13.1 available)
  audio_session 0.2.2 (0.2.3 available)
  bip340 0.3.0 (0.3.1 available)
  build 4.0.3 (4.0.5 available)
  build_config 1.2.0 (1.3.0 available)
  build_runner 2.10.4 (2.13.1 available)
  built_value 8.12.1 (8.12.5 available)
  cli_launcher 0.3.2+1 (0.3.3+1 available)
  code_builder 4.11.0 (4.11.1 available)
  connectivity_plus 7.0.0 (7.1.1 available)
  connectivity_plus_platform_interface 2.0.1 (2.1.0 available)
  cookie_jar 4.0.8 (4.0.9 available)
  cross_file 0.3.5+1 (0.3.5+2 available)
! cryptography_flutter 2.3.2 from path overrides/cryptography_flutter-2.3.2 (overridden)
  cupertino_icons 1.0.8 (1.0.9 available)
  custom_lint_core 0.8.1 (0.8.2 available)
  custom_lint_visitor 1.0.0+8.4.0 (1.0.0+9.0.0 available)
  dart_style 3.1.3 (3.1.8 available)
  dbus 0.7.11 (0.7.12 available)
  dev_build 1.1.3+1 (1.1.5+2 available)
! device_info_plus 10.1.2 (overridden) (13.0.0 available)
  device_info_plus_platform_interface 7.0.3 (8.0.0 available)
  dio 5.9.0 (5.9.2 available)
  dio_cookie_manager 3.3.0 (3.4.0 available)
  dio_web_adapter 2.1.1 (2.1.2 available)
  drift 2.30.0 (2.32.1 available)
  drift_dev 2.30.0 (2.32.1 available)
  drift_flutter 0.2.8 (0.3.0 available)
  ffi 2.1.5 (2.2.0 available)
  file_picker 10.3.8 (11.0.2 available)
  file_selector_android 0.5.2+4 (0.5.2+5 available)
  firebase_analytics 12.1.2 (12.3.0 available)
  firebase_analytics_platform_interface 5.0.6 (5.1.1 available)
  firebase_analytics_web 0.6.1+2 (0.6.1+5 available)
  firebase_core 4.4.0 (4.7.0 available)
  firebase_core_platform_interface 6.0.2 (6.0.3 available)
  firebase_core_web 3.4.0 (3.6.0 available)
  firebase_crashlytics 5.0.7 (5.2.0 available)
  firebase_crashlytics_platform_interface 3.8.17 (3.8.20 available)
  firebase_messaging 16.1.1 (16.2.0 available)
  firebase_messaging_platform_interface 4.7.6 (4.7.9 available)
  firebase_messaging_web 4.1.2 (4.1.5 available)
  firebase_performance 0.11.1+4 (0.11.3 available)
  firebase_performance_platform_interface 0.1.6+4 (0.1.6+7 available)
  firebase_performance_web 0.1.8+2 (0.1.8+5 available)
  flutter_local_notifications 19.5.0 (21.0.0 available)
  flutter_local_notifications_linux 6.0.0 (8.0.0 available)
  flutter_local_notifications_platform_interface 9.1.0 (11.0.0 available)
  flutter_local_notifications_windows 1.0.3 (3.0.0 available)
  flutter_plugin_android_lifecycle 2.0.33 (2.0.34 available)
  flutter_riverpod 3.0.3 (3.3.1 available)
  flutter_secure_storage 9.2.4 (10.0.0 available)
  flutter_secure_storage_linux 1.2.3 (3.0.0 available)
  flutter_secure_storage_macos 3.1.3 (4.0.0 available)
  flutter_secure_storage_platform_interface 1.1.2 (2.0.1 available)
  flutter_secure_storage_web 1.2.1 (2.1.0 available)
  flutter_secure_storage_windows 3.1.2 (4.1.0 available)
  flutter_svg 2.2.3 (2.2.4 available)
  flutter_web_auth_2 4.1.0 (5.0.2 available)
  flutter_web_auth_2_platform_interface 4.1.0 (5.0.0 available)
  freezed 3.2.3 (3.2.5 available)
  go_router 16.3.0 (17.2.1 available)
  golden_toolkit 0.15.0 (discontinued)
  google_fonts 6.3.3 (8.0.2 available)
  hive_ce 2.16.0 (2.19.3 available)
  hive_ce_flutter 2.3.3 (2.3.4 available)
  hive_ce_generator 1.10.0 (1.11.1 available)
  image 4.7.2 (4.8.0 available)
  image_picker_android 0.8.13+10 (0.8.13+16 available)
  image_picker_ios 0.8.13+3 (0.8.13+6 available)
  isolate_channel 0.2.2+1 (0.6.1 available)
  js 0.6.7 (0.7.2 available)
  json_annotation 4.9.0 (4.11.0 available)
  json_serializable 6.11.2 (6.13.1 available)
  lints 6.0.0 (6.1.0 available)
  melos 7.3.0 (7.5.1 available)
! meta 1.17.0 (overridden) (1.18.2 available)
  mockito 5.6.1 (5.6.4 available)
  mocktail 1.0.4 (1.0.5 available)
  mustache_template 2.0.2 (2.0.4 available)
  package_info_plus 9.0.0 (10.0.0 available)
  package_info_plus_platform_interface 3.2.1 (4.0.0 available)
  path_provider_android 2.2.22 (2.3.1 available)
  path_provider_foundation 2.5.1 (2.6.0 available)
  patrol 4.2.0 (4.5.0 available)
  patrol_finders 3.1.0 (3.2.0 available)
  patrol_log 0.7.1 (0.8.0 available)
  petitparser 7.0.1 (7.0.2 available)
  pointycastle 3.9.1 (4.0.0 available)
  posix 6.0.3 (6.5.0 available)
  pro_image_editor 12.0.13 (12.4.1 available)
  pro_video_editor 1.14.2 (1.15.0 available)
  process_run 1.2.4 (1.3.2 available)
  riverpod 3.0.3 (3.2.1 available)
  riverpod_analyzer_utils 1.0.0-dev.7 (1.0.0-dev.9 available)
  riverpod_annotation 3.0.3 (4.0.2 available)
  riverpod_generator 3.0.3 (4.0.3 available)
! rxdart 0.28.0 (overridden)
  share_plus 12.0.1 (13.0.0 available)
  share_plus_platform_interface 6.1.0 (7.0.0 available)
  shared_preferences 2.5.4 (2.5.5 available)
  shared_preferences_android 2.4.18 (2.4.23 available)
  shared_preferences_platform_interface 2.4.1 (2.4.2 available)
  shelf_web_socket 2.0.1 (3.0.0 available)
  skeletonizer 2.1.2 (2.1.3 available)
  source_gen 4.1.1 (4.2.2 available)
  source_helper 1.3.8 (1.3.11 available)
  source_span 1.10.1 (1.10.2 available)
  sqflite_android 2.4.2+2 (2.4.2+3 available)
  sqflite_common_ffi 2.3.6 (2.4.0+2 available)
  sqflite_common_ffi_web 0.4.5+4 (1.1.1 available)
  sqlite3 2.9.4 (3.3.1 available)
  sqlite3_flutter_libs 0.5.41 (0.6.0+eol available)
  sqlparser 0.42.1 (0.44.3 available)
  test 1.30.0 (1.31.0 available)
  test_api 0.7.10 (0.7.11 available)
  test_core 0.6.16 (0.6.17 available)
  timezone 0.10.1 (0.11.0 available)
  unique_names_generator 3.0.0 (3.1.2 available)
  url_launcher_android 6.3.28 (6.3.29 available)
  url_launcher_ios 6.3.6 (6.4.1 available)
  url_launcher_web 2.4.1 (2.4.2 available)
  uuid 4.5.2 (4.5.3 available)
  vector_graphics 1.1.19 (1.1.21 available)
  vector_graphics_compiler 1.1.19 (1.2.0 available)
  vector_math 2.2.0 (2.3.0 available)
  video_player 2.10.1 (2.11.1 available)
  video_player_android 2.9.1 (2.9.5 available)
  video_player_avfoundation 2.8.8 (2.9.4 available)
  vm_service 15.0.2 (15.1.0 available)
  wakelock_plus 1.4.0 (1.6.0 available)
  wakelock_plus_platform_interface 1.3.0 (1.5.0 available)
  watcher 1.2.0 (1.2.1 available)
  webview_flutter_android 4.10.13 (4.11.0 available)
  webview_flutter_platform_interface 2.14.0 (2.15.1 available)
  webview_flutter_wkwebview 3.24.1 (3.24.3 available)
  win32 5.15.0 (6.0.1 available)
  win32_registry 1.1.5 (3.0.3 available)
  yaml_edit 2.2.3 (2.2.4 available)
Got dependencies!
1 package is discontinued.
144 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
00:00 +0: loading /Users/rabble/code/divine/divine-mobile/.worktrees/web-search-404-handling/mobile/test/widgets/web_video_feed_test.dart
00:00 +0: /Users/rabble/code/divine/divine-mobile/.worktrees/web-search-404-handling/mobile/test/widgets/web_video_feed_test.dart: rebuilds itemBuilder when the web controller initializes
00:00 +1: /Users/rabble/code/divine/divine-mobile/.worktrees/web-search-404-handling/mobile/test/widgets/web_video_feed_test.dart: rebuilds itemBuilder when the web controller initializes
00:00 +2: /Users/rabble/code/divine/divine-mobile/.worktrees/web-search-404-handling/mobile/test/screens/feed/web_video_not_found_confirmation_test.dart: does not mark web video missing on non-404 responses
00:00 +3: /Users/rabble/code/divine/divine-mobile/.worktrees/web-search-404-handling/mobile/test/widgets/web_video_feed_test.dart: fires onCompleted when the active video loops
00:00 +4: /Users/rabble/code/divine/divine-mobile/.worktrees/web-search-404-handling/mobile/test/widgets/web_video_feed_test.dart: animateToPage moves to the requested page
00:00 +5: /Users/rabble/code/divine/divine-mobile/.worktrees/web-search-404-handling/mobile/test/widgets/web_video_feed_test.dart: auto-skips when the active web video error handler confirms removal
00:00 +6: /Users/rabble/code/divine/divine-mobile/.worktrees/web-search-404-handling/mobile/test/widgets/web_video_feed_test.dart: drops controller entries when WebVideoPlayer items are disposed
00:00 +7: /Users/rabble/code/divine/divine-mobile/.worktrees/web-search-404-handling/mobile/test/widgets/web_video_feed_test.dart: prunes stale controller entries when videos list shrinks
00:00 +8: /Users/rabble/code/divine/divine-mobile/.worktrees/web-search-404-handling/mobile/test/widgets/web_video_feed_test.dart: does not rebuild the feed itemBuilder for every controller init
00:00 +9: All tests passed!
- [x] Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 91.0.0 (99.0.0 available)
  _flutterfire_internals 1.3.66 (1.3.69 available)
  alchemist 0.12.1 (0.14.0 available)
  analyzer 8.4.0 (12.1.0 available)
  analyzer_buffer 0.1.11 (0.3.1 available)
  analyzer_plugin 0.13.10 (0.14.8 available)
! app_device_integrity 1.1.0 from path overrides/app_device_integrity-1.1.0 (overridden)
  app_links 6.4.1 (7.0.0 available)
  archive 4.0.7 (4.0.9 available)
  async 2.13.0 (2.13.1 available)
  audio_session 0.2.2 (0.2.3 available)
  bip340 0.3.0 (0.3.1 available)
  build 4.0.3 (4.0.5 available)
  build_config 1.2.0 (1.3.0 available)
  build_runner 2.10.4 (2.13.1 available)
  built_value 8.12.1 (8.12.5 available)
  cli_launcher 0.3.2+1 (0.3.3+1 available)
  code_builder 4.11.0 (4.11.1 available)
  connectivity_plus 7.0.0 (7.1.1 available)
  connectivity_plus_platform_interface 2.0.1 (2.1.0 available)
  cookie_jar 4.0.8 (4.0.9 available)
  cross_file 0.3.5+1 (0.3.5+2 available)
! cryptography_flutter 2.3.2 from path overrides/cryptography_flutter-2.3.2 (overridden)
  cupertino_icons 1.0.8 (1.0.9 available)
  custom_lint_core 0.8.1 (0.8.2 available)
  custom_lint_visitor 1.0.0+8.4.0 (1.0.0+9.0.0 available)
  dart_style 3.1.3 (3.1.8 available)
  dbus 0.7.11 (0.7.12 available)
  dev_build 1.1.3+1 (1.1.5+2 available)
! device_info_plus 10.1.2 (overridden) (13.0.0 available)
  device_info_plus_platform_interface 7.0.3 (8.0.0 available)
  dio 5.9.0 (5.9.2 available)
  dio_cookie_manager 3.3.0 (3.4.0 available)
  dio_web_adapter 2.1.1 (2.1.2 available)
  drift 2.30.0 (2.32.1 available)
  drift_dev 2.30.0 (2.32.1 available)
  drift_flutter 0.2.8 (0.3.0 available)
  ffi 2.1.5 (2.2.0 available)
  file_picker 10.3.8 (11.0.2 available)
  file_selector_android 0.5.2+4 (0.5.2+5 available)
  firebase_analytics 12.1.2 (12.3.0 available)
  firebase_analytics_platform_interface 5.0.6 (5.1.1 available)
  firebase_analytics_web 0.6.1+2 (0.6.1+5 available)
  firebase_core 4.4.0 (4.7.0 available)
  firebase_core_platform_interface 6.0.2 (6.0.3 available)
  firebase_core_web 3.4.0 (3.6.0 available)
  firebase_crashlytics 5.0.7 (5.2.0 available)
  firebase_crashlytics_platform_interface 3.8.17 (3.8.20 available)
  firebase_messaging 16.1.1 (16.2.0 available)
  firebase_messaging_platform_interface 4.7.6 (4.7.9 available)
  firebase_messaging_web 4.1.2 (4.1.5 available)
  firebase_performance 0.11.1+4 (0.11.3 available)
  firebase_performance_platform_interface 0.1.6+4 (0.1.6+7 available)
  firebase_performance_web 0.1.8+2 (0.1.8+5 available)
  flutter_local_notifications 19.5.0 (21.0.0 available)
  flutter_local_notifications_linux 6.0.0 (8.0.0 available)
  flutter_local_notifications_platform_interface 9.1.0 (11.0.0 available)
  flutter_local_notifications_windows 1.0.3 (3.0.0 available)
  flutter_plugin_android_lifecycle 2.0.33 (2.0.34 available)
  flutter_riverpod 3.0.3 (3.3.1 available)
  flutter_secure_storage 9.2.4 (10.0.0 available)
  flutter_secure_storage_linux 1.2.3 (3.0.0 available)
  flutter_secure_storage_macos 3.1.3 (4.0.0 available)
  flutter_secure_storage_platform_interface 1.1.2 (2.0.1 available)
  flutter_secure_storage_web 1.2.1 (2.1.0 available)
  flutter_secure_storage_windows 3.1.2 (4.1.0 available)
  flutter_svg 2.2.3 (2.2.4 available)
  flutter_web_auth_2 4.1.0 (5.0.2 available)
  flutter_web_auth_2_platform_interface 4.1.0 (5.0.0 available)
  freezed 3.2.3 (3.2.5 available)
  go_router 16.3.0 (17.2.1 available)
  golden_toolkit 0.15.0 (discontinued)
  google_fonts 6.3.3 (8.0.2 available)
  hive_ce 2.16.0 (2.19.3 available)
  hive_ce_flutter 2.3.3 (2.3.4 available)
  hive_ce_generator 1.10.0 (1.11.1 available)
  image 4.7.2 (4.8.0 available)
  image_picker_android 0.8.13+10 (0.8.13+16 available)
  image_picker_ios 0.8.13+3 (0.8.13+6 available)
  isolate_channel 0.2.2+1 (0.6.1 available)
  js 0.6.7 (0.7.2 available)
  json_annotation 4.9.0 (4.11.0 available)
  json_serializable 6.11.2 (6.13.1 available)
  lints 6.0.0 (6.1.0 available)
  melos 7.3.0 (7.5.1 available)
! meta 1.17.0 (overridden) (1.18.2 available)
  mockito 5.6.1 (5.6.4 available)
  mocktail 1.0.4 (1.0.5 available)
  mustache_template 2.0.2 (2.0.4 available)
  package_info_plus 9.0.0 (10.0.0 available)
  package_info_plus_platform_interface 3.2.1 (4.0.0 available)
  path_provider_android 2.2.22 (2.3.1 available)
  path_provider_foundation 2.5.1 (2.6.0 available)
  patrol 4.2.0 (4.5.0 available)
  patrol_finders 3.1.0 (3.2.0 available)
  patrol_log 0.7.1 (0.8.0 available)
  petitparser 7.0.1 (7.0.2 available)
  pointycastle 3.9.1 (4.0.0 available)
  posix 6.0.3 (6.5.0 available)
  pro_image_editor 12.0.13 (12.4.1 available)
  pro_video_editor 1.14.2 (1.15.0 available)
  process_run 1.2.4 (1.3.2 available)
  riverpod 3.0.3 (3.2.1 available)
  riverpod_analyzer_utils 1.0.0-dev.7 (1.0.0-dev.9 available)
  riverpod_annotation 3.0.3 (4.0.2 available)
  riverpod_generator 3.0.3 (4.0.3 available)
! rxdart 0.28.0 (overridden)
  share_plus 12.0.1 (13.0.0 available)
  share_plus_platform_interface 6.1.0 (7.0.0 available)
  shared_preferences 2.5.4 (2.5.5 available)
  shared_preferences_android 2.4.18 (2.4.23 available)
  shared_preferences_platform_interface 2.4.1 (2.4.2 available)
  shelf_web_socket 2.0.1 (3.0.0 available)
  skeletonizer 2.1.2 (2.1.3 available)
  source_gen 4.1.1 (4.2.2 available)
  source_helper 1.3.8 (1.3.11 available)
  source_span 1.10.1 (1.10.2 available)
  sqflite_android 2.4.2+2 (2.4.2+3 available)
  sqflite_common_ffi 2.3.6 (2.4.0+2 available)
  sqflite_common_ffi_web 0.4.5+4 (1.1.1 available)
  sqlite3 2.9.4 (3.3.1 available)
  sqlite3_flutter_libs 0.5.41 (0.6.0+eol available)
  sqlparser 0.42.1 (0.44.3 available)
  test 1.30.0 (1.31.0 available)
  test_api 0.7.10 (0.7.11 available)
  test_core 0.6.16 (0.6.17 available)
  timezone 0.10.1 (0.11.0 available)
  unique_names_generator 3.0.0 (3.1.2 available)
  url_launcher_android 6.3.28 (6.3.29 available)
  url_launcher_ios 6.3.6 (6.4.1 available)
  url_launcher_web 2.4.1 (2.4.2 available)
  uuid 4.5.2 (4.5.3 available)
  vector_graphics 1.1.19 (1.1.21 available)
  vector_graphics_compiler 1.1.19 (1.2.0 available)
  vector_math 2.2.0 (2.3.0 available)
  video_player 2.10.1 (2.11.1 available)
  video_player_android 2.9.1 (2.9.5 available)
  video_player_avfoundation 2.8.8 (2.9.4 available)
  vm_service 15.0.2 (15.1.0 available)
  wakelock_plus 1.4.0 (1.6.0 available)
  wakelock_plus_platform_interface 1.3.0 (1.5.0 available)
  watcher 1.2.0 (1.2.1 available)
  webview_flutter_android 4.10.13 (4.11.0 available)
  webview_flutter_platform_interface 2.14.0 (2.15.1 available)
  webview_flutter_wkwebview 3.24.1 (3.24.3 available)
  win32 5.15.0 (6.0.1 available)
  win32_registry 1.1.5 (3.0.3 available)
  yaml_edit 2.2.3 (2.2.4 available)
Got dependencies!
1 package is discontinued.
144 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
00:00 +0: loading /Users/rabble/code/divine/divine-mobile/.worktrees/web-search-404-handling/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_web_test.dart
00:00 +0: PooledFullscreenVideoFeedScreen web (setUpAll)
00:00 +0: PooledFullscreenVideoFeedScreen web renders social controls overlay for web video feed
00:00 +0 ~1: PooledFullscreenVideoFeedScreen web renders Auto action in the fullscreen web overlay
00:00 +0 ~2: PooledFullscreenVideoFeedScreen web removes and skips confirmed missing web videos
00:00 +0 ~3: PooledFullscreenVideoFeedScreen web (tearDownAll)
00:00 +0 ~3: All tests skipped.
- [x] Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 91.0.0 (99.0.0 available)
  _flutterfire_internals 1.3.66 (1.3.69 available)
  alchemist 0.12.1 (0.14.0 available)
  analyzer 8.4.0 (12.1.0 available)
  analyzer_buffer 0.1.11 (0.3.1 available)
  analyzer_plugin 0.13.10 (0.14.8 available)
! app_device_integrity 1.1.0 from path overrides/app_device_integrity-1.1.0 (overridden)
  app_links 6.4.1 (7.0.0 available)
  archive 4.0.7 (4.0.9 available)
  async 2.13.0 (2.13.1 available)
  audio_session 0.2.2 (0.2.3 available)
  bip340 0.3.0 (0.3.1 available)
  build 4.0.3 (4.0.5 available)
  build_config 1.2.0 (1.3.0 available)
  build_runner 2.10.4 (2.13.1 available)
  built_value 8.12.1 (8.12.5 available)
  cli_launcher 0.3.2+1 (0.3.3+1 available)
  code_builder 4.11.0 (4.11.1 available)
  connectivity_plus 7.0.0 (7.1.1 available)
  connectivity_plus_platform_interface 2.0.1 (2.1.0 available)
  cookie_jar 4.0.8 (4.0.9 available)
  cross_file 0.3.5+1 (0.3.5+2 available)
! cryptography_flutter 2.3.2 from path overrides/cryptography_flutter-2.3.2 (overridden)
  cupertino_icons 1.0.8 (1.0.9 available)
  custom_lint_core 0.8.1 (0.8.2 available)
  custom_lint_visitor 1.0.0+8.4.0 (1.0.0+9.0.0 available)
  dart_style 3.1.3 (3.1.8 available)
  dbus 0.7.11 (0.7.12 available)
  dev_build 1.1.3+1 (1.1.5+2 available)
! device_info_plus 10.1.2 (overridden) (13.0.0 available)
  device_info_plus_platform_interface 7.0.3 (8.0.0 available)
  dio 5.9.0 (5.9.2 available)
  dio_cookie_manager 3.3.0 (3.4.0 available)
  dio_web_adapter 2.1.1 (2.1.2 available)
  drift 2.30.0 (2.32.1 available)
  drift_dev 2.30.0 (2.32.1 available)
  drift_flutter 0.2.8 (0.3.0 available)
  ffi 2.1.5 (2.2.0 available)
  file_picker 10.3.8 (11.0.2 available)
  file_selector_android 0.5.2+4 (0.5.2+5 available)
  firebase_analytics 12.1.2 (12.3.0 available)
  firebase_analytics_platform_interface 5.0.6 (5.1.1 available)
  firebase_analytics_web 0.6.1+2 (0.6.1+5 available)
  firebase_core 4.4.0 (4.7.0 available)
  firebase_core_platform_interface 6.0.2 (6.0.3 available)
  firebase_core_web 3.4.0 (3.6.0 available)
  firebase_crashlytics 5.0.7 (5.2.0 available)
  firebase_crashlytics_platform_interface 3.8.17 (3.8.20 available)
  firebase_messaging 16.1.1 (16.2.0 available)
  firebase_messaging_platform_interface 4.7.6 (4.7.9 available)
  firebase_messaging_web 4.1.2 (4.1.5 available)
  firebase_performance 0.11.1+4 (0.11.3 available)
  firebase_performance_platform_interface 0.1.6+4 (0.1.6+7 available)
  firebase_performance_web 0.1.8+2 (0.1.8+5 available)
  flutter_local_notifications 19.5.0 (21.0.0 available)
  flutter_local_notifications_linux 6.0.0 (8.0.0 available)
  flutter_local_notifications_platform_interface 9.1.0 (11.0.0 available)
  flutter_local_notifications_windows 1.0.3 (3.0.0 available)
  flutter_plugin_android_lifecycle 2.0.33 (2.0.34 available)
  flutter_riverpod 3.0.3 (3.3.1 available)
  flutter_secure_storage 9.2.4 (10.0.0 available)
  flutter_secure_storage_linux 1.2.3 (3.0.0 available)
  flutter_secure_storage_macos 3.1.3 (4.0.0 available)
  flutter_secure_storage_platform_interface 1.1.2 (2.0.1 available)
  flutter_secure_storage_web 1.2.1 (2.1.0 available)
  flutter_secure_storage_windows 3.1.2 (4.1.0 available)
  flutter_svg 2.2.3 (2.2.4 available)
  flutter_web_auth_2 4.1.0 (5.0.2 available)
  flutter_web_auth_2_platform_interface 4.1.0 (5.0.0 available)
  freezed 3.2.3 (3.2.5 available)
  go_router 16.3.0 (17.2.1 available)
  golden_toolkit 0.15.0 (discontinued)
  google_fonts 6.3.3 (8.0.2 available)
  hive_ce 2.16.0 (2.19.3 available)
  hive_ce_flutter 2.3.3 (2.3.4 available)
  hive_ce_generator 1.10.0 (1.11.1 available)
  image 4.7.2 (4.8.0 available)
  image_picker_android 0.8.13+10 (0.8.13+16 available)
  image_picker_ios 0.8.13+3 (0.8.13+6 available)
  isolate_channel 0.2.2+1 (0.6.1 available)
  js 0.6.7 (0.7.2 available)
  json_annotation 4.9.0 (4.11.0 available)
  json_serializable 6.11.2 (6.13.1 available)
  lints 6.0.0 (6.1.0 available)
  melos 7.3.0 (7.5.1 available)
! meta 1.17.0 (overridden) (1.18.2 available)
  mockito 5.6.1 (5.6.4 available)
  mocktail 1.0.4 (1.0.5 available)
  mustache_template 2.0.2 (2.0.4 available)
  package_info_plus 9.0.0 (10.0.0 available)
  package_info_plus_platform_interface 3.2.1 (4.0.0 available)
  path_provider_android 2.2.22 (2.3.1 available)
  path_provider_foundation 2.5.1 (2.6.0 available)
  patrol 4.2.0 (4.5.0 available)
  patrol_finders 3.1.0 (3.2.0 available)
  patrol_log 0.7.1 (0.8.0 available)
  petitparser 7.0.1 (7.0.2 available)
  pointycastle 3.9.1 (4.0.0 available)
  posix 6.0.3 (6.5.0 available)
  pro_image_editor 12.0.13 (12.4.1 available)
  pro_video_editor 1.14.2 (1.15.0 available)
  process_run 1.2.4 (1.3.2 available)
  riverpod 3.0.3 (3.2.1 available)
  riverpod_analyzer_utils 1.0.0-dev.7 (1.0.0-dev.9 available)
  riverpod_annotation 3.0.3 (4.0.2 available)
  riverpod_generator 3.0.3 (4.0.3 available)
! rxdart 0.28.0 (overridden)
  share_plus 12.0.1 (13.0.0 available)
  share_plus_platform_interface 6.1.0 (7.0.0 available)
  shared_preferences 2.5.4 (2.5.5 available)
  shared_preferences_android 2.4.18 (2.4.23 available)
  shared_preferences_platform_interface 2.4.1 (2.4.2 available)
  shelf_web_socket 2.0.1 (3.0.0 available)
  skeletonizer 2.1.2 (2.1.3 available)
  source_gen 4.1.1 (4.2.2 available)
  source_helper 1.3.8 (1.3.11 available)
  source_span 1.10.1 (1.10.2 available)
  sqflite_android 2.4.2+2 (2.4.2+3 available)
  sqflite_common_ffi 2.3.6 (2.4.0+2 available)
  sqflite_common_ffi_web 0.4.5+4 (1.1.1 available)
  sqlite3 2.9.4 (3.3.1 available)
  sqlite3_flutter_libs 0.5.41 (0.6.0+eol available)
  sqlparser 0.42.1 (0.44.3 available)
  test 1.30.0 (1.31.0 available)
  test_api 0.7.10 (0.7.11 available)
  test_core 0.6.16 (0.6.17 available)
  timezone 0.10.1 (0.11.0 available)
  unique_names_generator 3.0.0 (3.1.2 available)
  url_launcher_android 6.3.28 (6.3.29 available)
  url_launcher_ios 6.3.6 (6.4.1 available)
  url_launcher_web 2.4.1 (2.4.2 available)
  uuid 4.5.2 (4.5.3 available)
  vector_graphics 1.1.19 (1.1.21 available)
  vector_graphics_compiler 1.1.19 (1.2.0 available)
  vector_math 2.2.0 (2.3.0 available)
  video_player 2.10.1 (2.11.1 available)
  video_player_android 2.9.1 (2.9.5 available)
  video_player_avfoundation 2.8.8 (2.9.4 available)
  vm_service 15.0.2 (15.1.0 available)
  wakelock_plus 1.4.0 (1.6.0 available)
  wakelock_plus_platform_interface 1.3.0 (1.5.0 available)
  watcher 1.2.0 (1.2.1 available)
  webview_flutter_android 4.10.13 (4.11.0 available)
  webview_flutter_platform_interface 2.14.0 (2.15.1 available)
  webview_flutter_wkwebview 3.24.1 (3.24.3 available)
  win32 5.15.0 (6.0.1 available)
  win32_registry 1.1.5 (3.0.3 available)
  yaml_edit 2.2.3 (2.2.4 available)
Got dependencies!
1 package is discontinued.
144 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
Analyzing 6 items...                                            
No issues found! (ran in 3.4s)
- [x] repo pre-push hook
