### PR TITLE
fix(auth): nudge pubkey-only users toward Nostr sign-in on failed login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Git worktrees
 .worktrees/
+worktrees/
 
 # Flutter repo-specific
 /bin/cache/

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -107,7 +107,19 @@ class _SignInContentState extends ConsumerState<_SignInContent> {
   late TextEditingController _passwordController;
   late FocusNode _emailFocusNode;
   late FocusNode _passwordFocusNode;
+  final GlobalKey _alternativesKey = GlobalKey();
   bool _isConnectingAmber = false;
+
+  Future<void> _scrollToAlternatives() async {
+    final ctx = _alternativesKey.currentContext;
+    if (ctx == null) return;
+    await Scrollable.ensureVisible(
+      ctx,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOut,
+      alignment: 0.5,
+    );
+  }
 
   @override
   void initState() {
@@ -302,10 +314,18 @@ class _SignInContentState extends ConsumerState<_SignInContent> {
                   ),
                 ),
 
-                // General error
+                // General error + Nostr-login recovery hint.
+                // Shown on every failed login — preserves security (doesn't
+                // leak whether the account exists). The ~98% of Keycast users
+                // who signed up via Nostr (not email) otherwise have no way
+                // to discover that the alternatives below apply to them.
                 if (widget.state.generalError != null) ...[
                   const SizedBox(height: 16),
                   AuthErrorBox(message: widget.state.generalError!),
+                  const SizedBox(height: 12),
+                  _NostrLoginHint(
+                    onTap: isDisabled ? null : _scrollToAlternatives,
+                  ),
                 ],
 
                 const SizedBox(height: 24),
@@ -344,6 +364,7 @@ class _SignInContentState extends ConsumerState<_SignInContent> {
 
                 // Alternative login methods
                 DivineButton(
+                  key: _alternativesKey,
                   type: .secondary,
                   expanded: true,
                   label: 'Import Nostr key',
@@ -432,6 +453,53 @@ void _showInfoSheet(BuildContext context) {
       ),
     ),
   );
+}
+
+/// Secondary hint shown alongside a failed-login error.
+///
+/// Points users who may have signed up with a Nostr signer (rather than
+/// email + password) toward the alternative sign-in options at the bottom
+/// of the screen. Tapping scrolls those options into view.
+class _NostrLoginHint extends StatelessWidget {
+  const _NostrLoginHint({required this.onTap});
+
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: 'Sign in with Nostr. Scroll to alternative options.',
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: const Padding(
+          padding: EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+          child: Text.rich(
+            TextSpan(
+              children: [
+                TextSpan(text: 'Signed up with Nostr? '),
+                TextSpan(
+                  text: 'Use an option below ↓',
+                  style: TextStyle(
+                    decoration: TextDecoration.underline,
+                    decorationColor: VineTheme.vineGreenLight,
+                    color: VineTheme.vineGreenLight,
+                  ),
+                ),
+              ],
+            ),
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: VineTheme.secondaryText,
+              fontSize: 14,
+              height: 1.4,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 /// Single info item in the info sheet.

--- a/mobile/packages/keycast_flutter/lib/src/oauth/headless_models.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/headless_models.dart
@@ -67,6 +67,15 @@ class HeadlessLoginResult {
     this.errorDescription,
   });
 
+  /// Machine-readable server error code when [success] is `false`.
+  ///
+  /// Returns `null` for successful responses (where [code] holds the OAuth
+  /// authorization code instead). On failure this is the `code` field from
+  /// the server response body — e.g. `INVALID_CREDENTIALS`, `RATE_LIMITED`,
+  /// `EMAIL_NOT_VERIFIED`. UI layers can branch on this for targeted
+  /// messaging while keeping a generic human fallback in [errorDescription].
+  String? get errorCode => success ? null : code;
+
   factory HeadlessLoginResult.fromJson(Map<String, dynamic> json) {
     return HeadlessLoginResult(
       success: json['success'] as bool? ?? false,
@@ -81,6 +90,7 @@ class HeadlessLoginResult {
   factory HeadlessLoginResult.error(String message, {String? code}) {
     return HeadlessLoginResult(
       success: false,
+      code: code ?? 'client_error',
       error: code ?? 'client_error',
       errorDescription: message,
     );

--- a/mobile/packages/keycast_flutter/test/headless_models_test.dart
+++ b/mobile/packages/keycast_flutter/test/headless_models_test.dart
@@ -161,15 +161,47 @@ void main() {
       test('parses error fields', () {
         final json = {
           'success': false,
-          'error': 'invalid_credentials',
+          'error': 'Invalid email or password',
+          'code': 'INVALID_CREDENTIALS',
           'error_description': 'Wrong password',
         };
 
         final result = HeadlessLoginResult.fromJson(json);
 
         expect(result.success, isFalse);
-        expect(result.error, 'invalid_credentials');
+        expect(result.error, 'Invalid email or password');
         expect(result.errorDescription, 'Wrong password');
+        expect(result.errorCode, 'INVALID_CREDENTIALS');
+      });
+    });
+
+    group('errorCode', () {
+      test('returns null on successful login', () {
+        final result = HeadlessLoginResult(
+          success: true,
+          code: 'auth_code_xyz',
+        );
+
+        expect(result.errorCode, isNull);
+      });
+
+      test('returns server code on failed login from JSON', () {
+        final result = HeadlessLoginResult.fromJson({
+          'success': false,
+          'code': 'RATE_LIMITED',
+          'error': 'Too many attempts',
+        });
+
+        expect(result.errorCode, 'RATE_LIMITED');
+      });
+
+      test('returns factory code on client-side error', () {
+        final result = HeadlessLoginResult.error(
+          'Cannot connect',
+          code: 'connection_error',
+        );
+
+        expect(result.errorCode, 'connection_error');
       });
     });
 
@@ -180,6 +212,7 @@ void main() {
         expect(result.success, isFalse);
         expect(result.error, 'client_error');
         expect(result.errorDescription, 'Login failed');
+        expect(result.errorCode, 'client_error');
       });
 
       test('creates error result with custom code', () {
@@ -191,6 +224,7 @@ void main() {
         expect(result.success, isFalse);
         expect(result.error, 'connection_error');
         expect(result.errorDescription, 'Network error');
+        expect(result.errorCode, 'connection_error');
       });
     });
   });

--- a/mobile/test/screens/auth/login_options_screen_test.dart
+++ b/mobile/test/screens/auth/login_options_screen_test.dart
@@ -127,10 +127,7 @@ void main() {
           findsOneWidget,
         );
         expect(
-          find.ancestor(
-            of: emailField,
-            matching: find.byType(AutofillGroup),
-          ),
+          find.ancestor(of: emailField, matching: find.byType(AutofillGroup)),
           findsOneWidget,
         );
         expect(
@@ -175,10 +172,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(
-          find.widgetWithText(
-            DivineButton,
-            'Connect with a signer app',
-          ),
+          find.widgetWithText(DivineButton, 'Connect with a signer app'),
           findsOneWidget,
         );
       });
