### PR TITLE
fix(auth): clear all per-user DB tables on signOut (#2999)

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -1302,7 +1302,7 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
   final db = ref.watch(databaseProvider);
   final service = UserDataCleanupService(prefs);
 
-  // Wire database cleanup callback so signOut() clears DM and notification data.
+  // Wire database cleanup callback so signOut() clears every per-user table.
   // Stop DM listening FIRST to prevent in-flight event handlers from writing
   // to tables that are being cleared (H3 race condition fix).
   service.onDatabaseCleanup = () async {
@@ -1311,9 +1311,18 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
     } catch (_) {
       // DmRepository may not exist yet (e.g., first launch).
     }
+    // Messaging & notifications.
     await db.directMessagesDao.clearAll();
     await db.conversationsDao.clearAll();
     await db.notificationsDao.clearAll();
+    // Authoring surfaces: drafts, clips, pending uploads (#2999).
+    await db.draftsDao.clearAll();
+    await db.clipsDao.clearAll();
+    await db.pendingUploadsDao.clearAll();
+    // Personal engagement & offline action queue (#2999).
+    await db.personalReactionsDao.deleteAll();
+    await db.personalRepostsDao.deleteAll();
+    await db.pendingActionsDao.deleteAll();
     await NotificationServiceEnhanced.instance.clearAllData();
     // Clear DM sync cursors so the next login triggers a full re-fetch
     // from relays instead of using stale `since:` boundaries.
@@ -1717,9 +1726,7 @@ Nip98AuthService nip98AuthService(Ref ref) {
 @riverpod
 BlossomAuthService blossomAuthService(Ref ref) {
   final authService = ref.watch(authServiceProvider);
-  return BlossomAuthService(
-    authProvider: _BlossomAuthAdapter(authService),
-  );
+  return BlossomAuthService(authProvider: _BlossomAuthAdapter(authService));
 }
 
 /// Shared viewer auth service for media GET requests.

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -2673,7 +2673,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'56d99094bba86b89b54ababd0ab82604bc95cc4e';
+    r'ed6df8ebc20f3942eefe6003a6f1794d73ab2a3e';
 
 /// Subscription manager for centralized subscription management
 

--- a/mobile/packages/db_client/lib/src/database/daos/pending_actions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_actions_dao.dart
@@ -8,14 +8,7 @@ import 'package:meta/meta.dart';
 part 'pending_actions_dao.g.dart';
 
 /// Type of social action queued for offline sync
-enum PendingActionType {
-  like,
-  unlike,
-  repost,
-  unrepost,
-  follow,
-  unfollow,
-}
+enum PendingActionType { like, unlike, repost, unrepost, follow, unfollow }
 
 /// Status of a pending action in the sync queue
 enum PendingActionStatus {
@@ -209,9 +202,9 @@ class PendingActionsDao extends DatabaseAccessor<AppDatabase>
 
   /// Upsert a pending action
   Future<void> upsertAction(PendingAction action) {
-    return into(pendingActions).insertOnConflictUpdate(
-      _modelToCompanion(action),
-    );
+    return into(
+      pendingActions,
+    ).insertOnConflictUpdate(_modelToCompanion(action));
   }
 
   /// Get action by ID
@@ -368,6 +361,14 @@ class PendingActionsDao extends DatabaseAccessor<AppDatabase>
     return (delete(
       pendingActions,
     )..where((t) => t.userPubkey.equals(userPubkey))).go();
+  }
+
+  /// Delete every pending action, regardless of user.
+  ///
+  /// Used when logging out to wipe queued offline actions so they do not
+  /// sync under a different account on the next login.
+  Future<int> deleteAll() {
+    return delete(pendingActions).go();
   }
 
   /// Reset syncing actions to pending (for app restart recovery)

--- a/mobile/packages/db_client/test/src/database/daos/pending_actions_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/pending_actions_dao_test.dart
@@ -614,6 +614,36 @@ void main() {
       });
     });
 
