### PR TITLE
feat(web): HLS + NIP-98 auth video player behind feature flag

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -29,6 +29,8 @@ jobs:
         run: flutter pub get
       - name: 🌐 Verify HLS auth web shim is synced
         run: bash scripts/check_hls_auth_web_shim_sync.sh
+      - name: 🌐 Smoke-test HLS auth web shim
+        run: node scripts/test_hls_auth_web_shim.mjs
       - name: 🔨 Verify generated files are up-to-date
         run: |
           dart run build_runner build --delete-conflicting-outputs

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -27,6 +27,8 @@ jobs:
           cache: true
       - name: 📦 Install dependencies
         run: flutter pub get
+      - name: 🌐 Verify HLS auth web shim is synced
+        run: bash scripts/check_hls_auth_web_shim_sync.sh
       - name: 🔨 Verify generated files are up-to-date
         run: |
           dart run build_runner build --delete-conflicting-outputs

--- a/docs/superpowers/specs/2026-04-17-hls-auth-web-player-spike.md
+++ b/docs/superpowers/specs/2026-04-17-hls-auth-web-player-spike.md
@@ -1,0 +1,247 @@
+# HLS + NIP-98 auth on Flutter web — spike design
+
+Status: draft
+Owner: @rabble
+Date: 2026-04-17
+Branch: spike/hls-auth-web-player
+
+## Problem statement
+
+Divine hosts videos on Blossom-style storage at `https://media.divine.video/<sha256>`. For age-gated or otherwise restricted content, the media server responds `HTTP 401 Unauthorized` to any request that does not carry an `Authorization: Nostr <base64 NIP-98 event>` header. On native (iOS, Android, macOS) the pooled media_kit-based player pipes request headers into its underlying HTTP client, and the viewer-auth retry flow (PR #3127) reclassifies `401` as `VideoErrorType.ageRestricted`, prompts the user, signs a NIP-98 event, and retries with the header attached. On Flutter web this path is architecturally broken: `WebVideoPlayer` delegates to `VideoPlayerController.networkUrl(url, httpHeaders: headers)` which — on the web platform — sets `videoElement.src = uri` on a plain HTML5 `<video>` element. HTML5 `<video>` ignores `httpHeaders` entirely for direct MP4, so the browser issues an unauthenticated GET, receives 401, and surfaces a generic `MEDIA_ERR_SRC_NOT_SUPPORTED`. The classifier in `pooled_video_player` that recognises the string "401" is not on the hot path for web, so even a raw 401 never becomes `ageRestricted`, the viewer-auth retry never fires, and the user sees the "Failed to load video" copy from `WebVideoPlayer`. PR #3107 only removes confirmed 404s and is intentionally silent about 401, which is why the preview deploy still shows auth-gated items stuck.
+
+## Current state
+
+Native (working): `PooledVideoFeed` → `media_kit` with a pooled controller → HTTP client honors `httpHeaders`. If the initial load errors with a 401 string, `VideoFeedController._classifyError` (`.../pooled_video_player/lib/src/controllers/video_feed_controller.dart:651`) maps it to `VideoErrorType.ageRestricted`. `playbackStatusFromError` in `video_playback_status_state.dart:99` lifts that to `PlaybackStatus.ageRestricted`. The feed shows an age-restricted overlay that triggers `retryAgeRestrictedPooledVideo` (`mobile/lib/screens/feed/pooled_age_restricted_retry.dart`), which calls `ref.read(mediaAuthInterceptorProvider).handleUnauthorizedMedia(...)`, gets back signed `Authorization` headers, and invokes `feedController.updateRequestHeadersAndRetry(index, headers)`. Native session-level NIP-98 signing lives in `mobile/lib/services/media_viewer_auth_service.dart` and is backed by `BlossomAuthService.createGetAuthHeader` / `Nip98AuthService.createAuthToken`.
+
+Web (broken): `WebVideoFeed` → `WebVideoPlayer` (`mobile/lib/widgets/web_video_player.dart`) → `VideoPlayerController.networkUrl(url, httpHeaders: headers)` → the `video_player_web_hls` plugin (`~/.pub-cache/.../video_player_web_hls-1.3.0/lib/src/video_player.dart`). In that plugin's `initialize()`:
+- For HLS manifests (`m3u8`), it constructs an hls.js instance with `HlsConfig(xhrSetup: ...)` and the Dart-side `headers` map is applied to each XHR via `xhr.setRequestHeader`. So if an HLS URL is used, Dart-provided headers *can* reach the network. However, `xhrSetup` is synchronous — it cannot await a Dart future that computes a fresh NIP-98 signature for each segment — and the current `WebVideoPlayer` never calls `MediaViewerAuthService` anyway, so even the HLS path carries no `Authorization`.
+- For direct MP4 it sets `_videoElement.src = uri` (line 136) and drops `headers` on the floor. This is the exact path the production feed uses today (direct MP4 first), and it is the unrecoverable case: HTML5 `<video>` cannot carry custom headers, and the error surfaced via `MediaError.code = 4 (MEDIA_ERR_SRC_NOT_SUPPORTED)` does not contain the string "401".
+
+Confirmed via `curl -sI` against the known auth-gated hash `a9bbbce1b03958553a5ee1546140d5d930b8a86c1fa967ea874fb5241bd5e41c`: every variant (`<hash>`, `<hash>.mp4`, `<hash>/hls/master.m3u8`, `<hash>.jpg`) returns HTTP/2 401 with `access-control-allow-origin: *` and `access-control-allow-headers: Authorization, Content-Type, X-Sha256`. CORS is already open for `Authorization`, so the constraint is purely "how do we attach the header from a Dart web build".
+
+## Reference implementation (divine-web)
+
+divine-web solved this by bypassing the platform video wrapper entirely and driving `hls.js` directly, using its MSE pipeline plus a custom loader. The load-bearing pieces are all short:
+
+- `divine-web/src/lib/hlsAuthLoader.ts:14-51` — `createAuthLoader(getAuthHeader)` returns a class extending `Hls.DefaultConfig.loader`. Its `load(context, config, callbacks)` awaits `getAuthHeader(context.url, 'GET')`, stuffs the result into `context.headers['Authorization']`, then delegates to `super.load(...)` via `.finally(...)`. Because `load` is async-delegated (not `xhrSetup`-based), per-segment NIP-98 signing is fine. This is how the "different header per URL per segment" requirement is met.
+- `divine-web/src/lib/nip98Auth.ts:19-36` — `createNip98AuthHeader(signer, url, method)` builds a kind-27235 event template via `NIP98.template(new Request(url, {method}))`, signs it, base64-encodes the JSON, returns `Nostr ${encoded}`.
+- `divine-web/src/hooks/useAdultVerification.ts:8-111` — gates header generation on a `localStorage`-persisted verification flag (30 day TTL, key `adult-verification-confirmed`), broadcasts changes via a `storage`-style event, and exposes `getAuthHeader(url, method)` that returns `null` when the user is not verified or has no signer.
+- `divine-web/src/components/VideoPlayer.tsx:687-889` — the effect that wires it up:
+  - does a HEAD preflight via `checkMediaAuth(url)` (`useAdultVerification.ts:116-130`); if it returns 401/403 and the user is not yet verified, it flips `requiresAuth=true` and renders `AgeVerificationOverlay` instead of a `<video>` tag. Critical detail: the `poster` is withheld during `requiresAuth || authCheckPending` so the poster's 401 does not itself trip an error.
+  - once `isAdultVerified` is true, it instantiates `new Hls({ ..., loader: createAuthLoader(getAuthHeader) })`, `hls.loadSource(hlsUrl)`, `hls.attachMedia(videoElement)`.
+  - on `Hls.Events.ERROR` with `data.response.code in (401, 403)` it destroys the instance and re-flips `requiresAuth`, prompting re-verification.
+  - for direct MP4 with auth, it does a `fetch(url, { headers: { Authorization } })`, builds a blob URL via `URL.createObjectURL(blob)`, assigns to `video.src`, and tracks the blob URL in a ref so it can `revokeObjectURL` on unmount. This works but loses Range/seek granularity and streams the whole file — acceptable because classic Vine content is ~6s / 2-4 MB.
+- `divine-web/src/components/VideoCard.tsx:118-134` — direct MP4 first, HLS as fallback: `effectiveHlsUrl = hlsFallbackUrl || ((isClassicVine || isShortForm) ? undefined : ...)`. Short-form (≤60s) and classic Vine (migrated / timestamp < 2017-01-17) skip HLS entirely because the 2+ RTs for manifest+segment are slower than one MP4 GET for 6-second clips, and the transcoder distorts square aspect ratios.
+
+## Options evaluated
+
+### Option A — New Flutter package `packages/hls_auth_web_player`, JS interop to hls.js
+
+Build a `kIsWeb`-only package that mirrors the `WebVideoPlayer` surface (init / play / pause / seekTo / setVolume / setLooping / dispose, plus an `onInitialized(controller)` for external access). Internally it uses `dart:js_interop` + `package:web` to instantiate `hls.js`, attach to a registered `HTMLVideoElement` platform view, and install a custom loader that calls back into Dart for per-URL `Authorization` headers. MP4 path uses `fetch`+blob-URL mirroring divine-web. The Dart `WebVideoPlayer` becomes a thin shim that picks between the legacy `video_player` controller factory and the new package based on a feature flag / host check.
+
+Pros:
+- Solves the actual problem. Per-segment NIP-98 signing is the whole reason we need a proper loader — `xhrSetup` cannot await Dart futures.
+- Reuses `MediaViewerAuthService` as the single source of truth for signing. The Dart-JS boundary is an `async` callback: JS `(url, method) => jsPromise` backed by a Dart `Future<String?>`.
+- Direct MP4 fallback + HLS retry parity with divine-web means we can share the same UX and tests.
+- Keeps the change isolated to a new package; `WebVideoFeed` only needs a controller-factory swap.
+
+Cons:
+- New package surface to maintain. JS interop is inherently brittle to hls.js API shifts.
+- Requires pinning `hls.js` in `web/index.html` (already present at `latest`, which we should change to a known-good version anyway).
+- Tests need a fake hls.js shim.
+
+### Option B — Fork / patch `video_player_web_hls` to expose a loader hook
+
+Add an optional `loader`/`loaderFactory` parameter to `HlsConfig` in the pub package, plumb it through `xhrSetup`'s call site so Dart callers can pass a Dart-side loader. Upstream if accepted.
+
+Pros:
+- Smallest surface change in divine-mobile (`WebVideoPlayer` would pass a loader factory through `httpHeaders`-equivalent config).
+- Benefits the wider Flutter ecosystem.
+
+Cons:
+- `video_player_web_hls` 1.3.0's `HlsConfig` only has `xhrSetup` (see `~/.pub-cache/.../video_player_web_hls-1.3.0/lib/hls.dart:33-38`). Exposing `loader` means a real API addition, not just a pass-through — the type has to model a JS class constructor from Dart, which is the same JS interop work as Option A without the benefit of owning the direct-MP4 path.
+- Even with a loader hook, the direct-MP4 case is still `_videoElement.src = uri` in `video_player.dart:136` which ignores headers. So this option still doesn't fix MP4 — we would still need the blob-URL fetch dance somewhere.
+- Upstream review and release are gated on external maintainers. Can't ship the fix behind a fork URL without adding a long-lived `git:` dependency.
+
+### Option C — Cloudflare Worker proxy attaches auth server-side
+
+Run a worker on an app-owned origin (e.g. `media-proxy.divine.video`). The web build requests `https://media-proxy.divine.video/<sha256>` with a short-lived app cookie or JWT; the worker validates and rewrites to a media.divine.video URL with a server-held NIP-98 identity or a signed presign.
+
+Pros:
+- Web player needs no hls.js integration; the HTML5 `<video>` element "just works".
+- Could share the same presign pattern with non-browser clients.
+
+Cons:
+- Moves user-scoped signing to the server — the worker either needs the user's key (unacceptable) or a server-side identity that impersonates "the viewer", which breaks the NIP-98 semantic (the auth is meant to bind to a user event, not a relay-of-relays). This is a nostr protocol regression.
+- Adds a new always-on piece of infra and a new auth story (cookie/JWT to the proxy).
+- Doesn't match divine-web's approach, so web and mobile drift.
+- Introduces a trusted intermediary for content delivery.
+
+## Recommendation
+
+**Option A.** Ship a new `packages/hls_auth_web_player` Flutter package with a JS interop wrapper around hls.js, a custom auth loader that calls back into Dart, a direct-MP4 `fetch`+blob fallback, and a controller-factory-shaped drop-in for `WebVideoPlayer`. This is the smallest change that correctly solves both the MP4 and HLS cases, preserves the user-bound NIP-98 semantic (each segment carries the current viewer's signed event), and keeps `MediaViewerAuthService` as the single signing authority. It matches the working reference implementation on divine-web function-for-function, so the UX, verification dialog, and age-restricted retry flow all have a known shape to reach parity with.
+
+The fork-the-plugin path (Option B) buys less than it costs: the plugin's direct-MP4 path still ignores `httpHeaders`, so even after the upstream patch we would still have to write the blob-URL dance ourselves — at which point we might as well own the full web player. The proxy path (Option C) is incompatible with a per-user NIP-98 model.
+
+## Design sketch
+
+### File layout
+```
+mobile/packages/hls_auth_web_player/
+  pubspec.yaml
+  lib/
+    hls_auth_web_player.dart               # barrel (public API)
+    src/
+      hls_auth_web_controller.dart         # Dart-facing controller, mirrors VideoPlayerController shape
+      hls_auth_loader.dart                 # Dart wrapper that installs the JS auth loader
+      js/
+        hls_interop.dart                   # @JS bindings: Hls, HlsConfig, Loader, LoaderContext, Events
+        media_interop.dart                 # HTMLVideoElement helpers, platform view registry
+      blob_mp4_source.dart                 # fetch(url, Authorization) -> Blob -> objectURL lifecycle
+  test/
+    hls_auth_web_controller_test.dart
+    hls_auth_loader_test.dart
+  web/
+    hls_auth_web_player_init.js            # Optional tiny shim exposing helpers; may not be needed
+
+mobile/lib/widgets/
+  web_video_player.dart                    # unchanged public API; factory switches on feature flag
+  web_video_player_factories.dart          # NEW: exposes hlsAuthWebControllerFactory
+```
+
+### Interop surface
+
+Minimum bindings (Dart side `@JS()` externs), enough to drive hls.js and install our loader:
+
+```dart
+@JS()
+library hls_interop;
+
+import 'dart:js_interop';
+import 'package:web/web.dart' as web;
+
+@JS('Hls.isSupported')
+external bool hlsIsSupported();
+
+@JS('Hls')
+extension type Hls._(JSObject _) implements JSObject {
+  external factory Hls(HlsConfig config);
+  external void loadSource(String url);
+  external void attachMedia(web.HTMLVideoElement video);
+  external void on(String event, JSFunction handler);
+  external void destroy();
+}
+
+@JS()
+@anonymous
+extension type HlsConfig._(JSObject _) implements JSObject {
+  external factory HlsConfig({
+    bool? enableWorker,
+    bool? lowLatencyMode,
+    int? backBufferLength,
+    int? maxBufferLength,
+    int? startLevel,
+    bool? capLevelToPlayerSize,
+    JSAny? loader,          // constructor function returned by our Dart wrapper
+  });
+}
+
+// Pulled out so we can subclass Hls.DefaultConfig.loader from Dart.
+@JS('Hls.DefaultConfig')
+external JSObject get hlsDefaultConfig;
+```
+
+The custom loader is installed by executing a tiny JS snippet once, at app bootstrap, that declares `window.__divineAuthLoader(getAuthHeader)` — it closes over the divine-web-style loader subclass (`class extends Hls.DefaultConfig.loader`). Dart passes a `Future<String?> Function(String url, String method)` that interop converts to a JS async function using `(url, method) => (() async => ...)().toJS` via `dart:js_interop`. The cleanest path is to ship the loader factory as JS (matching `hlsAuthLoader.ts` 1:1), and from Dart just call `window.__divineHlsAuthLoader(authCallback)` to get back the constructor, then hand it to `HlsConfig.loader`.
+
+### Auth callback wiring
+
+```
+WebVideoFeed (Flutter, lib/)
+  └─ hlsAuthWebControllerFactory(url, video) { ... }
+       └─ HlsAuthWebController
+            ├─ preflight: HEAD url
+            │    └─ 401/403 + not verified -> emit onRequiresAuth
+            ├─ request auth header:
+            │    ref.read(mediaAuthInterceptorProvider)
+            │       .handleUnauthorizedMedia(context, sha256, url, serverUrl)
+            │    -> Map<String,String> headers
+            ├─ MP4 path: blobMp4Source.load(url, authorization)
+            │    └─ fetch -> blob -> URL.createObjectURL -> video.src
+            └─ HLS path: new Hls({ loader: window.__divineHlsAuthLoader(authCb) })
+                  authCb(url, method) is a JS function backed by
+                  MediaViewerAuthService.createAuthHeaders(
+                    sha256Hash: sha256FromUrl(url),
+                    url: url,
+                    serverUrl: originOf(url),
+                  ) -> Authorization
+```
+
+The age-verification dialog (existing `MediaAuthInterceptor`) is called once per feed session; the returned `Authorization` header is cached at the controller level (not persisted). Re-entry to a cold feed re-prompts via the existing dialog flow. We do NOT introduce the divine-web `localStorage` 30-day cache in this spike — the mobile app uses the in-process `AgeVerificationService` and `MediaAuthInterceptor` already, and the `shouldAutoShowAdultContent` path in `mobile/lib/services/media_auth_interceptor.dart:47` gives the same "verify once per session/preference" behaviour. Keeping a single verification store avoids a mobile/web drift.
+
+### Fallback order (web only)
+
+1. Direct MP4 with `Authorization` via `fetch`+blob (mirrors `VideoPlayer.tsx:812-868`), because classic Vine content is ~6s / 2-4MB and one GET beats manifest+segment.
+2. HLS via hls.js + custom loader for anything longer-form or when MP4 returns a non-401 error (e.g. 404 against the raw blob but the transcoded master.m3u8 exists — mirrors `hlsFallbackUrl` in `VideoCard.tsx:131-134`).
+3. On HLS fatal error: surface `PlaybackStatus.generic`; feed skips.
+
+The bandwidth-aware URL selection from divine-web (`getOptimalVideoUrl`) is out of scope for this spike.
+
+### Preserving existing native flow
+
+No behavioral change for native. The native `pooled_video_player` 401-classifier + `retryAgeRestrictedPooledVideo` flow remains the source of truth for iOS/Android/macOS. The new package is web-only and is selected inside `WebVideoPlayer` by a factory switch. `MediaAuthInterceptor` and `MediaViewerAuthService` are reused unchanged.
+
+### Hooking age-restricted state into the existing cubit
+
+On web, when the preflight HEAD returns 401 or the hls.js `ERROR` event has `data.response.code == 401`, the controller emits a `HlsAuthWebEvent.requiresAuth` that the feed translates into `VideoPlaybackStatusCubit.report(video.id, PlaybackStatus.ageRestricted)`. The existing `AgeRestrictedOverlay` / verification retry UI then applies. This keeps one UI path instead of inventing a web-only verification flow.
+
+## Open questions
+
+1. **hls.js version pin.** `mobile/web/index.html:157` currently loads `hls.js@latest` via jsDelivr. For the loader subclass to keep working we should pin a known-good version (e.g. 1.5.x) and ship it as an asset or subresource-integrity-verified CDN URL. Decide: self-host in `web/` vs pinned jsDelivr tag.
+2. **Per-segment signing cost.** Each HLS segment load triggers a NIP-98 sign. Amber/nsec.app-style remote signers have user-visible latency per sign. For in-app signing (local key) this is sub-ms; for remote signers it could be seconds per segment. Open question: should we cache a single per-URL-prefix header for the manifest's segment lifetime? divine-web does NOT cache and it works, but signers are browser-local there.
+3. **Poster 401 poisoning.** Thumbnails at `<hash>.jpg` also 401. Need to confirm `VineCachedImage` / blurhash placeholder shows on web without hitting poster URL before auth; the divine-web workaround is "withhold `poster=` during `requiresAuth || authCheckPending`".
+4. **Range header forwarding.** The custom loader needs to preserve hls.js's `context.rangeStart`/`rangeEnd` — it should, because we just append `Authorization` to `context.headers` and delegate to `super.load`. Verify with a manifest that includes byte-range segments.
+5. **CSP.** If we self-host hls.js, confirm the existing CSP permits inline JS for the loader factory shim. Alternatively, ship the shim as a separate file rather than an inline `<script>`.
+6. **Serving MP4 as blob breaks native `<video>` controls seeking on large files.** Fine for 6s Vines; will need proper HLS for anything over ~20MB. Document the cutoff where Option A's MP4 blob path becomes unsuitable.
+
+## Test strategy
+
+Unit tests (`packages/hls_auth_web_player/test/`):
+
+- `HlsAuthWebController` with a fake auth callback and a fake `web.HTMLVideoElement`. Assert: preflight 401 emits `requiresAuth`; preflight 200 proceeds to load; auth-provided header is what the loader sees.
+- `blob_mp4_source` with a faked `fetch`: 200 → objectURL assigned + revoked on dispose; 401 → `requiresAuth`; non-OK → `generic` error.
+- Loader wrapper: inject a mock hls.js double (just a constructor that records the `loader` field); assert the configured loader invokes the Dart auth callback with each URL.
+
+Widget tests (`mobile/test/widgets/`):
+
+- `WebVideoFeed` with a stubbed controller factory: when the stub reports `requiresAuth`, the feed reports `PlaybackStatus.ageRestricted` to `VideoPlaybackStatusCubit` and the existing age-restricted overlay renders.
+- Factory switch: with the feature flag off, `WebVideoPlayer` still calls the legacy `VideoPlayerController.networkUrl` factory.
+
+Integration (`mobile/integration_test/`):
+
+- `flutter drive -d chrome` against a test origin that mirrors `media.divine.video`'s 401 behaviour (a local `dhttpd` serving 401 JSON for unauth, 200 for `Authorization: Nostr *`). Asserts: feed item transitions from "auth required" to "playing" after a simulated age-verification tap.
+
+Fake hls.js for tests: the cleanest pattern is a Dart-side `HlsFactory` that returns either the real `new Hls(cfg)` (production) or a `FakeHls` that exposes `loadSource`, `attachMedia`, `on`, `destroy` as recording spies. Widget tests inject the fake via Provider/Riverpod override, avoiding any real JS interop in unit tests.
+
+## Scope / out-of-scope
+
+In scope:
+- New `packages/hls_auth_web_player` package.
+- `WebVideoPlayer` factory switch behind `kIsWeb` + a feature flag (default on for staging, off for prod until QA passes).
+- Integration with existing `MediaAuthInterceptor`, `AgeVerificationService`, `MediaViewerAuthService`, `VideoPlaybackStatusCubit`.
+- hls.js version pin in `web/index.html`.
+- Unit + widget tests for the new package and the factory switch.
+
+Out of scope (not this PR, explicitly):
+- Anything PR #3107 owns (skipping confirmed 404s). We are strictly about 401.
+- The bandwidth-aware URL selection (`getOptimalVideoUrl`) — port later if needed.
+- The localStorage 30-day verification cache — keep in-process mobile verification as the only store.
+- Poster 401 handling fixes outside the feed (profile grids, categories strip) — follow-up.
+- Native player changes (no changes to `pooled_video_player`, `media_kit`, or PR #3127's flow).
+
+## Rollout
+
+- Ship behind a `FeatureFlag.hlsAuthWebPlayer` default-off in prod, default-on in staging. The flag is web-only (`kIsWeb`-gated at the factory).
+- Deploy to `preview.divine.video` first. Smoke test against the known auth-gated hash `a9bbbce1b...`.
+- Success metric: the existing `VideoPlaybackStatusCubit` status distribution (ageRestricted dialog shown, then ready) surfaces in app logs. Rollback signal: a rise in `PlaybackStatus.generic` events tagged with the web factory, or a rise in `Failed to generate auth header` logs from the loader wrapper.
+- Once staging is green and at least one full feed scroll on the preview deploy succeeds on a previously-401 video, flip the flag on in prod. Keep the flag for one release before deleting the legacy path.
+- Rollback is a single remote-config flip back to the legacy `VideoPlayerController.networkUrl` factory. No schema or persisted-state migration.

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -46,6 +46,11 @@ enum FeatureFlag {
     'Feed Auto Advance',
     'Show the Auto rail control and let the feed advance automatically '
         'after each completed play',
+  ),
+  hlsAuthWebPlayer(
+    'HLS + NIP-98 Web Player',
+    'Route web video playback through hls.js with NIP-98 auth headers so '
+        'age-gated and other 401-protected media can be viewed on web',
   )
   ;
 

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -41,6 +41,8 @@ class BuildConfiguration {
         return const bool.fromEnvironment('FF_ACCOUNT_SWITCHING');
       case FeatureFlag.feedAutoAdvance:
         return const bool.fromEnvironment('FF_FEED_AUTO_ADVANCE');
+      case FeatureFlag.hlsAuthWebPlayer:
+        return const bool.fromEnvironment('FF_HLS_AUTH_WEB_PLAYER');
     }
   }
 
@@ -81,6 +83,8 @@ class BuildConfiguration {
         return 'FF_ACCOUNT_SWITCHING';
       case FeatureFlag.feedAutoAdvance:
         return 'FF_FEED_AUTO_ADVANCE';
+      case FeatureFlag.hlsAuthWebPlayer:
+        return 'FF_HLS_AUTH_WEB_PLAYER';
     }
   }
 }

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -457,6 +457,18 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
     _handleAutoAdvanceCompleted();
   }
 
