### PR TITLE
chore(nostr-publish): deprecate NIP-04 share, annotate intentional fire-and-forget

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -2006,19 +2006,18 @@ Future<MuteService> muteService(Ref ref) async {
   );
 }
 
-/// Video sharing service
+/// Video sharing service (NIP-17 gift-wrapped DMs only).
 ///
-/// When a [DmRepository] is available the service sends videos via NIP-17
-/// encrypted DMs (NIP-17). Otherwise falls back to NIP-04 kind 4.
+/// The deprecated NIP-04 fallback was removed as part of the
+/// reliable-nostr-publish cleanup. See
+/// docs/superpowers/plans/2026-04-20-reliable-nostr-publish-pr8-cleanup.md.
 @riverpod
 VideoSharingService videoSharingService(Ref ref) {
-  final nostrService = ref.watch(nostrServiceProvider);
   final authService = ref.watch(authServiceProvider);
   final profileRepository = ref.watch(profileRepositoryProvider);
   final dmRepository = ref.watch(dmRepositoryProvider);
 
   return VideoSharingService(
-    nostrService: nostrService,
     authService: authService,
     profileRepository: profileRepository!,
     dmRepository: dmRepository,

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -4128,18 +4128,20 @@ final class MuteServiceProvider
 
 String _$muteServiceHash() => r'a7faf00b4fe5d420db0bff450d444db5aa5d4934';
 
-/// Video sharing service
+/// Video sharing service (NIP-17 gift-wrapped DMs only).
 ///
-/// When a [DmRepository] is available the service sends videos via NIP-17
-/// encrypted DMs (NIP-17). Otherwise falls back to NIP-04 kind 4.
+/// The deprecated NIP-04 fallback was removed as part of the
+/// reliable-nostr-publish cleanup. See
+/// docs/superpowers/plans/2026-04-20-reliable-nostr-publish-pr8-cleanup.md.
 
 @ProviderFor(videoSharingService)
 const videoSharingServiceProvider = VideoSharingServiceProvider._();
 
-/// Video sharing service
+/// Video sharing service (NIP-17 gift-wrapped DMs only).
 ///
-/// When a [DmRepository] is available the service sends videos via NIP-17
-/// encrypted DMs (NIP-17). Otherwise falls back to NIP-04 kind 4.
+/// The deprecated NIP-04 fallback was removed as part of the
+/// reliable-nostr-publish cleanup. See
+/// docs/superpowers/plans/2026-04-20-reliable-nostr-publish-pr8-cleanup.md.
 
 final class VideoSharingServiceProvider
     extends
@@ -4149,10 +4151,11 @@ final class VideoSharingServiceProvider
           VideoSharingService
         >
     with $Provider<VideoSharingService> {
-  /// Video sharing service
+  /// Video sharing service (NIP-17 gift-wrapped DMs only).
   ///
-  /// When a [DmRepository] is available the service sends videos via NIP-17
-  /// encrypted DMs (NIP-17). Otherwise falls back to NIP-04 kind 4.
+  /// The deprecated NIP-04 fallback was removed as part of the
+  /// reliable-nostr-publish cleanup. See
+  /// docs/superpowers/plans/2026-04-20-reliable-nostr-publish-pr8-cleanup.md.
   const VideoSharingServiceProvider._()
     : super(
         from: null,
@@ -4188,7 +4191,7 @@ final class VideoSharingServiceProvider
 }
 
 String _$videoSharingServiceHash() =>
-    r'4c869ac60484c15c6c196f164af34d658d9f2cac';
+    r'886c91da195c5a1f8d115ca21f95e8dca64085de';
 
 /// Content deletion service for NIP-09 delete events
 

--- a/mobile/lib/services/corrupted_video_repair_service.dart
+++ b/mobile/lib/services/corrupted_video_repair_service.dart
@@ -123,6 +123,11 @@ class CorruptedVideoRepairService {
         continue;
       }
 
+      // Fire-and-forget by design: video repair is best-effort background
+      // cleanup. A failed repair re-runs on the next cycle; going through
+      // publishEventWithRetry would amplify relay load without any user
+      // benefit (the user never sees this path run). See
+      // docs/superpowers/plans/2026-04-20-reliable-nostr-publish-pr8-cleanup.md.
       final sent = await _nostrClient.publishEvent(signedEvent);
       if (sent != null) {
         repairedCount++;

--- a/mobile/lib/services/push_notification_service.dart
+++ b/mobile/lib/services/push_notification_service.dart
@@ -117,6 +117,11 @@ class PushNotificationService {
       return;
     }
 
+    // Push service events are ephemeral hand-offs to the divine push relay.
+    // Delivery retry is managed by the push relay's own retry queue, not
+    // the client; using publishEventWithRetry here would duplicate that
+    // retry logic. See
+    // docs/superpowers/plans/2026-04-20-reliable-nostr-publish-pr8-cleanup.md.
     final published = await _nostrClient.publishEvent(event);
     if (published == null) {
       Log.error(
@@ -179,6 +184,11 @@ class PushNotificationService {
       return;
     }
 
+    // Push service events are ephemeral hand-offs to the divine push relay.
+    // Delivery retry is managed by the push relay's own retry queue, not
+    // the client; using publishEventWithRetry here would duplicate that
+    // retry logic. See
+    // docs/superpowers/plans/2026-04-20-reliable-nostr-publish-pr8-cleanup.md.
     final published = await _nostrClient.publishEvent(event);
     if (published == null) {
       Log.error(
@@ -273,6 +283,11 @@ class PushNotificationService {
       return;
     }
 
+    // Push service events are ephemeral hand-offs to the divine push relay.
+    // Delivery retry is managed by the push relay's own retry queue, not
+    // the client; using publishEventWithRetry here would duplicate that
+    // retry logic. See
+    // docs/superpowers/plans/2026-04-20-reliable-nostr-publish-pr8-cleanup.md.
     final published = await _nostrClient.publishEvent(event);
     if (published == null) {
       Log.error(

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -1,11 +1,10 @@
-// ABOUTME: Service for sharing videos with other users via Nostr DMs and social features
+// ABOUTME: Service for sharing videos with other users via Nostr NIP-17 DMs
 // ABOUTME: Handles sending videos to specific users and managing sharing options
 
 import 'dart:async';
 
 import 'package:dm_repository/dm_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
-import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -65,22 +64,24 @@ class ShareResult {
       ShareResult(success: false, error: error);
 }
 
-/// Service for sharing videos with other users
-/// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
+/// Service for sharing videos with other users via NIP-17 gift-wrapped DMs.
+///
+/// This service is NIP-17-only. The deprecated NIP-04 fallback (kind 4)
+/// was removed as part of the reliable-nostr-publish cleanup — see
+/// docs/superpowers/plans/2026-04-20-reliable-nostr-publish-pr8-cleanup.md.
+/// All publishing now flows through [DmRepository.sendMessage], which builds
+/// the NIP-17 gift-wrap envelope and delegates to the shared publish path.
 class VideoSharingService {
   VideoSharingService({
-    required NostrClient nostrService,
     required AuthService authService,
     required ProfileRepository profileRepository,
-    DmRepository? dmRepository,
-  }) : _nostrService = nostrService,
-       _authService = authService,
+    required DmRepository dmRepository,
+  }) : _authService = authService,
        _profileRepository = profileRepository,
        _dmRepository = dmRepository;
-  final NostrClient _nostrService;
   final AuthService _authService;
   final ProfileRepository _profileRepository;
-  final DmRepository? _dmRepository;
+  final DmRepository _dmRepository;
 
   final List<ShareableUser> _recentlySharedWith = [];
   final Map<String, DateTime> _shareHistory = {};
@@ -89,11 +90,7 @@ class VideoSharingService {
   List<ShareableUser> get recentlySharedWith =>
       List.unmodifiable(_recentlySharedWith);
 
-  /// Share a video with a specific user via Nostr DM.
-  ///
-  /// When a [DmRepository] is available (user is authenticated with NIP-17),
-  /// uses gift-wrapped encrypted DMs (kind 14/13/1059). Otherwise falls back
-  /// to legacy NIP-04 encrypted DMs (kind 4).
+  /// Share a video with a specific user via Nostr NIP-17 gift-wrapped DM.
   Future<ShareResult> shareVideoWithUser({
     required VideoEvent video,
     required String recipientPubkey,
@@ -112,17 +109,7 @@ class VideoSharingService {
 
       final dmContent = _createShareMessage(video, personalMessage);
 
-      // Prefer NIP-17 when DmRepository is available
-      if (_dmRepository != null) {
-        return _shareViaNip17(
-          recipientPubkey: recipientPubkey,
-          content: dmContent,
-        );
-      }
-
-      // Fallback to NIP-04 (legacy)
-      return _shareViaNip04(
-        video: video,
+      return _shareViaNip17(
         recipientPubkey: recipientPubkey,
         content: dmContent,
       );
@@ -140,8 +127,7 @@ class VideoSharingService {
     required String recipientPubkey,
     required String content,
   }) async {
-    final dmRepo = _dmRepository!;
-    final result = await dmRepo.sendMessage(
+    final result = await _dmRepository.sendMessage(
       recipientPubkey: recipientPubkey,
       content: content,
     );
@@ -150,7 +136,7 @@ class VideoSharingService {
       _shareHistory[recipientPubkey] = DateTime.now();
       await _updateRecentlySharedWith(recipientPubkey);
 
-      final participants = [dmRepo.userPubkey, recipientPubkey]..sort();
+      final participants = [_dmRepository.userPubkey, recipientPubkey]..sort();
       final conversationId = DmRepository.computeConversationId(participants);
 
       Log.info(
@@ -168,45 +154,6 @@ class VideoSharingService {
     return ShareResult.failure(
       result.error ?? 'Failed to send NIP-17 message',
     );
-  }
-
-  Future<ShareResult> _shareViaNip04({
-    required VideoEvent video,
-    required String recipientPubkey,
-    required String content,
-  }) async {
-    final tags = <List<String>>[
-      ['p', recipientPubkey],
-      ['client', 'diVine'],
-      ['e', video.id],
-    ];
-
-    final event = await _authService.createAndSignEvent(
-      kind: 4,
-      content: content,
-      tags: tags,
-    );
-
-    if (event == null) {
-      return ShareResult.failure('Failed to create share message');
-    }
-
-    final sentEvent = await _nostrService.publishEvent(event);
-
-    if (sentEvent != null) {
-      _shareHistory[recipientPubkey] = DateTime.now();
-      await _updateRecentlySharedWith(recipientPubkey);
-
-      Log.info(
-        'Video shared via NIP-04: ${event.id}',
-        name: 'VideoSharingService',
-        category: LogCategory.video,
-      );
-
-      return ShareResult.createSuccess(event.id);
-    }
-
-    return ShareResult.failure('Failed to publish share message');
   }
 
   /// Share video to multiple users at once

--- a/mobile/lib/services/view_event_publisher.dart
+++ b/mobile/lib/services/view_event_publisher.dart
@@ -176,7 +176,11 @@ class ViewEventPublisher {
         return false;
       }
 
-      // Publish to relays (fire-and-forget for ephemeral events)
+      // Kind 22236 view analytics are NIP-01 ephemeral events. Relays are
+      // not required to OK them, and client-side retry would skew
+      // analytics by publishing duplicates. Fire-and-forget is the
+      // contract. See
+      // docs/superpowers/plans/2026-04-20-reliable-nostr-publish-pr8-cleanup.md.
       final sentEvent = await _nostrService.publishEvent(event);
 
       if (sentEvent != null) {
@@ -281,6 +285,11 @@ class ViewEventPublisher {
         return false;
       }
 
+      // Kind 22236 view analytics are NIP-01 ephemeral events. Relays are
+      // not required to OK them, and client-side retry would skew
+      // analytics by publishing duplicates. Fire-and-forget is the
+      // contract. See
+      // docs/superpowers/plans/2026-04-20-reliable-nostr-publish-pr8-cleanup.md.
       final sentEvent = await _nostrService.publishEvent(event);
 
       if (sentEvent != null) {

--- a/mobile/test/services/video_sharing_service_test.dart
+++ b/mobile/test/services/video_sharing_service_test.dart
@@ -1,18 +1,14 @@
-// ABOUTME: Tests for VideoSharingService social features integration
-// ABOUTME: Covers NIP-17 share path, NIP-04 fallback, getShareableUsers,
-// ABOUTME: searchUsersToShareWith, shareVideoWithUser, and sharing utilities.
+// ABOUTME: Tests for VideoSharingService NIP-17 share flow
+// ABOUTME: Covers shareVideoWithUser, getShareableUsers,
+// ABOUTME: searchUsersToShareWith, and sharing utilities.
 
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
-import 'package:nostr_client/nostr_client.dart';
-import 'package:nostr_sdk/event.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:profile_repository/profile_repository.dart';
-
-class _MockNostrClient extends Mock implements NostrClient {}
 
 class _MockAuthService extends Mock implements AuthService {}
 
@@ -26,26 +22,41 @@ const _testPubkey =
 const _recipientPubkey =
     'b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3';
 
+NIP17SendResult _successResult() => NIP17SendResult.success(
+  rumorEventId: 'nip17-rumor-id',
+  messageEventId: 'nip17-msg-id',
+  recipientPubkey: _recipientPubkey,
+);
+
+VideoEvent _video({String? title}) {
+  final now = DateTime.now();
+  return VideoEvent(
+    id: 'video1',
+    pubkey: _testPubkey,
+    createdAt: now.millisecondsSinceEpoch ~/ 1000,
+    timestamp: now,
+    content: 'Test video',
+    title: title,
+  );
+}
+
 void main() {
   late VideoSharingService service;
-  late _MockNostrClient mockNostrService;
   late _MockAuthService mockAuthService;
   late _MockProfileRepository mockProfileRepository;
-
-  setUpAll(() {
-    registerFallbackValue(Event(_testPubkey, 4, <List<String>>[], ''));
-  });
+  late _MockDmRepository mockDmRepository;
 
   setUp(() {
-    mockNostrService = _MockNostrClient();
     mockAuthService = _MockAuthService();
     mockProfileRepository = _MockProfileRepository();
+    mockDmRepository = _MockDmRepository();
 
-    // Default: no DmRepository (NIP-04 fallback path)
+    when(() => mockDmRepository.userPubkey).thenReturn(_testPubkey);
+
     service = VideoSharingService(
-      nostrService: mockNostrService,
       authService: mockAuthService,
       profileRepository: mockProfileRepository,
+      dmRepository: mockDmRepository,
     );
   });
 
@@ -57,20 +68,13 @@ void main() {
     });
 
     test('returns recently shared users after sharing', () async {
-      // Arrange - set up successful share
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
       when(
-        () => mockAuthService.createAndSignEvent(
-          kind: any(named: 'kind'),
+        () => mockDmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
-          tags: any(named: 'tags'),
         ),
-      ).thenAnswer(
-        (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
-      );
-      when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
-      );
+      ).thenAnswer((_) async => _successResult());
       when(
         () => mockProfileRepository.fetchFreshProfile(
           pubkey: _recipientPubkey,
@@ -86,24 +90,13 @@ void main() {
         ),
       );
 
-      final now = DateTime.now();
-      final testVideo = VideoEvent(
-        id: 'video1',
-        pubkey: _testPubkey,
-        createdAt: now.millisecondsSinceEpoch ~/ 1000,
-        timestamp: now,
-        content: 'Test video',
-      );
-
-      // Act - share a video, which populates recently shared list
       await service.shareVideoWithUser(
-        video: testVideo,
+        video: _video(),
         recipientPubkey: _recipientPubkey,
       );
 
       final result = await service.getShareableUsers();
 
-      // Assert
       expect(result, hasLength(1));
       expect(result[0].pubkey, _recipientPubkey);
       expect(result[0].displayName, 'Alice');
@@ -111,48 +104,29 @@ void main() {
     });
 
     test('respects limit parameter', () async {
-      // Arrange - share with multiple users
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
       when(
-        () => mockAuthService.createAndSignEvent(
-          kind: any(named: 'kind'),
+        () => mockDmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
-          tags: any(named: 'tags'),
         ),
-      ).thenAnswer(
-        (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
-      );
-      when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
-      );
+      ).thenAnswer((_) async => _successResult());
       when(
         () => mockProfileRepository.fetchFreshProfile(
           pubkey: any(named: 'pubkey'),
         ),
       ).thenAnswer((_) async => null);
 
-      final now = DateTime.now();
-      final testVideo = VideoEvent(
-        id: 'video1',
-        pubkey: _testPubkey,
-        createdAt: now.millisecondsSinceEpoch ~/ 1000,
-        timestamp: now,
-        content: 'Test video',
-      );
-
-      // Share with 6 users to exceed the limit of 5 recent
       for (var i = 0; i < 6; i++) {
         final hexI = i.toRadixString(16).padLeft(64, '0');
         await service.shareVideoWithUser(
-          video: testVideo,
+          video: _video(),
           recipientPubkey: hexI,
         );
       }
 
-      // Act - request with limit 3
       final result = await service.getShareableUsers(limit: 3);
 
-      // Assert - getShareableUsers takes up to 5 recent, then limits
       expect(result.length, 3);
     });
   });
@@ -201,8 +175,6 @@ void main() {
 
         final result = await service.searchUsersToShareWith(hexPubkey);
 
-        // Implementation always returns a ShareableUser for hex pubkeys,
-        // even when profile is null
         expect(result, hasLength(1));
         expect(result[0].pubkey, hexPubkey);
         expect(result[0].displayName, isNull);
@@ -210,14 +182,12 @@ void main() {
     );
 
     test('returns empty list for non-hex text queries', () async {
-      // Name-based search is not yet implemented
       final result = await service.searchUsersToShareWith('alice');
 
       expect(result, isEmpty);
     });
 
     test('returns empty list for short hex-like queries', () async {
-      // Must be exactly 64 chars to be treated as a pubkey
       final result = await service.searchUsersToShareWith('abcdef');
 
       expect(result, isEmpty);
@@ -228,15 +198,8 @@ void main() {
     test('returns failure when user is not authenticated', () async {
       when(() => mockAuthService.isAuthenticated).thenReturn(false);
 
-      final now = DateTime.now();
       final result = await service.shareVideoWithUser(
-        video: VideoEvent(
-          id: 'video1',
-          pubkey: _testPubkey,
-          createdAt: now.millisecondsSinceEpoch ~/ 1000,
-          timestamp: now,
-          content: 'Test',
-        ),
+        video: _video(),
         recipientPubkey: _recipientPubkey,
       );
 
@@ -244,146 +207,22 @@ void main() {
       expect(result.error, contains('not authenticated'));
     });
 
-    test('returns failure when event creation fails', () async {
-      when(() => mockAuthService.isAuthenticated).thenReturn(true);
-      when(
-        () => mockAuthService.createAndSignEvent(
-          kind: any(named: 'kind'),
-          content: any(named: 'content'),
-          tags: any(named: 'tags'),
-        ),
-      ).thenAnswer((_) async => null);
-
-      final now = DateTime.now();
-      final result = await service.shareVideoWithUser(
-        video: VideoEvent(
-          id: 'video1',
-          pubkey: _testPubkey,
-          createdAt: now.millisecondsSinceEpoch ~/ 1000,
-          timestamp: now,
-          content: 'Test',
-        ),
-        recipientPubkey: _recipientPubkey,
-      );
-
-      expect(result.success, isFalse);
-      expect(result.error, contains('Failed to create'));
-    });
-
-    test('returns success on successful publish', () async {
-      when(() => mockAuthService.isAuthenticated).thenReturn(true);
-      final signedEvent = Event(_testPubkey, 4, <List<String>>[], 'test');
-      signedEvent.id = 'signed_event_id';
-
-      when(
-        () => mockAuthService.createAndSignEvent(
-          kind: any(named: 'kind'),
-          content: any(named: 'content'),
-          tags: any(named: 'tags'),
-        ),
-      ).thenAnswer((_) async => signedEvent);
-      when(
-        () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => signedEvent);
-      when(
-        () => mockProfileRepository.fetchFreshProfile(
-          pubkey: any(named: 'pubkey'),
-        ),
-      ).thenAnswer((_) async => null);
-
-      final now = DateTime.now();
-      final result = await service.shareVideoWithUser(
-        video: VideoEvent(
-          id: 'video1',
-          pubkey: _testPubkey,
-          createdAt: now.millisecondsSinceEpoch ~/ 1000,
-          timestamp: now,
-          content: 'Test',
-        ),
-        recipientPubkey: _recipientPubkey,
-      );
-
-      expect(result.success, isTrue);
-      expect(result.messageEventId, equals('signed_event_id'));
-    });
-
-    test('returns failure when publish fails', () async {
-      when(() => mockAuthService.isAuthenticated).thenReturn(true);
-      when(
-        () => mockAuthService.createAndSignEvent(
-          kind: any(named: 'kind'),
-          content: any(named: 'content'),
-          tags: any(named: 'tags'),
-        ),
-      ).thenAnswer(
-        (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
-      );
-      when(
-        () => mockNostrService.publishEvent(any()),
-      ).thenAnswer((_) async => null);
-
-      final now = DateTime.now();
-      final result = await service.shareVideoWithUser(
-        video: VideoEvent(
-          id: 'video1',
-          pubkey: _testPubkey,
-          createdAt: now.millisecondsSinceEpoch ~/ 1000,
-          timestamp: now,
-          content: 'Test',
-        ),
-        recipientPubkey: _recipientPubkey,
-      );
-
-      expect(result.success, isFalse);
-      expect(result.error, contains('Failed to publish'));
-    });
-  });
-
-  group('shareVideoWithUser (NIP-17 path)', () {
-    late _MockDmRepository mockDmRepository;
-    late VideoSharingService nip17Service;
-
-    setUp(() {
-      mockDmRepository = _MockDmRepository();
-      when(() => mockDmRepository.userPubkey).thenReturn(_testPubkey);
-
-      nip17Service = VideoSharingService(
-        nostrService: mockNostrService,
-        authService: mockAuthService,
-        profileRepository: mockProfileRepository,
-        dmRepository: mockDmRepository,
-      );
-    });
-
-    test('uses NIP-17 when DmRepository is available', () async {
+    test('uses NIP-17 via DmRepository.sendMessage', () async {
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
       when(
         () => mockDmRepository.sendMessage(
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
         ),
-      ).thenAnswer(
-        (_) async => NIP17SendResult.success(
-          rumorEventId: 'nip17-rumor-id',
-          messageEventId: 'nip17-msg-id',
-          recipientPubkey: _recipientPubkey,
-        ),
-      );
+      ).thenAnswer((_) async => _successResult());
       when(
         () => mockProfileRepository.fetchFreshProfile(
           pubkey: any(named: 'pubkey'),
         ),
       ).thenAnswer((_) async => null);
 
-      final now = DateTime.now();
-      final result = await nip17Service.shareVideoWithUser(
-        video: VideoEvent(
-          id: 'video1',
-          pubkey: _testPubkey,
-          createdAt: now.millisecondsSinceEpoch ~/ 1000,
-          timestamp: now,
-          content: 'Test',
-        ),
+      final result = await service.shareVideoWithUser(
+        video: _video(),
         recipientPubkey: _recipientPubkey,
       );
 
@@ -391,20 +230,12 @@ void main() {
       expect(result.messageEventId, equals('nip17-msg-id'));
       expect(result.conversationId, isNotNull);
 
-      // Verify NIP-17 was used, NOT NIP-04
       verify(
         () => mockDmRepository.sendMessage(
           recipientPubkey: _recipientPubkey,
           content: any(named: 'content'),
         ),
       ).called(1);
-      verifyNever(
-        () => mockAuthService.createAndSignEvent(
-          kind: any(named: 'kind'),
-          content: any(named: 'content'),
-          tags: any(named: 'tags'),
-        ),
-      );
     });
 
     test('returns failure when NIP-17 send fails', () async {
@@ -418,15 +249,8 @@ void main() {
         (_) async => NIP17SendResult.failure('Relay rejected'),
       );
 
-      final now = DateTime.now();
-      final result = await nip17Service.shareVideoWithUser(
-        video: VideoEvent(
-          id: 'video1',
-          pubkey: _testPubkey,
-          createdAt: now.millisecondsSinceEpoch ~/ 1000,
-          timestamp: now,
-          content: 'Test',
-        ),
+      final result = await service.shareVideoWithUser(
+        video: _video(),
         recipientPubkey: _recipientPubkey,
       );
 
@@ -441,28 +265,15 @@ void main() {
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
         ),
-      ).thenAnswer(
-        (_) async => NIP17SendResult.success(
-          rumorEventId: 'nip17-rumor-id',
-          messageEventId: 'nip17-msg-id',
-          recipientPubkey: _recipientPubkey,
-        ),
-      );
+      ).thenAnswer((_) async => _successResult());
       when(
         () => mockProfileRepository.fetchFreshProfile(
           pubkey: any(named: 'pubkey'),
         ),
       ).thenAnswer((_) async => null);
 
-      final now = DateTime.now();
-      await nip17Service.shareVideoWithUser(
-        video: VideoEvent(
-          id: 'video1',
-          pubkey: _testPubkey,
-          createdAt: now.millisecondsSinceEpoch ~/ 1000,
-          timestamp: now,
-          content: 'Test',
-        ),
+      await service.shareVideoWithUser(
+        video: _video(),
         recipientPubkey: _recipientPubkey,
         personalMessage: 'Check this out!',
       );
@@ -484,29 +295,15 @@ void main() {
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
         ),
-      ).thenAnswer(
-        (_) async => NIP17SendResult.success(
-          rumorEventId: 'nip17-rumor-id',
-          messageEventId: 'nip17-msg-id',
-          recipientPubkey: _recipientPubkey,
-        ),
-      );
+      ).thenAnswer((_) async => _successResult());
       when(
         () => mockProfileRepository.fetchFreshProfile(
           pubkey: any(named: 'pubkey'),
         ),
       ).thenAnswer((_) async => null);
 
-      final now = DateTime.now();
-      await nip17Service.shareVideoWithUser(
-        video: VideoEvent(
-          id: 'video1',
-          pubkey: _testPubkey,
-          createdAt: now.millisecondsSinceEpoch ~/ 1000,
-          timestamp: now,
-          content: 'Test',
-          title: 'Indigenous cultures',
-        ),
+      await service.shareVideoWithUser(
+        video: _video(title: 'Indigenous cultures'),
         recipientPubkey: _recipientPubkey,
       );
 
@@ -529,28 +326,15 @@ void main() {
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
         ),
-      ).thenAnswer(
-        (_) async => NIP17SendResult.success(
-          rumorEventId: 'nip17-rumor-id',
-          messageEventId: 'nip17-msg-id',
-          recipientPubkey: _recipientPubkey,
-        ),
-      );
+      ).thenAnswer((_) async => _successResult());
       when(
         () => mockProfileRepository.fetchFreshProfile(
           pubkey: any(named: 'pubkey'),
         ),
       ).thenAnswer((_) async => null);
 
-      final now = DateTime.now();
-      await nip17Service.shareVideoWithUser(
-        video: VideoEvent(
-          id: 'video1',
-          pubkey: _testPubkey,
-          createdAt: now.millisecondsSinceEpoch ~/ 1000,
-          timestamp: now,
-          content: 'Test',
-        ),
+      await service.shareVideoWithUser(
+        video: _video(),
         recipientPubkey: _recipientPubkey,
       );
 
@@ -573,32 +357,18 @@ void main() {
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
         ),
-      ).thenAnswer(
-        (_) async => NIP17SendResult.success(
-          rumorEventId: 'nip17-rumor-id',
-          messageEventId: 'nip17-msg-id',
-          recipientPubkey: _recipientPubkey,
-        ),
-      );
+      ).thenAnswer((_) async => _successResult());
       when(
         () => mockProfileRepository.fetchFreshProfile(
           pubkey: any(named: 'pubkey'),
         ),
       ).thenAnswer((_) async => null);
 
-      final now = DateTime.now();
-      final result = await nip17Service.shareVideoWithUser(
-        video: VideoEvent(
-          id: 'video1',
-          pubkey: _testPubkey,
-          createdAt: now.millisecondsSinceEpoch ~/ 1000,
-          timestamp: now,
-          content: 'Test',
-        ),
+      final result = await service.shareVideoWithUser(
+        video: _video(),
         recipientPubkey: _recipientPubkey,
       );
 
-      // Verify conversation ID matches DmRepository computation
       final participants = [_testPubkey, _recipientPubkey]..sort();
       final expectedId = DmRepository.computeConversationId(participants);
       expect(result.conversationId, equals(expectedId));
@@ -611,32 +381,19 @@ void main() {
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
         ),
-      ).thenAnswer(
-        (_) async => NIP17SendResult.success(
-          rumorEventId: 'nip17-rumor-id',
-          messageEventId: 'nip17-msg-id',
-          recipientPubkey: _recipientPubkey,
-        ),
-      );
+      ).thenAnswer((_) async => _successResult());
       when(
         () => mockProfileRepository.fetchFreshProfile(
           pubkey: any(named: 'pubkey'),
         ),
       ).thenAnswer((_) async => null);
 
-      final now = DateTime.now();
-      await nip17Service.shareVideoWithUser(
-        video: VideoEvent(
-          id: 'video1',
-          pubkey: _testPubkey,
-          createdAt: now.millisecondsSinceEpoch ~/ 1000,
-          timestamp: now,
-          content: 'Test',
-        ),
+      await service.shareVideoWithUser(
+        video: _video(),
         recipientPubkey: _recipientPubkey,
       );
 
-      expect(nip17Service.hasSharedWithRecently(_recipientPubkey), isTrue);
+      expect(service.hasSharedWithRecently(_recipientPubkey), isTrue);
     });
   });
 
@@ -654,7 +411,6 @@ void main() {
 
       final url = service.generateShareUrl(video);
 
-      // stableId returns vineId when set, otherwise falls back to id
       expect(url, equals('https://divine.video/video/my-vine-id'));
     });
 
@@ -663,35 +419,21 @@ void main() {
     });
 
     test('hasSharedWithRecently returns true after sharing', () async {
-      // Arrange
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
       when(
-        () => mockAuthService.createAndSignEvent(
-          kind: any(named: 'kind'),
+        () => mockDmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
-          tags: any(named: 'tags'),
         ),
-      ).thenAnswer(
-        (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
-      );
-      when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
-      );
+      ).thenAnswer((_) async => _successResult());
       when(
         () => mockProfileRepository.fetchFreshProfile(
           pubkey: any(named: 'pubkey'),
         ),
       ).thenAnswer((_) async => null);
 
-      final now = DateTime.now();
       await service.shareVideoWithUser(
-        video: VideoEvent(
-          id: 'video1',
-          pubkey: _testPubkey,
-          createdAt: now.millisecondsSinceEpoch ~/ 1000,
-          timestamp: now,
-          content: 'Test',
-        ),
+        video: _video(),
         recipientPubkey: _recipientPubkey,
       );
 
@@ -699,42 +441,26 @@ void main() {
     });
 
     test('clearSharingHistory removes all data', () async {
-      // Arrange - populate some history
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
       when(
-        () => mockAuthService.createAndSignEvent(
-          kind: any(named: 'kind'),
+        () => mockDmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
-          tags: any(named: 'tags'),
         ),
-      ).thenAnswer(
-        (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
-      );
-      when(() => mockNostrService.publishEvent(any())).thenAnswer(
-        (_) async => Event(_testPubkey, 4, <List<String>>[], 'test'),
-      );
+      ).thenAnswer((_) async => _successResult());
       when(
         () => mockProfileRepository.fetchFreshProfile(
           pubkey: any(named: 'pubkey'),
         ),
       ).thenAnswer((_) async => null);
 
-      final now = DateTime.now();
       await service.shareVideoWithUser(
-        video: VideoEvent(
-          id: 'video1',
-          pubkey: _testPubkey,
-          createdAt: now.millisecondsSinceEpoch ~/ 1000,
-          timestamp: now,
-          content: 'Test',
-        ),
+        video: _video(),
         recipientPubkey: _recipientPubkey,
       );
 
-      // Act
       service.clearSharingHistory();
 
-      // Assert
       expect(service.recentlySharedWith, isEmpty);
       expect(service.hasSharedWithRecently(_recipientPubkey), isFalse);
 


### PR DESCRIPTION
Closes #3195

## Summary

Final cleanup PR (#8) of the reliable-nostr-publish series. Every publish in `mobile/lib/` is now either routed through `publishEventWithRetry` (handled by PRs 2–7) or annotated with a rationale comment explaining why it intentionally stays fire-and-forget.

- **Chunk 1 (Path A — modify in place):** `VideoSharingService` NIP-04 fallback removed. The service is now NIP-17-only; the raw `publishEvent(kind: 4)` site at `video_sharing_service.dart:194` is gone. `DmRepository` becomes a required constructor arg and the deprecated `NostrClient` / `AuthService.createAndSignEvent` dependencies are dropped. Provider simplified, tests rewritten to exercise only the NIP-17 path.
- **Chunk 2:** `corrupted_video_repair_service.dart:126` — annotated as fire-and-forget background cleanup. Retry would amplify relay load without user benefit.
- **Chunk 3:** `view_event_publisher.dart:180/:284` annotated as NIP-01 ephemeral kind 22236 analytics. `push_notification_service.dart:120/:182/:276` annotated as ephemeral hand-offs to the divine push relay, which owns delivery retry.

## Path taken for Chunk 1

**Path A (hybrid)** — removed the deprecated NIP-04 fallback branch rather than deleting the whole service. The service was still live via `ShareSheetBloc` (quick-send / send-with-message flows) and the UI share action button, so Path B (full delete) would have cascaded into the share sheet. Removing just the NIP-04 branch achieves the plan's goal (eliminate the bare `publishEvent` site) while keeping the public API intact for `ShareSheetBloc`. The NIP-17 path was already the production default (`dmRepositoryProvider` is non-nullable), so the removed fallback was dead runtime code.

## Invariant check

Ran `grep -rn "\.publishEvent(\|\.sendEvent(" lib/ packages/ --include='*.dart' | grep -v "publishEventWithRetry\|publishEventAwaitOk\|sendEventAwaitOk"` against this branch.

**Annotated in this PR (fire-and-forget by design):**
- `lib/services/corrupted_video_repair_service.dart:131`
- `lib/services/view_event_publisher.dart:184, :293`
- `lib/services/push_notification_service.dart:125, :192, :291`

**Internal SDK / client plumbing (expected — the `publishEventWithRetry` primitive is built on top of these):**
- `packages/nostr_client/lib/src/nostr_client.dart` (the `publishEvent*` implementations)
- `packages/nostr_sdk/lib/**` (kinds 29, 58, 65; NIP-95 uploader)
- `packages/dm_repository/lib/src/dm_repository.dart`, `nip17_message_service.dart`
- `packages/comments_repository/lib/src/comments_repository.dart`
- `packages/curation_service/lib/src/curation_service.dart`
- `mobile/lib/services/base/social_event_service_base.dart`

**Documented exception — owned by sibling PRs not yet stacked on this base:**

This PR branches off `feat/reliable-nostr-publish` (PR #3177 / PR 1) plus the PR 7 deletion commits. PRs 2–6 (video / social / moderation / lists / DM) migrate the remaining sites and are not on this base. As a result, the following call sites are still bare `publishEvent` on this branch and are expected to be handled by their respective PRs before the series lands:

- `lib/services/account_label_service.dart:148`
- `lib/services/bookmark_service.dart:608, :669`
- `lib/services/curated_list_service.dart:900`
- `lib/services/social_service.dart:386, :514`
- `lib/services/video_event_publisher.dart:208`
- `lib/services/content_reporting_service.dart:179`
- `lib/services/content_blocklist_service.dart:240`
- `lib/services/mute_service.dart:530`
- `lib/services/account_deletion_service.dart:104, :188` (NIP-62 account deletion; distinct from PR 7's NIP-09 content deletion)
- `lib/widgets/share_video_menu.dart:1742`

Once the series is stacked, these will either be migrated (by PRs 2–6) or — if the stack settles on keeping them fire-and-forget — follow-up annotation commits can land with the same template used here. The invariant check is therefore fully satisfied once the full stack is merged.

## Test plan

- [x] `flutter analyze lib test` — clean (only pre-existing package-level info lints)
- [x] `flutter test test/services/video_sharing_service_test.dart` — 20/20 pass (rewritten for NIP-17 only)
- [x] `flutter test test/services/view_event_publisher_test.dart` — 17/17 pass
- [x] `flutter test test/services/push_notification_service_test.dart` — 15/15 pass
- [x] `flutter test test/blocs/share_sheet/share_sheet_bloc_test.dart test/widgets/video_feed_item/actions/share_action_button_test.dart test/widgets/share_video_menu_comprehensive_test.dart` — all pass (callers of VideoSharingService)
- [x] `dart run build_runner build --delete-conflicting-outputs` — clean, `app_providers.g.dart` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)