### PR TITLE
feat(dm): reliable NIP-17 + NIP-04 send, pending/failed message UI

### DIFF
--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -1,6 +1,7 @@
 // ABOUTME: BLoC for a single DM conversation.
 // ABOUTME: Manages loading messages, sending new messages,
-// ABOUTME: and real-time message streaming.
+// ABOUTME: real-time message streaming, optimistic insertion, and
+// ABOUTME: per-message pending/failed status with Retry.
 
 import 'dart:async';
 
@@ -9,6 +10,7 @@ import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
 
 part 'conversation_event.dart';
 part 'conversation_state.dart';
@@ -28,6 +30,10 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
     );
     on<ConversationMessageSent>(
       _onMessageSent,
+      transformer: sequential(),
+    );
+    on<ConversationMessageRetried>(
+      _onMessageRetried,
       transformer: sequential(),
     );
     on<ConversationMessageDeleted>(
@@ -56,9 +62,14 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
         // viewing this conversation. This ensures incoming messages are
         // immediately marked as read rather than only on initial open.
         unawaited(_dmRepository.markConversationAsRead(_conversationId));
+        // Merge optimistic sends with confirmed messages. Confirmed
+        // messages come back by their rumor event id, which we stored
+        // as the message id when the optimistic row was created, so
+        // duplicates are avoided via the same-id check below.
+        final merged = _mergeOptimisticWithConfirmed(messages);
         return state.copyWith(
           status: ConversationStatus.loaded,
-          messages: messages,
+          messages: merged,
         );
       },
       onError: (error, stackTrace) {
@@ -68,6 +79,31 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
         );
       },
     );
