### PR TITLE
fix(feed): populate collaboratorPubkeys from Funnelcake REST payload

### DIFF
--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -41,6 +41,7 @@ class VideoStats {
     this.textTrackRef,
     this.textTrackContent,
     this.categories = const [],
+    this.collaboratorPubkeys = const [],
     List<String> moderationLabels = const [],
     @Deprecated('Use moderationLabels') List<String>? contentLabels,
   }) : moderationLabels = contentLabels ?? moderationLabels;
@@ -179,6 +180,7 @@ class VideoStats {
     int? publishedAt;
     final rawTags = <String, String>{};
     final contentWarningLabels = <String>[];
+    final collaboratorPubkeys = <String>[];
 
     if (eventData['tags'] is List) {
       final tags = eventData['tags'] as List<dynamic>;
@@ -229,6 +231,13 @@ class VideoStats {
               tagValue.isNotEmpty &&
               !contentWarningLabels.contains(tagValue)) {
             contentWarningLabels.add(tagValue);
+          }
+          if (tagName == 'p' && tagValue.isNotEmpty) {
+            final normalized = tagValue.toLowerCase();
+            if (normalized != pubkey &&
+                !collaboratorPubkeys.contains(normalized)) {
+              collaboratorPubkeys.add(normalized);
+            }
           }
         }
       }
