### PR TITLE
feat(social): reliable follow/comment/reaction/repost publishing

### DIFF
--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -11,6 +11,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:meta/meta.dart' show visibleForTesting;
+import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event_kind.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/content_blocklist_service.dart';
@@ -306,7 +307,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
       }
     }
 
-    emit(state.copyWith(isPosting: true));
+    emit(state.copyWith(isPosting: true, clearFeedback: true));
 
     try {
       final postedComment = await _commentsRepository.postComment(
@@ -342,7 +343,22 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
           ),
         );
       }
-    } catch (e) {
+    } on PostCommentFailedException catch (e, stackTrace) {
+      addError(e, stackTrace);
+      // Preserve the draft text on the state so the user can retry
+      // without retyping (contract: keep mainInputText / replyInputText
+      // untouched on failure).
+      emit(
+        state.copyWith(
+          isPosting: false,
+          error: isReply
+              ? CommentsError.postReplyFailed
+              : CommentsError.postCommentFailed,
+          lastActionFeedback: e.feedback,
+        ),
+      );
+    } catch (e, stackTrace) {
+      addError(e, stackTrace);
       Log.error(
         'Error posting comment: $e',
         name: 'CommentsBloc',
@@ -389,7 +405,16 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
           replyCountsByCommentId: _computeReplyCounts(updatedCommentsById),
         ),
       );
