### PR TITLE
fix(l10n): default to English when device locale is unsupported

### DIFF
--- a/mobile/lib/l10n/resolve_app_ui_locale.dart
+++ b/mobile/lib/l10n/resolve_app_ui_locale.dart
@@ -1,0 +1,37 @@
+// ABOUTME: Resolves app UI locale from device preferences with English fallback
+// ABOUTME: Used by MaterialApp.localeListResolutionCallback in main.dart
+
+import 'package:flutter/widgets.dart';
+
+/// Picks a [Locale] using [basicLocaleListResolution], except when Flutter
+/// would fall back to [supportedLocales.first] without any of the device's
+/// preferred [Locale.languageCode] values matching that locale — then English
+/// is used instead (today [supportedLocales.first] is Arabic).
+///
+/// Usable as [MaterialApp.localeListResolutionCallback] (a non-null
+/// [Locale] is assignable where [Locale?] is expected).
+Locale resolveAppUiLocale(
+  List<Locale>? preferredLocales,
+  Iterable<Locale> supportedLocales,
+) {
+  final preferred = preferredLocales ?? const <Locale>[];
+  final supported = List<Locale>.from(supportedLocales);
+  final deviceLanguageCodes = preferred
+      .map((locale) => locale.languageCode)
+      .toSet();
+
+  final resolved = basicLocaleListResolution(preferred, supported);
+  // [basicLocaleListResolution] ends with supported.first when nothing matched.
+  if (resolved.languageCode == supported.first.languageCode &&
+      !deviceLanguageCodes.contains(resolved.languageCode)) {
+    return _englishLocale(supported);
+  }
+  return resolved;
+}
+
+Locale _englishLocale(List<Locale> supported) {
+  return supported.firstWhere(
+    (locale) => locale.languageCode == 'en',
+    orElse: () => const Locale('en'),
+  );
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -36,6 +36,7 @@ import 'package:openvine/features/app/startup/startup_coordinator.dart';
 import 'package:openvine/features/app/startup/startup_phase.dart';
 import 'package:openvine/l10n/email_verification_error_l10n.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/l10n/resolve_app_ui_locale.dart';
 import 'package:openvine/network/vine_cdn_http_overrides.dart'
     if (dart.library.html) 'package:openvine/utils/platform_io_web.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
@@ -1493,6 +1494,7 @@ class _DivineAppState extends ConsumerState<DivineApp> {
             locale: locale,
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
+            localeListResolutionCallback: resolveAppUiLocale,
           ),
         );
       }
@@ -1512,6 +1514,7 @@ class _DivineAppState extends ConsumerState<DivineApp> {
             locale: locale,
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
+            localeListResolutionCallback: resolveAppUiLocale,
           ),
         ),
       );

