### PR TITLE
feat(auth): publish bootstrap kind:10002 when NIP-65 discovery returns empty

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -940,6 +940,7 @@ AuthService authService(Ref ref) {
     pendingVerificationService: pendingVerificationService,
     profileCheckIndexerUrl: authEnv.indexerRelays.first,
     indexerRelays: authEnv.indexerRelays,
+    primaryRelayUrl: authEnv.relayUrl,
     preFetchFollowing: (pubkeyHex) async {
       // Pre-fetch following list from funnelcake REST API during login
       // setup. This populates SharedPreferences BEFORE auth state is

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -2270,7 +2270,7 @@ final class AuthServiceProvider
   }
 }
 
-String _$authServiceHash() => r'4bb86052429096d3a396412f9e64f695e882f92e';
+String _$authServiceHash() => r'0186da78bd76297e5f2a4ad6f558b4108cbd8015';
 
 /// Provider that returns current auth state and rebuilds when it changes.
 /// Widgets should watch this instead of authService.authState directly

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -96,6 +96,17 @@ class NostrService extends _$NostrService {
       });
     });
 
+    // Register bootstrap kind:10002 callback — AuthService calls this when
+    // indexer discovery returns empty, so we self-publish a minimal relay
+    // list on the user's behalf. See divine-mobile#3174 / keycast#94.
+    authService.registerBootstrapRelayListCallback((event, targetRelays) async {
+      final published = await client.publishEvent(
+        event,
+        targetRelays: targetRelays,
+      );
+      return published != null;
+    });
+
     // Schedule initialization after build completes
     // Add user relays BEFORE initialize() to avoid race condition
     Future.microtask(() async {
@@ -123,6 +134,7 @@ class NostrService extends _$NostrService {
     // Capture client reference for disposal - can't access state inside onDispose
     ref.onDispose(() {
       authService.registerUserRelaysDiscoveredCallback(null);
+      authService.registerBootstrapRelayListCallback(null);
       _authSubscription?.cancel();
       client.dispose();
     });
@@ -157,6 +169,7 @@ class NostrService extends _$NostrService {
 
       // Unregister callback for old client before disposing it
       authService.registerUserRelaysDiscoveredCallback(null);
+      authService.registerBootstrapRelayListCallback(null);
       state.dispose();
 
       // Create new client with updated signer and public key
@@ -200,6 +213,19 @@ class NostrService extends _$NostrService {
             );
           }
         });
+      });
+
+      // Register bootstrap kind:10002 callback for the new client. See
+      // divine-mobile#3174 / keycast#94.
+      authService.registerBootstrapRelayListCallback((
+        event,
+        targetRelays,
+      ) async {
+        final published = await newClient.publishEvent(
+          event,
+          targetRelays: targetRelays,
+        );
+        return published != null;
       });
 
       _lastPubkey = newPubkey;

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -109,7 +109,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'39a5b4d9ac0a0909ab7c752b27de9b128f58b55f';
+String _$nostrServiceHash() => r'2f734b9d954903334679854afc9ab9e8a2dc09ec';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -168,6 +168,7 @@ class AuthService implements BackgroundAwareService {
     PreFetchFollowingCallback? preFetchFollowing,
     String? profileCheckIndexerUrl,
     List<String>? indexerRelays,
+    String? primaryRelayUrl,
     RelayDiscoveryService? relayDiscoveryService,
   }) : _keyStorage = keyStorage ?? SecureKeyStorage(),
        _nostrKeyManager = nostrKeyManager,
