### PR TITLE
feat(account-deletion): reliable NIP-62 + parallel kind-5 batch

### DIFF
--- a/mobile/lib/services/account_deletion_service.dart
+++ b/mobile/lib/services/account_deletion_service.dart
@@ -1,41 +1,180 @@
 // ABOUTME: Account deletion service implementing NIP-62 Request to Vanish
-// ABOUTME: Handles network-wide account deletion by publishing kind 5 events for all user content
-// ABOUTME: then publishing kind 62 event to all relays
+// ABOUTME: NIP-62 publish is bounded-retry (5 attempts). Kind-5 batch runs in
+// ABOUTME: parallel with a concurrency cap and per-event outcome tracking.
 
+import 'dart:async';
+
+import 'package:meta/meta.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-/// Result of account deletion operation
+/// Maximum concurrent kind-5 deletion publishes. Conservative to avoid
+/// triggering relay rate limits during burst deletion of thousands of events.
+const int kAccountDeletionBatchConcurrency = 4;
+
+/// Retry policy for NIP-62 account-deletion events. Higher than the default
+/// (3 attempts) because a missing NIP-62 event means downstream indexers
+/// keep surfacing the account even after the user requested deletion.
+const RetryPolicy kNip62RetryPolicy = RetryPolicy(
+  maxAttempts: 5,
+  timeoutPerAttempt: Duration(seconds: 20),
+);
+
+/// Pre-publish failure classification for account deletion.
+enum AccountDeletionFailureKind {
+  /// Caller was not authenticated / had no pubkey.
+  notAuthenticated,
+
+  /// Signing the NIP-62 event failed.
+  couldNotSign,
+
+  /// NIP-62 event was published but every relay rejected or timed out.
+  /// Consult [DeleteAccountResult.nip62Outcome] / [nip62Feedback] for the
+  /// relay-level details.
+  nip62Failed,
+
+  /// Unexpected error (outer catch).
+  unknown,
+}
+
+/// Per-event outcome for a kind-5 batch deletion.
+///
+/// One [BatchDeletionResult] is produced per [AccountDeletionService.deleteAccount]
+/// call when the NIP-62 event landed and the batch ran.
+@immutable
+class BatchDeletionResult {
+  const BatchDeletionResult({
+    required this.succeededEventIds,
+    required this.failedEventIds,
+    required this.feedbacks,
+  });
+
+  /// Event IDs for which at least one relay accepted the kind-5 deletion.
+  final Set<String> succeededEventIds;
+
+  /// Event IDs whose deletion publish failed across every targeted relay.
+  final Set<String> failedEventIds;
+
+  /// Per-event user-facing feedback, keyed by the original event id. Both
+  /// succeeded and failed event ids are present; UI filters on
+  /// [PublishUserFeedback.retryable] when offering a retry affordance.
+  final Map<String, PublishUserFeedback> feedbacks;
+
+  int get total => succeededEventIds.length + failedEventIds.length;
+
+  bool get allSucceeded =>
+      failedEventIds.isEmpty && succeededEventIds.isNotEmpty;
+
+  bool get allFailed => succeededEventIds.isEmpty && failedEventIds.isNotEmpty;
+}
+
+/// Cooperative cancellation token for an in-flight account deletion.
+///
+/// In-flight publishes finish naturally; newly-queued publishes are skipped
+/// once [cancel] is called. The token cannot be reused after cancellation.
+class AccountDeletionCancellationToken {
+  bool _cancelled = false;
+
+  bool get isCancelled => _cancelled;
+
+  void cancel() {
+    _cancelled = true;
+  }
+}
+
+/// Result of an account deletion operation.
+///
+/// [success] is true iff the NIP-62 event landed on at least one relay. The
+/// kind-5 batch is allowed to partially fail — those failures are reported
+/// via [batch.failedEventIds] and the user can retry the subset without
+/// re-signing NIP-62.
+@immutable
 class DeleteAccountResult {
   const DeleteAccountResult({
     required this.success,
     this.error,
     this.deleteEventId,
-    this.deletedEventsCount = 0,
+    this.failureKind,
+    this.nip62Outcome,
+    this.nip62Feedback,
+    this.batch,
+    this.fetchedEvents = const <Event>[],
   });
 
   final bool success;
   final String? error;
-  final String? deleteEventId;
-  final int deletedEventsCount;
 
-  static DeleteAccountResult createSuccess(
-    String deleteEventId, {
-    int deletedEventsCount = 0,
+  /// NIP-62 event ID when publish landed on at least one relay.
+  final String? deleteEventId;
+
+  /// Classification of the pre-publish / NIP-62 failure. `null` when the
+  /// flow succeeded.
+  final AccountDeletionFailureKind? failureKind;
+
+  /// Per-relay outcome for the NIP-62 publish. `null` when the failure
+  /// occurred before the publish attempt (e.g. not authenticated).
+  final PublishOutcome? nip62Outcome;
+
+  /// User-facing feedback for the NIP-62 publish. `null` when
+  /// [nip62Outcome] is null.
+  final PublishUserFeedback? nip62Feedback;
+
+  /// Result of the kind-5 batch. `null` when the batch was not run (NIP-62
+  /// failed, user had no events, or flow aborted before batch started).
+  final BatchDeletionResult? batch;
+
+  /// Original user events fetched from relays, retained so Retry-failed can
+  /// re-publish kind-5 deletions for the [BatchDeletionResult.failedEventIds]
+  /// subset without re-fetching.
+  final List<Event> fetchedEvents;
+
+  /// Number of user events for which deletion was successfully published.
+  /// Zero when the batch did not run.
+  int get deletedEventsCount => batch?.succeededEventIds.length ?? 0;
+
+  static DeleteAccountResult nip62Success({
+    required String deleteEventId,
+    required PublishOutcome outcome,
+    required PublishUserFeedback feedback,
+    BatchDeletionResult? batch,
+    List<Event> fetchedEvents = const <Event>[],
   }) => DeleteAccountResult(
     success: true,
     deleteEventId: deleteEventId,
-    deletedEventsCount: deletedEventsCount,
+    nip62Outcome: outcome,
+    nip62Feedback: feedback,
+    batch: batch,
+    fetchedEvents: fetchedEvents,
   );
 
-  static DeleteAccountResult failure(String error) =>
-      DeleteAccountResult(success: false, error: error);
+  static DeleteAccountResult failure({
+    required String error,
+    required AccountDeletionFailureKind failureKind,
+    PublishOutcome? nip62Outcome,
+    PublishUserFeedback? nip62Feedback,
+  }) => DeleteAccountResult(
+    success: false,
+    error: error,
+    failureKind: failureKind,
+    nip62Outcome: nip62Outcome,
+    nip62Feedback: nip62Feedback,
+  );
 }
 
-/// Service for deleting user's entire Nostr account via NIP-62
+/// Service for deleting a user's entire Nostr account via NIP-62.
+///
+/// Contract:
+/// 1. Publish the NIP-62 kind-62 event first using a 5-attempt retry policy.
+/// 2. If it never lands on any relay, **abort** — do not issue any kind-5
+///    deletion requests. Local auth-state cleanup (performed by the caller)
+///    must also be skipped so the user can retry.
+/// 3. If NIP-62 lands, run the kind-5 batch in parallel (concurrency 4) with
+///    per-event [publishEventWithRetry]. Partial failures are surfaced via
+///    [BatchDeletionResult]; the user can retry the failed subset without
+///    re-publishing NIP-62.
 class AccountDeletionService {
   AccountDeletionService({
     required NostrClient nostrService,
@@ -46,21 +185,30 @@ class AccountDeletionService {
   final NostrClient _nostrService;
   final AuthService _authService;
 
-  /// Delete user's account using NIP-62 Request to Vanish
-  /// First fetches all user events and publishes kind 5 deletion requests for each
-  /// Then publishes kind 62 account deletion request
+  /// Delete the user's account using NIP-62 Request to Vanish.
+  ///
+  /// [onProgress] receives `(completed, total)` during the kind-5 batch.
+  /// [cancellationToken] lets the user abort mid-batch; in-flight publishes
+  /// finish naturally, queued ones are skipped.
   Future<DeleteAccountResult> deleteAccount({
     String? customReason,
-    void Function(int current, int total)? onProgress,
+    void Function(int completed, int total)? onProgress,
+    AccountDeletionCancellationToken? cancellationToken,
   }) async {
     try {
       if (!_authService.isAuthenticated) {
-        return DeleteAccountResult.failure('Not authenticated');
+        return DeleteAccountResult.failure(
+          error: 'Not authenticated',
+          failureKind: AccountDeletionFailureKind.notAuthenticated,
+        );
       }
 
       final pubkey = _authService.currentPublicKeyHex;
       if (pubkey == null || pubkey.isEmpty) {
-        return DeleteAccountResult.failure('No pubkey available');
+        return DeleteAccountResult.failure(
+          error: 'No pubkey available',
+          failureKind: AccountDeletionFailureKind.notAuthenticated,
+        );
       }
 
       final reason =
@@ -72,162 +220,268 @@ class AccountDeletionService {
         category: LogCategory.system,
       );
 
-      final allUserEvents = await _fetchAllUserEvents(pubkey);
+      // Step 1: Publish the NIP-62 kind-62 event FIRST.
+      // If this never lands on any relay, abort the flow — local auth
+      // cleanup (handled by the caller) must also be skipped so the user
+      // can retry.
+      final nip62Event = await createNip62Event(reason: reason);
+      if (nip62Event == null) {
+        return DeleteAccountResult.failure(
+          error: 'Failed to create deletion event',
+          failureKind: AccountDeletionFailureKind.couldNotSign,
+        );
+      }
 
-      Log.info(
-        'Found ${allUserEvents.length} events to delete',
-        name: 'AccountDeletionService',
-        category: LogCategory.system,
+      final nip62Outcome = await _nostrService.publishEventWithRetry(
+        nip62Event,
+        policy: kNip62RetryPolicy,
       );
+      final nip62Feedback = PublishResultMapper.map(nip62Outcome);
 
-      int deletedCount = 0;
-      if (allUserEvents.isNotEmpty) {
-        deletedCount = await _publishDeletionEventsForAll(
-          allUserEvents,
-          reason,
-          onProgress: onProgress,
-        );
-
-        Log.info(
-          'Published $deletedCount NIP-09 deletion requests',
-          name: 'AccountDeletionService',
-          category: LogCategory.system,
-        );
-      }
-
-      final event = await createNip62Event(reason: reason);
-
-      if (event == null) {
-        return DeleteAccountResult.failure('Failed to create deletion event');
-      }
-
-      final sentEvent = await _nostrService.publishEvent(event);
-
-      if (sentEvent == null) {
+      if (!nip62Outcome.acceptedByAny) {
         Log.error(
-          'Failed to publish NIP-62 deletion request to any relay',
+          'NIP-62 publish failed, aborting account deletion flow: '
+          '$nip62Outcome',
           name: 'AccountDeletionService',
           category: LogCategory.system,
         );
         return DeleteAccountResult.failure(
-          'Failed to publish deletion request to relays',
+          error: 'Failed to publish deletion request to relays',
+          failureKind: AccountDeletionFailureKind.nip62Failed,
+          nip62Outcome: nip62Outcome,
+          nip62Feedback: nip62Feedback,
         );
       }
 
       Log.info(
-        'NIP-62 deletion request published to relays',
+        'NIP-62 deletion request accepted by '
+        '${nip62Outcome.acceptedBy.length} relay(s)',
         name: 'AccountDeletionService',
         category: LogCategory.system,
       );
 
-      return DeleteAccountResult.createSuccess(
-        event.id,
-        deletedEventsCount: deletedCount,
-      );
-    } catch (e) {
-      Log.error(
-        'Account deletion failed: $e',
+      // Step 2: Run the kind-5 batch.
+      final userEvents = await _fetchAllUserEvents(pubkey);
+      Log.info(
+        'Found ${userEvents.length} events for kind-5 batch deletion',
         name: 'AccountDeletionService',
         category: LogCategory.system,
       );
-      return DeleteAccountResult.failure('Account deletion failed: $e');
+
+      BatchDeletionResult? batch;
+      if (userEvents.isNotEmpty) {
+        batch = await _publishDeletionEventsForAll(
+          userEvents,
+          reason,
+          onProgress: onProgress,
+          cancellationToken: cancellationToken,
+        );
+        Log.info(
+          'Kind-5 batch complete: '
+          '${batch.succeededEventIds.length} succeeded, '
+          '${batch.failedEventIds.length} failed',
+          name: 'AccountDeletionService',
+          category: LogCategory.system,
+        );
+      }
+
+      return DeleteAccountResult.nip62Success(
+        deleteEventId: nip62Event.id,
+        outcome: nip62Outcome,
+        feedback: nip62Feedback,
+        batch: batch,
+        fetchedEvents: userEvents,
+      );
+    } catch (e, stackTrace) {
+      Log.error(
+        'Account deletion failed: $e\nStack: $stackTrace',
+        name: 'AccountDeletionService',
+        category: LogCategory.system,
+      );
+      return DeleteAccountResult.failure(
+        error: 'Account deletion failed: $e',
+        failureKind: AccountDeletionFailureKind.unknown,
+      );
     }
   }
 
-  /// Fetch all events authored by the user from relays
-  Future<List<Event>> _fetchAllUserEvents(String pubkey) async {
-    final allEvents = <Event>[];
+  /// Re-run kind-5 deletion for a previously-failed subset.
+  ///
+  /// Given the full original event list and the set of event IDs that
+  /// failed in the first pass, publish kind-5 deletion requests for just
+  /// those events. Returns a new [BatchDeletionResult] scoped to the
+  /// subset.
+  Future<BatchDeletionResult> retryFailedDeletions({
+    required List<Event> originalEvents,
+    required Set<String> failedEventIds,
+    String? customReason,
+    void Function(int completed, int total)? onProgress,
+    AccountDeletionCancellationToken? cancellationToken,
+  }) async {
+    final subset = originalEvents
+        .where((e) => failedEventIds.contains(e.id))
+        .toList();
+    if (subset.isEmpty) {
+      return const BatchDeletionResult(
+        succeededEventIds: <String>{},
+        failedEventIds: <String>{},
+        feedbacks: <String, PublishUserFeedback>{},
+      );
+    }
+    final reason =
+        customReason ?? 'User requested account deletion via Divine app';
+    return _publishDeletionEventsForAll(
+      subset,
+      reason,
+      onProgress: onProgress,
+      cancellationToken: cancellationToken,
+    );
+  }
 
+  /// Fetch all events authored by the user from relays.
+  Future<List<Event>> _fetchAllUserEvents(String pubkey) async {
     try {
       final filter = Filter(authors: [pubkey], limit: 10000);
       final events = await _nostrService.queryEvents([filter]);
-
-      allEvents.addAll(events);
-
       Log.debug(
         'Fetched ${events.length} events for user $pubkey',
         name: 'AccountDeletionService',
         category: LogCategory.system,
       );
+      return events;
     } catch (e) {
       Log.error(
         'Failed to fetch user events: $e',
         name: 'AccountDeletionService',
         category: LogCategory.system,
       );
+      return <Event>[];
     }
-
-    return allEvents;
   }
 
-  /// Publish NIP-09 kind 5 deletion events for all user events
-  Future<int> _publishDeletionEventsForAll(
+  /// Publish NIP-09 kind-5 deletion events for [events] in parallel with
+  /// a concurrency cap. Returns per-event outcomes.
+  ///
+  /// We group by kind (one kind-5 event can reference multiple events of
+  /// the same kind via multiple `e` tags), and then publish each grouped
+  /// kind-5 event with [publishEventWithRetry]. When a grouped publish
+  /// succeeds, every original event id in that group is marked as
+  /// succeeded; when it fails, every id is marked as failed.
+  Future<BatchDeletionResult> _publishDeletionEventsForAll(
     List<Event> events,
     String reason, {
-    void Function(int current, int total)? onProgress,
+    int concurrency = kAccountDeletionBatchConcurrency,
+    void Function(int completed, int total)? onProgress,
+    AccountDeletionCancellationToken? cancellationToken,
   }) async {
-    int successCount = 0;
-    final total = events.length;
+    final succeeded = <String>{};
+    final failed = <String>{};
+    final feedbacks = <String, PublishUserFeedback>{};
 
+    // Group events by kind — kind-5 events can reference many events of the
+    // same kind (one `e` tag per). This keeps relay round-trips proportional
+    // to the number of distinct kinds rather than the number of events.
     final eventsByKind = <int, List<Event>>{};
     for (final event in events) {
       eventsByKind.putIfAbsent(event.kind, () => []).add(event);
     }
 
-    for (final entry in eventsByKind.entries) {
-      final kind = entry.key;
-      final kindEvents = entry.value;
+    final groups = eventsByKind.entries.toList();
+    final queue = List<MapEntry<int, List<Event>>>.from(groups);
+    var completedEvents = 0;
+    final total = events.length;
 
-      final deleteEvent = await _createBatchDeleteEvent(
-        events: kindEvents,
-        kind: kind,
-        reason: reason,
-      );
+    Future<void> worker() async {
+      while (queue.isNotEmpty) {
+        if (cancellationToken?.isCancelled ?? false) return;
+        final MapEntry<int, List<Event>> entry;
+        if (queue.isEmpty) return;
+        entry = queue.removeAt(0);
 
-      if (deleteEvent != null) {
-        final sentEvent = await _nostrService.publishEvent(deleteEvent);
-        if (sentEvent != null) {
-          successCount += kindEvents.length;
+        final kind = entry.key;
+        final kindEvents = entry.value;
+
+        final deleteEvent = await _createBatchDeleteEvent(
+          events: kindEvents,
+          kind: kind,
+          reason: reason,
+        );
+
+        if (deleteEvent == null) {
+          for (final e in kindEvents) {
+            failed.add(e.id);
+            feedbacks[e.id] = const PublishUserFeedback(
+              severity: PublishSeverity.error,
+              messageKey: 'publish_rejected_permanent',
+              retryable: false,
+            );
+          }
+          completedEvents += kindEvents.length;
+          onProgress?.call(completedEvents, total);
+          continue;
+        }
+
+        final outcome = await _nostrService.publishEventWithRetry(deleteEvent);
+        final feedback = PublishResultMapper.map(outcome);
+
+        if (outcome.acceptedByAny) {
+          for (final e in kindEvents) {
+            succeeded.add(e.id);
+            feedbacks[e.id] = feedback;
+          }
           Log.debug(
-            'Published batch deletion for ${kindEvents.length} kind $kind events',
+            'Published batch deletion for ${kindEvents.length} '
+            'kind $kind events',
+            name: 'AccountDeletionService',
+            category: LogCategory.system,
+          );
+        } else {
+          for (final e in kindEvents) {
+            failed.add(e.id);
+            feedbacks[e.id] = feedback;
+          }
+          Log.warning(
+            'Batch deletion for kind $kind failed: $outcome',
             name: 'AccountDeletionService',
             category: LogCategory.system,
           );
         }
-      }
 
-      onProgress?.call(successCount, total);
+        completedEvents += kindEvents.length;
+        onProgress?.call(completedEvents, total);
+      }
     }
 
-    return successCount;
+    await Future.wait(List.generate(concurrency, (_) => worker()));
+
+    return BatchDeletionResult(
+      succeededEventIds: succeeded,
+      failedEventIds: failed,
+      feedbacks: feedbacks,
+    );
   }
 
-  /// Create NIP-09 kind 5 deletion event for multiple events of the same kind
+  /// Create NIP-09 kind-5 deletion event for multiple events of the same
+  /// kind.
   Future<Event?> _createBatchDeleteEvent({
     required List<Event> events,
     required int kind,
     required String reason,
   }) async {
     try {
-      if (!_authService.isAuthenticated) {
-        return null;
-      }
+      if (!_authService.isAuthenticated) return null;
 
       final tags = <List<String>>[];
-
       for (final event in events) {
         tags.add(['e', event.id]);
       }
-
       tags.add(['k', kind.toString()]);
 
-      final signedEvent = await _authService.createAndSignEvent(
+      return await _authService.createAndSignEvent(
         kind: 5,
         content: reason,
         tags: tags,
       );
-
-      return signedEvent;
     } catch (e) {
       Log.error(
         'Failed to create batch delete event: $e',
@@ -238,7 +492,7 @@ class AccountDeletionService {
     }
   }
 
-  /// Create NIP-62 kind 62 event with ALL_RELAYS tag
+  /// Create NIP-62 kind-62 event with ALL_RELAYS tag.
   Future<Event?> createNip62Event({required String reason}) async {
     try {
       if (!_authService.isAuthenticated) {
@@ -260,7 +514,7 @@ class AccountDeletionService {
         return null;
       }
 
-      // NIP-62 requires relay tag with ALL_RELAYS for network-wide deletion
+      // NIP-62 requires relay tag with ALL_RELAYS for network-wide deletion.
       final tags = <List<String>>[
         ['relay', 'ALL_RELAYS'],
       ];
@@ -271,9 +525,8 @@ class AccountDeletionService {
         category: LogCategory.system,
       );
 
-      // Create and sign event via AuthService
       final signedEvent = await _authService.createAndSignEvent(
-        kind: 62, // NIP-62 account deletion kind
+        kind: 62,
         content: reason,
         tags: tags,
       );
@@ -292,7 +545,6 @@ class AccountDeletionService {
         name: 'AccountDeletionService',
         category: LogCategory.system,
       );
-
       return signedEvent;
     } catch (e, stackTrace) {
       Log.error(

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -10,6 +10,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart'
     show SecureKeyStorageException;
+import 'package:nostr_sdk/event.dart';
 import 'package:openvine/services/account_deletion_service.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -292,6 +293,11 @@ Future<void> executeAccountDeletion({
     );
 
     if (result.success) {
+      // Keep a copy of the per-event batch outcome so Retry-failed can
+      // re-run on just the failed subset.
+      final batch = result.batch;
+      final fetchedEvents = result.fetchedEvents;
+
       // Step 2: Delete Keycast account if one exists (invalidates signer)
       final (keycastSuccess, keycastError) = await authService
           .deleteKeycastAccount();
@@ -350,20 +356,42 @@ Future<void> executeAccountDeletion({
       // Router will automatically redirect to /welcome after sign out
       dismissDialog();
       if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          DivineSnackbarContainer.snackBar(
-            keyDeletionWarning ?? 'Your account has been deleted',
-            error: keyDeletionWarning != null,
-          ),
-        );
+        // Prefer the per-event summary when the batch ran with failures;
+        // the user can tap Retry to re-publish only the failed subset.
+        if (keyDeletionWarning != null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            DivineSnackbarContainer.snackBar(
+              keyDeletionWarning,
+              error: true,
+            ),
+          );
+        } else if (batch != null && batch.failedEventIds.isNotEmpty) {
+          _showBatchSummarySnackBar(
+            context: context,
+            batch: batch,
+            deletionService: deletionService,
+            originalEvents: fetchedEvents,
+            screenName: screenName,
+          );
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            DivineSnackbarContainer.snackBar(
+              'Your account has been deleted',
+            ),
+          );
+        }
       }
     } else {
       // Close loading indicator and show error
       dismissDialog();
       if (context.mounted) {
+        final feedback = result.nip62Feedback;
+        final errorText = feedback?.firstRejectionReason != null
+            ? 'Account deletion failed: ${feedback!.firstRejectionReason}'
+            : (result.error ?? 'Failed to delete content from relays');
         ScaffoldMessenger.of(context).showSnackBar(
           DivineSnackbarContainer.snackBar(
-            result.error ?? 'Failed to delete content from relays',
+            errorText,
             error: true,
           ),
         );
@@ -375,6 +403,60 @@ Future<void> executeAccountDeletion({
     // Ensure dialog is dismissed even if an exception occurred
     dismissDialog();
   }
+}
+
+/// Render the N-of-M summary snack bar with a Retry action that re-invokes
+/// only the failed subset via [AccountDeletionService.retryFailedDeletions].
+void _showBatchSummarySnackBar({
+  required BuildContext context,
+  required BatchDeletionResult batch,
+  required AccountDeletionService deletionService,
+  required List<Event> originalEvents,
+  required String screenName,
+}) {
+  final succeeded = batch.succeededEventIds.length;
+  final failed = batch.failedEventIds.length;
+  final total = batch.total;
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+      behavior: SnackBarBehavior.floating,
+      backgroundColor: VineTheme.warning,
+      duration: const Duration(seconds: 8),
+      content: Text(
+        'Account deleted. $succeeded of $total events published successfully; '
+        '$failed can be retried.',
+        style: const TextStyle(color: VineTheme.whiteText),
+      ),
+      action: SnackBarAction(
+        label: 'Retry failed',
+        textColor: VineTheme.whiteText,
+        onPressed: () async {
+          final retry = await deletionService.retryFailedDeletions(
+            originalEvents: originalEvents,
+            failedEventIds: batch.failedEventIds,
+          );
+          if (!context.mounted) return;
+          final retrySucceeded = retry.succeededEventIds.length;
+          final retryFailed = retry.failedEventIds.length;
+          final message = retryFailed == 0
+              ? 'All $retrySucceeded remaining events deleted.'
+              : '$retrySucceeded published, $retryFailed still failed.';
+          ScaffoldMessenger.of(context).showSnackBar(
+            DivineSnackbarContainer.snackBar(
+              message,
+              error: retryFailed > 0,
+            ),
+          );
+          Log.info(
+            'Retry failed deletions: '
+            '$retrySucceeded succeeded, $retryFailed still failed',
+            name: screenName,
+            category: LogCategory.system,
+          );
+        },
+      ),
+    ),
+  );
 }
 
 /// Cubit for managing account deletion progress state.

--- a/mobile/test/services/account_deletion_flow_test.dart
+++ b/mobile/test/services/account_deletion_flow_test.dart
@@ -1,17 +1,13 @@
 @Tags(['skip_very_good_optimization', 'integration'])
-// ABOUTME: Integration test for complete account deletion flow
-// ABOUTME: Tests end-to-end deletion from Settings through sign out
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+// ABOUTME: Integration test for the reliable account deletion flow
+// ABOUTME: Asserts the PR7 contract: NIP-62 retry + abort-on-failure +
+// ABOUTME: parallel kind-5 batch + Retry-failed subset.
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
-import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/event.dart';
-import 'package:openvine/l10n/generated/app_localizations.dart';
-import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/screens/settings/settings_screen.dart';
+import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/services/account_deletion_service.dart';
 import 'package:openvine/services/auth_service.dart';
 
@@ -19,164 +15,264 @@ class _MockNostrClient extends Mock implements NostrClient {}
 
 class _MockAuthService extends Mock implements AuthService {}
 
-class _MockNostrKeyManager extends Mock implements NostrKeyManager {}
-
-class _MockKeychain extends Mock implements Keychain {}
-
-/// Fake [Event] for use with registerFallbackValue.
 class _FakeEvent extends Fake implements Event {}
 
 void main() {
   setUpAll(() {
     registerFallbackValue(_FakeEvent());
+    registerFallbackValue(<Filter>[]);
+    registerFallbackValue(const RetryPolicy());
   });
 
-  group('Account Deletion Flow Integration', () {
-    late _MockNostrClient mockNostrService;
-    late _MockAuthService mockAuthService;
-    late _MockNostrKeyManager mockKeyManager;
-    late _MockKeychain mockKeychain;
-    late String testPrivateKey;
-    late String testPublicKey;
+  group('Account Deletion Flow — reliable publish contract', () {
+    late _MockNostrClient nostr;
+    late _MockAuthService auth;
+    late String pubkey;
 
     setUp(() {
-      // Generate valid keys for testing
-      testPrivateKey = generatePrivateKey();
-      testPublicKey = getPublicKey(testPrivateKey);
-
-      mockNostrService = _MockNostrClient();
-      mockAuthService = _MockAuthService();
-      mockKeyManager = _MockNostrKeyManager();
-      mockKeychain = _MockKeychain();
-
-      // Setup common mocks with valid keys
-      when(() => mockKeyManager.keyPair).thenReturn(mockKeychain);
-      when(() => mockKeychain.public).thenReturn(testPublicKey);
-      when(() => mockKeychain.private).thenReturn(testPrivateKey);
-    });
-
-    testWidgets('complete deletion flow from settings to sign out', (
-      tester,
-    ) async {
-      // Arrange
-      when(() => mockAuthService.isAuthenticated).thenReturn(true);
-      when(() => mockAuthService.currentProfile).thenReturn(null);
-      when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPublicKey);
-      when(() => mockNostrService.hasKeys).thenReturn(true);
-
-      final mockEvent = Event(
-        testPublicKey,
-        62,
-        [
-          ['relay', 'ALL_RELAYS'],
-        ],
-        'User requested account deletion via Divine app',
-        createdAt: 1234567890,
-      );
-
+      nostr = _MockNostrClient();
+      auth = _MockAuthService();
+      final priv = generatePrivateKey();
+      pubkey = getPublicKey(priv);
+      when(() => auth.isAuthenticated).thenReturn(true);
+      when(() => auth.currentPublicKeyHex).thenReturn(pubkey);
       when(
-        () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => mockEvent);
-
+        () => nostr.queryEvents(any()),
+      ).thenAnswer((_) async => <Event>[]);
       when(
-        () => mockAuthService.signOut(deleteKeys: true),
-      ).thenAnswer((_) async => Future.value());
-
-      final deletionService = AccountDeletionService(
-        nostrService: mockNostrService,
-        authService: mockAuthService,
-      );
-
-      // Act
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            accountDeletionServiceProvider.overrideWithValue(deletionService),
-            authServiceProvider.overrideWithValue(mockAuthService),
-          ],
-          child: const MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: SettingsScreen(),
-          ),
+        () => auth.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
         ),
-      );
-
-      await tester.pumpAndSettle();
-
-      // Tap Delete Account
-      await tester.tap(find.text('Delete Account'));
-      await tester.pumpAndSettle();
-
-      // Verify warning dialog appears
-      expect(find.text('⚠️ Delete Account?'), findsOneWidget);
-
-      // Confirm deletion
-      await tester.tap(find.text('Delete My Account'));
-      await tester.pump(); // Start deletion
-      await tester.pump(const Duration(milliseconds: 100)); // Loading indicator
-      await tester.pumpAndSettle(); // Complete deletion
-
-      // Verify NIP-62 event was published
-      verify(() => mockNostrService.publishEvent(any())).called(1);
-
-      // Verify user was signed out with keys deleted
-      verify(() => mockAuthService.signOut(deleteKeys: true)).called(1);
-
-      // Verify completion dialog appears
-      expect(find.text('✓ Account Deleted'), findsOneWidget);
-      expect(find.text('Create New Account'), findsOneWidget);
+      ).thenAnswer((invocation) async {
+        final kind = invocation.namedArguments[#kind] as int;
+        final content = invocation.namedArguments[#content] as String;
+        final tags = invocation.namedArguments[#tags] as List<List<String>>;
+        return Event(pubkey, kind, tags, content)
+          ..id = 'signed_${kind}_${DateTime.now().microsecondsSinceEpoch}'
+          ..sig = 'sig';
+      });
     });
 
-    testWidgets('should show error when publish fails', (tester) async {
-      // Arrange
-      when(() => mockAuthService.isAuthenticated).thenReturn(true);
-      when(() => mockAuthService.currentProfile).thenReturn(null);
-      when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPublicKey);
-      when(() => mockNostrService.hasKeys).thenReturn(true);
+    test(
+      'aborts entire flow when NIP-62 never lands on any relay',
+      () async {
+        // User has events — but the batch MUST NOT run if NIP-62 fails.
+        final userVideo = Event(pubkey, 34236, const [], 'v')..id = 'v1';
+        when(
+          () => nostr.queryEvents(any()),
+        ).thenAnswer((_) async => [userVideo]);
 
-      // publishEvent returns null on failure
-      when(
-        () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => null);
-
-      final deletionService = AccountDeletionService(
-        nostrService: mockNostrService,
-        authService: mockAuthService,
-      );
-
-      // Act
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            accountDeletionServiceProvider.overrideWithValue(deletionService),
-            authServiceProvider.overrideWithValue(mockAuthService),
-          ],
-          child: const MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: SettingsScreen(),
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
-        ),
-      );
+        ).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments[0] as Event;
+          return PublishOutcome(
+            eventId: event.id,
+            acceptedBy: const {},
+            rejectedBy: const {},
+            noResponseFrom: const {'wss://a', 'wss://b'},
+          );
+        });
 
-      await tester.pumpAndSettle();
+        final service = AccountDeletionService(
+          nostrService: nostr,
+          authService: auth,
+        );
+        final result = await service.deleteAccount();
 
-      // Tap Delete Account
-      await tester.tap(find.text('Delete Account'));
-      await tester.pumpAndSettle();
+        expect(result.success, isFalse);
+        expect(result.failureKind, AccountDeletionFailureKind.nip62Failed);
+        expect(result.batch, isNull);
+        // Only one publish was attempted — the NIP-62 event.
+        verify(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
+        // And critically, queryEvents was never called — we aborted before
+        // fetching the user's events.
+        verifyNever(() => nostr.queryEvents(any()));
+      },
+    );
 
-      // Confirm deletion
-      await tester.tap(find.text('Delete My Account'));
-      await tester.pump();
-      await tester.pumpAndSettle();
+    test(
+      'partial kind-5 failure surfaces failedEventIds in result.batch',
+      () async {
+        final v1 = Event(pubkey, 34236, const [], 'a')..id = 'v1';
+        final v2 = Event(pubkey, 1, const [], 'b')..id = 'n1';
+        when(
+          () => nostr.queryEvents(any()),
+        ).thenAnswer((_) async => [v1, v2]);
 
-      // Verify error message appears
-      expect(find.textContaining('Failed to'), findsOneWidget);
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments[0] as Event;
+          if (event.kind == 62) {
+            return PublishOutcome(
+              eventId: event.id,
+              acceptedBy: const {'wss://a'},
+              rejectedBy: const {},
+              noResponseFrom: const {},
+            );
+          }
+          // Fail the batch event targeting v1.
+          final isForV1 = event.tags.any(
+            (t) => t.length >= 2 && t[0] == 'e' && t[1] == 'v1',
+          );
+          if (isForV1) {
+            return PublishOutcome(
+              eventId: event.id,
+              acceptedBy: const {},
+              rejectedBy: const {'wss://a': 'blocked: not allowed'},
+              noResponseFrom: const {},
+            );
+          }
+          return PublishOutcome(
+            eventId: event.id,
+            acceptedBy: const {'wss://a'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          );
+        });
 
-      // Verify user was NOT signed out
-      verifyNever(() => mockAuthService.signOut(deleteKeys: true));
-    });
-    // TODO(any): Fix and reenable this test
-  }, skip: true);
+        final service = AccountDeletionService(
+          nostrService: nostr,
+          authService: auth,
+        );
+        final result = await service.deleteAccount();
+
+        expect(result.success, isTrue);
+        expect(result.batch, isNotNull);
+        expect(result.batch!.failedEventIds, equals({'v1'}));
+        expect(result.batch!.succeededEventIds, equals({'n1'}));
+        // The original user events must be retained so Retry-failed can
+        // re-invoke the service on the subset without another fetch.
+        expect(
+          result.fetchedEvents.map((e) => e.id),
+          containsAll(['v1', 'n1']),
+        );
+      },
+    );
+
+    test(
+      'Retry-failed re-runs only the failed subset',
+      () async {
+        final v1 = Event(pubkey, 34236, const [], 'a')..id = 'v1';
+        final v2 = Event(pubkey, 1, const [], 'b')..id = 'n1';
+        when(
+          () => nostr.queryEvents(any()),
+        ).thenAnswer((_) async => [v1, v2]);
+
+        // First pass: NIP-62 ok, v1 batch fails (transient), v2 ok. Second
+        // pass (retry): the single batch publish succeeds.
+        var call = 0;
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          call++;
+          final event = invocation.positionalArguments[0] as Event;
+          if (event.kind == 62) {
+            return PublishOutcome(
+              eventId: event.id,
+              acceptedBy: const {'wss://a'},
+              rejectedBy: const {},
+              noResponseFrom: const {},
+            );
+          }
+          final isForV1 = event.tags.any(
+            (t) => t.length >= 2 && t[0] == 'e' && t[1] == 'v1',
+          );
+          if (isForV1 && call <= 3) {
+            return PublishOutcome(
+              eventId: event.id,
+              acceptedBy: const {},
+              rejectedBy: const {},
+              noResponseFrom: const {'wss://a'},
+            );
+          }
+          return PublishOutcome(
+            eventId: event.id,
+            acceptedBy: const {'wss://a'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          );
+        });
+
+        final service = AccountDeletionService(
+          nostrService: nostr,
+          authService: auth,
+        );
+        final first = await service.deleteAccount();
+        expect(first.batch!.failedEventIds, {'v1'});
+
+        final retry = await service.retryFailedDeletions(
+          originalEvents: first.fetchedEvents,
+          failedEventIds: first.batch!.failedEventIds,
+        );
+        expect(retry.succeededEventIds, contains('v1'));
+        expect(retry.failedEventIds, isEmpty);
+      },
+    );
+
+    test(
+      'progress callback fires monotonically during kind-5 batch',
+      () async {
+        final events = [
+          Event(pubkey, 1, const [], 'a')..id = 'e1',
+          Event(pubkey, 7, const [], 'b')..id = 'e2',
+          Event(pubkey, 34236, const [], 'c')..id = 'e3',
+        ];
+        when(
+          () => nostr.queryEvents(any()),
+        ).thenAnswer((_) async => events);
+
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (invocation) async => PublishOutcome(
+            eventId: (invocation.positionalArguments[0] as Event).id,
+            acceptedBy: const {'wss://a'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          ),
+        );
+
+        final updates = <(int, int)>[];
+        final service = AccountDeletionService(
+          nostrService: nostr,
+          authService: auth,
+        );
+        await service.deleteAccount(
+          onProgress: (c, t) => updates.add((c, t)),
+        );
+
+        expect(updates, isNotEmpty);
+        expect(updates.last, (3, 3));
+        for (var i = 1; i < updates.length; i++) {
+          expect(updates[i].$1, greaterThanOrEqualTo(updates[i - 1].$1));
+        }
+      },
+    );
+  });
 }

--- a/mobile/test/services/account_deletion_service_test.dart
+++ b/mobile/test/services/account_deletion_service_test.dart
@@ -17,10 +17,25 @@ class _MockAuthService extends Mock implements AuthService {}
 
 class _FakeEvent extends Fake implements Event {}
 
+PublishOutcome _accepted(String eventId) => PublishOutcome(
+  eventId: eventId,
+  acceptedBy: const {'wss://relay.a'},
+  rejectedBy: const {},
+  noResponseFrom: const {},
+);
+
+PublishOutcome _allTimedOut(String eventId) => PublishOutcome(
+  eventId: eventId,
+  acceptedBy: const {},
+  rejectedBy: const {},
+  noResponseFrom: const {'wss://relay.a'},
+);
+
 void main() {
   setUpAll(() {
     registerFallbackValue(_FakeEvent());
     registerFallbackValue(<Filter>[]);
+    registerFallbackValue(const RetryPolicy());
   });
 
   group('AccountDeletionService', () {
@@ -165,14 +180,27 @@ void main() {
       ).thenAnswer((_) async => expectedEvent);
 
       when(
-        () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => expectedEvent);
+        () => mockNostrService.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        final event = invocation.positionalArguments[0] as Event;
+        return _accepted(event.id);
+      });
 
       // Act
       await expectLater(service.deleteAccount(), completes);
 
       // Assert
-      verify(() => mockNostrService.publishEvent(any())).called(1);
+      verify(
+        () => mockNostrService.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).called(1);
     });
 
     test(
@@ -197,8 +225,15 @@ void main() {
         ).thenAnswer((_) async => expectedEvent);
 
         when(
-          () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => expectedEvent);
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments[0] as Event;
+          return _accepted(event.id);
+        });
 
         // Act
         final result = await service.deleteAccount();
@@ -228,10 +263,17 @@ void main() {
         ),
       ).thenAnswer((_) async => expectedEvent);
 
-      // publishEvent returns null on failure
+      // No relay accepts — every attempt times out.
       when(
-        () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => null);
+        () => mockNostrService.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        final event = invocation.positionalArguments[0] as Event;
+        return _allTimedOut(event.id);
+      });
 
       // Act
       final result = await service.deleteAccount();
