### PR TITLE
fix(auth): stop confetti sticker from swallowing invite-code input taps

### DIFF
--- a/mobile/lib/screens/auth/invite_gate_screen.dart
+++ b/mobile/lib/screens/auth/invite_gate_screen.dart
@@ -268,9 +268,16 @@ class _InviteCodeEntryPage extends StatelessWidget {
                 Positioned(
                   top: constraints.maxHeight / 2 - 80,
                   left: -36,
-                  child: Transform.rotate(
-                    angle: 12 * 3.14159 / 180,
-                    child: const DivineSticker(sticker: .confetti, size: 174),
+                  child: IgnorePointer(
+                    child: ExcludeSemantics(
+                      child: Transform.rotate(
+                        angle: 12 * 3.14159 / 180,
+                        child: const DivineSticker(
+                          sticker: .confetti,
+                          size: 174,
+                        ),
+                      ),
+                    ),
                   ),
                 ),
 

--- a/mobile/test/screens/auth/invite_gate_screen_test.dart
+++ b/mobile/test/screens/auth/invite_gate_screen_test.dart
@@ -156,6 +156,48 @@ void main() {
       verify(() => mockInviteApiClient.validateCode('AB12-EF34')).called(1);
     });
 
+    testWidgets(
+      'confetti sticker ignores pointer events so input remains tappable',
+      (tester) async {
+        when(
+          () => mockInviteApiClient.getClientConfig(),
+        ).thenAnswer(
+          (_) async => const InviteClientConfig(
+            mode: OnboardingMode.inviteCodeRequired,
+            supportEmail: 'support@divine.video',
+          ),
+        );
+
+        await tester.pumpWidget(createTestWidget());
+        await tester.pumpAndSettle();
+
+        final confettiFinder = find.byWidgetPredicate(
+          (widget) =>
+              widget is DivineSticker &&
+              widget.sticker == DivineStickerName.confetti,
+        );
+        expect(confettiFinder, findsOneWidget);
+        expect(
+          find.ancestor(
+            of: confettiFinder,
+            matching: find.byWidgetPredicate(
+              (widget) => widget is IgnorePointer && widget.ignoring,
+            ),
+          ),
+          findsOneWidget,
+        );
+
+        await tester.tap(
+          find.byType(TextField),
+          warnIfMissed: false,
+        );
+        await tester.enterText(find.byType(TextField), 'ab12ef34');
+        await tester.pumpAndSettle();
+
+        expect(find.text('AB12-EF34'), findsOneWidget);
+      },
+    );
+
     testWidgets('shows initial recovery error from query params', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

Fixes #2323 — the decorative confetti sticker on the invite-code screen swallows pointer events that fall through transparent gaps in the form subtree, interrupting `TextField` gestures (most visibly, paste).

Wraps the confetti `Positioned` in `IgnorePointer` + `ExcludeSemantics` so pointer events pass through to the input and the sticker is no longer announced by screen readers (it is purely decorative — per `.claude/rules/accessibility.md`).

## Steps to reproduce (on `main`)

1. Launch the app on a device/simulator where invite-code onboarding is active, or run with `flutter run -d <device>` and navigate to `/invite`.
2. Tap **Add your invite code**.
3. Long-press the invite code `TextField`, or tap the field and try to paste a code from the clipboard.

### Actual (before this PR)
- The paste / context-menu gesture is intermittently swallowed in the region where the confetti sticker overlaps the input (roughly `y ≈ maxHeight/2`, `x ∈ [-36, 138]`). Paste either fails to trigger or the menu dismisses itself.
- See the screenshot on #2323.

### Expected (after this PR)
- Long-press reliably opens the paste menu and the pasted value lands in the field; the confetti is still visible but no longer interactive.

## Root cause

In `Stack`, hit testing cascades last→first. The `Padding` wrapping the form defers to its child (`HitTestBehavior.deferToChild`), so taps in transparent gaps of the form subtree fall through to the confetti `Positioned` underneath. `SvgPicture.asset` (inside `DivineSticker`) accepts hits by default, silently consuming them and preventing the `TextField`'s gesture recognizer from claiming the long-press.

## Fix

`mobile/lib/screens/auth/invite_gate_screen.dart:268`

```diff
- child: Transform.rotate(
-   angle: 12 * 3.14159 / 180,
-   child: const DivineSticker(sticker: .confetti, size: 174),
+ child: IgnorePointer(
+   child: ExcludeSemantics(
+     child: Transform.rotate(
+       angle: 12 * 3.14159 / 180,
+       child: const DivineSticker(sticker: .confetti, size: 174),
+     ),
+   ),
  ),
```

## Test plan

- [x] `flutter analyze lib/screens/auth/invite_gate_screen.dart test/screens/auth/invite_gate_screen_test.dart` — clean.
- [x] `flutter test test/screens/auth/invite_gate_screen_test.dart` — 5/5 passing.
- [x] New widget test `confetti sticker ignores pointer events so input remains tappable` asserts:
  - The confetti `DivineSticker` has an `IgnorePointer(ignoring: true)` ancestor.
  - Tapping + entering text on the `TextField` still lands the formatted value (`AB12-EF34`).
- [ ] Manual: launch locally, long-press invite code field, verify the paste menu appears and paste completes.

## Risk

Negligible — the change only opts a purely decorative widget out of hit-testing and the semantics tree.