### PR TITLE
feat(lists): reliable bookmark / curated-list / curation / account-label publishing

### DIFF
--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -11,6 +11,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:nostr_client/nostr_client.dart' show PublishUserFeedback;
 import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/services/bookmark_service.dart';
 import 'package:openvine/services/video_sharing_service.dart';
@@ -312,12 +313,15 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     }
 
     try {
-      final succeeded = await bookmarkService.addVideoToGlobalBookmarks(
+      final result = await bookmarkService.addVideoToGlobalBookmarks(
         _video.id,
       );
       emit(
         state.copyWith(
-          actionResult: ShareSheetSaveResult(succeeded: succeeded),
+          actionResult: ShareSheetSaveResult(
+            succeeded: result.success,
+            feedback: result.feedback,
+          ),
         ),
       );
     } catch (e) {

--- a/mobile/lib/blocs/share_sheet/share_sheet_state.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_state.dart
@@ -46,10 +46,17 @@ class ShareSheetSendFailure extends ShareSheetActionResult {
 
 /// Consolidates the former ShareSheetSaveSuccess and ShareSheetSaveFailure
 /// into a single class, using [succeeded] to distinguish the outcome.
+///
+/// When [succeeded] is `false`, [feedback] carries the mapped publish
+/// feedback so the UI can render a retryable snackbar for transient
+/// failures. [feedback] may be `null` on pre-publish failures (not
+/// authenticated, service unavailable) — the UI falls back to a generic
+/// failure message in that case.
 class ShareSheetSaveResult extends ShareSheetActionResult {
-  ShareSheetSaveResult({required this.succeeded});
+  ShareSheetSaveResult({required this.succeeded, this.feedback});
 
   final bool succeeded;
+  final PublishUserFeedback? feedback;
 }
 
 /// Generic failure for utility actions (copy link, share via, etc.).

--- a/mobile/lib/screens/settings/content_preferences_screen.dart
+++ b/mobile/lib/screens/settings/content_preferences_screen.dart
@@ -321,10 +321,33 @@ class _AccountContentLabelsTileState
 
     if (result != null && mounted) {
       final service = ref.read(accountLabelServiceProvider);
-      await service.setAccountLabels(result);
-      setState(() {
-        _accountLabels = result;
-      });
+      final publishResult = await service.setAccountLabels(result);
+      if (!mounted) return;
+
+      if (publishResult.success) {
+        setState(() {
+          _accountLabels = result;
+        });
+      } else {
+        // Rollback already happened inside the service — surface the
+        // failure so the user can retry. The retry affordance is only
+        // shown when the feedback is classified as transient.
+        final retryable = publishResult.feedback?.retryable ?? false;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('Failed to update account labels'),
+            duration: const Duration(seconds: 3),
+            action: retryable
+                ? SnackBarAction(
+                    // Retry label — follow-up PR will introduce dedicated
+                    // l10n keys for the migrated reliability errors.
+                    label: 'Retry',
+                    onPressed: _selectLabels,
+                  )
+                : null,
+          ),
+        );
+      }
     }
   }
 

--- a/mobile/lib/services/account_label_service.dart
+++ b/mobile/lib/services/account_label_service.dart
@@ -9,6 +9,50 @@ import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Result of [AccountLabelService.setAccountLabels].
+///
+/// On success the local labels are persisted and, when labels are
+/// non-empty, the kind 1985 self-label event has been accepted by at
+/// least one relay. On failure [feedback] carries the mapped publish
+/// feedback for retry UX; the local mutation is rolled back so app state
+/// matches the relay.
+class AccountLabelResult {
+  const AccountLabelResult({
+    required this.success,
+    this.outcome,
+    this.feedback,
+  });
+
+  /// Whether the requested mutation is durable (persisted locally and, for
+  /// non-empty label sets, accepted by at least one relay).
+  final bool success;
+
+  /// Per-relay outcome. `null` when the mutation skipped publishing
+  /// (e.g. clearing labels when already empty, unauthenticated user).
+  final PublishOutcome? outcome;
+
+  /// Mapped user feedback. `null` iff [outcome] is `null`.
+  final PublishUserFeedback? feedback;
+
+  static AccountLabelResult successResult({
+    PublishOutcome? outcome,
+    PublishUserFeedback? feedback,
+  }) => AccountLabelResult(
+    success: true,
+    outcome: outcome,
+    feedback: feedback,
+  );
+
+  static AccountLabelResult failure({
+    PublishOutcome? outcome,
+    PublishUserFeedback? feedback,
+  }) => AccountLabelResult(
+    success: false,
+    outcome: outcome,
+    feedback: feedback,
+  );
+}
+
 /// Service for managing account-level content warning labels.
 ///
 /// Allows creators to declare their account contains sensitive content.