@@ -240,6 +282,7 @@ void main() {
       expect(result.success, isFalse);
       expect(result.error, isNotNull);
       expect(result.error, contains('Failed to publish'));
+      expect(result.failureKind, AccountDeletionFailureKind.nip62Failed);
     });
 
     test('deleteAccount should fail when not authenticated', () async {
@@ -253,8 +296,14 @@ void main() {
       expect(result.success, isFalse);
       expect(result.error, contains('Not authenticated'));
 
-      // Verify publishEvent was NOT called
-      verifyNever(() => mockNostrService.publishEvent(any()));
+      // Verify publish was NOT called
+      verifyNever(
+        () => mockNostrService.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      );
     });
 
     test(
@@ -275,14 +324,21 @@ void main() {
         // Assert
         expect(result.success, isFalse);
         expect(result.error, contains('Failed to create deletion event'));
+        expect(result.failureKind, AccountDeletionFailureKind.couldNotSign);
 
-        // Verify publishEvent was NOT called
-        verifyNever(() => mockNostrService.publishEvent(any()));
+        // Verify publish was NOT called
+        verifyNever(
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
       },
     );
 
     group('NIP-09 batch deletion', () {
-      test('should fetch all user events before deletion', () async {
+      test('should fetch all user events before batch deletion', () async {
         // Arrange
         final nip62Event = createTestEvent(
           pubkey: testPublicKey,
@@ -304,18 +360,25 @@ void main() {
           ),
         ).thenAnswer((_) async => nip62Event);
         when(
-          () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => nip62Event);
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments[0] as Event;
+          return _accepted(event.id);
+        });
 
         // Act
         await service.deleteAccount();
 
-        // Assert
+        // Assert — queryEvents runs once (fetch) after NIP-62 succeeds.
         verify(() => mockNostrService.queryEvents(any())).called(1);
       });
 
       test(
-        'should publish kind 5 events for user events before NIP-62',
+        'should publish kind 5 events for user events after NIP-62 succeeds',
         () async {
           // Arrange
           final userVideoEvent = createTestEvent(
@@ -358,20 +421,34 @@ void main() {
             ),
           ).thenAnswer((_) async {
             createCallCount++;
-            if (createCallCount == 1) return kind5Event;
-            return nip62Event;
+            // NIP-62 is signed first, then the kind-5 batch event.
+            if (createCallCount == 1) return nip62Event;
+            return kind5Event;
           });
 
           when(
-            () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => nip62Event);
+            () => mockNostrService.publishEventWithRetry(
+              any(),
+              policy: any(named: 'policy'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((invocation) async {
+            final event = invocation.positionalArguments[0] as Event;
+            return _accepted(event.id);
+          });
 
           // Act
           final result = await service.deleteAccount();
 
           // Assert
           expect(result.success, isTrue);
-          verify(() => mockNostrService.publishEvent(any())).called(2);
+          verify(
+            () => mockNostrService.publishEventWithRetry(
+              any(),
+              policy: any(named: 'policy'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).called(2);
         },
       );
 
@@ -399,6 +476,14 @@ void main() {
           id: 'like_1',
         );
 
+        final nip62Event = createTestEvent(
+          pubkey: testPublicKey,
+          kind: 62,
+          tags: [
+            ['relay', 'ALL_RELAYS'],
+          ],
+          content: 'deletion',
+        );
         final kind5VideoEvent = createTestEvent(
           pubkey: testPublicKey,
           kind: 5,
@@ -418,14 +503,6 @@ void main() {
           ],
           content: 'deletion',
         );
-        final nip62Event = createTestEvent(
-          pubkey: testPublicKey,
-          kind: 62,
-          tags: [
-            ['relay', 'ALL_RELAYS'],
-          ],
-          content: 'deletion',
-        );
 
         when(
           () => mockNostrService.queryEvents(any()),
@@ -440,14 +517,21 @@ void main() {
           ),
         ).thenAnswer((_) async {
           createCallCount++;
-          if (createCallCount == 1) return kind5VideoEvent;
-          if (createCallCount == 2) return kind5LikeEvent;
-          return nip62Event;
+          if (createCallCount == 1) return nip62Event;
+          if (createCallCount == 2) return kind5VideoEvent;
+          return kind5LikeEvent;
         });
 
         when(
-          () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => nip62Event);
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments[0] as Event;
+          return _accepted(event.id);
+        });
 
         // Act
         final result = await service.deleteAccount();
@@ -455,7 +539,14 @@ void main() {
         // Assert
         expect(result.success, isTrue);
         expect(result.deletedEventsCount, equals(3));
-        verify(() => mockNostrService.publishEvent(any())).called(3);
+        // 1 NIP-62 + 2 grouped kind-5 (one per kind) = 3 publish calls.
+        verify(
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(3);
       });
 
       test('should return deletedEventsCount in result', () async {
@@ -499,13 +590,20 @@ void main() {
           ),
         ).thenAnswer((_) async {
           createCallCount++;
-          if (createCallCount == 1) return kind5Event;
-          return nip62Event;
+          if (createCallCount == 1) return nip62Event;
+          return kind5Event;
         });
 
         when(
-          () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => nip62Event);
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments[0] as Event;
+          return _accepted(event.id);
+        });
 
         // Act
         final result = await service.deleteAccount();
@@ -537,8 +635,15 @@ void main() {
           ),
         ).thenAnswer((_) async => nip62Event);
         when(
-          () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => nip62Event);
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments[0] as Event;
+          return _accepted(event.id);
+        });
 
         // Act
         final result = await service.deleteAccount();
@@ -546,7 +651,13 @@ void main() {
         // Assert
         expect(result.success, isTrue);
         expect(result.deletedEventsCount, equals(0));
-        verify(() => mockNostrService.publishEvent(any())).called(1);
+        verify(
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
       });
     });
   });