@@ -319,6 +313,61 @@ void main() {
         await tester.pump(const Duration(milliseconds: 100));
 
         expect(find.text('Invalid email or password'), findsOneWidget);
+      });
+
+      testWidgets('does not show Nostr-login hint before any sign-in attempt', (
+        tester,
+      ) async {
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('Signed up with Nostr?'), findsNothing);
+      });
+
+      testWidgets('shows Nostr-login hint after a failed sign-in', (
+        tester,
+      ) async {
+        when(
+          () => mockOAuth.headlessLogin(
+            email: any(named: 'email'),
+            password: any(named: 'password'),
+            scope: any(named: 'scope'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            HeadlessLoginResult(
+              success: false,
+              error: 'invalid_credentials',
+              errorDescription: 'Invalid email or password',
+            ),
+            'test-verifier',
+          ),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        await tester.enterText(
+          find.descendant(
+            of: find.widgetWithText(DivineAuthTextField, 'Email'),
+            matching: find.byType(TextField),
+          ),
+          'nostr-user@example.com',
+        );
+        await tester.enterText(
+          find.descendant(
+            of: find.widgetWithText(DivineAuthTextField, 'Password'),
+            matching: find.byType(TextField),
+          ),
+          'NotTheirActualMethod!',
+        );
+
+        await tester.tap(find.widgetWithText(DivineButton, 'Sign in'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.textContaining('Signed up with Nostr?'), findsOneWidget);
+        expect(find.textContaining('Use an option below'), findsOneWidget);
       });
 
       testWidgets('shows email validation error for empty form', (


### PR DESCRIPTION
Closes #3158

## Why

A user reported "I typed the right email and password but login fails." Investigation (prod Keycast DB on `dv-platform-prod`, all-time ILIKE queries across both tenants) confirmed the account **does not exist** in `users` — and that's true for the vast majority of users trying this flow.

Stats from prod: **998 of 98,569 Keycast users have an email credential.** The other 97,571 are pubkey-only Nostr accounts (Amber / nsec import / NIP-46). For those users, typing an email + password will always return `INVALID_CREDENTIALS` — regardless of what they type — because they never had an email credential to begin with. The current UI gives them no signal that the right path is one of the "Import Nostr key / Signer app / Amber" buttons pushed below a `Spacer` and often out of sight.

## What this changes

1. **Hint under the login error** — when sign-in fails for any reason, render a subtle secondary line under `AuthErrorBox`: "Signed up with Nostr? Use an option below ↓". Tappable, scrolls the alternatives into view. Shown on **every** failed login, so no account-existence leak.

2. **`errorCode` on `HeadlessLoginResult`** — new getter that surfaces the server-side machine code (`INVALID_CREDENTIALS`, `RATE_LIMITED`, `EMAIL_NOT_VERIFIED`) only when `success == false`. Disambiguates from the existing `code` field which also holds the OAuth auth code on success. Unblocks future UX branches (rate-limit banner, verification-pending CTA) without another refactor.

## What this deliberately doesn't do

- **No Keycast changes.** Keeping `INVALID_CREDENTIALS` identical for "user not found" vs "wrong password" is the right security posture — don't enumerate accounts.
- **No new screens, no dialogs, no bottom sheets** — extends the existing error surface in place.
- **No copy change to the error itself** — the hint is additive.

## Test plan

- [x] `flutter test test/screens/auth/login_options_screen_test.dart` — 17 tests pass (2 new: hint absent initially, hint appears after failed sign-in).
- [x] `flutter test packages/keycast_flutter/test/headless_models_test.dart` — 38 tests pass (3 new: `errorCode` null on success, from JSON on failure, from error factory).
- [x] `flutter test test/blocs/divine_auth/divine_auth_cubit_test.dart` — 64 tests pass (no regressions from the `.error` factory now populating `code`).
- [x] `flutter analyze` on all changed files — clean.
- [ ] Manual QA on a real device: fail a login, confirm the hint appears under the error and tapping it scrolls the Nostr options into view.

## Follow-ups (not in this PR)

- Keycast HTTP request logging (endpoint + status, not body) so "did the POST reach Keycast?" questions are answerable from `gcloud logging`. Zero of our current request paths are logged — found during investigation.
- Reset-password screen autofill + `finishAutofillContext()` gaps (separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)