+  /// Treat auth-gated web playback as the existing age-restricted state,
+  /// not as a broken video. This keeps 401/403 out of the #3107 404-removal
+  /// path, which is only for confirmed missing assets.
+  void _handleWebPlayerRequiresAuth(VideoEvent video, int index) {
+    final bloc = context.read<FullscreenFeedBloc>();
+    if (index != bloc.state.currentIndex) return;
+    context.read<VideoPlaybackStatusCubit>().report(
+      video.id,
+      PlaybackStatus.ageRestricted,
+    );
+  }
+
   /// Dispatch a [FullscreenFeedVideoUnavailable] event for the active video
   /// when the cubit reports [PlaybackStatus.notFound]. Replaces the prior
   /// per-item post-frame callback that violated the "no business logic in
@@ -723,6 +735,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                       },
                       onCompleted: (_) => _handleAutoAdvanceCompleted(),
                       onErrored: _handleWebPlayerErrored,
+                      onRequiresAuth: _handleWebPlayerRequiresAuth,
                       onNearEnd: (index) => _onNearEnd(state, index),
                       itemBuilder:
                           (

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -43,6 +43,7 @@ import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/video_feed_item/video_player_subtitle_layer.dart';
+import 'package:openvine/widgets/web_video_auth_header_provider.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
 import 'package:openvine/widgets/web_video_player.dart';
 import 'package:pooled_video_player/pooled_video_player.dart';
@@ -674,6 +675,19 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                   )
                 : null;
 