@@ -72,10 +116,64 @@ class AccountLabelService {
 
   /// Set the account-level content labels and publish a Kind 1985 event.
   ///
-  /// Pass an empty set to clear account labels.
-  Future<void> setAccountLabels(Set<ContentLabel> labels) async {
-    _accountLabels = Set.of(labels);
+  /// Pass an empty set to clear account labels. Clearing is a local-only
+  /// operation that never reaches the relay — NIP-32 does not define a
+  /// kind 1985 "clear labels" event, so the relay retains the previous
+  /// self-label until the creator publishes a new one with content-warning
+  /// tags. Callers that need to revoke labels should publish a new empty
+  /// kind 1985 via a dedicated relay path.
+  ///
+  /// For non-empty label sets, this method gates the local commit on a
+  /// successful publish: on transient or permanent failure the in-memory
+  /// and on-disk state is rolled back to the previous value so the UI
+  /// can surface a retryable error.
+  Future<AccountLabelResult> setAccountLabels(
+    Set<ContentLabel> labels,
+  ) async {
+    final previousLabels = Set<ContentLabel>.of(_accountLabels);
 
+    // Optimistically update local state so downstream readers see the new
+    // value while the publish is in flight.
+    _accountLabels = Set.of(labels);
+    await _persistLabels(labels);
+
+    // Clearing labels is a local-only operation. The relay already has the
+    // previous self-label; without a dedicated "revoke" event kind we
+    // cannot durably clear it. Report success so the UI reflects local
+    // state; callers that need durable revocation must publish a fresh
+    // kind 1985 with the empty content-warning namespace.
+    if (labels.isEmpty) {
+      Log.info(
+        'Cleared account labels locally (no kind 1985 publish)',
+        name: 'AccountLabelService',
+        category: LogCategory.system,
+      );
+      return AccountLabelResult.successResult();
+    }
+
+    final pubkey = _authService.currentPublicKeyHex;
+    if (pubkey == null) {
+      Log.warning(
+        'Cannot publish account labels - not authenticated',
+        name: 'AccountLabelService',
+        category: LogCategory.system,
+      );
+      // No relay round-trip possible, but the local state still reflects
+      // the caller's intent — report failure so the UI can surface the
+      // auth problem rather than silently claim success.
+      return AccountLabelResult.failure();
+    }
+
+    final result = await _publishAccountLabels(labels: labels, pubkey: pubkey);
+    if (!result.success) {
+      // Rollback: restore previous labels in memory and on disk.
+      _accountLabels = previousLabels;
+      await _persistLabels(previousLabels);
+    }
+    return result;
+  }
+
+  Future<void> _persistLabels(Set<ContentLabel> labels) async {
     try {
       final prefs = await SharedPreferences.getInstance();
       final csv = ContentLabel.toCsv(labels);
@@ -91,14 +189,13 @@ class AccountLabelService {
         category: LogCategory.system,
       );
     }
-
-    // Publish Kind 1985 self-label event if labels are set
-    if (labels.isNotEmpty) {
-      await _publishAccountLabels(labels);
-    }
   }
 
   /// Publish a Kind 1985 self-label event targeting own pubkey.
+  ///
+  /// Uses [NostrClient.publishEventWithRetry] so transient failures retry
+  /// on a bounded schedule. Returns an [AccountLabelResult] carrying the
+  /// per-relay [PublishOutcome] and mapped [PublishUserFeedback].
   ///
   /// Format:
   /// ```json
@@ -112,61 +209,52 @@ class AccountLabelService {
   ///   ]
   /// }
   /// ```
-  Future<void> _publishAccountLabels(Set<ContentLabel> labels) async {
-    final pubkey = _authService.currentPublicKeyHex;
-    if (pubkey == null) {
-      Log.warning(
-        'Cannot publish account labels - not authenticated',
-        name: 'AccountLabelService',
-        category: LogCategory.system,
-      );
-      return;
-    }
+  Future<AccountLabelResult> _publishAccountLabels({
+    required Set<ContentLabel> labels,
+    required String pubkey,
+  }) async {
+    final tags = <List<String>>[
+      ['L', 'content-warning'],
+      for (final label in labels) ['l', label.value, 'content-warning'],
+      ['p', pubkey, 'wss://relay.divine.video'],
+    ];
 
-    try {
-      final tags = <List<String>>[
-        ['L', 'content-warning'],
-        for (final label in labels) ['l', label.value, 'content-warning'],
-        ['p', pubkey, 'wss://relay.divine.video'],
-      ];
+    final event = await _authService.createAndSignEvent(
+      kind: 1985,
+      content: '',
+      tags: tags,
+    );
 
-      final event = await _authService.createAndSignEvent(
-        kind: 1985,
-        content: '',
-        tags: tags,
-      );
-
-      if (event == null) {
-        Log.error(
-          'Failed to create Kind 1985 event',
-          name: 'AccountLabelService',
-          category: LogCategory.system,
-        );
-        return;
-      }
-
-      final sentEvent = await _nostrClient.publishEvent(event);
-      if (sentEvent != null) {
-        Log.info(
-          'Published account labels: '
-          '${labels.map((l) => l.value).join(", ")}',
-          name: 'AccountLabelService',
-          category: LogCategory.system,
-        );
-      } else {
-        Log.warning(
-          'Failed to publish account labels to relays',
-          name: 'AccountLabelService',
-          category: LogCategory.system,
-        );
-      }
-    } catch (e, stackTrace) {
+    if (event == null) {
       Log.error(
-        'Error publishing account labels: $e\n$stackTrace',
+        'Failed to create Kind 1985 event',
         name: 'AccountLabelService',
         category: LogCategory.system,
       );
+      return AccountLabelResult.failure();
     }
+
+    final outcome = await _nostrClient.publishEventWithRetry(event);
+    final feedback = PublishResultMapper.map(outcome);
+
+    if (!outcome.acceptedByAny) {
+      Log.warning(
+        'Account-label publish not accepted by any relay: $outcome',
+        name: 'AccountLabelService',
+        category: LogCategory.system,
+      );
+      return AccountLabelResult.failure(outcome: outcome, feedback: feedback);
+    }
+
+    Log.info(
+      'Published account labels: ${labels.map((l) => l.value).join(", ")}',
+      name: 'AccountLabelService',
+      category: LogCategory.system,
+    );
+    return AccountLabelResult.successResult(
+      outcome: outcome,
+      feedback: feedback,
+    );
   }
 
   /// Build NIP-32 content-warning tags for a Kind 0 profile event.

--- a/mobile/lib/services/bookmark_service.dart
+++ b/mobile/lib/services/bookmark_service.dart
@@ -130,6 +130,65 @@ class BookmarkSet {
   );
 }
 
+/// Result of a bookmark publish operation.
+///
+/// Carries the per-relay [PublishOutcome] and the mapped
+/// [PublishUserFeedback] so the UI can render a retry affordance for
+/// transient failures and surface rejection reasons when the relay refused
+/// the event. For replaceable bookmark events (kind 10003, 30003), local
+/// state is only committed when [success] is true (i.e. at least one relay
+/// acknowledged). On failure, any in-memory mutation has been rolled back.
+class BookmarkResult {
+  const BookmarkResult({
+    required this.success,
+    this.outcome,
+    this.feedback,
+    this.set,
+  });
+
+  /// Whether at least one relay accepted the publish and local state has been
+  /// committed. `false` when the operation was a no-op, failed pre-publish
+  /// (not authenticated), or every relay rejected/timed out.
+  final bool success;
+
+  /// Per-relay outcome. `null` when the publish never reached a relay
+  /// (e.g. auth missing, event construction failed).
+  final PublishOutcome? outcome;
+
+  /// Mapped user feedback for snackbars. `null` iff [outcome] is `null`.
+  final PublishUserFeedback? feedback;
+
+  /// Populated only by [BookmarkService.createBookmarkSet] on success — the
+  /// set as persisted locally with its assigned id.
+  final BookmarkSet? set;
+
+  static BookmarkResult successResult({
+    required PublishOutcome outcome,
+    required PublishUserFeedback feedback,
+    BookmarkSet? set,
+  }) => BookmarkResult(
+    success: true,
+    outcome: outcome,
+    feedback: feedback,
+    set: set,
+  );
+
+  static BookmarkResult failure({
+    PublishOutcome? outcome,
+    PublishUserFeedback? feedback,
+  }) => BookmarkResult(
+    success: false,
+    outcome: outcome,
+    feedback: feedback,
+  );
+
+  /// Result when an operation short-circuits (e.g. already bookmarked, not
+  /// authenticated) without publishing an event. [success] reflects whether
+  /// the post-condition holds locally despite no publish being attempted.
+  static BookmarkResult noop({required bool success}) =>
+      BookmarkResult(success: success);
+}
+
 /// Service for managing NIP-51 bookmarks and bookmark sets
 class BookmarkService with NostrListServiceMixin {
   BookmarkService({
@@ -208,7 +267,7 @@ class BookmarkService with NostrListServiceMixin {
   // === GLOBAL BOOKMARKS (Kind 10003) ===
 
   /// Add a video event to global bookmarks
-  Future<bool> addVideoToGlobalBookmarks(
+  Future<BookmarkResult> addVideoToGlobalBookmarks(
     String videoEventId, {
     String? relay,
     String? petname,
@@ -218,79 +277,93 @@ class BookmarkService with NostrListServiceMixin {
     );
   }
 
-  /// Add an item to global bookmarks
-  Future<bool> addToGlobalBookmarks(BookmarkItem item) async {
-    try {
-      // Check if already bookmarked
-      if (_globalBookmarks.contains(item)) {
-        Log.debug(
-          'Item already in global bookmarks: ${item.id}',
-          name: 'BookmarkService',
-          category: LogCategory.system,
-        );
-        return true;
-      }
-
-      _globalBookmarks.add(item);
-      await _saveBookmarks();
-
-      // Publish to Nostr if authenticated
-      if (_authService.isAuthenticated) {
-        await _publishGlobalBookmarksToNostr();
-      }
-
-      Log.info(
-        'Added item to global bookmarks: ${item.id}',
+  /// Add an item to global bookmarks.
+  ///
+  /// For the replaceable kind 10003 event we optimistically mutate the in-
+  /// memory list, publish with retry, and roll back the mutation if no relay
+  /// accepted.
+  Future<BookmarkResult> addToGlobalBookmarks(BookmarkItem item) async {
+    // Check if already bookmarked — short-circuit without a publish.
+    if (_globalBookmarks.contains(item)) {
+      Log.debug(
+        'Item already in global bookmarks: ${item.id}',
         name: 'BookmarkService',
         category: LogCategory.system,
       );
-
-      return true;
-    } catch (e) {
-      Log.error(
-        'Failed to add to global bookmarks: $e',
-        name: 'BookmarkService',
-        category: LogCategory.system,
-      );
-      return false;
+      return BookmarkResult.noop(success: true);
     }
+
+    if (!_authService.isAuthenticated) {
+      Log.warning(
+        'Cannot bookmark - user not authenticated',
+        name: 'BookmarkService',
+        category: LogCategory.system,
+      );
+      return BookmarkResult.noop(success: false);
+    }
+
+    // Optimistically mutate, persist cache so the UI reads through state.
+    _globalBookmarks.add(item);
+    await _saveBookmarks();
+
+    final result = await _publishGlobalBookmarksToNostr();
+    if (!result.success) {
+      // Rollback: addressable/replaceable kinds demand relay confirmation
+      // before we treat the bookmark as durable.
+      _globalBookmarks.remove(item);
+      await _saveBookmarks();
+      return result;
+    }
+
+    Log.info(
+      'Added item to global bookmarks: ${item.id}',
+      name: 'BookmarkService',
+      category: LogCategory.system,
+    );
+    return result;
   }
 
-  /// Remove an item from global bookmarks
-  Future<bool> removeFromGlobalBookmarks(BookmarkItem item) async {
-    try {
-      final removed = _globalBookmarks.remove(item);
-      if (!removed) {
-        Log.warning(
-          'Item not found in global bookmarks: ${item.id}',
-          name: 'BookmarkService',
-          category: LogCategory.system,
-        );
-        return false;
-      }
-
-      await _saveBookmarks();
-
-      // Update on Nostr if authenticated
-      if (_authService.isAuthenticated) {
-        await _publishGlobalBookmarksToNostr();
-      }
-
-      Log.info(
-        'Removed item from global bookmarks: ${item.id}',
+  /// Remove an item from global bookmarks.
+  ///
+  /// Optimistically removes the item, publishes the replacement event, and
+  /// re-inserts on failure so the UI reverts to "bookmarked".
+  Future<BookmarkResult> removeFromGlobalBookmarks(BookmarkItem item) async {
+    final originalIndex = _globalBookmarks.indexOf(item);
+    if (originalIndex == -1) {
+      Log.warning(
+        'Item not found in global bookmarks: ${item.id}',
         name: 'BookmarkService',
         category: LogCategory.system,
       );
-
-      return true;
-    } catch (e) {
-      Log.error(
-        'Failed to remove from global bookmarks: $e',
-        name: 'BookmarkService',
-        category: LogCategory.system,
-      );
-      return false;
+      return BookmarkResult.noop(success: false);
     }
+
+    if (!_authService.isAuthenticated) {
+      Log.warning(
+        'Cannot remove bookmark - user not authenticated',
+        name: 'BookmarkService',
+        category: LogCategory.system,
+      );
+      return BookmarkResult.noop(success: false);
+    }
+
+    _globalBookmarks.removeAt(originalIndex);
+    await _saveBookmarks();
+
+    final result = await _publishGlobalBookmarksToNostr();
+    if (!result.success) {
+      // Rollback: re-insert at the original position so the order is stable.
+      _globalBookmarks.insert(originalIndex, item);
+      await _saveBookmarks();
+      return result;
+    }
+
+    Log.info(
+      'Removed item from global bookmarks: ${item.id}',
+      name: 'BookmarkService',
+      category: LogCategory.system,
+    );
+    return result;
   }
 
   /// Check if an item is in global bookmarks
@@ -307,197 +380,183 @@ class BookmarkService with NostrListServiceMixin {
 
   // === BOOKMARK SETS (Kind 30003) ===
 
-  /// Create a new bookmark set
-  Future<BookmarkSet?> createBookmarkSet({
+  /// Create a new bookmark set.
+  ///
+  /// Optimistically appends the set to local state, publishes, and removes it
+  /// on failure so the UI doesn't surface a ghost set.
+  Future<BookmarkResult> createBookmarkSet({
     required String name,
     String? description,
     String? imageUrl,
   }) async {
-    try {
-      final setId = 'bookmarkset_${DateTime.now().millisecondsSinceEpoch}';
-      final now = DateTime.now();
+    final setId = 'bookmarkset_${DateTime.now().millisecondsSinceEpoch}';
+    final now = DateTime.now();
 
-      final newSet = BookmarkSet(
-        id: setId,
-        name: name,
-        description: description,
-        imageUrl: imageUrl,
-        items: [],
-        createdAt: now,
-        updatedAt: now,
-      );
+    final newSet = BookmarkSet(
+      id: setId,
+      name: name,
+      description: description,
+      imageUrl: imageUrl,
+      items: [],
+      createdAt: now,
+      updatedAt: now,
+    );
 
+    if (!_authService.isAuthenticated) {
+      // Allow local-only use when not authenticated: persist but surface
+      // a failure so the UI can explain the missing sync.
       _bookmarkSets.add(newSet);
       await _saveBookmarks();
-
-      // Publish to Nostr if authenticated
-      if (_authService.isAuthenticated) {
-        await _publishBookmarkSetToNostr(newSet);
-      }
-
-      Log.info(
-        'Created new bookmark set: $name ($setId)',
-        name: 'BookmarkService',
-        category: LogCategory.system,
-      );
-
-      return newSet;
-    } catch (e) {
-      Log.error(
-        'Failed to create bookmark set: $e',
-        name: 'BookmarkService',
-        category: LogCategory.system,
-      );
-      return null;
+      return BookmarkResult.noop(success: false);
     }
-  }
 
-  /// Add an item to a bookmark set
-  Future<bool> addToBookmarkSet(String setId, BookmarkItem item) async {
-    try {
-      final setIndex = _bookmarkSets.indexWhere((set) => set.id == setId);
-      if (setIndex == -1) {
-        Log.warning(
-          'Bookmark set not found: $setId',
-          name: 'BookmarkService',
-          category: LogCategory.system,
-        );
-        return false;
-      }
+    _bookmarkSets.add(newSet);
+    await _saveBookmarks();
 
-      final set = _bookmarkSets[setIndex];
-
-      // Check if item is already in the set
-      if (set.items.contains(item)) {
-        Log.debug(
-          'Item already in bookmark set: ${item.id}',
-          name: 'BookmarkService',
-          category: LogCategory.system,
-        );
-        return true;
-      }
-
-      final updatedItems = [...set.items, item];
-      final updatedSet = set.copyWith(
-        items: updatedItems,
-        updatedAt: DateTime.now(),
-      );
-
-      _bookmarkSets[setIndex] = updatedSet;
+    final result = await _publishBookmarkSetToNostr(newSet);
+    if (!result.success) {
+      _bookmarkSets.removeWhere((s) => s.id == newSet.id);
       await _saveBookmarks();
-
-      // Update on Nostr if authenticated
-      if (_authService.isAuthenticated) {
-        await _publishBookmarkSetToNostr(updatedSet);
-      }
-
-      Log.debug(
-        'Added item to bookmark set "${set.name}": ${item.id}',
-        name: 'BookmarkService',
-        category: LogCategory.system,
-      );
-
-      return true;
-    } catch (e) {
-      Log.error(
-        'Failed to add to bookmark set: $e',
-        name: 'BookmarkService',
-        category: LogCategory.system,
-      );
-      return false;
+      return result;
     }
+
+    // Re-read the possibly-updated set (published with nostrEventId).
+    final stored = _bookmarkSets.firstWhere(
+      (s) => s.id == newSet.id,
+      orElse: () => newSet,
+    );
+    Log.info(
+      'Created new bookmark set: $name ($setId)',
+      name: 'BookmarkService',
+      category: LogCategory.system,
+    );
+    return BookmarkResult.successResult(
+      outcome: result.outcome!,
+      feedback: result.feedback!,
+      set: stored,
+    );
   }
 
-  /// Remove an item from a bookmark set
-  Future<bool> removeFromBookmarkSet(String setId, BookmarkItem item) async {
-    try {
-      final setIndex = _bookmarkSets.indexWhere((set) => set.id == setId);
-      if (setIndex == -1) {
-        Log.warning(
-          'Bookmark set not found: $setId',
-          name: 'BookmarkService',
-          category: LogCategory.system,
-        );
-        return false;
-      }
-
-      final set = _bookmarkSets[setIndex];
-      final updatedItems = set.items.where((i) => i != item).toList();
-
-      final updatedSet = set.copyWith(
-        items: updatedItems,
-        updatedAt: DateTime.now(),
+  /// Add an item to a bookmark set.
+  Future<BookmarkResult> addToBookmarkSet(
+    String setId,
+    BookmarkItem item,
+  ) async {
+    final setIndex = _bookmarkSets.indexWhere((set) => set.id == setId);
+    if (setIndex == -1) {
+      Log.warning(
+        'Bookmark set not found: $setId',
+        name: 'BookmarkService',
+        category: LogCategory.system,
       );
+      return BookmarkResult.noop(success: false);
+    }
 
-      _bookmarkSets[setIndex] = updatedSet;
+    final set = _bookmarkSets[setIndex];
+    if (set.items.contains(item)) {
+      Log.debug(
+        'Item already in bookmark set: ${item.id}',
+        name: 'BookmarkService',
+        category: LogCategory.system,
+      );
+      return BookmarkResult.noop(success: true);
+    }
+
+    if (!_authService.isAuthenticated) {
+      return BookmarkResult.noop(success: false);
+    }
+
+    final updatedSet = set.copyWith(
+      items: [...set.items, item],
+      updatedAt: DateTime.now(),
+    );
+    _bookmarkSets[setIndex] = updatedSet;
+    await _saveBookmarks();
+
+    final result = await _publishBookmarkSetToNostr(updatedSet);
+    if (!result.success) {
+      // Rollback: restore previous set value at the original index.
+      _bookmarkSets[setIndex] = set;
       await _saveBookmarks();
-
-      // Update on Nostr if authenticated
-      if (_authService.isAuthenticated) {
-        await _publishBookmarkSetToNostr(updatedSet);
-      }
-
-      Log.debug(
-        'Removed item from bookmark set "${set.name}": ${item.id}',
-        name: 'BookmarkService',
-        category: LogCategory.system,
-      );
-
-      return true;
-    } catch (e) {
-      Log.error(
-        'Failed to remove from bookmark set: $e',
-        name: 'BookmarkService',
-        category: LogCategory.system,
-      );
-      return false;
+      return result;
     }
+    return result;
   }
 
-  /// Update bookmark set metadata
-  Future<bool> updateBookmarkSet({
+  /// Remove an item from a bookmark set.
+  Future<BookmarkResult> removeFromBookmarkSet(
+    String setId,
+    BookmarkItem item,
+  ) async {
+    final setIndex = _bookmarkSets.indexWhere((set) => set.id == setId);
+    if (setIndex == -1) {
+      Log.warning(
+        'Bookmark set not found: $setId',
+        name: 'BookmarkService',
+        category: LogCategory.system,
+      );
+      return BookmarkResult.noop(success: false);
+    }
+
+    final set = _bookmarkSets[setIndex];
+    if (!set.items.contains(item)) {
+      return BookmarkResult.noop(success: true);
+    }
+
+    if (!_authService.isAuthenticated) {
+      return BookmarkResult.noop(success: false);
+    }
+
+    final updatedSet = set.copyWith(
+      items: set.items.where((i) => i != item).toList(),
+      updatedAt: DateTime.now(),
+    );
+    _bookmarkSets[setIndex] = updatedSet;
+    await _saveBookmarks();
+
+    final result = await _publishBookmarkSetToNostr(updatedSet);
+    if (!result.success) {
+      _bookmarkSets[setIndex] = set;
+      await _saveBookmarks();
+      return result;
+    }
+    return result;
+  }
+
+  /// Update bookmark set metadata.
+  Future<BookmarkResult> updateBookmarkSet({
     required String setId,
     String? name,
     String? description,
     String? imageUrl,
   }) async {
-    try {
-      final setIndex = _bookmarkSets.indexWhere((set) => set.id == setId);
-      if (setIndex == -1) {
-        return false;
-      }
-
-      final set = _bookmarkSets[setIndex];
-      final updatedSet = set.copyWith(
-        name: name ?? set.name,
-        description: description ?? set.description,
-        imageUrl: imageUrl ?? set.imageUrl,
-        updatedAt: DateTime.now(),
-      );
-
-      _bookmarkSets[setIndex] = updatedSet;
-      await _saveBookmarks();
-
-      // Update on Nostr if authenticated
-      if (_authService.isAuthenticated) {
-        await _publishBookmarkSetToNostr(updatedSet);
-      }
-
-      Log.debug(
-        'Updated bookmark set: ${updatedSet.name}',
-        name: 'BookmarkService',
-        category: LogCategory.system,
-      );
-
-      return true;
-    } catch (e) {
-      Log.error(
-        'Failed to update bookmark set: $e',
-        name: 'BookmarkService',
-        category: LogCategory.system,
-      );
-      return false;
+    final setIndex = _bookmarkSets.indexWhere((set) => set.id == setId);
+    if (setIndex == -1) {
+      return BookmarkResult.noop(success: false);
     }
+
+    if (!_authService.isAuthenticated) {
+      return BookmarkResult.noop(success: false);
+    }
+
+    final set = _bookmarkSets[setIndex];
+    final updatedSet = set.copyWith(
+      name: name ?? set.name,
+      description: description ?? set.description,
+      imageUrl: imageUrl ?? set.imageUrl,
+      updatedAt: DateTime.now(),
+    );
+
+    _bookmarkSets[setIndex] = updatedSet;
+    await _saveBookmarks();
+
+    final result = await _publishBookmarkSetToNostr(updatedSet);
+    if (!result.success) {
+      _bookmarkSets[setIndex] = set;
+      await _saveBookmarks();
+      return result;
+    }
+    return result;
   }
 
   /// Delete a bookmark set
@@ -551,143 +610,154 @@ class BookmarkService with NostrListServiceMixin {
 
   // === NOSTR PUBLISHING ===
 
-  /// Public method to publish a bookmark set to Nostr (for background sync)
-  Future<bool> publishBookmarkSetToNostr(String setId) async {
-    try {
-      final set = getBookmarkSetById(setId);
-      if (set == null) {
-        Log.warning(
-          'Cannot publish bookmark set - not found: $setId',
-          name: 'BookmarkService',
-          category: LogCategory.system,
-        );
-        return false;
-      }
-
-      await _publishBookmarkSetToNostr(set);
-      return true;
-    } catch (e) {
-      Log.error(
-        'Failed to publish bookmark set $setId: $e',
+  /// Public method to publish a bookmark set to Nostr (for background sync).
+  ///
+  /// Returns [BookmarkResult.success] when at least one relay accepted.
+  Future<BookmarkResult> publishBookmarkSetToNostr(String setId) async {
+    final set = getBookmarkSetById(setId);
+    if (set == null) {
+      Log.warning(
+        'Cannot publish bookmark set - not found: $setId',
         name: 'BookmarkService',
         category: LogCategory.system,
       );
-      return false;
+      return BookmarkResult.noop(success: false);
     }
+    return _publishBookmarkSetToNostr(set);
   }
 
-  /// Publish global bookmarks to Nostr as NIP-51 kind 10003 event
-  Future<void> _publishGlobalBookmarksToNostr() async {
-    try {
-      if (!_authService.isAuthenticated) {
-        Log.warning(
-          'Cannot publish bookmarks - user not authenticated',
-          name: 'BookmarkService',
-          category: LogCategory.system,
-        );
-        return;
-      }
-
-      // Create NIP-51 kind 10003 tags
-      final tags = <List<String>>[
-        ['client', 'diVine'],
-      ];
-
-      // Add bookmark items as tags
-      for (final item in _globalBookmarks) {
-        tags.add(item.toTag());
-      }
-
-      final event = await _authService.createAndSignEvent(
-        kind: 10003, // NIP-51 global bookmarks
-        content: 'Divine global bookmarks',
-        tags: tags,
-      );
-
-      if (event != null) {
-        final sentEvent = await _nostrService.publishEvent(event);
-        if (sentEvent != null) {
-          Log.debug(
-            'Published global bookmarks to Nostr: ${event.id}',
-            name: 'BookmarkService',
-            category: LogCategory.system,
-          );
-        }
-      }
-    } catch (e) {
-      Log.error(
-        'Failed to publish global bookmarks to Nostr: $e',
+  /// Publish global bookmarks to Nostr as NIP-51 kind 10003 event.
+  ///
+  /// Uses [NostrClient.publishEventWithRetry] so transient failures
+  /// automatically retry once per relay. Returns a [BookmarkResult]; callers
+  /// gate local state commits on `result.success`.
+  Future<BookmarkResult> _publishGlobalBookmarksToNostr() async {
+    if (!_authService.isAuthenticated) {
+      Log.warning(
+        'Cannot publish bookmarks - user not authenticated',
         name: 'BookmarkService',
         category: LogCategory.system,
       );
+      return BookmarkResult.noop(success: false);
     }
+
+    // Create NIP-51 kind 10003 tags
+    final tags = <List<String>>[
+      ['client', 'diVine'],
+    ];
+
+    // Add bookmark items as tags
+    for (final item in _globalBookmarks) {
+      tags.add(item.toTag());
+    }
+
+    final event = await _authService.createAndSignEvent(
+      kind: 10003, // NIP-51 global bookmarks
+      content: 'Divine global bookmarks',
+      tags: tags,
+    );
+
+    if (event == null) {
+      Log.error(
+        'Failed to sign kind 10003 bookmark event',
+        name: 'BookmarkService',
+        category: LogCategory.system,
+      );
+      return BookmarkResult.failure();
+    }
+
+    final outcome = await _nostrService.publishEventWithRetry(event);
+    final feedback = PublishResultMapper.map(outcome);
+
+    if (!outcome.acceptedByAny) {
+      Log.warning(
+        'Global bookmark publish not accepted by any relay: $outcome',
+        name: 'BookmarkService',
+        category: LogCategory.system,
+      );
+      return BookmarkResult.failure(outcome: outcome, feedback: feedback);
+    }
+
+    Log.debug(
+      'Published global bookmarks to Nostr: ${event.id}',
+      name: 'BookmarkService',
+      category: LogCategory.system,
+    );
+    return BookmarkResult.successResult(outcome: outcome, feedback: feedback);
   }
 
-  /// Publish bookmark set to Nostr as NIP-51 kind 30003 event
-  Future<void> _publishBookmarkSetToNostr(BookmarkSet set) async {
-    try {
-      if (!_authService.isAuthenticated) {
-        Log.warning(
-          'Cannot publish bookmark set - user not authenticated',
-          name: 'BookmarkService',
-          category: LogCategory.system,
-        );
-        return;
-      }
-
-      // Create NIP-51 kind 30003 tags
-      final tags = <List<String>>[
-        ['d', set.id], // Identifier for replaceable event
-        ['title', set.name],
-        ['client', 'diVine'],
-      ];
-
-      // Add description if present
-      if (set.description != null && set.description!.isNotEmpty) {
-        tags.add(['description', set.description!]);
-      }
-
-      // Add image if present
-      if (set.imageUrl != null && set.imageUrl!.isNotEmpty) {
-        tags.add(['image', set.imageUrl!]);
-      }
-
-      // Add bookmark items as tags
-      for (final item in set.items) {
-        tags.add(item.toTag());
-      }
-
-      final content = set.description ?? 'Bookmark collection: ${set.name}';
-
-      final event = await _authService.createAndSignEvent(
-        kind: 30003, // NIP-51 bookmark set
-        content: content,
-        tags: tags,
-      );
-
-      if (event != null) {
-        final sentEvent = await _nostrService.publishEvent(event);
-        if (sentEvent != null) {
-          // Update local set with Nostr event ID
-          final setIndex = _bookmarkSets.indexWhere((s) => s.id == set.id);
-          if (setIndex != -1) {
-            _bookmarkSets[setIndex] = set.copyWith(nostrEventId: event.id);
-            await _saveBookmarks();
-          }
-          Log.debug(
-            'Published bookmark set to Nostr: ${set.name} (${event.id})',
-            name: 'BookmarkService',
-            category: LogCategory.system,
-          );
-        }
-      }
-    } catch (e) {
-      Log.error(
-        'Failed to publish bookmark set to Nostr: $e',
+  /// Publish bookmark set to Nostr as NIP-51 kind 30003 event.
+  Future<BookmarkResult> _publishBookmarkSetToNostr(BookmarkSet set) async {
+    if (!_authService.isAuthenticated) {
+      Log.warning(
+        'Cannot publish bookmark set - user not authenticated',
         name: 'BookmarkService',
         category: LogCategory.system,
       );
+      return BookmarkResult.noop(success: false);
     }
+
+    // Create NIP-51 kind 30003 tags
+    final tags = <List<String>>[
+      ['d', set.id], // Identifier for replaceable event
+      ['title', set.name],
+      ['client', 'diVine'],
+    ];
+
+    if (set.description != null && set.description!.isNotEmpty) {
+      tags.add(['description', set.description!]);
+    }
+
+    if (set.imageUrl != null && set.imageUrl!.isNotEmpty) {
+      tags.add(['image', set.imageUrl!]);
+    }
+
+    for (final item in set.items) {
+      tags.add(item.toTag());
+    }
+
+    final content = set.description ?? 'Bookmark collection: ${set.name}';
+
+    final event = await _authService.createAndSignEvent(
+      kind: 30003, // NIP-51 bookmark set
+      content: content,
+      tags: tags,
+    );
+
+    if (event == null) {
+      Log.error(
+        'Failed to sign kind 30003 bookmark-set event',
+        name: 'BookmarkService',
+        category: LogCategory.system,
+      );
+      return BookmarkResult.failure();
+    }
+
+    final outcome = await _nostrService.publishEventWithRetry(event);
+    final feedback = PublishResultMapper.map(outcome);
+
+    if (!outcome.acceptedByAny) {
+      Log.warning(
+        'Bookmark-set publish not accepted by any relay: $outcome',
+        name: 'BookmarkService',
+        category: LogCategory.system,
+      );
+      return BookmarkResult.failure(outcome: outcome, feedback: feedback);
+    }
+
+    // Update local set with Nostr event ID so subsequent loads/persistence
+    // can link the local set back to its latest published event.
+    final setIndex = _bookmarkSets.indexWhere((s) => s.id == set.id);
+    if (setIndex != -1) {
+      _bookmarkSets[setIndex] = set.copyWith(nostrEventId: event.id);
+      await _saveBookmarks();
+    }
+    Log.debug(
+      'Published bookmark set to Nostr: ${set.name} (${event.id})',
+      name: 'BookmarkService',
+      category: LogCategory.system,
+    );
+    return BookmarkResult.successResult(outcome: outcome, feedback: feedback);
   }
 
   // === NOSTR LOADING ===

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -34,6 +34,62 @@ typedef OnListSubscribedCallback =
 /// Called with listId when a list is unsubscribed
 typedef OnListUnsubscribedCallback = void Function(String listId);
 
+/// Result of a curated-list mutation that can trigger a Nostr publish.
+///
+/// Mirrors the bookmark/deletion result shapes: on success, [outcome] and
+/// [feedback] are populated and callers can render a success confirmation;
+/// on failure, [feedback.retryable] drives whether the UI exposes a retry
+/// affordance.
+///
+/// Operations that can skip the publish (unauthenticated user, private
+/// list, empty list) return a "noop" result where [outcome] and [feedback]
+/// are both null and [success] reflects whether the local state mutation
+/// is durable.
+class CuratedListResult {
+  const CuratedListResult({
+    required this.success,
+    this.outcome,
+    this.feedback,
+    this.list,
+  });
+
+  /// Whether the requested mutation is durable — either because a relay
+  /// accepted the publish, or because the operation did not require a
+  /// publish in the first place (private list, unauthenticated user).
+  final bool success;
+
+  /// Per-relay publish outcome. `null` when the mutation skipped publishing.
+  final PublishOutcome? outcome;
+
+  /// Mapped user feedback. `null` iff [outcome] is `null`.
+  final PublishUserFeedback? feedback;
+
+  /// Populated by mutators that return a new/updated list (e.g. [create]).
+  final CuratedList? list;
+
+  static CuratedListResult successResult({
+    PublishOutcome? outcome,
+    PublishUserFeedback? feedback,
+    CuratedList? list,
+  }) => CuratedListResult(
+    success: true,
+    outcome: outcome,
+    feedback: feedback,
+    list: list,
+  );
+
+  static CuratedListResult failure({
+    PublishOutcome? outcome,
+    PublishUserFeedback? feedback,
+    CuratedList? list,
+  }) => CuratedListResult(
+    success: false,
+    outcome: outcome,
+    feedback: feedback,
+    list: list,
+  );
+}
+
 /// Service for managing NIP-51 curated lists
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
 class CuratedListService extends ChangeNotifier {
@@ -196,7 +252,11 @@ class CuratedListService extends ChangeNotifier {
     );
   }
 
-  /// Internal method to create a list with optional explicit ID
+  /// Internal method to create a list with optional explicit ID.
+  ///
+  /// Returns the created list on success, or `null` if publish failed and
+  /// local state was rolled back. For the default (empty, private) list
+  /// creation, publishing is skipped and the list is always persisted.
   Future<CuratedList?> _createList({
     required String name,
     String? id,
@@ -209,154 +269,185 @@ class CuratedListService extends ChangeNotifier {
     String? thumbnailEventId,
     PlayOrder playOrder = PlayOrder.chronological,
   }) async {
-    try {
-      final now = DateTime.now();
-      final listId = id ?? 'list_${now.millisecondsSinceEpoch}';
+    final now = DateTime.now();
+    final listId = id ?? 'list_${now.millisecondsSinceEpoch}';
 
-      final newList = CuratedList(
-        id: listId,
-        name: name,
-        description: description,
-        imageUrl: imageUrl,
-        videoEventIds: const [],
-        createdAt: now,
-        updatedAt: now,
-        isPublic: isPublic,
-        tags: tags,
-        isCollaborative: isCollaborative,
-        allowedCollaborators: allowedCollaborators,
-        thumbnailEventId: thumbnailEventId,
-        playOrder: playOrder,
-      );
+    final newList = CuratedList(
+      id: listId,
+      name: name,
+      description: description,
+      imageUrl: imageUrl,
+      videoEventIds: const [],
+      createdAt: now,
+      updatedAt: now,
+      isPublic: isPublic,
+      tags: tags,
+      isCollaborative: isCollaborative,
+      allowedCollaborators: allowedCollaborators,
+      thumbnailEventId: thumbnailEventId,
+      playOrder: playOrder,
+    );
 
-      _lists.add(newList);
-      await _saveLists();
+    _lists.add(newList);
+    await _saveLists();
 
-      // Publish to Nostr if user is authenticated and list is public
-      if (_authService.isAuthenticated && isPublic) {
-        await _publishListToNostr(newList);
-      }
-
+    // Empty lists don't publish (see _publishListToNostr) and private lists
+    // never publish — both are local-only success.
+    if (!_authService.isAuthenticated ||
+        !isPublic ||
+        newList.videoEventIds.isEmpty) {
       Log.info(
         'Created new curated list: $name ($listId)',
         name: 'CuratedListService',
         category: LogCategory.system,
       );
-
       return newList;
-    } catch (e) {
-      Log.error(
-        'Failed to create curated list: $e',
-        name: 'CuratedListService',
-        category: LogCategory.system,
-      );
+    }
+
+    final publish = await _publishListToNostr(newList);
+    if (!publish.success) {
+      _lists.removeWhere((l) => l.id == listId);
+      await _saveLists();
       return null;
     }
+
+    Log.info(
+      'Created new curated list: $name ($listId)',
+      name: 'CuratedListService',
+      category: LogCategory.system,
+    );
+    // Prefer the published (nostrEventId-stamped) copy when available.
+    return publish.list ?? newList;
   }
 
-  /// Add video to a list
-  Future<bool> addVideoToList(String listId, String videoEventId) async {
-    try {
-      final listIndex = _lists.indexWhere((list) => list.id == listId);
-      if (listIndex == -1) {
-        Log.warning(
-          'List not found: $listId',
-          name: 'CuratedListService',
-          category: LogCategory.system,
-        );
-        return false;
-      }
+  /// Add video to a list.
+  ///
+  /// Returns `true` when the video is persisted locally and (for public
+  /// lists) the kind 30005 event has been accepted by at least one relay.
+  /// Returns `false` on relay-level failure — the local mutation is
+  /// rolled back in that case so local and relay state stay consistent.
+  ///
+  /// Prefer [addVideoToListResult] when the caller needs the per-relay
+  /// outcome to drive a retry affordance in the UI.
+  Future<bool> addVideoToList(String listId, String videoEventId) async =>
+      (await addVideoToListResult(listId, videoEventId)).success;
 
-      final list = _lists[listIndex];
-
-      // Check if video is already in the list
-      if (list.videoEventIds.contains(videoEventId)) {
-        Log.warning(
-          'Video already in list: $videoEventId',
-          name: 'CuratedListService',
-          category: LogCategory.system,
-        );
-        return true; // Return true since it's already there
-      }
-
-      // Add video to list
-      final updatedVideoIds = [...list.videoEventIds, videoEventId];
-      final updatedList = list.copyWith(
-        videoEventIds: updatedVideoIds,
-        updatedAt: DateTime.now(),
-      );
-
-      _lists[listIndex] = updatedList;
-      await _saveLists();
-
-      // Update on Nostr if public
-      if (updatedList.isPublic && _authService.isAuthenticated) {
-        await _publishListToNostr(updatedList);
-      }
-
-      Log.debug(
-        '➕ Added video to list "${list.name}": $videoEventId',
+  /// [addVideoToList] variant that returns the full [CuratedListResult]
+  /// so the UI can render retry-able failure snackbars.
+  Future<CuratedListResult> addVideoToListResult(
+    String listId,
+    String videoEventId,
+  ) async {
+    final listIndex = _lists.indexWhere((list) => list.id == listId);
+    if (listIndex == -1) {
+      Log.warning(
+        'List not found: $listId',
         name: 'CuratedListService',
         category: LogCategory.system,
       );
-
-      return true;
-    } catch (e) {
-      Log.error(
-        'Failed to add video to list: $e',
-        name: 'CuratedListService',
-        category: LogCategory.system,
-      );
-      return false;
+      return CuratedListResult.failure();
     }
+
+    final originalList = _lists[listIndex];
+
+    // Already in the list — no-op (local + relay state already match).
+    if (originalList.videoEventIds.contains(videoEventId)) {
+      Log.warning(
+        'Video already in list: $videoEventId',
+        name: 'CuratedListService',
+        category: LogCategory.system,
+      );
+      return CuratedListResult.successResult(list: originalList);
+    }
+
+    final updatedList = originalList.copyWith(
+      videoEventIds: [...originalList.videoEventIds, videoEventId],
+      updatedAt: DateTime.now(),
+    );
+
+    _lists[listIndex] = updatedList;
+    await _saveLists();
+
+    // Private lists never publish — the local mutation is authoritative.
+    if (!updatedList.isPublic || !_authService.isAuthenticated) {
+      Log.debug(
+        '➕ Added video to list "${originalList.name}": $videoEventId',
+        name: 'CuratedListService',
+        category: LogCategory.system,
+      );
+      return CuratedListResult.successResult(list: updatedList);
+    }
+
+    final publish = await _publishListToNostr(updatedList);
+    if (!publish.success) {
+      // Rollback: restore the previous list so local state matches relay.
+      _lists[listIndex] = originalList;
+      await _saveLists();
+      return publish;
+    }
+
+    Log.debug(
+      '➕ Added video to list "${originalList.name}": $videoEventId',
+      name: 'CuratedListService',
+      category: LogCategory.system,
+    );
+    return publish;
   }
 
-  /// Remove video from a list
-  Future<bool> removeVideoFromList(String listId, String videoEventId) async {
-    try {
-      final listIndex = _lists.indexWhere((list) => list.id == listId);
-      if (listIndex == -1) {
-        Log.warning(
-          'List not found: $listId',
-          name: 'CuratedListService',
-          category: LogCategory.system,
-        );
-        return false;
-      }
+  /// Remove video from a list. Returns `true` on durable success.
+  Future<bool> removeVideoFromList(
+    String listId,
+    String videoEventId,
+  ) async => (await removeVideoFromListResult(listId, videoEventId)).success;
 
-      final list = _lists[listIndex];
-      final updatedVideoIds = list.videoEventIds
+  /// [removeVideoFromList] variant returning the full [CuratedListResult].
+  Future<CuratedListResult> removeVideoFromListResult(
+    String listId,
+    String videoEventId,
+  ) async {
+    final listIndex = _lists.indexWhere((list) => list.id == listId);
+    if (listIndex == -1) {
+      Log.warning(
+        'List not found: $listId',
+        name: 'CuratedListService',
+        category: LogCategory.system,
+      );
+      return CuratedListResult.failure();
+    }
+
+    final originalList = _lists[listIndex];
+    final updatedList = originalList.copyWith(
+      videoEventIds: originalList.videoEventIds
           .where((id) => id != videoEventId)
-          .toList();
+          .toList(),
+      updatedAt: DateTime.now(),
+    );
 
-      final updatedList = list.copyWith(
-        videoEventIds: updatedVideoIds,
-        updatedAt: DateTime.now(),
-      );
+    _lists[listIndex] = updatedList;
+    await _saveLists();
 
-      _lists[listIndex] = updatedList;
-      await _saveLists();
-
-      // Update on Nostr if public
-      if (updatedList.isPublic && _authService.isAuthenticated) {
-        await _publishListToNostr(updatedList);
-      }
-
+    if (!updatedList.isPublic || !_authService.isAuthenticated) {
       Log.debug(
-        '➖ Removed video from list "${list.name}": $videoEventId',
+        '➖ Removed video from list "${originalList.name}": $videoEventId',
         name: 'CuratedListService',
         category: LogCategory.system,
       );
-
-      return true;
-    } catch (e) {
-      Log.error(
-        'Failed to remove video from list: $e',
-        name: 'CuratedListService',
-        category: LogCategory.system,
-      );
-      return false;
+      return CuratedListResult.successResult(list: updatedList);
     }
+
+    final publish = await _publishListToNostr(updatedList);
+    if (!publish.success) {
+      _lists[listIndex] = originalList;
+      await _saveLists();
+      return publish;
+    }
+
+    Log.debug(
+      '➖ Removed video from list "${originalList.name}": $videoEventId',
+      name: 'CuratedListService',
+      category: LogCategory.system,
+    );
+    return publish;
   }
 
   /// Check if video is in a specific list
@@ -378,7 +469,10 @@ class CuratedListService extends ChangeNotifier {
     }
   }
 
-  /// Update list metadata with enhanced playlist features
+  /// Update list metadata with enhanced playlist features.
+  ///
+  /// Gates local state commit on relay confirmation when the list is
+  /// public — transient failures roll back the local mutation.
   Future<bool> updateList({
     required String listId,
     String? name,
@@ -391,49 +485,51 @@ class CuratedListService extends ChangeNotifier {
     String? thumbnailEventId,
     PlayOrder? playOrder,
   }) async {
-    try {
-      final listIndex = _lists.indexWhere((list) => list.id == listId);
-      if (listIndex == -1) {
-        return false;
-      }
+    final listIndex = _lists.indexWhere((list) => list.id == listId);
+    if (listIndex == -1) {
+      return false;
+    }
 
-      final list = _lists[listIndex];
-      final updatedList = list.copyWith(
-        name: name ?? list.name,
-        description: description ?? list.description,
-        imageUrl: imageUrl ?? list.imageUrl,
-        isPublic: isPublic ?? list.isPublic,
-        tags: tags ?? list.tags,
-        isCollaborative: isCollaborative ?? list.isCollaborative,
-        allowedCollaborators: allowedCollaborators ?? list.allowedCollaborators,
-        thumbnailEventId: thumbnailEventId ?? list.thumbnailEventId,
-        playOrder: playOrder ?? list.playOrder,
-        updatedAt: DateTime.now(),
-      );
+    final originalList = _lists[listIndex];
+    final updatedList = originalList.copyWith(
+      name: name ?? originalList.name,
+      description: description ?? originalList.description,
+      imageUrl: imageUrl ?? originalList.imageUrl,
+      isPublic: isPublic ?? originalList.isPublic,
+      tags: tags ?? originalList.tags,
+      isCollaborative: isCollaborative ?? originalList.isCollaborative,
+      allowedCollaborators:
+          allowedCollaborators ?? originalList.allowedCollaborators,
+      thumbnailEventId: thumbnailEventId ?? originalList.thumbnailEventId,
+      playOrder: playOrder ?? originalList.playOrder,
+      updatedAt: DateTime.now(),
+    );
 
-      _lists[listIndex] = updatedList;
-      await _saveLists();
+    _lists[listIndex] = updatedList;
+    await _saveLists();
 
-      // Update on Nostr if public
-      if (updatedList.isPublic && _authService.isAuthenticated) {
-        await _publishListToNostr(updatedList);
-      }
-
+    if (!updatedList.isPublic || !_authService.isAuthenticated) {
       Log.debug(
         '✏️ Updated list: ${updatedList.name}',
         name: 'CuratedListService',
         category: LogCategory.system,
       );
-
       return true;
-    } catch (e) {
-      Log.error(
-        'Failed to update list: $e',
-        name: 'CuratedListService',
-        category: LogCategory.system,
-      );
+    }
+
+    final publish = await _publishListToNostr(updatedList);
+    if (!publish.success) {
+      _lists[listIndex] = originalList;
+      await _saveLists();
       return false;
     }
+
+    Log.debug(
+      '✏️ Updated list: ${updatedList.name}',
+      name: 'CuratedListService',
+      category: LogCategory.system,
+    );
+    return true;
   }
 
   /// Delete a list
@@ -481,64 +577,68 @@ class CuratedListService extends ChangeNotifier {
 
   // === ENHANCED PLAYLIST FEATURES ===
 
-  /// Reorder videos in a playlist (manual play order)
+  /// Reorder videos in a playlist (manual play order).
+  ///
+  /// Gates local commit on relay confirmation for public lists; rolls
+  /// back on transient failure.
   Future<bool> reorderVideos(String listId, List<String> newOrder) async {
-    try {
-      final listIndex = _lists.indexWhere((list) => list.id == listId);
-      if (listIndex == -1) {
-        Log.warning(
-          'List not found: $listId',
-          name: 'CuratedListService',
-          category: LogCategory.system,
-        );
-        return false;
-      }
-
-      final list = _lists[listIndex];
-
-      // Validate that all current videos are included in the new order
-      final currentVideos = Set<String>.from(list.videoEventIds);
-      final newOrderSet = Set<String>.from(newOrder);
-
-      if (currentVideos.difference(newOrderSet).isNotEmpty ||
-          newOrderSet.difference(currentVideos).isNotEmpty) {
-        Log.warning(
-          'Invalid reorder: video lists do not match',
-          name: 'CuratedListService',
-          category: LogCategory.system,
-        );
-        return false;
-      }
-
-      final updatedList = list.copyWith(
-        videoEventIds: newOrder,
-        playOrder: PlayOrder.manual, // Set to manual when reordering
-        updatedAt: DateTime.now(),
-      );
-
-      _lists[listIndex] = updatedList;
-      await _saveLists();
-
-      // Update on Nostr if public
-      if (updatedList.isPublic && _authService.isAuthenticated) {
-        await _publishListToNostr(updatedList);
-      }
-
-      Log.debug(
-        '📱 Reordered videos in list "${list.name}"',
-        name: 'CuratedListService',
-        category: LogCategory.system,
-      );
-
-      return true;
-    } catch (e) {
-      Log.error(
-        'Failed to reorder videos: $e',
+    final listIndex = _lists.indexWhere((list) => list.id == listId);
+    if (listIndex == -1) {
+      Log.warning(
+        'List not found: $listId',
         name: 'CuratedListService',
         category: LogCategory.system,
       );
       return false;
     }
+
+    final originalList = _lists[listIndex];
+
+    // Validate that all current videos are included in the new order.
+    final currentVideos = Set<String>.from(originalList.videoEventIds);
+    final newOrderSet = Set<String>.from(newOrder);
+
+    if (currentVideos.difference(newOrderSet).isNotEmpty ||
+        newOrderSet.difference(currentVideos).isNotEmpty) {
+      Log.warning(
+        'Invalid reorder: video lists do not match',
+        name: 'CuratedListService',
+        category: LogCategory.system,
+      );
+      return false;
+    }
+
+    final updatedList = originalList.copyWith(
+      videoEventIds: newOrder,
+      playOrder: PlayOrder.manual, // Set to manual when reordering.
+      updatedAt: DateTime.now(),
+    );
+
+    _lists[listIndex] = updatedList;
+    await _saveLists();
+
+    if (!updatedList.isPublic || !_authService.isAuthenticated) {
+      Log.debug(
+        '📱 Reordered videos in list "${originalList.name}"',
+        name: 'CuratedListService',
+        category: LogCategory.system,
+      );
+      return true;
+    }
+
+    final publish = await _publishListToNostr(updatedList);
+    if (!publish.success) {
+      _lists[listIndex] = originalList;
+      await _saveLists();
+      return false;
+    }
+
+    Log.debug(
+      '📱 Reordered videos in list "${originalList.name}"',
+      name: 'CuratedListService',
+      category: LogCategory.system,
+    );
+    return true;
   }
 
   /// Get ordered video list based on play order setting
@@ -560,105 +660,104 @@ class CuratedListService extends ChangeNotifier {
     }
   }
 
-  /// Add collaborator to a list
+  /// Add collaborator to a list.
   Future<bool> addCollaborator(String listId, String pubkey) async {
-    try {
-      final listIndex = _lists.indexWhere((list) => list.id == listId);
-      if (listIndex == -1) {
-        return false;
-      }
+    final listIndex = _lists.indexWhere((list) => list.id == listId);
+    if (listIndex == -1) {
+      return false;
+    }
 
-      final list = _lists[listIndex];
-      if (!list.isCollaborative) {
-        Log.warning(
-          'Cannot add collaborator - list is not collaborative',
-          name: 'CuratedListService',
-          category: LogCategory.system,
-        );
-        return false;
-      }
-
-      if (list.allowedCollaborators.contains(pubkey)) {
-        Log.debug(
-          'User already a collaborator: $pubkey',
-          name: 'CuratedListService',
-          category: LogCategory.system,
-        );
-        return true;
-      }
-
-      final updatedCollaborators = [...list.allowedCollaborators, pubkey];
-      final updatedList = list.copyWith(
-        allowedCollaborators: updatedCollaborators,
-        updatedAt: DateTime.now(),
-      );
-
-      _lists[listIndex] = updatedList;
-      await _saveLists();
-
-      // Update on Nostr if public
-      if (updatedList.isPublic && _authService.isAuthenticated) {
-        await _publishListToNostr(updatedList);
-      }
-
-      Log.debug(
-        '✅ Added collaborator to list "${list.name}": $pubkey',
-        name: 'CuratedListService',
-        category: LogCategory.system,
-      );
-
-      return true;
-    } catch (e) {
-      Log.error(
-        'Failed to add collaborator: $e',
+    final originalList = _lists[listIndex];
+    if (!originalList.isCollaborative) {
+      Log.warning(
+        'Cannot add collaborator - list is not collaborative',
         name: 'CuratedListService',
         category: LogCategory.system,
       );
       return false;
     }
+
+    if (originalList.allowedCollaborators.contains(pubkey)) {
+      Log.debug(
+        'User already a collaborator: $pubkey',
+        name: 'CuratedListService',
+        category: LogCategory.system,
+      );
+      return true;
+    }
+
+    final updatedList = originalList.copyWith(
+      allowedCollaborators: [...originalList.allowedCollaborators, pubkey],
+      updatedAt: DateTime.now(),
+    );
+
+    _lists[listIndex] = updatedList;
+    await _saveLists();
+
+    if (!updatedList.isPublic || !_authService.isAuthenticated) {
+      Log.debug(
+        '✅ Added collaborator to list "${originalList.name}": $pubkey',
+        name: 'CuratedListService',
+        category: LogCategory.system,
+      );
+      return true;
+    }
+
+    final publish = await _publishListToNostr(updatedList);
+    if (!publish.success) {
+      _lists[listIndex] = originalList;
+      await _saveLists();
+      return false;
+    }
+
+    Log.debug(
+      '✅ Added collaborator to list "${originalList.name}": $pubkey',
+      name: 'CuratedListService',
+      category: LogCategory.system,
+    );
+    return true;
   }
 
-  /// Remove collaborator from a list
+  /// Remove collaborator from a list.
   Future<bool> removeCollaborator(String listId, String pubkey) async {
-    try {
-      final listIndex = _lists.indexWhere((list) => list.id == listId);
-      if (listIndex == -1) {
-        return false;
-      }
-
-      final list = _lists[listIndex];
-      final updatedCollaborators = list.allowedCollaborators
-          .where((collaborator) => collaborator != pubkey)
-          .toList();
-
-      final updatedList = list.copyWith(
-        allowedCollaborators: updatedCollaborators,
-        updatedAt: DateTime.now(),
-      );
-
-      _lists[listIndex] = updatedList;
-      await _saveLists();
-
-      // Update on Nostr if public
-      if (updatedList.isPublic && _authService.isAuthenticated) {
-        await _publishListToNostr(updatedList);
-      }
-
-      Log.debug(
-        '➖ Removed collaborator from list "${list.name}": $pubkey',
-        name: 'CuratedListService',
-        category: LogCategory.system,
-      );
-
-      return true;
-    } catch (e) {
-      Log.error(
-        'Failed to remove collaborator: $e',
-        name: 'CuratedListService',
-        category: LogCategory.system,
-      );
+    final listIndex = _lists.indexWhere((list) => list.id == listId);
+    if (listIndex == -1) {
       return false;
     }
+
+    final originalList = _lists[listIndex];
+    final updatedList = originalList.copyWith(
+      allowedCollaborators: originalList.allowedCollaborators
+          .where((collaborator) => collaborator != pubkey)
+          .toList(),
+      updatedAt: DateTime.now(),
+    );
+
+    _lists[listIndex] = updatedList;
+    await _saveLists();
+
+    if (!updatedList.isPublic || !_authService.isAuthenticated) {
+      Log.debug(
+        '➖ Removed collaborator from list "${originalList.name}": $pubkey',
+        name: 'CuratedListService',
+        category: LogCategory.system,
+      );
+      return true;
+    }
+
+    final publish = await _publishListToNostr(updatedList);
+    if (!publish.success) {
+      _lists[listIndex] = originalList;
+      await _saveLists();
+      return false;
+    }
+
+    Log.debug(
+      '➖ Removed collaborator from list "${originalList.name}": $pubkey',
+      name: 'CuratedListService',
+      category: LogCategory.system,
+    );
+    return true;
   }
 
   /// Check if a user can collaborate on a list
@@ -865,60 +964,88 @@ class CuratedListService extends ChangeNotifier {
     );
   }
 
-  /// Publish list to Nostr as NIP-51 kind 30005 event
-  Future<void> _publishListToNostr(CuratedList list) async {
-    try {
-      if (!_authService.isAuthenticated) {
-        Log.warning(
-          'Cannot publish list - user not authenticated',
-          name: 'CuratedListService',
-          category: LogCategory.system,
-        );
-        return;
-      }
-
-      // Don't spam relay with empty lists
-      if (list.videoEventIds.isEmpty) {
-        Log.debug(
-          'Skipping publish of empty list: ${list.name}',
-          name: 'CuratedListService',
-          category: LogCategory.system,
-        );
-        return;
-      }
-
-      final content = list.description ?? 'Curated video list: ${list.name}';
-      final tags = list.getEventTags();
-
-      final event = await _authService.createAndSignEvent(
-        kind: 30005, // NIP-51 curated list
-        content: content,
-        tags: tags,
-      );
-
-      if (event != null) {
-        final sentEvent = await _nostrService.publishEvent(event);
-        if (sentEvent != null) {
-          // Update local list with Nostr event ID
-          final listIndex = _lists.indexWhere((l) => l.id == list.id);
-          if (listIndex != -1) {
-            _lists[listIndex] = list.copyWith(nostrEventId: event.id);
-            await _saveLists();
-          }
-          Log.debug(
-            'Published list to Nostr: ${list.name} (${event.id})',
-            name: 'CuratedListService',
-            category: LogCategory.system,
-          );
-        }
-      }
-    } catch (e) {
-      Log.error(
-        'Failed to publish list to Nostr: $e',
+  /// Publish list to Nostr as NIP-51 kind 30005 event.
+  ///
+  /// Uses [NostrClient.publishEventWithRetry] so transient failures retry
+  /// on a bounded schedule. Returns a [CuratedListResult]; callers are
+  /// responsible for rolling back local state when `success` is false.
+  ///
+  /// Returns a "noop success" when the publish is deliberately skipped
+  /// (unauthenticated user or empty list). Those cases do not represent
+  /// relay-level failure and don't need to trigger a rollback.
+  Future<CuratedListResult> _publishListToNostr(CuratedList list) async {
+    if (!_authService.isAuthenticated) {
+      Log.warning(
+        'Cannot publish list - user not authenticated',
         name: 'CuratedListService',
         category: LogCategory.system,
       );
+      return CuratedListResult.successResult(list: list);
     }
+
+    // Don't spam relay with empty lists.
+    if (list.videoEventIds.isEmpty) {
+      Log.debug(
+        'Skipping publish of empty list: ${list.name}',
+        name: 'CuratedListService',
+        category: LogCategory.system,
+      );
+      return CuratedListResult.successResult(list: list);
+    }
+
+    final content = list.description ?? 'Curated video list: ${list.name}';
+    final tags = list.getEventTags();
+
+    final event = await _authService.createAndSignEvent(
+      kind: 30005, // NIP-51 curated list
+      content: content,
+      tags: tags,
+    );
+
+    if (event == null) {
+      Log.error(
+        'Failed to sign kind 30005 curated-list event',
+        name: 'CuratedListService',
+        category: LogCategory.system,
+      );
+      return CuratedListResult.failure(list: list);
+    }
+
+    final outcome = await _nostrService.publishEventWithRetry(event);
+    final feedback = PublishResultMapper.map(outcome);
+
+    if (!outcome.acceptedByAny) {
+      Log.warning(
+        'Curated-list publish not accepted by any relay: $outcome',
+        name: 'CuratedListService',
+        category: LogCategory.system,
+      );
+      return CuratedListResult.failure(
+        outcome: outcome,
+        feedback: feedback,
+        list: list,
+      );
+    }
+
+    // Update local list with Nostr event ID so subsequent loads can link
+    // the local cache back to its latest published event.
+    final listIndex = _lists.indexWhere((l) => l.id == list.id);
+    CuratedList updatedList = list;
+    if (listIndex != -1) {
+      updatedList = list.copyWith(nostrEventId: event.id);
+      _lists[listIndex] = updatedList;
+      await _saveLists();
+    }
+    Log.debug(
+      'Published list to Nostr: ${list.name} (${event.id})',
+      name: 'CuratedListService',
+      category: LogCategory.system,
+    );
+    return CuratedListResult.successResult(
+      outcome: outcome,
+      feedback: feedback,
+      list: updatedList,
+    );
   }
 
   /// Load lists from local storage

--- a/mobile/lib/widgets/add_to_list_dialog.dart
+++ b/mobile/lib/widgets/add_to_list_dialog.dart
@@ -117,14 +117,19 @@ class SelectListDialog extends StatelessWidget {
     bool isCurrentlyInList,
   ) async {
     try {
-      bool success;
+      final CuratedListResult result;
       if (isCurrentlyInList) {
-        success = await listService.removeVideoFromList(list.id, video.id);
+        result = await listService.removeVideoFromListResult(
+          list.id,
+          video.id,
+        );
       } else {
-        success = await listService.addVideoToList(list.id, video.id);
+        result = await listService.addVideoToListResult(list.id, video.id);
       }
 
-      if (success && context.mounted) {
+      if (!context.mounted) return;
+
+      if (result.success) {
         final message = isCurrentlyInList
             ? context.l10n.listRemovedFrom(list.name)
             : context.l10n.listAddedTo(list.name);
@@ -132,6 +137,31 @@ class SelectListDialog extends StatelessWidget {
           SnackBar(
             content: Text(message),
             duration: const Duration(seconds: 1),
+          ),
+        );
+      } else {
+        final retryable = result.feedback?.retryable ?? false;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            // Failure copy — follow-up PR will add dedicated l10n keys for
+            // the migrated list-reliability errors.
+            content: Text(
+              isCurrentlyInList
+                  ? 'Failed to remove from "${list.name}"'
+                  : 'Failed to add to "${list.name}"',
+            ),
+            duration: const Duration(seconds: 2),
+            action: retryable
+                ? SnackBarAction(
+                    label: 'Retry',
+                    onPressed: () => _toggleVideoInList(
+                      context,
+                      listService,
+                      list,
+                      isCurrentlyInList,
+                    ),
+                  )
+                : null,
           ),
         );
       }

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -762,23 +762,28 @@ class _ShareVideoMenuState extends ConsumerState<ShareVideoMenu> {
   Future<void> _addToGlobalBookmarks() async {
     try {
       final bookmarkService = await ref.read(bookmarkServiceProvider.future);
-      final success = await bookmarkService.addVideoToGlobalBookmarks(
+      final result = await bookmarkService.addVideoToGlobalBookmarks(
         widget.video.id,
       );
 
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              success
-                  ? context.l10n.shareMenuAddedToBookmarks
-                  : context.l10n.shareMenuFailedToAddBookmark,
-            ),
-            duration: const Duration(seconds: 2),
+      if (!mounted) return;
+
+      final retryable = result.feedback?.retryable ?? false;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            result.success
+                ? context.l10n.shareMenuAddedToBookmarks
+                : context.l10n.shareMenuFailedToAddBookmark,
           ),
-        );
-        _safePop(context);
-      }
+          duration: const Duration(seconds: 2),
+          action: !result.success && retryable
+              // Retry label — follow-up PR will add dedicated l10n keys.
+              ? SnackBarAction(label: 'Retry', onPressed: _addToGlobalBookmarks)
+              : null,
+        ),
+      );
+      _safePop(context);
     } catch (e) {
       Log.error(
         'Failed to add bookmark: $e',
@@ -2585,19 +2590,24 @@ class _SelectBookmarkSetDialog extends StatelessWidget {
     bool isCurrentlyInSet,
   ) async {
     try {
-      bool success;
       final bookmarkItem = BookmarkItem(type: 'e', id: video.id);
+      final BookmarkResult result;
 
       if (isCurrentlyInSet) {
-        success = await bookmarkService.removeFromBookmarkSet(
+        result = await bookmarkService.removeFromBookmarkSet(
           set.id,
           bookmarkItem,
         );
       } else {
-        success = await bookmarkService.addToBookmarkSet(set.id, bookmarkItem);
+        result = await bookmarkService.addToBookmarkSet(
+          set.id,
+          bookmarkItem,
+        );
       }
 
-      if (success && context.mounted) {
+      if (!context.mounted) return;
+
+      if (result.success) {
         final message = isCurrentlyInSet
             ? 'Removed from "${set.name}"'
             : 'Added to "${set.name}"';
@@ -2609,6 +2619,33 @@ class _SelectBookmarkSetDialog extends StatelessWidget {
           SnackBar(
             content: Text(message),
             duration: const Duration(seconds: 2),
+          ),
+        );
+      } else {
+        // Publish failed — show retryable snackbar when transient.
+        final retryable = result.feedback?.retryable ?? false;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              isCurrentlyInSet
+                  ? 'Failed to remove from "${set.name}"'
+                  : 'Failed to add to "${set.name}"',
+            ),
+            duration: const Duration(seconds: 2),
+            action: retryable
+                ? SnackBarAction(
+                    // Retry label — see PR 4 delete UI note.
+                    label: 'Retry',
+                    onPressed: () => _toggleVideoInBookmarkSet(
+                      context,
+                      ref,
+                      bookmarkService,
+                      set,
+                      video,
+                      isCurrentlyInSet,
+                    ),
+                  )
+                : null,
           ),
         );
       }
@@ -2693,14 +2730,17 @@ class _CreateBookmarkSetDialogState
 
     try {
       final bookmarkService = await ref.read(bookmarkServiceProvider.future);
-      final newSet = await bookmarkService.createBookmarkSet(
+      final createResult = await bookmarkService.createBookmarkSet(
         name: name,
         description: _descriptionController.text.trim().isEmpty
             ? null
             : _descriptionController.text.trim(),
       );
 
-      if (newSet != null && mounted) {
+      if (!mounted) return;
+
+      final newSet = createResult.set;
+      if (createResult.success && newSet != null) {
         // Add the video to the new set
         final bookmarkItem = BookmarkItem(type: 'e', id: widget.video.id);
         await bookmarkService.addToBookmarkSet(newSet.id, bookmarkItem);
@@ -2717,6 +2757,18 @@ class _CreateBookmarkSetDialogState
             ),
           );
         }
+      } else {
+        // Create failed — surface a retryable snackbar when transient.
+        final retryable = createResult.feedback?.retryable ?? false;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('Failed to create bookmark set'),
+            duration: const Duration(seconds: 2),
+            action: retryable
+                ? SnackBarAction(label: 'Retry', onPressed: _createBookmarkSet)
+                : null,
+          ),
+        );
       }
     } catch (e) {
       Log.error(

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -195,16 +195,35 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
             error: true,
           ),
         );
-      case ShareSheetSaveResult(:final succeeded):
+      case ShareSheetSaveResult(:final succeeded, :final feedback):
         _safePop(context);
-        messenger.showSnackBar(
-          DivineSnackbarContainer.snackBar(
-            succeeded
-                ? context.l10n.shareAddedToBookmarks
-                : context.l10n.shareFailedToAddBookmark,
-            error: !succeeded,
-          ),
-        );
+        if (succeeded) {
+          messenger.showSnackBar(
+            DivineSnackbarContainer.snackBar(
+              context.l10n.shareAddedToBookmarks,
+            ),
+          );
+        } else {
+          final retryable = feedback?.retryable ?? false;
+          // Capture the bloc before the async gap of snackbar dismissal so
+          // the retry action doesn't depend on context being valid later.
+          final shareSheetBloc = context.read<ShareSheetBloc>();
+          messenger.showSnackBar(
+            DivineSnackbarContainer.snackBar(
+              context.l10n.shareFailedToAddBookmark,
+              error: true,
+              // Retry label — a follow-up PR will add dedicated l10n keys
+              // for the retry UX shared across migrated services. For now
+              // we ship the English fallback used by PR 4 (deletion UI).
+              actionLabel: retryable ? 'Retry' : null,
+              onActionPressed: retryable
+                  ? () => shareSheetBloc.add(
+                      const ShareSheetSaveRequested(),
+                    )
+                  : null,
+            ),
+          );
+        }
       case ShareSheetCopiedToClipboard(:final label, :final text):
         Clipboard.setData(ClipboardData(text: text));
         _safePop(context);

--- a/mobile/packages/curation_service/lib/curation_service.dart
+++ b/mobile/packages/curation_service/lib/curation_service.dart
@@ -1,3 +1,11 @@
+export 'package:nostr_client/nostr_client.dart'
+    show
+        PublishOutcome,
+        PublishResultMapper,
+        PublishSeverity,
+        PublishUserFeedback,
+        RetryPolicy;
 export 'package:video_event_cache/video_event_cache.dart';
 
 export 'src/curation_service.dart';
+export 'src/curation_result.dart';

--- a/mobile/packages/curation_service/lib/src/curation_result.dart
+++ b/mobile/packages/curation_service/lib/src/curation_result.dart
@@ -1,0 +1,69 @@
+// ABOUTME: Result type for CurationService.publishCuration surfacing the
+// ABOUTME: per-relay outcome and user feedback for reliable publishing.
+
+import 'package:nostr_client/nostr_client.dart';
+
+/// Result of a [CurationService.publishCuration] call.
+///
+/// Exposes the per-relay [PublishOutcome] and the mapped
+/// [PublishUserFeedback] so the UI can render retry-able failure snackbars.
+/// [duplicate] distinguishes a short-circuited "already publishing" result
+/// from a genuine relay-level failure — the latter populates [outcome] and
+/// [feedback] while the former leaves them null.
+class CurationResult {
+  const CurationResult({
+    required this.success,
+    this.outcome,
+    this.feedback,
+    this.eventId,
+    this.duplicate = false,
+  });
+
+  /// Whether the curation publish is durable (at least one relay accepted).
+  final bool success;
+
+  /// Per-relay outcome. `null` when no publish was attempted (duplicate,
+  /// unauthenticated signer, event creation failed).
+  final PublishOutcome? outcome;
+
+  /// Mapped user feedback. `null` iff [outcome] is `null`.
+  final PublishUserFeedback? feedback;
+
+  /// Event id of the signed event (present when the publish reached the
+  /// relay round-trip, even if every relay rejected).
+  final String? eventId;
+
+  /// `true` when the publish was skipped because another publish of the
+  /// same curation id is already in flight. Callers typically ignore these
+  /// results and let the in-flight publish finish.
+  final bool duplicate;
+
+  /// A "duplicate" failure result — emitted when another publish of the
+  /// same curation id is already in flight.
+  const CurationResult.duplicate()
+    : success = false,
+      outcome = null,
+      feedback = null,
+      eventId = null,
+      duplicate = true;
+
+  /// Pre-flight failure — auth, signing, or event construction failed.
+  const CurationResult.preFlight()
+    : success = false,
+      outcome = null,
+      feedback = null,
+      eventId = null,
+      duplicate = false;
+
+  /// Build a [CurationResult] from a per-relay [PublishOutcome].
+  factory CurationResult.fromOutcome({
+    required PublishOutcome outcome,
+    required PublishUserFeedback feedback,
+    required String eventId,
+  }) => CurationResult(
+    success: outcome.acceptedByAny,
+    outcome: outcome,
+    feedback: feedback,
+    eventId: eventId,
+  );
+}

--- a/mobile/packages/curation_service/lib/src/curation_service.dart
+++ b/mobile/packages/curation_service/lib/src/curation_service.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:curation_service/src/curation_result.dart';
 import 'package:http/http.dart' as http;
 import 'package:likes_repository/likes_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
@@ -1059,33 +1060,37 @@ class CurationService {
     }
   }
 
-  /// Publish a curation set to Nostr
-  Future<CurationPublishResult> publishCuration({
+  /// Publish a curation set to Nostr.
+  ///
+  /// Routes through [NostrClient.publishEventWithRetry] so transient
+  /// failures retry on a bounded schedule. Returns a [CurationResult]
+  /// carrying the per-relay [PublishOutcome] and mapped
+  /// [PublishUserFeedback]; callers render a retry affordance when
+  /// `feedback.retryable` is true and a permanent-error snackbar when it
+  /// is false. The previous 5-second timeout and `failedAttempts`/
+  /// `lastFailureReason` instance state have been retired — retry logic
+  /// now lives in the shared `RetryPolicy`, and error messaging lives on
+  /// `CurationResult.feedback`.
+  Future<CurationResult> publishCuration({
     required String id,
     required String title,
     required List<String> videoIds,
     String? description,
     String? imageUrl,
   }) async {
-    // Prevent duplicate concurrent publishes
+    // Prevent duplicate concurrent publishes.
     if (_currentlyPublishing.contains(id)) {
       Log.debug(
-        'Curation $id already being published, '
-        'skipping duplicate',
+        'Curation $id already being published, skipping duplicate',
         name: 'CurationService',
         category: LogCategory.system,
       );
-      return const CurationPublishResult(
-        success: false,
-        successCount: 0,
-        totalRelays: 0,
-        errors: {'duplicate': 'Already publishing'},
-      );
+      return const CurationResult.duplicate();
     }
 
     _currentlyPublishing.add(id);
 
-    // Mark as publishing
+    // Mark as publishing.
     _publishStatuses[id] = CurationPublishStatus(
       curationId: id,
       isPublishing: true,
@@ -1094,7 +1099,6 @@ class CurationService {
     );
 
     try {
-      // Build the event
       final event = await buildCurationEvent(
         id: id,
         title: title,
@@ -1109,128 +1113,72 @@ class CurationService {
           name: 'CurationService',
           category: LogCategory.system,
         );
-
         _publishStatuses[id] = CurationPublishStatus(
           curationId: id,
           isPublishing: false,
           isPublished: false,
-          failedAttempts: (_publishStatuses[id]?.failedAttempts ?? 0) + 1,
+          hasFailed: true,
           lastAttemptAt: DateTime.now(),
-          lastFailureReason: 'Failed to create and sign event',
         );
-
-        return const CurationPublishResult(
-          success: false,
-          successCount: 0,
-          totalRelays: 0,
-          errors: {
-            'signing': 'Failed to create and sign event',
-          },
-        );
+        return const CurationResult.preFlight();
       }
 
-      // Publish with timeout
-      final publishFuture = _nostrService.publishEvent(event);
-      const timeoutDuration = Duration(seconds: 5);
+      // Retry policy: the default RetryPolicy (3 attempts, exponential
+      // backoff, 15s per-attempt timeout) is appropriate for a
+      // user-initiated kind 30005 publish. See nostr_client/RetryPolicy.
+      final outcome = await _nostrService.publishEventWithRetry(event);
+      final feedback = PublishResultMapper.map(outcome);
 
-      Event? sentEvent;
-
-      try {
-        sentEvent = await publishFuture.timeout(timeoutDuration);
-      } on TimeoutException {
-        Log.warning(
-          'Curation publish timed out after 5s: $id',
-          name: 'CurationService',
-          category: LogCategory.system,
-        );
-
-        _publishStatuses[id] = CurationPublishStatus(
-          curationId: id,
-          isPublishing: false,
-          isPublished: false,
-          failedAttempts: (_publishStatuses[id]?.failedAttempts ?? 0) + 1,
-          lastAttemptAt: DateTime.now(),
-          lastFailureReason: 'Timeout after 5 seconds',
-        );
-
-        return const CurationPublishResult(
-          success: false,
-          successCount: 0,
-          totalRelays: 0,
-          errors: {
-            'timeout': 'Publish timed out after 5 seconds',
-          },
-        );
-      }
-
-      final isSuccess = sentEvent != null;
-
-      if (isSuccess) {
-        // Mark as successfully published
+      if (outcome.acceptedByAny) {
         _publishStatuses[id] = CurationPublishStatus(
           curationId: id,
           isPublishing: false,
           isPublished: true,
           lastPublishedAt: DateTime.now(),
-          publishedEventId: sentEvent.id,
-          successfulRelays: _nostrService.connectedRelays,
+          publishedEventId: event.id,
+          successfulRelays: outcome.acceptedBy.toList(),
           lastAttemptAt: DateTime.now(),
         );
-
         Log.info(
-          '✅ Published curation "$title" to relays',
+          '✅ Published curation "$title" to '
+          '${outcome.acceptedBy.length} relay(s)',
           name: 'CurationService',
           category: LogCategory.system,
         );
       } else {
-        // Mark as failed
         _publishStatuses[id] = CurationPublishStatus(
           curationId: id,
           isPublishing: false,
           isPublished: false,
-          failedAttempts: (_publishStatuses[id]?.failedAttempts ?? 0) + 1,
+          hasFailed: true,
           lastAttemptAt: DateTime.now(),
-          lastFailureReason: 'Failed to publish to relays',
         );
-
         Log.warning(
-          '❌ Failed to publish curation "$title" '
-          'to relays',
+          '❌ Curation "$title" not accepted by any relay: $outcome',
           name: 'CurationService',
           category: LogCategory.system,
         );
       }
 
-      return CurationPublishResult(
-        success: isSuccess,
-        successCount: isSuccess ? 1 : 0,
-        totalRelays: 1,
-        eventId: isSuccess ? sentEvent.id : null,
-        errors: isSuccess ? {} : {'publish': 'Failed to publish to relays'},
-        failedRelays: isSuccess ? [] : ['relays'],
+      return CurationResult.fromOutcome(
+        outcome: outcome,
+        feedback: feedback,
+        eventId: event.id,
       );
-    } on Exception catch (e) {
+    } on Exception catch (e, stackTrace) {
       Log.error(
-        'Error publishing curation: $e',
+        'Error publishing curation: $e\n$stackTrace',
         name: 'CurationService',
         category: LogCategory.system,
       );
-
       _publishStatuses[id] = CurationPublishStatus(
         curationId: id,
         isPublishing: false,
         isPublished: false,
-        failedAttempts: (_publishStatuses[id]?.failedAttempts ?? 0) + 1,
+        hasFailed: true,
         lastAttemptAt: DateTime.now(),
-        lastFailureReason: e.toString(),
       );
-
-      return CurationPublishResult(
-        success: false,
-        successCount: 0,
-        totalRelays: 0,
-        errors: {'exception': e.toString()},
-      );
+      return const CurationResult.preFlight();
     } finally {
       _currentlyPublishing.remove(id);
     }
@@ -1248,80 +1196,11 @@ class CurationService {
         );
   }
 
-  /// Retry all unpublished curations with exponential
-  /// backoff
-  Future<void> retryUnpublishedCurations() async {
-    final now = DateTime.now();
-
-    for (final entry in _publishStatuses.entries) {
-      final curationId = entry.key;
-      final status = entry.value;
-
-      // Skip if already published or currently publishing
-      if (status.isPublished || status.isPublishing) {
-        continue;
-      }
-
-      // Skip if max retries reached
-      // coverage:ignore-start
-      if (!status.shouldRetry) {
-        Log.debug(
-          'Skipping retry for $curationId: '
-          'max attempts reached',
-          name: 'CurationService',
-          category: LogCategory.system,
-        );
-        continue;
-      }
-      // coverage:ignore-end
-
-      // Calculate next retry time with exponential backoff
-      final retryDelay = getRetryDelay(status.failedAttempts);
-      final nextRetryTime = status.lastAttemptAt?.add(retryDelay);
-
-      if (nextRetryTime == null || now.isBefore(nextRetryTime)) {
-        Log.debug(
-          'Skipping retry for $curationId: '
-          'backoff not elapsed',
-          name: 'CurationService',
-          category: LogCategory.system,
-        );
-        continue;
-      }
-
-      // coverage:ignore-start
-      Log.info(
-        '🔄 Retrying publish for curation $curationId '
-        '(attempt ${status.failedAttempts + 1})',
-        name: 'CurationService',
-        category: LogCategory.system,
-      );
-
-      // Get curation details to retry
-      final curation = _curationSets[curationId];
-      if (curation != null) {
-        await publishCuration(
-          id: curation.id,
-          title: curation.title ?? 'Untitled',
-          videoIds: curation.videoIds,
-          description: curation.description,
-          imageUrl: curation.imageUrl,
-        );
-      }
-      // coverage:ignore-end
-    }
-  }
-
-  /// Get retry delay based on attempt count (exponential
-  /// backoff)
-  Duration getRetryDelay(int attemptCount) {
-    // Exponential backoff: 2^n seconds
-    // Max ~17 minutes
-    final seconds = 1 << attemptCount.clamp(0, 10);
-    return Duration(seconds: seconds);
-  }
-
-  /// Create a new curation set and publish to Nostr
+  /// Create a new curation set and publish to Nostr.
+  ///
+  /// Returns `true` when at least one relay accepted the publish.
+  /// Prefer [publishCuration] when the caller needs the full per-relay
+  /// outcome (e.g. to render a retry-able failure snackbar).
   Future<bool> createCurationSet({
     required String id,
     required String title,
@@ -1336,7 +1215,6 @@ class CurationService {
         category: LogCategory.system,
       );
 
-      // Publish to Nostr
       final result = await publishCuration(
         id: id,
         title: title,

--- a/mobile/packages/curation_service/test/src/curation_publish_test.dart
+++ b/mobile/packages/curation_service/test/src/curation_publish_test.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Tests for CurationService Nostr publishing functionality
 // ABOUTME: (kind 30005). Verifies curation sets are correctly published
-// ABOUTME: to Nostr relays with retry logic.
+// ABOUTME: via NostrClient.publishEventWithRetry.
 
 import 'dart:async';
 
@@ -8,7 +8,6 @@ import 'package:curation_service/curation_service.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:models/models.dart' show CurationPublishResult;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
@@ -27,7 +26,6 @@ const _testPubkey =
     'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6'
     'e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
 
-/// Creates a test Event with a valid 64-char hex pubkey.
 Event _testEvent({
   int kind = 30005,
   List<List<String>> tags = const [],
@@ -36,12 +34,27 @@ Event _testEvent({
   return Event(_testPubkey, kind, tags, content);
 }
 
+PublishOutcome _acceptedOutcome() => PublishOutcome(
+  eventId: 'a' * 64,
+  acceptedBy: const {'wss://a'},
+  rejectedBy: const {},
+  noResponseFrom: const {},
+);
+
+PublishOutcome _failedOutcome() => PublishOutcome(
+  eventId: 'a' * 64,
+  acceptedBy: const {},
+  rejectedBy: const {},
+  noResponseFrom: const {'wss://a'},
+);
+
 void main() {
   setUpAll(() {
     registerFallbackValue(<Filter>[]);
     registerFallbackValue(_testEvent());
     registerFallbackValue(<String>[]);
     registerFallbackValue(<List<String>>[]);
+    registerFallbackValue(const RetryPolicy());
   });
 
   group('CurationService Publishing', () {
@@ -57,23 +70,14 @@ void main() {
       mockLikesRepository = _MockLikesRepository();
       mockSigner = _MockNostrSigner();
 
-      // Mock NostrSigner
       when(
         () => mockSigner.getPublicKey(),
       ).thenAnswer((_) async => _testPubkey);
-      when(
-        () => mockSigner.signEvent(any()),
-      ).thenAnswer((invocation) async {
+      when(() => mockSigner.signEvent(any())).thenAnswer((invocation) async {
         final event = invocation.positionalArguments[0] as Event;
-        return Event(
-          event.pubkey,
-          event.kind,
-          event.tags,
-          event.content,
-        );
+        return Event(event.pubkey, event.kind, event.tags, event.content);
       });
 
-      // Mock NostrClient
       when(
         () => mockNostrService.connectedRelays,
       ).thenReturn(['wss://relay1.example.com']);
@@ -81,10 +85,7 @@ void main() {
         () => mockNostrService.subscribe(any()),
       ).thenAnswer((_) => const Stream.empty());
 
-      // Mock empty video events initially
       when(() => mockVideoEventCache.discoveryVideos).thenReturn([]);
-
-      // Mock getLikeCounts to return empty counts
       when(
         () => mockLikesRepository.getLikeCounts(any()),
       ).thenAnswer((_) async => {});
@@ -100,8 +101,7 @@ void main() {
 
     group('buildCurationEvent', () {
       test(
-        'should create kind 30005 event with correct '
-        'structure',
+        'should create kind 30005 event with correct structure',
         () async {
           final event = await curationService.buildCurationEvent(
             id: 'test_curation_1',
@@ -116,19 +116,16 @@ void main() {
         },
       );
 
-      test(
-        'should handle optional fields correctly',
-        () async {
-          final event = await curationService.buildCurationEvent(
-            id: 'minimal_curation',
-            title: 'Minimal Curation',
-            videoIds: ['video1'],
-          );
+      test('should handle optional fields correctly', () async {
+        final event = await curationService.buildCurationEvent(
+          id: 'minimal_curation',
+          title: 'Minimal Curation',
+          videoIds: ['video1'],
+        );
 
-          expect(event, isNotNull);
-          expect(event!.kind, equals(30005));
-        },
-      );
+        expect(event, isNotNull);
+        expect(event!.kind, equals(30005));
+      });
 
       test('should handle empty video list', () async {
         final event = await curationService.buildCurationEvent(
@@ -139,112 +136,75 @@ void main() {
 
         expect(event, isNotNull);
         expect(event!.kind, equals(30005));
-        expect(
-          event.tags.where((tag) => tag[0] == 'e'),
-          isEmpty,
-        );
+        expect(event.tags.where((tag) => tag[0] == 'e'), isEmpty);
       });
     });
 
     group('publishCuration', () {
-      test(
-        'should publish event to Nostr and return success',
-        () async {
-          when(
-            () => mockNostrService.publishEvent(any()),
-          ).thenAnswer(
-            (_) async => _testEvent(
-              tags: [
-                ['d', 'test_id'],
-              ],
-              content: 'Test content',
-            ),
-          );
+      test('should publish event to Nostr and return success', () async {
+        when(
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _acceptedOutcome());
 
-          final result = await curationService.publishCuration(
-            id: 'test_curation',
-            title: 'Test Curation',
-            videoIds: ['video1', 'video2'],
-            description: 'Test description',
-          );
+        final result = await curationService.publishCuration(
+          id: 'test_curation',
+          title: 'Test Curation',
+          videoIds: ['video1', 'video2'],
+          description: 'Test description',
+        );
 
-          expect(result.success, isTrue);
-          expect(result.successCount, equals(1));
-          expect(result.totalRelays, equals(1));
-          expect(result.eventId, isNotNull);
+        expect(result.success, isTrue);
+        expect(result.outcome, isNotNull);
+        expect(result.outcome!.acceptedBy, {'wss://a'});
+        expect(result.eventId, isNotNull);
 
-          verify(
-            () => mockNostrService.publishEvent(any()),
-          ).called(1);
-        },
-      );
+        verify(
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
+      });
 
-      test(
-        'should handle complete failure gracefully',
-        () async {
-          when(
-            () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+      test('should handle complete failure gracefully', () async {
+        when(
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _failedOutcome());
 
-          final result = await curationService.publishCuration(
-            id: 'test_curation',
-            title: 'Test',
-            videoIds: [],
-          );
+        final result = await curationService.publishCuration(
+          id: 'test_curation',
+          title: 'Test',
+          videoIds: [],
+        );
 
-          expect(result.success, isFalse);
-          expect(result.successCount, equals(0));
-          expect(result.errors, isNotEmpty);
-          expect(
-            result.errors.containsKey('publish'),
-            isTrue,
-          );
-        },
-      );
-
-      test('should timeout after 5 seconds', () {
-        fakeAsync((async) {
-          when(
-            () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async {
-            await Future<void>.delayed(
-              const Duration(seconds: 10),
-            );
-            return _testEvent();
-          });
-
-          CurationPublishResult? result;
-          unawaited(
-            curationService
-                .publishCuration(
-                  id: 'test_curation',
-                  title: 'Test',
-                  videoIds: [],
-                )
-                .then((r) => result = r),
-          );
-
-          // Advance past the 5-second timeout
-          async
-            ..elapse(const Duration(seconds: 6))
-            ..flushMicrotasks();
-
-          expect(result!.success, isFalse);
-          expect(result!.errors['timeout'], isNotNull);
-        });
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isTrue);
       });
 
       test(
-        'should prevent duplicate concurrent publishes',
+        'prevents duplicate concurrent publishes via duplicate flag',
         () {
           fakeAsync((async) {
-            final completer = Completer<Event?>();
+            final completer = Completer<PublishOutcome>();
             when(
-              () => mockNostrService.publishEvent(any()),
+              () => mockNostrService.publishEventWithRetry(
+                any(),
+                policy: any(named: 'policy'),
+                targetRelays: any(named: 'targetRelays'),
+              ),
             ).thenAnswer((_) => completer.future);
 
-            // Start first publish (will block on completer)
-            CurationPublishResult? firstResult;
+            // Start first publish (will block on completer).
+            CurationResult? firstResult;
             unawaited(
               curationService
                   .publishCuration(
@@ -255,11 +215,10 @@ void main() {
                   .then((r) => firstResult = r),
             );
 
-            // Allow async code to start
             async.flushMicrotasks();
 
-            // Second publish of same ID should be rejected
-            CurationPublishResult? secondResult;
+            // Second publish of same id should be rejected as duplicate.
+            CurationResult? secondResult;
             unawaited(
               curationService
                   .publishCuration(
@@ -273,13 +232,10 @@ void main() {
             async.flushMicrotasks();
 
             expect(secondResult!.success, isFalse);
-            expect(
-              secondResult!.errors.containsKey('duplicate'),
-              isTrue,
-            );
+            expect(secondResult!.duplicate, isTrue);
 
-            // Complete the first publish
-            completer.complete(_testEvent());
+            // Complete the first publish.
+            completer.complete(_acceptedOutcome());
             async.flushMicrotasks();
             expect(firstResult!.success, isTrue);
           });
@@ -288,201 +244,122 @@ void main() {
     });
 
     group('Local Persistence', () {
-      test(
-        'should mark curation as published locally after '
-        'success',
-        () async {
-          when(
-            () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => _testEvent());
+      test('marks curation as published locally after success', () async {
+        when(
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _acceptedOutcome());
 
-          await curationService.publishCuration(
-            id: 'test_curation',
-            title: 'Test',
-            videoIds: [],
-          );
+        await curationService.publishCuration(
+          id: 'test_curation',
+          title: 'Test',
+          videoIds: [],
+        );
 
-          final publishStatus = curationService.getCurationPublishStatus(
-            'test_curation',
-          );
-          expect(publishStatus.isPublished, isTrue);
-          expect(
-            publishStatus.lastPublishedAt,
-            isNotNull,
-          );
-          expect(publishStatus.isPublishing, isFalse);
-        },
-      );
+        final status = curationService.getCurationPublishStatus(
+          'test_curation',
+        );
+        expect(status.isPublished, isTrue);
+        expect(status.lastPublishedAt, isNotNull);
+        expect(status.isPublishing, isFalse);
+      });
 
-      test(
-        'should track failed publish attempts',
-        () async {
-          when(
-            () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+      test('records hasFailed after publish failure', () async {
+        when(
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _failedOutcome());
 
-          await curationService.publishCuration(
-            id: 'failed_curation',
-            title: 'Test',
-            videoIds: [],
-          );
+        await curationService.publishCuration(
+          id: 'failed_curation',
+          title: 'Test',
+          videoIds: [],
+        );
 
-          final publishStatus = curationService.getCurationPublishStatus(
-            'failed_curation',
-          );
-          expect(publishStatus.isPublished, isFalse);
-          expect(
-            publishStatus.failedAttempts,
-            greaterThan(0),
-          );
-          expect(
-            publishStatus.lastFailureReason,
-            isNotNull,
-          );
-        },
-      );
+        final status = curationService.getCurationPublishStatus(
+          'failed_curation',
+        );
+        expect(status.isPublished, isFalse);
+        expect(status.hasFailed, isTrue);
+      });
 
-      test(
-        'should return default status for unknown curation',
-        () {
-          final status = curationService.getCurationPublishStatus(
-            'unknown_curation',
-          );
-          expect(status.isPublished, isFalse);
-          expect(status.isPublishing, isFalse);
-          expect(status.failedAttempts, equals(0));
-        },
-      );
-    });
-
-    group('Background Retry Worker', () {
-      test(
-        'should use exponential backoff timing',
-        () async {
-          final delay1 = curationService.getRetryDelay(1);
-          final delay2 = curationService.getRetryDelay(2);
-          final delay3 = curationService.getRetryDelay(3);
-
-          expect(delay1.inSeconds, equals(2));
-          expect(delay2.inSeconds, equals(4));
-          expect(delay3.inSeconds, equals(8));
-
-          expect(
-            delay2.inSeconds,
-            greaterThan(delay1.inSeconds),
-          );
-          expect(
-            delay3.inSeconds,
-            greaterThan(delay2.inSeconds),
-          );
-        },
-      );
-
-      test(
-        'should cap retry delay at a reasonable maximum',
-        () {
-          final maxDelay = curationService.getRetryDelay(100);
-          expect(maxDelay.inSeconds, equals(1024));
-        },
-      );
-
-      test(
-        'should coalesce rapid updates to same curation',
-        () async {
-          when(
-            () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => _testEvent());
-
-          final futures = <Future<dynamic>>[];
-          for (var i = 0; i < 5; i++) {
-            futures.add(
-              curationService.publishCuration(
-                id: 'rapid_curation',
-                title: 'Test $i',
-                videoIds: [],
-              ),
-            );
-          }
-          await Future.wait(futures);
-
-          verify(
-            () => mockNostrService.publishEvent(any()),
-          ).called(1);
-        },
-      );
+      test('returns default status for unknown curation', () {
+        final status = curationService.getCurationPublishStatus(
+          'unknown_curation',
+        );
+        expect(status.isPublished, isFalse);
+        expect(status.isPublishing, isFalse);
+        expect(status.hasFailed, isFalse);
+      });
     });
 
     group('Publishing Status UI', () {
-      test(
-        'should report "Publishing..." status during '
-        'publish',
-        () {
-          fakeAsync((async) {
-            final completer = Completer<Event?>();
-            when(
-              () => mockNostrService.publishEvent(any()),
-            ).thenAnswer((_) => completer.future);
-
-            unawaited(
-              curationService.publishCuration(
-                id: 'publishing_curation',
-                title: 'Test',
-                videoIds: [],
-              ),
-            );
-
-            // Allow async code to start
-            async.flushMicrotasks();
-
-            final status = curationService.getCurationPublishStatus(
-              'publishing_curation',
-            );
-            expect(status.isPublishing, isTrue);
-            expect(
-              status.statusText,
-              equals('Publishing...'),
-            );
-
-            // Complete the publish
-            completer.complete(_testEvent());
-            async.flushMicrotasks();
-
-            final finalStatus = curationService.getCurationPublishStatus(
-              'publishing_curation',
-            );
-            expect(finalStatus.isPublishing, isFalse);
-            expect(finalStatus.isPublished, isTrue);
-            expect(
-              finalStatus.statusText,
-              contains('Published'),
-            );
-          });
-        },
-      );
-
-      test(
-        'should show error status for failed publishes',
-        () async {
+      test('reports "Publishing..." status during publish', () {
+        fakeAsync((async) {
+          final completer = Completer<PublishOutcome>();
           when(
-            () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => null);
+            () => mockNostrService.publishEventWithRetry(
+              any(),
+              policy: any(named: 'policy'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) => completer.future);
 
-          await curationService.publishCuration(
-            id: 'error_curation',
-            title: 'Test',
-            videoIds: [],
+          unawaited(
+            curationService.publishCuration(
+              id: 'publishing_curation',
+              title: 'Test',
+              videoIds: [],
+            ),
           );
+
+          async.flushMicrotasks();
 
           final status = curationService.getCurationPublishStatus(
-            'error_curation',
+            'publishing_curation',
           );
-          expect(
-            status.statusText,
-            contains('Error'),
+          expect(status.isPublishing, isTrue);
+          expect(status.statusText, equals('Publishing...'));
+
+          completer.complete(_acceptedOutcome());
+          async.flushMicrotasks();
+
+          final finalStatus = curationService.getCurationPublishStatus(
+            'publishing_curation',
           );
-          expect(status.isError, isTrue);
-        },
-      );
+          expect(finalStatus.isPublishing, isFalse);
+          expect(finalStatus.isPublished, isTrue);
+          expect(finalStatus.statusText, contains('Published'));
+        });
+      });
+
+      test('shows error status for failed publishes', () async {
+        when(
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _failedOutcome());
+
+        await curationService.publishCuration(
+          id: 'error_curation',
+          title: 'Test',
+          videoIds: [],
+        );
+
+        final status = curationService.getCurationPublishStatus(
+          'error_curation',
+        );
+        expect(status.statusText, contains('Error'));
+        expect(status.isError, isTrue);
+      });
     });
   });
 }

--- a/mobile/packages/curation_service/test/src/curation_service_create_test.dart
+++ b/mobile/packages/curation_service/test/src/curation_service_create_test.dart
@@ -36,7 +36,46 @@ void main() {
         Event(_testPubkey, 30005, <List<String>>[], ''),
       );
       registerFallbackValue(<Filter>[]);
+      registerFallbackValue(const RetryPolicy());
     });
+
+    // Helper: set up a publishEventWithRetry stub that returns a
+    // per-relay outcome derived from whether the signed event is
+    // non-null. Mirrors how publishEvent was previously used.
+    void stubPublishAcceptedOnSuccess() {
+      when(
+        () => mockNostrService.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        final event = invocation.positionalArguments[0] as Event;
+        return PublishOutcome(
+          eventId: event.id,
+          acceptedBy: const {'wss://a'},
+          rejectedBy: const {},
+          noResponseFrom: const {},
+        );
+      });
+    }
+
+    void stubPublishFailed() {
+      when(
+        () => mockNostrService.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer(
+        (_) async => PublishOutcome(
+          eventId: 'a' * 64,
+          acceptedBy: const {},
+          rejectedBy: const {},
+          noResponseFrom: const {'wss://a'},
+        ),
+      );
+    }
 
     setUp(() {
       mockNostrService = _MockNostrClient();
@@ -82,9 +121,7 @@ void main() {
         when(
           () => mockSigner.signEvent(any()),
         ).thenAnswer((_) async => signedEvent);
-        when(
-          () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => signedEvent);
+        stubPublishAcceptedOnSuccess();
         when(
           () => mockNostrService.connectedRelays,
         ).thenReturn(['wss://relay']);
@@ -99,7 +136,11 @@ void main() {
 
         expect(result, isTrue);
         verify(
-          () => mockNostrService.publishEvent(any()),
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
         ).called(1);
       },
     );
@@ -117,9 +158,7 @@ void main() {
         when(
           () => mockSigner.signEvent(any()),
         ).thenAnswer((_) async => signedEvent);
-        when(
-          () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => signedEvent);
+        stubPublishAcceptedOnSuccess();
         when(() => mockNostrService.connectedRelays).thenReturn([]);
 
         await curationService.createCurationSet(
@@ -148,9 +187,7 @@ void main() {
       when(
         () => mockSigner.signEvent(any()),
       ).thenAnswer((_) async => signedEvent);
-      when(
-        () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => signedEvent);
+      stubPublishAcceptedOnSuccess();
       when(() => mockNostrService.connectedRelays).thenReturn([]);
 
       await curationService.createCurationSet(
@@ -208,9 +245,7 @@ void main() {
       when(
         () => mockSigner.signEvent(any()),
       ).thenAnswer((_) async => signedEvent);
-      when(
-        () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => null);
+      stubPublishFailed();
 
       final result = await curationService.createCurationSet(
         id: 'test_list',
@@ -237,7 +272,11 @@ void main() {
 
         expect(result, isFalse);
         verifyNever(
-          () => mockNostrService.publishEvent(any()),
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
         );
       },
     );
@@ -256,7 +295,11 @@ void main() {
           () => mockSigner.signEvent(any()),
         ).thenAnswer((_) async => signedEvent);
         when(
-          () => mockNostrService.publishEvent(any()),
+          () => mockNostrService.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
         ).thenThrow(Exception('Network error'));
 
         final result = await curationService.createCurationSet(
@@ -282,9 +325,7 @@ void main() {
         when(
           () => mockSigner.signEvent(any()),
         ).thenAnswer((_) async => signedEvent);
-        when(
-          () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => signedEvent);
+        stubPublishAcceptedOnSuccess();
         when(() => mockNostrService.connectedRelays).thenReturn([]);
 
         final result = await curationService.createCurationSet(
@@ -319,9 +360,7 @@ void main() {
         when(
           () => mockSigner.signEvent(any()),
         ).thenAnswer((_) async => signedEvent);
-        when(
-          () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => signedEvent);
+        stubPublishAcceptedOnSuccess();
         when(() => mockNostrService.connectedRelays).thenReturn([]);
 
         final result = await curationService.createCurationSet(
@@ -358,9 +397,7 @@ void main() {
         when(
           () => mockSigner.signEvent(any()),
         ).thenAnswer((_) async => signedEvent);
-        when(
-          () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => signedEvent);
+        stubPublishAcceptedOnSuccess();
         when(
           () => mockNostrService.connectedRelays,
         ).thenReturn(['wss://relay']);
@@ -396,9 +433,7 @@ void main() {
         when(
           () => mockSigner.signEvent(any()),
         ).thenAnswer((_) async => signedEvent);
-        when(
-          () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => null);
+        stubPublishFailed();
 
         await curationService.createCurationSet(
           id: 'fail_status',
@@ -411,7 +446,7 @@ void main() {
         );
         expect(status.isPublished, isFalse);
         expect(status.isPublishing, isFalse);
-        expect(status.failedAttempts, 1);
+        expect(status.hasFailed, isTrue);
       },
     );
 
@@ -428,9 +463,7 @@ void main() {
         when(
           () => mockSigner.signEvent(any()),
         ).thenAnswer((_) async => signedEvent);
-        when(
-          () => mockNostrService.publishEvent(any()),
-        ).thenAnswer((_) async => signedEvent);
+        stubPublishAcceptedOnSuccess();
         when(() => mockNostrService.connectedRelays).thenReturn([]);
 
         // With description

--- a/mobile/packages/curation_service/test/src/curation_service_edge_cases_test.dart
+++ b/mobile/packages/curation_service/test/src/curation_service_edge_cases_test.dart
@@ -22,9 +22,8 @@ class _MockLikesRepository extends Mock implements LikesRepository {}
 
 class _MockNostrSigner extends Mock implements NostrSigner {}
 
-const _testPubkey =
-    'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6'
-    'e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+// Test pubkey removed — the bespoke retry tests that used it were
+// deleted along with retryUnpublishedCurations / failedAttempts.
 
 void main() {
   setUpAll(() {
@@ -33,6 +32,7 @@ void main() {
       Event('0' * 64, 1, <List<String>>[], ''),
     );
     registerFallbackValue(<String>[]);
+    registerFallbackValue(const RetryPolicy());
     registerFallbackValue(
       VideoEvent(
         id: 'fallback',
@@ -274,84 +274,9 @@ void main() {
       );
     });
 
-    group(
-      'retryUnpublishedCurations with eligible retry',
-      () {
-        test(
-          'retries a failed curation when backoff has '
-          'elapsed',
-          () async {
-            when(
-              () => mockSigner.getPublicKey(),
-            ).thenAnswer((_) async => _testPubkey);
-            when(
-              () => mockSigner.signEvent(any()),
-            ).thenAnswer((invocation) async {
-              final event = invocation.positionalArguments[0] as Event;
-              return Event(
-                event.pubkey,
-                event.kind,
-                event.tags,
-                event.content,
-              );
-            });
-            when(
-              () => mockNostrService.connectedRelays,
-            ).thenReturn(['wss://relay1.example.com']);
-
-            curationService = CurationService(
-              nostrService: mockNostrService,
-              videoEventCache: mockVideoEventCache,
-              likesRepository: mockLikesRepository,
-              signer: mockSigner,
-              divineTeamPubkeys: const [],
-            );
-
-            // First: fail a publish to create a failed
-            // status
-            when(
-              () => mockNostrService.publishEvent(any()),
-            ).thenAnswer((_) async => null);
-
-            await curationService.publishCuration(
-              id: CurationSetType.editorsPicks.id,
-              title: 'Editors Picks',
-              videoIds: ['v1'],
-            );
-
-            final status = curationService.getCurationPublishStatus(
-              CurationSetType.editorsPicks.id,
-            );
-            expect(status.failedAttempts, equals(1));
-
-            // Now make publish succeed for the retry
-            final signedEvent = Event(
-              _testPubkey,
-              30005,
-              <List<String>>[],
-              'test',
-            )..id = 'retry_event_id';
-
-            when(
-              () => mockNostrService.publishEvent(any()),
-            ).thenAnswer((_) async => signedEvent);
-
-            // The lastAttemptAt is set to DateTime.now()
-            // during the failed publish, and getRetryDelay
-            // for 1 attempt is 2 seconds. We need the
-            // backoff to have elapsed.
-            // Since we can't easily manipulate time here,
-            // and the retry delay for 1 attempt is 2s,
-            // we'd need to wait. Instead, verify the
-            // method runs without error.
-            await curationService.retryUnpublishedCurations();
-
-            // The backoff hasn't elapsed (just published),
-            // so no retry happens. This exercises the
-            // backoff-not-elapsed path.
-          },
-        );
-      },
-    );
+    // The bespoke retryUnpublishedCurations/backoff API was removed in
+    // favour of NostrClient.publishEventWithRetry (see PR 5 of the
+    // reliable-nostr-publish series). Retry semantics are now covered by
+    // curation_service_reliability_test.dart.
   });
 }

--- a/mobile/packages/curation_service/test/src/curation_service_reliability_test.dart
+++ b/mobile/packages/curation_service/test/src/curation_service_reliability_test.dart
@@ -1,0 +1,221 @@
+// ABOUTME: Tests that CurationService uses publishEventWithRetry for kind
+// ABOUTME: 30005 curation-set publishes and gates results on acceptedByAny.
+
+import 'dart:async';
+
+import 'package:curation_service/curation_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:likes_repository/likes_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:nostr_sdk/signer/nostr_signer.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockVideoEventCache extends Mock implements VideoEventCache {}
+
+class _MockLikesRepository extends Mock implements LikesRepository {}
+
+class _MockNostrSigner extends Mock implements NostrSigner {}
+
+const _testPubkey =
+    'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6'
+    'e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
+
+Event _buildEvent({
+  int kind = 30005,
+  List<List<String>> tags = const [],
+  String content = '',
+}) {
+  return Event(_testPubkey, kind, tags, content);
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<Filter>[]);
+    registerFallbackValue(_buildEvent());
+    registerFallbackValue(<String>[]);
+    registerFallbackValue(const RetryPolicy());
+  });
+
+  late CurationService service;
+  late _MockNostrClient mockNostr;
+  late _MockVideoEventCache mockCache;
+  late _MockLikesRepository mockLikes;
+  late _MockNostrSigner mockSigner;
+
+  setUp(() {
+    mockNostr = _MockNostrClient();
+    mockCache = _MockVideoEventCache();
+    mockLikes = _MockLikesRepository();
+    mockSigner = _MockNostrSigner();
+
+    when(() => mockSigner.getPublicKey()).thenAnswer((_) async => _testPubkey);
+    when(() => mockSigner.signEvent(any())).thenAnswer((invocation) async {
+      final e = invocation.positionalArguments[0] as Event;
+      return Event(e.pubkey, e.kind, e.tags, e.content);
+    });
+
+    when(() => mockNostr.connectedRelays).thenReturn([
+      'wss://relay1.example.com',
+    ]);
+    when(
+      () => mockNostr.subscribe(any()),
+    ).thenAnswer((_) => const Stream.empty());
+
+    when(() => mockCache.discoveryVideos).thenReturn([]);
+    when(() => mockLikes.getLikeCounts(any())).thenAnswer((_) async => {});
+
+    service = CurationService(
+      nostrService: mockNostr,
+      videoEventCache: mockCache,
+      likesRepository: mockLikes,
+      signer: mockSigner,
+      divineTeamPubkeys: const [],
+    );
+  });
+
+  PublishOutcome acceptedOutcome() => PublishOutcome(
+    eventId: 'a' * 64,
+    acceptedBy: const {'wss://a'},
+    rejectedBy: const {},
+    noResponseFrom: const {},
+  );
+
+  PublishOutcome transientOutcome() => PublishOutcome(
+    eventId: 'a' * 64,
+    acceptedBy: const {},
+    rejectedBy: const {},
+    noResponseFrom: const {'wss://a'},
+  );
+
+  PublishOutcome rejectedOutcome() => PublishOutcome(
+    eventId: 'a' * 64,
+    acceptedBy: const {},
+    rejectedBy: const {'wss://a': 'blocked: not allowed'},
+    noResponseFrom: const {},
+  );
+
+  group('CurationService reliability', () {
+    test(
+      'accepted-by-any → CurationResult.success with feedback.severity=success',
+      () async {
+        when(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
+
+        final result = await service.publishCuration(
+          id: 'curation_ok',
+          title: 'Test',
+          videoIds: const ['v1'],
+        );
+
+        expect(result.success, isTrue);
+        expect(result.feedback?.severity, PublishSeverity.success);
+        expect(result.feedback?.retryable, isFalse);
+        expect(result.outcome?.acceptedBy, {'wss://a'});
+
+        final status = service.getCurationPublishStatus('curation_ok');
+        expect(status.isPublished, isTrue);
+      },
+    );
+
+    test(
+      'transient failure → CurationResult.failure, feedback.retryable=true',
+      () async {
+        when(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => transientOutcome());
+
+        final result = await service.publishCuration(
+          id: 'curation_transient',
+          title: 'Test',
+          videoIds: const ['v1'],
+        );
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isTrue);
+        expect(result.feedback?.messageKey, 'publish_no_relay_response');
+
+        final status = service.getCurationPublishStatus('curation_transient');
+        expect(status.isPublished, isFalse);
+      },
+    );
+
+    test(
+      'permanent rejection → retryable=false, firstRejectionReason surfaced',
+      () async {
+        when(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => rejectedOutcome());
+
+        final result = await service.publishCuration(
+          id: 'curation_rejected',
+          title: 'Test',
+          videoIds: const ['v1'],
+        );
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isFalse);
+        expect(result.feedback?.firstRejectionReason, 'blocked: not allowed');
+
+        final status = service.getCurationPublishStatus('curation_rejected');
+        expect(status.isPublished, isFalse);
+      },
+    );
+
+    test(
+      'duplicate concurrent publish returns duplicate failure',
+      () async {
+        // The first publish blocks indefinitely.
+        when(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) => Future<PublishOutcome>.delayed(
+            const Duration(seconds: 10),
+            acceptedOutcome,
+          ),
+        );
+
+        // Start the first publish (don't await).
+        unawaited(
+          service.publishCuration(
+            id: 'curation_dupe',
+            title: 'Test',
+            videoIds: const ['v1'],
+          ),
+        );
+
+        // Give the first call a microtask to register.
+        await Future<void>.delayed(Duration.zero);
+
+        final duplicate = await service.publishCuration(
+          id: 'curation_dupe',
+          title: 'Test',
+          videoIds: const ['v1'],
+        );
+
+        expect(duplicate.success, isFalse);
+        expect(duplicate.duplicate, isTrue);
+      },
+    );
+  });
+}

--- a/mobile/packages/curation_service/test/src/curation_service_retry_test.dart
+++ b/mobile/packages/curation_service/test/src/curation_service_retry_test.dart
@@ -1,7 +1,6 @@
-// ABOUTME: Tests for CurationService.retryUnpublishedCurations()
-// ABOUTME: and retry-related edge cases
-
-import 'dart:async';
+// ABOUTME: Retry semantics for CurationService.publishCuration — retry
+// ABOUTME: is delegated to NostrClient.publishEventWithRetry and only the
+// ABOUTME: final outcome is surfaced on CurationResult.
 
 import 'package:curation_service/curation_service.dart';
 import 'package:likes_repository/likes_repository.dart';
@@ -37,158 +36,119 @@ void main() {
     registerFallbackValue(<Filter>[]);
     registerFallbackValue(_testEvent());
     registerFallbackValue(<String>[]);
+    registerFallbackValue(const RetryPolicy());
   });
 
-  group('CurationService Retry Logic', () {
+  group('CurationService retry delegation', () {
     late CurationService curationService;
-    late _MockNostrClient mockNostrService;
-    late _MockVideoEventCache mockVideoEventCache;
-    late _MockLikesRepository mockLikesRepository;
+    late _MockNostrClient mockNostr;
+    late _MockVideoEventCache mockCache;
+    late _MockLikesRepository mockLikes;
     late _MockNostrSigner mockSigner;
 
     setUp(() {
-      mockNostrService = _MockNostrClient();
-      mockVideoEventCache = _MockVideoEventCache();
-      mockLikesRepository = _MockLikesRepository();
+      mockNostr = _MockNostrClient();
+      mockCache = _MockVideoEventCache();
+      mockLikes = _MockLikesRepository();
       mockSigner = _MockNostrSigner();
 
       when(
         () => mockSigner.getPublicKey(),
       ).thenAnswer((_) async => _testPubkey);
-      when(
-        () => mockSigner.signEvent(any()),
-      ).thenAnswer((invocation) async {
+      when(() => mockSigner.signEvent(any())).thenAnswer((invocation) async {
         final event = invocation.positionalArguments[0] as Event;
-        return Event(
-          event.pubkey,
-          event.kind,
-          event.tags,
-          event.content,
-        );
+        return Event(event.pubkey, event.kind, event.tags, event.content);
       });
 
       when(
-        () => mockNostrService.connectedRelays,
+        () => mockNostr.connectedRelays,
       ).thenReturn(['wss://relay1.example.com']);
       when(
-        () => mockNostrService.subscribe(any()),
+        () => mockNostr.subscribe(any()),
       ).thenAnswer((_) => const Stream.empty());
 
+      when(() => mockCache.discoveryVideos).thenReturn([]);
       when(
-        () => mockVideoEventCache.discoveryVideos,
-      ).thenReturn([]);
-      when(
-        () => mockLikesRepository.getLikeCounts(any()),
+        () => mockLikes.getLikeCounts(any()),
       ).thenAnswer((_) async => {});
 
       curationService = CurationService(
-        nostrService: mockNostrService,
-        videoEventCache: mockVideoEventCache,
-        likesRepository: mockLikesRepository,
+        nostrService: mockNostr,
+        videoEventCache: mockCache,
+        likesRepository: mockLikes,
         signer: mockSigner,
         divineTeamPubkeys: const [],
       );
     });
 
-    group('retryUnpublishedCurations', () {
-      test(
-        'does nothing when no publish statuses exist',
-        () async {
-          await curationService.retryUnpublishedCurations();
-          // No publishEvent calls should be made
-          verifyNever(
-            () => mockNostrService.publishEvent(any()),
-          );
-        },
-      );
+    test(
+      'publishCuration invokes publishEventWithRetry exactly once',
+      () async {
+        when(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'a' * 64,
+            acceptedBy: const {'wss://a'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          ),
+        );
 
-      test(
-        'skips curations that are already published',
-        () async {
-          // Publish a curation successfully first
-          when(
-            () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => _testEvent());
+        await curationService.publishCuration(
+          id: 'single',
+          title: 'Single',
+          videoIds: const [],
+        );
 
-          await curationService.publishCuration(
-            id: 'published_one',
-            title: 'Published',
-            videoIds: [],
-          );
+        // publishEventWithRetry is called once — the RetryPolicy is applied
+        // inside NostrClient. The service must NOT implement its own retry
+        // loop (that would double-count attempts).
+        verify(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
+      },
+    );
 
-          // Reset mock to track new calls
-          reset(mockNostrService);
-          when(
-            () => mockNostrService.subscribe(any()),
-          ).thenAnswer((_) => const Stream.empty());
-          when(
-            () => mockNostrService.connectedRelays,
-          ).thenReturn(['wss://relay1.example.com']);
+    test(
+      'failed publish surfaces hasFailed on CurationPublishStatus',
+      () async {
+        when(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'a' * 64,
+            acceptedBy: const {},
+            rejectedBy: const {},
+            noResponseFrom: const {'wss://a'},
+          ),
+        );
 
-          await curationService.retryUnpublishedCurations();
+        await curationService.publishCuration(
+          id: 'failed_once',
+          title: 'Failed Once',
+          videoIds: const [],
+        );
 
-          verifyNever(
-            () => mockNostrService.publishEvent(any()),
-          );
-        },
-      );
-
-      test(
-        'skips curations that have not passed the backoff '
-        'period',
-        () async {
-          // Fail a publish to create a failed status
-          when(
-            () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => null);
-
-          await curationService.publishCuration(
-            id: 'failed_one',
-            title: 'Failed',
-            videoIds: [],
-          );
-
-          // Reset mock
-          reset(mockNostrService);
-          when(
-            () => mockNostrService.subscribe(any()),
-          ).thenAnswer((_) => const Stream.empty());
-          when(
-            () => mockNostrService.connectedRelays,
-          ).thenReturn(['wss://relay1.example.com']);
-
-          // Retry immediately - backoff not elapsed
-          await curationService.retryUnpublishedCurations();
-
-          verifyNever(
-            () => mockNostrService.publishEvent(any()),
-          );
-        },
-      );
-
-      test(
-        'records failed attempt after publish failure',
-        () async {
-          when(
-            () => mockNostrService.publishEvent(any()),
-          ).thenAnswer((_) async => null);
-
-          await curationService.publishCuration(
-            id: 'failed_once',
-            title: 'Failed Once',
-            videoIds: [],
-          );
-
-          final status = curationService.getCurationPublishStatus(
-            'failed_once',
-          );
-          // Each publish resets then increments, so
-          // failedAttempts is 1
-          expect(status.failedAttempts, equals(1));
-          expect(status.isPublished, isFalse);
-          expect(status.shouldRetry, isTrue);
-        },
-      );
-    });
+        final status = curationService.getCurationPublishStatus(
+          'failed_once',
+        );
+        expect(status.isPublished, isFalse);
+        expect(status.hasFailed, isTrue);
+        expect(status.isError, isTrue);
+      },
+    );
   });
 }

--- a/mobile/packages/models/lib/src/curation_publish_status.dart
+++ b/mobile/packages/models/lib/src/curation_publish_status.dart
@@ -1,7 +1,13 @@
 // ABOUTME: Models for curation publishing status and results
-// ABOUTME: Tracks publish state, retry logic, and relay success/failure for NIP-51 curations
+// ABOUTME: Tracks publish state for NIP-51 curations (kind 30005).
 
-/// Status of a curation publish attempt
+/// Status of a curation publish attempt.
+///
+/// After the migration to [NostrClient.publishEventWithRetry], relay-level
+/// retries, timeouts, and backoff are handled inside the client — this
+/// status only needs to carry a few UI-visible fields: whether a publish
+/// is currently in flight, whether the last publish succeeded, and which
+/// relays accepted it.
 class CurationPublishStatus {
   const CurationPublishStatus({
     required this.curationId,
@@ -9,9 +15,8 @@ class CurationPublishStatus {
     required this.isPublished,
     this.lastPublishedAt,
     this.publishedEventId,
-    this.failedAttempts = 0,
     this.lastAttemptAt,
-    this.lastFailureReason,
+    this.hasFailed = false,
     this.successfulRelays = const [],
   });
 
@@ -20,18 +25,18 @@ class CurationPublishStatus {
   final bool isPublished;
   final DateTime? lastPublishedAt;
   final String? publishedEventId;
-  final int failedAttempts;
   final DateTime? lastAttemptAt;
-  final String? lastFailureReason;
+
+  /// Whether the last publish attempt finished without any relay
+  /// accepting. The root-cause reason lives on the [PublishOutcome]
+  /// returned from [CurationService.publishCuration] — callers that need
+  /// a human-readable message should read that outcome's feedback via
+  /// [PublishResultMapper], not a string stored on this status.
+  final bool hasFailed;
+
   final List<String> successfulRelays;
 
-  /// Maximum number of retry attempts
-  static const int maxRetries = 5;
-
-  /// Whether this curation should be retried
-  bool get shouldRetry => failedAttempts < maxRetries && !isPublished;
-
-  /// UI-friendly status text
+  /// UI-friendly status text.
   String get statusText {
     if (isPublishing) return 'Publishing...';
     if (isPublished) {
@@ -40,17 +45,23 @@ class CurationPublishStatus {
       }
       return 'Published';
     }
-    if (failedAttempts > 0) {
+    if (hasFailed) {
       return 'Error publishing';
     }
     return 'Not published';
   }
 
-  /// Whether this status represents an error state
-  bool get isError => !isPublished && !isPublishing && failedAttempts > 0;
+  /// Whether this status represents an error state.
+  bool get isError => !isPublished && !isPublishing && hasFailed;
 }
 
-/// Result of a curation publish operation
+/// Result of a curation publish operation.
+///
+/// Retained for backwards compatibility with callers that only need a
+/// coarse success flag. For per-relay diagnostics and retry affordances,
+/// use the richer `CurationResult` returned by
+/// `CurationService.publishCuration` (carries `PublishOutcome` +
+/// `PublishUserFeedback`).
 class CurationPublishResult {
   const CurationPublishResult({
     required this.success,

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -596,7 +596,9 @@ void main() {
         setUp: () {
           when(
             () => mockBookmarkService.addVideoToGlobalBookmarks(any()),
-          ).thenAnswer((_) async => true);
+          ).thenAnswer(
+            (_) async => BookmarkResult.noop(success: true),
+          );
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetSaveRequested()),
@@ -618,7 +620,9 @@ void main() {
         setUp: () {
           when(
             () => mockBookmarkService.addVideoToGlobalBookmarks(any()),
-          ).thenAnswer((_) async => false);
+          ).thenAnswer(
+            (_) async => BookmarkResult.noop(success: false),
+          );
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetSaveRequested()),
@@ -680,7 +684,9 @@ void main() {
         setUp: () {
           when(
             () => mockBookmarkService.addVideoToGlobalBookmarks(any()),
-          ).thenAnswer((_) async => true);
+          ).thenAnswer(
+            (_) async => BookmarkResult.noop(success: true),
+          );
         },
         build: createBloc,
         act: (bloc) async {

--- a/mobile/test/services/curated_list_service_collaboration_test.dart
+++ b/mobile/test/services/curated_list_service_collaboration_test.dart
@@ -35,6 +35,7 @@ void main() {
         }),
       );
       registerFallbackValue(<Filter>[]);
+      registerFallbackValue(const RetryPolicy());
     });
 
     // Helper to stub publishEvent - call after reset(mockNostr)
@@ -42,6 +43,20 @@ void main() {
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
         return invocation.positionalArguments[0] as Event;
       });
+      when(
+        () => mockNostr.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer(
+        (_) async => PublishOutcome(
+          eventId: 'a' * 64,
+          acceptedBy: const {'wss://a'},
+          rejectedBy: const {},
+          noResponseFrom: const {},
+        ),
+      );
     }
 
     setUp(() async {
@@ -176,7 +191,13 @@ void main() {
 
         await service.addCollaborator(list.id, 'collaborator_1');
 
-        verify(() => mockNostr.publishEvent(any())).called(1);
+        verify(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
       });
 
       test('updates updatedAt timestamp', () async {
@@ -256,7 +277,13 @@ void main() {
 
         await service.removeCollaborator(list.id, 'collaborator_1');
 
-        verify(() => mockNostr.publishEvent(any())).called(1);
+        verify(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
       });
 
       test('handles removing last collaborator', () async {

--- a/mobile/test/services/curated_list_service_crud_test.dart
+++ b/mobile/test/services/curated_list_service_crud_test.dart
@@ -37,6 +37,7 @@ void main() {
         ),
       );
       registerFallbackValue(<Filter>[]);
+      registerFallbackValue(const RetryPolicy());
     });
 
     setUp(() async {
@@ -55,6 +56,20 @@ void main() {
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
         return invocation.positionalArguments[0] as Event;
       });
+      when(
+        () => mockNostr.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer(
+        (_) async => PublishOutcome(
+          eventId: 'a' * 64,
+          acceptedBy: const {'wss://a'},
+          rejectedBy: const {},
+          noResponseFrom: const {},
+        ),
+      );
 
       // Mock subscribeToEvents for relay sync
       when(
@@ -160,6 +175,25 @@ void main() {
           final event = invocation.positionalArguments[0] as Event;
           lists.add(event.toCuratedList());
           return Future.value(event);
+        });
+        // Capture events via publishEventWithRetry (used by the migrated
+        // service) and return an accepted-by-any outcome so local state
+        // commits.
+        when(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments[0] as Event;
+          lists.add(event.toCuratedList());
+          return PublishOutcome(
+            eventId: event.id,
+            acceptedBy: const {'wss://a'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          );
         });
 
         // Mock subscription to return collected lists
@@ -344,8 +378,14 @@ void main() {
           ),
         ).called(1);
 
-        // Should publish event
-        verify(() => mockNostr.publishEvent(any())).called(1);
+        // Should publish event via the retry-backed path.
+        verify(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
       });
 
       test('does not publish empty public list to Nostr', () async {
@@ -359,7 +399,13 @@ void main() {
             tags: any(named: 'tags'),
           ),
         );
-        verifyNever(() => mockNostr.publishEvent(any()));
+        verifyNever(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
       });
 
       test('does not publish private list to Nostr', () async {
@@ -477,15 +523,30 @@ void main() {
         reset(mockNostr); // Clear previous invocations
 
         // Re-setup mocks after reset
-        when(() => mockNostr.publishEvent(any())).thenAnswer((
-          invocation,
-        ) async {
-          return invocation.positionalArguments[0] as Event;
-        });
+        when(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'a' * 64,
+            acceptedBy: const {'wss://a'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          ),
+        );
 
         await service.updateList(listId: list.id, name: 'Updated Name');
 
-        verify(() => mockNostr.publishEvent(any())).called(1);
+        verify(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
       });
 
       test('does not publish update for private list', () async {
@@ -497,7 +558,13 @@ void main() {
 
         await service.updateList(listId: list!.id, name: 'Updated Name');
 
-        verifyNever(() => mockNostr.publishEvent(any()));
+        verifyNever(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
       });
 
       test('returns false for non-existent list', () async {

--- a/mobile/test/services/curated_list_service_persistence_test.dart
+++ b/mobile/test/services/curated_list_service_persistence_test.dart
@@ -37,6 +37,7 @@ void main() {
         }),
       );
       registerFallbackValue(<Filter>[]);
+      registerFallbackValue(const RetryPolicy());
     });
 
     setUp(() async {
@@ -53,6 +54,20 @@ void main() {
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
         return invocation.positionalArguments[0] as Event;
       });
+      when(
+        () => mockNostr.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer(
+        (_) async => PublishOutcome(
+          eventId: 'a' * 64,
+          acceptedBy: const {'wss://a'},
+          rejectedBy: const {},
+          noResponseFrom: const {},
+        ),
+      );
 
       when(
         () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),

--- a/mobile/test/services/curated_list_service_playlist_test.dart
+++ b/mobile/test/services/curated_list_service_playlist_test.dart
@@ -36,6 +36,7 @@ void main() {
         }),
       );
       registerFallbackValue(<Filter>[]);
+      registerFallbackValue(const RetryPolicy());
     });
 
     setUp(() async {
@@ -52,6 +53,20 @@ void main() {
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
         return invocation.positionalArguments[0] as Event;
       });
+      when(
+        () => mockNostr.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer(
+        (_) async => PublishOutcome(
+          eventId: 'a' * 64,
+          acceptedBy: const {'wss://a'},
+          rejectedBy: const {},
+          noResponseFrom: const {},
+        ),
+      );
 
       when(
         () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
@@ -159,15 +174,30 @@ void main() {
         await service.addVideoToList(list.id, 'video_2');
         reset(mockNostr);
 
-        when(() => mockNostr.publishEvent(any())).thenAnswer((
-          invocation,
-        ) async {
-          return invocation.positionalArguments[0] as Event;
-        });
+        when(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: 'a' * 64,
+            acceptedBy: const {'wss://a'},
+            rejectedBy: const {},
+            noResponseFrom: const {},
+          ),
+        );
 
         await service.reorderVideos(list.id, ['video_2', 'video_1']);
 
-        verify(() => mockNostr.publishEvent(any())).called(1);
+        verify(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
       });
 
       test('updates updatedAt timestamp', () async {

--- a/mobile/test/services/curated_list_service_query_test.dart
+++ b/mobile/test/services/curated_list_service_query_test.dart
@@ -36,6 +36,7 @@ void main() {
         }),
       );
       registerFallbackValue(<Filter>[]);
+      registerFallbackValue(const RetryPolicy());
     });
 
     setUp(() async {
@@ -56,6 +57,20 @@ void main() {
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
         return invocation.positionalArguments[0] as Event;
       });
+      when(
+        () => mockNostr.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer(
+        (_) async => PublishOutcome(
+          eventId: 'a' * 64,
+          acceptedBy: const {'wss://a'},
+          rejectedBy: const {},
+          noResponseFrom: const {},
+        ),
+      );
 
       // Mock subscribeToEvents for relay sync
       when(

--- a/mobile/test/services/curated_list_service_video_management_test.dart
+++ b/mobile/test/services/curated_list_service_video_management_test.dart
@@ -35,6 +35,7 @@ void main() {
         }),
       );
       registerFallbackValue(<Filter>[]);
+      registerFallbackValue(const RetryPolicy());
     });
 
     // Helper to stub common mocks - call after reset(mockNostr)
@@ -42,6 +43,20 @@ void main() {
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
         return invocation.positionalArguments[0] as Event;
       });
+      when(
+        () => mockNostr.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer(
+        (_) async => PublishOutcome(
+          eventId: 'a' * 64,
+          acceptedBy: const {'wss://a'},
+          rejectedBy: const {},
+          noResponseFrom: const {},
+        ),
+      );
 
       when(
         () => mockNostr.subscribe(any(), onEose: any(named: 'onEose')),
@@ -64,6 +79,20 @@ void main() {
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) async {
         return invocation.positionalArguments[0] as Event;
       });
+      when(
+        () => mockNostr.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer(
+        (_) async => PublishOutcome(
+          eventId: 'a' * 64,
+          acceptedBy: const {'wss://a'},
+          rejectedBy: const {},
+          noResponseFrom: const {},
+        ),
+      );
 
       // Mock subscribeToEvents for relay sync
       when(
@@ -171,7 +200,13 @@ void main() {
 
         await service.addVideoToList(list!.id, 'video_event_123');
 
-        verify(() => mockNostr.publishEvent(any())).called(1);
+        verify(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
       });
 
       test('does not publish update for private list', () async {
@@ -184,7 +219,13 @@ void main() {
 
         await service.addVideoToList(list!.id, 'video_event_123');
 
-        verifyNever(() => mockNostr.publishEvent(any()));
+        verifyNever(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
       });
 
       test('saves to SharedPreferences after adding', () async {
@@ -279,7 +320,13 @@ void main() {
 
         await service.removeVideoFromList(list.id, 'video_event_123');
 
-        verify(() => mockNostr.publishEvent(any())).called(1);
+        verify(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
       });
 
       test('does not publish update for private list', () async {
@@ -293,7 +340,13 @@ void main() {
 
         await service.removeVideoFromList(list.id, 'video_event_123');
 
-        verifyNever(() => mockNostr.publishEvent(any()));
+        verifyNever(
+          () => mockNostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
       });
 
       test('saves to SharedPreferences after removing', () async {

--- a/mobile/test/unit/services/account_label_service_reliability_test.dart
+++ b/mobile/test/unit/services/account_label_service_reliability_test.dart
@@ -1,0 +1,204 @@
+// ABOUTME: Tests that AccountLabelService uses publishEventWithRetry for
+// ABOUTME: kind 1985 self-label publishes and gates local commit on
+// ABOUTME: acceptedByAny.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/models/content_label.dart';
+import 'package:openvine/services/account_label_service.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+const _testPubkey =
+    '0000000000000000000000000000000000000000000000000000000000000001';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(
+      Event(_testPubkey, 1985, const [], '')
+        ..id = 'e' * 64
+        ..sig = 'sig',
+    );
+    registerFallbackValue(const RetryPolicy());
+  });
+
+  late _MockNostrClient nostr;
+  late _MockAuthService auth;
+
+  Event signed({required int kind, required List<List<String>> tags}) {
+    return Event(_testPubkey, kind, tags, '')
+      ..id = 'e' * 64
+      ..sig = 'sig';
+  }
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    nostr = _MockNostrClient();
+    auth = _MockAuthService();
+
+    when(() => auth.isAuthenticated).thenReturn(true);
+    when(() => auth.currentPublicKeyHex).thenReturn(_testPubkey);
+    when(
+      () => auth.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer((invocation) async {
+      final kind = invocation.namedArguments[#kind] as int;
+      final tags = invocation.namedArguments[#tags] as List<List<String>>;
+      return signed(kind: kind, tags: tags);
+    });
+  });
+
+  PublishOutcome acceptedOutcome() => PublishOutcome(
+    eventId: 'e' * 64,
+    acceptedBy: const {'wss://a'},
+    rejectedBy: const {},
+    noResponseFrom: const {},
+  );
+
+  PublishOutcome transientOutcome() => PublishOutcome(
+    eventId: 'e' * 64,
+    acceptedBy: const {},
+    rejectedBy: const {},
+    noResponseFrom: const {'wss://a'},
+  );
+
+  PublishOutcome rejectedOutcome() => PublishOutcome(
+    eventId: 'e' * 64,
+    acceptedBy: const {},
+    rejectedBy: const {'wss://a': 'blocked: not allowed'},
+    noResponseFrom: const {},
+  );
+
+  group('AccountLabelService reliability (kind 1985)', () {
+    test(
+      'success: accepted-by-any commits local labels and reports success',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
+
+        final service = AccountLabelService(
+          authService: auth,
+          nostrClient: nostr,
+        );
+        await service.initialize();
+
+        final result = await service.setAccountLabels(
+          {ContentLabel.nudity},
+        );
+
+        expect(result.success, isTrue);
+        expect(result.feedback?.severity, PublishSeverity.success);
+        expect(service.accountLabels, {ContentLabel.nudity});
+      },
+    );
+
+    test(
+      'transient failure: retryable feedback, rollback to previous labels',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
+
+        // Seed with an initial label accepted by the relay.
+        final service = AccountLabelService(
+          authService: auth,
+          nostrClient: nostr,
+        );
+        await service.initialize();
+        await service.setAccountLabels({ContentLabel.violence});
+        expect(service.accountLabels, {ContentLabel.violence});
+
+        // Now change the labels under a transient failure.
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => transientOutcome());
+
+        final result = await service.setAccountLabels(
+          {ContentLabel.nudity},
+        );
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isTrue);
+        // Rollback: previous labels intact.
+        expect(service.accountLabels, {ContentLabel.violence});
+      },
+    );
+
+    test(
+      'permanent rejection: non-retryable feedback with reason, rollback',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => rejectedOutcome());
+
+        final service = AccountLabelService(
+          authService: auth,
+          nostrClient: nostr,
+        );
+        await service.initialize();
+
+        final result = await service.setAccountLabels(
+          {ContentLabel.nudity},
+        );
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isFalse);
+        expect(result.feedback?.firstRejectionReason, 'blocked: not allowed');
+        expect(service.accountLabels, isEmpty);
+      },
+    );
+
+    test(
+      'clear labels (empty set): no publish attempted, local commit wins',
+      () async {
+        // Starting with empty labels, clearing should be a no-op success
+        // that never hits the relay.
+        final service = AccountLabelService(
+          authService: auth,
+          nostrClient: nostr,
+        );
+        await service.initialize();
+
+        final result = await service.setAccountLabels(const {});
+
+        expect(result.success, isTrue);
+        expect(service.accountLabels, isEmpty);
+        verifyNever(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/unit/services/bookmark_service_reliability_test.dart
+++ b/mobile/test/unit/services/bookmark_service_reliability_test.dart
@@ -1,0 +1,249 @@
+// ABOUTME: Tests that BookmarkService uses publishEventWithRetry for kind
+// ABOUTME: 10003 / 30003 publishes and gates local commit on acceptedByAny.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/bookmark_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+const _testPubkey =
+    '0000000000000000000000000000000000000000000000000000000000000001';
+const _videoId =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(
+      Event(_testPubkey, 10003, const [], '')
+        ..id = 'f' * 64
+        ..sig = 'sig',
+    );
+    registerFallbackValue(const RetryPolicy());
+    registerFallbackValue(<Filter>[]);
+    registerFallbackValue(<String>[]);
+  });
+
+  late _MockNostrClient nostr;
+  late _MockAuthService auth;
+  late SharedPreferences prefs;
+
+  Event signed({required int kind, required List<List<String>> tags}) {
+    final event = Event(_testPubkey, kind, tags, 'content')
+      ..id = 'e' * 64
+      ..sig = 'sig';
+    return event;
+  }
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    nostr = _MockNostrClient();
+    auth = _MockAuthService();
+
+    when(() => nostr.isInitialized).thenReturn(true);
+    when(() => nostr.publicKey).thenReturn(_testPubkey);
+    // Subscribe is used by the list-service mixin when loading from relay.
+    when(
+      () => nostr.subscribe(
+        any(),
+        subscriptionId: any(named: 'subscriptionId'),
+        tempRelays: any(named: 'tempRelays'),
+        targetRelays: any(named: 'targetRelays'),
+      ),
+    ).thenAnswer((_) => const Stream.empty());
+
+    when(() => auth.isAuthenticated).thenReturn(true);
+    when(() => auth.currentPublicKeyHex).thenReturn(_testPubkey);
+    when(
+      () => auth.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer((invocation) async {
+      final kind = invocation.namedArguments[#kind] as int;
+      final tags = invocation.namedArguments[#tags] as List<List<String>>;
+      return signed(kind: kind, tags: tags);
+    });
+  });
+
+  PublishOutcome acceptedOutcome() => PublishOutcome(
+    eventId: 'e' * 64,
+    acceptedBy: const {'wss://a'},
+    rejectedBy: const {},
+    noResponseFrom: const {},
+  );
+
+  PublishOutcome transientOutcome() => PublishOutcome(
+    eventId: 'e' * 64,
+    acceptedBy: const {},
+    rejectedBy: const {},
+    noResponseFrom: const {'wss://a', 'wss://b'},
+  );
+
+  PublishOutcome rejectedOutcome() => PublishOutcome(
+    eventId: 'e' * 64,
+    acceptedBy: const {},
+    rejectedBy: const {'wss://a': 'blocked: not allowed'},
+    noResponseFrom: const {},
+  );
+
+  BookmarkService buildService() => BookmarkService(
+    nostrService: nostr,
+    authService: auth,
+    prefs: prefs,
+  );
+
+  group('BookmarkService global bookmarks (kind 10003)', () {
+    test(
+      'success: accepted-by-any → commits local state and surfaces success',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
+
+        final service = buildService();
+        final result = await service.addVideoToGlobalBookmarks(_videoId);
+
+        expect(result.success, isTrue);
+        expect(result.outcome, isNotNull);
+        expect(result.feedback?.severity, PublishSeverity.success);
+        expect(service.isVideoBookmarkedGlobally(_videoId), isTrue);
+      },
+    );
+
+    test(
+      'transient failure: retryable feedback, rollback local state',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => transientOutcome());
+
+        final service = buildService();
+        final result = await service.addVideoToGlobalBookmarks(_videoId);
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isTrue);
+        expect(result.feedback?.messageKey, 'publish_no_relay_response');
+        // Rollback: bookmark not persisted locally.
+        expect(service.isVideoBookmarkedGlobally(_videoId), isFalse);
+      },
+    );
+
+    test(
+      'permanent rejection: non-retryable feedback with reason, no commit',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => rejectedOutcome());
+
+        final service = buildService();
+        final result = await service.addVideoToGlobalBookmarks(_videoId);
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isFalse);
+        expect(result.feedback?.firstRejectionReason, 'blocked: not allowed');
+        expect(service.isVideoBookmarkedGlobally(_videoId), isFalse);
+      },
+    );
+
+    test(
+      'remove: transient failure keeps item in bookmarks (rollback)',
+      () async {
+        // Seed: first add a bookmark successfully.
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
+        final service = buildService();
+        await service.addVideoToGlobalBookmarks(_videoId);
+        expect(service.isVideoBookmarkedGlobally(_videoId), isTrue);
+
+        // Now remove under a transient failure; item should stay.
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => transientOutcome());
+
+        final result = await service.removeFromGlobalBookmarks(
+          const BookmarkItem(type: 'e', id: _videoId),
+        );
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isTrue);
+        expect(service.isVideoBookmarkedGlobally(_videoId), isTrue);
+      },
+    );
+  });
+
+  group('BookmarkService bookmark sets (kind 30003)', () {
+    test(
+      'createBookmarkSet: success commits local state',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
+
+        final service = buildService();
+        final result = await service.createBookmarkSet(name: 'Favourites');
+
+        expect(result.success, isTrue);
+        expect(result.set, isNotNull);
+        expect(result.set!.name, 'Favourites');
+        expect(service.bookmarkSets, hasLength(1));
+      },
+    );
+
+    test(
+      'createBookmarkSet: transient failure rolls back local state',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => transientOutcome());
+
+        final service = buildService();
+        final result = await service.createBookmarkSet(name: 'Favourites');
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isTrue);
+        expect(service.bookmarkSets, isEmpty);
+      },
+    );
+  });
+}

--- a/mobile/test/unit/services/curated_list_service_reliability_test.dart
+++ b/mobile/test/unit/services/curated_list_service_reliability_test.dart
@@ -1,0 +1,253 @@
+// ABOUTME: Tests that CuratedListService uses publishEventWithRetry for
+// ABOUTME: kind 30005 publishes and gates local commit on acceptedByAny.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/curated_list_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+const _testPubkey =
+    '0000000000000000000000000000000000000000000000000000000000000001';
+const _videoId =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(
+      Event(_testPubkey, 30005, const [], '')
+        ..id = 'e' * 64
+        ..sig = 'sig',
+    );
+    registerFallbackValue(const RetryPolicy());
+    registerFallbackValue(<Filter>[]);
+    registerFallbackValue(<String>[]);
+  });
+
+  late _MockNostrClient nostr;
+  late _MockAuthService auth;
+  late SharedPreferences prefs;
+
+  Event signed({required int kind, required List<List<String>> tags}) {
+    return Event(_testPubkey, kind, tags, 'content')
+      ..id = 'e' * 64
+      ..sig = 'sig';
+  }
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    nostr = _MockNostrClient();
+    auth = _MockAuthService();
+
+    when(() => nostr.isInitialized).thenReturn(true);
+    when(() => nostr.publicKey).thenReturn(_testPubkey);
+    when(
+      () => nostr.subscribe(
+        any(),
+        subscriptionId: any(named: 'subscriptionId'),
+        tempRelays: any(named: 'tempRelays'),
+        targetRelays: any(named: 'targetRelays'),
+        onEose: any(named: 'onEose'),
+      ),
+    ).thenAnswer((_) => const Stream.empty());
+
+    when(() => auth.isAuthenticated).thenReturn(true);
+    when(() => auth.currentPublicKeyHex).thenReturn(_testPubkey);
+    when(
+      () => auth.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer((invocation) async {
+      final kind = invocation.namedArguments[#kind] as int;
+      final tags = invocation.namedArguments[#tags] as List<List<String>>;
+      return signed(kind: kind, tags: tags);
+    });
+  });
+
+  PublishOutcome acceptedOutcome() => PublishOutcome(
+    eventId: 'e' * 64,
+    acceptedBy: const {'wss://a'},
+    rejectedBy: const {},
+    noResponseFrom: const {},
+  );
+
+  PublishOutcome transientOutcome() => PublishOutcome(
+    eventId: 'e' * 64,
+    acceptedBy: const {},
+    rejectedBy: const {},
+    noResponseFrom: const {'wss://a'},
+  );
+
+  PublishOutcome rejectedOutcome() => PublishOutcome(
+    eventId: 'e' * 64,
+    acceptedBy: const {},
+    rejectedBy: const {'wss://a': 'blocked: not allowed'},
+    noResponseFrom: const {},
+  );
+
+  CuratedListService buildService() => CuratedListService(
+    nostrService: nostr,
+    authService: auth,
+    prefs: prefs,
+  );
+
+  group('CuratedListService reliability (kind 30005)', () {
+    test(
+      'addVideoToListResult: accepted-by-any commits and reports success',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
+
+        final service = buildService();
+        final created = await service.createList(name: 'My Picks');
+        expect(created, isNotNull);
+
+        final result = await service.addVideoToListResult(
+          created!.id,
+          _videoId,
+        );
+
+        expect(result.success, isTrue);
+        expect(result.outcome?.acceptedBy, {'wss://a'});
+        expect(result.feedback?.severity, PublishSeverity.success);
+
+        final list = service.getListById(created.id);
+        expect(list!.videoEventIds, [_videoId]);
+      },
+    );
+
+    test(
+      'addVideoToListResult: transient failure rolls back local state',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
+
+        final service = buildService();
+        final created = await service.createList(name: 'My Picks');
+        final listId = created!.id;
+
+        // Next publish fails transiently.
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => transientOutcome());
+
+        final result = await service.addVideoToListResult(listId, _videoId);
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isTrue);
+        expect(result.feedback?.messageKey, 'publish_no_relay_response');
+        // Rollback: video must be gone.
+        expect(service.getListById(listId)!.videoEventIds, isEmpty);
+      },
+    );
+
+    test(
+      'addVideoToListResult: permanent rejection surfaces reason, no commit',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
+
+        final service = buildService();
+        final created = await service.createList(name: 'My Picks');
+        final listId = created!.id;
+
+        // Next publish is rejected permanently.
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => rejectedOutcome());
+
+        final result = await service.addVideoToListResult(listId, _videoId);
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isFalse);
+        expect(result.feedback?.firstRejectionReason, 'blocked: not allowed');
+        expect(service.getListById(listId)!.videoEventIds, isEmpty);
+      },
+    );
+
+    test(
+      'removeVideoFromListResult: transient failure restores the video',
+      () async {
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => acceptedOutcome());
+
+        final service = buildService();
+        final created = await service.createList(name: 'My Picks');
+        final listId = created!.id;
+        const secondVideoId =
+            '3333333333333333333333333333333333333333333333333333333333333333';
+        // Populate the list with two videos so removing one still leaves
+        // a non-empty list (which triggers a relay publish per our
+        // "skip empty lists" policy).
+        await service.addVideoToListResult(listId, _videoId);
+        await service.addVideoToListResult(listId, secondVideoId);
+        expect(
+          service.getListById(listId)!.videoEventIds,
+          [_videoId, secondVideoId],
+        );
+
+        // Next publish fails transiently.
+        when(
+          () => nostr.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => transientOutcome());
+
+        final result = await service.removeVideoFromListResult(
+          listId,
+          _videoId,
+        );
+
+        expect(result.success, isFalse);
+        expect(result.feedback?.retryable, isTrue);
+        // Rollback: both videos still present in the original order.
+        expect(
+          service.getListById(listId)!.videoEventIds,
+          [_videoId, secondVideoId],
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/widgets/add_to_list_dialog_test.dart
+++ b/mobile/test/widgets/add_to_list_dialog_test.dart
@@ -160,8 +160,8 @@ void main() {
       ];
 
       when(
-        () => mockListService.addVideoToList(any(), any()),
-      ).thenAnswer((_) async => true);
+        () => mockListService.addVideoToListResult(any(), any()),
+      ).thenAnswer((_) async => CuratedListResult.successResult());
 
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
@@ -170,7 +170,7 @@ void main() {
       await tester.pumpAndSettle();
 
       verify(
-        () => mockListService.addVideoToList(listId, testVideo.id),
+        () => mockListService.addVideoToListResult(listId, testVideo.id),
       ).called(1);
       expect(find.text('Added to My List'), findsOneWidget);
     });
@@ -193,8 +193,8 @@ void main() {
       ];
 
       when(
-        () => mockListService.removeVideoFromList(any(), any()),
-      ).thenAnswer((_) async => true);
+        () => mockListService.removeVideoFromListResult(any(), any()),
+      ).thenAnswer((_) async => CuratedListResult.successResult());
 
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
@@ -203,7 +203,7 @@ void main() {
       await tester.pumpAndSettle();
 
       verify(
-        () => mockListService.removeVideoFromList(listId, testVideo.id),
+        () => mockListService.removeVideoFromListResult(listId, testVideo.id),
       ).called(1);
       expect(find.text('Removed from My List'), findsOneWidget);
     });


### PR DESCRIPTION
## Summary

Migrates every list / curation / label publish to the shared reliable-publish primitives from PR 1. All five kinds (10003, 30003, 30005 × 2, 1985) now route through `NostrClient.publishEventWithRetry` and gate local state commits on `outcome.acceptedByAny`, matching the contract introduced in PR 4 (deletions).

**Kinds covered:**
- `10003` — Global bookmarks (`BookmarkService`)
- `30003` — Named bookmark sets (`BookmarkService`)
- `30005` — Curated lists (`CuratedListService`)
- `30005` — Curation sets (`CurationService` in the `curation_service` package)
- `1985` — Account content-warning self-labels (`AccountLabelService`)

**Contract changes**

- Replaceable / addressable list publishes no longer commit local cache before the relay confirms. On transient failure the in-memory mutation and its SharedPreferences mirror are rolled back so local state stays consistent with the relay.
- `CurationService`'s bespoke 5-second `TimeoutException` wrapper, `failedAttempts`/`lastFailureReason` instance state, and `retryUnpublishedCurations`/`getRetryDelay` retry loop are **deleted**. They violated the "no mutable instance variables in BLoC" rule; retry is now a responsibility of `NostrClient.publishEventWithRetry`.
- `CurationPublishStatus.failedAttempts` / `lastFailureReason` are replaced by a `hasFailed` bool; error messaging lives on `CurationResult.feedback` (`PublishUserFeedback.retryable` / `firstRejectionReason`). `maxRetries` / `shouldRetry` are gone — the shared `RetryPolicy` owns retry bounds.

**UI**

- Bookmark (share sheet + share menu): retryable snackbar with Retry action via `PublishUserFeedback.retryable`.
- Bookmark sets (create / add / remove): same pattern.
- Curated lists (add_to_list_dialog): same pattern.
- Account labels settings screen: same pattern.

Retry snackbar labels ship as English literals (`'Retry'`) matching the PR 4 pattern; dedicated l10n keys will follow in a later PR.

**New result types**

Each migrated service returns a result class carrying `PublishOutcome` + mapped `PublishUserFeedback`:
- `BookmarkResult`, `CuratedListResult`, `CurationResult`, `AccountLabelResult`.

`CuratedListService` keeps the legacy `Future<bool>`/`Future<CuratedList?>` signatures on `createList`, `addVideoToList`, etc. to preserve backward compatibility with ~300 existing test call sites; the new `*Result` siblings (`addVideoToListResult`, `removeVideoFromListResult`) expose the feedback for the UI.

## Test plan

- [x] `flutter test mobile/test/unit/services/bookmark_service_reliability_test.dart` — 6 tests pass
- [x] `flutter test mobile/test/unit/services/curated_list_service_reliability_test.dart` — 4 tests pass
- [x] `flutter test mobile/test/unit/services/account_label_service_reliability_test.dart` — 4 tests pass
- [x] `flutter test mobile/packages/curation_service/test/src/curation_service_reliability_test.dart` — 4 tests pass
- [x] Existing `curated_list_service_*_test.dart` suite (173 tests) updated to stub `publishEventWithRetry` alongside `publishEvent`; all pass
- [x] Existing `curation_service` package tests (78 tests) updated to use the new `CurationResult` shape; all pass
- [x] `share_sheet_bloc_test.dart` updated for `BookmarkResult`; all pass
- [x] `add_to_list_dialog_test.dart` updated for `*Result` API; all pass
- [x] `flutter analyze lib test` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)