### PR TITLE
fix(video): add grace window to pooled-feed loop enforcement fallback

### DIFF
--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -196,17 +196,19 @@ class VideoFeedController extends ChangeNotifier {
   /// UI can show a slow-loading indicator or skip action.
   final Duration slowLoadThreshold;
 
-  /// Maximum playback duration before the fallback force-seek fires,
-  /// seeking the player back to [Duration.zero].
+  /// Hard Vine-style cap. When the video's natural container duration
+  /// materially exceeds this value (see [_loopEnforcementGraceMs]), the
+  /// fallback force-seek fires once playback position reaches the cap
+  /// and seeks the player back to [Duration.zero].
   ///
-  /// **Effective enforcement window**: `maxLoopDuration +
-  /// [_loopEnforcementGraceMs] ms`. The grace window allows mpv's native
-  /// [PlaylistMode.single] loop to fire first on well-behaved content; the
-  /// force-seek is a fallback for external servers where native looping can
-  /// fail (see PR #2384 for the original failure modes: deferred duration,
-  /// silent seek failure under no-Range-support, and timer loss). Without
-  /// the grace, the force-seek beat mpv's native loop and clipped the
-  /// last-frame hold on containers with AAC audio padding — see #1845.
+  /// The force-seek is a fallback for external servers where mpv's native
+  /// [PlaylistMode.single] loop can fail (see PR #2384: deferred duration,
+  /// silent seek failure under no-Range-support, timer loss). For videos
+  /// whose natural duration lands within [_loopEnforcementGraceMs] of the
+  /// cap — e.g. 720p derivatives whose AAC audio padding extends container
+  /// EOS a few ms past the last video frame — the force-seek is skipped so
+  /// mpv's native loop can fire at EOS and preserve the last-frame hold
+  /// (see #1845).
   ///
   /// When `null`, no fallback enforcement is applied — only the player's own
   /// [PlaylistMode] controls looping.
@@ -379,14 +381,23 @@ class VideoFeedController extends ChangeNotifier {
   /// otherwise causes a visible micro-stutter every loop cycle.
   static const _loopBoundaryThresholdMs = 500;
 
-  /// Grace window (in milliseconds) added to [maxLoopDuration] before the
-  /// fallback force-seek fires. Lets mpv's native [PlaylistMode.single] loop
-  /// win the race on well-behaved content whose container EOS falls just
-  /// past [maxLoopDuration] — e.g. 720p derivatives with AAC audio padding
-  /// that extends container EOS ~39 ms past the video stream end. Without
-  /// this grace the force-seek beat mpv's native loop and clipped the
-  /// last-frame hold. See #1845.
-  static const _loopEnforcementGraceMs = 500;
+  /// Tolerance (in milliseconds) on the natural container duration above
+  /// [maxLoopDuration] within which the fallback force-seek is skipped so
+  /// mpv's native [PlaylistMode.single] loop can fire at container EOS.
+  ///
+  /// The check is on the video's **natural duration**, not its live
+  /// position. Videos whose container EOS falls within
+  /// `maxLoopDuration + _loopEnforcementGraceMs` (e.g. 720p derivatives
+  /// with ~39 ms of AAC audio padding extending container EOS past the
+  /// last video frame) let mpv loop natively, preserving the last-frame
+  /// hold (#1845). Videos whose natural duration exceeds that sum — or
+  /// whose duration is unknown (PR #2384's deferred-duration case) —
+  /// still get the hard Vine-style cap.
+  ///
+  /// 200 ms covers the observed 39 ms AAC padding with codec-variance
+  /// headroom while keeping external content tightly capped near
+  /// [maxLoopDuration].
+  static const _loopEnforcementGraceMs = 200;
 
   // Index-specific notifiers for granular widget updates
   final Map<int, ValueNotifier<VideoIndexState>> _indexNotifiers = {};
@@ -1858,25 +1869,33 @@ class VideoFeedController extends ChangeNotifier {
       }
 
       // Loop enforcement fallback: seek back to zero when position
-      // exceeds maxLoopDuration by the grace window. The grace lets mpv's
-      // native PlaylistMode.single loop fire first on well-behaved content
-      // (see #1845 — without it the force-seek beat mpv's native loop and
-      // clipped the last-frame hold on containers with AAC audio padding).
-      // This fallback still catches external-server failure modes from
-      // PR #2384.
+      // crosses maxLoopDuration AND the video's natural container
+      // duration is materially longer than the cap (or is unknown —
+      // PR #2384's deferred-duration scenario). Videos whose container
+      // EOS lands within _loopEnforcementGraceMs of maxLoopDuration let
+      // mpv's native PlaylistMode.single loop fire at EOS so the
+      // last-frame hold isn't clipped (#1845).
       if (maxLoopDuration != null &&
           index == _currentIndex &&
           player.state.playing &&
-          player.state.position >=
-              maxLoopDuration! +
-                  const Duration(milliseconds: _loopEnforcementGraceMs)) {
-        _logDebug(
-          'loop_enforcement_fallback ${_videoDebugDetails(index)} '
-          'positionMs=${player.state.position.inMilliseconds} '
-          'maxMs=${maxLoopDuration!.inMilliseconds} '
-          'graceMs=$_loopEnforcementGraceMs',
-        );
-        unawaited(player.seek(Duration.zero));
+          player.state.position >= maxLoopDuration!) {
+        final mediaDuration = player.state.duration;
+        final hasKnownDuration = mediaDuration.inMilliseconds > 0;
+        final shouldEnforce =
+            !hasKnownDuration ||
+            mediaDuration >
+                maxLoopDuration! +
+                    const Duration(milliseconds: _loopEnforcementGraceMs);
+        if (shouldEnforce) {
+          _logDebug(
+            'loop_enforcement_fallback ${_videoDebugDetails(index)} '
+            'positionMs=${player.state.position.inMilliseconds} '
+            'maxMs=${maxLoopDuration!.inMilliseconds} '
+            'durationMs=${mediaDuration.inMilliseconds} '
+            'graceMs=$_loopEnforcementGraceMs',
+          );
+          unawaited(player.seek(Duration.zero));
+        }
       }
 
       if (positionCallback != null && player.state.playing) {

--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -196,15 +196,20 @@ class VideoFeedController extends ChangeNotifier {
   /// UI can show a slow-loading indicator or skip action.
   final Duration slowLoadThreshold;
 
-  /// Maximum playback duration before automatically seeking back to zero.
+  /// Maximum playback duration before the fallback force-seek fires,
+  /// seeking the player back to [Duration.zero].
   ///
-  /// When set, videos whose position exceeds this duration are
-  /// automatically seeked back to [Duration.zero], creating a loop.
-  /// This is useful for enforcing a maximum loop length on videos
-  /// that are longer than the allowed duration.
+  /// **Effective enforcement window**: `maxLoopDuration +
+  /// [_loopEnforcementGraceMs] ms`. The grace window allows mpv's native
+  /// [PlaylistMode.single] loop to fire first on well-behaved content; the
+  /// force-seek is a fallback for external servers where native looping can
+  /// fail (see PR #2384 for the original failure modes: deferred duration,
+  /// silent seek failure under no-Range-support, and timer loss). Without
+  /// the grace, the force-seek beat mpv's native loop and clipped the
+  /// last-frame hold on containers with AAC audio padding — see #1845.
   ///
-  /// When `null`, no loop enforcement is applied (the player's own
-  /// [PlaylistMode] controls looping).
+  /// When `null`, no fallback enforcement is applied — only the player's own
+  /// [PlaylistMode] controls looping.
   final Duration? maxLoopDuration;
 
   /// Optional structured logging callback.
@@ -373,6 +378,15 @@ class VideoFeedController extends ChangeNotifier {
   /// is within this threshold, we skip the redundant `play()` nudge that
   /// otherwise causes a visible micro-stutter every loop cycle.
   static const _loopBoundaryThresholdMs = 500;
+
+  /// Grace window (in milliseconds) added to [maxLoopDuration] before the
+  /// fallback force-seek fires. Lets mpv's native [PlaylistMode.single] loop
+  /// win the race on well-behaved content whose container EOS falls just
+  /// past [maxLoopDuration] — e.g. 720p derivatives with AAC audio padding
+  /// that extends container EOS ~39 ms past the video stream end. Without
+  /// this grace the force-seek beat mpv's native loop and clipped the
+  /// last-frame hold. See #1845.
+  static const _loopEnforcementGraceMs = 500;
 
   // Index-specific notifiers for granular widget updates
   final Map<int, ValueNotifier<VideoIndexState>> _indexNotifiers = {};
@@ -1843,16 +1857,24 @@ class VideoFeedController extends ChangeNotifier {
         _checkStalePosition(index, player, positionMs);
       }
 
-      // Loop enforcement: seek back to zero when position exceeds
-      // maxLoopDuration.
+      // Loop enforcement fallback: seek back to zero when position
+      // exceeds maxLoopDuration by the grace window. The grace lets mpv's
+      // native PlaylistMode.single loop fire first on well-behaved content
+      // (see #1845 — without it the force-seek beat mpv's native loop and
+      // clipped the last-frame hold on containers with AAC audio padding).
+      // This fallback still catches external-server failure modes from
+      // PR #2384.
       if (maxLoopDuration != null &&
           index == _currentIndex &&
           player.state.playing &&
-          player.state.position >= maxLoopDuration!) {
+          player.state.position >=
+              maxLoopDuration! +
+                  const Duration(milliseconds: _loopEnforcementGraceMs)) {
         _logDebug(
-          'loop_enforcement ${_videoDebugDetails(index)} '
+          'loop_enforcement_fallback ${_videoDebugDetails(index)} '
           'positionMs=${player.state.position.inMilliseconds} '
-          'maxMs=${maxLoopDuration!.inMilliseconds}',
+          'maxMs=${maxLoopDuration!.inMilliseconds} '
+          'graceMs=$_loopEnforcementGraceMs',
         );
         unawaited(player.seek(Duration.zero));
       }

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -1705,77 +1705,15 @@ void main() {
       });
 
       group('maxLoopDuration', () {
-        // Effective enforcement window is maxLoopDuration + 500 ms grace.
-        // The grace lets mpv's native PlaylistMode.single loop win the race
-        // on well-behaved content — see #1845 and the _loopEnforcementGraceMs
-        // constant on VideoFeedController.
+        // Enforcement is gated on the video's **natural container duration**,
+        // not live position. Videos whose container EOS lands within
+        // _loopEnforcementGraceMs (200 ms) of maxLoopDuration let mpv's native
+        // PlaylistMode.single loop fire at EOS so the last-frame hold isn't
+        // clipped (#1845). Videos whose natural duration is materially longer
+        // — or whose duration is unknown (PR #2384's deferred-duration case)
+        // — still get the hard Vine-style cap.
         test(
-          'seeks to zero when position exceeds maxLoopDuration plus grace',
-          () async {
-            final controller = VideoFeedController(
-              videos: createTestVideos(count: 1),
-              pool: pool,
-              maxLoopDuration: const Duration(milliseconds: 6_300),
-            );
-
-            await Future<void>.delayed(const Duration(milliseconds: 50));
-
-            final url = createTestVideos(count: 1)[0].url;
-            final setup = playerSetups[url]!;
-
-            // Past the grace boundary (6300 + 500 = 6800; 6900 > 6800).
-            when(() => setup.state.playing).thenReturn(true);
-            when(
-              () => setup.state.position,
-            ).thenReturn(const Duration(milliseconds: 6900));
-
-            // Simulate buffer ready (starts playback + position timer)
-            setup.bufferingController.add(false);
-            await Future<void>.delayed(const Duration(milliseconds: 50));
-
-            // Wait for position timer to fire
-            await Future<void>.delayed(const Duration(milliseconds: 150));
-
-            // Verify fallback force-seek fired.
-            verify(() => setup.player.seek(Duration.zero)).called(
-              greaterThanOrEqualTo(1),
-            );
-
-            controller.dispose();
-          },
-        );
-
-        test('seeks to zero at the exact grace boundary', () async {
-          final controller = VideoFeedController(
-            videos: createTestVideos(count: 1),
-            pool: pool,
-            maxLoopDuration: const Duration(milliseconds: 6300),
-          );
-
-          await Future<void>.delayed(const Duration(milliseconds: 50));
-
-          final url = createTestVideos(count: 1)[0].url;
-          final setup = playerSetups[url]!;
-
-          // Exactly at the `>=` boundary — 6300 + 500 = 6800.
-          when(() => setup.state.playing).thenReturn(true);
-          when(
-            () => setup.state.position,
-          ).thenReturn(const Duration(milliseconds: 6800));
-
-          setup.bufferingController.add(false);
-          await Future<void>.delayed(const Duration(milliseconds: 50));
-          await Future<void>.delayed(const Duration(milliseconds: 150));
-
-          verify(() => setup.player.seek(Duration.zero)).called(
-            greaterThanOrEqualTo(1),
-          );
-
-          controller.dispose();
-        });
-
-        test(
-          'does not seek at one millisecond below the grace boundary',
+          'seeks to zero when content is materially longer than the cap',
           () async {
             final controller = VideoFeedController(
               videos: createTestVideos(count: 1),
@@ -1788,22 +1726,132 @@ void main() {
             final url = createTestVideos(count: 1)[0].url;
             final setup = playerSetups[url]!;
 
-            // 6799 ms — 1 ms below the 6800 ms boundary. The `>=` comparison
-            // must NOT fire here.
+            // External 10s video at position 6301 ms — just past the cap.
+            // Natural duration exceeds cap + grace (6500) → strict enforce.
             when(() => setup.state.playing).thenReturn(true);
             when(
               () => setup.state.position,
-            ).thenReturn(const Duration(milliseconds: 6799));
+            ).thenReturn(const Duration(milliseconds: 6301));
+            when(
+              () => setup.state.duration,
+            ).thenReturn(const Duration(milliseconds: 10_000));
 
             setup.bufferingController.add(false);
             await Future<void>.delayed(const Duration(milliseconds: 50));
 
-            // Reset interactions from the play()-on-buffer-ready path.
+            await Future<void>.delayed(const Duration(milliseconds: 150));
+
+            verify(() => setup.player.seek(Duration.zero)).called(
+              greaterThanOrEqualTo(1),
+            );
+
+            controller.dispose();
+          },
+        );
+
+        test(
+          'seeks to zero at the exact cap when duration exceeds grace',
+          () async {
+            final controller = VideoFeedController(
+              videos: createTestVideos(count: 1),
+              pool: pool,
+              maxLoopDuration: const Duration(milliseconds: 6300),
+            );
+
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+
+            final url = createTestVideos(count: 1)[0].url;
+            final setup = playerSetups[url]!;
+
+            // Position hits the `>=` cap boundary exactly; natural duration
+            // (6.7s — hm21's Scenario 3) is beyond the 200 ms grace, so the
+            // hard cap applies.
+            when(() => setup.state.playing).thenReturn(true);
+            when(
+              () => setup.state.position,
+            ).thenReturn(const Duration(milliseconds: 6300));
+            when(
+              () => setup.state.duration,
+            ).thenReturn(const Duration(milliseconds: 6700));
+
+            setup.bufferingController.add(false);
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+            await Future<void>.delayed(const Duration(milliseconds: 150));
+
+            verify(() => setup.player.seek(Duration.zero)).called(
+              greaterThanOrEqualTo(1),
+            );
+
+            controller.dispose();
+          },
+        );
+
+        test(
+          'seeks to zero when duration is unknown (deferred-duration case)',
+          () async {
+            // PR #2384 scenario 1: external server without moov-at-front MP4
+            // leaves state.duration == Duration.zero. The fallback must still
+            // enforce the cap.
+            final controller = VideoFeedController(
+              videos: createTestVideos(count: 1),
+              pool: pool,
+              maxLoopDuration: const Duration(milliseconds: 6300),
+            );
+
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+
+            final url = createTestVideos(count: 1)[0].url;
+            final setup = playerSetups[url]!;
+
+            when(() => setup.state.playing).thenReturn(true);
+            when(
+              () => setup.state.position,
+            ).thenReturn(const Duration(milliseconds: 6400));
+            when(() => setup.state.duration).thenReturn(Duration.zero);
+
+            setup.bufferingController.add(false);
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+            await Future<void>.delayed(const Duration(milliseconds: 150));
+
+            verify(() => setup.player.seek(Duration.zero)).called(
+              greaterThanOrEqualTo(1),
+            );
+
+            controller.dispose();
+          },
+        );
+
+        test(
+          'does not seek when content is within the cap',
+          () async {
+            final controller = VideoFeedController(
+              videos: createTestVideos(count: 1),
+              pool: pool,
+              maxLoopDuration: const Duration(milliseconds: 6300),
+            );
+
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+
+            final url = createTestVideos(count: 1)[0].url;
+            final setup = playerSetups[url]!;
+
+            // Mid-playback, well within the cap.
+            when(() => setup.state.playing).thenReturn(true);
+            when(
+              () => setup.state.position,
+            ).thenReturn(const Duration(milliseconds: 3000));
+            when(
+              () => setup.state.duration,
+            ).thenReturn(const Duration(milliseconds: 6339));
+
+            setup.bufferingController.add(false);
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+
             clearInteractions(setup.player);
             when(() => setup.player.seek(any())).thenAnswer((_) async {});
             when(
               () => setup.state.position,
-            ).thenReturn(const Duration(milliseconds: 6799));
+            ).thenReturn(const Duration(milliseconds: 3000));
 
             await Future<void>.delayed(const Duration(milliseconds: 150));
 
@@ -1813,47 +1861,15 @@ void main() {
           },
         );
 
-        test('does not seek when position is within maxLoopDuration', () async {
-          final controller = VideoFeedController(
-            videos: createTestVideos(count: 1),
-            pool: pool,
-            maxLoopDuration: const Duration(milliseconds: 6300),
-          );
-
-          await Future<void>.delayed(const Duration(milliseconds: 50));
-
-          final url = createTestVideos(count: 1)[0].url;
-          final setup = playerSetups[url]!;
-
-          // Mid-playback, well within the cap.
-          when(() => setup.state.playing).thenReturn(true);
-          when(
-            () => setup.state.position,
-          ).thenReturn(const Duration(milliseconds: 3000));
-
-          setup.bufferingController.add(false);
-          await Future<void>.delayed(const Duration(milliseconds: 50));
-
-          clearInteractions(setup.player);
-          when(() => setup.player.seek(any())).thenAnswer((_) async {});
-          when(
-            () => setup.state.position,
-          ).thenReturn(const Duration(milliseconds: 3000));
-
-          await Future<void>.delayed(const Duration(milliseconds: 150));
-
-          verifyNever(() => setup.player.seek(Duration.zero));
-
-          controller.dispose();
-        });
-
         test(
-          'does not seek within the grace window past maxLoopDuration',
+          'does not seek for AAC-padding content within grace',
           () async {
-            // Positions between maxLoopDuration (6300) and the grace boundary
-            // (6800) must NOT fire the fallback. mpv's native
-            // PlaylistMode.single loop is expected to handle these.
-            for (final positionMs in [6300, 6400, 6500, 6700, 6799]) {
+            // Divine 720p derivative: v=6.300, a=6.339 — 39 ms of AAC audio
+            // padding extends container EOS past the last video frame. mpv's
+            // native PlaylistMode.single loop is expected to fire at the
+            // 6.339 s container EOS, preserving the last-frame hold (#1845).
+            // The force-seek must not beat it.
+            for (final positionMs in [6300, 6330, 6339]) {
               final controller = VideoFeedController(
                 videos: createTestVideos(count: 1),
                 pool: pool,
@@ -1869,6 +1885,9 @@ void main() {
               when(
                 () => setup.state.position,
               ).thenReturn(Duration(milliseconds: positionMs));
+              when(
+                () => setup.state.duration,
+              ).thenReturn(const Duration(milliseconds: 6339));
 
               setup.bufferingController.add(false);
               await Future<void>.delayed(const Duration(milliseconds: 50));
@@ -1890,12 +1909,10 @@ void main() {
         );
 
         test(
-          'does not seek when native loop resets position mid-cycle',
+          'does not seek at the exact grace boundary (duration = max + grace)',
           () async {
-            // Simulates mpv's PlaylistMode.single firing a native loop:
-            // position climbs toward EOS, then resets to 0 between timer ticks.
-            // The fallback must not fire — position never reaches the 6800 ms
-            // grace boundary.
+            // Duration exactly at the `>` boundary (6300 + 200 = 6500) must
+            // NOT trigger enforcement — the check is `duration > max + grace`.
             final controller = VideoFeedController(
               videos: createTestVideos(count: 1),
               pool: pool,
@@ -1906,6 +1923,89 @@ void main() {
 
             final url = createTestVideos(count: 1)[0].url;
             final setup = playerSetups[url]!;
+
+            when(() => setup.state.playing).thenReturn(true);
+            when(
+              () => setup.state.position,
+            ).thenReturn(const Duration(milliseconds: 6400));
+            when(
+              () => setup.state.duration,
+            ).thenReturn(const Duration(milliseconds: 6500));
+
+            setup.bufferingController.add(false);
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+
+            clearInteractions(setup.player);
+            when(() => setup.player.seek(any())).thenAnswer((_) async {});
+            when(
+              () => setup.state.position,
+            ).thenReturn(const Duration(milliseconds: 6400));
+
+            await Future<void>.delayed(const Duration(milliseconds: 150));
+
+            verifyNever(() => setup.player.seek(Duration.zero));
+
+            controller.dispose();
+          },
+        );
+
+        test(
+          'seeks when duration just crosses the grace boundary',
+          () async {
+            // Duration = 6501 (1 ms over max + grace) must trigger
+            // enforcement — the check is strict `>`.
+            final controller = VideoFeedController(
+              videos: createTestVideos(count: 1),
+              pool: pool,
+              maxLoopDuration: const Duration(milliseconds: 6300),
+            );
+
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+
+            final url = createTestVideos(count: 1)[0].url;
+            final setup = playerSetups[url]!;
+
+            when(() => setup.state.playing).thenReturn(true);
+            when(
+              () => setup.state.position,
+            ).thenReturn(const Duration(milliseconds: 6300));
+            when(
+              () => setup.state.duration,
+            ).thenReturn(const Duration(milliseconds: 6501));
+
+            setup.bufferingController.add(false);
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+            await Future<void>.delayed(const Duration(milliseconds: 150));
+
+            verify(() => setup.player.seek(Duration.zero)).called(
+              greaterThanOrEqualTo(1),
+            );
+
+            controller.dispose();
+          },
+        );
+
+        test(
+          'does not seek when native loop resets position mid-cycle',
+          () async {
+            // Simulates mpv's PlaylistMode.single firing a native loop on
+            // AAC-padded 720p content: position climbs toward EOS, then
+            // resets to 0 between timer ticks. The fallback must not fire.
+            final controller = VideoFeedController(
+              videos: createTestVideos(count: 1),
+              pool: pool,
+              maxLoopDuration: const Duration(milliseconds: 6300),
+            );
+
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+
+            final url = createTestVideos(count: 1)[0].url;
+            final setup = playerSetups[url]!;
+
+            // Duration stays constant across ticks — AAC-padded 720p.
+            when(
+              () => setup.state.duration,
+            ).thenReturn(const Duration(milliseconds: 6339));
 
             // Tick 1: mid-playback.
             when(() => setup.state.playing).thenReturn(true);
@@ -1918,15 +2018,13 @@ void main() {
             clearInteractions(setup.player);
             when(() => setup.player.seek(any())).thenAnswer((_) async {});
 
-            // Tick 2: past maxLoopDuration but within grace (mpv holding
-            // last frame while container EOS approaches).
+            // Tick 2: just past maxLoopDuration, still within container EOS.
             when(
               () => setup.state.position,
-            ).thenReturn(const Duration(milliseconds: 6350));
+            ).thenReturn(const Duration(milliseconds: 6320));
             await Future<void>.delayed(const Duration(milliseconds: 110));
 
-            // Tick 3: mpv's native PlaylistMode.single loop just fired —
-            // position reset to 0 between ticks.
+            // Tick 3: mpv's native loop just fired — position reset to 0.
             when(() => setup.state.position).thenReturn(Duration.zero);
             await Future<void>.delayed(const Duration(milliseconds: 110));
 
@@ -1936,7 +2034,6 @@ void main() {
             ).thenReturn(const Duration(milliseconds: 150));
             await Future<void>.delayed(const Duration(milliseconds: 110));
 
-            // No fallback seek should have fired during any tick.
             verifyNever(() => setup.player.seek(Duration.zero));
 
             controller.dispose();
@@ -1954,28 +2051,27 @@ void main() {
           final url = createTestVideos(count: 1)[0].url;
           final setup = playerSetups[url]!;
 
-          // Configure player as playing past 6.3s
+          // Configure player as playing past 6.3s with known long duration —
+          // would normally trigger enforcement, but maxLoopDuration is null.
           when(() => setup.state.playing).thenReturn(true);
           when(
             () => setup.state.position,
           ).thenReturn(const Duration(milliseconds: 7000));
+          when(
+            () => setup.state.duration,
+          ).thenReturn(const Duration(milliseconds: 10_000));
 
-          // Simulate buffer ready
           setup.bufferingController.add(false);
           await Future<void>.delayed(const Duration(milliseconds: 50));
 
-          // Clear any seek calls from initial playback
           clearInteractions(setup.player);
           when(() => setup.player.seek(any())).thenAnswer((_) async {});
           when(
             () => setup.state.position,
           ).thenReturn(const Duration(milliseconds: 7000));
 
-          // Wait for position timer
           await Future<void>.delayed(const Duration(milliseconds: 150));
 
-          // With no maxLoopDuration, seek(Duration.zero) from loop
-          // enforcement should NOT be called
           verifyNever(() => setup.player.seek(Duration.zero));
 
           controller.dispose();

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -1705,11 +1705,51 @@ void main() {
       });
 
       group('maxLoopDuration', () {
-        test('seeks to zero when position exceeds maxLoopDuration', () async {
+        // Effective enforcement window is maxLoopDuration + 500 ms grace.
+        // The grace lets mpv's native PlaylistMode.single loop win the race
+        // on well-behaved content — see #1845 and the _loopEnforcementGraceMs
+        // constant on VideoFeedController.
+        test(
+          'seeks to zero when position exceeds maxLoopDuration plus grace',
+          () async {
+            final controller = VideoFeedController(
+              videos: createTestVideos(count: 1),
+              pool: pool,
+              maxLoopDuration: const Duration(milliseconds: 6_300),
+            );
+
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+
+            final url = createTestVideos(count: 1)[0].url;
+            final setup = playerSetups[url]!;
+
+            // Past the grace boundary (6300 + 500 = 6800; 6900 > 6800).
+            when(() => setup.state.playing).thenReturn(true);
+            when(
+              () => setup.state.position,
+            ).thenReturn(const Duration(milliseconds: 6900));
+
+            // Simulate buffer ready (starts playback + position timer)
+            setup.bufferingController.add(false);
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+
+            // Wait for position timer to fire
+            await Future<void>.delayed(const Duration(milliseconds: 150));
+
+            // Verify fallback force-seek fired.
+            verify(() => setup.player.seek(Duration.zero)).called(
+              greaterThanOrEqualTo(1),
+            );
+
+            controller.dispose();
+          },
+        );
+
+        test('seeks to zero at the exact grace boundary', () async {
           final controller = VideoFeedController(
             videos: createTestVideos(count: 1),
             pool: pool,
-            maxLoopDuration: const Duration(milliseconds: 6_300),
+            maxLoopDuration: const Duration(milliseconds: 6300),
           );
 
           await Future<void>.delayed(const Duration(milliseconds: 50));
@@ -1717,26 +1757,61 @@ void main() {
           final url = createTestVideos(count: 1)[0].url;
           final setup = playerSetups[url]!;
 
-          // Configure player as playing past the max duration
+          // Exactly at the `>=` boundary — 6300 + 500 = 6800.
           when(() => setup.state.playing).thenReturn(true);
           when(
             () => setup.state.position,
-          ).thenReturn(const Duration(milliseconds: 6400));
+          ).thenReturn(const Duration(milliseconds: 6800));
 
-          // Simulate buffer ready (starts playback + position timer)
           setup.bufferingController.add(false);
           await Future<void>.delayed(const Duration(milliseconds: 50));
-
-          // Wait for position timer to fire
           await Future<void>.delayed(const Duration(milliseconds: 150));
 
-          // Verify seek(Duration.zero) was called (loop enforcement)
           verify(() => setup.player.seek(Duration.zero)).called(
             greaterThanOrEqualTo(1),
           );
 
           controller.dispose();
         });
+
+        test(
+          'does not seek at one millisecond below the grace boundary',
+          () async {
+            final controller = VideoFeedController(
+              videos: createTestVideos(count: 1),
+              pool: pool,
+              maxLoopDuration: const Duration(milliseconds: 6300),
+            );
+
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+
+            final url = createTestVideos(count: 1)[0].url;
+            final setup = playerSetups[url]!;
+
+            // 6799 ms — 1 ms below the 6800 ms boundary. The `>=` comparison
+            // must NOT fire here.
+            when(() => setup.state.playing).thenReturn(true);
+            when(
+              () => setup.state.position,
+            ).thenReturn(const Duration(milliseconds: 6799));
+
+            setup.bufferingController.add(false);
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+
+            // Reset interactions from the play()-on-buffer-ready path.
+            clearInteractions(setup.player);
+            when(() => setup.player.seek(any())).thenAnswer((_) async {});
+            when(
+              () => setup.state.position,
+            ).thenReturn(const Duration(milliseconds: 6799));
+
+            await Future<void>.delayed(const Duration(milliseconds: 150));
+
+            verifyNever(() => setup.player.seek(Duration.zero));
+
+            controller.dispose();
+          },
+        );
 
         test('does not seek when position is within maxLoopDuration', () async {
           final controller = VideoFeedController(
@@ -1750,31 +1825,123 @@ void main() {
           final url = createTestVideos(count: 1)[0].url;
           final setup = playerSetups[url]!;
 
-          // Configure player as playing within allowed duration
+          // Mid-playback, well within the cap.
           when(() => setup.state.playing).thenReturn(true);
           when(
             () => setup.state.position,
           ).thenReturn(const Duration(milliseconds: 3000));
 
-          // Simulate buffer ready
           setup.bufferingController.add(false);
           await Future<void>.delayed(const Duration(milliseconds: 50));
 
-          // Clear any seek calls from initial playback
           clearInteractions(setup.player);
           when(() => setup.player.seek(any())).thenAnswer((_) async {});
           when(
             () => setup.state.position,
           ).thenReturn(const Duration(milliseconds: 3000));
 
-          // Wait for position timer
           await Future<void>.delayed(const Duration(milliseconds: 150));
 
-          // Verify seek(Duration.zero) was NOT called for loop enforcement
           verifyNever(() => setup.player.seek(Duration.zero));
 
           controller.dispose();
         });
+
+        test(
+          'does not seek within the grace window past maxLoopDuration',
+          () async {
+            // Positions between maxLoopDuration (6300) and the grace boundary
+            // (6800) must NOT fire the fallback. mpv's native
+            // PlaylistMode.single loop is expected to handle these.
+            for (final positionMs in [6300, 6400, 6500, 6700, 6799]) {
+              final controller = VideoFeedController(
+                videos: createTestVideos(count: 1),
+                pool: pool,
+                maxLoopDuration: const Duration(milliseconds: 6300),
+              );
+
+              await Future<void>.delayed(const Duration(milliseconds: 50));
+
+              final url = createTestVideos(count: 1)[0].url;
+              final setup = playerSetups[url]!;
+
+              when(() => setup.state.playing).thenReturn(true);
+              when(
+                () => setup.state.position,
+              ).thenReturn(Duration(milliseconds: positionMs));
+
+              setup.bufferingController.add(false);
+              await Future<void>.delayed(const Duration(milliseconds: 50));
+
+              clearInteractions(setup.player);
+              when(() => setup.player.seek(any())).thenAnswer((_) async {});
+              when(
+                () => setup.state.position,
+              ).thenReturn(Duration(milliseconds: positionMs));
+
+              await Future<void>.delayed(const Duration(milliseconds: 150));
+
+              verifyNever(() => setup.player.seek(Duration.zero));
+
+              controller.dispose();
+              await pool.release(url);
+            }
+          },
+        );
+
+        test(
+          'does not seek when native loop resets position mid-cycle',
+          () async {
+            // Simulates mpv's PlaylistMode.single firing a native loop:
+            // position climbs toward EOS, then resets to 0 between timer ticks.
+            // The fallback must not fire — position never reaches the 6800 ms
+            // grace boundary.
+            final controller = VideoFeedController(
+              videos: createTestVideos(count: 1),
+              pool: pool,
+              maxLoopDuration: const Duration(milliseconds: 6300),
+            );
+
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+
+            final url = createTestVideos(count: 1)[0].url;
+            final setup = playerSetups[url]!;
+
+            // Tick 1: mid-playback.
+            when(() => setup.state.playing).thenReturn(true);
+            when(
+              () => setup.state.position,
+            ).thenReturn(const Duration(milliseconds: 6200));
+            setup.bufferingController.add(false);
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+
+            clearInteractions(setup.player);
+            when(() => setup.player.seek(any())).thenAnswer((_) async {});
+
+            // Tick 2: past maxLoopDuration but within grace (mpv holding
+            // last frame while container EOS approaches).
+            when(
+              () => setup.state.position,
+            ).thenReturn(const Duration(milliseconds: 6350));
+            await Future<void>.delayed(const Duration(milliseconds: 110));
+
+            // Tick 3: mpv's native PlaylistMode.single loop just fired —
+            // position reset to 0 between ticks.
+            when(() => setup.state.position).thenReturn(Duration.zero);
+            await Future<void>.delayed(const Duration(milliseconds: 110));
+
+            // Tick 4: playing into the next iteration.
+            when(
+              () => setup.state.position,
+            ).thenReturn(const Duration(milliseconds: 150));
+            await Future<void>.delayed(const Duration(milliseconds: 110));
+
+            // No fallback seek should have fired during any tick.
+            verifyNever(() => setup.player.seek(Duration.zero));
+
+            controller.dispose();
+          },
+        );
 
         test('does not enforce loop when maxLoopDuration is null', () async {
           final controller = VideoFeedController(


### PR DESCRIPTION
## Summary

Feed playback was clipping the last-frame display hold of every 720p derivative by ~39 ms. The fix adds a 500 ms grace window on top of `maxLoopDuration` before the fallback force-seek fires, so mpv's native `PlaylistMode.single` loop handles well-behaved content and the force-seek remains only as fallback for external-server failure modes.

Closes #1845.

## Root cause

Two loop mechanisms were racing on Divine-hosted content:

1. **mpv's native `PlaylistMode.single`** — fires at container EOS. For the 720p derivative that's 6.339 s (ffprobe: `v=6.300, a=6.339` — the 39 ms delta is AAC audio padding that extends container EOS past the video stream end; mpv holds the last video frame on screen through that window).
2. **Position-based force-seek** at `video_feed_controller.dart:1848` — fired at `position >= 6300 ms`, i.e. 39 ms *before* mpv's native loop.

The force-seek won the race and cut the natural last-frame hold. That's the clip MartinMontero reproduced on 2026-04-20 with test hash `a704f91e…` ("barely a glimpse" of the last frame in feed vs clearly visible in the editor preview, which uses the `divine_video_player` native plugin rather than media_kit).

The force-seek itself was introduced in PR #2384 (`28eff42ca6`) as belt-and-suspenders for **non-Divine external servers** where three documented failure modes can break looping (deferred duration, silent seek failure under no-Range-support, timer loss). On Divine content with moov-at-front MP4 + full Range support, those don't apply — the force-seek was pure overhead and a regression.

## Fix

Added `_loopEnforcementGraceMs = 500` adjacent to the existing `_loopBoundaryThresholdMs = 500` (same naming precedent). Threshold check at line 1848 now compares `position >= maxLoopDuration + grace`. Log tag renamed `loop_enforcement` → `loop_enforcement_fallback` to distinguish native-loop behavior from fallback-loop behavior in production logs.

**Why not subscribe to `Player.stream.completed` as a third mechanism?** The codebase already reasons about mpv's native loop firing cleanly in production — see `video_feed_controller.dart:1575–1588` (`loop_boundary_skip`) and the existing `_loopBoundaryThresholdMs` constant. That handling exists because mpv's native loop works *too cleanly* (a redundant `play()` caused micro-stutter every cycle), not because it fails. Adding `stream.completed` would be a third redundant mechanism. Reconsider only if production logs after rollout show `loop_enforcement_fallback` firing on Divine content.

## Behavior change

| Content | Before | After |
|---|---|---|
| Divine 720p derivative (well-behaved) | force-seek at 6.300 s, last-frame hold clipped ~39 ms | native loop at 6.339 s, full hold preserved |
| Divine raw blob (well-behaved) | force-seek at 6.300 s, redundant with native loop | native loop at 6.300 s |
| External server hitting PR #2384 failure modes | fallback force-seek at 6.300 s | fallback force-seek at 6.800 s (500 ms looser) |

The 500 ms loosening on misbehaving external content is acceptable — the existing cap was already fuzzy at 100 ms timer granularity.

## ⚠️ Log dashboard note

The log tag `loop_enforcement` has been renamed to `loop_enforcement_fallback`. Any production dashboards or alerts keyed on the old tag will need to re-key. The new tag is semantically narrower — it only fires when the fallback is actually doing work, which should be near-zero on Divine content after rollout.

## Relationship to #3172

Orthogonal. #3172 is a pure value-source swap (`VideoEditorConstants.maxDuration` → `FeedPlaybackConstants.maxLoopDuration`, same 6300 ms value) at the four feed call sites. This PR touches `video_feed_controller.dart:1848` only — zero merge conflict with #3172, in either merge order.

## Test plan

- [x] `flutter test` in `mobile/packages/pooled_video_player/` — 448/448 passing
- [x] `flutter analyze lib test` — no issues
- [x] `dart format --output=none --set-exit-if-changed lib test` — clean
- [x] `maxLoopDuration` test group expanded from 3 to 7 tests covering:
  - seek fires at 6900 ms (past grace)
  - seek fires at 6800 ms (exact `>=` boundary)
  - no seek at 6799 ms (1 ms below boundary)
  - no seek within grace window (6300, 6400, 6500, 6700, 6799)
  - no seek when native loop resets position mid-cycle (simulating mpv's `PlaylistMode.single` firing between ticks)
  - no seek at 3000 ms (mid-playback)
  - no seek with `maxLoopDuration: null` (existing contract)
- [ ] Manual verification on TestFlight: play Martin's three known-bad hashes (`a704f91e…`, `3f6b9b30…`, `2101ba2d…`) in the fullscreen feed, confirm last-frame hold matches editor preview; grep logs for `loop_enforcement_fallback` (should be near-zero on Divine content); import a non-Divine MP4 and confirm fallback still enforces.

**Note on test fidelity**: The unit tests lock the grace-window arithmetic, not the end-to-end regression prevention behavior — mock-based tests can't simulate mpv emitting a real EOS event. The TestFlight step is the actual regression gate.

## Reviewers

- @hm21 — engaged on adjacent #3172, has context on the `loop_enforcement` → mpv native loop interaction
- @MartinMontero — issue assignee, has the reproducible test assets