+    group('deleteAll', () {
+      test('deletes actions for every user', () async {
+        final actionA = PendingAction.create(
+          type: PendingActionType.like,
+          targetId: testTargetId,
+          userPubkey: testUserPubkey,
+        );
+        final actionB = PendingAction.create(
+          type: PendingActionType.follow,
+          targetId: testTargetId2,
+          userPubkey: testUserPubkey2,
+        );
+
+        await dao.upsertAction(actionA);
+        await dao.upsertAction(actionB);
+
+        final deleted = await dao.deleteAll();
+
+        expect(deleted, equals(2));
+        expect(await dao.getAllActions(testUserPubkey), isEmpty);
+        expect(await dao.getAllActions(testUserPubkey2), isEmpty);
+      });
+
+      test('returns 0 when the table is already empty', () async {
+        final deleted = await dao.deleteAll();
+
+        expect(deleted, equals(0));
+      });
+    });
+
     group('resetSyncingToPending', () {
       test('resets syncing actions to pending', () async {
         final syncing = PendingAction.create(

--- a/mobile/test/providers/user_data_cleanup_service_provider_test.dart
+++ b/mobile/test/providers/user_data_cleanup_service_provider_test.dart
@@ -1,0 +1,283 @@
+// ABOUTME: Tests that userDataCleanupServiceProvider clears every per-user
+// ABOUTME: Drift table on signOut while leaving shared caches intact (#2999).
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeDmRepository extends Mock implements DmRepository {}
+
+void main() {
+  // 64-char hex pubkey used to own the seeded per-user rows.
+  const ownerPubkey =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  const otherPubkey =
+      'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+
+  group('userDataCleanupServiceProvider onDatabaseCleanup (#2999)', () {
+    late AppDatabase database;
+    late SharedPreferences prefs;
+    late _FakeDmRepository dmRepository;
+
+    setUp(() async {
+      database = AppDatabase.test(NativeDatabase.memory());
+
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      prefs = await SharedPreferences.getInstance();
+
+      dmRepository = _FakeDmRepository();
+      when(() => dmRepository.stopListening()).thenAnswer((_) async {});
+    });
+
+    tearDown(() async {
+      await database.close();
+    });
+
+    ProviderContainer createContainer() {
+      final container = ProviderContainer(
+        overrides: [
+          databaseProvider.overrideWithValue(database),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          dmRepositoryProvider.overrideWithValue(dmRepository),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    Future<void> seedPerUserRows() async {
+      // DMs & conversations — existing cleanup path.
+      await database
+          .into(database.directMessages)
+          .insert(
+            DirectMessagesCompanion.insert(
+              id: 'dm-1',
+              conversationId: 'conv-1',
+              senderPubkey: ownerPubkey,
+              content: 'hello',
+              createdAt: 1,
+              giftWrapId: 'gw-1',
+            ),
+          );
+      await database
+          .into(database.conversations)
+          .insert(
+            ConversationsCompanion.insert(
+              id: 'conv-1',
+              participantPubkeys: '["$ownerPubkey"]',
+              createdAt: 1,
+            ),
+          );
+      await database
+          .into(database.notifications)
+          .insert(
+            NotificationsCompanion.insert(
+              id: 'notif-1',
+              type: 'like',
+              fromPubkey: otherPubkey,
+              timestamp: 1,
+              cachedAt: DateTime.utc(2026),
+            ),
+          );
+
+      // Authoring surfaces (leaked before #2999 fix).
+      await database
+          .into(database.drafts)
+          .insert(
+            DraftsCompanion.insert(
+              id: 'draft-1',
+              createdAt: DateTime.utc(2026),
+              lastModified: DateTime.utc(2026),
+              data: '{}',
+              ownerPubkey: const Value(ownerPubkey),
+            ),
+          );
+      await database
+          .into(database.clips)
+          .insert(
+            ClipsCompanion.insert(
+              id: 'clip-1',
+              durationMs: 1000,
+              recordedAt: DateTime.utc(2026),
+              data: '{}',
+              ownerPubkey: const Value(ownerPubkey),
+            ),
+          );
+      await database
+          .into(database.pendingUploads)
+          .insert(
+            PendingUploadsCompanion.insert(
+              id: 'upload-1',
+              localVideoPath: '/tmp/x.mp4',
+              nostrPubkey: ownerPubkey,
+              status: 'pending',
+              createdAt: DateTime.utc(2026),
+            ),
+          );
+
+      // Personal engagement & offline queue (leaked before #2999 fix).
+      await database
+          .into(database.personalReactions)
+          .insert(
+            PersonalReactionsCompanion.insert(
+              targetEventId:
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              reactionEventId:
+                  'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+              userPubkey: ownerPubkey,
+              createdAt: 1,
+            ),
+          );
+      await database
+          .into(database.personalReposts)
+          .insert(
+            PersonalRepostsCompanion.insert(
+              addressableId: '34236:$otherPubkey:vine-1',
+              repostEventId:
+                  'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+              originalAuthorPubkey: otherPubkey,
+              userPubkey: ownerPubkey,
+              createdAt: 1,
+            ),
+          );
+      await database
+          .into(database.pendingActions)
+          .insert(
+            PendingActionsCompanion.insert(
+              id: 'action-1',
+              type: 'like',
+              targetId:
+                  'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+              status: 'pending',
+              userPubkey: ownerPubkey,
+              createdAt: DateTime.utc(2026),
+            ),
+          );
+    }
+
+    Future<void> seedSharedRows() async {
+      // Shared across users — MUST survive signOut.
+      await database
+          .into(database.nostrEvents)
+          .insert(
+            NostrEventsCompanion.insert(
+              id: 'event-1',
+              pubkey: otherPubkey,
+              createdAt: 1,
+              kind: 34236,
+              tags: '[]',
+              content: 'video',
+              sig: 'sig',
+            ),
+          );
+      await database
+          .into(database.userProfiles)
+          .insert(
+            UserProfilesCompanion.insert(
+              pubkey: otherPubkey,
+              createdAt: DateTime.utc(2026),
+              eventId: 'event-profile',
+              lastFetched: DateTime.utc(2026),
+            ),
+          );
+      await database
+          .into(database.videoMetrics)
+          .insert(
+            VideoMetricsCompanion.insert(
+              eventId: 'event-1',
+              updatedAt: DateTime.utc(2026),
+            ),
+          );
+      await database
+          .into(database.profileStats)
+          .insert(
+            ProfileStatsCompanion.insert(
+              pubkey: otherPubkey,
+              cachedAt: DateTime.utc(2026),
+            ),
+          );
+      await database
+          .into(database.hashtagStats)
+          .insert(
+            HashtagStatsCompanion.insert(
+              hashtag: 'flutter',
+              cachedAt: DateTime.utc(2026),
+            ),
+          );
+      await database
+          .into(database.nip05Verifications)
+          .insert(
+            Nip05VerificationsCompanion.insert(
+              pubkey: otherPubkey,
+              nip05: 'alice@example.com',
+              status: 'verified',
+              verifiedAt: DateTime.utc(2026),
+              expiresAt: DateTime.utc(2026, 1, 2),
+            ),
+          );
+    }
+
+    Future<int> countRows(String tableName) async {
+      final row = await database
+          .customSelect('SELECT COUNT(*) AS c FROM $tableName')
+          .getSingle();
+      return row.read<int>('c');
+    }
+
+    test('clears every per-user table on signOut', () async {
+      await seedPerUserRows();
+      await seedSharedRows();
+
+      final container = createContainer();
+      final service = container.read(userDataCleanupServiceProvider);
+
+      await service.clearUserSpecificData(reason: 'test_explicit_logout');
+
+      expect(await countRows('direct_messages'), equals(0));
+      expect(await countRows('conversations'), equals(0));
+      expect(await countRows('notifications'), equals(0));
+      expect(await countRows('drafts'), equals(0));
+      expect(await countRows('clips'), equals(0));
+      expect(await countRows('pending_uploads'), equals(0));
+      expect(await countRows('personal_reactions'), equals(0));
+      expect(await countRows('personal_reposts'), equals(0));
+      expect(await countRows('pending_actions'), equals(0));
+    });
+
+    test('leaves shared-across-users tables untouched', () async {
+      await seedPerUserRows();
+      await seedSharedRows();
+
+      final container = createContainer();
+      final service = container.read(userDataCleanupServiceProvider);
+
+      await service.clearUserSpecificData(reason: 'test_explicit_logout');
+
+      expect(await countRows('event'), equals(1));
+      expect(await countRows('user_profiles'), equals(1));
+      expect(await countRows('video_metrics'), equals(1));
+      expect(await countRows('profile_statistics'), equals(1));
+      expect(await countRows('hashtag_stats'), equals(1));
+      expect(await countRows('nip05_verifications'), equals(1));
+    });
+
+    test('stops the DM listener before clearing tables', () async {
+      await seedPerUserRows();
+
+      final container = createContainer();
+      final service = container.read(userDataCleanupServiceProvider);
+
+      await service.clearUserSpecificData(reason: 'test_explicit_logout');
+
+      verify(() => dmRepository.stopListening()).called(1);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #2999.

## Summary

- Widens `UserDataCleanupService.onDatabaseCleanup` to wipe every per-user Drift table on signOut. Previously only `direct_messages`, `conversations`, and `notifications` were cleared — drafts, clips, pending uploads, personal reactions, personal reposts, and queued offline actions survived, letting a second user on the same device see the previous user's data and inherit queued actions.
- Adds an unscoped `PendingActionsDao.deleteAll()` helper. The existing `clearAll(String userPubkey)` is user-scoped and can't reach rows owned by a user who has already signed out (or legacy NULL-owner rows). Other DAOs already had `clearAll()` / `deleteAll()`.

## Steps to reproduce (pre-fix)

1. Install a fresh build on a device and sign in as **user A**.
2. As user A, do each of the following — every one seeds a different leaked table:
   - Open the editor and save a draft video (→ `drafts`, `clips`).
   - Start a video upload and background the app before it finishes (→ `pending_uploads`).
   - Like a video (→ `personal_reactions` + possibly `pending_actions` if offline).
   - Repost a video (→ `personal_reposts`).
   - Go offline, like or follow something, stay offline (→ `pending_actions`).
3. Sign out (Settings → Sign out).
4. Sign in as **user B** (different nsec / different OAuth account).
5. As user B, check:
   - **Drafts tab** → user A's draft + clips are listed (legacy `NULL`-owner rows pass the `_ownedOrLegacy` filter).
   - **Library** → user A's recorded clips appear.
   - **Uploads** → user A's in-progress upload is still queued.
   - Background sync fires the queued `pending_actions` → user B's signer publishes likes/follows user A intended.

Expected: user B's session has no trace of user A's data.
Actual (before this PR): all six surfaces above leak.

## Steps to reproduce (post-fix)

Repeat steps 1–4 above. After step 4, every leaked surface is empty for user B. Shared caches (profiles, public video events, NIP-05 verifications, hashtag stats) survive signOut, so performance of the next login is unaffected.

## Scope of the change

- `mobile/lib/providers/app_providers.dart` — callback now also calls `draftsDao.clearAll()`, `clipsDao.clearAll()`, `pendingUploadsDao.clearAll()`, `personalReactionsDao.deleteAll()`, `personalRepostsDao.deleteAll()`, `pendingActionsDao.deleteAll()`.
- `mobile/packages/db_client/lib/src/database/daos/pending_actions_dao.dart` — adds `deleteAll()`.
- Tests: `pending_actions_dao_test.dart` covers the new helper; `user_data_cleanup_service_provider_test.dart` seeds all nine per-user tables plus the six shared caches, runs the provider cleanup, and asserts per-user tables end empty while shared caches are untouched.

Shared-across-users caches (`event`, `user_profiles`, `video_metrics`, `profile_statistics`, `hashtag_stats`, `nip05_verifications`) are intentionally left alone.

## Test plan

- [x] `flutter test` — `mobile/packages/db_client/test/src/database/daos/pending_actions_dao_test.dart` (existing `clearAll` tests + new `deleteAll` group).
- [x] `flutter test` — `mobile/test/providers/user_data_cleanup_service_provider_test.dart` (new; 3 scenarios: clears per-user tables, preserves shared caches, stops DM listener first).
- [x] `flutter test` — `mobile/test/services/auth_service_signout_cleanup_test.dart`, `mobile/test/services/user_data_cleanup_service_test.dart` (regression).
- [x] `flutter test` — `mobile/test/services/auth_service_data_cleanup_ordering_test.dart`, `mobile/test/services/auth_service_multi_account_test.dart` (regression, 73 tests).
- [x] `flutter analyze` clean for `mobile/lib/providers`, `mobile/test/providers`, and changed `db_client` files.
- [x] `dart run build_runner build --delete-conflicting-outputs` — only regenerates `app_providers.g.dart` hash (expected: closure body changed).
- [x] `dart format` — no formatting drift.

## Notes for reviewers

- The cleanup uses unscoped `clearAll()` / `deleteAll()` rather than per-user delete. Rationale: Daniel's rule ("could be another person's phone — treat signOut as a hard logout") plus the need to wipe legacy rows with `NULL` owner that would otherwise leak via the existing `_ownedOrLegacy` draft/clip filter.
- Callback order preserved: `dmRepository.stopListening()` still runs first so in-flight DM handlers can't write to tables being cleared (H3 race-condition fix from #2997).
- No schema migration — all DAOs already had the data; only the wiring was missing.