@@ -177,6 +178,7 @@ class AuthService implements BackgroundAwareService {
        _pendingVerificationService = pendingVerificationService,
        _preFetchFollowing = preFetchFollowing,
        _profileCheckIndexerUrl = profileCheckIndexerUrl,
+       _primaryRelayUrl = primaryRelayUrl ?? AppConstants.defaultRelayUrl,
        _relayDiscoveryService =
            relayDiscoveryService ??
            RelayDiscoveryService(indexerRelays: indexerRelays),
@@ -191,6 +193,13 @@ class AuthService implements BackgroundAwareService {
   final PendingVerificationService? _pendingVerificationService;
   final PreFetchFollowingCallback? _preFetchFollowing;
   final String? _profileCheckIndexerUrl;
+
+  /// Relay URL used when self-publishing the bootstrap kind:10002 event for
+  /// accounts whose indexer discovery returned empty. Injected from
+  /// [EnvironmentConfig.relayUrl] at the provider so non-prod builds do not
+  /// advertise the production relay. Falls back to
+  /// [AppConstants.defaultRelayUrl] when unset. See #3183.
+  final String _primaryRelayUrl;
 
   AuthState _authState = AuthState.checking;
   SecureKeyContainer? _currentKeyContainer;
@@ -4034,8 +4043,9 @@ class AuthService implements BackgroundAwareService {
   /// `relay.nos.social`). That in turn degrades reachability for every
   /// downstream publish operation (profile save, likes, comments) because
   /// the client can only connect to the fallback relay set. This method
-  /// self-publishes a minimal kind:10002 pointing at
-  /// [AppConstants.defaultRelayUrl] so subsequent logins on this or any other
+  /// self-publishes a minimal kind:10002 pointing at [_primaryRelayUrl] (the
+  /// current environment's primary relay, injected from
+  /// [EnvironmentConfig.relayUrl]) so subsequent logins on this or any other
   /// client can discover it.
   ///
   /// Guards:
@@ -4071,7 +4081,7 @@ class AuthService implements BackgroundAwareService {
         pubkeyHex,
         EventKind.relayListMetadata,
         <List<String>>[
-          <String>['r', AppConstants.defaultRelayUrl],
+          <String>['r', _primaryRelayUrl],
         ],
         '',
       );
@@ -4105,7 +4115,7 @@ class AuthService implements BackgroundAwareService {
       }
 
       final targetRelays = <String>[
-        AppConstants.defaultRelayUrl,
+        _primaryRelayUrl,
         ...IndexerRelayConfig.defaultIndexers,
       ];
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -17,6 +17,7 @@ import 'package:nostr_key_manager/nostr_key_manager.dart'
         SecureKeyStorage,
         SecureKeyStorageException;
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/models/known_account.dart';
@@ -145,6 +146,12 @@ typedef BootstrapRelayListCallback =
 /// SharedPreferences key prefix for the per-pubkey one-shot flag that records
 /// whether we have already published a bootstrap kind:10002 on this device.
 const _kBootstrapKind10002Prefix = 'bootstrap_kind10002_published_';
+
+/// Upper bound on how long to wait for the signer when producing the
+/// bootstrap kind:10002 event. If the signer does not respond within this
+/// window (hung Keycast RPC, unreachable Amber, etc.) we abandon the publish
+/// and leave the flag unset so the next login retries. See #3174 / #3162.
+const _kBootstrapSignTimeout = Duration(seconds: 10);
 
 /// Main authentication service for the Divine app
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via
@@ -4024,8 +4031,9 @@ class AuthService implements BackgroundAwareService {
   /// `relay.nos.social`). That in turn degrades reachability for every
   /// downstream publish operation (profile save, likes, comments) because
   /// the client can only connect to the fallback relay set. This method
-  /// self-publishes a minimal kind:10002 pointing at `wss://relay.divine.video`
-  /// so subsequent logins on this or any other client can discover it.
+  /// self-publishes a minimal kind:10002 pointing at
+  /// [AppConstants.defaultRelayUrl] so subsequent logins on this or any other
+  /// client can discover it.
   ///
   /// Guards:
   /// - fires at most once per (device, pubkey): tracked via
@@ -4060,12 +4068,29 @@ class AuthService implements BackgroundAwareService {
         pubkeyHex,
         EventKind.relayListMetadata,
         <List<String>>[
-          <String>['r', 'wss://relay.divine.video'],
+          <String>['r', AppConstants.defaultRelayUrl],
         ],
         '',
       );
 
-      final signed = await identity.signEvent(unsigned);
+      // Cap how long we wait for the signer. A hung Keycast RPC would
+      // otherwise block first-login past the existing NIP-65 discovery
+      // timeout. On timeout we leave the flag unset so the next login retries.
+      final Event? signed;
+      try {
+        signed = await identity
+            .signEvent(unsigned)
+            .timeout(_kBootstrapSignTimeout);
+      } on TimeoutException {
+        Log.warning(
+          'Bootstrap kind:10002: signer timed out after '
+          '${_kBootstrapSignTimeout.inSeconds}s — will retry on next login',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        return;
+      }
+
       if (signed == null || signed.sig.isEmpty) {
         Log.warning(
           'Bootstrap kind:10002: signer returned null / unsigned — will retry '
@@ -4077,7 +4102,7 @@ class AuthService implements BackgroundAwareService {
       }
 
       final targetRelays = <String>[
-        'wss://relay.divine.video',
+        AppConstants.defaultRelayUrl,
         ...IndexerRelayConfig.defaultIndexers,
       ];
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -133,6 +133,19 @@ typedef PreFetchFollowingCallback = Future<void> Function(String pubkeyHex);
 /// blocking app startup.
 typedef UserRelaysDiscoveredCallback = void Function(List<String> relayUrls);
 
+/// Callback invoked when AuthService wants to publish a bootstrap kind:10002
+/// relay list on behalf of the user (because indexer discovery returned empty).
+///
+/// The event is already signed. The implementer publishes it through the
+/// active [NostrClient] to [targetRelays] and reports success/failure via the
+/// returned future.
+typedef BootstrapRelayListCallback =
+    Future<bool> Function(Event event, List<String> targetRelays);
+
+/// SharedPreferences key prefix for the per-pubkey one-shot flag that records
+/// whether we have already published a bootstrap kind:10002 on this device.
+const _kBootstrapKind10002Prefix = 'bootstrap_kind10002_published_';
+
 /// Main authentication service for the Divine app
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via
 /// Riverpod
@@ -205,6 +218,12 @@ class AuthService implements BackgroundAwareService {
   /// Callback registered by NostrService to add discovered relays to the client
   /// when discovery completes (avoids race where client is built before discovery).
   UserRelaysDiscoveredCallback? _onUserRelaysDiscovered;
+
+  /// Callback registered by NostrService to publish a bootstrap kind:10002
+  /// event when indexer discovery returns empty for the signed-in user.
+  ///
+  /// See [registerBootstrapRelayListCallback].
+  BootstrapRelayListCallback? _onBootstrapRelayListRequested;
 
   /// The current user's atomic signing identity, or null if not authenticated.
   ///
@@ -650,6 +669,19 @@ class AuthService implements BackgroundAwareService {
     UserRelaysDiscoveredCallback? callback,
   ) {
     _onUserRelaysDiscovered = callback;
+  }
+
+  /// Register a callback to publish a bootstrap kind:10002 on behalf of the
+  /// signed-in user when indexer discovery returns empty. Pass [null] to
+  /// unregister.
+  ///
+  /// AuthService builds + signs the event; the callback owner is expected to
+  /// broadcast it via the current [NostrClient]. See
+  /// [_publishBootstrapRelayList] and #3174.
+  void registerBootstrapRelayListCallback(
+    BootstrapRelayListCallback? callback,
+  ) {
+    _onBootstrapRelayListRequested = callback;
   }
 
   /// Check if user has an existing profile (kind 0)
@@ -2999,6 +3031,7 @@ class AuthService implements BackgroundAwareService {
       // Unregister relay-discovery callback so we don't hold a client
       // reference
       _onUserRelaysDiscovered = null;
+      _onBootstrapRelayListRequested = null;
       _userRelays = [];
 
       // Clean up bunker signer if active
@@ -3966,6 +3999,7 @@ class AuthService implements BackgroundAwareService {
           category: LogCategory.auth,
         );
         _connectToFallbackRelays();
+        await _publishBootstrapRelayList();
       }
     } catch (e) {
       _userRelays = [];
@@ -3977,6 +4011,100 @@ class AuthService implements BackgroundAwareService {
         category: LogCategory.auth,
       );
       _connectToFallbackRelays();
+      await _publishBootstrapRelayList();
+    }
+  }
+
+  /// Publish a bootstrap kind:10002 relay list for the signed-in user when
+  /// indexer discovery returned empty.
+  ///
+  /// Divine/Keycast-provisioned accounts are created without a published
+  /// NIP-65 relay list, which leaves them invisible to the indexers the
+  /// mobile client queries (`purplepag.es`, `user.kindpag.es`,
+  /// `relay.nos.social`). That in turn degrades reachability for every
+  /// downstream publish operation (profile save, likes, comments) because
+  /// the client can only connect to the fallback relay set. This method
+  /// self-publishes a minimal kind:10002 pointing at `wss://relay.divine.video`
+  /// so subsequent logins on this or any other client can discover it.
+  ///
+  /// Guards:
+  /// - fires at most once per (device, pubkey): tracked via
+  ///   [SharedPreferences] flag `bootstrap_kind10002_published_<hexpubkey>`.
+  /// - no-op if no [currentIdentity] (read-only / unauthenticated sessions).
+  /// - no-op if no bootstrap callback has been registered.
+  /// - flag is set ONLY on callback success, so failures (signer unreachable,
+  ///   publish rejected) remain retriable on next login.
+  ///
+  /// The proper server-side fix lives in divinevideo/keycast#94; this is a
+  /// client-side safety net + backfill for pre-existing accounts. See
+  /// divinevideo/divine-mobile#3174.
+  Future<void> _publishBootstrapRelayList() async {
+    final identity = _currentIdentity;
+    if (identity == null) {
+      return;
+    }
+    final callback = _onBootstrapRelayListRequested;
+    if (callback == null) {
+      return;
+    }
+    final pubkeyHex = identity.pubkey;
+    final flagKey = '$_kBootstrapKind10002Prefix$pubkeyHex';
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      if (prefs.getBool(flagKey) ?? false) {
+        return;
+      }
+
+      final unsigned = Event(
+        pubkeyHex,
+        EventKind.relayListMetadata,
+        <List<String>>[
+          <String>['r', 'wss://relay.divine.video'],
+        ],
+        '',
+      );
+
+      final signed = await identity.signEvent(unsigned);
+      if (signed == null || signed.sig.isEmpty) {
+        Log.warning(
+          'Bootstrap kind:10002: signer returned null / unsigned — will retry '
+          'on next login',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        return;
+      }
+
+      final targetRelays = <String>[
+        'wss://relay.divine.video',
+        ...IndexerRelayConfig.defaultIndexers,
+      ];
+
+      final published = await callback(signed, targetRelays);
+      if (!published) {
+        Log.warning(
+          'Bootstrap kind:10002: NostrClient reported no relay accepted the '
+          'event — will retry on next login',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        return;
+      }
+
+      await prefs.setBool(flagKey, true);
+      Log.info(
+        '✅ Published bootstrap kind:10002 for $pubkeyHex to '
+        '${targetRelays.length} relays',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+    } catch (e) {
+      Log.error(
+        'Bootstrap kind:10002 publish failed: $e — will retry on next login',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
     }
   }
 
@@ -4008,6 +4136,15 @@ class AuthService implements BackgroundAwareService {
   @visibleForTesting
   Future<void> debugDiscoverUserRelays(String npub) =>
       _discoverUserRelays(npub);
+
+  /// Test seam that lets unit tests install a [NostrIdentity] without
+  /// going through the full sign-in pipeline. Used by tests that exercise
+  /// code paths (e.g. [_publishBootstrapRelayList]) which depend on
+  /// [currentIdentity] being set.
+  @visibleForTesting
+  void debugSetIdentity(NostrIdentity? identity) {
+    _currentIdentity = identity;
+  }
 
   /// Check if user has an existing profile (kind 0) on indexer relays.
   ///

--- a/mobile/test/services/auth_service_bootstrap_relay_list_test.dart
+++ b/mobile/test/services/auth_service_bootstrap_relay_list_test.dart
@@ -82,10 +82,12 @@ void main() {
       _ControllableRelayDiscoveryService discovery, {
       NostrIdentity? identity,
       _BootstrapCallbackRecorder? recorder,
+      String? primaryRelayUrl,
     }) {
       final authService = AuthService(
         userDataCleanupService: mockCleanupService,
         relayDiscoveryService: discovery,
+        primaryRelayUrl: primaryRelayUrl,
       );
       if (identity != null) {
         authService.debugSetIdentity(identity);
@@ -361,6 +363,51 @@ void main() {
           async.flushMicrotasks();
           expect(flagValue ?? false, isFalse);
         });
+      },
+    );
+
+    test(
+      'uses injected primaryRelayUrl in r tag and target relay list (#3183)',
+      () async {
+        const stagingRelayUrl = 'wss://relay.staging.dvines.org';
+
+        final discovery = _ControllableRelayDiscoveryService(
+          outcome: () => RelayDiscoveryResult.failure('No relay list found'),
+        );
+        final recorder = _BootstrapCallbackRecorder(publishResult: true);
+        final authService = buildAuthService(
+          discovery,
+          identity: buildIdentity(),
+          recorder: recorder,
+          primaryRelayUrl: stagingRelayUrl,
+        );
+
+        await authService.debugDiscoverUserRelays(testNpub);
+
+        expect(recorder.invocations, hasLength(1));
+        final invocation = recorder.invocations.single;
+
+        // Event r tag points at the injected (non-prod) relay.
+        expect(
+          invocation.event.tags,
+          equals([
+            ['r', stagingRelayUrl],
+          ]),
+        );
+        // Target-relay list leads with the injected relay, not the prod
+        // default — prevents non-prod builds from advertising prod relay to
+        // public indexers. See #3183.
+        expect(
+          invocation.targetRelays,
+          equals([
+            stagingRelayUrl,
+            ...IndexerRelayConfig.defaultIndexers,
+          ]),
+        );
+        expect(
+          invocation.targetRelays,
+          isNot(contains(AppConstants.defaultRelayUrl)),
+        );
       },
     );
   });

--- a/mobile/test/services/auth_service_bootstrap_relay_list_test.dart
+++ b/mobile/test/services/auth_service_bootstrap_relay_list_test.dart
@@ -133,7 +133,9 @@ void main() {
           recorder: recorder,
         );
 
+        final beforeCall = DateTime.now().millisecondsSinceEpoch ~/ 1000;
         await authService.debugDiscoverUserRelays(testNpub);
+        final afterCall = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
         expect(recorder.invocations, hasLength(1));
         final invocation = recorder.invocations.single;
@@ -148,6 +150,10 @@ void main() {
           ]),
         );
         expect(invocation.event.sig, isNotEmpty);
+        // NIP-65 consumers replace strictly by created_at, so a stale or
+        // zero timestamp would let a later real publish be silently ignored.
+        expect(invocation.event.createdAt, greaterThanOrEqualTo(beforeCall));
+        expect(invocation.event.createdAt, lessThanOrEqualTo(afterCall));
 
         // Target relays include Divine relay + the three indexers.
         expect(
@@ -356,12 +362,12 @@ void main() {
           // Signer timed out → callback never invoked → flag not set.
           expect(recorder.invocations, isEmpty);
 
-          bool? flagValue;
+          late bool flagValue;
           SharedPreferences.getInstance().then((prefs) {
-            flagValue = prefs.getBool(flagKey);
+            flagValue = prefs.getBool(flagKey) ?? false;
           });
           async.flushMicrotasks();
-          expect(flagValue ?? false, isFalse);
+          expect(flagValue, isFalse);
         });
       },
     );

--- a/mobile/test/services/auth_service_bootstrap_relay_list_test.dart
+++ b/mobile/test/services/auth_service_bootstrap_relay_list_test.dart
@@ -2,9 +2,13 @@
 // ABOUTME: relay list when indexer discovery returns empty, so
 // ABOUTME: Keycast-provisioned accounts become discoverable. #3174 / keycast#94.
 
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/nostr_identity.dart';
 import 'package:openvine/services/relay_discovery_service.dart';
@@ -138,7 +142,7 @@ void main() {
         expect(
           invocation.event.tags,
           equals([
-            ['r', 'wss://relay.divine.video'],
+            ['r', AppConstants.defaultRelayUrl],
           ]),
         );
         expect(invocation.event.sig, isNotEmpty);
@@ -147,7 +151,7 @@ void main() {
         expect(
           invocation.targetRelays,
           equals([
-            'wss://relay.divine.video',
+            AppConstants.defaultRelayUrl,
             ...IndexerRelayConfig.defaultIndexers,
           ]),
         );
@@ -320,5 +324,44 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
       expect(prefs.getBool(flagKey) ?? false, isFalse);
     });
+
+    test(
+      'flag is NOT set when signer hangs past timeout (retriable next login)',
+      () {
+        // Simulate a hung Keycast/Amber signer that never completes.
+        when(() => mockSigner.signEvent(any())).thenAnswer(
+          (_) => Completer<Event?>().future,
+        );
+
+        fakeAsync((async) {
+          final discovery = _ControllableRelayDiscoveryService(
+            outcome: () => RelayDiscoveryResult.failure('No relay list found'),
+          );
+          final recorder = _BootstrapCallbackRecorder(publishResult: true);
+          final authService = buildAuthService(
+            discovery,
+            identity: buildIdentity(),
+            recorder: recorder,
+          );
+
+          // Launch the operation (signer hangs forever).
+          authService.debugDiscoverUserRelays(testNpub);
+
+          // Drive past the 10s bootstrap sign timeout.
+          async.elapse(const Duration(seconds: 15));
+          async.flushMicrotasks();
+
+          // Signer timed out → callback never invoked → flag not set.
+          expect(recorder.invocations, isEmpty);
+
+          bool? flagValue;
+          SharedPreferences.getInstance().then((prefs) {
+            flagValue = prefs.getBool(flagKey);
+          });
+          async.flushMicrotasks();
+          expect(flagValue ?? false, isFalse);
+        });
+      },
+    );
   });
 }

