### PR TITLE
chore(release): bump version to 1.0.9+498

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.8+497
+version: 1.0.9+498
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
## Summary
- Bump `version` in `mobile/pubspec.yaml` from `1.0.8+497` to `1.0.9+498`.
- Unblocks the Codemagic iOS release: App Store Connect rejected the previous build because `CFBundleShortVersionString` 1.0.8 was already approved, and the validator requires a strictly higher version on each submission.
- `ios/Runner/Info.plist` reads `$(FLUTTER_BUILD_NAME)` / `$(FLUTTER_BUILD_NUMBER)`, so the pubspec bump is sufficient; no iOS project edits needed.

## Test plan
- [ ] Codemagic iOS release build succeeds
- [ ] App Store Connect validation passes for 1.0.9 (498)

🤖 Generated with [Claude Code](https://claude.com/claude-code)