### PR TITLE
fix(ci): derive Codemagic Android build number from Google Play

### DIFF
--- a/.github/scripts/tests/test_codemagic_android_build_number.py
+++ b/.github/scripts/tests/test_codemagic_android_build_number.py
@@ -1,0 +1,29 @@
+import unittest
+from pathlib import Path
+
+
+CODEMAGIC_PATH = Path(__file__).resolve().parents[3] / "codemagic.yaml"
+
+
+class CodemagicAndroidBuildNumberTest(unittest.TestCase):
+    def test_android_aab_build_uses_google_play_floor(self) -> None:
+        contents = CODEMAGIC_PATH.read_text()
+
+        self.assertIn(
+            'google-play get-latest-build-number --package-name "co.openvine.app"',
+            contents,
+        )
+        self.assertIn("BUILD_NUMBER=$PROJECT_BUILD_NUMBER", contents)
+        self.assertIn(
+            'NEXT_PLAY_BUILD_NUMBER=$((LATEST_GOOGLE_PLAY_BUILD_NUMBER + 1))',
+            contents,
+        )
+        self.assertIn(
+            'if [ "$NEXT_PLAY_BUILD_NUMBER" -gt "$BUILD_NUMBER" ]; then',
+            contents,
+        )
+        self.assertNotIn("PROJECT_BUILD_NUMBER + 8", contents)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -87,8 +87,19 @@ definitions:
     - &build_aab
       name: Build Android AAB
       script: |
-        # Offset to continue from existing Google Play builds (GP has up to 108, CM at 100)
-        BUILD_NUMBER=$((PROJECT_BUILD_NUMBER + 8))
+        # Use the latest Play versionCode as the primary source of truth.
+        LATEST_GOOGLE_PLAY_BUILD_NUMBER=$(google-play get-latest-build-number --package-name "co.openvine.app" 2>/dev/null || true)
+        BUILD_NUMBER=$PROJECT_BUILD_NUMBER
+        case "$LATEST_GOOGLE_PLAY_BUILD_NUMBER" in
+          ''|*[!0-9]*)
+            ;;
+          *)
+            NEXT_PLAY_BUILD_NUMBER=$((LATEST_GOOGLE_PLAY_BUILD_NUMBER + 1))
+            if [ "$NEXT_PLAY_BUILD_NUMBER" -gt "$BUILD_NUMBER" ]; then
+              BUILD_NUMBER=$NEXT_PLAY_BUILD_NUMBER
+            fi
+            ;;
+        esac
         flutter build appbundle --release --build-number=$BUILD_NUMBER \
           --dart-define=ZENDESK_APP_ID=$ZENDESK_APP_ID \
           --dart-define=ZENDESK_CLIENT_ID=$ZENDESK_CLIENT_ID \


### PR DESCRIPTION
Closes #3136

## Summary
- replace the stale Codemagic Android AAB build-number offset with a Google Play lookup
- keep PROJECT_BUILD_NUMBER as the fallback floor when the Play lookup is unavailable
- add a regression test that locks the expected Codemagic script behavior

## Verification
- python3 .github/scripts/tests/test_codemagic_android_build_number.py
- ruby -e 'require "yaml"; YAML.load_file("codemagic.yaml"); puts "codemagic.yaml OK"'