--- a/mobile/test/services/auth_service_bootstrap_relay_list_test.dart
+++ b/mobile/test/services/auth_service_bootstrap_relay_list_test.dart
@@ -1,0 +1,324 @@
+// ABOUTME: Tests that AuthService self-publishes a bootstrap kind:10002
+// ABOUTME: relay list when indexer discovery returns empty, so
+// ABOUTME: Keycast-provisioned accounts become discoverable. #3174 / keycast#94.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/nostr_identity.dart';
+import 'package:openvine/services/relay_discovery_service.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../test_setup.dart';
+
+class _MockUserDataCleanupService extends Mock
+    implements UserDataCleanupService {}
+
+class _MockNostrSigner extends Mock implements NostrSigner {}
+
+/// Test double for [RelayDiscoveryService] that lets each test control the
+/// discovery outcome without hitting real WebSockets.
+class _ControllableRelayDiscoveryService extends RelayDiscoveryService {
+  _ControllableRelayDiscoveryService({required this.outcome})
+    : super(indexerRelays: const ['wss://test.invalid']);
+
+  final RelayDiscoveryResult Function() outcome;
+
+  @override
+  Future<RelayDiscoveryResult> discoverRelays(String npub) async {
+    return outcome();
+  }
+}
+
+/// Records every bootstrap callback invocation so tests can assert on
+/// payload, targets, and invocation count.
+class _BootstrapCallbackRecorder {
+  _BootstrapCallbackRecorder({required this.publishResult});
+
+  final bool publishResult;
+  final List<_BootstrapInvocation> invocations = [];
+
+  Future<bool> call(Event event, List<String> targetRelays) async {
+    invocations.add(
+      _BootstrapInvocation(event: event, targetRelays: targetRelays),
+    );
+    return publishResult;
+  }
+}
+
+class _BootstrapInvocation {
+  _BootstrapInvocation({required this.event, required this.targetRelays});
+
+  final Event event;
+  final List<String> targetRelays;
+}
+
+void main() {
+  setupTestEnvironment();
+
+  const testNpub =
+      'npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsutm2dy';
+  const testPubkeyHex =
+      '0000000000000000000000000000000000000000000000000000000000000001';
+  const flagKey =
+      'bootstrap_kind10002_published_'
+      '0000000000000000000000000000000000000000000000000000000000000001';
+
+  setUpAll(() {
+    registerFallbackValue(Event(testPubkeyHex, 0, const [], ''));
+  });
+
+  group('AuthService bootstrap kind:10002 (#3174)', () {
+    late _MockUserDataCleanupService mockCleanupService;
+    late _MockNostrSigner mockSigner;
+
+    AuthService buildAuthService(
+      _ControllableRelayDiscoveryService discovery, {
+      NostrIdentity? identity,
+      _BootstrapCallbackRecorder? recorder,
+    }) {
+      final authService = AuthService(
+        userDataCleanupService: mockCleanupService,
+        relayDiscoveryService: discovery,
+      );
+      if (identity != null) {
+        authService.debugSetIdentity(identity);
+      }
+      if (recorder != null) {
+        authService.registerBootstrapRelayListCallback(recorder.call);
+      }
+      return authService;
+    }
+
+    KeycastNostrIdentity buildIdentity() {
+      // KeycastNostrIdentity is a concrete subtype of the sealed
+      // NostrIdentity class, so tests can construct one directly while
+      // controlling signing behavior via the mock rpcSigner.
+      return KeycastNostrIdentity(
+        pubkey: testPubkeyHex,
+        rpcSigner: mockSigner,
+      );
+    }
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      mockCleanupService = _MockUserDataCleanupService();
+      mockSigner = _MockNostrSigner();
+      // Default: signer succeeds by attaching a non-empty signature.
+      when(() => mockSigner.signEvent(any())).thenAnswer((invocation) async {
+        final event = invocation.positionalArguments[0] as Event;
+        event.sig = 'a' * 128;
+        return event;
+      });
+    });
+
+    test(
+      'publishes bootstrap kind:10002 when discovery returns empty',
+      () async {
+        final discovery = _ControllableRelayDiscoveryService(
+          outcome: () => RelayDiscoveryResult.failure('No relay list found'),
+        );
+        final recorder = _BootstrapCallbackRecorder(publishResult: true);
+        final authService = buildAuthService(
+          discovery,
+          identity: buildIdentity(),
+          recorder: recorder,
+        );
+
+        await authService.debugDiscoverUserRelays(testNpub);
+
+        expect(recorder.invocations, hasLength(1));
+        final invocation = recorder.invocations.single;
+
+        // Event payload is a valid NIP-65 kind:10002 pointing at Divine relay.
+        expect(invocation.event.kind, equals(EventKind.relayListMetadata));
+        expect(invocation.event.pubkey, equals(testPubkeyHex));
+        expect(
+          invocation.event.tags,
+          equals([
+            ['r', 'wss://relay.divine.video'],
+          ]),
+        );
+        expect(invocation.event.sig, isNotEmpty);
+
+        // Target relays include Divine relay + the three indexers.
+        expect(
+          invocation.targetRelays,
+          equals([
+            'wss://relay.divine.video',
+            ...IndexerRelayConfig.defaultIndexers,
+          ]),
+        );
+
+        // Flag is set so subsequent logins skip the bootstrap.
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getBool(flagKey), isTrue);
+      },
+    );
+
+    test(
+      'also publishes when discovery throws (catch branch)',
+      () async {
+        final discovery = _ControllableRelayDiscoveryService(
+          outcome: () => throw Exception('connection refused'),
+        );
+        final recorder = _BootstrapCallbackRecorder(publishResult: true);
+        final authService = buildAuthService(
+          discovery,
+          identity: buildIdentity(),
+          recorder: recorder,
+        );
+
+        await authService.debugDiscoverUserRelays(testNpub);
+
+        expect(recorder.invocations, hasLength(1));
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getBool(flagKey), isTrue);
+      },
+    );
+
+    test(
+      "does NOT publish when discovery returns the user's real relay list",
+      () async {
+        final discovery = _ControllableRelayDiscoveryService(
+          outcome: () => RelayDiscoveryResult.success(
+            [const DiscoveredRelay(url: 'wss://relay.example.com')],
+            'wss://test-indexer',
+          ),
+        );
+        final recorder = _BootstrapCallbackRecorder(publishResult: true);
+        final authService = buildAuthService(
+          discovery,
+          identity: buildIdentity(),
+          recorder: recorder,
+        );
+
+        await authService.debugDiscoverUserRelays(testNpub);
+
+        expect(recorder.invocations, isEmpty);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getBool(flagKey) ?? false, isFalse);
+      },
+    );
+
+    test('does NOT publish twice when flag is already set', () async {
+      SharedPreferences.setMockInitialValues({flagKey: true});
+
+      final discovery = _ControllableRelayDiscoveryService(
+        outcome: () => RelayDiscoveryResult.failure('No relay list found'),
+      );
+      final recorder = _BootstrapCallbackRecorder(publishResult: true);
+      final authService = buildAuthService(
+        discovery,
+        identity: buildIdentity(),
+        recorder: recorder,
+      );
+
+      await authService.debugDiscoverUserRelays(testNpub);
+
+      expect(recorder.invocations, isEmpty);
+    });
+
+    test('does NOT publish when no identity is set', () async {
+      final discovery = _ControllableRelayDiscoveryService(
+        outcome: () => RelayDiscoveryResult.failure('No relay list found'),
+      );
+      final recorder = _BootstrapCallbackRecorder(publishResult: true);
+      // No identity passed — simulates unauthenticated / read-only session.
+      final authService = buildAuthService(discovery, recorder: recorder);
+
+      await authService.debugDiscoverUserRelays(testNpub);
+
+      expect(recorder.invocations, isEmpty);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool(flagKey) ?? false, isFalse);
+    });
+
+    test('does NOT publish when no callback is registered', () async {
+      final discovery = _ControllableRelayDiscoveryService(
+        outcome: () => RelayDiscoveryResult.failure('No relay list found'),
+      );
+      // No recorder passed — simulates window where AuthService runs
+      // discovery before NostrService registers the callback.
+      final authService = buildAuthService(
+        discovery,
+        identity: buildIdentity(),
+      );
+
+      await authService.debugDiscoverUserRelays(testNpub);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool(flagKey) ?? false, isFalse);
+    });
+
+    test(
+      'flag is NOT set when signer returns null (retriable next login)',
+      () async {
+        when(() => mockSigner.signEvent(any())).thenAnswer((_) async => null);
+
+        final discovery = _ControllableRelayDiscoveryService(
+          outcome: () => RelayDiscoveryResult.failure('No relay list found'),
+        );
+        final recorder = _BootstrapCallbackRecorder(publishResult: true);
+        final authService = buildAuthService(
+          discovery,
+          identity: buildIdentity(),
+          recorder: recorder,
+        );
+
+        await authService.debugDiscoverUserRelays(testNpub);
+
+        // Signer failed → callback never invoked → flag not set.
+        expect(recorder.invocations, isEmpty);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getBool(flagKey) ?? false, isFalse);
+      },
+    );
+
+    test(
+      'flag is NOT set when callback reports publish failure',
+      () async {
+        final discovery = _ControllableRelayDiscoveryService(
+          outcome: () => RelayDiscoveryResult.failure('No relay list found'),
+        );
+        final recorder = _BootstrapCallbackRecorder(publishResult: false);
+        final authService = buildAuthService(
+          discovery,
+          identity: buildIdentity(),
+          recorder: recorder,
+        );
+
+        await authService.debugDiscoverUserRelays(testNpub);
+
+        // Callback was invoked (we tried), but publish returned false so
+        // the flag stays unset and the next login will retry.
+        expect(recorder.invocations, hasLength(1));
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getBool(flagKey) ?? false, isFalse);
+      },
+    );
+
+    test('flag is NOT set when callback throws', () async {
+      final discovery = _ControllableRelayDiscoveryService(
+        outcome: () => RelayDiscoveryResult.failure('No relay list found'),
+      );
+      Future<bool> throwingCallback(Event _, List<String> _) async =>
+          throw Exception('publish broke');
+
+      final authService = AuthService(
+        userDataCleanupService: mockCleanupService,
+        relayDiscoveryService: discovery,
+      );
+      authService.debugSetIdentity(buildIdentity());
+      authService.registerBootstrapRelayListCallback(throwingCallback);
+
+      // Should not throw — AuthService swallows the exception.
+      await authService.debugDiscoverUserRelays(testNpub);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool(flagKey) ?? false, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- When indexer NIP-65 discovery returns empty for the signed-in user, `AuthService` now self-publishes a minimal kind:10002 pointing at the current environment's primary relay and broadcasts it to the three indexer relays the client queries.
- Guarded by a one-shot SharedPreferences flag per `(device, pubkey)`; no-op when no identity / callback / successful publish, so failures remain retriable on next login.
- Wired into the existing `nostr_client_provider` plumbing at both client-creation sites (initial build + account switch) with matching teardown.
- **Env-aware relay URL** (#3183, folded in): the bootstrap event's `r` tag and its target-relay list are both sourced from `authEnv.relayUrl` via a new optional `primaryRelayUrl` ctor param on `AuthService`. Non-prod builds (staging, POC, test, local) no longer advertise the production relay to public indexers. Default preserves back-compat for callers that don't inject a URL.

## Why
Divine/Keycast-provisioned accounts never publish a kind:10002 list, which is the upstream contributor behind #3152, #3161, #3162 (see investigation in issue thread). The proper fix lives server-side in [keycast#94](https://github.com/divinevideo/keycast/issues/94) — publish kind:10002 at provisioning. This PR is the complementary client-side safety net that also backfills accounts provisioned before that ships.

## Test plan
- [x] `flutter test test/services/auth_service_bootstrap_relay_list_test.dart` — 10 tests (9 original + 1 new for #3183) cover empty/throw/success paths, flag, identity, callback, signer-null, publish-false, callback-throws, signer-timeout, and env-URL injection
- [x] `flutter test test/services/` — 1773 tests pass, 0 regressions
- [x] `flutter test test/providers/` — 481 tests pass, 0 regressions
- [x] `flutter analyze lib test` — clean
- [x] `dart format --set-exit-if-changed` — clean
- [x] Pre-commit hook passed
- [x] Assertion tightening (`75b6f955e`): happy-path test now bounds `event.createdAt` against a capture window (guards against replaceable-event supersession by a stale/zero timestamp); signer-timeout test uses `late bool` + non-nullable `expect` so a future regression to async `SharedPreferences.getInstance` fails loudly instead of silently passing on an uninitialized variable.

## Risk
- **Publishing on behalf of the user when a real list exists on a non-queried indexer**: discovery's empty-result gate + replaceable-event semantics bound the blast radius to one kind:10002 per device; a later real edit from another client overwrites.
- **First-login startup latency**: bootstrap is awaited inside `_discoverUserRelays`; one extra broadcast RTT on first login for affected accounts. Trivial next to existing NIP-65 discovery timeout.

## Out of scope
- Touching the actual save/publish path
- Changing the current fallback relay set (#2931 / PR #2955)
- Fixing the Keycast-signer reachability issue observed in #3162 (separate)
- Full outbox routing (#2513)

## Follow-ups — merge order
Three PRs together address the review thread. They must land in this order:

1. **This PR (#3175)** — ships first. Adds the bootstrap publish + the in-PR assertion tightenings (commit `75b6f955e`).
2. **#3181** — narrow `RelayDiscoveryService` to distinguish empty-list from transport/parse failure, and drop the bootstrap publish from `_discoverUserRelays`' outer `catch`. Must land **after** #3175 merges because it inverts the `'also publishes when discovery throws (catch branch)'` test that ships with #3175 (a thrown discovery becomes a transport error → no publish). Stacking on `main`, not on this branch.
3. **#3182** — pure refactor: extract the two structurally identical bootstrap callback closures in `nostr_client_provider.dart` into a single `_bootstrapCallbackFor(NostrClient)` helper. Behavior-preserving; can land in either order relative to #3181 after #3175 merges, but keep as a separate PR for revertability.

Closes #3174
Closes #3183
Refs #3152, #3161, #3162, [keycast#94](https://github.com/divinevideo/keycast/issues/94)