--- a/mobile/test/unit/services/account_deletion_service_reliability_test.dart
+++ b/mobile/test/unit/services/account_deletion_service_reliability_test.dart
@@ -1,0 +1,449 @@
+// ABOUTME: Tests that AccountDeletionService uses publishEventWithRetry for
+// ABOUTME: NIP-62 with a 5-attempt policy, aborts on NIP-62 failure, and
+// ABOUTME: executes the kind-5 batch in parallel with per-event outcome
+// ABOUTME: tracking.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/account_deletion_service.dart';
+import 'package:openvine/services/auth_service.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const testPubkey =
+      '0000000000000000000000000000000000000000000000000000000000000001';
+
+  setUpAll(() {
+    registerFallbackValue(
+      Event(testPubkey, EventKind.eventDeletion, const [], '')
+        ..id = 'x' * 64
+        ..sig = 'sig',
+    );
+    registerFallbackValue(const RetryPolicy());
+    registerFallbackValue(<Filter>[]);
+  });
+
+  late _MockNostrClient nostr;
+  late _MockAuthService auth;
+
+  PublishOutcome acceptedOutcome(String eventId) => PublishOutcome(
+    eventId: eventId,
+    acceptedBy: const {'wss://relay.a'},
+    rejectedBy: const {},
+    noResponseFrom: const {},
+  );
+
+  PublishOutcome noResponseOutcome(String eventId) => PublishOutcome(
+    eventId: eventId,
+    acceptedBy: const {},
+    rejectedBy: const {},
+    noResponseFrom: const {'wss://relay.a', 'wss://relay.b'},
+  );
+
+  PublishOutcome permanentlyRejectedOutcome(String eventId) => PublishOutcome(
+    eventId: eventId,
+    acceptedBy: const {},
+    rejectedBy: const {'wss://relay.a': 'blocked: not allowed'},
+    noResponseFrom: const {},
+  );
+
+  Event buildUserEvent({required int kind, required String id}) {
+    final e = Event(testPubkey, kind, const [], 'content')
+      ..id = id
+      ..sig = 'sig';
+    return e;
+  }
+
+  setUp(() {
+    nostr = _MockNostrClient();
+    auth = _MockAuthService();
+    when(() => auth.isAuthenticated).thenReturn(true);
+    when(() => auth.currentPublicKeyHex).thenReturn(testPubkey);
+    when(
+      () => nostr.queryEvents(any()),
+    ).thenAnswer((_) async => <Event>[]);
+    // Default: signer returns a signed event echoing kind/content/tags.
+    when(
+      () => auth.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer((invocation) async {
+      final kind = invocation.namedArguments[#kind] as int;
+      final content = invocation.namedArguments[#content] as String;
+      final tags = invocation.namedArguments[#tags] as List<List<String>>;
+      return Event(testPubkey, kind, tags, content)
+        ..id = 'signed_${kind}_${DateTime.now().microsecondsSinceEpoch}'
+        ..sig = 'sig';
+    });
+  });
+
+  group('AccountDeletionService NIP-62 publish', () {
+    test(
+      'success path: NIP-62 publish succeeds and kind-5 batch runs',
+      () async {
+        final userVideo = buildUserEvent(kind: 34236, id: 'video_1');
+        when(
+          () => nostr.queryEvents(any()),
+        ).thenAnswer((_) async => [userVideo]);
+
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (invocation) async =>
+              acceptedOutcome((invocation.positionalArguments[0] as Event).id),
+        );
+
+        final service = AccountDeletionService(
+          nostrService: nostr,
+          authService: auth,
+        );
+        final result = await service.deleteAccount();
+
+        expect(result.success, isTrue);
+        expect(result.nip62Outcome, isNotNull);
+        expect(result.nip62Outcome!.acceptedByAny, isTrue);
+        expect(result.nip62Feedback?.severity, PublishSeverity.success);
+        expect(result.batch, isNotNull);
+        expect(result.batch!.succeededEventIds, hasLength(1));
+        expect(result.batch!.failedEventIds, isEmpty);
+        // 2 publish calls: 1 NIP-62 + 1 per-kind batch kind-5 event.
+        verify(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(2);
+      },
+    );
+
+    test(
+      'NIP-62 never lands: aborts before running kind-5 batch',
+      () async {
+        // Even if the user has events, the batch must not run when NIP-62
+        // fails.
+        final userVideo = buildUserEvent(kind: 34236, id: 'video_1');
+        when(
+          () => nostr.queryEvents(any()),
+        ).thenAnswer((_) async => [userVideo]);
+
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (invocation) async => noResponseOutcome(
+            (invocation.positionalArguments[0] as Event).id,
+          ),
+        );
+
+        final service = AccountDeletionService(
+          nostrService: nostr,
+          authService: auth,
+        );
+        final result = await service.deleteAccount();
+
+        expect(result.success, isFalse);
+        expect(result.failureKind, AccountDeletionFailureKind.nip62Failed);
+        expect(result.nip62Outcome, isNotNull);
+        expect(result.nip62Feedback?.retryable, isTrue);
+        expect(result.batch, isNull);
+        // Only the NIP-62 publish was attempted.
+        verify(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'NIP-62 permanent rejection surfaces non-retryable feedback + reason',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (invocation) async => permanentlyRejectedOutcome(
+            (invocation.positionalArguments[0] as Event).id,
+          ),
+        );
+
+        final service = AccountDeletionService(
+          nostrService: nostr,
+          authService: auth,
+        );
+        final result = await service.deleteAccount();
+
+        expect(result.success, isFalse);
+        expect(result.failureKind, AccountDeletionFailureKind.nip62Failed);
+        expect(result.nip62Feedback?.retryable, isFalse);
+        expect(
+          result.nip62Feedback?.messageKey,
+          'publish_rejected_permanent',
+        );
+        expect(
+          result.nip62Feedback?.firstRejectionReason,
+          'blocked: not allowed',
+        );
+        expect(result.batch, isNull);
+      },
+    );
+
+    test(
+      'NIP-62 uses RetryPolicy with maxAttempts = 5',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (invocation) async =>
+              acceptedOutcome((invocation.positionalArguments[0] as Event).id),
+        );
+
+        final service = AccountDeletionService(
+          nostrService: nostr,
+          authService: auth,
+        );
+        await service.deleteAccount();
+
+        final captured = verify(
+          () => nostr.publishEventWithRetry(
+            any(that: predicate<Event>((e) => e.kind == 62)),
+            policy: captureAny(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).captured;
+        final policy = captured.first as RetryPolicy;
+        expect(policy.maxAttempts, 5);
+      },
+    );
+  });
+
+  group('AccountDeletionService batch kind-5', () {
+    test(
+      'partial failure reports succeeded + failed event IDs and feedbacks',
+      () async {
+        // Two user events of different kinds → two kind-5 batch events.
+        final v1 = buildUserEvent(kind: 34236, id: 'video_a');
+        final v2 = buildUserEvent(kind: 7, id: 'react_a');
+        when(
+          () => nostr.queryEvents(any()),
+        ).thenAnswer((_) async => [v1, v2]);
+
+        // Signer returns predictable kind-5 events we can match on. First
+        // kind-5 for kind=34236, second for kind=7, third is the NIP-62.
+        var signCount = 0;
+        when(
+          () => auth.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) async {
+          final kind = invocation.namedArguments[#kind] as int;
+          final content = invocation.namedArguments[#content] as String;
+          final tags = invocation.namedArguments[#tags] as List<List<String>>;
+          signCount++;
+          return Event(testPubkey, kind, tags, content)
+            ..id = 'signed_${kind}_$signCount'
+            ..sig = 'sig';
+        });
+
+        // NIP-62 accepted, one kind-5 accepted, other kind-5 rejected
+        // permanently.
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments[0] as Event;
+          if (event.kind == 62) return acceptedOutcome(event.id);
+          // kind-5: match on e-tag to decide which fails.
+          final isForReact = event.tags.any(
+            (t) => t.length >= 2 && t[0] == 'e' && t[1] == 'react_a',
+          );
+          if (isForReact) return permanentlyRejectedOutcome(event.id);
+          return acceptedOutcome(event.id);
+        });
+
+        final service = AccountDeletionService(
+          nostrService: nostr,
+          authService: auth,
+        );
+        final result = await service.deleteAccount();
+
+        expect(result.success, isTrue); // NIP-62 landed → flow succeeded.
+        expect(result.batch, isNotNull);
+        expect(result.batch!.succeededEventIds, contains('video_a'));
+        expect(result.batch!.failedEventIds, contains('react_a'));
+        expect(result.batch!.feedbacks['react_a']?.retryable, isFalse);
+      },
+    );
+
+    test(
+      'progress callback fires with (completed, total) during batch',
+      () async {
+        final v1 = buildUserEvent(kind: 34236, id: 'v1');
+        final v2 = buildUserEvent(kind: 1, id: 'v2');
+        final v3 = buildUserEvent(kind: 7, id: 'v3');
+        when(
+          () => nostr.queryEvents(any()),
+        ).thenAnswer((_) async => [v1, v2, v3]);
+
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (invocation) async =>
+              acceptedOutcome((invocation.positionalArguments[0] as Event).id),
+        );
+
+        final updates = <({int completed, int total})>[];
+        final service = AccountDeletionService(
+          nostrService: nostr,
+          authService: auth,
+        );
+        await service.deleteAccount(
+          onProgress: (c, t) => updates.add((completed: c, total: t)),
+        );
+
+        expect(updates, isNotEmpty);
+        // Final update is (3, 3).
+        expect(updates.last, (completed: 3, total: 3));
+        // Monotonic progress.
+        for (var i = 1; i < updates.length; i++) {
+          expect(
+            updates[i].completed,
+            greaterThanOrEqualTo(updates[i - 1].completed),
+          );
+        }
+      },
+    );
+
+    test(
+      'retryFailedDeletions re-runs only the failed subset',
+      () async {
+        final v1 = buildUserEvent(kind: 34236, id: 'v1');
+        final v2 = buildUserEvent(kind: 1, id: 'v2');
+        when(
+          () => nostr.queryEvents(any()),
+        ).thenAnswer((_) async => [v1, v2]);
+
+        // First pass: NIP-62 ok, v1 fails, v2 ok.
+        // Second pass: only v1's kind-5 should be retried; this time ok.
+        var callNumber = 0;
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          callNumber++;
+          final event = invocation.positionalArguments[0] as Event;
+          if (event.kind == 62) return acceptedOutcome(event.id);
+          final isForV1 = event.tags.any(
+            (t) => t.length >= 2 && t[0] == 'e' && t[1] == 'v1',
+          );
+          if (isForV1 && callNumber <= 3) {
+            return noResponseOutcome(event.id);
+          }
+          return acceptedOutcome(event.id);
+        });
+
+        final service = AccountDeletionService(
+          nostrService: nostr,
+          authService: auth,
+        );
+        final first = await service.deleteAccount();
+        expect(first.batch!.failedEventIds, equals({'v1'}));
+
+        // Now retry only the failed subset.
+        final retry = await service.retryFailedDeletions(
+          originalEvents: [v1, v2],
+          failedEventIds: first.batch!.failedEventIds,
+        );
+        expect(retry.succeededEventIds, contains('v1'));
+        expect(retry.failedEventIds, isEmpty);
+      },
+    );
+
+    test(
+      'cancel mid-batch stops queueing new publishes',
+      () async {
+        // Many events so we can cancel before they all finish.
+        final events = List.generate(
+          20,
+          (i) => buildUserEvent(kind: 30023 + i, id: 'e$i'),
+        );
+        when(
+          () => nostr.queryEvents(any()),
+        ).thenAnswer((_) async => events);
+
+        final token = AccountDeletionCancellationToken();
+        var calls = 0;
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments[0] as Event;
+          if (event.kind == 62) return acceptedOutcome(event.id);
+          calls++;
+          // Cancel as soon as the batch starts.
+          if (calls == 1) token.cancel();
+          // Simulate a slow relay so concurrency matters.
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          return acceptedOutcome(event.id);
+        });
+
+        final service = AccountDeletionService(
+          nostrService: nostr,
+          authService: auth,
+        );
+        final result = await service.deleteAccount(cancellationToken: token);
+
+        // We should NOT have published a kind-5 for every event — the batch
+        // was cancelled after the first in-flight publish.
+        expect(result.batch, isNotNull);
+        final totalTouched =
+            result.batch!.succeededEventIds.length +
+            result.batch!.failedEventIds.length;
+        expect(totalTouched, lessThan(events.length));
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #3180

## Summary

- `AccountDeletionService` now uses `publishEventWithRetry` with a **5-attempt** policy for the NIP-62 kind-62 event. If NIP-62 never lands on any relay, the flow **aborts before the kind-5 batch** — previously the code proceeded silently, leaving users with some content deletion-requested but the authoritative NIP-62 signal missing.
- The kind-5 batch runs in **parallel (concurrency 4)** with per-event `publishEventWithRetry`. Events are grouped by kind so round-trips scale with number of distinct kinds rather than number of events.
- New `BatchDeletionResult` tracks `succeededEventIds`, `failedEventIds`, and per-event `PublishUserFeedback`. Delete Account dialog renders an **N-of-M summary snackbar** with a **Retry-failed** action that re-invokes only the failed subset (no second NIP-62 publish, no re-fetch).
- `AccountDeletionCancellationToken` supports user abort mid-batch: in-flight publishes finish naturally, queued ones are skipped. `rate-limited:` prefix is permanent per NIP-01 / `PublishOutcome.transientRelays` so no infinite retry on rate-limited relays.

### Contract changes

- **Order**: NIP-62 is now published FIRST, kind-5 batch SECOND (was reversed).
- **Abort**: On NIP-62 publish failure, kind-5 batch is NOT started and local auth-state cleanup must NOT run (caller responsibility — see `delete_account_dialog.dart`).
- **Local history**: Not affected here (this service was never writing to local history; that contract change was PR 1 for `ContentDeletionService`).

### Files

- `mobile/lib/services/account_deletion_service.dart` — rewritten around `publishEventWithRetry` + `BatchDeletionResult` + cancellation token.
- `mobile/lib/widgets/delete_account_dialog.dart` — summary snackbar + Retry-failed action consuming `result.batch` and `result.fetchedEvents`.
- `mobile/test/unit/services/account_deletion_service_reliability_test.dart` — **new**, 8 tests covering NIP-62 success / abort / 5-attempt policy / permanent rejection + batch partial failure / progress / retry-subset / cancellation.
- `mobile/test/services/account_deletion_service_test.dart` — adapted existing 11 tests to the `publishEventWithRetry` stub contract; kept `deletedEventsCount` semantics.
- `mobile/test/services/account_deletion_flow_test.dart` — was skipped against silent-success contract. Rewritten against the new reliable contract (abort-on-NIP-62-failure, partial failure reporting, Retry-failed subset, monotonic progress).

## Test plan

- [x] `flutter test test/services/account_deletion_service_test.dart test/services/account_deletion_flow_test.dart test/unit/services/account_deletion_service_reliability_test.dart test/providers/account_deletion_provider_test.dart` — **24 pass, 1 skip** (pre-existing provider smoke test).
- [x] `flutter analyze lib test` — **zero issues**.
- [x] Pre-commit + pre-push hooks (format + analyze + codegen + changed-file tests) — all green.
- [ ] Manual smoke test against local stack (out of scope for this session — ready to run once PR is reviewed).

## Risks & notes

- `BatchDeletionResult` groups by kind (one kind-5 event with many `e` tags per kind) — matches the prior implementation's batching, so per-event outcomes for events sharing a kind share the same outcome. The UI reports this correctly via `batch.failedEventIds`.
- Local auth-state cleanup (`authService.signOut(deleteKeys: true)` and Keycast deletion) only runs when `result.success == true`, which by the new contract requires NIP-62 to have landed.
- The pre-existing PR1 UI for per-video delete (`share_video_menu.dart`) continues to use `PublishResultMapper` feedback — no changes needed.