+            // Wire the NIP-98 auth header provider into WebVideoFeed only
+            // when running on web AND the HLS auth web player flag is on.
+            // When either condition is false, authHeaderProvider stays null
+            // and the legacy VideoPlayerController path is used unchanged.
+            final hlsAuthWebPlayerEnabled = ref.watch(
+              isFeatureEnabledProvider(FeatureFlag.hlsAuthWebPlayer),
+            );
+            final webAuthHeaderProvider = kIsWeb && hlsAuthWebPlayerEnabled
+                ? buildWebVideoAuthHeaderProvider(
+                    ref.watch(mediaViewerAuthServiceProvider),
+                  )
+                : null;
+
             return Scaffold(
               backgroundColor: VineTheme.backgroundColor,
               extendBodyBehindAppBar: true,
@@ -695,6 +709,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                       controllerFactory:
                           widget.webControllerFactory ??
                           defaultWebVideoPlayerControllerFactory,
+                      authHeaderProvider: webAuthHeaderProvider,
                       onActiveVideoChanged: (video, index) {
                         _pagePosition.value = index.toDouble();
                         _resumeAutoAdvanceAfterSwipe();

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -289,6 +289,16 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     _handleAutoAdvanceCompleted();
   }
 
+  /// Treat auth-gated web playback as the existing age-restricted state,
+  /// not as a broken video that should be auto-skipped.
+  void _handleWebPlayerRequiresAuth(VideoEvent video, int index) {
+    if (index != _currentFeedIndex()) return;
+    context.read<VideoPlaybackStatusCubit>().report(
+      video.id,
+      PlaybackStatus.ageRestricted,
+    );
+  }
+
   void _continuePendingAutoAdvance(VideoFeedState state) {
     continueFeedAutoAdvanceAfterPagination(
       cubit: _autoAdvanceCubit,
@@ -619,6 +629,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                       },
                       onCompleted: (_) => _handleAutoAdvanceCompleted(),
                       onErrored: _handleWebPlayerErrored,
+                      onRequiresAuth: _handleWebPlayerRequiresAuth,
                       onNearEnd: (index) {
                         if (state.hasMore) {
                           context.read<VideoFeedBloc>().add(

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -34,6 +34,7 @@ import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_feed_item/content_warning_helpers.dart';
 import 'package:openvine/widgets/video_feed_item/double_tap_heart_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
+import 'package:openvine/widgets/web_video_auth_header_provider.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
 import 'package:openvine/widgets/web_video_player.dart';
 import 'package:pooled_video_player/pooled_video_player.dart';
@@ -583,6 +584,19 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
               final effectiveAutoActive =
                   autoAdvanceAvailable && autoState.isEffectivelyActive;
 
+              // Wire the NIP-98 auth header provider into the web feed only
+              // when the HLS auth web player flag is on. When the flag is
+              // off the provider is null and the legacy video_player path
+              // is used, preserving current behavior.
+              final hlsAuthWebPlayerEnabled = ref.watch(
+                isFeatureEnabledProvider(FeatureFlag.hlsAuthWebPlayer),
+              );
+              final webAuthHeaderProvider = kIsWeb && hlsAuthWebPlayerEnabled
+                  ? buildWebVideoAuthHeaderProvider(
+                      ref.watch(mediaViewerAuthServiceProvider),
+                    )
+                  : null;
+
               // Note: RefreshIndicator removed - it conflicts with PageView
               // scrolling and adds memory overhead. Use the refresh button
               // instead.
@@ -597,6 +611,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                       controllerFactory:
                           widget.webControllerFactory ??
                           defaultWebVideoPlayerControllerFactory,
+                      authHeaderProvider: webAuthHeaderProvider,
                       onActiveVideoChanged: (video, index) {
                         _currentWebIndex = index;
                         _pagePosition.value = index.toDouble();

--- a/mobile/lib/widgets/web_video_auth_header_provider.dart
+++ b/mobile/lib/widgets/web_video_auth_header_provider.dart
@@ -1,0 +1,70 @@
+// ABOUTME: Builds the async AuthHeaderProvider closure wired into the web
+// ABOUTME: HLS auth player, backed by MediaViewerAuthService.
+
+import 'package:hls_auth_web_player/hls_auth_web_player.dart'
+    show AuthHeaderProvider;
+import 'package:openvine/services/media_viewer_auth_service.dart';
+
+/// Re-export of the [AuthHeaderProvider] signature from
+/// `hls_auth_web_player` so callers in the `openvine` package don't need
+/// to import the package directly.
+typedef WebVideoAuthHeaderProvider = AuthHeaderProvider;
+
+/// Builds an [AuthHeaderProvider] closure that delegates to
+/// [MediaViewerAuthService] for NIP-98 signing.
+///
+/// The returned callback:
+/// * Returns `null` when the viewer cannot create auth headers (not
+///   authenticated or not age-verified). The `HlsAuthWebPlayer` treats a
+///   `null` result as "no auth available", which for a 401-gated origin
+///   surfaces `requiresAuth` to the overlay layer.
+/// * Extracts the `sha256` hash and origin server from [url] so the
+///   Blossom-style GET auth endpoint picks the right signing path.
+///
+/// The widget layer calls this once per item with the current URL when
+/// constructing the player. Per-segment signing happens inside the hls.js
+/// loader via the returned closure.
+WebVideoAuthHeaderProvider buildWebVideoAuthHeaderProvider(
+  MediaViewerAuthService service,
+) {
+  return (String url, String method) async {
+    // Only GET requests are ever made by the hls loader + MP4 fallback.
+    // The method param is kept for future use.
+    final headers = await service.createAuthHeaders(
+      sha256Hash: _extractSha256FromUrl(url),
+      url: url,
+      serverUrl: _extractServerUrl(url),
+    );
+    return headers?['Authorization'];
+  };
+}
+
+/// Extracts a 64-character hex sha256 segment from a Blossom-style URL, or
+/// `null` if the URL doesn't carry one.
+String? _extractSha256FromUrl(String url) {
+  try {
+    final uri = Uri.parse(url);
+    for (final segment in uri.pathSegments.reversed) {
+      final cleanSegment = segment.split('.').first;
+      if (cleanSegment.length == 64 &&
+          RegExp(r'^[a-fA-F0-9]+$').hasMatch(cleanSegment)) {
+        return cleanSegment.toLowerCase();
+      }
+    }
+  } catch (_) {
+    return null;
+  }
+  return null;
+}
+
+/// Returns the `scheme://host[:port]` origin for [url], or `null` if [url]
+/// is not a valid URI.
+String? _extractServerUrl(String url) {
+  try {
+    final uri = Uri.parse(url);
+    final portSuffix = uri.hasPort ? ':${uri.port}' : '';
+    return '${uri.scheme}://${uri.host}$portSuffix';
+  } catch (_) {
+    return null;
+  }
+}

--- a/mobile/lib/widgets/web_video_feed.dart
+++ b/mobile/lib/widgets/web_video_feed.dart
@@ -4,6 +4,8 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:hls_auth_web_player/hls_auth_web_player.dart'
+    show AuthHeaderProvider;
 import 'package:models/models.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_policy.dart';
 import 'package:openvine/widgets/web_video_player.dart';
@@ -53,6 +55,7 @@ class WebVideoFeed extends StatefulWidget {
     this.startThreshold = FeedAutoAdvanceDefaults.startThreshold,
     this.endThreshold = FeedAutoAdvanceDefaults.endThreshold,
     this.controllerFactory = defaultWebVideoPlayerControllerFactory,
+    this.authHeaderProvider,
     super.key,
   });
 
@@ -94,6 +97,14 @@ class WebVideoFeed extends StatefulWidget {
 
   /// Factory used to create underlying web video controllers.
   final WebVideoPlayerControllerFactory controllerFactory;
+
+  /// Provides NIP-98 `Authorization` header values for per-segment signing.
+  ///
+  /// When non-null, each [WebVideoPlayer] item routes playback through the
+  /// `HlsAuthWebPlayer` runtime. When null, the legacy `VideoPlayerController`
+  /// path is used. Callers are expected to gate this on
+  /// `kIsWeb && FeatureFlag.hlsAuthWebPlayer`.
+  final AuthHeaderProvider? authHeaderProvider;
 
   @override
   State<WebVideoFeed> createState() => WebVideoFeedState();
@@ -324,6 +335,7 @@ class WebVideoFeedState extends State<WebVideoFeed> {
           controllerFactory: widget.controllerFactory,
           controllersListenable: _controllers,
           itemBuilder: widget.itemBuilder,
+          authHeaderProvider: widget.authHeaderProvider,
           onInitialized: (controller) {
             if (!mounted) return;
             setState(() {
@@ -360,6 +372,7 @@ class _WebVideoFeedItem extends StatelessWidget {
     required this.controllerFactory,
     required this.controllersListenable,
     required this.itemBuilder,
+    required this.authHeaderProvider,
     required this.onInitialized,
     required this.onDisposed,
     required this.onError,
@@ -374,6 +387,7 @@ class _WebVideoFeedItem extends StatelessWidget {
   final WebVideoPlayerControllerFactory controllerFactory;
   final ValueListenable<Map<int, VideoPlayerController>> controllersListenable;
   final WebVideoFeedItemBuilder? itemBuilder;
+  final AuthHeaderProvider? authHeaderProvider;
   final ValueChanged<VideoPlayerController> onInitialized;
   final VoidCallback onDisposed;
   final VoidCallback onError;
@@ -389,6 +403,7 @@ class _WebVideoFeedItem extends StatelessWidget {
           autoPlay: isActive,
           headers: headers,
           controllerFactory: controllerFactory,
+          authHeaderProvider: authHeaderProvider,
           onInitialized: onInitialized,
           onDisposed: onDisposed,
           onError: onError,

--- a/mobile/lib/widgets/web_video_feed.dart
+++ b/mobile/lib/widgets/web_video_feed.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:hls_auth_web_player/hls_auth_web_player.dart'
     show AuthHeaderProvider;
 import 'package:models/models.dart';
+import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_policy.dart';
 import 'package:openvine/widgets/web_video_player.dart';
 import 'package:video_player/video_player.dart';
@@ -36,6 +37,9 @@ typedef WebOnCompleted = void Function(int index);
 /// on them — a failed player never emits a loop-boundary crossing.
 typedef WebOnErrored = void Function(int index);
 
+/// Callback fired when a web player needs viewer auth for [video].
+typedef WebOnRequiresAuth = void Function(VideoEvent video, int index);
+
 /// A vertical-scrolling video feed for web platforms.
 ///
 /// Uses Flutter's [video_player] package (HTML5 video via video_player_web_hls)
@@ -49,6 +53,7 @@ class WebVideoFeed extends StatefulWidget {
     this.onActiveVideoChanged,
     this.onCompleted,
     this.onErrored,
+    this.onRequiresAuth,
     this.onNearEnd,
     this.nearEndThreshold = 3,
     this.headers = const {},
@@ -79,6 +84,12 @@ class WebVideoFeed extends StatefulWidget {
   /// Wired to auto-advance so the feed can skip past a broken video instead
   /// of getting stuck on it.
   final WebOnErrored? onErrored;
+
+  /// Called when the NIP-98 web player reports `401`/`403`.
+  ///
+  /// This must stay separate from [onErrored] so auth-gated videos enter the
+  /// age-restricted UI instead of the broken-video skip/removal path.
+  final WebOnRequiresAuth? onRequiresAuth;
 
   /// Called when near the end of the list for pagination.
   final void Function(int index)? onNearEnd;
@@ -336,6 +347,7 @@ class WebVideoFeedState extends State<WebVideoFeed> {
           controllersListenable: _controllers,
           itemBuilder: widget.itemBuilder,
           authHeaderProvider: widget.authHeaderProvider,
+          hlsFallbackUrl: video.getFallbackUrl(),
           onInitialized: (controller) {
             if (!mounted) return;
             setState(() {
@@ -349,6 +361,10 @@ class WebVideoFeedState extends State<WebVideoFeed> {
           onError: () {
             if (!mounted) return;
             widget.onErrored?.call(index);
+          },
+          onRequiresAuth: () {
+            if (!mounted) return;
+            widget.onRequiresAuth?.call(video, index);
           },
         );
       },
@@ -373,9 +389,11 @@ class _WebVideoFeedItem extends StatelessWidget {
     required this.controllersListenable,
     required this.itemBuilder,
     required this.authHeaderProvider,
+    required this.hlsFallbackUrl,
     required this.onInitialized,
     required this.onDisposed,
     required this.onError,
+    required this.onRequiresAuth,
   });
 
   final VideoEvent video;
@@ -388,9 +406,11 @@ class _WebVideoFeedItem extends StatelessWidget {
   final ValueListenable<Map<int, VideoPlayerController>> controllersListenable;
   final WebVideoFeedItemBuilder? itemBuilder;
   final AuthHeaderProvider? authHeaderProvider;
+  final String? hlsFallbackUrl;
   final ValueChanged<VideoPlayerController> onInitialized;
   final VoidCallback onDisposed;
   final VoidCallback onError;
+  final VoidCallback onRequiresAuth;
 
   @override
   Widget build(BuildContext context) {
@@ -404,9 +424,11 @@ class _WebVideoFeedItem extends StatelessWidget {
           headers: headers,
           controllerFactory: controllerFactory,
           authHeaderProvider: authHeaderProvider,
+          hlsFallbackUrl: hlsFallbackUrl,
           onInitialized: onInitialized,
           onDisposed: onDisposed,
           onError: onError,
+          onRequiresAuth: onRequiresAuth,
         ),
         if (itemBuilder != null)
           ValueListenableBuilder<Map<int, VideoPlayerController>>(

--- a/mobile/lib/widgets/web_video_player.dart
+++ b/mobile/lib/widgets/web_video_player.dart
@@ -4,7 +4,9 @@
 import 'dart:math' as math;
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:hls_auth_web_player/hls_auth_web_player.dart' as hls_auth;
 import 'package:video_player/video_player.dart';
 
 typedef WebVideoPlayerControllerFactory =
@@ -20,6 +22,12 @@ VideoPlayerController defaultWebVideoPlayerControllerFactory({
 
 /// A simple video player widget for web that uses Flutter's video_player
 /// package (backed by HTML5 video element via video_player_web_hls).
+///
+/// When [authHeaderProvider] is non-null AND running on web, the widget
+/// swaps in the `HlsAuthWebPlayer` which attaches NIP-98 auth headers per
+/// segment. Callers are expected to gate [authHeaderProvider] on
+/// `kIsWeb && FeatureFlag.hlsAuthWebPlayer` — when either condition is
+/// false, pass `null` to preserve the legacy behavior.
 class WebVideoPlayer extends StatefulWidget {
   /// Creates a web video player.
   const WebVideoPlayer({
@@ -31,8 +39,11 @@ class WebVideoPlayer extends StatefulWidget {
     this.onInitialized,
     this.onDisposed,
     this.onError,
+    this.onRequiresAuth,
     this.initializeTimeout = const Duration(seconds: 8),
     this.controllerFactory = defaultWebVideoPlayerControllerFactory,
+    this.authHeaderProvider,
+    this.hlsFallbackUrl,
     super.key,
   });
 
@@ -48,10 +59,10 @@ class WebVideoPlayer extends StatefulWidget {
   /// How the video should fit within its container.
   final BoxFit fit;
 
-  /// HTTP headers for the video request.
+  /// HTTP headers for the video request (legacy path only).
   final Map<String, String> headers;
 
-  /// Called when the video controller is initialized.
+  /// Called when the video controller is initialized (legacy path only).
   final ValueChanged<VideoPlayerController>? onInitialized;
 
   /// Called when the underlying [VideoPlayerController] has been disposed.
@@ -63,11 +74,26 @@ class WebVideoPlayer extends StatefulWidget {
   /// Called when an error occurs.
   final VoidCallback? onError;
 
+  /// Called when the NIP-98 path reports the origin needs viewer auth
+  /// (`401`/`403`). The feed layer translates this into the
+  /// `ageRestricted` playback status.
+  final VoidCallback? onRequiresAuth;
+
   /// Maximum time to wait for the underlying HTML5 player to initialize.
   final Duration initializeTimeout;
 
-  /// Factory used to create the underlying controller.
+  /// Factory used to create the underlying controller (legacy path).
   final WebVideoPlayerControllerFactory controllerFactory;
+
+  /// Provides NIP-98 `Authorization` header values for per-segment signing.
+  /// When non-null and running on web, the widget routes playback through
+  /// `HlsAuthWebPlayer`. When null, the legacy `VideoPlayerController` path
+  /// is used (preserves all existing behavior).
+  final hls_auth.AuthHeaderProvider? authHeaderProvider;
+
+  /// Optional HLS manifest to try if the primary MP4 source fails with a
+  /// non-auth error. Only used on the NIP-98 path.
+  final String? hlsFallbackUrl;
 
   @override
   State<WebVideoPlayer> createState() => WebVideoPlayerState();
@@ -82,10 +108,14 @@ class WebVideoPlayerState extends State<WebVideoPlayer> {
   /// The video player controller for external access.
   VideoPlayerController? get controller => _controller;
 
+  bool get _useAuthPlayer => kIsWeb && widget.authHeaderProvider != null;
+
   @override
   void initState() {
     super.initState();
-    _initializeController();
+    if (!_useAuthPlayer) {
+      _initializeController();
+    }
   }
 
   @override
@@ -93,7 +123,9 @@ class WebVideoPlayerState extends State<WebVideoPlayer> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.url != widget.url) {
       _disposeController();
-      _initializeController();
+      if (!_useAuthPlayer) {
+        _initializeController();
+      }
     }
   }
 
@@ -175,6 +207,16 @@ class WebVideoPlayerState extends State<WebVideoPlayer> {
 
   @override
   Widget build(BuildContext context) {
+    if (_useAuthPlayer) {
+      return _HlsAuthPlayerShim(
+        url: widget.url,
+        hlsFallbackUrl: widget.hlsFallbackUrl,
+        authHeader: widget.authHeaderProvider!,
+        onError: widget.onError,
+        onRequiresAuth: widget.onRequiresAuth,
+      );
+    }
+
     if (_hasError) {
       return const ColoredBox(
         color: VineTheme.backgroundColor,
@@ -276,4 +318,98 @@ Size _fittedVideoSize({
   }
 
   return Size(videoSize.width * scale, videoSize.height * scale);
+}
+
+class _HlsAuthPlayerShim extends StatelessWidget {
+  const _HlsAuthPlayerShim({
+    required this.url,
+    required this.hlsFallbackUrl,
+    required this.authHeader,
+    required this.onError,
+    required this.onRequiresAuth,
+  });
+
+  final String url;
+  final String? hlsFallbackUrl;
+  final hls_auth.AuthHeaderProvider authHeader;
+  final VoidCallback? onError;
+  final VoidCallback? onRequiresAuth;
+
+  @override
+  Widget build(BuildContext context) {
+    return hls_auth.HlsAuthWebPlayer(
+      url: url,
+      hlsFallbackUrl: hlsFallbackUrl,
+      authHeader: authHeader,
+      onStatusChanged: (status) {
+        switch (status) {
+          case hls_auth.HlsAuthWebPlaybackStatus.requiresAuth:
+            onRequiresAuth?.call();
+          case hls_auth.HlsAuthWebPlaybackStatus.failure:
+            onError?.call();
+          case hls_auth.HlsAuthWebPlaybackStatus.idle:
+          case hls_auth.HlsAuthWebPlaybackStatus.loading:
+          case hls_auth.HlsAuthWebPlaybackStatus.ready:
+            break;
+        }
+      },
+      overlayBuilder: (context, status) {
+        switch (status) {
+          case hls_auth.HlsAuthWebPlaybackStatus.failure:
+            return const _AuthPlayerFailureSurface();
+          case hls_auth.HlsAuthWebPlaybackStatus.idle:
+          case hls_auth.HlsAuthWebPlaybackStatus.loading:
+            return const _AuthPlayerLoadingSurface();
+          case hls_auth.HlsAuthWebPlaybackStatus.requiresAuth:
+          case hls_auth.HlsAuthWebPlaybackStatus.ready:
+            return const SizedBox.shrink();
+        }
+      },
+    );
+  }
+}
+
+class _AuthPlayerLoadingSurface extends StatelessWidget {
+  const _AuthPlayerLoadingSurface();
+
+  @override
+  Widget build(BuildContext context) {
+    return const ColoredBox(
+      color: VineTheme.backgroundColor,
+      child: Center(
+        child: CircularProgressIndicator(color: VineTheme.whiteText),
+      ),
+    );
+  }
+}
+
+class _AuthPlayerFailureSurface extends StatelessWidget {
+  const _AuthPlayerFailureSurface();
+
+  @override
+  Widget build(BuildContext context) {
+    return const ColoredBox(
+      color: VineTheme.backgroundColor,
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline,
+              color: VineTheme.secondaryText,
+              size: 48,
+            ),
+            SizedBox(height: 16),
+            Text(
+              'Failed to load video',
+              style: TextStyle(
+                color: VineTheme.secondaryText,
+                fontSize: 16,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }

--- a/mobile/lib/widgets/web_video_player.dart
+++ b/mobile/lib/widgets/web_video_player.dart
@@ -121,7 +121,11 @@ class WebVideoPlayerState extends State<WebVideoPlayer> {
   @override
   void didUpdateWidget(WebVideoPlayer oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.url != widget.url) {
+    final oldUseAuthPlayer = kIsWeb && oldWidget.authHeaderProvider != null;
+    final authModeChanged = oldUseAuthPlayer != _useAuthPlayer;
+    final urlChanged = oldWidget.url != widget.url;
+
+    if (authModeChanged || urlChanged) {
       _disposeController();
       if (!_useAuthPlayer) {
         _initializeController();

--- a/mobile/packages/hls_auth_web_player/analysis_options.yaml
+++ b/mobile/packages/hls_auth_web_player/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:very_good_analysis/analysis_options.yaml
+
+analyzer:
+  exclude:
+    - lib/src/js/**

--- a/mobile/packages/hls_auth_web_player/lib/hls_auth_web_player.dart
+++ b/mobile/packages/hls_auth_web_player/lib/hls_auth_web_player.dart
@@ -1,0 +1,16 @@
+/// Public API for the HLS + NIP-98 auth web video player.
+///
+/// This package is strictly web-only. On non-web builds the widget renders
+/// a failure state so callers can keep the import unconditional and gate
+/// usage at the call site (e.g. `kIsWeb && FeatureFlag.hlsAuthWebPlayer`).
+library;
+
+export 'src/auth_header_provider.dart' show AuthHeaderProvider, AuthHttpMethod;
+export 'src/hls_auth_source_policy.dart'
+    show HlsAuthWebSourceKind, sourceKindFor;
+export 'src/hls_auth_web_controller.dart' show HlsAuthWebController;
+export 'src/hls_auth_web_player.dart'
+    show HlsAuthWebPlayer, HlsAuthWebStatusBuilder;
+export 'src/hls_auth_web_runtime.dart'
+    show HlsAuthWebAttemptResult, HlsAuthWebRuntime;
+export 'src/hls_auth_web_status.dart' show HlsAuthWebPlaybackStatus;

--- a/mobile/packages/hls_auth_web_player/lib/src/auth_header_provider.dart
+++ b/mobile/packages/hls_auth_web_player/lib/src/auth_header_provider.dart
@@ -1,0 +1,15 @@
+/// Async callback that returns a NIP-98 `Authorization` header value for the
+/// given media URL, or `null` when no auth header can be produced (for
+/// example, when the viewer is not authenticated).
+///
+/// The returned string, if non-null, MUST be the complete header value,
+/// including the scheme prefix — typically `Nostr <base64-json>`.
+typedef AuthHeaderProvider =
+    Future<String?> Function(String url, String method);
+
+/// HTTP methods accepted by [AuthHeaderProvider]. The loader and MP4 fallback
+/// only need `GET`, but the type is kept open for future use.
+abstract class AuthHttpMethod {
+  /// The HTTP GET method.
+  static const String get = 'GET';
+}

--- a/mobile/packages/hls_auth_web_player/lib/src/hls_auth_source_policy.dart
+++ b/mobile/packages/hls_auth_web_player/lib/src/hls_auth_source_policy.dart
@@ -1,0 +1,22 @@
+/// Source format the runtime should drive for a given URL.
+enum HlsAuthWebSourceKind {
+  /// Direct MP4 (or unknown non-HLS) — use the `fetch` + blob path.
+  mp4,
+
+  /// HLS playlist — use hls.js with the auth loader.
+  hls,
+}
+
+/// Chooses between the MP4 and HLS paths. The rule mirrors divine-web:
+/// anything ending in `.m3u8` uses HLS; everything else (including direct
+/// `.mp4`, no extension, signed URLs with query strings) starts on MP4.
+/// Callers can still fall back to HLS on 404 by explicitly requesting an
+/// HLS URL through [sourceKindFor].
+HlsAuthWebSourceKind sourceKindFor(String url) {
+  final withoutQuery = url.split('?').first;
+  final lower = withoutQuery.toLowerCase();
+  if (lower.endsWith('.m3u8')) {
+    return HlsAuthWebSourceKind.hls;
+  }
+  return HlsAuthWebSourceKind.mp4;
+}

--- a/mobile/packages/hls_auth_web_player/lib/src/hls_auth_source_policy.dart
+++ b/mobile/packages/hls_auth_web_player/lib/src/hls_auth_source_policy.dart
@@ -10,6 +10,10 @@ enum HlsAuthWebSourceKind {
 /// Chooses between the MP4 and HLS paths. The rule mirrors divine-web:
 /// anything ending in `.m3u8` uses HLS; everything else (including direct
 /// `.mp4`, no extension, signed URLs with query strings) starts on MP4.
+///
+/// The MP4 path fetches the full response into a browser blob before assigning
+/// an object URL to the video element. That is acceptable for Divine's
+/// short-form videos, but longer media should prefer an HLS source.
 /// Callers can still fall back to HLS on 404 by explicitly requesting an
 /// HLS URL through [sourceKindFor].
 HlsAuthWebSourceKind sourceKindFor(String url) {

--- a/mobile/packages/hls_auth_web_player/lib/src/hls_auth_web_controller.dart
+++ b/mobile/packages/hls_auth_web_player/lib/src/hls_auth_web_controller.dart
@@ -1,0 +1,122 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:hls_auth_web_player/src/auth_header_provider.dart';
+import 'package:hls_auth_web_player/src/hls_auth_source_policy.dart';
+import 'package:hls_auth_web_player/src/hls_auth_web_runtime.dart';
+import 'package:hls_auth_web_player/src/hls_auth_web_status.dart';
+
+/// Drives a single web video element through the MP4 blob path first, then
+/// falls back to HLS on `404`. On `401`/`403` it stops and surfaces the
+/// age-verification flow via [status].
+///
+/// This class owns no browser state directly — all side effects go through
+/// the injected [HlsAuthWebRuntime], which keeps it testable without JS.
+class HlsAuthWebController extends ChangeNotifier {
+  /// Creates a controller that drives the single [viewType] on [runtime].
+  HlsAuthWebController({
+    required HlsAuthWebRuntime runtime,
+    required String viewType,
+    required String url,
+    required AuthHeaderProvider authHeader,
+    String? hlsFallbackUrl,
+  }) : _runtime = runtime,
+       _viewType = viewType,
+       _url = url,
+       _authHeader = authHeader,
+       _hlsFallbackUrl = hlsFallbackUrl;
+
+  final HlsAuthWebRuntime _runtime;
+  final String _viewType;
+  final String _url;
+  final String? _hlsFallbackUrl;
+  final AuthHeaderProvider _authHeader;
+
+  HlsAuthWebPlaybackStatus _status = HlsAuthWebPlaybackStatus.idle;
+  bool _disposed = false;
+
+  /// Current playback status.
+  HlsAuthWebPlaybackStatus get status => _status;
+
+  /// The `HtmlElementView`-compatible view type this controller drives.
+  String get viewType => _viewType;
+
+  /// Starts loading the source. Safe to call only once per controller; the
+  /// widget manages lifecycle so we do not re-enter.
+  Future<void> load() async {
+    if (_disposed) return;
+    if (!_runtime.isSupported) {
+      _emit(HlsAuthWebPlaybackStatus.failure);
+      return;
+    }
+    _runtime.ensureVideoViewFactory(_viewType);
+    _emit(HlsAuthWebPlaybackStatus.loading);
+
+    final primaryKind = sourceKindFor(_url);
+    final outcome = await _loadOne(_url, primaryKind);
+    if (_disposed) return;
+
+    switch (outcome) {
+      case HlsAuthWebAttemptResult.ok:
+        _emit(HlsAuthWebPlaybackStatus.ready);
+      case HlsAuthWebAttemptResult.requiresAuth:
+        _emit(HlsAuthWebPlaybackStatus.requiresAuth);
+      case HlsAuthWebAttemptResult.failure:
+        await _tryHlsFallback();
+    }
+  }
+
+  Future<void> _tryHlsFallback() async {
+    final hlsUrl = _hlsFallbackUrl;
+    if (hlsUrl == null || hlsUrl.isEmpty) {
+      _emit(HlsAuthWebPlaybackStatus.failure);
+      return;
+    }
+    final outcome = await _loadOne(hlsUrl, HlsAuthWebSourceKind.hls);
+    if (_disposed) return;
+    switch (outcome) {
+      case HlsAuthWebAttemptResult.ok:
+        _emit(HlsAuthWebPlaybackStatus.ready);
+      case HlsAuthWebAttemptResult.requiresAuth:
+        _emit(HlsAuthWebPlaybackStatus.requiresAuth);
+      case HlsAuthWebAttemptResult.failure:
+        _emit(HlsAuthWebPlaybackStatus.failure);
+    }
+  }
+
+  Future<HlsAuthWebAttemptResult> _loadOne(
+    String url,
+    HlsAuthWebSourceKind kind,
+  ) async {
+    switch (kind) {
+      case HlsAuthWebSourceKind.mp4:
+        final authorization = await _authHeader(url, AuthHttpMethod.get);
+        if (_disposed) return HlsAuthWebAttemptResult.failure;
+        return _runtime.loadMp4Blob(
+          viewType: _viewType,
+          url: url,
+          authorization: authorization,
+        );
+      case HlsAuthWebSourceKind.hls:
+        return _runtime.loadHls(
+          viewType: _viewType,
+          url: url,
+          authHeader: _authHeader,
+        );
+    }
+  }
+
+  void _emit(HlsAuthWebPlaybackStatus next) {
+    if (_disposed || _status == next) return;
+    _status = next;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    unawaited(_runtime.dispose(_viewType));
+    super.dispose();
+  }
+}

--- a/mobile/packages/hls_auth_web_player/lib/src/hls_auth_web_player.dart
+++ b/mobile/packages/hls_auth_web_player/lib/src/hls_auth_web_player.dart
@@ -112,6 +112,8 @@ class _HlsAuthWebPlayerState extends State<HlsAuthWebPlayer> {
 
   String _buildViewType(String url) {
     final hash = url.hashCode.toUnsigned(32).toRadixString(16);
+    // Each widget instance owns a distinct <video> element, even when the
+    // same URL appears more than once in a feed.
     final salt = DateTime.now().microsecondsSinceEpoch.toRadixString(16);
     return 'hls-auth-web-player-$hash-$salt';
   }

--- a/mobile/packages/hls_auth_web_player/lib/src/hls_auth_web_player.dart
+++ b/mobile/packages/hls_auth_web_player/lib/src/hls_auth_web_player.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:hls_auth_web_player/src/auth_header_provider.dart';
+import 'package:hls_auth_web_player/src/hls_auth_web_controller.dart';
+import 'package:hls_auth_web_player/src/hls_auth_web_runtime.dart';
+import 'package:hls_auth_web_player/src/hls_auth_web_status.dart';
+import 'package:hls_auth_web_player/src/runtime_factory.dart';
+
+/// Builder for the per-status overlay widget (loading, failure,
+/// requiresAuth, ready). The host app provides this so the player can stay
+/// chrome-free and reuse the app's age-restricted overlay, dark placeholder,
+/// etc.
+typedef HlsAuthWebStatusBuilder =
+    Widget Function(BuildContext context, HlsAuthWebPlaybackStatus status);
+
+/// Web-only video player widget that wraps hls.js with NIP-98 auth support.
+///
+/// Exposes three host-provided pieces:
+///
+/// * [url] — the source URL. `.m3u8` triggers the HLS path, anything else
+///   starts with direct MP4 via fetch + blob, then falls back to
+///   [hlsFallbackUrl] on non-auth failure.
+/// * [authHeader] — an async callback returning the full NIP-98 auth header
+///   value for the given URL, or `null` when no header can be made.
+/// * [overlayBuilder] — renders state-specific UI on top of the video
+///   surface (loading spinner, age-restricted overlay, error fallback).
+class HlsAuthWebPlayer extends StatefulWidget {
+  /// Creates an [HlsAuthWebPlayer].
+  HlsAuthWebPlayer({
+    required this.url,
+    required this.authHeader,
+    this.hlsFallbackUrl,
+    this.overlayBuilder,
+    this.onStatusChanged,
+    HlsAuthWebRuntime? runtime,
+    super.key,
+  }) : runtime = runtime ?? createDefaultHlsAuthWebRuntime();
+
+  /// Primary source URL. `.m3u8` uses HLS, everything else starts on MP4.
+  final String url;
+
+  /// Optional HLS manifest used as a fallback when the primary MP4 path
+  /// fails with a non-auth error (e.g. `404`).
+  final String? hlsFallbackUrl;
+
+  /// Callback providing the `Authorization` header for each request.
+  final AuthHeaderProvider authHeader;
+
+  /// Renders overlay UI keyed off the current status. Called on every
+  /// status transition.
+  final HlsAuthWebStatusBuilder? overlayBuilder;
+
+  /// Optional observer for status transitions. Use to bridge the player's
+  /// status into the app's `VideoPlaybackStatusCubit`.
+  final ValueChanged<HlsAuthWebPlaybackStatus>? onStatusChanged;
+
+  /// Runtime that drives the JS side. Tests inject a fake; production picks
+  /// the web or unsupported runtime automatically.
+  final HlsAuthWebRuntime runtime;
+
+  @override
+  State<HlsAuthWebPlayer> createState() => _HlsAuthWebPlayerState();
+}
+
+class _HlsAuthWebPlayerState extends State<HlsAuthWebPlayer> {
+  late String _viewType;
+  late HlsAuthWebController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _viewType = _buildViewType(widget.url);
+    _controller = _createController(widget);
+    _controller.addListener(_onControllerUpdate);
+    unawaited(_controller.load());
+  }
+
+  @override
+  void didUpdateWidget(covariant HlsAuthWebPlayer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.url == widget.url &&
+        oldWidget.hlsFallbackUrl == widget.hlsFallbackUrl &&
+        identical(oldWidget.runtime, widget.runtime)) {
+      return;
+    }
+    _controller
+      ..removeListener(_onControllerUpdate)
+      ..dispose();
+    _viewType = _buildViewType(widget.url);
+    _controller = _createController(widget);
+    _controller.addListener(_onControllerUpdate);
+    unawaited(_controller.load());
+  }
+
+  void _onControllerUpdate() {
+    if (!mounted) return;
+    widget.onStatusChanged?.call(_controller.status);
+    setState(() {});
+  }
+
+  HlsAuthWebController _createController(HlsAuthWebPlayer config) {
+    return HlsAuthWebController(
+      runtime: config.runtime,
+      viewType: _viewType,
+      url: config.url,
+      authHeader: config.authHeader,
+      hlsFallbackUrl: config.hlsFallbackUrl,
+    );
+  }
+
+  String _buildViewType(String url) {
+    final hash = url.hashCode.toUnsigned(32).toRadixString(16);
+    final salt = DateTime.now().microsecondsSinceEpoch.toRadixString(16);
+    return 'hls-auth-web-player-$hash-$salt';
+  }
+
+  @override
+  void dispose() {
+    _controller
+      ..removeListener(_onControllerUpdate)
+      ..dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final overlayBuilder = widget.overlayBuilder;
+    final status = _controller.status;
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        if (kIsWeb && status == HlsAuthWebPlaybackStatus.ready)
+          HtmlElementView(viewType: _viewType),
+        if (overlayBuilder != null)
+          Positioned.fill(child: overlayBuilder(context, status)),
+      ],
+    );
+  }
+}

--- a/mobile/packages/hls_auth_web_player/lib/src/hls_auth_web_player.dart
+++ b/mobile/packages/hls_auth_web_player/lib/src/hls_auth_web_player.dart
@@ -133,8 +133,7 @@ class _HlsAuthWebPlayerState extends State<HlsAuthWebPlayer> {
     return Stack(
       fit: StackFit.expand,
       children: [
-        if (kIsWeb && status == HlsAuthWebPlaybackStatus.ready)
-          HtmlElementView(viewType: _viewType),
+        if (kIsWeb) HtmlElementView(viewType: _viewType),
         if (overlayBuilder != null)
           Positioned.fill(child: overlayBuilder(context, status)),
       ],

--- a/mobile/packages/hls_auth_web_player/lib/src/hls_auth_web_runtime.dart
+++ b/mobile/packages/hls_auth_web_player/lib/src/hls_auth_web_runtime.dart
@@ -1,0 +1,49 @@
+import 'package:hls_auth_web_player/src/auth_header_provider.dart';
+
+/// Result of a single preflight or fetch attempt.
+enum HlsAuthWebAttemptResult {
+  /// Source was loaded and attached to the video element.
+  ok,
+
+  /// Origin responded 401 / 403. UI should surface the verification flow.
+  requiresAuth,
+
+  /// Any other failure. Caller decides whether to fall back.
+  failure,
+}
+
+/// A thin, test-replaceable port for browser-side work. One implementation
+/// uses `dart:js_interop` + hls.js on web; another is an in-memory fake for
+/// tests. Keeping the seam here lets the controller stay pure Dart and avoids
+/// shipping real JS interop into non-web builds.
+abstract class HlsAuthWebRuntime {
+  /// Whether this runtime can drive hls.js. On native builds the
+  /// implementation returns false so the feature flag can short-circuit.
+  bool get isSupported;
+
+  /// Tells the runtime the video element identified by [viewType] exists.
+  /// Registers an `HtmlElementView`-compatible factory as a side-effect when
+  /// running on web.
+  void ensureVideoViewFactory(String viewType);
+
+  /// Fetches the given MP4 [url] with the optional [authorization] header and
+  /// pipes the resulting blob URL into the registered video element for
+  /// [viewType]. On 401/403 returns [HlsAuthWebAttemptResult.requiresAuth]
+  /// without touching the element's `src`.
+  Future<HlsAuthWebAttemptResult> loadMp4Blob({
+    required String viewType,
+    required String url,
+    String? authorization,
+  });
+
+  /// Wires hls.js to the element for [viewType] using a loader subclass that
+  /// calls [authHeader] per request.
+  Future<HlsAuthWebAttemptResult> loadHls({
+    required String viewType,
+    required String url,
+    required AuthHeaderProvider authHeader,
+  });
+
+  /// Releases any blob URL, hls.js instance, or video element handlers.
+  Future<void> dispose(String viewType);
+}

--- a/mobile/packages/hls_auth_web_player/lib/src/hls_auth_web_runtime_web.dart
+++ b/mobile/packages/hls_auth_web_player/lib/src/hls_auth_web_runtime_web.dart
@@ -1,0 +1,161 @@
+// Web-only runtime. Bridges the Dart controller to the JS shim installed by
+// `web/hls_auth_web_player.js`.
+
+import 'dart:async';
+import 'dart:developer' as developer;
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import 'dart:ui_web' as ui_web;
+
+import 'package:flutter/foundation.dart';
+import 'package:hls_auth_web_player/src/auth_header_provider.dart';
+import 'package:hls_auth_web_player/src/hls_auth_web_runtime.dart';
+import 'package:hls_auth_web_player/src/js/hls_js_bindings.dart';
+
+/// Web implementation of [HlsAuthWebRuntime]. Creates a `<video>` element per
+/// registered view type, hands it to the JS shim, and dispatches MP4 / HLS
+/// loads through `window.__divine*` helpers installed by
+/// `web/hls_auth_web_player.js`.
+class WebHlsAuthRuntime implements HlsAuthWebRuntime {
+  /// Creates a [WebHlsAuthRuntime] that uses the default browser globals.
+  WebHlsAuthRuntime();
+
+  final Set<String> _registeredFactories = <String>{};
+
+  @override
+  bool get isSupported {
+    if (!kIsWeb) return false;
+    final ctor = hlsConstructor;
+    if (ctor == null) return false;
+    try {
+      return hlsIsSupportedJs().toDart;
+    } on Object catch (error, stackTrace) {
+      developer.log(
+        'hls.isSupported threw',
+        name: 'hls_auth_web_player',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return false;
+    }
+  }
+
+  @override
+  void ensureVideoViewFactory(String viewType) {
+    if (_registeredFactories.contains(viewType)) return;
+    ui_web.platformViewRegistry.registerViewFactory(viewType, (int _) {
+      final element = _createVideoElement(viewType);
+      final register = divineRegisterVideo;
+      if (register != null) {
+        register.callAsFunction(null, viewType.toJS, element);
+      }
+      return element;
+    });
+    _registeredFactories.add(viewType);
+  }
+
+  @override
+  Future<HlsAuthWebAttemptResult> loadMp4Blob({
+    required String viewType,
+    required String url,
+    String? authorization,
+  }) async {
+    final fetchMp4 = divineFetchMp4;
+    if (fetchMp4 == null) return HlsAuthWebAttemptResult.failure;
+    final promise = fetchMp4.callAsFunction(
+      null,
+      viewType.toJS,
+      url.toJS,
+      authorization?.toJS,
+    );
+    final result = await _awaitResult(promise);
+    return _attemptFromStatus(result);
+  }
+
+  @override
+  Future<HlsAuthWebAttemptResult> loadHls({
+    required String viewType,
+    required String url,
+    required AuthHeaderProvider authHeader,
+  }) async {
+    final loadHls = divineLoadHls;
+    if (loadHls == null) return HlsAuthWebAttemptResult.failure;
+    JSPromise<JSString?> bridge(JSString jsUrl, JSString jsMethod) {
+      final completer = Completer<JSString?>();
+      unawaited(
+        authHeader(jsUrl.toDart, jsMethod.toDart).then(
+          (value) => completer.complete(value?.toJS),
+          onError: (Object error, StackTrace stackTrace) {
+            developer.log(
+              'auth header callback threw',
+              name: 'hls_auth_web_player',
+              error: error,
+              stackTrace: stackTrace,
+            );
+            completer.complete(null);
+          },
+        ),
+      );
+      return completer.future.toJS;
+    }
+
+    final jsCallback = bridge.toJS;
+    final promise = loadHls.callAsFunction(
+      null,
+      viewType.toJS,
+      url.toJS,
+      jsCallback,
+    );
+    final result = await _awaitResult(promise);
+    return _attemptFromStatus(result);
+  }
+
+  @override
+  Future<void> dispose(String viewType) async {
+    final disposeView = divineDisposeView;
+    if (disposeView == null) return;
+    disposeView.callAsFunction(null, viewType.toJS);
+  }
+
+  JSObject _createVideoElement(String viewType) {
+    final element = _documentCreateElement('video'.toJS);
+    element['id'] = 'divine-hls-$viewType'.toJS;
+    element['playsInline'] = true.toJS;
+    element['controls'] = false.toJS;
+    element['muted'] = true.toJS;
+    element['autoplay'] = true.toJS;
+    final style = element['style'] as JSObject?;
+    if (style != null) {
+      style['width'] = '100%'.toJS;
+      style['height'] = '100%'.toJS;
+      style['objectFit'] = 'cover'.toJS;
+      style['background'] = '#000'.toJS;
+    }
+    return element;
+  }
+
+  Future<JSObject?> _awaitResult(JSAny? maybePromise) async {
+    if (maybePromise == null) return null;
+    final promise = maybePromise as JSPromise<JSAny?>;
+    final value = await promise.toDart;
+    if (value == null) return null;
+    return value as JSObject;
+  }
+
+  HlsAuthWebAttemptResult _attemptFromStatus(JSObject? result) {
+    if (result == null) return HlsAuthWebAttemptResult.failure;
+    final statusValue = result['status'] as JSString?;
+    final status = statusValue?.toDart;
+    switch (status) {
+      case 'ok':
+        return HlsAuthWebAttemptResult.ok;
+      case 'requiresAuth':
+        return HlsAuthWebAttemptResult.requiresAuth;
+      default:
+        return HlsAuthWebAttemptResult.failure;
+    }
+  }
+}
+
+@JS('document.createElement')
+external JSObject _documentCreateElement(JSString tag);

--- a/mobile/packages/hls_auth_web_player/lib/src/hls_auth_web_status.dart
+++ b/mobile/packages/hls_auth_web_player/lib/src/hls_auth_web_status.dart
@@ -1,0 +1,18 @@
+/// Playback status surfaced by the web player. The app layer maps these to
+/// the existing `VideoPlaybackStatusCubit` / `PlaybackStatus` values.
+enum HlsAuthWebPlaybackStatus {
+  /// Controller was created but playback has not started.
+  idle,
+
+  /// Fetching or preparing the source.
+  loading,
+
+  /// Playback is ready. Media is either playing or paused.
+  ready,
+
+  /// The origin returned 401 / 403 and the viewer must verify to continue.
+  requiresAuth,
+
+  /// A non-auth failure occurred. The feed should skip or retry.
+  failure,
+}

--- a/mobile/packages/hls_auth_web_player/lib/src/js/hls_js_bindings.dart
+++ b/mobile/packages/hls_auth_web_player/lib/src/js/hls_js_bindings.dart
@@ -1,0 +1,41 @@
+// Web-only JS bindings for hls.js and the minimal DOM surface the player
+// needs. Intentionally narrow — the public surface is `WebHlsAuthRuntime`
+// (`hls_auth_web_runtime_web.dart`), and nothing outside this subtree should
+// import these externs directly.
+
+@JS()
+library;
+
+import 'dart:js_interop';
+
+/// Top-level `Hls` constructor. Null when hls.js has not been loaded.
+@JS('Hls')
+external JSFunction? get hlsConstructor;
+
+/// hls.js static `isSupported()` method.
+@JS('Hls.isSupported')
+external JSBoolean hlsIsSupportedJs();
+
+/// Registers the video element created by the Dart runtime so the JS shim
+/// can manage its lifecycle (`attachMedia`, `src` assignment, blob URL
+/// revocation).
+@JS('window.__divineRegisterVideo')
+external JSFunction? get divineRegisterVideo;
+
+/// Tells the JS side to fetch the MP4 at `url` (with an optional
+/// `Authorization` header), convert it to a blob, and attach it to the
+/// element for `viewType`. Resolves to an object shaped
+/// `{status: 'ok'|'requiresAuth'|'failure', code?: number}`.
+@JS('window.__divineFetchMp4')
+external JSFunction? get divineFetchMp4;
+
+/// Tells the JS side to instantiate hls.js with the auth loader and attach
+/// it to the registered video element. Resolves with the same shape as
+/// [divineFetchMp4].
+@JS('window.__divineLoadHls')
+external JSFunction? get divineLoadHls;
+
+/// Tells the JS side to dispose an active hls.js instance and release any
+/// blob URL held for the given `viewType`.
+@JS('window.__divineDisposeView')
+external JSFunction? get divineDisposeView;

--- a/mobile/packages/hls_auth_web_player/lib/src/runtime_factory.dart
+++ b/mobile/packages/hls_auth_web_player/lib/src/runtime_factory.dart
@@ -1,0 +1,7 @@
+import 'package:hls_auth_web_player/src/hls_auth_web_runtime.dart';
+import 'package:hls_auth_web_player/src/runtime_factory_stub.dart'
+    if (dart.library.js_interop) 'package:hls_auth_web_player/src/runtime_factory_web.dart';
+
+/// Returns the platform-appropriate runtime. On web this drives hls.js;
+/// elsewhere it returns an unsupported stub so widgets can fail closed.
+HlsAuthWebRuntime createDefaultHlsAuthWebRuntime() => createDefaultRuntime();

--- a/mobile/packages/hls_auth_web_player/lib/src/runtime_factory_stub.dart
+++ b/mobile/packages/hls_auth_web_player/lib/src/runtime_factory_stub.dart
@@ -1,0 +1,32 @@
+import 'package:hls_auth_web_player/src/hls_auth_web_runtime.dart';
+
+/// Non-web platforms get a runtime that always reports unsupported. The
+/// widget short-circuits to its error builder in that case. This is a last
+/// line of defense; callers are expected to only instantiate the web player
+/// when `kIsWeb` is true.
+HlsAuthWebRuntime createDefaultRuntime() => _UnsupportedRuntime();
+
+class _UnsupportedRuntime implements HlsAuthWebRuntime {
+  @override
+  bool get isSupported => false;
+
+  @override
+  void ensureVideoViewFactory(String viewType) {}
+
+  @override
+  Future<HlsAuthWebAttemptResult> loadMp4Blob({
+    required String viewType,
+    required String url,
+    String? authorization,
+  }) async => HlsAuthWebAttemptResult.failure;
+
+  @override
+  Future<HlsAuthWebAttemptResult> loadHls({
+    required String viewType,
+    required String url,
+    required Future<String?> Function(String url, String method) authHeader,
+  }) async => HlsAuthWebAttemptResult.failure;
+
+  @override
+  Future<void> dispose(String viewType) async {}
+}

--- a/mobile/packages/hls_auth_web_player/lib/src/runtime_factory_web.dart
+++ b/mobile/packages/hls_auth_web_player/lib/src/runtime_factory_web.dart
@@ -1,0 +1,6 @@
+import 'package:hls_auth_web_player/src/hls_auth_web_runtime.dart';
+import 'package:hls_auth_web_player/src/hls_auth_web_runtime_web.dart';
+
+/// Returns the web-backed runtime. Used when the compile target supports
+/// `dart:ui_web` / `dart:js_interop` (i.e. real web builds).
+HlsAuthWebRuntime createDefaultRuntime() => WebHlsAuthRuntime();

--- a/mobile/packages/hls_auth_web_player/pubspec.yaml
+++ b/mobile/packages/hls_auth_web_player/pubspec.yaml
@@ -1,0 +1,20 @@
+name: hls_auth_web_player
+description: >-
+  Web-only Flutter video player that wraps hls.js and attaches NIP-98
+  authorization headers per segment/manifest request.
+version: 0.1.0+1
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.11.0
+  flutter: ^3.41.1
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  very_good_analysis: ^10.0.0

--- a/mobile/packages/hls_auth_web_player/test/src/fake_hls_auth_web_runtime.dart
+++ b/mobile/packages/hls_auth_web_player/test/src/fake_hls_auth_web_runtime.dart
@@ -1,0 +1,81 @@
+import 'package:hls_auth_web_player/hls_auth_web_player.dart';
+
+/// Test double for [HlsAuthWebRuntime]. Records calls and returns
+/// pre-programmed results so controller tests can assert decision logic
+/// without pulling in any JS.
+class FakeHlsAuthWebRuntime implements HlsAuthWebRuntime {
+  FakeHlsAuthWebRuntime({
+    this.isSupported = true,
+    this.mp4Result = HlsAuthWebAttemptResult.ok,
+    this.hlsResult = HlsAuthWebAttemptResult.ok,
+  });
+
+  @override
+  bool isSupported;
+
+  HlsAuthWebAttemptResult mp4Result;
+  HlsAuthWebAttemptResult hlsResult;
+
+  final List<String> registeredViewTypes = <String>[];
+  final List<Mp4Call> mp4Calls = <Mp4Call>[];
+  final List<HlsCall> hlsCalls = <HlsCall>[];
+  final List<String> disposedViewTypes = <String>[];
+
+  @override
+  void ensureVideoViewFactory(String viewType) {
+    registeredViewTypes.add(viewType);
+  }
+
+  @override
+  Future<HlsAuthWebAttemptResult> loadMp4Blob({
+    required String viewType,
+    required String url,
+    String? authorization,
+  }) async {
+    mp4Calls.add(
+      Mp4Call(viewType: viewType, url: url, authorization: authorization),
+    );
+    return mp4Result;
+  }
+
+  @override
+  Future<HlsAuthWebAttemptResult> loadHls({
+    required String viewType,
+    required String url,
+    required AuthHeaderProvider authHeader,
+  }) async {
+    hlsCalls.add(HlsCall(viewType: viewType, url: url, authHeader: authHeader));
+    return hlsResult;
+  }
+
+  @override
+  Future<void> dispose(String viewType) async {
+    disposedViewTypes.add(viewType);
+  }
+}
+
+/// Captured MP4 blob request.
+class Mp4Call {
+  const Mp4Call({
+    required this.viewType,
+    required this.url,
+    required this.authorization,
+  });
+
+  final String viewType;
+  final String url;
+  final String? authorization;
+}
+
+/// Captured HLS load request.
+class HlsCall {
+  const HlsCall({
+    required this.viewType,
+    required this.url,
+    required this.authHeader,
+  });
+
+  final String viewType;
+  final String url;
+  final AuthHeaderProvider authHeader;
+}

--- a/mobile/packages/hls_auth_web_player/test/src/hls_auth_source_policy_test.dart
+++ b/mobile/packages/hls_auth_web_player/test/src/hls_auth_source_policy_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hls_auth_web_player/src/hls_auth_source_policy.dart';
+
+void main() {
+  group('sourceKindFor', () {
+    test('returns hls for .m3u8 URLs', () {
+      expect(
+        sourceKindFor('https://media.divine.video/abc/hls/master.m3u8'),
+        equals(HlsAuthWebSourceKind.hls),
+      );
+    });
+
+    test('returns hls when the path ends in .m3u8 and has a query string', () {
+      expect(
+        sourceKindFor('https://media.divine.video/abc/hls/master.m3u8?token=x'),
+        equals(HlsAuthWebSourceKind.hls),
+      );
+    });
+
+    test('returns mp4 for direct .mp4 URLs', () {
+      expect(
+        sourceKindFor('https://media.divine.video/abc.mp4'),
+        equals(HlsAuthWebSourceKind.mp4),
+      );
+    });
+
+    test('returns mp4 for URLs with no extension', () {
+      expect(
+        sourceKindFor('https://media.divine.video/abc'),
+        equals(HlsAuthWebSourceKind.mp4),
+      );
+    });
+
+    test('is case-insensitive on the extension', () {
+      expect(
+        sourceKindFor('https://media.divine.video/abc/master.M3U8'),
+        equals(HlsAuthWebSourceKind.hls),
+      );
+    });
+  });
+}

--- a/mobile/packages/hls_auth_web_player/test/src/hls_auth_web_controller_test.dart
+++ b/mobile/packages/hls_auth_web_player/test/src/hls_auth_web_controller_test.dart
@@ -1,0 +1,193 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hls_auth_web_player/hls_auth_web_player.dart';
+
+import 'fake_hls_auth_web_runtime.dart';
+
+void main() {
+  group(HlsAuthWebController, () {
+    late FakeHlsAuthWebRuntime runtime;
+
+    setUp(() {
+      runtime = FakeHlsAuthWebRuntime();
+    });
+
+    Future<String?> constantHeader(String url, String method) async =>
+        'Nostr base64payload';
+
+    test('load fails when runtime is unsupported', () async {
+      runtime.isSupported = false;
+      final controller = HlsAuthWebController(
+        runtime: runtime,
+        viewType: 'view',
+        url: 'https://media.example/a.mp4',
+        authHeader: constantHeader,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load();
+
+      expect(controller.status, equals(HlsAuthWebPlaybackStatus.failure));
+      expect(runtime.mp4Calls, isEmpty);
+      expect(runtime.hlsCalls, isEmpty);
+    });
+
+    test('MP4 path forwards the authorization header on success', () async {
+      final controller = HlsAuthWebController(
+        runtime: runtime,
+        viewType: 'view',
+        url: 'https://media.example/a.mp4',
+        authHeader: constantHeader,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load();
+
+      expect(controller.status, equals(HlsAuthWebPlaybackStatus.ready));
+      expect(runtime.mp4Calls, hasLength(1));
+      expect(
+        runtime.mp4Calls.single.authorization,
+        equals('Nostr base64payload'),
+      );
+      expect(runtime.hlsCalls, isEmpty);
+    });
+
+    test(
+      'MP4 401 surfaces requiresAuth without attempting HLS fallback',
+      () async {
+        runtime.mp4Result = HlsAuthWebAttemptResult.requiresAuth;
+        final controller = HlsAuthWebController(
+          runtime: runtime,
+          viewType: 'view',
+          url: 'https://media.example/a.mp4',
+          hlsFallbackUrl: 'https://media.example/a/hls/master.m3u8',
+          authHeader: constantHeader,
+        );
+        addTearDown(controller.dispose);
+
+        await controller.load();
+
+        expect(
+          controller.status,
+          equals(HlsAuthWebPlaybackStatus.requiresAuth),
+        );
+        expect(runtime.hlsCalls, isEmpty);
+      },
+    );
+
+    test('MP4 failure falls back to HLS when an HLS URL is provided', () async {
+      runtime
+        ..mp4Result = HlsAuthWebAttemptResult.failure
+        ..hlsResult = HlsAuthWebAttemptResult.ok;
+      final controller = HlsAuthWebController(
+        runtime: runtime,
+        viewType: 'view',
+        url: 'https://media.example/a.mp4',
+        hlsFallbackUrl: 'https://media.example/a/hls/master.m3u8',
+        authHeader: constantHeader,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load();
+
+      expect(controller.status, equals(HlsAuthWebPlaybackStatus.ready));
+      expect(runtime.hlsCalls, hasLength(1));
+      expect(
+        runtime.hlsCalls.single.url,
+        equals('https://media.example/a/hls/master.m3u8'),
+      );
+    });
+
+    test('MP4 failure without an HLS fallback reports failure', () async {
+      runtime.mp4Result = HlsAuthWebAttemptResult.failure;
+      final controller = HlsAuthWebController(
+        runtime: runtime,
+        viewType: 'view',
+        url: 'https://media.example/a.mp4',
+        authHeader: constantHeader,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load();
+
+      expect(controller.status, equals(HlsAuthWebPlaybackStatus.failure));
+      expect(runtime.hlsCalls, isEmpty);
+    });
+
+    test('HLS fallback surfacing requiresAuth propagates the status', () async {
+      runtime
+        ..mp4Result = HlsAuthWebAttemptResult.failure
+        ..hlsResult = HlsAuthWebAttemptResult.requiresAuth;
+      final controller = HlsAuthWebController(
+        runtime: runtime,
+        viewType: 'view',
+        url: 'https://media.example/a.mp4',
+        hlsFallbackUrl: 'https://media.example/a/hls/master.m3u8',
+        authHeader: constantHeader,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load();
+
+      expect(controller.status, equals(HlsAuthWebPlaybackStatus.requiresAuth));
+    });
+
+    test('primary HLS URL uses the HLS path and does not touch MP4', () async {
+      final controller = HlsAuthWebController(
+        runtime: runtime,
+        viewType: 'view',
+        url: 'https://media.example/a/hls/master.m3u8',
+        authHeader: constantHeader,
+      );
+      addTearDown(controller.dispose);
+
+      await controller.load();
+
+      expect(controller.status, equals(HlsAuthWebPlaybackStatus.ready));
+      expect(runtime.mp4Calls, isEmpty);
+      expect(runtime.hlsCalls, hasLength(1));
+    });
+
+    test('dispose delegates to the runtime and is idempotent', () async {
+      final controller = HlsAuthWebController(
+        runtime: runtime,
+        viewType: 'view',
+        url: 'https://media.example/a.mp4',
+        authHeader: constantHeader,
+      );
+
+      await controller.load();
+      controller
+        ..dispose()
+        ..dispose();
+
+      expect(runtime.disposedViewTypes, equals(const ['view']));
+    });
+
+    test(
+      'notifies listeners on every status transition with distinct values',
+      () async {
+        final observed = <HlsAuthWebPlaybackStatus>[];
+        final controller = HlsAuthWebController(
+          runtime: runtime,
+          viewType: 'view',
+          url: 'https://media.example/a.mp4',
+          authHeader: constantHeader,
+        );
+        addTearDown(controller.dispose);
+        controller.addListener(() {
+          observed.add(controller.status);
+        });
+
+        await controller.load();
+
+        expect(
+          observed,
+          equals(const [
+            HlsAuthWebPlaybackStatus.loading,
+            HlsAuthWebPlaybackStatus.ready,
+          ]),
+        );
+      },
+    );
+  });
+}

--- a/mobile/packages/hls_auth_web_player/test/src/hls_auth_web_player_test.dart
+++ b/mobile/packages/hls_auth_web_player/test/src/hls_auth_web_player_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hls_auth_web_player/hls_auth_web_player.dart';
+
+import 'fake_hls_auth_web_runtime.dart';
+
+void main() {
+  group(HlsAuthWebPlayer, () {
+    late FakeHlsAuthWebRuntime runtime;
+
+    setUp(() {
+      runtime = FakeHlsAuthWebRuntime();
+    });
+
+    Future<String?> constantHeader(String url, String method) async =>
+        'Nostr constant';
+
+    testWidgets('invokes overlayBuilder with the current status transitions', (
+      tester,
+    ) async {
+      final observed = <HlsAuthWebPlaybackStatus>[];
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: HlsAuthWebPlayer(
+            runtime: runtime,
+            url: 'https://media.example/a.mp4',
+            authHeader: constantHeader,
+            overlayBuilder: (_, status) {
+              observed.add(status);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(observed, contains(HlsAuthWebPlaybackStatus.ready));
+    });
+
+    testWidgets(
+      'calls onStatusChanged with requiresAuth when origin returns 401',
+      (tester) async {
+        runtime.mp4Result = HlsAuthWebAttemptResult.requiresAuth;
+        final statuses = <HlsAuthWebPlaybackStatus>[];
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: HlsAuthWebPlayer(
+              runtime: runtime,
+              url: 'https://media.example/a.mp4',
+              authHeader: constantHeader,
+              onStatusChanged: statuses.add,
+              overlayBuilder: (_, _) => const SizedBox.shrink(),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(statuses, contains(HlsAuthWebPlaybackStatus.requiresAuth));
+      },
+    );
+
+    testWidgets('disposes the underlying runtime when the widget is removed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: HlsAuthWebPlayer(
+            runtime: runtime,
+            url: 'https://media.example/a.mp4',
+            authHeader: constantHeader,
+            overlayBuilder: (_, _) => const SizedBox.shrink(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: SizedBox.shrink(),
+        ),
+      );
+
+      expect(runtime.disposedViewTypes, isNotEmpty);
+    });
+
+    testWidgets(
+      'swaps controllers when the URL changes and disposes the previous one',
+      (tester) async {
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: HlsAuthWebPlayer(
+              runtime: runtime,
+              url: 'https://media.example/first.mp4',
+              authHeader: constantHeader,
+              overlayBuilder: (_, _) => const SizedBox.shrink(),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: HlsAuthWebPlayer(
+              runtime: runtime,
+              url: 'https://media.example/second.mp4',
+              authHeader: constantHeader,
+              overlayBuilder: (_, _) => const SizedBox.shrink(),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(runtime.mp4Calls.map((c) => c.url).toList(), hasLength(2));
+        expect(runtime.disposedViewTypes, isNotEmpty);
+      },
+    );
+  });
+}

--- a/mobile/packages/hls_auth_web_player/web/hls_auth_web_player.js
+++ b/mobile/packages/hls_auth_web_player/web/hls_auth_web_player.js
@@ -1,0 +1,186 @@
+// ABOUTME: Browser-side shim for hls_auth_web_player. Bridges hls.js +
+// NIP-98 auth header generation to a Dart callback; manages video element
+// lifecycle (src assignment, blob revocation, hls.js destroy).
+
+(function () {
+  'use strict';
+
+  // Per-viewType state: { video, hls, blobUrl }.
+  const views = Object.create(null);
+
+  function registerVideo(viewType, video) {
+    views[viewType] = views[viewType] || {};
+    views[viewType].video = video;
+  }
+
+  // Returns a constructor that hls.js accepts as `config.loader`. The
+  // constructor subclasses the default loader and attaches an Authorization
+  // header to each XHR context after resolving the async Dart callback.
+  function createAuthLoaderFactory(getAuthHeader) {
+    if (typeof window.Hls === 'undefined') {
+      throw new Error('hls.js not loaded');
+    }
+    const DefaultLoader = window.Hls.DefaultConfig.loader;
+
+    function AuthLoader(config) {
+      DefaultLoader.call(this, config);
+    }
+    AuthLoader.prototype = Object.create(DefaultLoader.prototype);
+    AuthLoader.prototype.constructor = AuthLoader;
+
+    AuthLoader.prototype.load = function (context, config, callbacks) {
+      const loader = this;
+      Promise.resolve()
+        .then(function () {
+          return getAuthHeader(context.url, 'GET');
+        })
+        .then(function (authHeader) {
+          if (authHeader) {
+            if (!context.headers) {
+              context.headers = {};
+            }
+            context.headers['Authorization'] = authHeader;
+          }
+        })
+        .catch(function (error) {
+          // Swallow — downstream load will still run; server may 401.
+          // eslint-disable-next-line no-console
+          console.error('[hls_auth_web_player] auth header error:', error);
+        })
+        .finally(function () {
+          DefaultLoader.prototype.load.call(loader, context, config, callbacks);
+        });
+    };
+
+    return AuthLoader;
+  }
+
+  async function fetchMp4(viewType, url, authorization) {
+    const state = views[viewType];
+    if (!state || !state.video) {
+      return { status: 'failure' };
+    }
+    const headers = {};
+    if (authorization) {
+      headers['Authorization'] = authorization;
+    }
+    try {
+      const response = await fetch(url, { method: 'GET', headers });
+      if (response.status === 401 || response.status === 403) {
+        return { status: 'requiresAuth', code: response.status };
+      }
+      if (!response.ok) {
+        return { status: 'failure', code: response.status };
+      }
+      const blob = await response.blob();
+      if (state.blobUrl) {
+        URL.revokeObjectURL(state.blobUrl);
+      }
+      const blobUrl = URL.createObjectURL(blob);
+      state.blobUrl = blobUrl;
+      state.video.src = blobUrl;
+      return { status: 'ok' };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('[hls_auth_web_player] fetchMp4 failure:', error);
+      return { status: 'failure' };
+    }
+  }
+
+  function loadHls(viewType, url, getAuthHeader) {
+    return new Promise(function (resolve) {
+      const state = views[viewType];
+      if (!state || !state.video) {
+        resolve({ status: 'failure' });
+        return;
+      }
+      if (typeof window.Hls === 'undefined' || !window.Hls.isSupported()) {
+        resolve({ status: 'failure' });
+        return;
+      }
+      if (state.hls) {
+        try {
+          state.hls.destroy();
+        } catch (_) {
+          /* ignore */
+        }
+        state.hls = null;
+      }
+      const loaderCtor = createAuthLoaderFactory(getAuthHeader);
+      const hls = new window.Hls({
+        enableWorker: true,
+        lowLatencyMode: false,
+        backBufferLength: 90,
+        maxBufferLength: 30,
+        startLevel: -1,
+        capLevelToPlayerSize: true,
+        loader: loaderCtor,
+      });
+      state.hls = hls;
+      let settled = false;
+
+      hls.on(window.Hls.Events.MANIFEST_PARSED, function () {
+        if (settled) return;
+        settled = true;
+        resolve({ status: 'ok' });
+      });
+      hls.on(window.Hls.Events.ERROR, function (_event, data) {
+        if (settled) return;
+        if (data && data.response) {
+          const code = data.response.code;
+          if (code === 401 || code === 403) {
+            settled = true;
+            try { hls.destroy(); } catch (_) { /* ignore */ }
+            state.hls = null;
+            resolve({ status: 'requiresAuth', code: code });
+            return;
+          }
+        }
+        if (data && data.fatal) {
+          settled = true;
+          try { hls.destroy(); } catch (_) { /* ignore */ }
+          state.hls = null;
+          resolve({ status: 'failure' });
+        }
+      });
+      hls.loadSource(url);
+      hls.attachMedia(state.video);
+    });
+  }
+
+  function attachBlobUrl(viewType, blobUrl) {
+    const state = views[viewType];
+    if (!state || !state.video) return;
+    if (state.blobUrl) {
+      URL.revokeObjectURL(state.blobUrl);
+    }
+    state.blobUrl = blobUrl;
+    state.video.src = blobUrl;
+  }
+
+  function disposeView(viewType) {
+    const state = views[viewType];
+    if (!state) return;
+    if (state.hls) {
+      try { state.hls.destroy(); } catch (_) { /* ignore */ }
+      state.hls = null;
+    }
+    if (state.blobUrl) {
+      URL.revokeObjectURL(state.blobUrl);
+      state.blobUrl = null;
+    }
+    if (state.video) {
+      try { state.video.pause(); } catch (_) { /* ignore */ }
+      state.video.removeAttribute('src');
+      try { state.video.load(); } catch (_) { /* ignore */ }
+    }
+    delete views[viewType];
+  }
+
+  window.__divineHlsAuthLoaderFactory = createAuthLoaderFactory;
+  window.__divineRegisterVideo = registerVideo;
+  window.__divineAttachBlobUrl = attachBlobUrl;
+  window.__divineFetchMp4 = fetchMp4;
+  window.__divineLoadHls = loadHls;
+  window.__divineDisposeView = disposeView;
+})();

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -190,6 +190,11 @@ dependencies:
   # Hashtag Repository - Hashtag search data layer
   hashtag_repository:
 
+  # HLS + NIP-98 Auth Web Player - Web-only video player with per-segment
+  # NIP-98 signing for age-restricted media. Gated behind
+  # FeatureFlag.hlsAuthWebPlayer.
+  hls_auth_web_player:
+
   # Videos Repository - Video feed data layer
   videos_repository:
 

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -40,6 +40,7 @@ workspace:
   - packages/follow_repository
   - packages/funnelcake_api_client
   - packages/hashtag_repository
+  - packages/hls_auth_web_player
   - packages/image_metadata_stripper
   - packages/invite_api_client
   - packages/keycast_flutter

--- a/mobile/scripts/check_hls_auth_web_shim_sync.sh
+++ b/mobile/scripts/check_hls_auth_web_shim_sync.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+package_shim="packages/hls_auth_web_player/web/hls_auth_web_player.js"
+app_shim="web/hls_auth_web_player.js"
+
+if ! cmp -s "$package_shim" "$app_shim"; then
+  echo "HLS auth web shims are out of sync:"
+  echo "  $package_shim"
+  echo "  $app_shim"
+  echo
+  echo "Update the package shim first, then copy it to the app web directory."
+  diff -u "$package_shim" "$app_shim" || true
+  exit 1
+fi

--- a/mobile/scripts/test_hls_auth_web_shim.mjs
+++ b/mobile/scripts/test_hls_auth_web_shim.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+const source = readFileSync(
+  'packages/hls_auth_web_player/web/hls_auth_web_player.js',
+  'utf8',
+);
+
+const fetchCalls = [];
+const revokedUrls = [];
+let blobCounter = 0;
+let nextResponse = { status: 200, ok: true };
+
+globalThis.window = globalThis;
+globalThis.fetch = async (url, init) => {
+  fetchCalls.push({ url, init });
+  return {
+    status: nextResponse.status,
+    ok: nextResponse.ok,
+    blob: async () => ({ id: `blob-${blobCounter}` }),
+  };
+};
+globalThis.URL = {
+  createObjectURL(blob) {
+    blobCounter += 1;
+    return `blob://test/${blob.id}/${blobCounter}`;
+  },
+  revokeObjectURL(url) {
+    revokedUrls.push(url);
+  },
+};
+
+vm.runInThisContext(source, { filename: 'hls_auth_web_player.js' });
+
+assert.equal(typeof window.__divineRegisterVideo, 'function');
+assert.equal(typeof window.__divineFetchMp4, 'function');
+assert.equal(typeof window.__divineDisposeView, 'function');
+
+const missingViewResult = await window.__divineFetchMp4(
+  'missing-view',
+  'https://cdn.example/video.mp4',
+  'NIP98 missing',
+);
+assert.deepEqual(missingViewResult, { status: 'failure' });
+
+const video = {
+  src: '',
+  paused: false,
+  pauseCalled: false,
+  loadCalled: false,
+  pause() {
+    this.pauseCalled = true;
+    this.paused = true;
+  },
+  load() {
+    this.loadCalled = true;
+  },
+  removeAttribute(name) {
+    if (name === 'src') {
+      this.src = '';
+    }
+  },
+};
+
+window.__divineRegisterVideo('test-view', video);
+
+nextResponse = { status: 401, ok: false };
+const requiresAuthResult = await window.__divineFetchMp4(
+  'test-view',
+  'https://cdn.example/protected.mp4',
+  'NIP98 protected',
+);
+assert.deepEqual(requiresAuthResult, { status: 'requiresAuth', code: 401 });
+assert.equal(
+  fetchCalls.at(-1).init.headers.Authorization,
+  'NIP98 protected',
+);
+assert.equal(video.src, '');
+
+nextResponse = { status: 200, ok: true };
+const firstOkResult = await window.__divineFetchMp4(
+  'test-view',
+  'https://cdn.example/video.mp4',
+  'NIP98 first',
+);
+assert.deepEqual(firstOkResult, { status: 'ok' });
+assert.match(video.src, /^blob:\/\/test\/blob-0\/1$/);
+const firstBlobUrl = video.src;
+
+const secondOkResult = await window.__divineFetchMp4(
+  'test-view',
+  'https://cdn.example/video.mp4',
+  'NIP98 second',
+);
+assert.deepEqual(secondOkResult, { status: 'ok' });
+assert.match(video.src, /^blob:\/\/test\/blob-1\/2$/);
+assert.deepEqual(revokedUrls, [firstBlobUrl]);
+
+window.__divineDisposeView('test-view');
+assert.equal(video.pauseCalled, true);
+assert.equal(video.loadCalled, true);
+assert.equal(video.src, '');
+assert.deepEqual(revokedUrls, [firstBlobUrl, 'blob://test/blob-1/2']);
+
+console.log('hls_auth_web_player.js smoke test passed');

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -15,15 +15,21 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/features/feature_flags/services/build_configuration.dart';
+import 'package:openvine/features/feature_flags/services/feature_flag_service.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/media_auth_interceptor.dart';
+import 'package:openvine/services/media_viewer_auth_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_feed_item/actions/actions.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
 import 'package:pooled_video_player/pooled_video_player.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../helpers/test_provider_overrides.dart';
 import '../../test_data/video_test_data.dart';
@@ -41,6 +47,72 @@ class MockPlayerStream extends Mock implements PlayerStream {}
 class MockPlayerState extends Mock implements PlayerState {}
 
 class MockMediaAuthInterceptor extends Mock implements MediaAuthInterceptor {}
+
+class _MockMediaViewerAuthService extends Mock
+    implements MediaViewerAuthService {}
+
+class _MockSharedPreferences implements SharedPreferences {
+  @override
+  bool? getBool(String key) => null;
+
+  @override
+  Future<bool> setBool(String key, bool value) async => true;
+
+  @override
+  Future<bool> remove(String key) async => true;
+
+  @override
+  Object? get(String key) => null;
+
+  @override
+  double? getDouble(String key) => null;
+
+  @override
+  int? getInt(String key) => null;
+
+  @override
+  Set<String> getKeys() => const <String>{};
+
+  @override
+  String? getString(String key) => null;
+
+  @override
+  List<String>? getStringList(String key) => null;
+
+  @override
+  bool containsKey(String key) => false;
+
+  @override
+  Future<bool> setDouble(String key, double value) async => true;
+
+  @override
+  Future<bool> setInt(String key, int value) async => true;
+
+  @override
+  Future<bool> setString(String key, String value) async => true;
+
+  @override
+  Future<bool> setStringList(String key, List<String> value) async => true;
+
+  @override
+  Future<bool> clear() async => true;
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  Future<bool> commit() async => true;
+}
+
+class _FlagOverrideFeatureFlagService extends FeatureFlagService {
+  _FlagOverrideFeatureFlagService(this._enabled)
+    : super(_MockSharedPreferences(), const BuildConfiguration());
+
+  final Set<FeatureFlag> _enabled;
+
+  @override
+  bool isEnabled(FeatureFlag flag) => _enabled.contains(flag);
+}
 
 class _FakeBuildContext extends Fake implements BuildContext {}
 
@@ -329,6 +401,83 @@ void main() {
         expect(find.byType(WebVideoFeed), findsOneWidget);
         expect(find.byType(VideoOverlayActions), findsOneWidget);
       }, skip: !kIsWeb);
+
+      testWidgets(
+        'threads NIP-98 auth header provider into WebVideoFeed when the '
+        'hlsAuthWebPlayer flag is on',
+        (tester) async {
+          final mockAuthService = _MockMediaViewerAuthService();
+          when(
+            () => mockAuthService.createAuthHeaders(
+              sha256Hash: any(named: 'sha256Hash'),
+              url: any(named: 'url'),
+              serverUrl: any(named: 'serverUrl'),
+            ),
+          ).thenAnswer(
+            (_) async => const {'Authorization': 'Nostr threaded-token'},
+          );
+
+          final videos = createTestVideos(count: 1);
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: videos,
+              ),
+              additionalOverrides: [
+                featureFlagServiceProvider.overrideWith(
+                  (ref) => _FlagOverrideFeatureFlagService(
+                    const {FeatureFlag.hlsAuthWebPlayer},
+                  ),
+                ),
+                mediaViewerAuthServiceProvider.overrideWithValue(
+                  mockAuthService,
+                ),
+              ],
+            ),
+          );
+          await tester.pump();
+
+          final feed = tester.widget<WebVideoFeed>(find.byType(WebVideoFeed));
+          expect(feed.authHeaderProvider, isNotNull);
+
+          final header = await feed.authHeaderProvider!(
+            'https://media.divine.video/'
+                'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
+            'GET',
+          );
+          expect(header, equals('Nostr threaded-token'));
+        },
+        skip: !kIsWeb,
+      );
+
+      testWidgets(
+        'does not thread an auth header provider when the flag is off',
+        (tester) async {
+          final videos = createTestVideos(count: 1);
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: videos,
+              ),
+              additionalOverrides: [
+                featureFlagServiceProvider.overrideWith(
+                  (ref) =>
+                      _FlagOverrideFeatureFlagService(const <FeatureFlag>{}),
+                ),
+              ],
+            ),
+          );
+          await tester.pump();
+
+          final feed = tester.widget<WebVideoFeed>(find.byType(WebVideoFeed));
+          expect(feed.authHeaderProvider, isNull);
+        },
+        skip: !kIsWeb,
+      );
     });
 
     group('BLoC event dispatching', () {

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -427,9 +427,9 @@ void main() {
               ),
               additionalOverrides: [
                 featureFlagServiceProvider.overrideWith(
-                  (ref) => _FlagOverrideFeatureFlagService(
-                    const {FeatureFlag.hlsAuthWebPlayer},
-                  ),
+                  (ref) => _FlagOverrideFeatureFlagService(const {
+                    FeatureFlag.hlsAuthWebPlayer,
+                  }),
                 ),
                 mediaViewerAuthServiceProvider.overrideWithValue(
                   mockAuthService,
@@ -475,6 +475,39 @@ void main() {
 
           final feed = tester.widget<WebVideoFeed>(find.byType(WebVideoFeed));
           expect(feed.authHeaderProvider, isNull);
+        },
+        skip: !kIsWeb,
+      );
+
+      testWidgets(
+        'maps web auth-required status to age-restricted without removal',
+        (tester) async {
+          final videos = createTestVideos(count: 1);
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: videos,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          final feed = tester.widget<WebVideoFeed>(find.byType(WebVideoFeed));
+          feed.onRequiresAuth?.call(videos.first, 0);
+          await tester.pump();
+
+          final cubit = BlocProvider.of<VideoPlaybackStatusCubit>(
+            tester.element(find.byType(FullscreenFeedContent)),
+          );
+          expect(
+            cubit.state.statusFor(videos.first.id),
+            PlaybackStatus.ageRestricted,
+          );
+          verifyNever(
+            () => mockBloc.add(FullscreenFeedVideoUnavailable(videos.first.id)),
+          );
         },
         skip: !kIsWeb,
       );

--- a/mobile/test/screens/sounds_screen_test.dart
+++ b/mobile/test/screens/sounds_screen_test.dart
@@ -298,6 +298,9 @@ void main() {
               trendingSoundsProvider.overrideWith(
                 MockTrendingSoundsLoadingNotifier.new,
               ),
+              soundLibraryServiceProvider.overrideWith(
+                (_) => Completer<SoundLibraryService>().future,
+              ),
             ],
           ),
         );

--- a/mobile/test/widgets/web_video_auth_header_provider_test.dart
+++ b/mobile/test/widgets/web_video_auth_header_provider_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/media_viewer_auth_service.dart';
+import 'package:openvine/widgets/web_video_auth_header_provider.dart';
+
+class _MockMediaViewerAuthService extends Mock
+    implements MediaViewerAuthService {}
+
+void main() {
+  group(buildWebVideoAuthHeaderProvider, () {
+    late _MockMediaViewerAuthService service;
+
+    setUp(() {
+      service = _MockMediaViewerAuthService();
+    });
+
+    test(
+      'extracts sha256 and origin from a Blossom URL and forwards to the '
+      'auth service',
+      () async {
+        const sha256 =
+            'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+        const url = 'https://media.divine.video/$sha256';
+        when(
+          () => service.createAuthHeaders(
+            sha256Hash: sha256,
+            url: url,
+            serverUrl: 'https://media.divine.video',
+          ),
+        ).thenAnswer(
+          (_) async => const {'Authorization': 'Nostr signed-token'},
+        );
+
+        final provider = buildWebVideoAuthHeaderProvider(service);
+        final header = await provider(url, 'GET');
+
+        expect(header, equals('Nostr signed-token'));
+        verify(
+          () => service.createAuthHeaders(
+            sha256Hash: sha256,
+            url: url,
+            serverUrl: 'https://media.divine.video',
+          ),
+        ).called(1);
+      },
+    );
+
+    test('extracts sha256 from an hls manifest segment suffix', () async {
+      const sha256 =
+          'a9bbbce1b03958553a5ee1546140d5d930b8a86c1fa967ea874fb5241bd5e41c';
+      const url = 'https://media.divine.video/$sha256/hls/master.m3u8';
+      when(
+        () => service.createAuthHeaders(
+          sha256Hash: any(named: 'sha256Hash'),
+          url: any(named: 'url'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      ).thenAnswer(
+        (_) async => const {'Authorization': 'Nostr signed-manifest'},
+      );
+
+      final provider = buildWebVideoAuthHeaderProvider(service);
+      final header = await provider(url, 'GET');
+
+      expect(header, equals('Nostr signed-manifest'));
+      verify(
+        () => service.createAuthHeaders(
+          sha256Hash: sha256,
+          url: url,
+          serverUrl: 'https://media.divine.video',
+        ),
+      ).called(1);
+    });
+
+    test('returns null when the auth service returns null', () async {
+      when(
+        () => service.createAuthHeaders(
+          sha256Hash: any(named: 'sha256Hash'),
+          url: any(named: 'url'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      ).thenAnswer((_) async => null);
+
+      final provider = buildWebVideoAuthHeaderProvider(service);
+      final header = await provider(
+        'https://media.divine.video/'
+            'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
+        'GET',
+      );
+
+      expect(header, isNull);
+    });
+
+    test('returns null when the Authorization header is absent', () async {
+      when(
+        () => service.createAuthHeaders(
+          sha256Hash: any(named: 'sha256Hash'),
+          url: any(named: 'url'),
+          serverUrl: any(named: 'serverUrl'),
+        ),
+      ).thenAnswer((_) async => const {'X-Other': 'value'});
+
+      final provider = buildWebVideoAuthHeaderProvider(service);
+      final header = await provider(
+        'https://media.divine.video/'
+            'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
+        'GET',
+      );
+
+      expect(header, isNull);
+    });
+
+    test(
+      'passes null sha256 for URLs without a 64-char hex segment',
+      () async {
+        const url = 'https://example.com/video.mp4';
+        String? capturedSha256 = 'sentinel';
+        when(
+          () => service.createAuthHeaders(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: url,
+            serverUrl: 'https://example.com',
+          ),
+        ).thenAnswer((invocation) async {
+          capturedSha256 = invocation.namedArguments[#sha256Hash] as String?;
+          return null;
+        });
+
+        final provider = buildWebVideoAuthHeaderProvider(service);
+        await provider(url, 'GET');
+
+        expect(capturedSha256, isNull);
+      },
+    );
+  });
+}

--- a/mobile/test/widgets/web_video_feed_test.dart
+++ b/mobile/test/widgets/web_video_feed_test.dart
@@ -151,6 +151,20 @@ VideoEvent _makeVideo({int seed = 0}) {
   );
 }
 
+VideoEvent _makeDivineVideo() {
+  const hash =
+      'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+  return VideoEvent(
+    id: 'd4e5f6789012345678901234567890abcdef123456789012345678901234a1b2',
+    pubkey:
+        'd4e5f6789012345678901234567890abcdef123456789012345678901234a1b2c3',
+    createdAt: 1700000000,
+    content: 'Divine video',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
+    videoUrl: 'https://media.divine.video/$hash/720p.mp4',
+  );
+}
+
 void main() {
   late video_platform.VideoPlayerPlatform originalPlatform;
 
@@ -174,13 +188,7 @@ void main() {
           videos: [_makeVideo()],
           controllerFactory: ({required url, required headers}) => controller,
           itemBuilder:
-              (
-                context,
-                video,
-                index, {
-                required isActive,
-                controller,
-              }) {
+              (context, video, index, {required isActive, controller}) {
                 return Align(
                   alignment: Alignment.topLeft,
                   child: Text(controller == null ? 'waiting' : 'ready'),
@@ -285,14 +293,10 @@ void main() {
       await tester.pump();
 
       final state =
-          tester.state<State<WebVideoFeed>>(
-                find.byType(WebVideoFeed),
-              )
+          tester.state<State<WebVideoFeed>>(find.byType(WebVideoFeed))
               as dynamic;
       final pageController = tester
-          .widget<PageView>(
-            find.byType(PageView),
-          )
+          .widget<PageView>(find.byType(PageView))
           .controller!;
 
       // Drive PageView through several indices. Pages that drop out of the
@@ -319,59 +323,110 @@ void main() {
     },
   );
 
-  testWidgets(
-    'prunes stale controller entries when videos list shrinks',
-    (tester) async {
-      final initial = List.generate(4, (i) => _makeVideo(seed: i));
+  testWidgets('prunes stale controller entries when videos list shrinks', (
+    tester,
+  ) async {
+    final initial = List.generate(4, (i) => _makeVideo(seed: i));
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: WebVideoFeed(
-            videos: initial,
-            controllerFactory: ({required url, required headers}) =>
-                _FakeVideoPlayerController(),
-          ),
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WebVideoFeed(
+          videos: initial,
+          controllerFactory: ({required url, required headers}) =>
+              _FakeVideoPlayerController(),
         ),
-      );
-      await tester.pump();
+      ),
+    );
+    await tester.pump();
 
-      // Shrink the list — the feed should prune indices that no longer map
-      // to a valid video.
-      await tester.pumpWidget(
-        MaterialApp(
-          home: WebVideoFeed(
-            videos: [initial.first],
-            controllerFactory: ({required url, required headers}) =>
-                _FakeVideoPlayerController(),
-          ),
+    // Shrink the list — the feed should prune indices that no longer map
+    // to a valid video.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WebVideoFeed(
+          videos: [initial.first],
+          controllerFactory: ({required url, required headers}) =>
+              _FakeVideoPlayerController(),
         ),
-      );
-      await tester.pump();
+      ),
+    );
+    await tester.pump();
 
-      final state =
-          tester.state<State<WebVideoFeed>>(
-                find.byType(WebVideoFeed),
-              )
-              as dynamic;
+    final state =
+        tester.state<State<WebVideoFeed>>(find.byType(WebVideoFeed)) as dynamic;
 
-      expect(state.debugControllerCount as int, lessThanOrEqualTo(1));
-      expect(state.debugPlayerKeyCount as int, lessThanOrEqualTo(1));
-    },
-  );
+    expect(state.debugControllerCount as int, lessThanOrEqualTo(1));
+    expect(state.debugPlayerKeyCount as int, lessThanOrEqualTo(1));
+  });
+
+  testWidgets('forwards authHeaderProvider to each WebVideoPlayer item', (
+    tester,
+  ) async {
+    final calls = <(String, String)>[];
+    Future<String?> provider(String url, String method) async {
+      calls.add((url, method));
+      return 'Nostr test-header';
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WebVideoFeed(
+          videos: [_makeVideo()],
+          controllerFactory: ({required url, required headers}) =>
+              _FakeVideoPlayerController(),
+          authHeaderProvider: provider,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final player = tester.widget<WebVideoPlayer>(find.byType(WebVideoPlayer));
+    expect(player.authHeaderProvider, isNotNull);
+
+    // Invoking the propagated callback must reach the original closure.
+    final header = await player.authHeaderProvider!(
+      'https://media.divine.video/abc',
+      'GET',
+    );
+    expect(header, equals('Nostr test-header'));
+    expect(calls, equals([('https://media.divine.video/abc', 'GET')]));
+  });
+
+  testWidgets('forwards auth-required callbacks separately from load errors', (
+    tester,
+  ) async {
+    final callbacks = <(String, int)>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: WebVideoFeed(
+          videos: [_makeVideo()],
+          controllerFactory: ({required url, required headers}) =>
+              _FakeVideoPlayerController(),
+          onErrored: (index) => callbacks.add(('error', index)),
+          onRequiresAuth: (video, index) =>
+              callbacks.add(('auth:${video.id}', index)),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final player = tester.widget<WebVideoPlayer>(find.byType(WebVideoPlayer));
+    player.onRequiresAuth?.call();
+
+    expect(callbacks, equals([('auth:${_makeVideo().id}', 0)]));
+  });
 
   testWidgets(
-    'forwards authHeaderProvider to each WebVideoPlayer item',
+    'forwards HLS fallback URLs for Divine media to the auth player',
     (tester) async {
-      final calls = <(String, String)>[];
       Future<String?> provider(String url, String method) async {
-        calls.add((url, method));
         return 'Nostr test-header';
       }
 
       await tester.pumpWidget(
         MaterialApp(
           home: WebVideoFeed(
-            videos: [_makeVideo()],
+            videos: [_makeDivineVideo()],
             controllerFactory: ({required url, required headers}) =>
                 _FakeVideoPlayerController(),
             authHeaderProvider: provider,
@@ -380,18 +435,10 @@ void main() {
       );
       await tester.pump();
 
-      final player = tester.widget<WebVideoPlayer>(
-        find.byType(WebVideoPlayer),
-      );
-      expect(player.authHeaderProvider, isNotNull);
-
-      // Invoking the propagated callback must reach the original closure.
-      final header = await player.authHeaderProvider!(
-        'https://media.divine.video/abc',
-        'GET',
-      );
-      expect(header, equals('Nostr test-header'));
-      expect(calls, equals([('https://media.divine.video/abc', 'GET')]));
+      final player = tester.widget<WebVideoPlayer>(find.byType(WebVideoPlayer));
+      expect(player.hlsFallbackUrl, isNotNull);
+      expect(player.hlsFallbackUrl, contains('/hls/'));
+      expect(player.hlsFallbackUrl, endsWith('.m3u8'));
     },
   );
 
@@ -409,9 +456,7 @@ void main() {
       );
       await tester.pump();
 
-      final player = tester.widget<WebVideoPlayer>(
-        find.byType(WebVideoPlayer),
-      );
+      final player = tester.widget<WebVideoPlayer>(find.byType(WebVideoPlayer));
       expect(player.authHeaderProvider, isNull);
     },
   );
@@ -429,13 +474,7 @@ void main() {
             controllerFactory: ({required url, required headers}) =>
                 _FakeVideoPlayerController(),
             itemBuilder:
-                (
-                  context,
-                  video,
-                  index, {
-                  required isActive,
-                  controller,
-                }) {
+                (context, video, index, {required isActive, controller}) {
                   itemBuilderCalls.update(
                     index,
                     (prev) => prev + 1,

--- a/mobile/test/widgets/web_video_feed_test.dart
+++ b/mobile/test/widgets/web_video_feed_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/widgets/web_video_feed.dart';
+import 'package:openvine/widgets/web_video_player.dart';
 import 'package:video_player/video_player.dart';
 import 'package:video_player_platform_interface/video_player_platform_interface.dart'
     as video_platform;
@@ -355,6 +356,63 @@ void main() {
 
       expect(state.debugControllerCount as int, lessThanOrEqualTo(1));
       expect(state.debugPlayerKeyCount as int, lessThanOrEqualTo(1));
+    },
+  );
+
+  testWidgets(
+    'forwards authHeaderProvider to each WebVideoPlayer item',
+    (tester) async {
+      final calls = <(String, String)>[];
+      Future<String?> provider(String url, String method) async {
+        calls.add((url, method));
+        return 'Nostr test-header';
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WebVideoFeed(
+            videos: [_makeVideo()],
+            controllerFactory: ({required url, required headers}) =>
+                _FakeVideoPlayerController(),
+            authHeaderProvider: provider,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final player = tester.widget<WebVideoPlayer>(
+        find.byType(WebVideoPlayer),
+      );
+      expect(player.authHeaderProvider, isNotNull);
+
+      // Invoking the propagated callback must reach the original closure.
+      final header = await player.authHeaderProvider!(
+        'https://media.divine.video/abc',
+        'GET',
+      );
+      expect(header, equals('Nostr test-header'));
+      expect(calls, equals([('https://media.divine.video/abc', 'GET')]));
+    },
+  );
+
+  testWidgets(
+    'passes null authHeaderProvider by default (flag-off regression guard)',
+    (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WebVideoFeed(
+            videos: [_makeVideo()],
+            controllerFactory: ({required url, required headers}) =>
+                _FakeVideoPlayerController(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final player = tester.widget<WebVideoPlayer>(
+        find.byType(WebVideoPlayer),
+      );
+      expect(player.authHeaderProvider, isNull);
     },
   );
 

--- a/mobile/test/widgets/web_video_player_test.dart
+++ b/mobile/test/widgets/web_video_player_test.dart
@@ -242,4 +242,37 @@ void main() {
       expect(find.text('Failed to load video'), findsNothing);
     },
   );
+
+  testWidgets(
+    'uses the legacy controller factory when no auth provider is supplied',
+    (tester) async {
+      final controller = _MockVideoPlayerController();
+      final initializeCompleter = Completer<void>();
+      var factoryCalls = 0;
+
+      when(controller.initialize).thenAnswer((_) => initializeCompleter.future);
+      when(controller.dispose).thenAnswer((_) async {});
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: WebVideoPlayer(
+            url: 'https://example.com/video.mp4',
+            initializeTimeout: const Duration(milliseconds: 50),
+            controllerFactory: ({required url, required headers}) {
+              factoryCalls++;
+              return controller;
+            },
+          ),
+        ),
+      );
+
+      expect(factoryCalls, equals(1));
+
+      // Flush the timeout timer before the test ends so the framework's
+      // "Timer is still pending" invariant stays satisfied.
+      await tester.pump(const Duration(milliseconds: 60));
+    },
+  );
 }

--- a/mobile/web/hls_auth_web_player.js
+++ b/mobile/web/hls_auth_web_player.js
@@ -1,0 +1,186 @@
+// ABOUTME: Browser-side shim for hls_auth_web_player. Bridges hls.js +
+// NIP-98 auth header generation to a Dart callback; manages video element
+// lifecycle (src assignment, blob revocation, hls.js destroy).
+
+(function () {
+  'use strict';
+
+  // Per-viewType state: { video, hls, blobUrl }.
+  const views = Object.create(null);
+
+  function registerVideo(viewType, video) {
+    views[viewType] = views[viewType] || {};
+    views[viewType].video = video;
+  }
+
+  // Returns a constructor that hls.js accepts as `config.loader`. The
+  // constructor subclasses the default loader and attaches an Authorization
+  // header to each XHR context after resolving the async Dart callback.
+  function createAuthLoaderFactory(getAuthHeader) {
+    if (typeof window.Hls === 'undefined') {
+      throw new Error('hls.js not loaded');
+    }
+    const DefaultLoader = window.Hls.DefaultConfig.loader;
+
+    function AuthLoader(config) {
+      DefaultLoader.call(this, config);
+    }
+    AuthLoader.prototype = Object.create(DefaultLoader.prototype);
+    AuthLoader.prototype.constructor = AuthLoader;
+
+    AuthLoader.prototype.load = function (context, config, callbacks) {
+      const loader = this;
+      Promise.resolve()
+        .then(function () {
+          return getAuthHeader(context.url, 'GET');
+        })
+        .then(function (authHeader) {
+          if (authHeader) {
+            if (!context.headers) {
+              context.headers = {};
+            }
+            context.headers['Authorization'] = authHeader;
+          }
+        })
+        .catch(function (error) {
+          // Swallow — downstream load will still run; server may 401.
+          // eslint-disable-next-line no-console
+          console.error('[hls_auth_web_player] auth header error:', error);
+        })
+        .finally(function () {
+          DefaultLoader.prototype.load.call(loader, context, config, callbacks);
+        });
+    };
+
+    return AuthLoader;
+  }
+
+  async function fetchMp4(viewType, url, authorization) {
+    const state = views[viewType];
+    if (!state || !state.video) {
+      return { status: 'failure' };
+    }
+    const headers = {};
+    if (authorization) {
+      headers['Authorization'] = authorization;
+    }
+    try {
+      const response = await fetch(url, { method: 'GET', headers });
+      if (response.status === 401 || response.status === 403) {
+        return { status: 'requiresAuth', code: response.status };
+      }
+      if (!response.ok) {
+        return { status: 'failure', code: response.status };
+      }
+      const blob = await response.blob();
+      if (state.blobUrl) {
+        URL.revokeObjectURL(state.blobUrl);
+      }
+      const blobUrl = URL.createObjectURL(blob);
+      state.blobUrl = blobUrl;
+      state.video.src = blobUrl;
+      return { status: 'ok' };
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('[hls_auth_web_player] fetchMp4 failure:', error);
+      return { status: 'failure' };
+    }
+  }
+
+  function loadHls(viewType, url, getAuthHeader) {
+    return new Promise(function (resolve) {
+      const state = views[viewType];
+      if (!state || !state.video) {
+        resolve({ status: 'failure' });
+        return;
+      }
+      if (typeof window.Hls === 'undefined' || !window.Hls.isSupported()) {
+        resolve({ status: 'failure' });
+        return;
+      }
+      if (state.hls) {
+        try {
+          state.hls.destroy();
+        } catch (_) {
+          /* ignore */
+        }
+        state.hls = null;
+      }
+      const loaderCtor = createAuthLoaderFactory(getAuthHeader);
+      const hls = new window.Hls({
+        enableWorker: true,
+        lowLatencyMode: false,
+        backBufferLength: 90,
+        maxBufferLength: 30,
+        startLevel: -1,
+        capLevelToPlayerSize: true,
+        loader: loaderCtor,
+      });
+      state.hls = hls;
+      let settled = false;
+
+      hls.on(window.Hls.Events.MANIFEST_PARSED, function () {
+        if (settled) return;
+        settled = true;
+        resolve({ status: 'ok' });
+      });
+      hls.on(window.Hls.Events.ERROR, function (_event, data) {
+        if (settled) return;
+        if (data && data.response) {
+          const code = data.response.code;
+          if (code === 401 || code === 403) {
+            settled = true;
+            try { hls.destroy(); } catch (_) { /* ignore */ }
+            state.hls = null;
+            resolve({ status: 'requiresAuth', code: code });
+            return;
+          }
+        }
+        if (data && data.fatal) {
+          settled = true;
+          try { hls.destroy(); } catch (_) { /* ignore */ }
+          state.hls = null;
+          resolve({ status: 'failure' });
+        }
+      });
+      hls.loadSource(url);
+      hls.attachMedia(state.video);
+    });
+  }
+
+  function attachBlobUrl(viewType, blobUrl) {
+    const state = views[viewType];
+    if (!state || !state.video) return;
+    if (state.blobUrl) {
+      URL.revokeObjectURL(state.blobUrl);
+    }
+    state.blobUrl = blobUrl;
+    state.video.src = blobUrl;
+  }
+
+  function disposeView(viewType) {
+    const state = views[viewType];
+    if (!state) return;
+    if (state.hls) {
+      try { state.hls.destroy(); } catch (_) { /* ignore */ }
+      state.hls = null;
+    }
+    if (state.blobUrl) {
+      URL.revokeObjectURL(state.blobUrl);
+      state.blobUrl = null;
+    }
+    if (state.video) {
+      try { state.video.pause(); } catch (_) { /* ignore */ }
+      state.video.removeAttribute('src');
+      try { state.video.load(); } catch (_) { /* ignore */ }
+    }
+    delete views[viewType];
+  }
+
+  window.__divineHlsAuthLoaderFactory = createAuthLoaderFactory;
+  window.__divineRegisterVideo = registerVideo;
+  window.__divineAttachBlobUrl = attachBlobUrl;
+  window.__divineFetchMp4 = fetchMp4;
+  window.__divineLoadHls = loadHls;
+  window.__divineDisposeView = disposeView;
+})();

--- a/mobile/web/index.html
+++ b/mobile/web/index.html
@@ -153,8 +153,18 @@
     }
   </script>
 
-  <!-- HLS.js for video_player_web_hls package - enables HLS video playback on web -->
-  <script src="https://cdn.jsdelivr.net/npm/hls.js@latest" type="application/javascript"></script>
+  <!-- HLS.js for video_player_web_hls package - enables HLS video playback on web.
+       Pinned to a known-good version so the hls_auth_web_player loader
+       subclass stays compatible. -->
+  <script src="https://cdn.jsdelivr.net/npm/hls.js@1.5.15" type="application/javascript"></script>
+
+  <!-- hls_auth_web_player browser shim. Installs window.__divine* helpers
+       that the Dart runtime calls into. Gated at the app layer behind
+       FeatureFlag.hlsAuthWebPlayer so leaving this tag here has no effect
+       when the flag is off. The source of truth lives at
+       `packages/hls_auth_web_player/web/hls_auth_web_player.js` — keep this
+       copy in sync with it. -->
+  <script src="hls_auth_web_player.js" type="application/javascript"></script>
 
   <script src="flutter_bootstrap.js" defer></script>
   


### PR DESCRIPTION
Closes #3134

## Summary

Ships the web-side fix for age-gated video playback that PR #3127 added for native. On web today, `VideoPlayerController.networkUrl(url, httpHeaders: ...)` silently drops the `Authorization` header on the direct-MP4 path (HTML5 `<video>` doesn't support custom headers), so any 401 from `media.divine.video` surfaces as a generic "Failed to load video" with no path to recover. This PR adds the architecture to solve that, gated behind a feature flag so it is strictly additive.

- New `packages/hls_auth_web_player` Flutter package — JS-interop wrapper around hls.js with a custom loader that calls back into Dart for per-segment NIP-98 signing, plus a direct-MP4 `fetch` + `URL.createObjectURL` fallback that does attach the header. Mirrors the divine-web `hlsAuthLoader.ts` / `VideoPlayer.tsx` implementation function-for-function.
- Controller + source-policy + status enum are pure Dart; JS lives in `web/hls_auth_web_player.js` + `lib/src/hls_auth_web_runtime_web.dart`, with a `createDefaultHlsAuthWebRuntime()` conditional-import picking the right backing implementation. Tests use an injected `FakeHlsAuthWebRuntime`.
- Adds `FeatureFlag.hlsAuthWebPlayer` (default off). `WebVideoPlayer` gains an optional `authHeaderProvider`; when `kIsWeb` and that is non-null, playback routes through `HlsAuthWebPlayer`. When null — the flag-off state — the legacy `VideoPlayerController` path runs unchanged.
- `WebVideoFeed` forwards `authHeaderProvider` and HLS fallback URLs to each item. `FullscreenFeedContent` and `VideoFeedView` construct the provider from `MediaViewerAuthService` only when `kIsWeb && isFeatureEnabledProvider(FeatureFlag.hlsAuthWebPlayer)` is true.
- 401/403 from the auth player now routes through `onRequiresAuth` into the existing `PlaybackStatus.ageRestricted` UI instead of #3107's 404/unavailable removal path.
- Pins `hls.js` in `web/index.html` from `@latest` to `@1.5.15` so the loader subclass stays compatible.
- Adds CI coverage to keep the duplicated browser shim copies in sync and smoke-test the JS bridge behavior.

See the spec at `docs/superpowers/specs/2026-04-17-hls-auth-web-player-spike.md`.

## Files of note

- `mobile/packages/hls_auth_web_player/` — the new package.
- `mobile/packages/hls_auth_web_player/web/hls_auth_web_player.js` and `mobile/web/hls_auth_web_player.js` — the browser shim. Both copies must stay in sync; source of truth is in the package.
- `mobile/scripts/check_hls_auth_web_shim_sync.sh` — CI guard that fails if the package shim and app-served shim drift.
- `mobile/scripts/test_hls_auth_web_shim.mjs` — Node smoke test for the browser shim's MP4 fetch, auth header forwarding, blob URL replacement, and cleanup behavior.
- `mobile/lib/widgets/web_video_player.dart` — factory switch with `authHeaderProvider`; lifecycle handles toggling between legacy and auth-player modes.
- `mobile/lib/widgets/web_video_auth_header_provider.dart` — helper that adapts `MediaViewerAuthService` into the `AuthHeaderProvider` closure (extracts sha256 + origin from Blossom URLs, returns the `Nostr ...` string or null).
- `mobile/lib/widgets/web_video_feed.dart` — threads the provider, auth-required callback, and HLS fallback URL through each `WebVideoPlayer` item.
- `mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart` + `video_feed_page.dart` — construct the provider behind `kIsWeb && FeatureFlag.hlsAuthWebPlayer` and map auth-required status to `ageRestricted`.
- `mobile/lib/features/feature_flags/models/feature_flag.dart` + `build_configuration.dart` — new flag.

## Test plan

- [x] GitHub CI green on latest head: Format, Analyze, Generated Files, Tests, Mobile CI, Build Flutter Web Preview, mergeability, semantic PR, and CLA.
- [x] `flutter analyze lib test integration_test` — clean locally before final updates; targeted analyze also clean for lifecycle patch.
- [x] Unit + widget tests for the new package — 18 passing (controller decision tree across MP4 / 401 / 404 / HLS fallback, widget overlay builder, disposal).
- [x] `test/widgets/web_video_auth_header_provider_test.dart` — 5 passing (sha256 extraction for Blossom URLs + HLS manifests, pass-through of null, origin parsing, null result when auth unavailable).
- [x] `test/widgets/web_video_feed_test.dart` — covers provider forwarding, auth-required callback separation from load errors, HLS fallback forwarding, and flag-off default behavior.
- [x] `test/widgets/web_video_player_test.dart` — regression coverage for the legacy controller path when `authHeaderProvider` is null.
- [x] `test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart` — covers flag-on provider propagation, flag-off null provider, and 401/403 auth-required mapping to age-restricted without dispatching the unavailable/removal event.
- [x] `node scripts/test_hls_auth_web_shim.mjs` — smoke-tests `window.__divineFetchMp4` auth headers, 401 handling, blob URL replacement, and dispose cleanup.
- [x] `bash scripts/check_hls_auth_web_shim_sync.sh` — verifies the two shim copies match.
- [ ] Manual: with `FF_HLS_AUTH_WEB_PLAYER=true`, load `preview.divine.video`, scroll to a known 401 hash (e.g. `a9bbbce1b03958553a5ee1546140d5d930b8a86c1fa967ea874fb5241bd5e41c`). Verify the `requiresAuth` overlay path surfaces and the legacy "Failed to load video" copy does not.
- [ ] Manual: flag off — confirm current web feed behavior is byte-identical (legacy `VideoPlayerController` still used).

## Known limitations / follow-ups

- Real-browser preview verification is still required before staging/prod rollout. CI now smoke-tests the JS shim in Node and builds the web preview, but it does not exercise a live browser against `media.divine.video`.
- Preflight HEAD check + poster 401 handling from divine-web are out of scope for this spike; feed items continue to use the existing `VideoPlaybackStatusCubit` ageRestricted overlay. A 401 on an MP4 fetch or HLS segment/manifest surfaces as the `requiresAuth` status on `HlsAuthWebPlayer`, which the feed treats the same as the native `ageRestricted` flow via `onRequiresAuth`.
- The direct-MP4 auth path uses `fetch(...).blob()` + `URL.createObjectURL`, so it buffers the full short-form video before playback. That matches the divine-web fallback and is documented in the source-policy code.

## Rollout

- Flag defaults to off everywhere. Flip `FF_HLS_AUTH_WEB_PLAYER=true` on the preview deploy first, then staging, then prod.
- Rollback is a single flag flip — no persisted state or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