--- a/mobile/test/l10n/l10n_test.dart
+++ b/mobile/test/l10n/l10n_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/l10n/resolve_app_ui_locale.dart';
 
 void main() {
   group('AppLocalizations', () {
@@ -11,6 +12,7 @@ void main() {
         MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
+          localeListResolutionCallback: resolveAppUiLocale,
           home: Builder(
             builder: (context) {
               l10n = context.l10n;
@@ -57,7 +59,7 @@ void main() {
           locale: const Locale('zh'),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
-          localeListResolutionCallback: (_, __) => const Locale('en'),
+          localeListResolutionCallback: resolveAppUiLocale,
           home: Builder(
             builder: (context) {
               l10n = context.l10n;
@@ -77,6 +79,7 @@ void main() {
         MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
+          localeListResolutionCallback: resolveAppUiLocale,
           home: Builder(
             builder: (context) {
               l10n = context.l10n;
@@ -96,6 +99,7 @@ void main() {
         MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
+          localeListResolutionCallback: resolveAppUiLocale,
           home: Builder(
             builder: (context) {
               l10n = context.l10n;
@@ -123,6 +127,7 @@ void main() {
         MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
+          localeListResolutionCallback: resolveAppUiLocale,
           home: Builder(
             builder: (context) {
               l10n = context.l10n;
@@ -145,6 +150,7 @@ void main() {
         MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
+          localeListResolutionCallback: resolveAppUiLocale,
           home: Builder(
             builder: (context) {
               l10n = context.l10n;

--- a/mobile/test/l10n/resolve_app_ui_locale_test.dart
+++ b/mobile/test/l10n/resolve_app_ui_locale_test.dart
@@ -1,0 +1,87 @@
+// ABOUTME: Tests for resolveAppUiLocale (device locale vs supported list)
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/l10n/resolve_app_ui_locale.dart';
+
+void main() {
+  const supported = AppLocalizations.supportedLocales;
+
+  group('resolveAppUiLocale', () {
+    test('uses English when device language is not supported (Russian)', () {
+      final locale = resolveAppUiLocale(
+        const [Locale('ru')],
+        supported,
+      );
+      expect(locale.languageCode, 'en');
+    });
+
+    test('uses English when device language is not supported (Chinese)', () {
+      final locale = resolveAppUiLocale(
+        const [Locale('zh', 'CN')],
+        supported,
+      );
+      expect(locale.languageCode, 'en');
+    });
+
+    test(
+      'does not pick Arabic as implicit fallback for unsupported device',
+      () {
+        final locale = resolveAppUiLocale(
+          const [Locale('ru')],
+          supported,
+        );
+        expect(locale.languageCode, isNot('ar'));
+      },
+    );
+
+    test('matches supported German', () {
+      final locale = resolveAppUiLocale(
+        const [Locale('de', 'DE')],
+        supported,
+      );
+      expect(locale.languageCode, 'de');
+    });
+
+    test('matches English when preferred', () {
+      final locale = resolveAppUiLocale(
+        const [Locale('en', 'US')],
+        supported,
+      );
+      expect(locale.languageCode, 'en');
+    });
+
+    test('uses later preferred locale when earlier is unsupported', () {
+      final locale = resolveAppUiLocale(
+        const [Locale('zh'), Locale('es')],
+        supported,
+      );
+      expect(locale.languageCode, 'es');
+    });
+
+    test('uses Arabic when device prefers Arabic', () {
+      final locale = resolveAppUiLocale(
+        const [Locale('ar')],
+        supported,
+      );
+      expect(locale.languageCode, 'ar');
+    });
+
+    test('falls back to English when preferred list is empty', () {
+      final locale = resolveAppUiLocale(
+        const <Locale>[],
+        supported,
+      );
+      expect(locale.languageCode, 'en');
+    });
+
+    test('treats null preferred list like empty (English)', () {
+      final locale = resolveAppUiLocale(
+        null,
+        supported,
+      );
+      expect(locale.languageCode, 'en');
+    });
+  });
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Fixes **wrong UI language on first launch** when the OS language is **not** in `AppLocalizations.supportedLocales` (e.g. Russian or Chinese). Flutter's `basicLocaleListResolution` falls back to `supportedLocales.first`, which in our generated list is **Arabic**; product expectation is **English** (#3132).

### Behavior

- **`resolveAppUiLocale`** (`mobile/lib/l10n/resolve_app_ui_locale.dart`): always delegates to `basicLocaleListResolution`, then if the resolved locale is the **implicit list fallback** (`supported.first` by language) **and** none of the device's preferred `languageCode` values match that locale, replace with **English** from the supported list.
- **`main.dart`**: both `MaterialApp.router` branches set `localeListResolutionCallback: resolveAppUiLocale` (Android-only path and `PopScope` path).
- **Tests**: `mobile/test/l10n/resolve_app_ui_locale_test.dart` covers unsupported device languages, ordering (`zh` then `es`), explicit `ar`, empty / `null` preferred lists; **`l10n_test.dart`** wires the same callback on `MaterialApp` where tests assume English under default resolution (aligned with production).

**Verification (suggested):** `dart analyze lib/l10n/resolve_app_ui_locale.dart lib/main.dart test/l10n/`; `flutter test test/l10n/l10n_test.dart test/l10n/resolve_app_ui_locale_test.dart`; manual check: device/emulator system language `ru` or `zh`, clear app data, confirm English UI.

**Related Issue:** Closes #3132.

**Repository:** `divine-mobile` (paths under `mobile/`).

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