@@ -331,6 +340,7 @@ class VideoStats {
       rawTags: rawTags,
       categories: categories,
       contentWarningLabels: contentWarningLabels,
+      collaboratorPubkeys: collaboratorPubkeys,
       textTrackRef: textTrackRef,
       textTrackContent: textTrackContent,
       moderationLabels: moderationLabels,
@@ -418,6 +428,11 @@ class VideoStats {
   /// Author-applied content warning labels parsed from NIP-32/NIP-36 tags.
   final List<String> contentWarningLabels;
 
+  /// Pubkeys of NIP-71 collaborators (`p` tags whose value differs from the
+  /// event author). Empty when the event has no collaborators or when the
+  /// REST payload did not include tag data.
+  final List<String> collaboratorPubkeys;
+
   /// Addressable coordinates for subtitle event (from `text-track` tag or
   /// API `text_track_ref` field).
   final String? textTrackRef;
@@ -477,6 +492,7 @@ class VideoStats {
       textTrackContent: textTrackContent,
       categories: categories,
       contentWarningLabels: contentWarningLabels,
+      collaboratorPubkeys: collaboratorPubkeys,
       moderationLabels: moderationLabels,
       rawTags: {
         ...rawTags,

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -910,6 +910,142 @@ void main() {
       });
     });
 
+    group('collaboratorPubkeys (p tag extraction)', () {
+      const authorPubkey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      const collaborator1 =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      const collaborator2 =
+          'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+      Map<String, dynamic> buildJson(List<List<String>> tags) => {
+        'id': 'video-id',
+        'pubkey': authorPubkey,
+        'created_at': 1700000000,
+        'kind': 34236,
+        'video_url': 'https://example.com/video.mp4',
+        'tags': tags,
+        'reactions': 0,
+        'comments': 0,
+        'reposts': 0,
+        'engagement_score': 0,
+      };
+
+      test('extracts p-tag pubkeys from flat JSON', () {
+        final stats = VideoStats.fromJson(
+          buildJson([
+            ['p', collaborator1],
+            ['p', collaborator2],
+          ]),
+        );
+
+        expect(
+          stats.collaboratorPubkeys,
+          equals([collaborator1, collaborator2]),
+        );
+      });
+
+      test('extracts p-tag pubkeys from nested event payload', () {
+        final stats = VideoStats.fromJson(const {
+          'event': {
+            'id': 'video-id',
+            'pubkey': authorPubkey,
+            'created_at': 1700000000,
+            'kind': 34236,
+            'tags': [
+              ['d', 'video-1'],
+              ['url', 'https://example.com/video.mp4'],
+              ['p', collaborator1],
+            ],
+          },
+          'stats': {
+            'reactions': 0,
+            'comments': 0,
+            'reposts': 0,
+            'engagement_score': 0,
+          },
+        });
+
+        expect(stats.collaboratorPubkeys, equals([collaborator1]));
+      });
+
+      test('excludes the event author pubkey', () {
+        final stats = VideoStats.fromJson(
+          buildJson([
+            ['p', authorPubkey],
+            ['p', collaborator1],
+          ]),
+        );
+
+        expect(stats.collaboratorPubkeys, equals([collaborator1]));
+      });
+
+      test('deduplicates repeated p tags', () {
+        final stats = VideoStats.fromJson(
+          buildJson([
+            ['p', collaborator1],
+            ['p', collaborator1],
+            ['p', collaborator2],
+          ]),
+        );
+
+        expect(
+          stats.collaboratorPubkeys,
+          equals([collaborator1, collaborator2]),
+        );
+      });
+
+      test('lowercases uppercase p-tag values and compares against author', () {
+        final stats = VideoStats.fromJson(
+          buildJson([
+            ['p', collaborator1.toUpperCase()],
+            ['p', authorPubkey.toUpperCase()],
+          ]),
+        );
+
+        expect(stats.collaboratorPubkeys, equals([collaborator1]));
+      });
+
+      test('ignores empty p tags', () {
+        final stats = VideoStats.fromJson(
+          buildJson([
+            ['p', ''],
+            ['p', collaborator1],
+          ]),
+        );
+
+        expect(stats.collaboratorPubkeys, equals([collaborator1]));
+      });
+
+      test('returns empty list when no p tags present', () {
+        final stats = VideoStats.fromJson(
+          buildJson([
+            ['d', 'video-1'],
+            ['url', 'https://example.com/video.mp4'],
+          ]),
+        );
+
+        expect(stats.collaboratorPubkeys, isEmpty);
+      });
+
+      test('forwards collaboratorPubkeys through toVideoEvent', () {
+        final stats = VideoStats.fromJson(
+          buildJson([
+            ['p', collaborator1],
+            ['p', collaborator2],
+          ]),
+        );
+
+        final event = stats.toVideoEvent();
+
+        expect(
+          event.collaboratorPubkeys,
+          equals([collaborator1, collaborator2]),
+        );
+        expect(event.hasCollaborators, isTrue);
+      });
+    });
+
     group('toVideoEvent', () {
       test('converts to VideoEvent with all fields', () {
         final stats = VideoStats(

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -4139,6 +4139,46 @@ void main() {
           verifyNever(() => mockNostrClient.queryEvents(any()));
         });
 
+        test(
+          'preserves collaboratorPubkeys from Funnelcake REST response',
+          () async {
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getCollabVideos(
+                pubkey: any(named: 'pubkey'),
+                limit: any(named: 'limit'),
+                before: any(named: 'before'),
+              ),
+            ).thenAnswer(
+              (_) async => [
+                _createVideoStats(
+                  id: 'collab-event-1',
+                  pubkey: 'author-pubkey',
+                  dTag: 'dtag-1',
+                  videoUrl: 'https://example.com/collab.mp4',
+                  collaboratorPubkeys: const ['collab-pubkey'],
+                ),
+              ],
+            );
+
+            final repositoryWithApi = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repositoryWithApi.getCollabVideos(
+              taggedPubkey: 'collab-pubkey',
+            );
+
+            expect(result, hasLength(1));
+            expect(
+              result.first.collaboratorPubkeys,
+              equals(['collab-pubkey']),
+            );
+            expect(result.first.hasCollaborators, isTrue);
+          },
+        );
+
         test('passes parameters to Funnelcake API', () async {
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
           when(
@@ -6330,6 +6370,7 @@ VideoStats _createVideoStats({
   String thumbnail = 'https://example.com/thumb.jpg',
   int? loops,
   List<String> moderationLabels = const [],
+  List<String> collaboratorPubkeys = const [],
 }) {
   return VideoStats(
     id: id,
@@ -6346,6 +6387,7 @@ VideoStats _createVideoStats({
     engagementScore: 0,
     loops: loops,
     moderationLabels: moderationLabels,
+    collaboratorPubkeys: collaboratorPubkeys,
   );
 }
 


### PR DESCRIPTION
## Description

The profile **Collabs** tab was permanently empty even for users who had been tagged on collaboration videos. Root cause is in the Funnelcake REST transform, not in publishing or indexing.

`VideoStats.fromJson` iterates `eventData['tags']` but never extracts NIP-71 `p` tags, and `VideoStats.toVideoEvent()` does not forward `collaboratorPubkeys` — so every `VideoEvent` produced from the Funnelcake REST path has `collaboratorPubkeys == const []`. `ProfileCollabVideosBloc._isCollabVideo` then filters every result out (`video.collaboratorPubkeys.contains(targetPubkey)` is always false). Funnelcake is the primary path at `mobile/packages/videos_repository/lib/src/videos_repository.dart:1168-1178`, so the relay fallback almost never runs and the tab stays empty.

Blast radius is wider than the Collabs tab — `CollaboratorAvatarRow` (`mobile/lib/widgets/video_feed_item/collaborator_avatar_row.dart:34`) reads `video.hasCollaborators` and hides itself for every Funnelcake-sourced video in the main feed and on the expanded metadata sheet.

### Fix
- Extract `p` tags in `VideoStats.fromJson` during the existing tag-iteration loop: lowercase, skip the event author, dedupe — mirroring the relay path at `VideoEvent.fromNostrEvent:438-444`.
- Add `collaboratorPubkeys` as a field on `VideoStats` and forward it through `toVideoEvent()`.

**Related Issue:** Closes #2193

## Type of Change
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Reproducing the bug (before this PR)

1. User A posts a Kind 34236 video and tags User B as a collaborator (e.g. via the metadata collaborator chips).
2. Open User B's profile → **Collabs** tab.
3. The tab calls `VideosRepository.getCollabVideos(taggedPubkey: B)`, which hits Funnelcake `GET /api/users/{B}/collabs` (endpoint returns the video in production).
4. `VideoStats.fromJson` parses tags but drops `p` entries; `toVideoEvent()` omits `collaboratorPubkeys`.
5. `ProfileCollabVideosBloc._isCollabVideo` returns `false` for every result and the tab renders the empty state.

**Expected:** video list shows posts where User B was tagged as a collaborator.
**Actual (main):** "no collabs yet" empty state on every profile.

## Verifying the fix

### Automated
- `mobile/packages/models/test/src/video_stats_test.dart` — 8 new cases covering flat/nested JSON, author exclusion, dedup, case normalization, empty/missing `p`, and the `toVideoEvent` roundtrip.
- `mobile/packages/videos_repository/test/src/videos_repository_test.dart` — new `preserves collaboratorPubkeys from Funnelcake REST response` case proves the field survives `_transformVideoStats`.

Runs:
- `cd mobile/packages/models && flutter test` — 495 pass
- `cd mobile/packages/videos_repository && flutter test` — 223 pass (11 in `getCollabVideos`)
- `cd mobile/packages/funnelcake_api_client && flutter test` — 269 pass
- `cd mobile && flutter test test/blocs/profile_collab_videos` — 18 pass
- `cd mobile && flutter analyze lib test packages/models packages/videos_repository packages/funnelcake_api_client` — clean

### Manual
1. Run the app against production (`environmentConfig.apiBaseUrl = https://api.divine.video`).
2. Navigate to a profile known to have collaborator videos (e.g. the reporter's account from #2193).
3. Open the Collabs tab — expect posts to appear.
4. Scroll the home feed — expect `CollaboratorAvatarRow` to render on videos with collaborators.

## Test plan
- [ ] `flutter test` passes for `mobile/packages/models`, `mobile/packages/videos_repository`, `mobile/packages/funnelcake_api_client`
- [ ] `flutter test test/blocs/profile_collab_videos` passes in `mobile/`
- [ ] `flutter analyze` clean on touched packages and `mobile/lib`, `mobile/test`
- [ ] Manual verification on a profile with collaborator videos: Collabs tab populates
- [ ] Manual verification: collaborator avatar row renders on Funnelcake-sourced feed items

## Notes for reviewers
- The client-side filter in `ProfileCollabVideosBloc._isCollabVideo` is intentionally left in place — it still guards the relay-fallback path and is a cheap safety net in case `/api/users/{pubkey}/collabs` ever returns a video where the target pubkey appears in a non-`p` role.
- Follow-up worth opening: audit remaining NIP-71 field parity between `VideoEvent.fromNostrEvent` and `VideoStats.toVideoEvent()` (e.g. `inspiredByVideo`, `audioEventId`) since the same class of gap likely affects other attribution fields.