### PR TITLE
feat(moderation): reliable mute / blocklist / report publishing

### DIFF
--- a/mobile/lib/blocs/dm/conversation_actions/conversation_actions_cubit.dart
+++ b/mobile/lib/blocs/dm/conversation_actions/conversation_actions_cubit.dart
@@ -73,11 +73,25 @@ class ConversationActionsCubit extends Cubit<ConversationActionsState> {
   bool isBlocked(String pubkey) => _blocklistService.isBlocked(pubkey);
 
   /// Block a user from a DM conversation.
+  ///
+  /// Emits [ConversationActionsStatus.failure] for both relay-level
+  /// failure (e.g. all relays rejected the kind 30000 event) and thrown
+  /// exceptions. [BlocklistResult.success] is `false` for the former, so
+  /// we inspect the result before emitting success.
   Future<void> blockUser(String pubkey) async {
     emit(state.copyWith(status: ConversationActionsStatus.processing));
     try {
-      await _blocklistService.blockUser(pubkey, ourPubkey: _currentUserPubkey);
-      emit(state.copyWith(status: ConversationActionsStatus.success));
+      final result = await _blocklistService.blockUser(
+        pubkey,
+        ourPubkey: _currentUserPubkey,
+      );
+      emit(
+        state.copyWith(
+          status: result.success
+              ? ConversationActionsStatus.success
+              : ConversationActionsStatus.failure,
+        ),
+      );
     } catch (e, stackTrace) {
       addError(e, stackTrace);
       emit(state.copyWith(status: ConversationActionsStatus.failure));
@@ -88,8 +102,14 @@ class ConversationActionsCubit extends Cubit<ConversationActionsState> {
   Future<void> unblockUser(String pubkey) async {
     emit(state.copyWith(status: ConversationActionsStatus.processing));
     try {
-      await _blocklistService.unblockUser(pubkey);
-      emit(state.copyWith(status: ConversationActionsStatus.success));
+      final result = await _blocklistService.unblockUser(pubkey);
+      emit(
+        state.copyWith(
+          status: result.success
+              ? ConversationActionsStatus.success
+              : ConversationActionsStatus.failure,
+        ),
+      );
     } catch (e, stackTrace) {
       addError(e, stackTrace);
       emit(state.copyWith(status: ConversationActionsStatus.failure));

--- a/mobile/lib/screens/inbox/conversation/widgets/report_message_dialog.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/report_message_dialog.dart
@@ -163,12 +163,16 @@ class _ReportMessageDialogState extends ConsumerState<ReportMessageDialog> {
       );
 
       if (mounted) {
-        context.pop();
+        // Only close the dialog on success — otherwise leave it open so
+        // the Retry affordance can re-submit without re-opening.
+        if (result.success) {
+          context.pop();
+        }
 
         if (result.success) {
           if (_blockUser) {
             final muteService = await ref.read(muteServiceProvider.future);
-            await muteService.muteUser(
+            final muteResult = await muteService.muteUser(
               widget.senderPubkey,
               reason:
                   'Reported and blocked for '
@@ -177,14 +181,14 @@ class _ReportMessageDialogState extends ConsumerState<ReportMessageDialog> {
 
             final blocklistService = ref.read(contentBlocklistServiceProvider);
             final nostrClient = ref.read(nostrServiceProvider);
-            blocklistService.blockUser(
+            final blockResult = await blocklistService.blockUser(
               widget.senderPubkey,
               ourPubkey: nostrClient.publicKey,
             );
 
             Log.info(
-              'User blocked: kind 10000 mute list published for '
-              '${widget.senderPubkey}',
+              'User blocked for ${widget.senderPubkey} — '
+              'mute=${muteResult.success}, block=${blockResult.success}',
               name: 'ReportMessageDialog',
               category: LogCategory.ui,
             );
@@ -217,10 +221,24 @@ class _ReportMessageDialogState extends ConsumerState<ReportMessageDialog> {
             );
           }
         } else {
+          // Retry affordance for transient relay failures — drives off
+          // feedback.retryable per PublishResultMapper.
+          final feedback = result.feedback;
+          final retryable = feedback?.retryable ?? false;
+          final errorText =
+              result.error ??
+              feedback?.firstRejectionReason ??
+              'please try again';
           ScaffoldMessenger.of(context).showSnackBar(
-            DivineSnackbarContainer.snackBar(
-              'Failed to report message: ${result.error}',
-              error: true,
+            SnackBar(
+              backgroundColor: VineTheme.error,
+              content: Text('Failed to report message: $errorText'),
+              action: retryable
+                  ? SnackBarAction(
+                      label: 'Retry',
+                      onPressed: _submitReport,
+                    )
+                  : null,
             ),
           );
         }

--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -374,16 +374,39 @@ class _SafetySettingsScreenState extends ConsumerState<SafetySettingsScreen> {
 
   Future<void> _unblockUser(String pubkey) async {
     final blocklistService = ref.read(contentBlocklistServiceProvider);
-    blocklistService.unblockUser(pubkey);
+    final result = await blocklistService.unblockUser(pubkey);
 
-    if (mounted) {
+    if (!mounted) return;
+
+    if (result.success) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(context.l10n.safetySettingsUserUnblocked),
           duration: const Duration(seconds: 2),
         ),
       );
+      return;
     }
+
+    // Relay failure — surface it with Retry if the outcome is transient.
+    final feedback = result.feedback;
+    final retryable = feedback?.retryable ?? false;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        backgroundColor: VineTheme.error,
+        content: Text(
+          result.error ??
+              feedback?.firstRejectionReason ??
+              'Unblock failed — please try again',
+        ),
+        action: retryable
+            ? SnackBarAction(
+                label: 'Retry',
+                onPressed: () => _unblockUser(pubkey),
+              )
+            : null,
+      ),
+    );
   }
 }
 

--- a/mobile/lib/services/content_blocklist_service.dart
+++ b/mobile/lib/services/content_blocklist_service.dart
@@ -19,6 +19,59 @@ const _blockedUsersPrefsKey = 'blocked_users_list';
 /// SharedPreferences key for severed followers (follow broken by block)
 const _severedFollowersPrefsKey = 'severed_followers_list';
 
+/// Result of a block/unblock operation.
+///
+/// Contract: [success] requires [outcome.acceptedByAny]. The service
+/// does NOT commit the runtime blocklist until at least one relay has
+/// acknowledged the updated kind 30000 event. This prevents the
+/// silent-divergence bug where the device thought a pubkey was blocked
+/// but on reinstall/account-switch the relay had no record.
+class BlocklistResult {
+  const BlocklistResult({
+    required this.success,
+    required this.timestamp,
+    this.outcome,
+    this.feedback,
+    this.error,
+  });
+
+  final bool success;
+  final DateTime timestamp;
+
+  /// Per-relay outcome. `null` for pre-publish failures (not
+  /// authenticated, self-block attempt, sign failure).
+  final PublishOutcome? outcome;
+
+  /// User-facing feedback mapped via [PublishResultMapper]. `null` for
+  /// pre-publish failures.
+  final PublishUserFeedback? feedback;
+
+  /// Human-readable error for pre-publish failures.
+  final String? error;
+
+  static BlocklistResult success_({
+    PublishOutcome? outcome,
+    PublishUserFeedback? feedback,
+  }) => BlocklistResult(
+    success: true,
+    outcome: outcome,
+    feedback: feedback,
+    timestamp: DateTime.now(),
+  );
+
+  static BlocklistResult failure({
+    String? error,
+    PublishOutcome? outcome,
+    PublishUserFeedback? feedback,
+  }) => BlocklistResult(
+    success: false,
+    error: error,
+    outcome: outcome,
+    feedback: feedback,
+    timestamp: DateTime.now(),
+  );
+}
+
 /// Service for managing content blocklist
 ///
 /// This service maintains an internal blocklist of npubs whose content
@@ -196,8 +249,30 @@ class ContentBlocklistService {
     }
   }
 
-  /// Publish our block list to Nostr as kind 30000 with d=block
-  Future<void> _publishBlockListToNostr() async {
+  /// Attach Nostr services without starting a subscription.
+  ///
+  /// Exposed for tests and for eager setup where the caller wants to
+  /// publish block events before kicking off [syncBlockListsInBackground].
+  /// Safe to call multiple times; the latest services win.
+  Future<void> attachNostrServices({
+    required NostrClient nostrClient,
+    required AuthService authService,
+    required String ourPubkey,
+  }) async {
+    _nostrClient = nostrClient;
+    _authService = authService;
+    _ourPubkey = ourPubkey;
+  }
+
+  /// Publish the [proposedBlocklist] to Nostr as kind 30000 with d=block.
+  ///
+  /// Uses [NostrClient.publishEventWithRetry] so a single transient relay
+  /// failure won't leave the list unsynced. Returns a [_PublishAttempt]
+  /// wrapping either the relay [PublishOutcome] or a pre-publish error
+  /// string (not authenticated, sign failure, services not attached).
+  Future<_PublishAttempt> _publishBlockListToNostr(
+    Set<String> proposedBlocklist,
+  ) async {
     final authService = _authService;
     final nostrClient = _nostrClient;
 
@@ -207,16 +282,11 @@ class ContentBlocklistService {
         name: 'ContentBlocklistService',
         category: LogCategory.system,
       );
-      return;
+      return const _PublishAttempt.error('services_not_attached');
     }
 
     if (!authService.isAuthenticated) {
-      Log.warning(
-        'Cannot publish block list - user not authenticated',
-        name: 'ContentBlocklistService',
-        category: LogCategory.system,
-      );
-      return;
+      return const _PublishAttempt.error('not_authenticated');
     }
 
     try {
@@ -226,7 +296,7 @@ class ContentBlocklistService {
         ['client', 'diVine'],
       ];
 
-      for (final pubkey in _runtimeBlocklist) {
+      for (final pubkey in proposedBlocklist) {
         tags.add(['p', pubkey]);
       }
 
@@ -236,29 +306,24 @@ class ContentBlocklistService {
         tags: tags,
       );
 
-      if (event != null) {
-        final sentEvent = await nostrClient.publishEvent(event);
-
-        if (sentEvent != null) {
-          Log.info(
-            'Published block list to Nostr with ${_runtimeBlocklist.length} entries',
-            name: 'ContentBlocklistService',
-            category: LogCategory.system,
-          );
-        } else {
-          Log.warning(
-            'Failed to publish block list event to relays',
-            name: 'ContentBlocklistService',
-            category: LogCategory.system,
-          );
-        }
+      if (event == null) {
+        return const _PublishAttempt.error('sign_failed');
       }
+
+      final outcome = await nostrClient.publishEventWithRetry(event);
+      Log.debug(
+        'Block list publish outcome: $outcome',
+        name: 'ContentBlocklistService',
+        category: LogCategory.system,
+      );
+      return _PublishAttempt.outcome(outcome);
     } catch (e) {
       Log.error(
         'Error publishing block list to Nostr: $e',
         name: 'ContentBlocklistService',
         category: LogCategory.system,
       );
+      return _PublishAttempt.error('Failed to publish block list: $e');
     }
   }
 
@@ -296,13 +361,20 @@ class ContentBlocklistService {
   /// users who have blocked us, and prevent following them.
   bool hasBlockedUs(String pubkey) => _blockedByOthers.contains(pubkey);
 
-  /// Add a public key to the runtime blocklist
+  /// Add a public key to the runtime blocklist.
   ///
-  /// Persists to SharedPreferences and publishes to Nostr (kind 30000).
-  /// Awaits the local write so the block survives an immediate app kill.
-  /// If [ourPubkey] is provided, it will be used to prevent self-blocking.
-  /// Otherwise falls back to [_ourPubkey] set during [syncMuteListsInBackground].
-  Future<void> blockUser(String pubkey, {String? ourPubkey}) async {
+  /// Contract: the runtime blocklist is NOT committed until the kind 30000
+  /// event is accepted by at least one relay. This prevents the
+  /// silent-divergence bug where the device thought a pubkey was blocked
+  /// but no relay had the updated list. On failure the blocklist and
+  /// severed-follower tracking both roll back.
+  ///
+  /// If [ourPubkey] is provided, it prevents self-blocking; otherwise
+  /// falls back to [_ourPubkey] set during [syncMuteListsInBackground].
+  Future<BlocklistResult> blockUser(
+    String pubkey, {
+    String? ourPubkey,
+  }) async {
     // Guard: Prevent blocking self
     final selfPubkey = ourPubkey ?? _ourPubkey;
     if (selfPubkey != null && pubkey == selfPubkey) {
@@ -311,54 +383,143 @@ class ContentBlocklistService {
         name: 'ContentBlocklistService',
         category: LogCategory.system,
       );
-      return;
+      return BlocklistResult.failure(error: 'Cannot block yourself');
     }
 
-    if (!_runtimeBlocklist.contains(pubkey)) {
-      _runtimeBlocklist.add(pubkey);
-      await _saveBlockedUsers();
-      _notifyChanged();
-      await _publishBlockListToNostr();
+    if (_runtimeBlocklist.contains(pubkey)) {
+      // Already blocked — no-op success, no relay call.
+      return BlocklistResult.success_();
+    }
 
-      Log.debug(
-        'Added user to blocklist: $pubkey',
+    // Degraded mode: Nostr services not yet attached (e.g. first launch
+    // before sign-in wiring). Persist locally so the user's block takes
+    // effect in-session; the relay sync will reconcile when services
+    // attach. This preserves the pre-PR-4 behavior only for this
+    // unauthenticated path — once Nostr is available we gate strictly on
+    // relay acceptance.
+    if (_authService == null || _nostrClient == null) {
+      return _commitLocalBlock(pubkey);
+    }
+
+    final proposed = {..._runtimeBlocklist, pubkey};
+    final publish = await _publishBlockListToNostr(proposed);
+    if (publish.outcome == null) {
+      return BlocklistResult.failure(error: publish.error);
+    }
+
+    final feedback = PublishResultMapper.map(publish.outcome!);
+    if (!publish.outcome!.acceptedByAny) {
+      Log.warning(
+        'Block publish rejected by every relay: ${publish.outcome}',
         name: 'ContentBlocklistService',
         category: LogCategory.system,
       );
+      return BlocklistResult.failure(
+        outcome: publish.outcome,
+        feedback: feedback,
+      );
     }
 
-    // Track as severed follower so they stay hidden from our followers
-    // list even after unblocking (until they explicitly re-follow).
+    // Commit locally only after relay acceptance.
+    await _commitLocalBlock(pubkey);
+    return BlocklistResult.success_(
+      outcome: publish.outcome,
+      feedback: feedback,
+    );
+  }
+
+  /// Persist a block locally and notify listeners.
+  ///
+  /// Shared between the relay-accepted path and the degraded pre-attach
+  /// mode. Returns a bare [BlocklistResult.success_] with no outcome —
+  /// the relay-accepted path layers its own feedback on top.
+  Future<BlocklistResult> _commitLocalBlock(String pubkey) async {
+    _runtimeBlocklist.add(pubkey);
+    await _saveBlockedUsers();
+
     if (!_severedFollowers.contains(pubkey)) {
       _severedFollowers.add(pubkey);
       await _saveSeveredFollowers();
     }
+    _notifyChanged();
+
+    Log.debug(
+      'Added user to blocklist: $pubkey',
+      name: 'ContentBlocklistService',
+      category: LogCategory.system,
+    );
+
+    return BlocklistResult.success_();
   }
 
-  /// Remove a public key from the runtime blocklist
+  /// Remove a public key from the runtime blocklist.
   ///
-  /// Persists to SharedPreferences and publishes updated list to Nostr.
-  /// Awaits the local write so the change survives an immediate app kill.
+  /// Contract mirrors [blockUser]: the runtime blocklist stays unchanged
+  /// until the updated kind 30000 event is accepted. On relay failure the
+  /// pubkey stays blocked so the user isn't silently exposed to content
+  /// they thought they unblocked.
+  ///
   /// Note: Cannot remove users from internal blocklist.
-  Future<void> unblockUser(String pubkey) async {
-    if (_runtimeBlocklist.contains(pubkey)) {
-      _runtimeBlocklist.remove(pubkey);
-      await _saveBlockedUsers();
-      _notifyChanged();
-      await _publishBlockListToNostr();
+  Future<BlocklistResult> unblockUser(String pubkey) async {
+    if (!_runtimeBlocklist.contains(pubkey)) {
+      if (_internalBlocklist.contains(pubkey)) {
+        Log.warning(
+          'Cannot unblock user from internal blocklist: $pubkey',
+          name: 'ContentBlocklistService',
+          category: LogCategory.system,
+        );
+        return BlocklistResult.failure(
+          error: 'Cannot unblock user from internal blocklist',
+        );
+      }
+      // Already unblocked — no-op success.
+      return BlocklistResult.success_();
+    }
 
-      Log.info(
-        'Removed user from blocklist: $pubkey',
+    // Degraded mode: see [blockUser] — mirror the unauthenticated path.
+    if (_authService == null || _nostrClient == null) {
+      return _commitLocalUnblock(pubkey);
+    }
+
+    final proposed = _runtimeBlocklist.where((p) => p != pubkey).toSet();
+    final publish = await _publishBlockListToNostr(proposed);
+    if (publish.outcome == null) {
+      return BlocklistResult.failure(error: publish.error);
+    }
+
+    final feedback = PublishResultMapper.map(publish.outcome!);
+    if (!publish.outcome!.acceptedByAny) {
+      Log.warning(
+        'Unblock publish rejected by every relay: ${publish.outcome}',
         name: 'ContentBlocklistService',
         category: LogCategory.system,
       );
-    } else if (_internalBlocklist.contains(pubkey)) {
-      Log.warning(
-        'Cannot unblock user from internal blocklist: $pubkey',
-        name: 'ContentBlocklistService',
-        category: LogCategory.system,
+      return BlocklistResult.failure(
+        outcome: publish.outcome,
+        feedback: feedback,
       );
     }
+
+    await _commitLocalUnblock(pubkey);
+    return BlocklistResult.success_(
+      outcome: publish.outcome,
+      feedback: feedback,
+    );
+  }
+
+  /// Mirror of [_commitLocalBlock] for unblocks.
+  Future<BlocklistResult> _commitLocalUnblock(String pubkey) async {
+    _runtimeBlocklist.remove(pubkey);
+    await _saveBlockedUsers();
+    _notifyChanged();
+
+    Log.info(
+      'Removed user from blocklist: $pubkey',
+      name: 'ContentBlocklistService',
+      category: LogCategory.system,
+    );
+
+    return BlocklistResult.success_();
   }
 
   /// Get all blocked public keys (for debugging)
@@ -710,4 +871,17 @@ class ContentBlocklistService {
     _mutualMuteSubscriptionId = null;
     _blockListSyncStarted = false;
   }
+}
+
+/// Internal wrapper for the result of a block list publish attempt.
+///
+/// Either holds a [PublishOutcome] (reached the relay round-trip) or a
+/// pre-publish [error] string (services not attached, not authenticated,
+/// sign failure).
+class _PublishAttempt {
+  const _PublishAttempt.outcome(PublishOutcome this.outcome) : error = null;
+  const _PublishAttempt.error(String this.error) : outcome = null;
+
+  final PublishOutcome? outcome;
+  final String? error;
 }

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -12,28 +12,66 @@ import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-/// Report submission result
-/// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
+/// Report submission result.
+///
+/// Carries the per-relay [PublishOutcome] and mapped [PublishUserFeedback]
+/// so the UI can drive retry affordances for transient failures and show
+/// accurate confirmation only when the moderation relay actually accepted
+/// the kind 1984 event. Contract: [success] requires
+/// [PublishOutcome.acceptedByAny].
 class ReportResult {
   const ReportResult({
     required this.success,
     required this.timestamp,
     this.error,
     this.reportId,
+    this.outcome,
+    this.feedback,
   });
   final bool success;
+
+  /// Pre-publish failure reason. `null` for relay-level failures —
+  /// consult [feedback] instead.
   final String? error;
+
+  /// Stable report ID populated on success; may also be present on relay
+  /// failures to let the UI correlate retries with the original attempt.
   final String? reportId;
   final DateTime timestamp;
 
-  static ReportResult createSuccess(String reportId) => ReportResult(
+  /// Per-relay outcome. `null` for pre-publish failures (not initialized,
+  /// not authenticated, sign failure).
+  final PublishOutcome? outcome;
+
+  /// User-facing feedback mapped via [PublishResultMapper]. `null` for
+  /// pre-publish failures.
+  final PublishUserFeedback? feedback;
+
+  static ReportResult createSuccess({
+    required String reportId,
+    PublishOutcome? outcome,
+    PublishUserFeedback? feedback,
+  }) => ReportResult(
     success: true,
     reportId: reportId,
+    outcome: outcome,
+    feedback: feedback,
     timestamp: DateTime.now(),
   );
 
-  static ReportResult failure(String error) =>
-      ReportResult(success: false, error: error, timestamp: DateTime.now());
+  static ReportResult failure(
+    String error, {
+    String? reportId,
+    PublishOutcome? outcome,
+    PublishUserFeedback? feedback,
+  }) => ReportResult(
+    success: false,
+    error: error,
+    reportId: reportId,
+    outcome: outcome,
+    feedback: feedback,
+    timestamp: DateTime.now(),
+  );
 }
 
 /// Content report data
@@ -140,7 +178,19 @@ class ContentReportingService {
     }
   }
 
-  /// Report content for violation
+  /// Report content for violation.
+  ///
+  /// Publishes a NIP-56 kind 1984 event to the moderation relay using
+  /// [NostrClient.publishEventWithRetry]. Contract: local report history
+  /// is committed only after at least one relay has accepted the event.
+  /// The old behavior "save locally even if publish fails" was a silent
+  /// bug: the UI showed "Report submitted" while the moderation pipeline
+  /// never saw the event.
+  ///
+  /// On relay-level failure the returned [ReportResult] carries both the
+  /// [PublishOutcome] and mapped [PublishUserFeedback] so the UI can
+  /// render a localized message plus a retry affordance for transient
+  /// failures.
   Future<ReportResult> reportContent({
     required String eventId,
     required String authorPubkey,
@@ -176,26 +226,40 @@ class ContentReportingService {
         return ReportResult.failure('Failed to create report event');
       }
 
-      final sentEvent = await _nostrService.publishEvent(
+      // Reports target the moderation relay only — preserve through retry.
+      // 10 s per attempt trims the default 15 s: reports are user-facing so
+      // we want feedback sooner when the moderation relay is unreachable.
+      final outcome = await _nostrService.publishEventWithRetry(
         reportEvent,
-        targetRelays: [moderationRelayUrl],
+        policy: const RetryPolicy(
+          timeoutPerAttempt: Duration(seconds: 10),
+        ),
+        targetRelays: const [moderationRelayUrl],
       );
-      if (sentEvent == null) {
+      final feedback = PublishResultMapper.map(outcome);
+
+      if (!outcome.acceptedByAny) {
         Log.error(
-          'Failed to publish report to relays',
+          'Report rejected by every relay: $outcome',
           name: 'ContentReportingService',
           category: LogCategory.system,
         );
-        // Still save locally even if publish fails
-      } else {
-        Log.info(
-          'Report published to relays',
-          name: 'ContentReportingService',
-          category: LogCategory.system,
+        return ReportResult.failure(
+          'Failed to publish report',
+          reportId: reportId,
+          outcome: outcome,
+          feedback: feedback,
         );
       }
 
-      // Create Zendesk ticket silently for moderation tracking
+      Log.info(
+        'Report accepted by ${outcome.acceptedBy.length} relay(s)',
+        name: 'ContentReportingService',
+        category: LogCategory.system,
+      );
+
+      // Create Zendesk ticket silently for moderation tracking. This is
+      // a supplementary channel — failure does not affect the outcome.
       await _createZendeskTicket(
         reportId: reportId,
         eventId: eventId,
@@ -205,7 +269,7 @@ class ContentReportingService {
         additionalContext: additionalContext,
       );
 
-      // Save report to local history
+      // Commit to local history only after relay acceptance.
       final report = ContentReport(
         reportId: reportId,
         eventId: eventId,
@@ -225,7 +289,11 @@ class ContentReportingService {
         name: 'ContentReportingService',
         category: LogCategory.system,
       );
-      return ReportResult.createSuccess(reportId);
+      return ReportResult.createSuccess(
+        reportId: reportId,
+        outcome: outcome,
+        feedback: feedback,
+      );
     } catch (e) {
       Log.error(
         'Failed to submit content report: $e',

--- a/mobile/lib/services/mute_service.dart
+++ b/mobile/lib/services/mute_service.dart
@@ -110,6 +110,62 @@ class MuteItem {
   int get hashCode => Object.hash(type, value);
 }
 
+/// Result of a mute/unmute/clear operation.
+///
+/// Carries the per-relay [PublishOutcome] and the mapped
+/// [PublishUserFeedback] so callers can drive localized snackbars and
+/// retry affordances. Success requires [outcome.acceptedByAny] — the
+/// service does NOT commit the in-memory mute set until at least one
+/// relay has acknowledged the updated list. This closes the
+/// silent-divergence bug where a failed publish left the device believing
+/// a pubkey was muted but no relay stored the change.
+class MuteResult {
+  const MuteResult({
+    required this.success,
+    required this.timestamp,
+    this.outcome,
+    this.feedback,
+    this.error,
+  });
+
+  final bool success;
+  final DateTime timestamp;
+
+  /// Per-relay outcome for the publish. `null` only when the request
+  /// never reached the publish stage (e.g. not authenticated, sign
+  /// failure).
+  final PublishOutcome? outcome;
+
+  /// User-facing feedback mapped via [PublishResultMapper]. `null` for
+  /// pre-publish failures; always populated when [outcome] is populated.
+  final PublishUserFeedback? feedback;
+
+  /// Human-readable error for pre-publish failures (not relay failures).
+  final String? error;
+
+  static MuteResult success_({
+    PublishOutcome? outcome,
+    PublishUserFeedback? feedback,
+  }) => MuteResult(
+    success: true,
+    outcome: outcome,
+    feedback: feedback,
+    timestamp: DateTime.now(),
+  );
+
+  static MuteResult failure({
+    String? error,
+    PublishOutcome? outcome,
+    PublishUserFeedback? feedback,
+  }) => MuteResult(
+    success: false,
+    error: error,
+    outcome: outcome,
+    feedback: feedback,
+    timestamp: DateTime.now(),
+  );
+}
+
 /// Service for managing NIP-51 mute lists
 class MuteService {
   MuteService({
@@ -177,7 +233,7 @@ class MuteService {
   // === MUTE MANAGEMENT ===
 
   /// Mute a user by pubkey
-  Future<bool> muteUser(
+  Future<MuteResult> muteUser(
     String pubkey, {
     String? reason,
     Duration? duration,
@@ -186,7 +242,7 @@ class MuteService {
   }
 
   /// Mute a hashtag
-  Future<bool> muteHashtag(
+  Future<MuteResult> muteHashtag(
     String hashtag, {
     String? reason,
     Duration? duration,
@@ -204,7 +260,7 @@ class MuteService {
   }
 
   /// Mute a keyword or phrase
-  Future<bool> muteKeyword(
+  Future<MuteResult> muteKeyword(
     String keyword, {
     String? reason,
     Duration? duration,
@@ -218,7 +274,7 @@ class MuteService {
   }
 
   /// Mute an entire thread by event ID
-  Future<bool> muteThread(
+  Future<MuteResult> muteThread(
     String eventId, {
     String? reason,
     Duration? duration,
@@ -231,8 +287,13 @@ class MuteService {
     );
   }
 
-  /// Generic method to mute any type of item
-  Future<bool> muteItem(
+  /// Generic method to mute any type of item.
+  ///
+  /// Contract: the in-memory mute set is NOT committed until the relay
+  /// has accepted the updated kind 10000 list. This prevents
+  /// silent-divergence where the UI thinks a pubkey is muted but on the
+  /// next device sign-in the user sees the unmuted content.
+  Future<MuteResult> muteItem(
     MuteType type,
     String value, {
     String? reason,
@@ -241,7 +302,7 @@ class MuteService {
     try {
       final expireAt = duration != null ? DateTime.now().add(duration) : null;
 
-      final muteItem = MuteItem(
+      final newItem = MuteItem(
         type: type,
         value: value,
         reason: reason,
@@ -249,66 +310,128 @@ class MuteService {
         expireAt: expireAt,
       );
 
-      // Check if already muted
-      if (_mutedItems.contains(muteItem)) {
+      // Check if already muted — no-op success.
+      if (_mutedItems.contains(newItem)) {
         Log.debug(
           'Item already muted: $value',
           name: 'MuteService',
           category: LogCategory.system,
         );
-        return true;
+        return MuteResult.success_();
       }
 
-      _mutedItems.add(muteItem);
+      // Compute the proposed mute list locally but do NOT commit until
+      // the relay accepts.
+      final proposed = List<MuteItem>.from(_mutedItems)..add(newItem);
+
+      if (!_authService.isAuthenticated) {
+        Log.warning(
+          'Cannot mute item: user not authenticated',
+          name: 'MuteService',
+          category: LogCategory.system,
+        );
+        return MuteResult.failure(error: 'Not authenticated');
+      }
+
+      final publish = await _publishMuteListToNostr(proposed);
+      if (publish.outcome == null) {
+        return MuteResult.failure(error: publish.error);
+      }
+
+      final feedback = PublishResultMapper.map(publish.outcome!);
+      if (!publish.outcome!.acceptedByAny) {
+        // Rollback — no state change since we never committed.
+        Log.warning(
+          'Mute publish rejected by every relay: ${publish.outcome}',
+          name: 'MuteService',
+          category: LogCategory.system,
+        );
+        return MuteResult.failure(
+          outcome: publish.outcome,
+          feedback: feedback,
+        );
+      }
+
+      // Commit to memory and disk only after relay acceptance.
+      _mutedItems.add(newItem);
       await _saveMutedItems();
 
-      // Publish to Nostr if authenticated
-      if (_authService.isAuthenticated) {
-        await _publishMuteListToNostr();
-      }
-
       Log.info(
-        'Muted ${type.value}: $value${duration != null ? ' (expires in ${duration.inHours}h)' : ' (permanent)'}',
+        'Muted ${type.value}: $value'
+        '${duration != null ? ' (expires in ${duration.inHours}h)' : ' (permanent)'}',
         name: 'MuteService',
         category: LogCategory.system,
       );
 
-      return true;
+      return MuteResult.success_(
+        outcome: publish.outcome,
+        feedback: feedback,
+      );
     } catch (e) {
       Log.error(
         'Failed to mute item: $e',
         name: 'MuteService',
         category: LogCategory.system,
       );
-      return false;
+      return MuteResult.failure(error: 'Failed to mute item: $e');
     }
   }
 
-  /// Unmute an item
-  Future<bool> unmuteItem(MuteType type, String value) async {
+  /// Unmute an item.
+  ///
+  /// Contract: the in-memory mute set stays unchanged until the relay
+  /// accepts the new list. If publish fails, the item stays muted so
+  /// the user isn't silently exposed to content they thought they
+  /// unmuted.
+  Future<MuteResult> unmuteItem(MuteType type, String value) async {
     try {
-      final muteItem = MuteItem(
+      final target = MuteItem(
         type: type,
         value: value,
         createdAt: DateTime.now(), // Doesn't matter for equality check
       );
 
-      final removed = _mutedItems.remove(muteItem);
-      if (!removed) {
+      if (!_mutedItems.contains(target)) {
         Log.warning(
           'Item not found in mute list: $value',
           name: 'MuteService',
           category: LogCategory.system,
         );
-        return false;
+        return MuteResult.failure(error: 'Item not found in mute list');
       }
 
+      // Proposed list excludes the target.
+      final proposed = _mutedItems.where((i) => i != target).toList();
+
+      if (!_authService.isAuthenticated) {
+        Log.warning(
+          'Cannot unmute item: user not authenticated',
+          name: 'MuteService',
+          category: LogCategory.system,
+        );
+        return MuteResult.failure(error: 'Not authenticated');
+      }
+
+      final publish = await _publishMuteListToNostr(proposed);
+      if (publish.outcome == null) {
+        return MuteResult.failure(error: publish.error);
+      }
+
+      final feedback = PublishResultMapper.map(publish.outcome!);
+      if (!publish.outcome!.acceptedByAny) {
+        Log.warning(
+          'Unmute publish rejected by every relay: ${publish.outcome}',
+          name: 'MuteService',
+          category: LogCategory.system,
+        );
+        return MuteResult.failure(
+          outcome: publish.outcome,
+          feedback: feedback,
+        );
+      }
+
+      _mutedItems.remove(target);
       await _saveMutedItems();
-
-      // Update on Nostr if authenticated
-      if (_authService.isAuthenticated) {
-        await _publishMuteListToNostr();
-      }
 
       Log.info(
         'Unmuted ${type.value}: $value',
@@ -316,24 +439,27 @@ class MuteService {
         category: LogCategory.system,
       );
 
-      return true;
+      return MuteResult.success_(
+        outcome: publish.outcome,
+        feedback: feedback,
+      );
     } catch (e) {
       Log.error(
         'Failed to unmute item: $e',
         name: 'MuteService',
         category: LogCategory.system,
       );
-      return false;
+      return MuteResult.failure(error: 'Failed to unmute item: $e');
     }
   }
 
   /// Unmute a user
-  Future<bool> unmuteUser(String pubkey) async {
+  Future<MuteResult> unmuteUser(String pubkey) async {
     return unmuteItem(MuteType.user, pubkey);
   }
 
   /// Unmute a hashtag
-  Future<bool> unmuteHashtag(String hashtag) async {
+  Future<MuteResult> unmuteHashtag(String hashtag) async {
     final normalizedHashtag = hashtag.startsWith('#')
         ? hashtag.substring(1).toLowerCase()
         : hashtag.toLowerCase();
@@ -341,12 +467,12 @@ class MuteService {
   }
 
   /// Unmute a keyword
-  Future<bool> unmuteKeyword(String keyword) async {
+  Future<MuteResult> unmuteKeyword(String keyword) async {
     return unmuteItem(MuteType.keyword, keyword.toLowerCase());
   }
 
   /// Unmute a thread
-  Future<bool> unmuteThread(String eventId) async {
+  Future<MuteResult> unmuteThread(String eventId) async {
     return unmuteItem(MuteType.thread, eventId);
   }
 
@@ -425,41 +551,55 @@ class MuteService {
 
   // === BULK OPERATIONS ===
 
-  /// Import mute list from another platform or backup
-  Future<bool> importMuteList(List<MuteItem> items) async {
+  /// Import mute list from another platform or backup.
+  ///
+  /// Commits to memory only when the relay accepts the merged list.
+  Future<MuteResult> importMuteList(List<MuteItem> items) async {
     try {
-      var importedCount = 0;
-
-      for (final item in items) {
-        if (!_mutedItems.contains(item)) {
-          _mutedItems.add(item);
-          importedCount++;
-        }
+      final newItems = items.where((i) => !_mutedItems.contains(i)).toList();
+      if (newItems.isEmpty) {
+        return MuteResult.success_();
       }
 
-      if (importedCount > 0) {
-        await _saveMutedItems();
+      final proposed = List<MuteItem>.from(_mutedItems)..addAll(newItems);
 
-        // Publish to Nostr if authenticated
-        if (_authService.isAuthenticated) {
-          await _publishMuteListToNostr();
-        }
+      if (!_authService.isAuthenticated) {
+        return MuteResult.failure(error: 'Not authenticated');
       }
+
+      final publish = await _publishMuteListToNostr(proposed);
+      if (publish.outcome == null) {
+        return MuteResult.failure(error: publish.error);
+      }
+
+      final feedback = PublishResultMapper.map(publish.outcome!);
+      if (!publish.outcome!.acceptedByAny) {
+        return MuteResult.failure(
+          outcome: publish.outcome,
+          feedback: feedback,
+        );
+      }
+
+      _mutedItems.addAll(newItems);
+      await _saveMutedItems();
 
       Log.info(
-        'Imported $importedCount new muted items',
+        'Imported ${newItems.length} new muted items',
         name: 'MuteService',
         category: LogCategory.system,
       );
 
-      return true;
+      return MuteResult.success_(
+        outcome: publish.outcome,
+        feedback: feedback,
+      );
     } catch (e) {
       Log.error(
         'Failed to import mute list: $e',
         name: 'MuteService',
         category: LogCategory.system,
       );
-      return false;
+      return MuteResult.failure(error: 'Failed to import mute list: $e');
     }
   }
 
@@ -468,16 +608,34 @@ class MuteService {
     return List.from(mutedItems);
   }
 
-  /// Clear all mutes
-  Future<bool> clearAllMutes() async {
+  /// Clear all mutes.
+  ///
+  /// Commits to memory only when the relay accepts the empty list.
+  Future<MuteResult> clearAllMutes() async {
     try {
+      if (_mutedItems.isEmpty) {
+        return MuteResult.success_();
+      }
+
+      if (!_authService.isAuthenticated) {
+        return MuteResult.failure(error: 'Not authenticated');
+      }
+
+      final publish = await _publishMuteListToNostr(const <MuteItem>[]);
+      if (publish.outcome == null) {
+        return MuteResult.failure(error: publish.error);
+      }
+
+      final feedback = PublishResultMapper.map(publish.outcome!);
+      if (!publish.outcome!.acceptedByAny) {
+        return MuteResult.failure(
+          outcome: publish.outcome,
+          feedback: feedback,
+        );
+      }
+
       _mutedItems.clear();
       await _saveMutedItems();
-
-      // Update on Nostr if authenticated
-      if (_authService.isAuthenticated) {
-        await _publishMuteListToNostr();
-      }
 
       Log.info(
         'Cleared all muted items',
@@ -485,29 +643,36 @@ class MuteService {
         category: LogCategory.system,
       );
 
-      return true;
+      return MuteResult.success_(
+        outcome: publish.outcome,
+        feedback: feedback,
+      );
     } catch (e) {
       Log.error(
         'Failed to clear mute list: $e',
         name: 'MuteService',
         category: LogCategory.system,
       );
-      return false;
+      return MuteResult.failure(error: 'Failed to clear mute list: $e');
     }
   }
 
   // === NOSTR PUBLISHING ===
 
-  /// Publish mute list to Nostr as NIP-51 kind 10000 event
-  Future<void> _publishMuteListToNostr() async {
+  /// Publish the [proposed] mute list to Nostr as a NIP-51 kind 10000
+  /// event using [NostrClient.publishEventWithRetry].
+  ///
+  /// Returns a [_PublishAttempt] wrapper exposing either the
+  /// [PublishOutcome] (on a successful publish attempt) or an [error]
+  /// string (pre-publish failure — signing, not authenticated, etc.).
+  ///
+  /// Only non-expired permanent items are included in the kind 10000 tags.
+  Future<_PublishAttempt> _publishMuteListToNostr(
+    List<MuteItem> proposed,
+  ) async {
     try {
       if (!_authService.isAuthenticated) {
-        Log.warning(
-          'Cannot publish mute list - user not authenticated',
-          name: 'MuteService',
-          category: LogCategory.system,
-        );
-        return;
+        return const _PublishAttempt.error('not_authenticated');
       }
 
       // Create NIP-51 kind 10000 tags
@@ -516,7 +681,9 @@ class MuteService {
       ];
 
       // Add muted items as tags (only non-expired, permanent mutes for Nostr)
-      for (final item in mutedItems.where((item) => item.isPermanent)) {
+      for (final item in proposed.where(
+        (item) => item.isPermanent && !item.isExpired,
+      )) {
         tags.add(item.toTag());
       }
 
@@ -526,22 +693,24 @@ class MuteService {
         tags: tags,
       );
 
-      if (event != null) {
-        final sentEvent = await _nostrService.publishEvent(event);
-        if (sentEvent != null) {
-          Log.debug(
-            'Published mute list to Nostr: ${event.id}',
-            name: 'MuteService',
-            category: LogCategory.system,
-          );
-        }
+      if (event == null) {
+        return const _PublishAttempt.error('sign_failed');
       }
+
+      final outcome = await _nostrService.publishEventWithRetry(event);
+      Log.debug(
+        'Mute list publish outcome: $outcome',
+        name: 'MuteService',
+        category: LogCategory.system,
+      );
+      return _PublishAttempt.outcome(outcome);
     } catch (e) {
       Log.error(
         'Failed to publish mute list to Nostr: $e',
         name: 'MuteService',
         category: LogCategory.system,
       );
+      return _PublishAttempt.error('Failed to publish mute list: $e');
     }
   }
 
@@ -625,4 +794,16 @@ class MuteService {
       );
     }
   }
+}
+
+/// Internal wrapper for the result of a mute list publish attempt.
+///
+/// Either holds a [PublishOutcome] (reached the relay round-trip) or a
+/// pre-publish [error] string (signing failed, not authenticated, etc.).
+class _PublishAttempt {
+  const _PublishAttempt.outcome(PublishOutcome this.outcome) : error = null;
+  const _PublishAttempt.error(String this.error) : outcome = null;
+
+  final PublishOutcome? outcome;
+  final String? error;
 }

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -181,9 +181,14 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
       );
 
       if (mounted) {
-        context.pop(); // Close report dialog
-        if (widget.isFromShareMenu) {
-          context.pop(); // Close share menu (only if opened from share menu)
+        if (result.success) {
+          // Close dialog only on success so retry can re-submit without
+          // re-opening the dialog from scratch.
+          context.pop(); // Close report dialog
+          if (widget.isFromShareMenu) {
+            // Close share menu (only if opened from share menu)
+            context.pop();
+          }
         }
 
         if (result.success) {
@@ -191,24 +196,31 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
           // The Kind 1984 published by reportContent() already includes the
           // author pubkey in the `p` tag, so no second Kind 1984 is needed.
           if (_blockUser) {
-            // 1. Add to mute list (publishes kind 10000 NIP-51 mute list)
+            // 1. Add to mute list (publishes kind 10000 NIP-51 mute list).
+            // 2. Also add to local blocklist for immediate filtering
+            //    (publishes kind 30000 addressable block list).
+            // Both results are logged but not surfaced — the primary
+            // report already succeeded. Secondary block failures will
+            // reconcile on the next relay sync; the user can retry from
+            // the safety settings screen if needed.
             final muteService = await ref.read(muteServiceProvider.future);
-            await muteService.muteUser(
+            final muteResult = await muteService.muteUser(
               widget.video.pubkey,
               reason:
-                  'Reported and blocked for ${_getReasonDisplayName(_selectedReason!)}',
+                  'Reported and blocked for '
+                  '${_getReasonDisplayName(_selectedReason!)}',
             );
 
-            // 2. Also add to local blocklist for immediate filtering
             final blocklistService = ref.read(contentBlocklistServiceProvider);
             final nostrClient = ref.read(nostrServiceProvider);
-            blocklistService.blockUser(
+            final blockResult = await blocklistService.blockUser(
               widget.video.pubkey,
               ourPubkey: nostrClient.publicKey,
             );
 
             Log.info(
-              'User blocked: kind 10000 mute list published for ${widget.video.pubkey}',
+              'User blocked for ${widget.video.pubkey} — '
+              'mute=${muteResult.success}, block=${blockResult.success}',
               name: 'ReportContentDialog',
               category: LogCategory.ui,
             );
@@ -244,13 +256,27 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
             );
           }
         } else {
-          // Show error snackbar
+          // Show error snackbar. When the publish reached the relay but
+          // was not accepted, expose a Retry affordance driven by
+          // feedback.retryable. The raw error string is still useful
+          // for pre-publish failures (not authenticated, etc.).
+          final feedback = result.feedback;
+          final retryable = feedback?.retryable ?? false;
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(
                 context.l10n.reportFailed(result.error ?? ''),
               ),
               backgroundColor: VineTheme.error,
+              action: retryable
+                  ? SnackBarAction(
+                      // Reused English fallback — PR 8 introduces
+                      // dedicated l10n keys for the retry affordance
+                      // across all migrated services.
+                      label: 'Retry',
+                      onPressed: _submitReport,
+                    )
+                  : null,
             ),
           );
         }

--- a/mobile/test/blocs/comments/comments_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_bloc_test.dart
@@ -2038,7 +2038,9 @@ void main() {
               reason: any(named: 'reason'),
               details: any(named: 'details'),
             ),
-          ).thenAnswer((_) async => ReportResult.createSuccess('report-id'));
+          ).thenAnswer(
+            (_) async => ReportResult.createSuccess(reportId: 'report-id'),
+          );
         },
         build: createBloc,
         act: (bloc) => bloc.add(
@@ -2097,7 +2099,7 @@ void main() {
         setUp: () {
           when(
             () => mockContentBlocklistService.blockUser(any()),
-          ).thenAnswer((_) async {});
+          ).thenAnswer((_) async => BlocklistResult.success_());
           when(() => mockFollowRepository.isFollowing(any())).thenReturn(false);
         },
         build: createBloc,

--- a/mobile/test/blocs/dm/conversation_actions/conversation_actions_cubit_test.dart
+++ b/mobile/test/blocs/dm/conversation_actions/conversation_actions_cubit_test.dart
@@ -75,7 +75,7 @@ void main() {
               details: 'Reported from DM conversation',
             ),
           ).thenAnswer(
-            (_) async => ReportResult.createSuccess('report-id'),
+            (_) async => ReportResult.createSuccess(reportId: 'report-id'),
           );
         },
         build: createCubit,
@@ -150,7 +150,7 @@ void main() {
               pubkey,
               ourPubkey: currentUserPubkey,
             ),
-          ).thenAnswer((_) async {});
+          ).thenAnswer((_) async => BlocklistResult.success_());
         },
         build: createCubit,
         act: (cubit) => cubit.blockUser(pubkey),
@@ -202,7 +202,7 @@ void main() {
         setUp: () {
           when(
             () => mockBlocklistService.unblockUser(pubkey),
-          ).thenAnswer((_) async {});
+          ).thenAnswer((_) async => BlocklistResult.success_());
         },
         build: createCubit,
         act: (cubit) => cubit.unblockUser(pubkey),

--- a/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
+++ b/mobile/test/blocs/other_profile/other_profile_bloc_test.dart
@@ -528,7 +528,7 @@ void main() {
             any(),
             ourPubkey: any(named: 'ourPubkey'),
           ),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => BlocklistResult.success_());
       });
 
       blocTest<OtherProfileBloc, OtherProfileState>(
@@ -599,7 +599,7 @@ void main() {
       setUp(() {
         when(
           () => mockBlocklistService.unblockUser(any()),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => BlocklistResult.success_());
       });
 
       blocTest<OtherProfileBloc, OtherProfileState>(

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -28,13 +28,18 @@ class MockContentBlocklistService extends Mock
   Set<String> get runtimeBlockedUsers => Set.unmodifiable(_runtimeBlocklist);
 
   @override
-  Future<void> blockUser(String pubkey, {String? ourPubkey}) async {
+  Future<BlocklistResult> blockUser(
+    String pubkey, {
+    String? ourPubkey,
+  }) async {
     _runtimeBlocklist.add(pubkey);
+    return BlocklistResult.success_();
   }
 
   @override
-  Future<void> unblockUser(String pubkey) async {
+  Future<BlocklistResult> unblockUser(String pubkey) async {
     _runtimeBlocklist.remove(pubkey);
+    return BlocklistResult.success_();
   }
 
   @override

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -18,9 +18,18 @@ class _MockAuthService extends Mock implements AuthService {}
 
 class _FakeEvent extends Fake implements Event {}
 
+/// Builds a success [PublishOutcome] for stubbing publishEventWithRetry.
+PublishOutcome _successOutcome(String eventId) => PublishOutcome(
+  eventId: eventId,
+  acceptedBy: const {'wss://relay.divine.video'},
+  rejectedBy: const {},
+  noResponseFrom: const {},
+);
+
 void main() {
   setUpAll(() {
     registerFallbackValue(_FakeEvent());
+    registerFallbackValue(const RetryPolicy());
   });
 
   group('ContentReportingService', () {
@@ -143,11 +152,12 @@ void main() {
         ).thenAnswer((_) async => reportEvent);
 
         when(
-          () => mockNostrService.publishEvent(
+          () => mockNostrService.publishEventWithRetry(
             any(),
+            policy: any(named: 'policy'),
             targetRelays: any(named: 'targetRelays'),
           ),
-        ).thenAnswer((_) async => reportEvent);
+        ).thenAnswer((_) async => _successOutcome(reportEvent.id));
 
         // Act
         final result = await service.reportContent(
@@ -172,8 +182,9 @@ void main() {
 
         // Verify Nostr event was published to moderation relay
         verify(
-          () => mockNostrService.publishEvent(
+          () => mockNostrService.publishEventWithRetry(
             any(),
+            policy: any(named: 'policy'),
             targetRelays: any(named: 'targetRelays'),
           ),
         ).called(1);
@@ -199,11 +210,12 @@ void main() {
       ).thenAnswer((_) async => reportEvent);
 
       when(
-        () => mockNostrService.publishEvent(
+        () => mockNostrService.publishEventWithRetry(
           any(),
+          policy: any(named: 'policy'),
           targetRelays: any(named: 'targetRelays'),
         ),
-      ).thenAnswer((_) async => reportEvent);
+      ).thenAnswer((_) async => _successOutcome(reportEvent.id));
 
       const reasons = ContentFilterReason.values;
 
@@ -253,11 +265,12 @@ void main() {
       ).thenAnswer((_) async => reportEvent);
 
       when(
-        () => mockNostrService.publishEvent(
+        () => mockNostrService.publishEventWithRetry(
           any(),
+          policy: any(named: 'policy'),
           targetRelays: any(named: 'targetRelays'),
         ),
-      ).thenAnswer((_) async => reportEvent);
+      ).thenAnswer((_) async => _successOutcome(reportEvent.id));
 
       // Act - This should not throw an exception due to missing switch case
       final result = await service.reportContent(
@@ -272,48 +285,59 @@ void main() {
       expect(result.error, isNull);
     });
 
-    test('reportContent() handles broadcast failures gracefully', () async {
-      // Arrange
-      final reportEvent = createTestEvent(
-        pubkey: testPublicKey,
-        kind: 1984,
-        tags: [],
-        content: 'Spam content',
-      );
+    test(
+      'reportContent() fails when every relay rejects (NO history commit)',
+      () async {
+        // Contract change (PR 4 moderation reliability): the legacy
+        // behavior was to save report history even if the broadcast failed.
+        // That was a silent bug — the UI showed "Report submitted" while
+        // the moderation relay never saw the kind 1984. History now
+        // commits only after the relay accepts.
+        final reportEvent = createTestEvent(
+          pubkey: testPublicKey,
+          kind: 1984,
+          tags: [],
+          content: 'Spam content',
+        );
 
-      when(
-        () => mockAuthService.createAndSignEvent(
-          kind: any(named: 'kind'),
-          content: any(named: 'content'),
-          tags: any(named: 'tags'),
-        ),
-      ).thenAnswer((_) async => reportEvent);
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((_) async => reportEvent);
 
-      // Mock failed publish - returns null on failure
-      when(
-        () => mockNostrService.publishEvent(
-          any(),
-          targetRelays: any(named: 'targetRelays'),
-        ),
-      ).thenAnswer((_) async => null);
+        when(
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: reportEvent.id,
+            acceptedBy: const {},
+            rejectedBy: const {},
+            noResponseFrom: const {'wss://relay.divine.video'},
+          ),
+        );
 
-      // Act
-      final result = await service.reportContent(
-        eventId: 'event_123',
-        authorPubkey: 'author_456',
-        reason: ContentFilterReason.spam,
-        details: 'Spam content',
-      );
+        final result = await service.reportContent(
+          eventId: 'event_123',
+          authorPubkey: 'author_456',
+          reason: ContentFilterReason.spam,
+          details: 'Spam content',
+        );
 
-      // Assert - Service is resilient: saves report locally even if broadcast
-      // fails
-      expect(result.success, true);
-      expect(result.error, isNull);
-      expect(result.reportId, isNotNull);
-
-      // Verify report was saved to local history
-      expect(service.reportHistory, isNotEmpty);
-    });
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isTrue);
+        // Report ID is carried even on failure so the caller can correlate
+        // retries with the original attempt.
+        expect(result.reportId, isNotNull);
+        expect(service.reportHistory, isEmpty);
+      },
+    );
 
     test('reportContent() stores report in history on success', () async {
       // Arrange
@@ -333,11 +357,12 @@ void main() {
       ).thenAnswer((_) async => reportEvent);
 
       when(
-        () => mockNostrService.publishEvent(
+        () => mockNostrService.publishEventWithRetry(
           any(),
+          policy: any(named: 'policy'),
           targetRelays: any(named: 'targetRelays'),
         ),
-      ).thenAnswer((_) async => reportEvent);
+      ).thenAnswer((_) async => _successOutcome(reportEvent.id));
 
       // Act
       await service.reportContent(
@@ -404,8 +429,9 @@ void main() {
 
         // Verify publishEvent was NOT called
         verifyNever(
-          () => mockNostrService.publishEvent(
+          () => mockNostrService.publishEventWithRetry(
             any(),
+            policy: any(named: 'policy'),
             targetRelays: any(named: 'targetRelays'),
           ),
         );
@@ -461,11 +487,12 @@ void main() {
       ).thenAnswer((_) async => reportEvent);
 
       when(
-        () => mockNostrService.publishEvent(
+        () => mockNostrService.publishEventWithRetry(
           any(),
+          policy: any(named: 'policy'),
           targetRelays: any(named: 'targetRelays'),
         ),
-      ).thenAnswer((_) async => reportEvent);
+      ).thenAnswer((_) async => _successOutcome(reportEvent.id));
 
       await service.reportContent(
         eventId: 'evt_1',
@@ -507,17 +534,18 @@ void main() {
       });
 
       when(
-        () => mockNostrService.publishEvent(
+        () => mockNostrService.publishEventWithRetry(
           any(),
+          policy: any(named: 'policy'),
           targetRelays: any(named: 'targetRelays'),
         ),
       ).thenAnswer(
-        (_) async => Event(
-          testPublicKey,
-          EventKind.report,
-          [],
-          '',
-          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        (_) async => PublishOutcome(
+          eventId:
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          acceptedBy: const {'wss://a'},
+          rejectedBy: const {},
+          noResponseFrom: const {},
         ),
       );
 
@@ -586,17 +614,18 @@ void main() {
         });
 
         when(
-          () => mockNostrService.publishEvent(
+          () => mockNostrService.publishEventWithRetry(
             any(),
+            policy: any(named: 'policy'),
             targetRelays: any(named: 'targetRelays'),
           ),
         ).thenAnswer(
-          (_) async => Event(
-            testPublicKey,
-            EventKind.report,
-            [],
-            '',
-            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          (_) async => PublishOutcome(
+            eventId:
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            acceptedBy: const {'wss://a'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
           ),
         );
 
@@ -664,11 +693,12 @@ void main() {
       ).thenAnswer((_) async => reportEvent);
 
       when(
-        () => mockNostrService.publishEvent(
+        () => mockNostrService.publishEventWithRetry(
           any(),
+          policy: any(named: 'policy'),
           targetRelays: any(named: 'targetRelays'),
         ),
-      ).thenAnswer((_) async => reportEvent);
+      ).thenAnswer((_) async => _successOutcome(reportEvent.id));
 
       // Now reportContent should work
       final result = await service.reportContent(

--- a/mobile/test/unit/services/content_blocklist_service_reliability_test.dart
+++ b/mobile/test/unit/services/content_blocklist_service_reliability_test.dart
@@ -1,0 +1,289 @@
+// ABOUTME: Tests that ContentBlocklistService uses publishEventWithRetry
+// ABOUTME: and gates runtime blocklist on relay acceptance of the kind 30000 event.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/content_blocklist_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const ourPubkey =
+      '0000000000000000000000000000000000000000000000000000000000000001';
+  const targetPubkey =
+      '0000000000000000000000000000000000000000000000000000000000000002';
+
+  setUpAll(() {
+    registerFallbackValue(
+      Event(ourPubkey, 30000, const [], '')
+        ..id = 'a' * 64
+        ..sig = 'sig',
+    );
+    registerFallbackValue(const RetryPolicy());
+  });
+
+  late _MockNostrClient nostr;
+  late _MockAuthService auth;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    nostr = _MockNostrClient();
+    auth = _MockAuthService();
+    when(() => nostr.isInitialized).thenReturn(true);
+    when(() => nostr.publicKey).thenReturn(ourPubkey);
+    when(() => auth.isAuthenticated).thenReturn(true);
+    when(() => auth.currentPublicKeyHex).thenReturn(ourPubkey);
+    when(
+      () => auth.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer((invocation) async {
+      final kind = invocation.namedArguments[#kind] as int;
+      final content = invocation.namedArguments[#content] as String;
+      final tags = invocation.namedArguments[#tags] as List<List<String>>;
+      return Event(ourPubkey, kind, tags, content)
+        ..id = 'b' * 64
+        ..sig = 'sig';
+    });
+  });
+
+  Future<ContentBlocklistService> buildService() async {
+    final prefs = await SharedPreferences.getInstance();
+    final service = ContentBlocklistService(prefs: prefs);
+    await service.attachNostrServices(
+      nostrClient: nostr,
+      authService: auth,
+      ourPubkey: ourPubkey,
+    );
+    return service;
+  }
+
+  group('ContentBlocklistService reliability', () {
+    test(
+      'success path: relay accepts → pubkey added + success feedback',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {'wss://a'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          ),
+        );
+
+        final service = await buildService();
+
+        final result = await service.blockUser(
+          targetPubkey,
+          ourPubkey: ourPubkey,
+        );
+
+        expect(result.success, isTrue);
+        expect(result.outcome!.acceptedBy, {'wss://a'});
+        expect(result.feedback?.severity, PublishSeverity.success);
+        expect(result.feedback?.retryable, isFalse);
+        expect(service.isBlocked(targetPubkey), isTrue);
+        // Severed-follower tracking commits with the block.
+        expect(service.isFollowSevered(targetPubkey), isTrue);
+      },
+    );
+
+    test(
+      'transient failure: rollback + retryable feedback, pubkey NOT added',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {},
+            rejectedBy: const {},
+            noResponseFrom: const {'wss://a'},
+          ),
+        );
+
+        final service = await buildService();
+
+        final result = await service.blockUser(
+          targetPubkey,
+          ourPubkey: ourPubkey,
+        );
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isTrue);
+        expect(result.feedback?.messageKey, 'publish_no_relay_response');
+        // Silent-divergence fix: blocklist must NOT commit when no relay
+        // accepted — otherwise on reinstall the relay has no record and the
+        // user sees content from the supposedly-blocked pubkey.
+        expect(service.isBlocked(targetPubkey), isFalse);
+        expect(service.isFollowSevered(targetPubkey), isFalse);
+      },
+    );
+
+    test(
+      'permanent rejection: non-retryable feedback with reason + rollback',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {},
+            rejectedBy: const {'wss://a': 'blocked: spam'},
+            noResponseFrom: const {},
+          ),
+        );
+
+        final service = await buildService();
+
+        final result = await service.blockUser(
+          targetPubkey,
+          ourPubkey: ourPubkey,
+        );
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isFalse);
+        expect(result.feedback?.messageKey, 'publish_rejected_permanent');
+        expect(result.feedback?.firstRejectionReason, 'blocked: spam');
+        expect(service.isBlocked(targetPubkey), isFalse);
+      },
+    );
+
+    test(
+      'unblock: rollback keeps user blocked when relay rejects',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {'wss://a'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          ),
+        );
+
+        final service = await buildService();
+        final blockResult = await service.blockUser(
+          targetPubkey,
+          ourPubkey: ourPubkey,
+        );
+        expect(blockResult.success, isTrue);
+        expect(service.isBlocked(targetPubkey), isTrue);
+
+        // Fail the unblock.
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {},
+            rejectedBy: const {},
+            noResponseFrom: const {'wss://a'},
+          ),
+        );
+
+        final unblockResult = await service.unblockUser(targetPubkey);
+        expect(unblockResult.success, isFalse);
+        expect(unblockResult.feedback?.retryable, isTrue);
+        expect(
+          service.isBlocked(targetPubkey),
+          isTrue,
+          reason:
+              'Unblock must not commit locally when the relay did not '
+              'accept the updated kind 30000 event.',
+        );
+      },
+    );
+
+    test(
+      'blocking an already-blocked user is a no-op success (no relay call)',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {'wss://a'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          ),
+        );
+
+        final service = await buildService();
+        await service.blockUser(targetPubkey, ourPubkey: ourPubkey);
+
+        final result = await service.blockUser(
+          targetPubkey,
+          ourPubkey: ourPubkey,
+        );
+        expect(result.success, isTrue);
+        verify(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'self-block is rejected as a pre-publish failure — no relay call',
+      () async {
+        final service = await buildService();
+
+        final result = await service.blockUser(
+          ourPubkey,
+          ourPubkey: ourPubkey,
+        );
+
+        expect(result.success, isFalse);
+        expect(service.isBlocked(ourPubkey), isFalse);
+        verifyNever(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/unit/services/content_reporting_service_reliability_test.dart
+++ b/mobile/test/unit/services/content_reporting_service_reliability_test.dart
@@ -1,0 +1,222 @@
+// ABOUTME: Tests that ContentReportingService uses publishEventWithRetry,
+// ABOUTME: preserves moderation relay targeting through retries, and only
+// ABOUTME: commits report history on relay acceptance.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/content_moderation_service.dart';
+import 'package:openvine/services/content_reporting_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const testPubkey =
+      '0000000000000000000000000000000000000000000000000000000000000001';
+  const authorPubkey =
+      '0000000000000000000000000000000000000000000000000000000000000002';
+
+  setUpAll(() {
+    registerFallbackValue(
+      Event(testPubkey, EventKind.report, const [], '')
+        ..id = 'a' * 64
+        ..sig = 'sig',
+    );
+    registerFallbackValue(const RetryPolicy());
+  });
+
+  late _MockNostrClient nostr;
+  late _MockAuthService auth;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    nostr = _MockNostrClient();
+    auth = _MockAuthService();
+    when(() => nostr.isInitialized).thenReturn(true);
+    when(() => nostr.publicKey).thenReturn(testPubkey);
+    when(() => auth.isAuthenticated).thenReturn(true);
+    when(() => auth.currentPublicKeyHex).thenReturn(testPubkey);
+    when(
+      () => auth.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer((invocation) async {
+      final kind = invocation.namedArguments[#kind] as int;
+      final content = invocation.namedArguments[#content] as String;
+      final tags = invocation.namedArguments[#tags] as List<List<String>>;
+      return Event(testPubkey, kind, tags, content)
+        ..id = 'b' * 64
+        ..sig = 'sig';
+    });
+  });
+
+  Future<ContentReportingService> buildService() async {
+    final prefs = await SharedPreferences.getInstance();
+    final service = ContentReportingService(
+      nostrService: nostr,
+      authService: auth,
+      prefs: prefs,
+    );
+    await service.initialize();
+    return service;
+  }
+
+  group('ContentReportingService reliability', () {
+    test(
+      'success: targetRelays is [moderationRelayUrl], history committed, '
+      'feedback success',
+      () async {
+        List<String>? capturedTargets;
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedTargets =
+              invocation.namedArguments[#targetRelays] as List<String>?;
+          return PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {'wss://relay.divine.video'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          );
+        });
+
+        final service = await buildService();
+
+        final result = await service.reportContent(
+          eventId: 'evt_1',
+          authorPubkey: authorPubkey,
+          reason: ContentFilterReason.spam,
+          details: 'spam',
+        );
+
+        expect(result.success, isTrue);
+        expect(result.outcome, isNotNull);
+        expect(result.feedback?.severity, PublishSeverity.success);
+        expect(result.reportId, isNotNull);
+        expect(service.reportHistory, hasLength(1));
+        expect(
+          capturedTargets,
+          equals([ContentReportingService.moderationRelayUrl]),
+          reason:
+              'Reports must be published to the moderation relay only — '
+              'preserve targetRelays through the retry path.',
+        );
+      },
+    );
+
+    test(
+      'transient failure: NO history entry, retryable feedback',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {},
+            rejectedBy: const {},
+            noResponseFrom: const {'wss://relay.divine.video'},
+          ),
+        );
+
+        final service = await buildService();
+
+        final result = await service.reportContent(
+          eventId: 'evt_1',
+          authorPubkey: authorPubkey,
+          reason: ContentFilterReason.spam,
+          details: 'spam',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isTrue);
+        expect(result.feedback?.messageKey, 'publish_no_relay_response');
+        // No history commit — previous "save locally even on failure" was
+        // a silent-failure bug for reports: user saw "Report submitted"
+        // while no moderation relay ever received the kind 1984.
+        expect(service.reportHistory, isEmpty);
+      },
+    );
+
+    test(
+      'permanent rejection: history NOT committed, reason surfaced',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {},
+            rejectedBy: const {
+              'wss://relay.divine.video': 'blocked: invalid report',
+            },
+            noResponseFrom: const {},
+          ),
+        );
+
+        final service = await buildService();
+
+        final result = await service.reportContent(
+          eventId: 'evt_1',
+          authorPubkey: authorPubkey,
+          reason: ContentFilterReason.spam,
+          details: 'spam',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isFalse);
+        expect(result.feedback?.messageKey, 'publish_rejected_permanent');
+        expect(
+          result.feedback?.firstRejectionReason,
+          'blocked: invalid report',
+        );
+        expect(service.reportHistory, isEmpty);
+      },
+    );
+
+    test('not-authenticated surfaces pre-publish failure', () async {
+      when(() => auth.isAuthenticated).thenReturn(false);
+      final service = await buildService();
+
+      final result = await service.reportContent(
+        eventId: 'evt_1',
+        authorPubkey: authorPubkey,
+        reason: ContentFilterReason.spam,
+        details: 'spam',
+      );
+
+      expect(result.success, isFalse);
+      expect(result.outcome, isNull);
+      expect(result.feedback, isNull);
+      expect(result.error, contains('Not authenticated'));
+      verifyNever(
+        () => nostr.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      );
+    });
+  });
+}

--- a/mobile/test/unit/services/mute_service_reliability_test.dart
+++ b/mobile/test/unit/services/mute_service_reliability_test.dart
@@ -1,0 +1,255 @@
+// ABOUTME: Tests that MuteService uses publishEventWithRetry and gates
+// ABOUTME: in-memory mute state on relay acceptance (fixes silent-divergence bug).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/mute_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const testPubkey =
+      '0000000000000000000000000000000000000000000000000000000000000001';
+  const targetPubkey =
+      '0000000000000000000000000000000000000000000000000000000000000002';
+
+  setUpAll(() {
+    registerFallbackValue(
+      Event(testPubkey, 10000, const [], '')
+        ..id = 'a' * 64
+        ..sig = 'sig',
+    );
+    registerFallbackValue(const RetryPolicy());
+  });
+
+  late _MockNostrClient nostr;
+  late _MockAuthService auth;
+
+  setUp(() async {
+    nostr = _MockNostrClient();
+    auth = _MockAuthService();
+    SharedPreferences.setMockInitialValues({});
+    when(() => nostr.isInitialized).thenReturn(true);
+    when(() => nostr.publicKey).thenReturn(testPubkey);
+    when(() => auth.isAuthenticated).thenReturn(true);
+    when(() => auth.currentPublicKeyHex).thenReturn(testPubkey);
+    when(
+      () => auth.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer((invocation) async {
+      final kind = invocation.namedArguments[#kind] as int;
+      final content = invocation.namedArguments[#content] as String;
+      final tags = invocation.namedArguments[#tags] as List<List<String>>;
+      return Event(testPubkey, kind, tags, content)
+        ..id = 'b' * 64
+        ..sig = 'sig';
+    });
+  });
+
+  Future<MuteService> buildService() async {
+    final prefs = await SharedPreferences.getInstance();
+    final service = MuteService(
+      nostrService: nostr,
+      authService: auth,
+      prefs: prefs,
+    );
+    await service.initialize();
+    return service;
+  }
+
+  group('MuteService reliability', () {
+    test(
+      'success path: relay accepts → item committed + success feedback',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {'wss://a'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          ),
+        );
+
+        final service = await buildService();
+
+        final result = await service.muteUser(targetPubkey);
+
+        expect(result.success, isTrue);
+        expect(result.outcome, isNotNull);
+        expect(result.outcome!.acceptedBy, {'wss://a'});
+        expect(result.feedback?.severity, PublishSeverity.success);
+        expect(result.feedback?.retryable, isFalse);
+        expect(service.isUserMuted(targetPubkey), isTrue);
+      },
+    );
+
+    test(
+      'transient failure: all-no-response → rollback + retryable feedback',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {},
+            rejectedBy: const {},
+            noResponseFrom: const {'wss://a', 'wss://b'},
+          ),
+        );
+
+        final service = await buildService();
+
+        final result = await service.muteUser(targetPubkey);
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isTrue);
+        expect(result.feedback?.messageKey, 'publish_no_relay_response');
+        // Critical: the silent-divergence fix — in-memory mute set must NOT
+        // commit when no relay accepted.
+        expect(
+          service.isUserMuted(targetPubkey),
+          isFalse,
+          reason:
+              'Mute set must roll back when no relay accepted — otherwise '
+              'the user believes the pubkey is muted but no relay stored it.',
+        );
+      },
+    );
+
+    test(
+      'permanent rejection surfaces non-retryable feedback with reason + rollback',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {},
+            rejectedBy: const {'wss://a': 'blocked: not allowed'},
+            noResponseFrom: const {},
+          ),
+        );
+
+        final service = await buildService();
+
+        final result = await service.muteUser(targetPubkey);
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isFalse);
+        expect(result.feedback?.messageKey, 'publish_rejected_permanent');
+        expect(result.feedback?.firstRejectionReason, 'blocked: not allowed');
+        expect(service.isUserMuted(targetPubkey), isFalse);
+      },
+    );
+
+    test(
+      'unmute: rollback restores muted state when relay rejects',
+      () async {
+        // First, successful mute
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {'wss://a'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          ),
+        );
+        final service = await buildService();
+        final mutedResult = await service.muteUser(targetPubkey);
+        expect(mutedResult.success, isTrue);
+        expect(service.isUserMuted(targetPubkey), isTrue);
+
+        // Now fail the unmute publish — the user must still be muted.
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {},
+            rejectedBy: const {},
+            noResponseFrom: const {'wss://a'},
+          ),
+        );
+        final unmutedResult = await service.unmuteUser(targetPubkey);
+        expect(unmutedResult.success, isFalse);
+        expect(unmutedResult.feedback?.retryable, isTrue);
+        expect(
+          service.isUserMuted(targetPubkey),
+          isTrue,
+          reason:
+              'Unmute rollback: user must remain muted when relay did not '
+              'accept the updated mute list.',
+        );
+      },
+    );
+
+    test(
+      'muting an already-muted item is a no-op success (no relay call)',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'b' * 64,
+            acceptedBy: const {'wss://a'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          ),
+        );
+        final service = await buildService();
+        await service.muteUser(targetPubkey);
+
+        // Second call: already muted, must not republish.
+        final result = await service.muteUser(targetPubkey);
+        expect(result.success, isTrue);
+        // One call for the first mute — second is short-circuited.
+        verify(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
+      },
+    );
+  });
+}

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -78,7 +78,9 @@ void main() {
         additionalContext: any(named: 'additionalContext'),
         hashtags: any(named: 'hashtags'),
       ),
-    ).thenAnswer((_) async => ReportResult.createSuccess('test_report_id'));
+    ).thenAnswer(
+      (_) async => ReportResult.createSuccess(reportId: 'test_report_id'),
+    );
 
     when(
       () => mockMuteService.muteUser(
@@ -86,7 +88,7 @@ void main() {
         reason: any(named: 'reason'),
         duration: any(named: 'duration'),
       ),
-    ).thenAnswer((_) async => true);
+    ).thenAnswer((_) async => MuteResult.success_());
   });
 
   group('$ReportContentDialog rendering', () {
@@ -452,7 +454,9 @@ void main() {
         );
         expect(hasDisabledReportButton, isTrue);
 
-        completer.complete(ReportResult.createSuccess('test_report_id'));
+        completer.complete(
+          ReportResult.createSuccess(reportId: 'test_report_id'),
+        );
         await tester.pumpAndSettle();
       },
     );


### PR DESCRIPTION
Closes #3189

PR 4 of the reliable-nostr-publish series (stacks on PR #3177). See \`docs/superpowers/plans/2026-04-20-reliable-nostr-publish-pr4-moderation.md\`.

## Summary
- Migrates mute (kind 10000), blocklist (kind 30000), and report (kind 1984) publishes to `publishEventWithRetry` with `PublishOutcome` / `PublishUserFeedback`.
- Fixes silent-divergence bug where in-memory moderation state (mute set, blocklist map) could diverge from what any relay actually stored. Local state now only commits after `outcome.acceptedByAny`.
- Preserves moderation-relay routing for reports (`targetRelays` threaded through retries).

## Test plan
- [x] `flutter analyze lib test` — clean.
- [x] 20 tests passing across `content_blocklist_service_reliability_test.dart`, `content_reporting_service_test.dart`, and related BLoC tests.
- [ ] Manual smoke: mute a pubkey, kill relay mid-publish, verify Retry snackbar.
- [ ] Manual smoke: submit a report, verify kind 1984 lands on moderation relay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)