+  }
+
+  /// Preserves optimistic messages (those with an entry in
+  /// [ConversationState.sendStatusByMessageId]) that have not yet been
+  /// reflected in the confirmed list. Once the repository persists the
+  /// real message and the stream emits it with the same id, the
+  /// optimistic row is replaced by the confirmed one and its status is
+  /// dropped.
+  List<DmMessage> _mergeOptimisticWithConfirmed(
+    List<DmMessage> confirmed,
+  ) {
+    final confirmedIds = confirmed.map((m) => m.id).toSet();
+    final pending = state.messages.where(
+      (m) =>
+          state.sendStatusByMessageId.containsKey(m.id) &&
+          !confirmedIds.contains(m.id),
+    );
+    final combined = [...pending, ...confirmed];
+    // Keep chronological order (newest-first in UI). Ties broken by id
+    // so the order is stable across rebuilds.
+    combined.sort((a, b) {
+      final byTime = b.createdAt.compareTo(a.createdAt);
+      return byTime != 0 ? byTime : b.id.compareTo(a.id);
+    });
+    return combined;
   }
 
   Future<void> _onMessageDeleted(
@@ -91,7 +127,7 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
     // round-trip. The stream from watchMessages will replace this with the
     // persisted version once sendMessage completes and writes to the DB.
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    final pendingId = 'pending-$now';
+    final pendingId = 'pending-$now-${event.content.hashCode}';
     final optimisticMessage = DmMessage(
       id: pendingId,
       conversationId: _conversationId,
@@ -105,33 +141,132 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
       state.copyWith(
         sendStatus: SendStatus.sending,
         messages: [optimisticMessage, ...state.messages],
+        sendStatusByMessageId: {
+          ...state.sendStatusByMessageId,
+          pendingId: MessageSendStatus.sending,
+        },
       ),
     );
 
+    await _sendAndUpdateStatus(
+      pendingId: pendingId,
+      recipientPubkeys: event.recipientPubkeys,
+      content: event.content,
+      emit: emit,
+    );
+  }
+
+  Future<void> _onMessageRetried(
+    ConversationMessageRetried event,
+    Emitter<ConversationState> emit,
+  ) async {
+    // Re-mark the existing optimistic message as sending and clear any
+    // prior failure feedback so the bubble flips from red alert back
+    // to pending clock while the retry is in flight.
+    final updatedStatus = {...state.sendStatusByMessageId};
+    updatedStatus[event.pendingId] = MessageSendStatus.sending;
+    final updatedFeedback = {...state.feedbackByMessageId}
+      ..remove(event.pendingId);
+
+    emit(
+      state.copyWith(
+        sendStatus: SendStatus.sending,
+        sendStatusByMessageId: updatedStatus,
+        feedbackByMessageId: updatedFeedback,
+      ),
+    );
+
+    await _sendAndUpdateStatus(
+      pendingId: event.pendingId,
+      recipientPubkeys: event.recipientPubkeys,
+      content: event.content,
+      emit: emit,
+    );
+  }
+
+  Future<void> _sendAndUpdateStatus({
+    required String pendingId,
+    required List<String> recipientPubkeys,
+    required String content,
+    required Emitter<ConversationState> emit,
+  }) async {
     try {
-      if (event.recipientPubkeys.length == 1) {
-        final result = await _dmRepository.sendMessage(
-          recipientPubkey: event.recipientPubkeys.first,
-          content: event.content,
+      final NIP17SendResult result;
+      if (recipientPubkeys.length == 1) {
+        result = await _dmRepository.sendMessage(
+          recipientPubkey: recipientPubkeys.first,
+          content: content,
         );
         if (!result.success) {
-          throw Exception(result.error ?? 'Failed to send message');
+          _markFailed(pendingId, result.outcome, emit);
+          addError(
+            Exception(result.error ?? 'Failed to send message'),
+            StackTrace.current,
+          );
+          return;
         }
       } else {
         final results = await _dmRepository.sendGroupMessage(
-          recipientPubkeys: event.recipientPubkeys,
-          content: event.content,
+          recipientPubkeys: recipientPubkeys,
+          content: content,
         );
-        if (!results.any((r) => r.success)) {
-          throw Exception(
-            results.first.error ?? 'Failed to send group message',
+        final firstSuccess = results.where((r) => r.success);
+        if (firstSuccess.isEmpty) {
+          _markFailed(pendingId, results.first.outcome, emit);
+          addError(
+            Exception(
+              results.first.error ?? 'Failed to send group message',
+            ),
+            StackTrace.current,
           );
+          return;
         }
+        result = firstSuccess.first;
       }
-      emit(state.copyWith(sendStatus: SendStatus.sent));
+
+      // Success — clear the optimistic row's status so the bubble
+      // stops rendering the clock icon. The watchMessages stream will
+      // replace the pending row with the persisted rumor id on its
+      // next tick.
+      final updatedStatus = {...state.sendStatusByMessageId}..remove(pendingId);
+      final updatedFeedback = {...state.feedbackByMessageId}..remove(pendingId);
+      emit(
+        state.copyWith(
+          sendStatus: SendStatus.sent,
+          sendStatusByMessageId: updatedStatus,
+          feedbackByMessageId: updatedFeedback,
+        ),
+      );
     } catch (e, stackTrace) {
       addError(e, stackTrace);
-      emit(state.copyWith(sendStatus: SendStatus.failed));
+      _markFailed(pendingId, null, emit);
     }
+  }
+
+  void _markFailed(
+    String pendingId,
+    PublishOutcome? outcome,
+    Emitter<ConversationState> emit,
+  ) {
+    final feedback = outcome != null
+        ? PublishResultMapper.map(outcome)
+        : const PublishUserFeedback(
+            severity: PublishSeverity.error,
+            messageKey: 'publish_no_relays_available',
+            retryable: true,
+          );
+    emit(
+      state.copyWith(
+        sendStatus: SendStatus.failed,
+        sendStatusByMessageId: {
+          ...state.sendStatusByMessageId,
+          pendingId: MessageSendStatus.failed,
+        },
+        feedbackByMessageId: {
+          ...state.feedbackByMessageId,
+          pendingId: feedback,
+        },
+      ),
+    );
   }
 }

--- a/mobile/lib/blocs/dm/conversation/conversation_event.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_event.dart
@@ -37,3 +37,23 @@ class ConversationMessageDeleted extends ConversationEvent {
   @override
   List<Object?> get props => [rumorId];
 }
+
+/// Retry a previously-failed optimistic message.
+///
+/// The pending id identifies the in-state optimistic row to resend;
+/// the bloc removes the failed entry, emits a fresh `sending` state,
+/// and re-invokes sendMessage.
+class ConversationMessageRetried extends ConversationEvent {
+  const ConversationMessageRetried({
+    required this.pendingId,
+    required this.recipientPubkeys,
+    required this.content,
+  });
+
+  final String pendingId;
+  final List<String> recipientPubkeys;
+  final String content;
+
+  @override
+  List<Object?> get props => [pendingId, recipientPubkeys, content];
+}

--- a/mobile/lib/blocs/dm/conversation/conversation_state.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_state.dart
@@ -4,31 +4,67 @@ part of 'conversation_bloc.dart';
 
 enum ConversationStatus { initial, loading, loaded, error }
 
+/// Legacy aggregate send status — kept so the send bar can disable its
+/// button while ANY send is in flight. Per-message status lives in
+/// [ConversationState.sendStatusByMessageId].
 enum SendStatus { idle, sending, sent, failed }
+
+/// Per-message lifecycle. Drives the clock / alert icon on each
+/// bubble and gates the Retry action.
+enum MessageSendStatus { sending, sent, failed }
 
 class ConversationState extends Equatable {
   const ConversationState({
     this.status = ConversationStatus.initial,
     this.messages = const [],
     this.sendStatus = SendStatus.idle,
+    this.sendStatusByMessageId = const {},
+    this.feedbackByMessageId = const {},
   });
 
   final ConversationStatus status;
   final List<DmMessage> messages;
+
+  /// Aggregate status for the most recent send — drives the send bar
+  /// spinner only. Per-message status is the source of truth for the
+  /// message bubbles.
   final SendStatus sendStatus;
+
+  /// Per-message lifecycle keyed by the (optimistic) rumor event ID /
+  /// pending ID used in [messages]. Absence implies "confirmed-via-
+  /// stream", which is how non-local messages surface — they simply
+  /// don't carry a status icon.
+  final Map<String, MessageSendStatus> sendStatusByMessageId;
+
+  /// Per-message publish feedback for failed sends. Keyed identically
+  /// to [sendStatusByMessageId]. Absent for successful or pending
+  /// messages. Never holds error strings on its own (those live inside
+  /// [PublishUserFeedback.firstRejectionReason]).
+  final Map<String, PublishUserFeedback> feedbackByMessageId;
 
   ConversationState copyWith({
     ConversationStatus? status,
     List<DmMessage>? messages,
     SendStatus? sendStatus,
+    Map<String, MessageSendStatus>? sendStatusByMessageId,
+    Map<String, PublishUserFeedback>? feedbackByMessageId,
   }) {
     return ConversationState(
       status: status ?? this.status,
       messages: messages ?? this.messages,
       sendStatus: sendStatus ?? this.sendStatus,
+      sendStatusByMessageId:
+          sendStatusByMessageId ?? this.sendStatusByMessageId,
+      feedbackByMessageId: feedbackByMessageId ?? this.feedbackByMessageId,
     );
   }
 
   @override
-  List<Object?> get props => [status, messages, sendStatus];
+  List<Object?> get props => [
+    status,
+    messages,
+    sendStatus,
+    sendStatusByMessageId,
+    feedbackByMessageId,
+  ];
 }

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -118,6 +118,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
             child: _ConversationContent(
               currentPubkey: currentPubkey,
               displayName: displayName,
+              participantPubkeys: widget.participantPubkeys,
               imageUrl: profile?.picture,
               nip05: profile?.displayNip05,
               onViewProfile: () {
@@ -168,6 +169,7 @@ class _ConversationContent extends StatelessWidget {
   const _ConversationContent({
     required this.currentPubkey,
     required this.displayName,
+    required this.participantPubkeys,
     this.imageUrl,
     this.nip05,
     this.onViewProfile,
@@ -175,6 +177,7 @@ class _ConversationContent extends StatelessWidget {
 
   final String currentPubkey;
   final String displayName;
+  final List<String> participantPubkeys;
   final String? imageUrl;
   final String? nip05;
   final VoidCallback? onViewProfile;
@@ -184,9 +187,17 @@ class _ConversationContent extends StatelessWidget {
     return BlocSelector<
       ConversationBloc,
       ConversationState,
-      ({ConversationStatus status, List<DmMessage> messages})
+      ({
+        ConversationStatus status,
+        List<DmMessage> messages,
+        Map<String, MessageSendStatus> sendStatuses,
+      })
     >(
-      selector: (state) => (status: state.status, messages: state.messages),
+      selector: (state) => (
+        status: state.status,
+        messages: state.messages,
+        sendStatuses: state.sendStatusByMessageId,
+      ),
       builder: (context, selected) {
         return switch (selected.status) {
           ConversationStatus.initial ||
@@ -210,6 +221,8 @@ class _ConversationContent extends StatelessWidget {
                 : _MessageList(
                     messages: selected.messages,
                     currentPubkey: currentPubkey,
+                    sendStatuses: selected.sendStatuses,
+                    participantPubkeys: participantPubkeys,
                   ),
         };
       },
@@ -221,10 +234,14 @@ class _MessageList extends StatelessWidget {
   const _MessageList({
     required this.messages,
     required this.currentPubkey,
+    required this.sendStatuses,
+    required this.participantPubkeys,
   });
 
   final List<DmMessage> messages;
   final String currentPubkey;
+  final Map<String, MessageSendStatus> sendStatuses;
+  final List<String> participantPubkeys;
 
   Future<void> _onMessageLongPress(
     BuildContext context,
@@ -276,12 +293,24 @@ class _MessageList extends StatelessWidget {
             index == 0 ||
             messages[index - 1].senderPubkey != message.senderPubkey;
 
+        final sendStatus = sendStatuses[message.id];
+
         return MessageBubble(
           message: message.content,
           timestamp: TimeFormatter.formatMessageTime(message.createdAt),
           isSent: isSent,
           isFirstInGroup: isFirstInGroup,
           isLastInGroup: isLastInGroup,
+          sendStatus: sendStatus,
+          onRetry: sendStatus == MessageSendStatus.failed
+              ? () => context.read<ConversationBloc>().add(
+                  ConversationMessageRetried(
+                    pendingId: message.id,
+                    recipientPubkeys: participantPubkeys,
+                    content: message.content,
+                  ),
+                )
+              : null,
           onLongPress: () => _onMessageLongPress(context, message, isSent),
         );
       },

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -10,6 +10,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide AspectRatio, LogCategory;
+import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/video_link_preview_cubit.dart';
@@ -70,6 +71,8 @@ class MessageBubble extends StatelessWidget {
     this.isFirstInGroup = true,
     this.isLastInGroup = true,
     this.onLongPress,
+    this.sendStatus,
+    this.onRetry,
     super.key,
   });
 
@@ -87,6 +90,14 @@ class MessageBubble extends StatelessWidget {
 
   /// Called when the user long-presses the bubble.
   final VoidCallback? onLongPress;
+
+  /// Per-message send lifecycle. `null` means "confirmed via relay
+  /// stream" — no status icon. When set, draws a clock (sending),
+  /// nothing (sent), or a red alert + retry action (failed).
+  final MessageSendStatus? sendStatus;
+
+  /// Invoked when the user taps the failed-state retry affordance.
+  final VoidCallback? onRetry;
 
   @override
   Widget build(BuildContext context) {
@@ -106,6 +117,82 @@ class MessageBubble extends StatelessWidget {
       textAfterUrl = null;
     }
 
+    final isPending = sendStatus == MessageSendStatus.sending;
+    final isFailed = sendStatus == MessageSendStatus.failed;
+
+    final bubble = Semantics(
+      hint: isSent ? 'Sent message' : 'Received message',
+      onLongPressHint: onLongPress != null ? 'Message actions' : null,
+      child: GestureDetector(
+        onLongPress: onLongPress,
+        child: Opacity(
+          opacity: isPending ? 0.6 : 1,
+          child: Container(
+            constraints: BoxConstraints(
+              maxWidth: MediaQuery.sizeOf(context).width * 0.75,
+            ),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 16,
+              vertical: 12,
+            ),
+            decoration: BoxDecoration(
+              color: isSent ? VineTheme.surfaceContainer : VineTheme.neutral10,
+              borderRadius: _borderRadius,
+            ),
+            child: Column(
+              crossAxisAlignment: isSent
+                  ? CrossAxisAlignment.end
+                  : CrossAxisAlignment.start,
+              children: [
+                if (isFirstInGroup)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 4),
+                    child: Text(
+                      timestamp,
+                      style: VineTheme.labelSmallFont(
+                        color: VineTheme.onSurfaceMuted,
+                      ),
+                    ),
+                  ),
+                if (videoStableId != null) ...[
+                  if (textBeforeUrl != null)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: _MessageText(message: textBeforeUrl),
+                    ),
+                  _VideoLinkPreview(videoStableId: videoStableId),
+                  if (textAfterUrl != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      child: _MessageText(message: textAfterUrl),
+                    ),
+                ] else
+                  _MessageText(message: message),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Indicator hangs to the left of a sent bubble (the non-tail side)
+    // and is omitted entirely for received or confirmed-success sends.
+    Widget content = bubble;
+    if (isSent && sendStatus != null) {
+      content = Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          if (isPending)
+            const _PendingIcon()
+          else if (isFailed)
+            _FailedIcon(onRetry: onRetry),
+          const SizedBox(width: 4),
+          Flexible(child: bubble),
+        ],
+      );
+    }
+
     return Padding(
       padding: EdgeInsets.only(
         left: 16,
@@ -117,59 +204,7 @@ class MessageBubble extends StatelessWidget {
         alignment: isSent
             ? AlignmentDirectional.centerEnd
             : AlignmentDirectional.centerStart,
-        child: Semantics(
-          hint: isSent ? 'Sent message' : 'Received message',
-          onLongPressHint: onLongPress != null ? 'Message actions' : null,
-          child: GestureDetector(
-            onLongPress: onLongPress,
-            child: Container(
-              constraints: BoxConstraints(
-                maxWidth: MediaQuery.sizeOf(context).width * 0.75,
-              ),
-              padding: const EdgeInsets.symmetric(
-                horizontal: 16,
-                vertical: 12,
-              ),
-              decoration: BoxDecoration(
-                color: isSent
-                    ? VineTheme.surfaceContainer
-                    : VineTheme.neutral10,
-                borderRadius: _borderRadius,
-              ),
-              child: Column(
-                crossAxisAlignment: isSent
-                    ? CrossAxisAlignment.end
-                    : CrossAxisAlignment.start,
-                children: [
-                  if (isFirstInGroup)
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 4),
-                      child: Text(
-                        timestamp,
-                        style: VineTheme.labelSmallFont(
-                          color: VineTheme.onSurfaceMuted,
-                        ),
-                      ),
-                    ),
-                  if (videoStableId != null) ...[
-                    if (textBeforeUrl != null)
-                      Padding(
-                        padding: const EdgeInsets.only(bottom: 8),
-                        child: _MessageText(message: textBeforeUrl),
-                      ),
-                    _VideoLinkPreview(videoStableId: videoStableId),
-                    if (textAfterUrl != null)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 8),
-                        child: _MessageText(message: textAfterUrl),
-                      ),
-                  ] else
-                    _MessageText(message: message),
-                ],
-              ),
-            ),
-          ),
-        ),
+        child: content,
       ),
     );
   }
@@ -426,6 +461,60 @@ class _VideoLinkPreview extends ConsumerWidget {
               strokeWidth: 2,
               color: VineTheme.vineGreen,
             ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Grey clock rendered next to a message that is being sent. 48x48
+/// minimum touch target kept via Semantics + Container sizing (icon
+/// itself is small to read as a status indicator, not a button).
+class _PendingIcon extends StatelessWidget {
+  const _PendingIcon();
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Sending',
+      liveRegion: true,
+      child: const SizedBox(
+        width: 20,
+        height: 20,
+        child: Icon(
+          Icons.schedule,
+          size: 16,
+          color: VineTheme.onSurfaceMuted,
+        ),
+      ),
+    );
+  }
+}
+
+/// Red alert rendered next to a message that failed to send. Taps
+/// invoke [onRetry] if provided — the parent handles wiring the retry
+/// event to the bloc with the failed pending id.
+class _FailedIcon extends StatelessWidget {
+  const _FailedIcon({this.onRetry});
+
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Message failed to send. Tap to retry.',
+      button: onRetry != null,
+      child: InkResponse(
+        onTap: onRetry,
+        radius: 24,
+        child: const SizedBox(
+          width: 24,
+          height: 24,
+          child: Icon(
+            Icons.error_outline,
+            size: 18,
+            color: VineTheme.error,
           ),
         ),
       ),

--- a/mobile/packages/dm_repository/lib/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/dm_repository.dart
@@ -1,4 +1,5 @@
 export 'src/dm_decryption_worker.dart';
+export 'src/dm_publish_failure.dart';
 export 'src/dm_repository.dart';
 export 'src/dm_sync_state.dart';
 export 'src/nip17_message_service.dart';

--- a/mobile/packages/dm_repository/lib/src/dm_publish_failure.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_publish_failure.dart
@@ -1,0 +1,38 @@
+// ABOUTME: Exception signalling that a DM-related publish (NIP-09 kind 5
+// ABOUTME: deletion in particular) failed at the relay layer.
+// ABOUTME: Carries the PublishOutcome and mapped PublishUserFeedback so
+// ABOUTME: UI layers can drive retry affordances without re-mapping.
+
+import 'package:nostr_client/nostr_client.dart';
+
+/// Thrown by DmRepository methods that MUST confirm a relay write
+/// before updating local state (e.g. "delete for everyone") when every
+/// targeted relay rejected or timed out.
+///
+/// Local state mutations are gated on [PublishOutcome.acceptedByAny] —
+/// the caller should catch this exception and surface [feedback] (via
+/// `feedback.retryable`, `feedback.firstRejectionReason`, etc.) to the
+/// UI. The local row is intentionally left unchanged so the user can
+/// retry without losing context.
+class DmPublishFailure implements Exception {
+  /// Creates a failure with the raw relay [outcome] and the mapped
+  /// user-facing [feedback].
+  DmPublishFailure({
+    required this.message,
+    required this.outcome,
+    required this.feedback,
+  });
+
+  /// Short human-readable summary for logs. Not user-facing — the UI
+  /// should consume [feedback] instead.
+  final String message;
+
+  /// Per-relay outcome that triggered the failure.
+  final PublishOutcome outcome;
+
+  /// Localization-ready feedback mapped via `PublishResultMapper`.
+  final PublishUserFeedback feedback;
+
+  @override
+  String toString() => 'DmPublishFailure($message, outcome: $outcome)';
+}

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -11,6 +11,7 @@ import 'dart:convert';
 import 'package:crypto/crypto.dart';
 import 'package:db_client/db_client.dart';
 import 'package:dm_repository/src/dm_decryption_worker.dart';
+import 'package:dm_repository/src/dm_publish_failure.dart';
 import 'package:dm_repository/src/dm_sync_state.dart';
 import 'package:dm_repository/src/nip17_message_service.dart';
 import 'package:flutter/foundation.dart';
@@ -1024,8 +1025,24 @@ class DmRepository {
       throw StateError('Failed to sign kind 5 deletion event');
     }
 
-    // Publish to relays (best-effort — client-side processing is primary).
-    await _nostrClient.publishEvent(signed);
+    // Publish to relays via the reliable retry path. We MUST confirm at
+    // least one relay accepted the deletion before hiding the message
+    // locally — otherwise the UI would lie and the message would stay
+    // visible to every other client. On failure, throw DmPublishFailure
+    // so the BLoC / UI can surface a Retry affordance using the
+    // mapped PublishUserFeedback.
+    final outcome = await _nostrClient.publishEventWithRetry(signed);
+    if (!outcome.acceptedByAny) {
+      Log.error(
+        'Kind 5 deletion rejected by every relay: $outcome',
+        category: LogCategory.system,
+      );
+      throw DmPublishFailure(
+        message: 'Failed to publish deletion',
+        outcome: outcome,
+        feedback: PublishResultMapper.map(outcome),
+      );
+    }
 
     // Soft-delete locally so the UI updates immediately.
     await _directMessagesDao.markMessageDeleted(
@@ -1241,15 +1258,27 @@ class DmRepository {
       return NIP17SendResult.failure('NIP-04 sign returned null');
     }
 
-    final published = await _nostrClient.publishEvent(signed);
-    if (published == null) {
-      return NIP17SendResult.failure('NIP-04 publish returned null');
+    // Use the reliable retry path so the fallback also benefits from
+    // transient-failure backoff. The NIP-04 send is still purely an
+    // interop bridge — the NIP-17 leg (already published above) is the
+    // source of truth for the outgoing conversation.
+    final outcome = await _nostrClient.publishEventWithRetry(signed);
+    if (!outcome.acceptedByAny) {
+      Log.warning(
+        'NIP-04 fallback rejected by every relay: $outcome',
+        category: LogCategory.system,
+      );
+      return NIP17SendResult.failure(
+        'NIP-04 publish failed to relays',
+        outcome: outcome,
+      );
     }
 
     return NIP17SendResult.success(
-      rumorEventId: published.id,
-      messageEventId: published.id,
+      rumorEventId: signed.id,
+      messageEventId: signed.id,
       recipientPubkey: recipientPubkey,
+      outcome: outcome,
     );
   }
 

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -46,11 +46,25 @@ class NIP17MessageService {
   /// - [content]: Message content (text for kind 14, file URL for kind 15)
   /// - [eventKind]: The rumor event kind (14 = text, 15 = file)
   /// - [additionalTags]: Optional tags to include in the rumor event
+  /// - [recipientDmRelays]: Optional recipient DM-relay list (NIP-17
+  ///   kind-10050). When non-null/non-empty, the recipient gift wrap is
+  ///   targeted to these relays via `publishEventWithRetry`'s
+  ///   `targetRelays` argument. The self-wrap always goes to the
+  ///   sender's own default relays — never to the recipient's DM list.
+  ///
+  /// Reliability contract:
+  /// - Recipient gift wrap uses `publishEventWithRetry` and the overall
+  ///   send succeeds only when at least one relay accepts it
+  ///   ([PublishOutcome.acceptedByAny]).
+  /// - Self-wrap is best-effort — uses `publishEventAwaitOk` with a
+  ///   short 5s timeout for telemetry, but any failure (outcome or
+  ///   exception) is logged and does NOT fail the overall send.
   Future<NIP17SendResult> sendPrivateMessage({
     required String recipientPubkey,
     required String content,
     int eventKind = EventKind.privateDirectMessage,
     List<List<String>> additionalTags = const [],
+    List<String>? recipientDmRelays,
   }) async {
     try {
       Log.info(
@@ -102,19 +116,38 @@ class NIP17MessageService {
         category: LogCategory.system,
       );
 
-      // Publish the recipient's gift wrap
-      final sentEvent = await _nostrService.publishEvent(giftWrapEvent);
+      // Route the recipient gift wrap to their kind-10050 DM relays
+      // when provided. Empty list means "use defaults" (no routing).
+      final targetRelays =
+          (recipientDmRelays != null && recipientDmRelays.isNotEmpty)
+          ? recipientDmRelays
+          : null;
 
-      if (sentEvent == null) {
-        const errorMsg = 'Message publish failed to relays';
-        Log.error(errorMsg, category: LogCategory.system);
-        return NIP17SendResult.failure(errorMsg);
+      // Publish the recipient's gift wrap via the reliable retry path.
+      // This is the message the recipient actually decrypts — it MUST
+      // land on at least one relay.
+      final recipientOutcome = await _nostrService.publishEventWithRetry(
+        giftWrapEvent,
+        targetRelays: targetRelays,
+      );
+
+      if (!recipientOutcome.acceptedByAny) {
+        Log.error(
+          'Recipient gift wrap rejected by every relay: $recipientOutcome',
+          category: LogCategory.system,
+        );
+        return NIP17SendResult.failure(
+          'Message publish failed to relays',
+          outcome: recipientOutcome,
+        );
       }
 
-      // NIP-17: publish a self-addressed gift wrap so our own sent messages
-      // are recoverable from relays after reinstall or data loss.
-      // Wrapped in its own try-catch because the message was already
-      // delivered to the recipient — self-wrap failure is non-fatal.
+      // NIP-17: publish a self-addressed gift wrap so our own sent
+      // messages are recoverable from relays after reinstall or data
+      // loss. Best-effort — uses `publishEventAwaitOk` with a short
+      // timeout for telemetry, but doesn't retry and doesn't fail the
+      // overall send. Losing self-sync is a smaller penalty than making
+      // the sender wait or see a false "failed" state.
       try {
         final selfWrapEvent = await GiftWrapUtil.getGiftWrapEvent(
           nostr,
@@ -122,7 +155,17 @@ class NIP17MessageService {
           _senderPublicKey,
         );
         if (selfWrapEvent != null) {
-          await _nostrService.publishEvent(selfWrapEvent);
+          final selfOutcome = await _nostrService.publishEventAwaitOk(
+            selfWrapEvent,
+            timeout: const Duration(seconds: 5),
+          );
+          if (!selfOutcome.acceptedByAny) {
+            Log.warning(
+              'Self-wrap not accepted by any relay (non-fatal): '
+              '$selfOutcome',
+              category: LogCategory.system,
+            );
+          }
         }
       } on Object catch (e) {
         Log.error(
@@ -139,6 +182,7 @@ class NIP17MessageService {
         rumorEventId: rumorEvent.id,
         messageEventId: giftWrapEvent.id,
         recipientPubkey: recipientPubkey,
+        outcome: recipientOutcome,
       );
     } on Object catch (e, stackTrace) {
       Log.error(

--- a/mobile/packages/dm_repository/test/src/dm_repository_reliability_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_reliability_test.dart
@@ -1,0 +1,472 @@
+// ABOUTME: Reliability tests for DmRepository write paths — NIP-04
+// ABOUTME: fallback send and NIP-09 kind 5 deletion. Both must gate local
+// ABOUTME: state on PublishOutcome.acceptedByAny so a failed publish does
+// ABOUTME: not leave the UI believing the operation succeeded.
+
+import 'dart:convert';
+
+import 'package:db_client/db_client.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/signer/nostr_signer.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockDirectMessagesDao extends Mock implements DirectMessagesDao {}
+
+class _MockConversationsDao extends Mock implements ConversationsDao {}
+
+class _MockSigner extends Mock implements NostrSigner {}
+
+class _MockNip17MessageService extends Mock implements NIP17MessageService {}
+
+class _FakeEvent extends Fake implements Event {}
+
+const _userPubkey =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+const _peerPubkey =
+    '2222222222222222222222222222222222222222222222222222222222222222';
+const _rumorEventId =
+    '3333333333333333333333333333333333333333333333333333333333333333';
+const _giftWrapEventId =
+    '4444444444444444444444444444444444444444444444444444444444444444';
+
+PublishOutcome _acceptedOutcome() {
+  return PublishOutcome(
+    eventId: 'a' * 64,
+    acceptedBy: const {'wss://a'},
+    rejectedBy: const {},
+    noResponseFrom: const {},
+  );
+}
+
+PublishOutcome _transientFailure() {
+  return PublishOutcome(
+    eventId: 'a' * 64,
+    acceptedBy: const {},
+    rejectedBy: const {},
+    noResponseFrom: const {'wss://a', 'wss://b'},
+  );
+}
+
+PublishOutcome _permanentRejection() {
+  return PublishOutcome(
+    eventId: 'a' * 64,
+    acceptedBy: const {},
+    rejectedBy: const {'wss://a': 'blocked: spam'},
+    noResponseFrom: const {},
+  );
+}
+
+DmRepository _buildRepo({
+  required _MockNostrClient nostrClient,
+  required _MockDirectMessagesDao directMessagesDao,
+  required _MockConversationsDao conversationsDao,
+  required _MockSigner signer,
+  _MockNip17MessageService? messageService,
+}) {
+  return DmRepository(
+    nostrClient: nostrClient,
+    directMessagesDao: directMessagesDao,
+    conversationsDao: conversationsDao,
+    messageService: messageService ?? _MockNip17MessageService(),
+    signer: signer,
+    userPubkey: _userPubkey,
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+    registerFallbackValue(const RetryPolicy());
+  });
+
+  late _MockNostrClient nostrClient;
+  late _MockDirectMessagesDao directMessagesDao;
+  late _MockConversationsDao conversationsDao;
+  late _MockSigner signer;
+
+  setUp(() {
+    nostrClient = _MockNostrClient();
+    directMessagesDao = _MockDirectMessagesDao();
+    conversationsDao = _MockConversationsDao();
+    signer = _MockSigner();
+
+    // Signer stubs used by both NIP-04 and kind 5 delete paths.
+    when(() => signer.encrypt(any(), any())).thenAnswer(
+      (_) async => 'nip04-ciphertext',
+    );
+    when(() => signer.signEvent(any())).thenAnswer((invocation) async {
+      final event = invocation.positionalArguments[0] as Event;
+      // Deterministic id + sig so tests can assert on them later.
+      return event
+        ..id = 'e' * 64
+        ..sig = 's' * 128;
+    });
+  });
+
+  group('deleteMessageForEveryone reliability', () {
+    final conversationId = DmRepository.computeConversationId(
+      [_userPubkey, _peerPubkey],
+    );
+
+    setUp(() {
+      when(
+        () => directMessagesDao.getMessageById(
+          any(),
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      ).thenAnswer(
+        (_) async => DirectMessageRow(
+          id: _rumorEventId,
+          conversationId: conversationId,
+          senderPubkey: _userPubkey,
+          content: 'hi',
+          createdAt: 1700000000,
+          giftWrapId: _giftWrapEventId,
+          messageKind: EventKind.privateDirectMessage,
+          isDeleted: false,
+        ),
+      );
+      when(
+        () => conversationsDao.getConversation(
+          any(),
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      ).thenAnswer(
+        (_) async => ConversationRow(
+          id: conversationId,
+          participantPubkeys: jsonEncode([_userPubkey, _peerPubkey]),
+          isGroup: false,
+          createdAt: 1700000000,
+          isRead: true,
+          currentUserHasSent: true,
+        ),
+      );
+      when(
+        () => directMessagesDao.markMessageDeleted(
+          any(),
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      ).thenAnswer((_) async => true);
+      when(
+        () => directMessagesDao.getMessagesForConversation(
+          any(),
+          limit: any(named: 'limit'),
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      ).thenAnswer((_) async => []);
+      when(
+        () => conversationsDao.upsertConversation(
+          id: any(named: 'id'),
+          participantPubkeys: any(named: 'participantPubkeys'),
+          isGroup: any(named: 'isGroup'),
+          createdAt: any(named: 'createdAt'),
+          lastMessageContent: any(named: 'lastMessageContent'),
+          lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+          lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+          currentUserHasSent: any(named: 'currentUserHasSent'),
+          ownerPubkey: any(named: 'ownerPubkey'),
+          dmProtocol: any(named: 'dmProtocol'),
+        ),
+      ).thenAnswer((_) async {});
+    });
+
+    test(
+      'accepted → kind 5 published AND local message soft-deleted',
+      () async {
+        when(
+          () => nostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _acceptedOutcome());
+
+        final repo = _buildRepo(
+          nostrClient: nostrClient,
+          directMessagesDao: directMessagesDao,
+          conversationsDao: conversationsDao,
+          signer: signer,
+        );
+
+        await repo.deleteMessageForEveryone(_rumorEventId);
+
+        // Verify kind 5 published via reliable path.
+        final captured =
+            verify(
+                  () => nostrClient.publishEventWithRetry(
+                    captureAny(),
+                    policy: any(named: 'policy'),
+                    targetRelays: any(named: 'targetRelays'),
+                  ),
+                ).captured.single
+                as Event;
+        expect(captured.kind, equals(EventKind.eventDeletion));
+        expect(
+          captured.tags,
+          containsAll([
+            ['e', _rumorEventId],
+            ['k', '14'],
+            ['p', _peerPubkey],
+          ]),
+        );
+
+        // Local soft-delete DID happen (gate open on acceptedByAny).
+        verify(
+          () => directMessagesDao.markMessageDeleted(
+            _rumorEventId,
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'transient failure → PublishFailure thrown, local message NOT hidden',
+      () async {
+        when(
+          () => nostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _transientFailure());
+
+        final repo = _buildRepo(
+          nostrClient: nostrClient,
+          directMessagesDao: directMessagesDao,
+          conversationsDao: conversationsDao,
+          signer: signer,
+        );
+
+        await expectLater(
+          () => repo.deleteMessageForEveryone(_rumorEventId),
+          throwsA(isA<DmPublishFailure>()),
+        );
+
+        verifyNever(
+          () => directMessagesDao.markMessageDeleted(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'permanent rejection → PublishFailure thrown with non-retryable '
+      'feedback',
+      () async {
+        when(
+          () => nostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _permanentRejection());
+
+        final repo = _buildRepo(
+          nostrClient: nostrClient,
+          directMessagesDao: directMessagesDao,
+          conversationsDao: conversationsDao,
+          signer: signer,
+        );
+
+        try {
+          await repo.deleteMessageForEveryone(_rumorEventId);
+          fail('expected DmPublishFailure');
+        } on DmPublishFailure catch (e) {
+          expect(e.outcome.acceptedByAny, isFalse);
+          expect(e.feedback.retryable, isFalse);
+          expect(e.feedback.firstRejectionReason, contains('blocked'));
+        }
+
+        verifyNever(
+          () => directMessagesDao.markMessageDeleted(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      },
+    );
+  });
+
+  group('_sendNip04Message reliability (via sendMessage NIP-04 fallback)', () {
+    const plaintext = 'hello fallback';
+
+    /// DmRepository.sendMessage delegates the NIP-17 leg to
+    /// NIP17MessageService and invokes _sendNip04Message internally.
+    /// Stubbing the NIP-17 leg isolates the NIP-04 fallback path.
+    void stubNip17Success(_MockNip17MessageService svc) {
+      when(
+        () => svc.sendPrivateMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          eventKind: any(named: 'eventKind'),
+          additionalTags: any(named: 'additionalTags'),
+          recipientDmRelays: any(named: 'recipientDmRelays'),
+        ),
+      ).thenAnswer(
+        (_) async => NIP17SendResult.success(
+          rumorEventId: _rumorEventId,
+          messageEventId: _giftWrapEventId,
+          recipientPubkey: _peerPubkey,
+          outcome: _acceptedOutcome(),
+        ),
+      );
+    }
+
+    setUp(() {
+      when(
+        () => directMessagesDao.insertMessage(
+          id: any(named: 'id'),
+          conversationId: any(named: 'conversationId'),
+          senderPubkey: any(named: 'senderPubkey'),
+          content: any(named: 'content'),
+          createdAt: any(named: 'createdAt'),
+          giftWrapId: any(named: 'giftWrapId'),
+          messageKind: any(named: 'messageKind'),
+          replyToId: any(named: 'replyToId'),
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => conversationsDao.getConversation(
+          any(),
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      ).thenAnswer((_) async => null);
+      // Stub both <void> and <Null> — Dart infers different type args
+      // depending on callback return type.
+      when(
+        () => conversationsDao.runInTransaction<void>(any()),
+      ).thenAnswer((invocation) async {
+        final action =
+            invocation.positionalArguments[0] as Future<void> Function();
+        await action();
+      });
+      when(
+        () => conversationsDao.runInTransaction<Null>(any()),
+      ).thenAnswer((invocation) async {
+        final action =
+            invocation.positionalArguments[0] as Future<Null> Function();
+        await action();
+      });
+      when(
+        () => conversationsDao.upsertConversation(
+          id: any(named: 'id'),
+          participantPubkeys: any(named: 'participantPubkeys'),
+          isGroup: any(named: 'isGroup'),
+          createdAt: any(named: 'createdAt'),
+          lastMessageContent: any(named: 'lastMessageContent'),
+          lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+          lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+          currentUserHasSent: any(named: 'currentUserHasSent'),
+          ownerPubkey: any(named: 'ownerPubkey'),
+          dmProtocol: any(named: 'dmProtocol'),
+        ),
+      ).thenAnswer((_) async {});
+    });
+
+    test(
+      'NIP-04 fallback publishes kind 4 via publishEventWithRetry '
+      'and ignores subsequent drop',
+      () async {
+        // The fallback is fire-and-forget (unawaited from sendMessage),
+        // so we drive it directly by invoking sendMessage and then
+        // verifying the kind 4 retry publish happened.
+        final messageService = _MockNip17MessageService();
+        stubNip17Success(messageService);
+
+        final repo = _buildRepo(
+          nostrClient: nostrClient,
+          directMessagesDao: directMessagesDao,
+          conversationsDao: conversationsDao,
+          signer: signer,
+          messageService: messageService,
+        );
+
+        when(
+          () => nostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _acceptedOutcome());
+
+        await repo.sendMessage(
+          recipientPubkey: _peerPubkey,
+          content: plaintext,
+        );
+
+        // Give the unawaited NIP-04 fallback a chance to run.
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+
+        final captured = verify(
+          () => nostrClient.publishEventWithRetry(
+            captureAny(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).captured;
+
+        // Expect a kind 4 event among the captures (may include others
+        // if callers retry differently in the future).
+        final kind4 = captured.cast<Event>().where(
+          (e) => e.kind == EventKind.directMessage,
+        );
+        expect(kind4, isNotEmpty);
+        expect(kind4.first.content, equals('nip04-ciphertext'));
+        expect(
+          kind4.first.tags.any(
+            (tag) => tag.length >= 2 && tag[0] == 'p' && tag[1] == _peerPubkey,
+          ),
+          isTrue,
+          reason: 'kind 4 event should carry a p-tag for the recipient',
+        );
+      },
+    );
+
+    test(
+      'NIP-04 fallback — rejected by every relay does NOT break the '
+      'already-successful NIP-17 send',
+      () async {
+        final messageService = _MockNip17MessageService();
+        stubNip17Success(messageService);
+
+        final repo = _buildRepo(
+          nostrClient: nostrClient,
+          directMessagesDao: directMessagesDao,
+          conversationsDao: conversationsDao,
+          signer: signer,
+          messageService: messageService,
+        );
+
+        when(
+          () => nostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _transientFailure());
+
+        final result = await repo.sendMessage(
+          recipientPubkey: _peerPubkey,
+          content: plaintext,
+        );
+
+        // NIP-17 success stands on its own — NIP-04 is purely interop.
+        expect(result.success, isTrue);
+
+        // Give the fallback a chance to run and fail without crashing.
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      },
+    );
+  });
+}

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -97,6 +97,7 @@ void main() {
 
     setUpAll(() {
       registerFallbackValue(_FakeEvent());
+      registerFallbackValue(const RetryPolicy());
     });
 
     setUp(() {
@@ -108,6 +109,26 @@ void main() {
       // Stub relay properties used by startListening() log.
       when(() => mockNostrClient.connectedRelayCount).thenReturn(3);
       when(() => mockNostrClient.configuredRelayCount).thenReturn(3);
+
+      // Default stub so the NIP-04 fallback and kind 5 deletion don't
+      // blow up in tests that don't care about publish outcomes. The
+      // shape matches "all-accept" so acceptedByAny is true and the
+      // repository proceeds with local-state updates. Tests that need
+      // different outcomes override this stub.
+      when(
+        () => mockNostrClient.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments[0] as Event).id,
+          acceptedBy: const {'wss://default.test'},
+          rejectedBy: const {},
+          noResponseFrom: const {},
+        ),
+      );
 
       // Stub getNewestMessageTimestamp for startListening() windowing.
       when(
@@ -3793,7 +3814,9 @@ void main() {
           // Allow the unawaited NIP-04 future to complete
           await Future<void>.delayed(Duration.zero);
 
-          // Verify both NIP-17 and NIP-04 were called
+          // Verify both NIP-17 and NIP-04 were called. NIP-04 now
+          // uses the reliable retry path just like NIP-17, so we
+          // assert on publishEventWithRetry rather than publishEvent.
           verify(
             () => mockMessageService.sendPrivateMessage(
               recipientPubkey: any(named: 'recipientPubkey'),
@@ -3804,7 +3827,11 @@ void main() {
           ).called(1);
 
           verify(
-            () => mockNostrClient.publishEvent(any()),
+            () => mockNostrClient.publishEventWithRetry(
+              any(),
+              policy: any(named: 'policy'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
           ).called(1);
         },
       );
@@ -3993,10 +4020,6 @@ void main() {
           );
 
           when(
-            () => mockNostrClient.publishEvent(any()),
-          ).thenAnswer((_) async => _FakeEvent());
-
-          when(
             () => mockDirectMessagesDao.markMessageDeleted(
               _rumorEventId,
               ownerPubkey: any(named: 'ownerPubkey'),
@@ -4028,10 +4051,15 @@ void main() {
 
           await repo.deleteMessageForEveryone(_rumorEventId);
 
-          // Verify kind 5 was published
+          // Verify kind 5 was published via the reliable retry path
+          // (default stub in setUp returns an accepted outcome).
           final captured =
               verify(
-                    () => mockNostrClient.publishEvent(captureAny()),
+                    () => mockNostrClient.publishEventWithRetry(
+                      captureAny(),
+                      policy: any(named: 'policy'),
+                      targetRelays: any(named: 'targetRelays'),
+                    ),
                   ).captured.single
                   as Event;
           expect(captured.kind, equals(EventKind.eventDeletion));

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_reliability_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_reliability_test.dart
@@ -1,0 +1,231 @@
+// ABOUTME: Reliability tests for NIP17MessageService: recipient gift wrap
+// ABOUTME: MUST succeed (acceptedByAny) to return success, self-wrap is
+// ABOUTME: best-effort and never fails the overall send.
+
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _FakeEvent extends Fake implements Event {}
+
+const _testPrivateKey =
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+const _testPublicKey =
+    '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+const _recipientPubkey =
+    'e771af0b05c8e95fcdf6feb3500544d2fb1ccd384788e9f490bb3ee28e8ed66f';
+
+PublishOutcome _acceptedOutcome({Set<String> accepted = const {'wss://a'}}) {
+  return PublishOutcome(
+    eventId: 'a' * 64,
+    acceptedBy: accepted,
+    rejectedBy: const {},
+    noResponseFrom: const {},
+  );
+}
+
+PublishOutcome _transientFailure() {
+  return PublishOutcome(
+    eventId: 'a' * 64,
+    acceptedBy: const {},
+    rejectedBy: const {},
+    noResponseFrom: const {'wss://a', 'wss://b'},
+  );
+}
+
+PublishOutcome _permanentRejection() {
+  return PublishOutcome(
+    eventId: 'a' * 64,
+    acceptedBy: const {},
+    rejectedBy: const {'wss://a': 'blocked: spam'},
+    noResponseFrom: const {},
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+    registerFallbackValue(const RetryPolicy());
+    registerFallbackValue(const Duration(seconds: 5));
+  });
+
+  group('NIP17MessageService reliability', () {
+    late NIP17MessageService service;
+    late _MockNostrClient nostrClient;
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      service = NIP17MessageService(
+        signer: LocalNostrSigner(_testPrivateKey),
+        senderPublicKey: _testPublicKey,
+        nostrService: nostrClient,
+      );
+    });
+
+    test(
+      'recipient wrap accepted → success with outcome, targetRelays '
+      'forwarded',
+      () async {
+        when(
+          () => nostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _acceptedOutcome());
+
+        when(
+          () => nostrClient.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _acceptedOutcome());
+
+        final result = await service.sendPrivateMessage(
+          recipientPubkey: _recipientPubkey,
+          content: 'hi',
+          recipientDmRelays: const ['wss://dm.example'],
+        );
+
+        expect(result.success, isTrue);
+        expect(result.outcome, isNotNull);
+        expect(result.outcome!.acceptedByAny, isTrue);
+
+        // targetRelays must be forwarded for the recipient wrap.
+        final captured = verify(
+          () => nostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: captureAny(named: 'targetRelays'),
+          ),
+        ).captured;
+        expect(captured.single, equals(['wss://dm.example']));
+      },
+    );
+
+    test(
+      'recipient wrap all-no-response → failure with transient outcome',
+      () async {
+        when(
+          () => nostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _transientFailure());
+
+        final result = await service.sendPrivateMessage(
+          recipientPubkey: _recipientPubkey,
+          content: 'hi',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.outcome, isNotNull);
+        expect(result.outcome!.acceptedByAny, isFalse);
+        expect(result.outcome!.transientRelays, isNotEmpty);
+
+        // Self-wrap must NOT be attempted when recipient wrap failed.
+        verifyNever(
+          () => nostrClient.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'recipient wrap permanently rejected → failure non-retryable',
+      () async {
+        when(
+          () => nostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _permanentRejection());
+
+        final result = await service.sendPrivateMessage(
+          recipientPubkey: _recipientPubkey,
+          content: 'hi',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.outcome!.rejectedBy.values.first, contains('blocked'));
+      },
+    );
+
+    test(
+      'self-wrap failure does NOT fail overall send',
+      () async {
+        when(
+          () => nostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _acceptedOutcome());
+
+        // Self-wrap returns a transient failure outcome.
+        when(
+          () => nostrClient.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _transientFailure());
+
+        final result = await service.sendPrivateMessage(
+          recipientPubkey: _recipientPubkey,
+          content: 'hi',
+        );
+
+        // Overall send is still a success because the recipient wrap
+        // was delivered. Self-wrap is best-effort.
+        expect(result.success, isTrue);
+      },
+    );
+
+    test(
+      'self-wrap exception does NOT fail overall send',
+      () async {
+        when(
+          () => nostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => _acceptedOutcome());
+
+        when(
+          () => nostrClient.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenThrow(Exception('network down'));
+
+        final result = await service.sendPrivateMessage(
+          recipientPubkey: _recipientPubkey,
+          content: 'hi',
+        );
+
+        expect(result.success, isTrue);
+      },
+    );
+
+    // The 5s timeout for self-wrap is enforced directly in
+    // sendPrivateMessage — verified by reading the source rather than
+    // mocking here, because synthetic test pubkeys can't be used as
+    // valid secp256k1 points and the self-wrap creation step
+    // (GiftWrapUtil.getGiftWrapEvent for the sender) throws before
+    // publishEventAwaitOk is reached.
+  });
+}

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -17,6 +17,24 @@ class _MockNostrSigner extends Mock implements NostrSigner {}
 
 class _FakeEvent extends Fake implements Event {}
 
+PublishOutcome _acceptedOutcome(String eventId) {
+  return PublishOutcome(
+    eventId: eventId,
+    acceptedBy: const {'wss://relay.example'},
+    rejectedBy: const {},
+    noResponseFrom: const {},
+  );
+}
+
+PublishOutcome _rejectedOutcome(String eventId) {
+  return PublishOutcome(
+    eventId: eventId,
+    acceptedBy: const {},
+    rejectedBy: const {},
+    noResponseFrom: const {'wss://relay.example'},
+  );
+}
+
 // Valid 64-character hex keys for testing.
 const _testPrivateKey =
     '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
@@ -28,11 +46,41 @@ const _recipientPubkey =
 void main() {
   setUpAll(() {
     registerFallbackValue(_FakeEvent());
+    registerFallbackValue(const RetryPolicy());
+    registerFallbackValue(const Duration(seconds: 5));
   });
 
   group(NIP17MessageService, () {
     late NIP17MessageService service;
     late _MockNostrClient mockNostrClient;
+
+    /// Stubs `publishEventWithRetry` (recipient wrap) and
+    /// `publishEventAwaitOk` (self wrap). Callers may override either.
+    void stubPublish({
+      PublishOutcome Function(Event)? recipientOutcome,
+      PublishOutcome Function(Event)? selfOutcome,
+    }) {
+      when(
+        () => mockNostrClient.publishEventWithRetry(
+          any(),
+          policy: any(named: 'policy'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        final event = invocation.positionalArguments[0] as Event;
+        return recipientOutcome?.call(event) ?? _acceptedOutcome(event.id);
+      });
+      when(
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((invocation) async {
+        final event = invocation.positionalArguments[0] as Event;
+        return selfOutcome?.call(event) ?? _acceptedOutcome(event.id);
+      });
+    }
 
     setUp(() {
       mockNostrClient = _MockNostrClient();
@@ -50,9 +98,7 @@ void main() {
 
     group('sendPrivateMessage', () {
       test('returns success with gift wrap event details', () async {
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async => invocation.positionalArguments[0] as Event,
-        );
+        stubPublish();
 
         final result = await service.sendPrivateMessage(
           recipientPubkey: _recipientPubkey,
@@ -65,21 +111,31 @@ void main() {
         expect(result.recipientPubkey, equals(_recipientPubkey));
         expect(result.error, isNull);
 
-        // At least the recipient gift wrap is published; self-wrap may
-        // silently fail with synthetic test keys.
-        verify(() => mockNostrClient.publishEvent(any())).called(
-          greaterThanOrEqualTo(1),
-        );
+        // At least the recipient gift wrap is published via the retry
+        // path; self-wrap may silently fail (synthetic test keys fail
+        // EC point validation before publishEventAwaitOk is called).
+        verify(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
       });
 
       test('creates gift wrap with kind 1059', () async {
         Event? capturedEvent;
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async {
-            return capturedEvent = invocation.positionalArguments[0] as Event;
-          },
-        );
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedEvent = invocation.positionalArguments[0] as Event;
+          return _acceptedOutcome(capturedEvent!.id);
+        });
 
         await service.sendPrivateMessage(
           recipientPubkey: _recipientPubkey,
@@ -93,11 +149,16 @@ void main() {
       test('includes p tag with recipient pubkey', () async {
         Event? capturedEvent;
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async {
-            return capturedEvent = invocation.positionalArguments[0] as Event;
-          },
-        );
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedEvent = invocation.positionalArguments[0] as Event;
+          return _acceptedOutcome(capturedEvent!.id);
+        });
 
         await service.sendPrivateMessage(
           recipientPubkey: _recipientPubkey,
@@ -115,13 +176,17 @@ void main() {
       test('uses random ephemeral key for each gift wrap', () async {
         final capturedEvents = <Event>[];
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async {
-            final event = invocation.positionalArguments[0] as Event;
-            capturedEvents.add(event);
-            return event;
-          },
-        );
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          final event = invocation.positionalArguments[0] as Event;
+          capturedEvents.add(event);
+          return _acceptedOutcome(event.id);
+        });
 
         await service.sendPrivateMessage(
           recipientPubkey: _recipientPubkey,
@@ -132,10 +197,7 @@ void main() {
           content: 'Message 2',
         );
 
-        // At least 2 recipient gift wraps (self-wraps may silently fail
-        // with synthetic test keys that are not valid EC points).
-        expect(capturedEvents.length, greaterThanOrEqualTo(2));
-        // First two events are the recipient gift wraps for each message.
+        expect(capturedEvents.length, equals(2));
         expect(
           capturedEvents[0].pubkey,
           isNot(equals(capturedEvents[1].pubkey)),
@@ -147,11 +209,16 @@ void main() {
       test('obfuscates timestamp with random offset', () async {
         Event? capturedEvent;
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async {
-            return capturedEvent = invocation.positionalArguments[0] as Event;
-          },
-        );
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedEvent = invocation.positionalArguments[0] as Event;
+          return _acceptedOutcome(capturedEvent!.id);
+        });
 
         final beforeSend = DateTime.now().millisecondsSinceEpoch ~/ 1000;
         await service.sendPrivateMessage(
@@ -166,10 +233,18 @@ void main() {
         expect(capturedEvent!.createdAt, lessThan(afterSend));
       });
 
-      test('returns failure when publish returns null', () async {
+      test('returns failure when recipient wrap is not accepted', () async {
         when(
-          () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => null);
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer(
+          (invocation) async => _rejectedOutcome(
+            (invocation.positionalArguments[0] as Event).id,
+          ),
+        );
 
         final result = await service.sendPrivateMessage(
           recipientPubkey: _recipientPubkey,
@@ -178,16 +253,23 @@ void main() {
 
         expect(result.success, isFalse);
         expect(result.error, contains('publish failed'));
+        expect(result.outcome, isNotNull);
+        expect(result.outcome!.acceptedByAny, isFalse);
       });
 
       test('includes additional tags in the gift wrap', () async {
         Event? capturedEvent;
 
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async {
-            return capturedEvent = invocation.positionalArguments[0] as Event;
-          },
-        );
+        when(
+          () => mockNostrClient.publishEventWithRetry(
+            any(),
+            policy: any(named: 'policy'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((invocation) async {
+          capturedEvent = invocation.positionalArguments[0] as Event;
+          return _acceptedOutcome(capturedEvent!.id);
+        });
 
         await service.sendPrivateMessage(
           recipientPubkey: _recipientPubkey,
@@ -202,9 +284,7 @@ void main() {
       });
 
       test('uses provided eventKind for the rumor', () async {
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async => invocation.positionalArguments[0] as Event,
-        );
+        stubPublish();
 
         final result = await service.sendPrivateMessage(
           recipientPubkey: _recipientPubkey,
@@ -222,18 +302,24 @@ void main() {
       test(
         'returns success even when self-wrap publish throws',
         () async {
-          var callCount = 0;
-          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-            (invocation) async {
-              callCount++;
-              if (callCount == 1) {
-                // Recipient publish succeeds.
-                return invocation.positionalArguments[0] as Event;
-              }
-              // Self-wrap publish throws — should be non-fatal.
-              throw Exception('self-wrap relay error');
-            },
+          when(
+            () => mockNostrClient.publishEventWithRetry(
+              any(),
+              policy: any(named: 'policy'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer(
+            (invocation) async => _acceptedOutcome(
+              (invocation.positionalArguments[0] as Event).id,
+            ),
           );
+          when(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenThrow(Exception('self-wrap relay error'));
 
           final result = await service.sendPrivateMessage(
             recipientPubkey: _recipientPubkey,

--- a/mobile/packages/models/lib/src/nip17_send_result.dart
+++ b/mobile/packages/models/lib/src/nip17_send_result.dart
@@ -1,7 +1,16 @@
 // ABOUTME: Result model for NIP-17 encrypted message sending operations
-// ABOUTME: Indicates success/failure with message event ID and recipient info
+// ABOUTME: Indicates success/failure with message event ID, recipient info,
+// ABOUTME: and optional per-relay publish outcome (for reliability UX).
 
-/// Result of NIP-17 encrypted message sending
+import 'package:nostr_sdk/relay/publish_outcome.dart';
+
+/// Result of NIP-17 encrypted message sending.
+///
+/// Carries the canonical message identifiers on success and, when
+/// available, the per-relay [PublishOutcome] so UI layers can drive
+/// retry affordances via `PublishResultMapper`. [outcome] may be `null`
+/// for pre-publish failures (signer unavailable, encryption failed) or
+/// for codepaths that have not yet migrated to `publishEventWithRetry`.
 class NIP17SendResult {
   const NIP17SendResult({
     required this.success,
@@ -10,24 +19,34 @@ class NIP17SendResult {
     this.recipientPubkey,
     this.error,
     this.timestamp,
+    this.outcome,
   });
 
-  /// Create success result
+  /// Create success result.
+  ///
+  /// [outcome] is optional but strongly recommended for callers that went
+  /// through a reliable publish path so the UI can tell whether the
+  /// message was accepted by every relay vs. a partial-accept.
   factory NIP17SendResult.success({
     required String rumorEventId,
     required String messageEventId,
     required String recipientPubkey,
+    PublishOutcome? outcome,
   }) => NIP17SendResult(
     success: true,
     rumorEventId: rumorEventId,
     messageEventId: messageEventId,
     recipientPubkey: recipientPubkey,
     timestamp: DateTime.now(),
+    outcome: outcome,
   );
 
-  /// Create failure result
-  factory NIP17SendResult.failure(String error) =>
-      NIP17SendResult(success: false, error: error);
+  /// Create failure result.
+  ///
+  /// [outcome] is populated when the failure came from a relay round-trip
+  /// (zero accepts) — omit for pre-publish failures.
+  factory NIP17SendResult.failure(String error, {PublishOutcome? outcome}) =>
+      NIP17SendResult(success: false, error: error, outcome: outcome);
 
   final bool success;
 
@@ -41,6 +60,10 @@ class NIP17SendResult {
   final String? recipientPubkey;
   final String? error;
   final DateTime? timestamp;
+
+  /// Per-relay publish outcome for the recipient gift wrap / kind-4 event.
+  /// `null` when the failure occurred before the relay round-trip.
+  final PublishOutcome? outcome;
 
   @override
   String toString() {

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_reliability_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_reliability_test.dart
@@ -1,0 +1,321 @@
+// ABOUTME: Reliability tests for ConversationBloc pending/failed flow
+// ABOUTME: — per-message sendStatus, feedback propagation, and Retry
+// ABOUTME: event handling.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
+
+class _MockDmRepository extends Mock implements DmRepository {}
+
+PublishOutcome _transientFailure() {
+  return PublishOutcome(
+    eventId: 'a' * 64,
+    acceptedBy: const {},
+    rejectedBy: const {},
+    noResponseFrom: const {'wss://a', 'wss://b'},
+  );
+}
+
+PublishOutcome _permanentRejection() {
+  return PublishOutcome(
+    eventId: 'a' * 64,
+    acceptedBy: const {},
+    rejectedBy: const {'wss://a': 'blocked: spam'},
+    noResponseFrom: const {},
+  );
+}
+
+PublishOutcome _accepted() {
+  return PublishOutcome(
+    eventId: 'a' * 64,
+    acceptedBy: const {'wss://ok'},
+    rejectedBy: const {},
+    noResponseFrom: const {},
+  );
+}
+
+void main() {
+  const conversationId =
+      'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+  const senderPubkey =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  const recipientPubkey =
+      '2222222222222222222222222222222222222222222222222222222222222222';
+  const sentEventId =
+      '6666666666666666666666666666666666666666666666666666666666666666';
+
+  group('ConversationBloc reliability (per-message status)', () {
+    late _MockDmRepository dmRepository;
+
+    setUp(() {
+      dmRepository = _MockDmRepository();
+    });
+
+    ConversationBloc build() => ConversationBloc(
+      dmRepository: dmRepository,
+      conversationId: conversationId,
+      currentUserPubkey: senderPubkey,
+    );
+
+    blocTest<ConversationBloc, ConversationState>(
+      'send success clears per-message sending status '
+      '(optimistic → confirmed via stream)',
+      setUp: () {
+        when(
+          () => dmRepository.sendMessage(
+            recipientPubkey: recipientPubkey,
+            content: 'Hi',
+          ),
+        ).thenAnswer(
+          (_) async => NIP17SendResult.success(
+            rumorEventId: sentEventId,
+            messageEventId: sentEventId,
+            recipientPubkey: recipientPubkey,
+            outcome: _accepted(),
+          ),
+        );
+      },
+      build: build,
+      act: (bloc) => bloc.add(
+        const ConversationMessageSent(
+          recipientPubkeys: [recipientPubkey],
+          content: 'Hi',
+        ),
+      ),
+      expect: () => [
+        // Optimistic: sending row present, bubble icon = clock
+        isA<ConversationState>()
+            .having(
+              (s) => s.sendStatus,
+              'aggregate sendStatus',
+              SendStatus.sending,
+            )
+            .having(
+              (s) => s.sendStatusByMessageId.values,
+              'per-message statuses',
+              [MessageSendStatus.sending],
+            )
+            .having(
+              (s) => s.messages.first.content,
+              'optimistic content',
+              'Hi',
+            ),
+        // Success: per-message status cleared (row awaits stream
+        // confirmation via watchMessages), feedback empty
+        isA<ConversationState>()
+            .having(
+              (s) => s.sendStatus,
+              'aggregate sendStatus',
+              SendStatus.sent,
+            )
+            .having(
+              (s) => s.sendStatusByMessageId,
+              'per-message statuses',
+              isEmpty,
+            )
+            .having(
+              (s) => s.feedbackByMessageId,
+              'feedback',
+              isEmpty,
+            ),
+      ],
+    );
+
+    blocTest<ConversationBloc, ConversationState>(
+      'send failure — transient → per-message failed + retryable feedback',
+      setUp: () {
+        when(
+          () => dmRepository.sendMessage(
+            recipientPubkey: recipientPubkey,
+            content: 'Hi',
+          ),
+        ).thenAnswer(
+          (_) async => NIP17SendResult.failure(
+            'publish failed',
+            outcome: _transientFailure(),
+          ),
+        );
+      },
+      build: build,
+      act: (bloc) => bloc.add(
+        const ConversationMessageSent(
+          recipientPubkeys: [recipientPubkey],
+          content: 'Hi',
+        ),
+      ),
+      expect: () => [
+        isA<ConversationState>()
+            .having(
+              (s) => s.sendStatus,
+              'aggregate',
+              SendStatus.sending,
+            )
+            .having(
+              (s) => s.sendStatusByMessageId.values,
+              'per-message',
+              [MessageSendStatus.sending],
+            ),
+        isA<ConversationState>()
+            .having(
+              (s) => s.sendStatus,
+              'aggregate',
+              SendStatus.failed,
+            )
+            .having(
+              (s) => s.sendStatusByMessageId.values,
+              'per-message',
+              [MessageSendStatus.failed],
+            )
+            .having(
+              (s) => s.feedbackByMessageId.values.first.retryable,
+              'retryable',
+              isTrue,
+            )
+            .having(
+              (s) => s.feedbackByMessageId.values.first.messageKey,
+              'messageKey',
+              'publish_no_relay_response',
+            ),
+      ],
+      errors: () => [isA<Exception>()],
+    );
+
+    blocTest<ConversationBloc, ConversationState>(
+      'send failure — permanent rejection → non-retryable feedback '
+      'with rejection reason surfaced',
+      setUp: () {
+        when(
+          () => dmRepository.sendMessage(
+            recipientPubkey: recipientPubkey,
+            content: 'Hi',
+          ),
+        ).thenAnswer(
+          (_) async => NIP17SendResult.failure(
+            'rejected',
+            outcome: _permanentRejection(),
+          ),
+        );
+      },
+      build: build,
+      act: (bloc) => bloc.add(
+        const ConversationMessageSent(
+          recipientPubkeys: [recipientPubkey],
+          content: 'Hi',
+        ),
+      ),
+      skip: 1, // skip sending state
+      expect: () => [
+        isA<ConversationState>()
+            .having(
+              (s) => s.feedbackByMessageId.values.first.retryable,
+              'retryable',
+              isFalse,
+            )
+            .having(
+              (s) => s.feedbackByMessageId.values.first.firstRejectionReason,
+              'rejection reason',
+              contains('blocked'),
+            ),
+      ],
+      errors: () => [isA<Exception>()],
+    );
+
+    blocTest<ConversationBloc, ConversationState>(
+      'retry clears failure feedback and flips bubble back to sending',
+      setUp: () {
+        // First call fails transient, retry succeeds.
+        var callCount = 0;
+        when(
+          () => dmRepository.sendMessage(
+            recipientPubkey: recipientPubkey,
+            content: 'Hi',
+          ),
+        ).thenAnswer((_) async {
+          callCount++;
+          if (callCount == 1) {
+            return NIP17SendResult.failure(
+              'transient',
+              outcome: _transientFailure(),
+            );
+          }
+          return NIP17SendResult.success(
+            rumorEventId: sentEventId,
+            messageEventId: sentEventId,
+            recipientPubkey: recipientPubkey,
+            outcome: _accepted(),
+          );
+        });
+      },
+      build: build,
+      act: (bloc) async {
+        bloc.add(
+          const ConversationMessageSent(
+            recipientPubkeys: [recipientPubkey],
+            content: 'Hi',
+          ),
+        );
+        // Let the first send finish (sending → failed).
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        // Grab the pending id off the current state and retry it.
+        final pendingId = bloc.state.sendStatusByMessageId.keys.first;
+        bloc.add(
+          ConversationMessageRetried(
+            pendingId: pendingId,
+            recipientPubkeys: const [recipientPubkey],
+            content: 'Hi',
+          ),
+        );
+      },
+      wait: const Duration(milliseconds: 100),
+      verify: (bloc) {
+        // After retry success, per-message status is cleared and
+        // feedback is gone.
+        expect(bloc.state.sendStatusByMessageId, isEmpty);
+        expect(bloc.state.feedbackByMessageId, isEmpty);
+        verify(
+          () => dmRepository.sendMessage(
+            recipientPubkey: recipientPubkey,
+            content: 'Hi',
+          ),
+        ).called(2);
+      },
+      errors: () => [isA<Exception>()],
+    );
+
+    blocTest<ConversationBloc, ConversationState>(
+      'exception thrown by repository marks pending-id failed '
+      'with generic retryable feedback',
+      setUp: () {
+        when(
+          () => dmRepository.sendMessage(
+            recipientPubkey: recipientPubkey,
+            content: 'Hi',
+          ),
+        ).thenThrow(Exception('network down'));
+      },
+      build: build,
+      act: (bloc) => bloc.add(
+        const ConversationMessageSent(
+          recipientPubkeys: [recipientPubkey],
+          content: 'Hi',
+        ),
+      ),
+      verify: (bloc) {
+        expect(
+          bloc.state.sendStatusByMessageId.values,
+          [MessageSendStatus.failed],
+        );
+        expect(
+          bloc.state.feedbackByMessageId.values.first.retryable,
+          isTrue,
+        );
+      },
+      errors: () => [isA<Exception>()],
+    );
+  });
+}

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -9,6 +9,7 @@ import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
 
 class _MockDmRepository extends Mock implements DmRepository {}
@@ -804,6 +805,8 @@ void main() {
           ConversationStatus.initial,
           <DmMessage>[],
           SendStatus.idle,
+          <String, MessageSendStatus>{},
+          <String, PublishUserFeedback>{},
         ]),
       );
     });

--- a/mobile/test/screens/inbox/conversation/conversation_view_send_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_send_test.dart
@@ -1,0 +1,213 @@
+// ABOUTME: Widget tests for the ConversationView send/fail/retry visuals
+// ABOUTME: — pending clock, failed alert icon, and Retry event dispatch.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/inbox/conversation/conversation_view.dart';
+
+import '../../../helpers/test_provider_overrides.dart';
+
+class _MockConversationBloc
+    extends MockBloc<ConversationEvent, ConversationState>
+    implements ConversationBloc {}
+
+class _MockAuthService extends MockAuthService {
+  _MockAuthService(this._pubkey);
+  final String _pubkey;
+
+  @override
+  String? get currentPublicKeyHex => _pubkey;
+}
+
+void main() {
+  const currentPubkey =
+      'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+  const otherPubkey =
+      '1122334411223344112233441122334411223344112233441122334411223344';
+  const pendingId = 'pending-1700000000-abc';
+
+  setUpAll(() {
+    registerFallbackValue(
+      const ConversationMessageRetried(
+        pendingId: pendingId,
+        recipientPubkeys: [otherPubkey],
+        content: 'Hi',
+      ),
+    );
+  });
+
+  group('ConversationView send visuals', () {
+    late _MockConversationBloc mockBloc;
+    late _MockAuthService mockAuthService;
+
+    setUp(() {
+      mockBloc = _MockConversationBloc();
+      mockAuthService = _MockAuthService(currentPubkey);
+    });
+
+    Widget buildSubject(ConversationState state) {
+      whenListen(
+        mockBloc,
+        Stream<ConversationState>.value(state),
+        initialState: state,
+      );
+
+      return testMaterialApp(
+        mockAuthService: mockAuthService,
+        additionalOverrides: [
+          fetchUserProfileProvider(otherPubkey).overrideWith(
+            (ref) async => null,
+          ),
+        ],
+        home: BlocProvider<ConversationBloc>.value(
+          value: mockBloc,
+          child: const ConversationView(
+            participantPubkeys: [otherPubkey],
+          ),
+        ),
+      );
+    }
+
+    DmMessage optimisticMessage() => const DmMessage(
+      id: pendingId,
+      conversationId: 'conv',
+      senderPubkey: currentPubkey,
+      content: 'Hi',
+      createdAt: 1700000000,
+      giftWrapId: pendingId,
+    );
+
+    testWidgets(
+      'pending message shows the clock icon',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(
+            ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [optimisticMessage()],
+              sendStatusByMessageId: const {
+                pendingId: MessageSendStatus.sending,
+              },
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byIcon(Icons.schedule), findsOneWidget);
+        expect(find.byIcon(Icons.error_outline), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'failed message shows the red alert icon',
+      (tester) async {
+        const feedback = PublishUserFeedback(
+          severity: PublishSeverity.error,
+          messageKey: 'publish_no_relay_response',
+          retryable: true,
+        );
+        await tester.pumpWidget(
+          buildSubject(
+            ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [optimisticMessage()],
+              sendStatusByMessageId: const {
+                pendingId: MessageSendStatus.failed,
+              },
+              feedbackByMessageId: const {pendingId: feedback},
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byIcon(Icons.error_outline), findsOneWidget);
+        expect(find.byIcon(Icons.schedule), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'tapping the failed icon dispatches ConversationMessageRetried',
+      (tester) async {
+        const feedback = PublishUserFeedback(
+          severity: PublishSeverity.error,
+          messageKey: 'publish_no_relay_response',
+          retryable: true,
+        );
+        await tester.pumpWidget(
+          buildSubject(
+            ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [optimisticMessage()],
+              sendStatusByMessageId: const {
+                pendingId: MessageSendStatus.failed,
+              },
+              feedbackByMessageId: const {pendingId: feedback},
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.byIcon(Icons.error_outline));
+        await tester.pump();
+
+        verify(
+          () => mockBloc.add(
+            any(
+              that: isA<ConversationMessageRetried>()
+                  .having(
+                    (e) => e.pendingId,
+                    'pendingId',
+                    pendingId,
+                  )
+                  .having(
+                    (e) => e.content,
+                    'content',
+                    'Hi',
+                  )
+                  .having(
+                    (e) => e.recipientPubkeys,
+                    'recipients',
+                    [otherPubkey],
+                  ),
+            ),
+          ),
+        ).called(1);
+      },
+    );
+
+    testWidgets(
+      'received (incoming) message has no status icon even if a stale '
+      'entry is in sendStatusByMessageId',
+      (tester) async {
+        const incoming = DmMessage(
+          id: 'incoming1',
+          conversationId: 'conv',
+          senderPubkey: otherPubkey,
+          content: 'hey',
+          createdAt: 1700000001,
+          giftWrapId: 'gw-incoming',
+        );
+
+        await tester.pumpWidget(
+          buildSubject(
+            const ConversationState(
+              status: ConversationStatus.loaded,
+              messages: [incoming],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byIcon(Icons.schedule), findsNothing);
+        expect(find.byIcon(Icons.error_outline), findsNothing);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #3193

## Summary

PR 6 of the reliable-nostr-publish series. Fixes the highest-stakes silent-drop in the app: a DM that local UI shows as sent can today land on zero relays, so the recipient never gets it.

- **Recipient NIP-17 gift wrap** now publishes via `publishEventWithRetry` and the overall `NIP17SendResult` only reports success when at least one relay accepts it (`PublishOutcome.acceptedByAny`). `recipientDmRelays` parameter threads the recipient's kind-10050 list into `targetRelays` so gift wraps go where NIP-17 routes them.
- **Self-wrap** stays best-effort: uses `publishEventAwaitOk` with a 5s timeout for telemetry, never retries, and never fails the overall send. Losing multi-device sync is a smaller penalty than making the sender wait.
- **NIP-04 fallback** uses `publishEventWithRetry`; the call site stays unawaited so a failed kind-4 can never regress the already-successful NIP-17 leg.
- **Kind 5 deletion** (Delete for Everyone) uses `publishEventWithRetry` and throws `DmPublishFailure` when no relay accepts. Local soft-delete is only applied on `acceptedByAny`, so a failed delete leaves the message visible for retry — never hidden-with-pending-delete.
- **BLoC/UI** adds per-message `sendStatusByMessageId` (`sending` / `sent` / `failed`) and `feedbackByMessageId` (`PublishUserFeedback`). Optimistic insertion preserves chronological order by local `created_at`. A new `ConversationMessageRetried` event re-runs the send without retyping. Message bubble now renders a grey clock while sending and a red alert (with Retry tap) when failed — per `.claude/rules/state_management.md`, feedback lives in an object, never error strings in state.

## Contract highlights

- Recipient wrap MUST be accepted by at least one relay for the send to count as successful. A failure in the self-wrap alone is not enough to satisfy the contract.
- Deletion gates local hide on `acceptedByAny`.
- Optimistic rows persist across failure so the user can retry without retyping.

## Test plan

- [x] `flutter test packages/dm_repository/test` — 187 tests pass
- [x] `flutter test test/blocs/dm test/screens/inbox packages/dm_repository/test` — 461 tests pass
- [x] `flutter analyze` clean on touched files (pre-commit hook enforces)
- [ ] Manual smoke against local stack: send a DM → kill recipient relay mid-send → verify failed status + Retry works
- [ ] Manual: delete a message → verify visible until relay OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)