-    } catch (e) {
+    } on DeleteCommentFailedException catch (e, stackTrace) {
+      addError(e, stackTrace);
+      emit(
+        state.copyWith(
+          error: CommentsError.deleteCommentFailed,
+          lastActionFeedback: e.feedback,
+        ),
+      );
+    } catch (e, stackTrace) {
+      addError(e, stackTrace);
       Log.error(
         'Error deleting comment: $e',
         name: 'CommentsBloc',

--- a/mobile/lib/blocs/comments/comments_state.dart
+++ b/mobile/lib/blocs/comments/comments_state.dart
@@ -113,6 +113,7 @@ final class CommentsState extends Equatable {
     this.rootAddressableId,
     this.commentsById = const {},
     this.error,
+    this.lastActionFeedback,
     this.mainInputText = '',
     this.replyInputText = '',
     this.activeReplyCommentId,
@@ -281,6 +282,12 @@ final class CommentsState extends Equatable {
   /// UI layer maps this to localized string via BlocListener.
   final CommentsError? error;
 
+  /// User-facing feedback describing the most recent post/delete comment
+  /// publish attempt, derived from [PublishResultMapper]. The UI reads
+  /// this to render a retry-aware snackbar, and the bloc clears it when
+  /// the next action begins.
+  final PublishUserFeedback? lastActionFeedback;
+
   /// Text content of the main comment input
   final String mainInputText;
 
@@ -312,6 +319,8 @@ final class CommentsState extends Equatable {
     String? rootAddressableId,
     Map<String, Comment>? commentsById,
     CommentsError? error,
+    PublishUserFeedback? lastActionFeedback,
+    bool clearFeedback = false,
     String? mainInputText,
     String? replyInputText,
     String? activeReplyCommentId,
@@ -340,6 +349,9 @@ final class CommentsState extends Equatable {
       rootAddressableId: rootAddressableId ?? this.rootAddressableId,
       commentsById: commentsById ?? this.commentsById,
       error: error,
+      lastActionFeedback: clearFeedback
+          ? null
+          : (lastActionFeedback ?? this.lastActionFeedback),
       mainInputText: mainInputText ?? this.mainInputText,
       replyInputText: replyInputText ?? this.replyInputText,
       activeReplyCommentId: activeReplyCommentId ?? this.activeReplyCommentId,
@@ -438,6 +450,7 @@ final class CommentsState extends Equatable {
     rootAddressableId,
     commentsById,
     error,
+    lastActionFeedback,
     mainInputText,
     replyInputText,
     activeReplyCommentId,

--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -8,6 +8,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:models/models.dart' show NIP71VideoKinds;
+import 'package:nostr_client/nostr_client.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -177,7 +178,13 @@ class VideoInteractionsBloc
     // Prevent double-taps
     if (state.isLikeInProgress) return;
 
-    emit(state.copyWith(isLikeInProgress: true, clearError: true));
+    emit(
+      state.copyWith(
+        isLikeInProgress: true,
+        clearError: true,
+        clearFeedback: true,
+      ),
+    );
 
     try {
       // Pass addressable ID and target kind for proper a-tag tagging
@@ -207,7 +214,28 @@ class VideoInteractionsBloc
     } on NotLikedException {
       // Not liked - just update state to reflect reality
       emit(state.copyWith(isLiked: false, isLikeInProgress: false));
-    } catch (e) {
+    } on LikeFailedException catch (e, stackTrace) {
+      // Preserve optimistic state rollback (repo never committed) and
+      // surface feedback so the UI can render a retry-aware snackbar.
+      addError(e, stackTrace);
+      emit(
+        state.copyWith(
+          isLikeInProgress: false,
+          error: VideoInteractionsError.likeFailed,
+          lastActionFeedback: e.feedback,
+        ),
+      );
+    } on UnlikeFailedException catch (e, stackTrace) {
+      addError(e, stackTrace);
+      emit(
+        state.copyWith(
+          isLikeInProgress: false,
+          error: VideoInteractionsError.likeFailed,
+          lastActionFeedback: e.feedback,
+        ),
+      );
+    } catch (e, stackTrace) {
+      addError(e, stackTrace);
       Log.error(
         'VideoInteractionsBloc: Like toggle failed for $_eventId - $e',
         name: 'VideoInteractionsBloc',

--- a/mobile/lib/blocs/video_interactions/video_interactions_state.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_state.dart
@@ -29,6 +29,9 @@ enum VideoInteractionsStatus {
 /// - [isLikeInProgress]: Whether a like/unlike operation is in progress
 /// - [isRepostInProgress]: Whether a repost/unrepost operation is in progress
 /// - [isCommentsInProgress]: Whether a comments operation is in progress
+/// - [lastActionFeedback]: Publish feedback from the most recent like/repost
+///   toggle, surfaced so the UI can render a retry-aware snackbar. Cleared
+///   when the user begins a new action.
 class VideoInteractionsState extends Equatable {
   const VideoInteractionsState({
     this.status = VideoInteractionsStatus.initial,
@@ -41,6 +44,7 @@ class VideoInteractionsState extends Equatable {
     this.isRepostInProgress = false,
     this.isCommentsInProgress = false,
     this.error,
+    this.lastActionFeedback,
   });
 
   /// Current status of the bloc.
@@ -76,6 +80,11 @@ class VideoInteractionsState extends Equatable {
   /// Error that occurred, if any.
   final VideoInteractionsError? error;
 
+  /// User-facing feedback describing the most recent failed like/repost
+  /// action, derived from [PublishResultMapper]. The UI reads this to show
+  /// a retry-aware snackbar and clears it on the next action.
+  final PublishUserFeedback? lastActionFeedback;
+
   /// Whether interaction counts are still loading.
   bool get isLoading =>
       status == VideoInteractionsStatus.initial ||
@@ -96,7 +105,9 @@ class VideoInteractionsState extends Equatable {
     bool? isRepostInProgress,
     bool? isCommentsInProgress,
     VideoInteractionsError? error,
+    PublishUserFeedback? lastActionFeedback,
     bool clearError = false,
+    bool clearFeedback = false,
   }) {
     return VideoInteractionsState(
       status: status ?? this.status,
@@ -109,6 +120,9 @@ class VideoInteractionsState extends Equatable {
       isRepostInProgress: isRepostInProgress ?? this.isRepostInProgress,
       isCommentsInProgress: isCommentsInProgress ?? this.isCommentsInProgress,
       error: clearError ? null : (error ?? this.error),
+      lastActionFeedback: clearFeedback
+          ? null
+          : (lastActionFeedback ?? this.lastActionFeedback),
     );
   }
 
@@ -124,6 +138,7 @@ class VideoInteractionsState extends Equatable {
     isRepostInProgress,
     isCommentsInProgress,
     error,
+    lastActionFeedback,
   ];
 }
 

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:models/models.dart' hide NIP71VideoKinds;
+import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/blocs/comments/comments_bloc.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -240,12 +241,55 @@ class _CommentsScreenBody extends StatelessWidget {
       listenWhen: (prev, next) =>
           prev.error != next.error && next.error != null,
       listener: (context, state) {
-        if (state.error != null) {
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text(_errorToString(state.error!))));
-          context.read<CommentsBloc>().add(const CommentErrorCleared());
-        }
+        if (state.error == null) return;
+
+        // When the failure is a publish outcome failure, prefer the
+        // PublishResultMapper-derived message over the generic label so
+        // the user learns whether to retry. Fall back to the legacy
+        // error label for non-publish errors (load/vote/report/block).
+        final feedback = state.lastActionFeedback;
+        final useFeedback =
+            feedback != null &&
+            (state.error == CommentsError.postCommentFailed ||
+                state.error == CommentsError.postReplyFailed ||
+                state.error == CommentsError.deleteCommentFailed);
+        final baseMessage = useFeedback
+            ? _feedbackToMessage(feedback)
+            : _errorToString(state.error!);
+        final messenger = ScaffoldMessenger.of(context);
+        final bloc = context.read<CommentsBloc>();
+
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(baseMessage),
+            action: (useFeedback && feedback.retryable)
+                ? SnackBarAction(
+                    label: 'Retry',
+                    onPressed: () {
+                      // Re-emit CommentSubmitted. The bloc still has the
+                      // preserved draft text in state.mainInputText /
+                      // state.replyInputText, so retrying won't lose the
+                      // user's typed comment.
+                      if (state.error == CommentsError.postReplyFailed &&
+                          state.activeReplyCommentId != null) {
+                        final parentId = state.activeReplyCommentId!;
+                        final reply = state.commentsById[parentId];
+                        bloc.add(
+                          CommentSubmitted(
+                            parentCommentId: parentId,
+                            parentAuthorPubkey: reply?.authorPubkey,
+                          ),
+                        );
+                      } else if (state.error ==
+                          CommentsError.postCommentFailed) {
+                        bloc.add(const CommentSubmitted());
+                      }
+                    },
+                  )
+                : null,
+          ),
+        );
+        bloc.add(const CommentErrorCleared());
       },
       child: SizedBox(
         child: CommentsList(
@@ -255,6 +299,20 @@ class _CommentsScreenBody extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Produces a terse human-readable message for a [PublishUserFeedback].
+String _feedbackToMessage(PublishUserFeedback feedback) {
+  final reason = feedback.firstRejectionReason;
+  return switch (feedback.messageKey) {
+    'publish_no_relays_available' =>
+      'Could not reach any relays. Check your connection.',
+    'publish_no_relay_response' => 'No response from relays. Try again?',
+    'publish_rejected_permanent' when reason != null && reason.isNotEmpty =>
+      'Could not send: $reason',
+    'publish_rejected_permanent' => 'Could not send.',
+    _ => 'Something went wrong.',
+  };
 }
 
 /// Main comment input widget that reads from CommentsBloc state

--- a/mobile/lib/services/base/social_event_service_base.dart
+++ b/mobile/lib/services/base/social_event_service_base.dart
@@ -6,8 +6,16 @@ import 'package:nostr_sdk/event.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/personal_event_cache_service.dart';
 
-/// Base class for services that publish and manage social events (reactions, reposts, etc)
-/// Provides shared patterns for event lifecycle: create → sign → publish → cache
+/// Base class for services that publish and manage social events
+/// (reactions, reposts, etc).
+///
+/// Provides shared patterns for event lifecycle:
+/// create → sign → publish-with-retry → cache.
+///
+/// The publish path routes through [NostrClient.publishEventWithRetry]
+/// so subclasses benefit from bounded retry on transient relay failures
+/// and can inspect per-relay NIP-20 OK state via the returned
+/// [PublishOutcome].
 abstract class SocialEventServiceBase {
   /// Nostr service for broadcasting events to relays
   NostrClient get nostrService;
@@ -18,26 +26,44 @@ abstract class SocialEventServiceBase {
   /// Optional cache for storing user's own events locally
   PersonalEventCacheService? get personalEventCache;
 
-  /// Publishes event to relays and caches it locally
+  /// Publishes [event] to relays with retry and caches it locally on
+  /// [PublishOutcome.acceptedByAny].
   ///
-  /// Throws Exception if publish fails
+  /// Throws [Exception] if no relay accepted. The caller can inspect
+  /// the outcome via [broadcastAndCacheEventAwaitOk] if finer-grained
+  /// feedback is required.
   Future<String> broadcastAndCacheEvent(Event event) async {
-    // Cache immediately before publishing (optimistic update)
-    personalEventCache?.cacheUserEvent(event);
-
-    // Publish to relays
-    final sentEvent = await nostrService.publishEvent(event);
-
-    if (sentEvent == null) {
-      throw Exception('Failed to publish event to relays');
+    final outcome = await broadcastAndCacheEventAwaitOk(event);
+    if (!outcome.acceptedByAny) {
+      final feedback = PublishResultMapper.map(outcome);
+      throw Exception(
+        'Failed to publish event to relays '
+        '(retryable=${feedback.retryable} '
+        'reason=${feedback.firstRejectionReason ?? 'n/a'})',
+      );
     }
-
     return event.id;
   }
 
-  /// Creates, signs, broadcasts, and caches an event in one atomic operation
+  /// Publishes [event] via [NostrClient.publishEventWithRetry] and, on
+  /// any relay acceptance, caches the event locally for
+  /// same-device continuity.
   ///
-  /// Throws Exception if creation, signing, or broadcast fails
+  /// Returns the full [PublishOutcome] so callers can thread the
+  /// per-relay result through a typed `Result` type or UI snackbar via
+  /// [PublishResultMapper].
+  Future<PublishOutcome> broadcastAndCacheEventAwaitOk(Event event) async {
+    final outcome = await nostrService.publishEventWithRetry(event);
+    if (outcome.acceptedByAny) {
+      personalEventCache?.cacheUserEvent(event);
+    }
+    return outcome;
+  }
+
+  /// Creates, signs, broadcasts (with retry), and caches an event in one
+  /// atomic operation.
+  ///
+  /// Throws [Exception] if creation, signing, or publish fails.
   Future<String> createSignBroadcastAndCache({
     required int kind,
     required String content,
@@ -56,9 +82,9 @@ abstract class SocialEventServiceBase {
     return broadcastAndCacheEvent(event);
   }
 
-  /// Publishes a deletion event (Kind 5) for the target event
+  /// Publishes a deletion event (Kind 5) for the target event.
   ///
-  /// Throws Exception if deletion event creation or broadcast fails
+  /// Throws [Exception] if deletion event creation or broadcast fails.
   Future<void> publishDeletionEvent(String targetEventId) async {
     await createSignBroadcastAndCache(
       kind: 5,

--- a/mobile/lib/services/social_service.dart
+++ b/mobile/lib/services/social_service.dart
@@ -380,18 +380,28 @@ class SocialService {
       );
 
       if (event != null) {
-        // Cache the follow set event immediately after creation
-        _personalEventCache?.cacheUserEvent(event);
-
-        final sentEvent = await _nostrService.publishEvent(event);
-        if (sentEvent != null) {
-          // Update local set with Nostr event ID
+        // Publish with retry. Gate the local follow-set mutation (commit
+        // of nostrEventId) on outcome.acceptedByAny so the local map only
+        // reflects events the relays acknowledged — per the PR contract
+        // "don't commit to local follow map until acceptedByAny".
+        final outcome = await _nostrService.publishEventWithRetry(event);
+        if (outcome.acceptedByAny) {
+          _personalEventCache?.cacheUserEvent(event);
           final setIndex = _followSets.indexWhere((s) => s.id == set.id);
           if (setIndex != -1) {
             _followSets[setIndex] = set.copyWith(nostrEventId: event.id);
           }
           Log.debug(
             'Published follow set to Nostr: ${set.name} (${event.id})',
+            name: 'SocialService',
+            category: LogCategory.system,
+          );
+        } else {
+          final feedback = PublishResultMapper.map(outcome);
+          Log.warning(
+            'Follow-set publish failed: ${set.name} '
+            'retryable=${feedback.retryable} '
+            'reason=${feedback.firstRejectionReason ?? 'n/a'}',
             name: 'SocialService',
             category: LogCategory.system,
           );
@@ -510,11 +520,18 @@ class SocialService {
         throw Exception('Failed to create deletion request event');
       }
 
-      // Publish the deletion request
-      final sentEvent = await _nostrService.publishEvent(event);
+      // Publish the deletion request with retry. This is a user-initiated
+      // destructive action — surface a typed failure so the caller can
+      // inspect PublishOutcome + feedback.
+      final outcome = await _nostrService.publishEventWithRetry(event);
 
-      if (sentEvent == null) {
-        throw Exception('Failed to publish deletion request to relays');
+      if (!outcome.acceptedByAny) {
+        final feedback = PublishResultMapper.map(outcome);
+        throw Exception(
+          'Failed to publish deletion request to relays '
+          '(retryable=${feedback.retryable} '
+          'reason=${feedback.firstRejectionReason ?? 'n/a'})',
+        );
       }
 
       Log.info(

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -10,6 +10,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory, NIP71VideoKinds;
+import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -193,6 +194,46 @@ class _VideoFeedItemState extends ConsumerState<VideoFeedItem> {
         _pauseButtonOpacity = 1.0; // Reset for next use
       });
     });
+  }
+
+  /// Shows a snackbar describing the most recent like/repost failure and
+  /// offers a retry affordance when the feedback is retryable. Invoked by
+  /// the [BlocListener] around [VideoOverlayActions] so every visible feed
+  /// item participates, not just the active one.
+  void _onInteractionFeedback(
+    BuildContext context,
+    VideoInteractionsState state,
+  ) {
+    final feedback = state.lastActionFeedback;
+    if (feedback == null || feedback.severity != PublishSeverity.error) return;
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+
+    // Keep the message terse — the relay reason is useful in logs but the
+    // user primarily needs to know "we couldn't send that; try again?".
+    final messageKey = feedback.messageKey;
+    final reason = feedback.firstRejectionReason;
+    final baseMessage = messageKey == 'publish_rejected_permanent'
+        ? (reason != null && reason.isNotEmpty
+              ? "Couldn't send: $reason"
+              : "Couldn't send.")
+        : "Couldn't reach the relays — check your connection.";
+
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(baseMessage),
+        action: feedback.retryable
+            ? SnackBarAction(
+                label: 'Retry',
+                onPressed: () {
+                  _interactionsBloc.add(
+                    const VideoInteractionsLikeToggled(),
+                  );
+                },
+              )
+            : null,
+      ),
+    );
   }
 
   /// Handles double-tap to like. Only likes (never unlikes) per Instagram
@@ -1228,17 +1269,25 @@ class _VideoFeedItemState extends ConsumerState<VideoFeedItem> {
             // Wrap with VideoInteractionsBloc if available
             BlocProvider<VideoInteractionsBloc>.value(
               value: _interactionsBloc,
-              child: VideoOverlayActions(
-                video: video,
-                isVisible: overlayVisible,
-                isActive: isActive,
-                hasBottomNavigation: widget.hasBottomNavigation,
-                contextTitle: widget.contextTitle,
-                isFullscreen: widget.isFullscreen,
-                listSources: widget.listSources,
-                showListAttribution: widget.showListAttribution,
-                hideFollowButtonIfFollowing: widget.hideFollowButtonIfFollowing,
-              ),
+              child:
+                  BlocListener<VideoInteractionsBloc, VideoInteractionsState>(
+                    listenWhen: (prev, curr) =>
+                        prev.lastActionFeedback != curr.lastActionFeedback &&
+                        curr.lastActionFeedback != null,
+                    listener: _onInteractionFeedback,
+                    child: VideoOverlayActions(
+                      video: video,
+                      isVisible: overlayVisible,
+                      isActive: isActive,
+                      hasBottomNavigation: widget.hasBottomNavigation,
+                      contextTitle: widget.contextTitle,
+                      isFullscreen: widget.isFullscreen,
+                      listSources: widget.listSources,
+                      showListAttribution: widget.showListAttribution,
+                      hideFollowButtonIfFollowing:
+                          widget.hideFollowButtonIfFollowing,
+                    ),
+                  ),
             ),
 
             Positioned.fill(

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -265,20 +265,26 @@ class CommentsRepository {
     );
 
     try {
-      // Broadcast the event (NostrClient handles signing)
-      final sentEvent = await _nostrClient.publishEvent(event);
+      // Broadcast with retry on transient relay failures. NostrClient
+      // signs the event before publishing and surfaces per-relay ack state
+      // via the returned outcome.
+      final outcome = await _nostrClient.publishEventWithRetry(event);
 
-      if (sentEvent == null) {
-        throw const PostCommentFailedException('Failed to publish comment');
+      if (!outcome.acceptedByAny) {
+        throw PostCommentFailedException(
+          'Failed to publish comment',
+          outcome,
+          PublishResultMapper.map(outcome),
+        );
       }
 
       final cached = _commentCountCache[rootEventId];
       if (cached != null) _commentCountCache[rootEventId] = cached + 1;
 
       return Comment(
-        id: sentEvent.id,
+        id: outcome.eventId,
         content: trimmedContent,
-        authorPubkey: sentEvent.pubkey,
+        authorPubkey: event.pubkey,
         createdAt: event.createdAtDateTime,
         rootEventId: rootEventId,
         rootAuthorPubkey: rootEventAuthorPubkey,
@@ -405,10 +411,12 @@ class CommentsRepository {
         reason ?? '',
       );
 
-      final sentEvent = await _nostrClient.publishEvent(event);
-      if (sentEvent == null) {
-        throw const DeleteCommentFailedException(
+      final outcome = await _nostrClient.publishEventWithRetry(event);
+      if (!outcome.acceptedByAny) {
+        throw DeleteCommentFailedException(
           'Failed to publish deletion request',
+          outcome,
+          PublishResultMapper.map(outcome),
         );
       }
 

--- a/mobile/packages/comments_repository/lib/src/exceptions.dart
+++ b/mobile/packages/comments_repository/lib/src/exceptions.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Provides typed exceptions for specific failure cases
 // ABOUTME: to enable precise error handling by consumers.
 
+import 'package:nostr_client/nostr_client.dart';
+
 /// Base exception for all comments repository errors.
 abstract class CommentsRepositoryException implements Exception {
   /// Creates a new comments repository exception.
@@ -28,7 +30,18 @@ class LoadCommentsFailedException extends CommentsRepositoryException {
 /// Exception thrown when posting a comment fails.
 class PostCommentFailedException extends CommentsRepositoryException {
   /// Creates a new post comment failed exception.
-  const PostCommentFailedException([super.message]);
+  const PostCommentFailedException([
+    super.message,
+    this.outcome,
+    this.feedback,
+  ]);
+
+  /// Per-relay OK/rejection state from the failed publish attempt, when
+  /// available. Null when the failure is from a legacy code path.
+  final PublishOutcome? outcome;
+
+  /// User-facing feedback derived from [outcome] via [PublishResultMapper].
+  final PublishUserFeedback? feedback;
 }
 
 /// Exception thrown when counting comments fails.
@@ -46,7 +59,18 @@ class InvalidCommentContentException extends CommentsRepositoryException {
 /// Exception thrown when deleting a comment fails.
 class DeleteCommentFailedException extends CommentsRepositoryException {
   /// Creates a new delete comment failed exception.
-  const DeleteCommentFailedException([super.message]);
+  const DeleteCommentFailedException([
+    super.message,
+    this.outcome,
+    this.feedback,
+  ]);
+
+  /// Per-relay OK/rejection state from the failed publish attempt, when
+  /// available. Null when the failure is from a legacy code path.
+  final PublishOutcome? outcome;
+
+  /// User-facing feedback derived from [outcome] via [PublishResultMapper].
+  final PublishUserFeedback? feedback;
 }
 
 /// Exception thrown when watching comments fails.

--- a/mobile/packages/comments_repository/test/src/comments_repository_reliability_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_reliability_test.dart
@@ -1,0 +1,166 @@
+// ABOUTME: Verifies CommentsRepository surfaces PublishOutcome + feedback via
+// ABOUTME: PostCommentFailedException / DeleteCommentFailedException so the UI
+// ABOUTME: can keep the draft text and render a retry-aware snackbar.
+
+import 'package:comments_repository/comments_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:test/test.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _FakeEvent extends Fake implements Event {}
+
+const _testUserPubkey =
+    '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2';
+const _testRootEventId =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+const _testRootAuthorPubkey =
+    '2222222222222222222222222222222222222222222222222222222222222222';
+const _testCommentId =
+    '3333333333333333333333333333333333333333333333333333333333333333';
+
+PublishOutcome _accepted(String id) => PublishOutcome(
+  eventId: id,
+  acceptedBy: const {'wss://relay.example.com'},
+  rejectedBy: const {},
+  noResponseFrom: const {},
+);
+
+PublishOutcome _transient(String id) => PublishOutcome(
+  eventId: id,
+  acceptedBy: const {},
+  rejectedBy: const {},
+  noResponseFrom: const {'wss://relay.example.com'},
+);
+
+PublishOutcome _permanent(String id) => PublishOutcome(
+  eventId: id,
+  acceptedBy: const {},
+  rejectedBy: const {'wss://relay.example.com': 'blocked: spam'},
+  noResponseFrom: const {},
+);
+
+void main() {
+  late _MockNostrClient mockNostr;
+  late CommentsRepository repo;
+
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+    registerFallbackValue(const RetryPolicy());
+  });
+
+  setUp(() {
+    mockNostr = _MockNostrClient();
+    when(() => mockNostr.publicKey).thenReturn(_testUserPubkey);
+    repo = CommentsRepository(nostrClient: mockNostr);
+  });
+
+  group('CommentsRepository publish reliability', () {
+    test(
+      'postComment success returns comment with event id from outcome',
+      () async {
+        when(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((inv) async {
+          final e = inv.positionalArguments.first as Event;
+          return _accepted(e.id);
+        });
+
+        final comment = await repo.postComment(
+          content: 'hello world',
+          rootEventId: _testRootEventId,
+          rootEventKind: 34236,
+          rootEventAuthorPubkey: _testRootAuthorPubkey,
+        );
+
+        expect(comment.content, equals('hello world'));
+        expect(comment.authorPubkey, equals(_testUserPubkey));
+      },
+    );
+
+    test(
+      'postComment transient failure → exception carries retryable feedback',
+      () async {
+        when(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((inv) async {
+          final e = inv.positionalArguments.first as Event;
+          return _transient(e.id);
+        });
+
+        try {
+          await repo.postComment(
+            content: 'hello',
+            rootEventId: _testRootEventId,
+            rootEventKind: 34236,
+            rootEventAuthorPubkey: _testRootAuthorPubkey,
+          );
+          fail('expected PostCommentFailedException');
+        } on PostCommentFailedException catch (e) {
+          expect(e.outcome, isNotNull);
+          expect(e.feedback, isNotNull);
+          expect(e.feedback!.retryable, isTrue);
+          expect(e.feedback!.messageKey, 'publish_no_relay_response');
+        }
+      },
+    );
+
+    test(
+      'deleteComment permanent rejection → non-retryable feedback with reason',
+      () async {
+        when(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((inv) async {
+          final e = inv.positionalArguments.first as Event;
+          return _permanent(e.id);
+        });
+
+        try {
+          await repo.deleteComment(commentId: _testCommentId);
+          fail('expected DeleteCommentFailedException');
+        } on DeleteCommentFailedException catch (e) {
+          expect(e.feedback!.retryable, isFalse);
+          expect(e.feedback!.messageKey, 'publish_rejected_permanent');
+          expect(e.feedback!.firstRejectionReason, 'blocked: spam');
+        }
+      },
+    );
+
+    test(
+      'deleteComment transient failure is retryable',
+      () async {
+        when(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((inv) async {
+          final e = inv.positionalArguments.first as Event;
+          return _transient(e.id);
+        });
+
+        try {
+          await repo.deleteComment(commentId: _testCommentId);
+          fail('expected DeleteCommentFailedException');
+        } on DeleteCommentFailedException catch (e) {
+          expect(e.feedback!.retryable, isTrue);
+        }
+      },
+    );
+  });
+}

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -38,6 +38,7 @@ void main() {
     setUpAll(() {
       registerFallbackValue(<Filter>[]);
       registerFallbackValue(FakeEvent());
+      registerFallbackValue(const RetryPolicy());
     });
 
     setUp(() {
@@ -721,8 +722,20 @@ void main() {
       test('posts top-level comment with correct tags', () async {
         Event? capturedEvent;
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          return capturedEvent = inv.positionalArguments.first as Event;
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((inv) async {
+          capturedEvent = inv.positionalArguments.first as Event;
+          return PublishOutcome(
+            eventId: capturedEvent!.id,
+            acceptedBy: const {'wss://relay.example.com'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          );
         });
 
         await repository.postComment(
@@ -789,8 +802,20 @@ void main() {
         const parentAuthorPubkey =
             'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          return capturedEvent = inv.positionalArguments.first as Event;
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((inv) async {
+          capturedEvent = inv.positionalArguments.first as Event;
+          return PublishOutcome(
+            eventId: capturedEvent!.id,
+            acceptedBy: const {'wss://relay.example.com'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          );
         });
 
         await repository.postComment(
@@ -856,10 +881,22 @@ void main() {
           Event? capturedEvent;
           const testAddressableId = '34236:$testRootAuthorPubkey:my-video-dtag';
 
-          when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+          when(
+            () => mockNostrClient.publishEventWithRetry(
+              any(),
+              policy: any(named: 'policy'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((
             inv,
           ) async {
-            return capturedEvent = inv.positionalArguments.first as Event;
+            capturedEvent = inv.positionalArguments.first as Event;
+            return PublishOutcome(
+              eventId: capturedEvent!.id,
+              acceptedBy: const {'wss://relay.example.com'},
+              rejectedBy: const {},
+              noResponseFrom: const {},
+            );
           });
 
           await repository.postComment(
@@ -908,10 +945,22 @@ void main() {
               'ffffffffffffffffffffffffffffffff'
               'ffffffffffffffff';
 
-          when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+          when(
+            () => mockNostrClient.publishEventWithRetry(
+              any(),
+              policy: any(named: 'policy'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((
             inv,
           ) async {
-            return capturedEvent = inv.positionalArguments.first as Event;
+            capturedEvent = inv.positionalArguments.first as Event;
+            return PublishOutcome(
+              eventId: capturedEvent!.id,
+              acceptedBy: const {'wss://relay.example.com'},
+              rejectedBy: const {},
+              noResponseFrom: const {},
+            );
           });
 
           await repository.postComment(
@@ -948,10 +997,22 @@ void main() {
         () async {
           Event? capturedEvent;
 
-          when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+          when(
+            () => mockNostrClient.publishEventWithRetry(
+              any(),
+              policy: any(named: 'policy'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((
             inv,
           ) async {
-            return capturedEvent = inv.positionalArguments.first as Event;
+            capturedEvent = inv.positionalArguments.first as Event;
+            return PublishOutcome(
+              eventId: capturedEvent!.id,
+              acceptedBy: const {'wss://relay.example.com'},
+              rejectedBy: const {},
+              noResponseFrom: const {},
+            );
           });
 
           await repository.postComment(
@@ -976,9 +1037,21 @@ void main() {
       );
 
       test('returns created Comment', () async {
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          return inv.positionalArguments.first as Event
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((inv) async {
+          final e = inv.positionalArguments.first as Event
             ..id = 'created_event_id';
+          return PublishOutcome(
+            eventId: e.id,
+            acceptedBy: const {'wss://relay.example.com'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          );
         });
 
         final result = await repository.postComment(
@@ -1024,8 +1097,20 @@ void main() {
       test('trims content before posting', () async {
         Event? capturedEvent;
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          return capturedEvent = inv.positionalArguments.first as Event;
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((inv) async {
+          capturedEvent = inv.positionalArguments.first as Event;
+          return PublishOutcome(
+            eventId: capturedEvent!.id,
+            acceptedBy: const {'wss://relay.example.com'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          );
         });
 
         await repository.postComment(
@@ -1040,8 +1125,19 @@ void main() {
 
       test('throws PostCommentFailedException when publish fails', () async {
         when(
-          () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => null);
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'placeholder' * 8,
+            acceptedBy: const {},
+            rejectedBy: const {},
+            noResponseFrom: const {'wss://relay.example.com'},
+          ),
+        );
 
         expect(
           () => repository.postComment(
@@ -1056,7 +1152,11 @@ void main() {
 
       test('throws PostCommentFailedException on exception', () async {
         when(
-          () => mockNostrClient.publishEvent(any()),
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
         ).thenThrow(Exception('Network error'));
 
         expect(
@@ -1190,8 +1290,22 @@ void main() {
         when(() => mockNostrClient.countEvents(any())).thenAnswer(
           (_) async => const CountResult(count: 5),
         );
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (inv) async => inv.positionalArguments.first as Event,
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (inv) async {
+            final e = inv.positionalArguments.first as Event;
+            return PublishOutcome(
+              eventId: e.id,
+              acceptedBy: const {'wss://relay.example.com'},
+              rejectedBy: const {},
+              noResponseFrom: const {},
+            );
+          },
         );
 
         await repository.getCommentsCount(testRootEventId);
@@ -1231,8 +1345,20 @@ void main() {
       test('publishes deletion event with correct tags', () async {
         Event? capturedEvent;
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          return capturedEvent = inv.positionalArguments.first as Event;
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((inv) async {
+          capturedEvent = inv.positionalArguments.first as Event;
+          return PublishOutcome(
+            eventId: capturedEvent!.id,
+            acceptedBy: const {'wss://relay.example.com'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          );
         });
 
         await repository.deleteComment(commentId: testCommentId);
@@ -1259,8 +1385,20 @@ void main() {
       test('publishes deletion event with reason when provided', () async {
         Event? capturedEvent;
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
-          return capturedEvent = inv.positionalArguments.first as Event;
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((inv) async {
+          capturedEvent = inv.positionalArguments.first as Event;
+          return PublishOutcome(
+            eventId: capturedEvent!.id,
+            acceptedBy: const {'wss://relay.example.com'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          );
         });
 
         await repository.deleteComment(
@@ -1277,10 +1415,22 @@ void main() {
         () async {
           Event? capturedEvent;
 
-          when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+          when(
+            () => mockNostrClient.publishEventWithRetry(
+              any(),
+              policy: any(named: 'policy'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((
             inv,
           ) async {
-            return capturedEvent = inv.positionalArguments.first as Event;
+            capturedEvent = inv.positionalArguments.first as Event;
+            return PublishOutcome(
+              eventId: capturedEvent!.id,
+              acceptedBy: const {'wss://relay.example.com'},
+              rejectedBy: const {},
+              noResponseFrom: const {},
+            );
           });
 
           await repository.deleteComment(commentId: testCommentId);
@@ -1294,8 +1444,19 @@ void main() {
         'throws DeleteCommentFailedException when publish returns null',
         () async {
           when(
-            () => mockNostrClient.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+            () => mockNostrClient.publishEventWithRetry(
+              any(),
+              policy: any(named: 'policy'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer(
+            (_) async => PublishOutcome(
+              eventId: 'placeholder' * 8,
+              acceptedBy: const {},
+              rejectedBy: const {},
+              noResponseFrom: const {'wss://relay.example.com'},
+            ),
+          );
 
           expect(
             () => repository.deleteComment(commentId: testCommentId),
@@ -1306,7 +1467,11 @@ void main() {
 
       test('throws DeleteCommentFailedException on exception', () async {
         when(
-          () => mockNostrClient.publishEvent(any()),
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
         ).thenThrow(Exception('Network error'));
 
         expect(
@@ -1316,7 +1481,13 @@ void main() {
       });
 
       test('rethrows DeleteCommentFailedException', () async {
-        when(() => mockNostrClient.publishEvent(any())).thenThrow(
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenThrow(
           const DeleteCommentFailedException('Custom error'),
         );
 
@@ -1336,8 +1507,22 @@ void main() {
         when(() => mockNostrClient.countEvents(any())).thenAnswer(
           (_) async => const CountResult(count: 10),
         );
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (inv) async => inv.positionalArguments.first as Event,
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (inv) async {
+            final e = inv.positionalArguments.first as Event;
+            return PublishOutcome(
+              eventId: e.id,
+              acceptedBy: const {'wss://relay.example.com'},
+              rejectedBy: const {},
+              noResponseFrom: const {},
+            );
+          },
         );
 
         await repository.getCommentsCount(testRootEventId);
@@ -1355,8 +1540,22 @@ void main() {
         when(() => mockNostrClient.countEvents(any())).thenAnswer(
           (_) async => const CountResult(count: 10),
         );
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (inv) async => inv.positionalArguments.first as Event,
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (inv) async {
+            final e = inv.positionalArguments.first as Event;
+            return PublishOutcome(
+              eventId: e.id,
+              acceptedBy: const {'wss://relay.example.com'},
+              rejectedBy: const {},
+              noResponseFrom: const {},
+            );
+          },
         );
 
         await repository.getCommentsCount(testRootEventId);

--- a/mobile/packages/likes_repository/lib/src/exceptions.dart
+++ b/mobile/packages/likes_repository/lib/src/exceptions.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Exception classes for the likes repository.
 // ABOUTME: Provides typed exceptions for like/unlike operations.
 
+import 'package:nostr_client/nostr_client.dart';
+
 /// Base exception for all likes repository errors.
 class LikesRepositoryException implements Exception {
   /// Creates a new likes repository exception.
@@ -19,9 +21,20 @@ class LikesRepositoryException implements Exception {
 /// - The Nostr client fails to publish the reaction event
 /// - The relay rejects the event
 /// - Network connectivity issues
+///
+/// When the failure came from `publishEventWithRetry`, [outcome] and
+/// [feedback] are populated so the UI can render a retry affordance via
+/// [PublishResultMapper].
 class LikeFailedException extends LikesRepositoryException {
   /// Creates a new like failed exception.
-  const LikeFailedException(super.message);
+  const LikeFailedException(super.message, {this.outcome, this.feedback});
+
+  /// Per-relay OK/rejection state from the failed publish attempt, when
+  /// available. Null when the failure is from a legacy code path.
+  final PublishOutcome? outcome;
+
+  /// User-facing feedback derived from [outcome] via [PublishResultMapper].
+  final PublishUserFeedback? feedback;
 
   @override
   String toString() => 'LikeFailedException: $message';
@@ -34,9 +47,20 @@ class LikeFailedException extends LikesRepositoryException {
 /// - The Nostr client fails to publish the deletion event
 /// - The relay rejects the deletion
 /// - Network connectivity issues
+///
+/// When the failure came from `publishEventWithRetry`, [outcome] and
+/// [feedback] are populated so the UI can render a retry affordance via
+/// [PublishResultMapper].
 class UnlikeFailedException extends LikesRepositoryException {
   /// Creates a new unlike failed exception.
-  const UnlikeFailedException(super.message);
+  const UnlikeFailedException(super.message, {this.outcome, this.feedback});
+
+  /// Per-relay OK/rejection state from the failed publish attempt, when
+  /// available. Null when the failure is from a legacy code path.
+  final PublishOutcome? outcome;
+
+  /// User-facing feedback derived from [outcome] via [PublishResultMapper].
+  final PublishUserFeedback? feedback;
 
   @override
   String toString() => 'UnlikeFailedException: $message';

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -229,23 +229,30 @@ class LikesRepository {
       return placeholderId;
     }
 
-    // Publish Kind 7 reaction event via NostrClient
-    final reactionEvent = await _nostrClient.sendLike(
-      eventId,
-      content: _likeContent,
+    // Publish Kind 7 reaction event via NostrClient with retry on transient
+    // relay failures. Surface a typed failure on outcome.failed so the UI
+    // can decide retryability via PublishResultMapper.
+    final outcome = await _nostrClient.sendLikeAwaitOk(
+      eventId: eventId,
+      authorPubkey: authorPubkey,
       addressableId: addressableId,
-      targetAuthorPubkey: authorPubkey,
       targetKind: targetKind,
+      content: _likeContent,
+      policy: const RetryPolicy(),
     );
 
-    if (reactionEvent == null) {
-      throw const LikeFailedException('Failed to publish like reaction');
+    if (!outcome.acceptedByAny) {
+      throw LikeFailedException(
+        'Failed to publish like reaction',
+        outcome: outcome,
+        feedback: PublishResultMapper.map(outcome),
+      );
     }
 
     // Create and store the like record
     final record = LikeRecord(
       targetEventId: eventId,
-      reactionEventId: reactionEvent.id,
+      reactionEventId: outcome.eventId,
       createdAt: DateTime.now(),
     );
 
@@ -256,7 +263,7 @@ class LikesRepository {
     final cached = _likeCountCache[eventId];
     if (cached != null) _likeCountCache[eventId] = cached + 1;
 
-    return reactionEvent.id;
+    return outcome.eventId;
   }
 
   /// Execute a like action directly (for use by sync service).
@@ -269,17 +276,22 @@ class LikesRepository {
     String? addressableId,
     int? targetKind,
   }) async {
-    // Publish Kind 7 reaction event via NostrClient
-    final reactionEvent = await _nostrClient.sendLike(
-      eventId,
-      content: _likeContent,
+    // Publish Kind 7 reaction event via NostrClient with retry.
+    final outcome = await _nostrClient.sendLikeAwaitOk(
+      eventId: eventId,
+      authorPubkey: authorPubkey,
       addressableId: addressableId,
-      targetAuthorPubkey: authorPubkey,
       targetKind: targetKind,
+      content: _likeContent,
+      policy: const RetryPolicy(),
     );
 
-    if (reactionEvent == null) {
-      throw const LikeFailedException('Failed to publish like reaction');
+    if (!outcome.acceptedByAny) {
+      throw LikeFailedException(
+        'Failed to publish like reaction',
+        outcome: outcome,
+        feedback: PublishResultMapper.map(outcome),
+      );
     }
 
     // Update local record with real event ID if we have a placeholder
@@ -288,14 +300,14 @@ class LikesRepository {
         existingRecord.reactionEventId.startsWith('pending_')) {
       final record = LikeRecord(
         targetEventId: eventId,
-        reactionEventId: reactionEvent.id,
+        reactionEventId: outcome.eventId,
         createdAt: existingRecord.createdAt,
       );
       _likeRecords[eventId] = record;
       await _localStorage?.saveLikeRecord(record);
     }
 
-    return reactionEvent.id;
+    return outcome.eventId;
   }
 
   /// Unlike an event.
@@ -341,13 +353,18 @@ class LikesRepository {
 
     // Skip publishing deletion if this was a pending like that never synced
     if (!record.reactionEventId.startsWith('pending_')) {
-      // Publish Kind 5 deletion event via NostrClient
-      final deletionEvent = await _nostrClient.deleteEvent(
+      // Publish Kind 5 deletion event via NostrClient with retry.
+      final outcome = await _nostrClient.deleteEventAwaitOk(
         record.reactionEventId,
+        policy: const RetryPolicy(),
       );
 
-      if (deletionEvent == null) {
-        throw const UnlikeFailedException('Failed to publish unlike deletion');
+      if (!outcome.acceptedByAny) {
+        throw UnlikeFailedException(
+          'Failed to publish unlike deletion',
+          outcome: outcome,
+          feedback: PublishResultMapper.map(outcome),
+        );
       }
     }
 
@@ -384,13 +401,18 @@ class LikesRepository {
       return;
     }
 
-    // Publish Kind 5 deletion event via NostrClient
-    final deletionEvent = await _nostrClient.deleteEvent(
+    // Publish Kind 5 deletion event via NostrClient with retry.
+    final outcome = await _nostrClient.deleteEventAwaitOk(
       record.reactionEventId,
+      policy: const RetryPolicy(),
     );
 
-    if (deletionEvent == null) {
-      throw const UnlikeFailedException('Failed to publish unlike deletion');
+    if (!outcome.acceptedByAny) {
+      throw UnlikeFailedException(
+        'Failed to publish unlike deletion',
+        outcome: outcome,
+        feedback: PublishResultMapper.map(outcome),
+      );
     }
 
     // Remove from cache and storage
@@ -711,27 +733,39 @@ class LikesRepository {
     required String authorPubkey,
     int? targetKind,
   }) async {
-    final reactionEvent = await _nostrClient.sendLike(
-      eventId,
-      content: _downvoteContent,
-      targetAuthorPubkey: authorPubkey,
+    final outcome = await _nostrClient.sendLikeAwaitOk(
+      eventId: eventId,
+      authorPubkey: authorPubkey,
       targetKind: targetKind,
+      content: _downvoteContent,
+      policy: const RetryPolicy(),
     );
 
-    if (reactionEvent == null) {
-      throw const LikeFailedException('Failed to publish downvote reaction');
+    if (!outcome.acceptedByAny) {
+      throw LikeFailedException(
+        'Failed to publish downvote reaction',
+        outcome: outcome,
+        feedback: PublishResultMapper.map(outcome),
+      );
     }
 
-    return reactionEvent.id;
+    return outcome.eventId;
   }
 
   /// Delete a reaction event by its ID (Kind 5 deletion).
   ///
   /// Used for vote switching (removing old vote before publishing new one).
   Future<void> deleteReaction(String reactionEventId) async {
-    final deletionEvent = await _nostrClient.deleteEvent(reactionEventId);
-    if (deletionEvent == null) {
-      throw const UnlikeFailedException('Failed to delete reaction');
+    final outcome = await _nostrClient.deleteEventAwaitOk(
+      reactionEventId,
+      policy: const RetryPolicy(),
+    );
+    if (!outcome.acceptedByAny) {
+      throw UnlikeFailedException(
+        'Failed to delete reaction',
+        outcome: outcome,
+        feedback: PublishResultMapper.map(outcome),
+      );
     }
   }
 

--- a/mobile/packages/likes_repository/test/src/likes_repository_reliability_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_reliability_test.dart
@@ -1,0 +1,242 @@
+// ABOUTME: Verifies LikesRepository surfaces PublishOutcome + feedback on
+// ABOUTME: the LikeFailed/UnlikeFailed exceptions and preserves the
+// ABOUTME: optimistic rollback contract when the relay rejects.
+
+import 'package:likes_repository/likes_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:test/test.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockLikesLocalStorage extends Mock implements LikesLocalStorage {}
+
+const _testUserPubkey =
+    '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2';
+const _testEventId =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+const _testAuthorPubkey =
+    '2222222222222222222222222222222222222222222222222222222222222222';
+const _testReactionId =
+    '3333333333333333333333333333333333333333333333333333333333333333';
+
+PublishOutcome _accepted(String id) => PublishOutcome(
+  eventId: id,
+  acceptedBy: const {'wss://relay.example.com'},
+  rejectedBy: const {},
+  noResponseFrom: const {},
+);
+
+PublishOutcome _transient(String id) => PublishOutcome(
+  eventId: id,
+  acceptedBy: const {},
+  rejectedBy: const {},
+  noResponseFrom: const {'wss://relay.example.com'},
+);
+
+PublishOutcome _permanent(String id) => PublishOutcome(
+  eventId: id,
+  acceptedBy: const {},
+  rejectedBy: const {'wss://relay.example.com': 'blocked: spam'},
+  noResponseFrom: const {},
+);
+
+void main() {
+  late _MockNostrClient mockNostr;
+  late _MockLikesLocalStorage mockStorage;
+
+  setUpAll(() {
+    registerFallbackValue(const RetryPolicy());
+    registerFallbackValue(
+      LikeRecord(
+        targetEventId: _testEventId,
+        reactionEventId: _testReactionId,
+        createdAt: DateTime(2026),
+      ),
+    );
+  });
+
+  setUp(() {
+    mockNostr = _MockNostrClient();
+    mockStorage = _MockLikesLocalStorage();
+    when(() => mockNostr.publicKey).thenReturn(_testUserPubkey);
+    when(() => mockNostr.hasKeys).thenReturn(false);
+    when(() => mockNostr.unsubscribe(any())).thenAnswer((_) async {});
+    when(() => mockStorage.getAllLikeRecords()).thenAnswer((_) async => []);
+    when(
+      () => mockStorage.watchLikedEventIds(),
+    ).thenAnswer((_) => Stream.value(<String>[]));
+    when(() => mockStorage.isLiked(any())).thenAnswer((_) async => false);
+    when(() => mockStorage.getLikeRecord(any())).thenAnswer((_) async => null);
+    when(() => mockStorage.saveLikeRecord(any())).thenAnswer((_) async {});
+    when(
+      () => mockStorage.deleteLikeRecord(any()),
+    ).thenAnswer((_) async => true);
+  });
+
+  group('LikesRepository publish reliability', () {
+    test(
+      'like succeeds on acceptedByAny → record saved, reaction id returned',
+      () async {
+        when(
+          () => mockNostr.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
+            addressableId: any(named: 'addressableId'),
+            targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _accepted(_testReactionId));
+
+        final repo = LikesRepository(
+          nostrClient: mockNostr,
+          localStorage: mockStorage,
+        );
+
+        final reactionId = await repo.likeEvent(
+          eventId: _testEventId,
+          authorPubkey: _testAuthorPubkey,
+        );
+
+        expect(reactionId, equals(_testReactionId));
+        expect(await repo.isLiked(_testEventId), isTrue);
+        verify(() => mockStorage.saveLikeRecord(any())).called(1);
+
+        repo.dispose();
+      },
+    );
+
+    test(
+      'like transient failure → exception carries retryable feedback, '
+      'no local record saved',
+      () async {
+        when(
+          () => mockNostr.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
+            addressableId: any(named: 'addressableId'),
+            targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _transient(_testReactionId));
+
+        final repo = LikesRepository(
+          nostrClient: mockNostr,
+          localStorage: mockStorage,
+        );
+
+        try {
+          await repo.likeEvent(
+            eventId: _testEventId,
+            authorPubkey: _testAuthorPubkey,
+          );
+          fail('expected LikeFailedException');
+        } on LikeFailedException catch (e) {
+          expect(e.outcome, isNotNull);
+          expect(e.outcome!.acceptedByAny, isFalse);
+          expect(e.outcome!.transientRelays, {'wss://relay.example.com'});
+          expect(e.feedback, isNotNull);
+          expect(e.feedback!.retryable, isTrue);
+          expect(e.feedback!.messageKey, 'publish_no_relay_response');
+        }
+
+        // No optimistic cache write when we haven't accepted yet — the
+        // repository doesn't insert into _likeRecords or save to storage.
+        expect(await repo.isLiked(_testEventId), isFalse);
+        verifyNever(() => mockStorage.saveLikeRecord(any()));
+
+        repo.dispose();
+      },
+    );
+
+    test(
+      'unlike permanent rejection → exception carries non-retryable feedback, '
+      'local record preserved',
+      () async {
+        // Seed the local cache so the repo has a record to unlike.
+        when(() => mockStorage.getAllLikeRecords()).thenAnswer(
+          (_) async => [
+            LikeRecord(
+              targetEventId: _testEventId,
+              reactionEventId: _testReactionId,
+              createdAt: DateTime.now(),
+            ),
+          ],
+        );
+        when(
+          () => mockNostr.deleteEventAwaitOk(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _permanent(_testReactionId));
+
+        final repo = LikesRepository(
+          nostrClient: mockNostr,
+          localStorage: mockStorage,
+        );
+        await repo.isLiked(_testEventId); // trigger init
+
+        try {
+          await repo.unlikeEvent(_testEventId);
+          fail('expected UnlikeFailedException');
+        } on UnlikeFailedException catch (e) {
+          expect(e.outcome, isNotNull);
+          expect(e.outcome!.rejectedBy, isNotEmpty);
+          expect(e.feedback!.retryable, isFalse);
+          expect(e.feedback!.messageKey, 'publish_rejected_permanent');
+          expect(e.feedback!.firstRejectionReason, 'blocked: spam');
+        }
+
+        // Contract: the like is still present locally when the relay
+        // rejected the deletion so the UI can re-try without losing state.
+        expect(await repo.isLiked(_testEventId), isTrue);
+        verifyNever(() => mockStorage.deleteLikeRecord(_testEventId));
+
+        repo.dispose();
+      },
+    );
+
+    test(
+      'unlike transient failure → exception carries retryable feedback',
+      () async {
+        when(() => mockStorage.getAllLikeRecords()).thenAnswer(
+          (_) async => [
+            LikeRecord(
+              targetEventId: _testEventId,
+              reactionEventId: _testReactionId,
+              createdAt: DateTime.now(),
+            ),
+          ],
+        );
+        when(
+          () => mockNostr.deleteEventAwaitOk(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _transient(_testReactionId));
+
+        final repo = LikesRepository(
+          nostrClient: mockNostr,
+          localStorage: mockStorage,
+        );
+        await repo.isLiked(_testEventId);
+
+        try {
+          await repo.unlikeEvent(_testEventId);
+          fail('expected UnlikeFailedException');
+        } on UnlikeFailedException catch (e) {
+          expect(e.feedback!.retryable, isTrue);
+          expect(e.feedback!.messageKey, 'publish_no_relay_response');
+        }
+
+        repo.dispose();
+      },
+    );
+  });
+}

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -78,11 +78,32 @@ void main() {
       );
     }
 
+    // Build a PublishOutcome that signals acceptance by one relay. We
+    // centralize this so individual tests can stub sendLikeAwaitOk /
+    // deleteEventAwaitOk consistently without repeating the constructor.
+    PublishOutcome acceptedOutcome({String id = testReactionEventId}) =>
+        PublishOutcome(
+          eventId: id,
+          acceptedBy: const {'wss://relay.example.com'},
+          rejectedBy: const {},
+          noResponseFrom: const {},
+        );
+
+    /// A transient outcome — no acceptance. Maps to a retryable failure.
+    PublishOutcome transientOutcome({String id = testReactionEventId}) =>
+        PublishOutcome(
+          eventId: id,
+          acceptedBy: const {},
+          rejectedBy: const {},
+          noResponseFrom: const {'wss://relay.example.com'},
+        );
+
     setUpAll(() {
       registerFallbackValue(MockEvent());
       registerFallbackValue(<Filter>[]);
       registerFallbackValue(createLikeRecord());
       registerFallbackValue('');
+      registerFallbackValue(const RetryPolicy());
     });
 
     setUp(() {
@@ -213,14 +234,16 @@ void main() {
         final mockEvent = MockEvent();
         when(() => mockEvent.id).thenReturn(testReactionEventId);
         when(
-          () => mockNostrClient.sendLike(
-            any(),
-            content: any(named: 'content'),
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
             addressableId: any(named: 'addressableId'),
-            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
             targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer((_) async => mockEvent);
+        ).thenAnswer((_) async => acceptedOutcome());
         when(
           () => mockLocalStorage.saveLikeRecord(any()),
         ).thenAnswer((_) async {});
@@ -233,10 +256,14 @@ void main() {
 
         expect(result, equals(testReactionEventId));
         verify(
-          () => mockNostrClient.sendLike(
-            testEventId,
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+            addressableId: any(named: 'addressableId'),
+            targetKind: any(named: 'targetKind'),
             content: '+',
-            targetAuthorPubkey: testAuthorPubkey,
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
         ).called(1);
         verify(() => mockLocalStorage.saveLikeRecord(any())).called(1);
@@ -247,14 +274,16 @@ void main() {
         final mockEvent = MockEvent();
         when(() => mockEvent.id).thenReturn(testReactionEventId);
         when(
-          () => mockNostrClient.sendLike(
-            any(),
-            content: any(named: 'content'),
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
             addressableId: any(named: 'addressableId'),
-            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
             targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer((_) async => mockEvent);
+        ).thenAnswer((_) async => acceptedOutcome());
         when(
           () => mockLocalStorage.saveLikeRecord(any()),
         ).thenAnswer((_) async {});
@@ -269,26 +298,30 @@ void main() {
 
         expect(result, equals(testReactionEventId));
         verify(
-          () => mockNostrClient.sendLike(
-            testEventId,
-            content: '+',
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
             addressableId: testAddressableId,
-            targetAuthorPubkey: testAuthorPubkey,
             targetKind: 34236,
+            content: '+',
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
         ).called(1);
       });
 
       test('throws LikeFailedException when publish fails', () async {
         when(
-          () => mockNostrClient.sendLike(
-            any(),
-            content: any(named: 'content'),
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
             addressableId: any(named: 'addressableId'),
-            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
             targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer((_) async => null);
+        ).thenAnswer((_) async => transientOutcome());
 
         repository = createRepository();
 
@@ -325,8 +358,12 @@ void main() {
           () => mockLocalStorage.getAllLikeRecords(),
         ).thenAnswer((_) async => [createLikeRecord()]);
         when(
-          () => mockNostrClient.deleteEvent(testReactionEventId),
-        ).thenAnswer((_) async => MockEvent());
+          () => mockNostrClient.deleteEventAwaitOk(
+            testReactionEventId,
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
         when(
           () => mockLocalStorage.deleteLikeRecord(testEventId),
         ).thenAnswer((_) async => true);
@@ -336,7 +373,11 @@ void main() {
         await repository.unlikeEvent(testEventId);
 
         verify(
-          () => mockNostrClient.deleteEvent(testReactionEventId),
+          () => mockNostrClient.deleteEventAwaitOk(
+            testReactionEventId,
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
         ).called(1);
         verify(() => mockLocalStorage.deleteLikeRecord(testEventId)).called(1);
       });
@@ -354,8 +395,12 @@ void main() {
           () => mockLocalStorage.getAllLikeRecords(),
         ).thenAnswer((_) async => [createLikeRecord()]);
         when(
-          () => mockNostrClient.deleteEvent(testReactionEventId),
-        ).thenAnswer((_) async => null);
+          () => mockNostrClient.deleteEventAwaitOk(
+            testReactionEventId,
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => transientOutcome());
 
         repository = createRepository();
         await repository.isLiked(testEventId); // Initialize
@@ -371,8 +416,12 @@ void main() {
           () => mockLocalStorage.getLikeRecord(testEventId),
         ).thenAnswer((_) async => createLikeRecord());
         when(
-          () => mockNostrClient.deleteEvent(testReactionEventId),
-        ).thenAnswer((_) async => MockEvent());
+          () => mockNostrClient.deleteEventAwaitOk(
+            testReactionEventId,
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
         when(
           () => mockLocalStorage.deleteLikeRecord(testEventId),
         ).thenAnswer((_) async => true);
@@ -382,7 +431,11 @@ void main() {
 
         verify(() => mockLocalStorage.getLikeRecord(testEventId)).called(1);
         verify(
-          () => mockNostrClient.deleteEvent(testReactionEventId),
+          () => mockNostrClient.deleteEventAwaitOk(
+            testReactionEventId,
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
         ).called(1);
       });
     });
@@ -392,14 +445,16 @@ void main() {
         final mockEvent = MockEvent();
         when(() => mockEvent.id).thenReturn(testReactionEventId);
         when(
-          () => mockNostrClient.sendLike(
-            any(),
-            content: any(named: 'content'),
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
             addressableId: any(named: 'addressableId'),
-            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
             targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer((_) async => mockEvent);
+        ).thenAnswer((_) async => acceptedOutcome());
         when(
           () => mockLocalStorage.saveLikeRecord(any()),
         ).thenAnswer((_) async {});
@@ -419,14 +474,16 @@ void main() {
         final mockEvent = MockEvent();
         when(() => mockEvent.id).thenReturn(testReactionEventId);
         when(
-          () => mockNostrClient.sendLike(
-            any(),
-            content: any(named: 'content'),
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
             addressableId: any(named: 'addressableId'),
-            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
             targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer((_) async => mockEvent);
+        ).thenAnswer((_) async => acceptedOutcome());
         when(
           () => mockLocalStorage.saveLikeRecord(any()),
         ).thenAnswer((_) async {});
@@ -440,12 +497,14 @@ void main() {
         );
 
         verify(
-          () => mockNostrClient.sendLike(
-            testEventId,
-            content: '+',
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
             addressableId: testAddressableId,
-            targetAuthorPubkey: testAuthorPubkey,
             targetKind: 34236,
+            content: '+',
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
         ).called(1);
       });
@@ -458,8 +517,12 @@ void main() {
           () => mockLocalStorage.isLiked(testEventId),
         ).thenAnswer((_) async => true);
         when(
-          () => mockNostrClient.deleteEvent(testReactionEventId),
-        ).thenAnswer((_) async => MockEvent());
+          () => mockNostrClient.deleteEventAwaitOk(
+            testReactionEventId,
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
         when(
           () => mockLocalStorage.deleteLikeRecord(testEventId),
         ).thenAnswer((_) async => true);
@@ -480,17 +543,23 @@ void main() {
         final mockEvent = MockEvent();
         when(() => mockEvent.id).thenReturn(testReactionEventId);
         when(
-          () => mockNostrClient.sendLike(
-            any(),
-            content: any(named: 'content'),
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
             addressableId: any(named: 'addressableId'),
-            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
             targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer((_) async => mockEvent);
+        ).thenAnswer((_) async => acceptedOutcome());
         when(
-          () => mockNostrClient.deleteEvent(testReactionEventId),
-        ).thenAnswer((_) async => MockEvent());
+          () => mockNostrClient.deleteEventAwaitOk(
+            testReactionEventId,
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
 
         repository = createRepository(withLocalStorage: false);
         await repository.likeEvent(
@@ -608,14 +677,16 @@ void main() {
         final reactionEvent = MockEvent();
         when(() => reactionEvent.id).thenReturn('reaction_1');
         when(
-          () => mockNostrClient.sendLike(
-            any(),
-            content: any(named: 'content'),
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
             addressableId: any(named: 'addressableId'),
-            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
             targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer((_) async => reactionEvent);
+        ).thenAnswer((_) async => acceptedOutcome());
         when(
           () => mockLocalStorage.saveLikeRecord(any()),
         ).thenAnswer((_) async {});
@@ -694,8 +765,12 @@ void main() {
           () => mockLocalStorage.deleteLikeRecord(any()),
         ).thenAnswer((_) async => true);
         when(
-          () => mockNostrClient.deleteEvent(any()),
-        ).thenAnswer((_) async => MockEvent());
+          () => mockNostrClient.deleteEventAwaitOk(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
 
         repository = createRepository();
         await repository.initialize();
@@ -1615,19 +1690,16 @@ void main() {
     group('executeLikeAction', () {
       test('publishes like directly to relays', () async {
         when(
-          () => mockNostrClient.sendLike(
-            any(),
-            content: any(named: 'content'),
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
             addressableId: any(named: 'addressableId'),
-            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
             targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer(
-          (_) async => createMockReaction(
-            id: testReactionEventId,
-            targetEventId: testEventId,
-          ),
-        );
+        ).thenAnswer((_) async => acceptedOutcome(id: testReactionEventId));
 
         repository = createRepository();
 
@@ -1639,31 +1711,30 @@ void main() {
         expect(eventId, equals(testReactionEventId));
 
         verify(
-          () => mockNostrClient.sendLike(
-            testEventId,
-            content: any(named: 'content'),
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
             addressableId: any(named: 'addressableId'),
-            targetAuthorPubkey: testAuthorPubkey,
             targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
         ).called(1);
       });
 
       test('updates placeholder record with real event ID', () async {
         when(
-          () => mockNostrClient.sendLike(
-            any(),
-            content: any(named: 'content'),
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
             addressableId: any(named: 'addressableId'),
-            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
             targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer(
-          (_) async => createMockReaction(
-            id: testReactionEventId,
-            targetEventId: testEventId,
-          ),
-        );
+        ).thenAnswer((_) async => acceptedOutcome(id: testReactionEventId));
         when(
           () => mockLocalStorage.saveLikeRecord(any()),
         ).thenAnswer((_) async {});
@@ -1704,14 +1775,16 @@ void main() {
 
       test('throws LikeFailedException when publish fails', () async {
         when(
-          () => mockNostrClient.sendLike(
-            any(),
-            content: any(named: 'content'),
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
             addressableId: any(named: 'addressableId'),
-            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
             targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer((_) async => null);
+        ).thenAnswer((_) async => transientOutcome());
 
         repository = createRepository();
 
@@ -1728,22 +1801,23 @@ void main() {
     group('executeUnlikeAction', () {
       test('publishes deletion directly to relays', () async {
         when(
-          () => mockNostrClient.sendLike(
-            any(),
-            content: any(named: 'content'),
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
             addressableId: any(named: 'addressableId'),
-            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
             targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer(
-          (_) async => createMockReaction(
-            id: testReactionEventId,
-            targetEventId: testEventId,
-          ),
-        );
+        ).thenAnswer((_) async => acceptedOutcome(id: testReactionEventId));
         when(
-          () => mockNostrClient.deleteEvent(any()),
-        ).thenAnswer((_) async => createMockDeletion([testReactionEventId]));
+          () => mockNostrClient.deleteEventAwaitOk(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
         when(
           () => mockLocalStorage.saveLikeRecord(any()),
         ).thenAnswer((_) async {});
@@ -1762,7 +1836,11 @@ void main() {
         await repository.executeUnlikeAction(testEventId);
 
         verify(
-          () => mockNostrClient.deleteEvent(testReactionEventId),
+          () => mockNostrClient.deleteEventAwaitOk(
+            testReactionEventId,
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
         ).called(1);
         verify(
           () => mockLocalStorage.deleteLikeRecord(testEventId),
@@ -1800,7 +1878,13 @@ void main() {
         // Execute unlike - should not call deleteEvent since never synced
         await repository.executeUnlikeAction(testEventId);
 
-        verifyNever(() => mockNostrClient.deleteEvent(any()));
+        verifyNever(
+          () => mockNostrClient.deleteEventAwaitOk(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
         verify(
           () => mockLocalStorage.deleteLikeRecord(testEventId),
         ).called(1);
@@ -1816,7 +1900,13 @@ void main() {
         // Should not throw, just return
         await repository.executeUnlikeAction(testEventId);
 
-        verifyNever(() => mockNostrClient.deleteEvent(any()));
+        verifyNever(
+          () => mockNostrClient.deleteEventAwaitOk(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
         verifyNever(
           () => mockLocalStorage.deleteLikeRecord(testEventId),
         );
@@ -1824,22 +1914,23 @@ void main() {
 
       test('throws UnlikeFailedException when deletion fails', () async {
         when(
-          () => mockNostrClient.sendLike(
-            any(),
-            content: any(named: 'content'),
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
             addressableId: any(named: 'addressableId'),
-            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
             targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer(
-          (_) async => createMockReaction(
-            id: testReactionEventId,
-            targetEventId: testEventId,
-          ),
-        );
+        ).thenAnswer((_) async => acceptedOutcome(id: testReactionEventId));
         when(
-          () => mockNostrClient.deleteEvent(any()),
-        ).thenAnswer((_) async => null);
+          () => mockNostrClient.deleteEventAwaitOk(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => transientOutcome());
         when(
           () => mockLocalStorage.saveLikeRecord(any()),
         ).thenAnswer((_) async {});
@@ -1864,8 +1955,12 @@ void main() {
           () => mockLocalStorage.getLikeRecord(testEventId),
         ).thenAnswer((_) async => record);
         when(
-          () => mockNostrClient.deleteEvent(any()),
-        ).thenAnswer((_) async => createMockDeletion([testReactionEventId]));
+          () => mockNostrClient.deleteEventAwaitOk(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
         when(
           () => mockLocalStorage.deleteLikeRecord(any()),
         ).thenAnswer((_) async => true);
@@ -1878,7 +1973,11 @@ void main() {
           () => mockLocalStorage.getLikeRecord(testEventId),
         ).called(1);
         verify(
-          () => mockNostrClient.deleteEvent(testReactionEventId),
+          () => mockNostrClient.deleteEventAwaitOk(
+            testReactionEventId,
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
         ).called(1);
       });
 
@@ -1887,22 +1986,23 @@ void main() {
           () => mockNostrClient.countEvents(any()),
         ).thenAnswer((_) async => const CountResult(count: 10));
         when(
-          () => mockNostrClient.sendLike(
-            any(),
-            content: any(named: 'content'),
+          () => mockNostrClient.sendLikeAwaitOk(
+            eventId: any(named: 'eventId'),
+            authorPubkey: any(named: 'authorPubkey'),
             addressableId: any(named: 'addressableId'),
-            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
             targetKind: any(named: 'targetKind'),
+            content: any(named: 'content'),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer(
-          (_) async => createMockReaction(
-            id: testReactionEventId,
-            targetEventId: testEventId,
-          ),
-        );
+        ).thenAnswer((_) async => acceptedOutcome(id: testReactionEventId));
         when(
-          () => mockNostrClient.deleteEvent(any()),
-        ).thenAnswer((_) async => createMockDeletion([testReactionEventId]));
+          () => mockNostrClient.deleteEventAwaitOk(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
         when(
           () => mockLocalStorage.saveLikeRecord(any()),
         ).thenAnswer((_) async {});

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -847,6 +847,42 @@ class NostrClient {
     return likeEvent;
   }
 
+  /// Publishes a Kind 7 reaction and resolves per-relay NIP-20 OK acks.
+  ///
+  /// Builds a reaction event with the same tag structure as [sendLike]
+  /// (`e`, `p`, optional `a`, optional `k`) and routes through
+  /// [publishEventAwaitOk] (or [publishEventWithRetry] when [policy] is
+  /// non-null) so callers can surface a [PublishOutcome] / retry the
+  /// transient relays.
+  ///
+  /// Parameters mirror [sendLike]. [content] defaults to `+` for an upvote;
+  /// pass `-` for a downvote.
+  Future<PublishOutcome> sendLikeAwaitOk({
+    required String eventId,
+    required String authorPubkey,
+    String? addressableId,
+    int? targetKind,
+    String content = '+',
+    RetryPolicy? policy,
+    List<String>? targetRelays,
+  }) async {
+    final tags = <List<String>>[
+      ['e', eventId],
+      ['p', authorPubkey],
+      if (addressableId != null && addressableId.isNotEmpty)
+        ['a', addressableId],
+      if (targetKind != null) ['k', '$targetKind'],
+    ];
+    final event = Event(publicKey, EventKind.reaction, tags, content);
+    return policy == null
+        ? publishEventAwaitOk(event, targetRelays: targetRelays)
+        : publishEventWithRetry(
+            event,
+            policy: policy,
+            targetRelays: targetRelays,
+          );
+  }
+
   /// Sends a user profile (Kind 0 metadata event).
   ///
   /// Routes through [publishEvent] to ensure relay health checks and
@@ -885,6 +921,34 @@ class NostrClient {
       _cacheEvent(repostEvent);
     }
     return repostEvent;
+  }
+
+  /// Publishes a Kind 6 repost and resolves per-relay NIP-20 OK acks.
+  ///
+  /// Builds the event locally with an `e` tag referencing [eventId] (and the
+  /// optional [relayHint] as the third tag element). Route through
+  /// [publishEventWithRetry] when [policy] is supplied so transient failures
+  /// are retried; otherwise [publishEventAwaitOk] is used.
+  Future<PublishOutcome> sendRepostAwaitOk({
+    required String eventId,
+    String? relayHint,
+    String content = '',
+    RetryPolicy? policy,
+    List<String>? targetRelays,
+  }) async {
+    final eTag = <String>[
+      'e',
+      eventId,
+      if (relayHint != null && relayHint.isNotEmpty) relayHint,
+    ];
+    final event = Event(publicKey, EventKind.repost, [eTag], content);
+    return policy == null
+        ? publishEventAwaitOk(event, targetRelays: targetRelays)
+        : publishEventWithRetry(
+            event,
+            policy: policy,
+            targetRelays: targetRelays,
+          );
   }
 
   /// Sends a generic repost (Kind 16) for addressable events.
@@ -964,6 +1028,35 @@ class NostrClient {
       _handleDeletionEvent(deletionEvent);
     }
     return deletionEvent;
+  }
+
+  /// Publishes a NIP-09 deletion request (Kind 5) and resolves per-relay
+  /// NIP-20 OK acks.
+  ///
+  /// Builds a Kind 5 event with a single `e` tag referencing [eventId] and
+  /// the content `"delete"`. Routes through [publishEventAwaitOk] (or
+  /// [publishEventWithRetry] when [policy] is non-null) so callers can
+  /// surface a [PublishOutcome] instead of a nullable [Event].
+  Future<PublishOutcome> deleteEventAwaitOk(
+    String eventId, {
+    RetryPolicy? policy,
+    List<String>? targetRelays,
+  }) async {
+    final event = Event(
+      publicKey,
+      EventKind.eventDeletion,
+      [
+        ['e', eventId],
+      ],
+      'delete',
+    );
+    return policy == null
+        ? publishEventAwaitOk(event, targetRelays: targetRelays)
+        : publishEventWithRetry(
+            event,
+            policy: policy,
+            targetRelays: targetRelays,
+          );
   }
 
   /// Deletes multiple events

--- a/mobile/packages/nostr_client/test/src/send_like_await_ok_test.dart
+++ b/mobile/packages/nostr_client/test/src/send_like_await_ok_test.dart
@@ -1,0 +1,391 @@
+// ABOUTME: Tests for NostrClient.sendLikeAwaitOk, .sendRepostAwaitOk, and
+// ABOUTME: .deleteEventAwaitOk — the publishEventWithRetry-aware variants of
+// ABOUTME: the reaction/repost/deletion helpers used by repositories.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+class _MockNostr extends Mock implements Nostr {}
+
+class _MockRelayManager extends Mock implements RelayManager {}
+
+class _FakeEvent extends Fake implements Event {}
+
+const _testPublicKey =
+    '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2';
+const _testAuthorPubkey =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+const _testEventId =
+    '2222222222222222222222222222222222222222222222222222222222222222';
+
+PublishOutcome _accepted(String id) => PublishOutcome(
+  eventId: id,
+  acceptedBy: const {'wss://relay.example.com'},
+  rejectedBy: const {},
+  noResponseFrom: const {},
+);
+
+PublishOutcome _transient(String id) => PublishOutcome(
+  eventId: id,
+  acceptedBy: const {},
+  rejectedBy: const {},
+  noResponseFrom: const {'wss://relay.example.com'},
+);
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+    registerFallbackValue(<String>[]);
+    registerFallbackValue(const Duration(seconds: 15));
+  });
+
+  group('NostrClient.sendLikeAwaitOk', () {
+    late _MockNostr mockNostr;
+    late _MockRelayManager mockRelayManager;
+    late NostrClient client;
+
+    setUp(() {
+      mockNostr = _MockNostr();
+      mockRelayManager = _MockRelayManager();
+      when(() => mockNostr.publicKey).thenReturn(_testPublicKey);
+      when(() => mockNostr.close()).thenReturn(null);
+      when(() => mockRelayManager.dispose()).thenAnswer((_) async {});
+      when(
+        () => mockRelayManager.connectedRelays,
+      ).thenReturn(['wss://relay.example.com']);
+      client = NostrClient.forTesting(
+        nostr: mockNostr,
+        relayManager: mockRelayManager,
+      );
+    });
+
+    tearDown(() {
+      reset(mockNostr);
+      reset(mockRelayManager);
+    });
+
+    test(
+      'builds reaction event with e, p tags and returns outcome',
+      () async {
+        Event? sentEvent;
+        when(
+          () => mockNostr.sendEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          sentEvent = invocation.positionalArguments[0] as Event;
+          return _accepted(sentEvent!.id);
+        });
+
+        final outcome = await client.sendLikeAwaitOk(
+          eventId: _testEventId,
+          authorPubkey: _testAuthorPubkey,
+        );
+
+        expect(outcome.acceptedByAny, isTrue);
+        expect(sentEvent, isNotNull);
+        expect(sentEvent!.kind, EventKind.reaction);
+        expect(sentEvent!.content, '+');
+        expect(
+          sentEvent!.tags,
+          containsAll(<List<String>>[
+            ['e', _testEventId],
+            ['p', _testAuthorPubkey],
+          ]),
+        );
+        // No a / k tags when addressableId + targetKind omitted.
+        expect(
+          sentEvent!.tags.where((t) => t.isNotEmpty && t[0] == 'a'),
+          isEmpty,
+        );
+        expect(
+          sentEvent!.tags.where((t) => t.isNotEmpty && t[0] == 'k'),
+          isEmpty,
+        );
+      },
+    );
+
+    test('includes a + k tags when addressable/kind provided', () async {
+      Event? sentEvent;
+      when(
+        () => mockNostr.sendEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        sentEvent = invocation.positionalArguments[0] as Event;
+        return _accepted(sentEvent!.id);
+      });
+
+      await client.sendLikeAwaitOk(
+        eventId: _testEventId,
+        authorPubkey: _testAuthorPubkey,
+        addressableId: '34236:$_testAuthorPubkey:video-d-tag',
+        targetKind: 34236,
+      );
+
+      expect(sentEvent, isNotNull);
+      expect(
+        sentEvent!.tags,
+        containsAll(<List<String>>[
+          ['a', '34236:$_testAuthorPubkey:video-d-tag'],
+          ['k', '34236'],
+        ]),
+      );
+    });
+
+    test('passes through custom content (downvote)', () async {
+      Event? sentEvent;
+      when(
+        () => mockNostr.sendEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        sentEvent = invocation.positionalArguments[0] as Event;
+        return _accepted(sentEvent!.id);
+      });
+
+      await client.sendLikeAwaitOk(
+        eventId: _testEventId,
+        authorPubkey: _testAuthorPubkey,
+        content: '-',
+      );
+
+      expect(sentEvent!.content, '-');
+    });
+
+    test('transient outcome passes through unchanged', () async {
+      when(
+        () => mockNostr.sendEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer(
+        (invocation) async =>
+            _transient((invocation.positionalArguments[0] as Event).id),
+      );
+
+      final outcome = await client.sendLikeAwaitOk(
+        eventId: _testEventId,
+        authorPubkey: _testAuthorPubkey,
+      );
+
+      expect(outcome.acceptedByAny, isFalse);
+      expect(outcome.transientRelays, {'wss://relay.example.com'});
+    });
+
+    test('with retry policy, retries transient relays', () async {
+      var callCount = 0;
+      when(
+        () => mockNostr.sendEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        callCount++;
+        final id = (invocation.positionalArguments[0] as Event).id;
+        if (callCount == 1) return _transient(id);
+        return _accepted(id);
+      });
+
+      final outcome = await client.sendLikeAwaitOk(
+        eventId: _testEventId,
+        authorPubkey: _testAuthorPubkey,
+        policy: const RetryPolicy(
+          maxAttempts: 2,
+          baseDelay: Duration(milliseconds: 1),
+        ),
+      );
+
+      expect(outcome.acceptedByAny, isTrue);
+      expect(callCount, 2);
+    });
+  });
+
+  group('NostrClient.sendRepostAwaitOk', () {
+    late _MockNostr mockNostr;
+    late _MockRelayManager mockRelayManager;
+    late NostrClient client;
+
+    setUp(() {
+      mockNostr = _MockNostr();
+      mockRelayManager = _MockRelayManager();
+      when(() => mockNostr.publicKey).thenReturn(_testPublicKey);
+      when(() => mockNostr.close()).thenReturn(null);
+      when(() => mockRelayManager.dispose()).thenAnswer((_) async {});
+      when(
+        () => mockRelayManager.connectedRelays,
+      ).thenReturn(['wss://relay.example.com']);
+      client = NostrClient.forTesting(
+        nostr: mockNostr,
+        relayManager: mockRelayManager,
+      );
+    });
+
+    tearDown(() {
+      reset(mockNostr);
+      reset(mockRelayManager);
+    });
+
+    test('builds kind 6 repost with e tag and returns outcome', () async {
+      Event? sentEvent;
+      when(
+        () => mockNostr.sendEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        sentEvent = invocation.positionalArguments[0] as Event;
+        return _accepted(sentEvent!.id);
+      });
+
+      final outcome = await client.sendRepostAwaitOk(
+        eventId: _testEventId,
+      );
+
+      expect(outcome.acceptedByAny, isTrue);
+      expect(sentEvent!.kind, EventKind.repost);
+      expect(sentEvent!.tags, [
+        ['e', _testEventId],
+      ]);
+      expect(sentEvent!.content, '');
+    });
+
+    test('includes relay hint as third element of e tag when set', () async {
+      Event? sentEvent;
+      when(
+        () => mockNostr.sendEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        sentEvent = invocation.positionalArguments[0] as Event;
+        return _accepted(sentEvent!.id);
+      });
+
+      await client.sendRepostAwaitOk(
+        eventId: _testEventId,
+        relayHint: 'wss://hint.example.com',
+      );
+
+      expect(sentEvent!.tags, [
+        ['e', _testEventId, 'wss://hint.example.com'],
+      ]);
+    });
+  });
+
+  group('NostrClient.deleteEventAwaitOk', () {
+    late _MockNostr mockNostr;
+    late _MockRelayManager mockRelayManager;
+    late NostrClient client;
+
+    setUp(() {
+      mockNostr = _MockNostr();
+      mockRelayManager = _MockRelayManager();
+      when(() => mockNostr.publicKey).thenReturn(_testPublicKey);
+      when(() => mockNostr.close()).thenReturn(null);
+      when(() => mockRelayManager.dispose()).thenAnswer((_) async {});
+      when(
+        () => mockRelayManager.connectedRelays,
+      ).thenReturn(['wss://relay.example.com']);
+      client = NostrClient.forTesting(
+        nostr: mockNostr,
+        relayManager: mockRelayManager,
+      );
+    });
+
+    tearDown(() {
+      reset(mockNostr);
+      reset(mockRelayManager);
+    });
+
+    test('builds kind 5 event with e tag and "delete" content', () async {
+      Event? sentEvent;
+      when(
+        () => mockNostr.sendEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        sentEvent = invocation.positionalArguments[0] as Event;
+        return _accepted(sentEvent!.id);
+      });
+
+      final outcome = await client.deleteEventAwaitOk(_testEventId);
+
+      expect(outcome.acceptedByAny, isTrue);
+      expect(sentEvent!.kind, EventKind.eventDeletion);
+      expect(sentEvent!.content, 'delete');
+      expect(sentEvent!.tags, [
+        ['e', _testEventId],
+      ]);
+    });
+
+    test('propagates transient outcome to caller', () async {
+      when(
+        () => mockNostr.sendEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer(
+        (invocation) async =>
+            _transient((invocation.positionalArguments[0] as Event).id),
+      );
+
+      final outcome = await client.deleteEventAwaitOk(_testEventId);
+
+      expect(outcome.failed, isTrue);
+      expect(outcome.transientRelays, {'wss://relay.example.com'});
+    });
+
+    test('with retry policy, retries transient relays', () async {
+      var callCount = 0;
+      when(
+        () => mockNostr.sendEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+          tempRelays: any(named: 'tempRelays'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        callCount++;
+        final id = (invocation.positionalArguments[0] as Event).id;
+        if (callCount == 1) return _transient(id);
+        return _accepted(id);
+      });
+
+      final outcome = await client.deleteEventAwaitOk(
+        _testEventId,
+        policy: const RetryPolicy(
+          maxAttempts: 2,
+          baseDelay: Duration(milliseconds: 1),
+        ),
+      );
+
+      expect(outcome.acceptedByAny, isTrue);
+      expect(callCount, 2);
+    });
+  });
+}

--- a/mobile/test/unit/services/base/social_event_service_base_test.dart
+++ b/mobile/test/unit/services/base/social_event_service_base_test.dart
@@ -1,0 +1,150 @@
+// ABOUTME: Tests SocialEventServiceBase.broadcastAndCacheEvent routes through
+// ABOUTME: publishEventWithRetry and surfaces PublishOutcome via the new
+// ABOUTME: broadcastAndCacheEventAwaitOk sibling.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/base/social_event_service_base.dart';
+import 'package:openvine/services/personal_event_cache_service.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockPersonalCache extends Mock implements PersonalEventCacheService {}
+
+class _TestSocialEventService extends SocialEventServiceBase {
+  _TestSocialEventService({
+    required this.nostrService,
+    required this.authService,
+    required this.personalEventCache,
+  });
+
+  @override
+  final NostrClient nostrService;
+  @override
+  final AuthService authService;
+  @override
+  final PersonalEventCacheService? personalEventCache;
+}
+
+const _testPubkey =
+    '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2';
+
+Event _buildEvent() {
+  return Event(_testPubkey, EventKind.reaction, const [
+      ['e', 'target'],
+    ], '+')
+    ..id = 'a' * 64
+    ..sig = 'sig';
+}
+
+PublishOutcome _accepted(String id) => PublishOutcome(
+  eventId: id,
+  acceptedBy: const {'wss://relay.example.com'},
+  rejectedBy: const {},
+  noResponseFrom: const {},
+);
+
+PublishOutcome _transient(String id) => PublishOutcome(
+  eventId: id,
+  acceptedBy: const {},
+  rejectedBy: const {},
+  noResponseFrom: const {'wss://relay.example.com'},
+);
+
+void main() {
+  late _MockNostrClient nostr;
+  late _MockAuthService auth;
+  late _MockPersonalCache cache;
+  late _TestSocialEventService service;
+
+  setUpAll(() {
+    registerFallbackValue(_buildEvent());
+    registerFallbackValue(const RetryPolicy());
+  });
+
+  setUp(() {
+    nostr = _MockNostrClient();
+    auth = _MockAuthService();
+    cache = _MockPersonalCache();
+    service = _TestSocialEventService(
+      nostrService: nostr,
+      authService: auth,
+      personalEventCache: cache,
+    );
+  });
+
+  group('SocialEventServiceBase', () {
+    test(
+      'broadcastAndCacheEvent returns event id and caches on acceptedByAny',
+      () async {
+        final event = _buildEvent();
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _accepted(event.id));
+
+        final id = await service.broadcastAndCacheEvent(event);
+
+        expect(id, equals(event.id));
+        verify(() => cache.cacheUserEvent(event)).called(1);
+      },
+    );
+
+    test(
+      'broadcastAndCacheEvent throws and does NOT cache on failure',
+      () async {
+        final event = _buildEvent();
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _transient(event.id));
+
+        expect(
+          () => service.broadcastAndCacheEvent(event),
+          throwsA(isA<Exception>()),
+        );
+
+        // Wait for the future to complete so mocktail settles.
+        try {
+          await service.broadcastAndCacheEvent(event);
+        } on Exception {
+          // expected
+        }
+
+        verifyNever(() => cache.cacheUserEvent(any()));
+      },
+    );
+
+    test(
+      'broadcastAndCacheEventAwaitOk surfaces outcome to caller',
+      () async {
+        final event = _buildEvent();
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _transient(event.id));
+
+        final outcome = await service.broadcastAndCacheEventAwaitOk(event);
+
+        expect(outcome.acceptedByAny, isFalse);
+        expect(outcome.transientRelays, {'wss://relay.example.com'});
+        verifyNever(() => cache.cacheUserEvent(any()));
+      },
+    );
+  });
+}

--- a/mobile/test/unit/services/social_service_reliability_test.dart
+++ b/mobile/test/unit/services/social_service_reliability_test.dart
@@ -1,0 +1,156 @@
+// ABOUTME: Verifies SocialService.publishRightToBeForgotten surfaces
+// ABOUTME: PublishOutcome-driven failure, and that follow-set publishing
+// ABOUTME: only commits to the local map when the relay acknowledges.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/social_service.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+const _testPubkey =
+    '82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2';
+
+PublishOutcome _accepted(String id) => PublishOutcome(
+  eventId: id,
+  acceptedBy: const {'wss://relay.example.com'},
+  rejectedBy: const {},
+  noResponseFrom: const {},
+);
+
+PublishOutcome _transient(String id) => PublishOutcome(
+  eventId: id,
+  acceptedBy: const {},
+  rejectedBy: const {},
+  noResponseFrom: const {'wss://relay.example.com'},
+);
+
+Event _buildSignedEvent({required int kind}) =>
+    Event(
+        _testPubkey,
+        kind,
+        const [],
+        'content',
+      )
+      ..id = 'a' * 64
+      ..sig = 'sig';
+
+void main() {
+  late _MockNostrClient nostr;
+  late _MockAuthService auth;
+  late SocialService service;
+
+  setUpAll(() {
+    registerFallbackValue(_buildSignedEvent(kind: 30000));
+    registerFallbackValue(const RetryPolicy());
+  });
+
+  setUp(() {
+    nostr = _MockNostrClient();
+    auth = _MockAuthService();
+    when(() => auth.isAuthenticated).thenReturn(true);
+    when(() => auth.currentPublicKeyHex).thenReturn(_testPubkey);
+    when(
+      () => auth.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer((invocation) async {
+      final kind = invocation.namedArguments[#kind] as int;
+      return _buildSignedEvent(kind: kind);
+    });
+    service = SocialService(nostr, auth);
+  });
+
+  group('SocialService.publishRightToBeForgotten', () {
+    test('accepts on acceptedByAny and does not throw', () async {
+      when(
+        () => nostr.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) async => _accepted('a' * 64));
+
+      await service.publishRightToBeForgotten();
+
+      verify(
+        () => nostr.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).called(1);
+    });
+
+    test(
+      'throws when no relay accepts — caller learns about the failure',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _transient('a' * 64));
+
+        expect(
+          () => service.publishRightToBeForgotten(),
+          throwsA(isA<Exception>()),
+        );
+      },
+    );
+  });
+
+  group('SocialService.createFollowSet', () {
+    test(
+      'returns the set; local nostrEventId commits only on accept',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          final e = invocation.positionalArguments.first as Event;
+          return _accepted(e.id);
+        });
+
+        final set = await service.createFollowSet(name: 'friends');
+
+        expect(set, isNotNull);
+        expect(service.followSets, hasLength(1));
+        expect(service.followSets.first.nostrEventId, isNotNull);
+      },
+    );
+
+    test(
+      'on transient failure: local set stays but nostrEventId stays null '
+      'so the UI knows it was never acknowledged',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          final e = invocation.positionalArguments.first as Event;
+          return _transient(e.id);
+        });
+
+        await service.createFollowSet(name: 'friends');
+
+        expect(service.followSets, hasLength(1));
+        expect(service.followSets.first.nostrEventId, isNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #3187

## Summary

Migrates the social-graph and interaction publish paths to `publishEventWithRetry` / `publishEventAwaitOk` so every like, unlike, comment, comment-deletion, follow-set publish, and NIP-62 right-to-be-forgotten attempt surfaces a `PublishOutcome` and `PublishUserFeedback` the UI can act on.

- **`NostrClient`** gains `sendLikeAwaitOk`, `deleteEventAwaitOk`, `sendRepostAwaitOk` — each builds the event locally with the same tag shape the SDK helpers produce and routes through `publishEventAwaitOk` / `publishEventWithRetry`.
- **`LikesRepository`** routes `likeEvent`, `executeLikeAction`, `unlikeEvent`, `executeUnlikeAction`, `downvoteEvent`, and `deleteReaction` through the new AwaitOk helpers with a default `RetryPolicy`. `LikeFailedException` / `UnlikeFailedException` now carry `outcome` + `feedback` for UI retry affordances. The existing optimistic rollback (records only committed after success) is preserved.
- **`CommentsRepository`** routes `postComment` / `deleteComment` through `publishEventWithRetry`. `PostCommentFailedException` / `DeleteCommentFailedException` carry `outcome` + `feedback`. The bloc preserves the draft text (`mainInputText` / `replyInputText`) on failure so Retry reuses the same content.
- **`SocialService`** gates the local follow-set `nostrEventId` mutation on `outcome.acceptedByAny` — the local map never reflects an unacknowledged publish. The right-to-be-forgotten Kind-5 throws a descriptive error when every relay fails.
- **`SocialEventServiceBase`** migrates `broadcastAndCacheEvent` to retry via `publishEventWithRetry` and caches only on acceptance. A new `broadcastAndCacheEventAwaitOk` returns the raw `PublishOutcome` for subclasses that want per-relay detail.
- **UI**: `VideoFeedItem` wraps `VideoOverlayActions` in a `BlocListener` that watches `VideoInteractionsState.lastActionFeedback` and renders a retry-aware snackbar via `PublishResultMapper`. The comments screen listener upgrades its snackbar to use feedback messages when a publish failed, with a Retry action that re-submits the draft.

## Test plan

- [x] `flutter test` in `packages/nostr_client` (251 pass, +10 new in `send_like_await_ok_test.dart`)
- [x] `flutter test` in `packages/likes_repository` (131 pass, +4 new in `likes_repository_reliability_test.dart`; adapted 62KB existing suite to AwaitOk mocks)
- [x] `flutter test` in `packages/comments_repository` (128 pass, +4 new in `comments_repository_reliability_test.dart`; adapted 61KB existing suite to `publishEventWithRetry` mocks)
- [x] `flutter test test/blocs test/screens/comments` (all pass)
- [x] `flutter test test/unit/services test/unit/services/base` (+3 new in `social_event_service_base_test.dart`, +4 new in `social_service_reliability_test.dart`)
- [x] `flutter analyze lib test` clean
- [ ] Manual: like a video with relays temporarily unreachable → snackbar appears with Retry; retry succeeds once the relay comes back.
- [ ] Manual: post a comment while offline → draft text stays in the input and snackbar offers Retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)