### PR TITLE
docs(claude): codify review-comment lessons from #2571 as auto-read rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,18 +2,28 @@
 
 Start with `/AGENTS.md` for repo workflow, worktree hygiene, verification, and commit expectations.
 
+## Read before every change
+
+**`rules/self_review_checklist.md`** is the single source of truth for
+"what to double-check before planning / implementing / committing /
+wrapping a PR." Every bullet there links to the detailed rule file.
+Most review comments this repo sees map directly to an item in that
+checklist — scan it mentally at each gate rather than waiting for a
+reviewer to catch the same things.
+
 ## Standards Reference
 
 Generic Flutter and Dart standards live in `.claude/rules/`:
 
+- `rules/self_review_checklist.md`: consolidated pre-plan / pre-commit / pre-PR checklist
 - `rules/architecture.md`: layered flow, package boundaries, barrel files
-- `rules/state_management.md`: BLoC-first UI, Riverpod legacy rules, event transformers
+- `rules/state_management.md`: BLoC-first UI, BlocProvider laziness, cross-route state persistence, Riverpod legacy rules, event transformers
 - `rules/code_style.md`: naming, widget composition, Effective Dart guidance
-- `rules/testing.md`: test structure, assertions, BLoC tests, goldens
+- `rules/testing.md`: test structure, assertions, BLoC tests, goldens, strict-coverage packages, l10n delegates in widget tests
 - `rules/routing.md`: `go_router` patterns
-- `rules/ui_theming.md`: theme usage, Page/View split, spacing and typography
+- `rules/ui_theming.md`: theme usage, Page/View split, spacing and typography, NestedScrollView edge-to-edge patterns
 - `rules/error_handling.md`: exceptions and failure handling
-- `rules/localization.md`: l10n-first UI, ARB workflow, `context.l10n` usage
+- `rules/localization.md`: l10n-first UI, ARB workflow, `context.l10n` usage, l10n-pass migration procedure
 
 ## Project Rules
 

--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -52,3 +52,58 @@ When creating new UI, add strings to the ARB file first:
 | `mobile/lib/l10n/l10n.dart` | `context.l10n` extension |
 | `mobile/lib/l10n/generated/` | Generated code (do not edit manually) |
 | `mobile/l10n.yaml` | gen-l10n configuration |
+
+---
+
+## Running an l10n pass over existing code
+
+When migrating a feature that was prototyped with hardcoded strings
+(or when addressing review comments that flag l10n gaps), work in
+this order:
+
+1. **Inventory** — scan the target files for hardcoded user-facing
+   strings. Exclude: log messages, asset paths, error messages passed
+   to `addError`, test fixtures, debug `assert` messages.
+2. **Check `app_en.arb` first.** Keys are often scaffolded in
+   anticipation of a migration and sit unused. `grep -n "profileXxx"
+   lib/l10n/app_en.arb` and `grep -rn "context.l10n.profileXxx" lib
+   test | grep -v l10n/generated` to see what's defined-but-unused
+   vs already-in-use.
+3. **Prefer reuse.** If an existing key has the right copy, use it —
+   even if its current callsite count is zero. Only add a new key
+   when the copy genuinely differs (e.g. "Library" vs "My Library").
+4. **Add missing keys** with `@keyName` metadata when the key takes
+   placeholders or when the meaning isn't obvious from the key name:
+   ```json
+   "profileUserFallback": "user",
+   "@profileUserFallback": {
+     "description": "Generic fallback noun for a user whose display name is unknown. Used in sentences like 'Unfollow {user}?'."
+   }
+   ```
+5. **Regenerate** via `flutter gen-l10n` from `mobile/`. Commit the
+   regenerated files under `lib/l10n/generated/` with the migration.
+6. **Swap call sites** to `context.l10n.xxx`. Add the l10n import
+   (`package:openvine/l10n/l10n.dart`) if the file doesn't have it.
+   For helpers that don't take `BuildContext`, thread it through — do
+   not fetch l10n through `navigatorKey.currentContext` or similar
+   workarounds.
+7. **Update tests** that pump these widgets: add
+   `AppLocalizations.localizationsDelegates` / `supportedLocales`
+   to the test's `MaterialApp` (see `testing.md`). Any existing
+   assertion on the hardcoded English string now needs to match the
+   ARB value verbatim.
+
+### Copy-alignment policy
+
+If the code's hardcoded string differs slightly from the existing ARB
+value (trailing period, capitalization, punctuation), **align the code
+to the ARB value** rather than changing the ARB:
+
+- ARB values are already translated into 16+ locales. Changing an
+  English value silently drifts the English source from every
+  translation.
+- The design / product team owns copy; a silent translation churn in
+  a review comment is not the place to ship copy changes.
+- If the copy really needs to change, do it as a separate,
+  clearly-scoped commit with a product note, not as an l10n-migration
+  side effect.

--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -1,0 +1,157 @@
+# Self-review checklist
+
+Run through this list mentally at every gate. Most review comments on
+this repo map directly to a rule that already exists — the failure mode
+is forgetting to self-check, not missing information. Keep the list
+flat and scannable; each bullet links to the detailed rule.
+
+If a bullet applies and you are unsure, stop and read the linked rule
+before continuing.
+
+---
+
+## Before planning a feature
+
+Architecture and ownership:
+
+- [ ] Which layer owns each concern? UI → BLoC → Repository → Client.
+  Any logic that filters, sorts, fetches conditionally, falls back, or
+  composes data sources belongs **below** the UI. See
+  [`architecture.md`](architecture.md).
+- [ ] "Cache warming" and "pre-fetch" work belongs in the **repository**
+  layer, not in a `BlocProvider` wrapper. BlocProviders are lazy — see
+  [`state_management.md`](state_management.md#blocprovider-is-lazy-by-default).
+- [ ] State that must survive route transitions (e.g. the active tab on
+  a screen that can be briefly unmounted when the URL leaves the route)
+  needs to live **outside** the widget — in a `StateProvider` keyed by a
+  stable identifier. See
+  [`state_management.md`](state_management.md#persisting-state-across-shell-route-transitions).
+
+Routing and URL:
+
+- [ ] Every navigable state should be expressible as a URL (go_router).
+  See [`routing.md`](routing.md).
+
+Localization and brand:
+
+- [ ] Every user-facing string will come from `context.l10n` — plan ARB
+  keys up front, not at commit time. See
+  [`localization.md`](localization.md).
+- [ ] Copy matches brand voice (`brand-guidelines/TONE_OF_VOICE.md`).
+
+---
+
+## While implementing
+
+Design system (check `divine_ui` first — most review nits map here):
+
+- [ ] No hardcoded `Color(0x...)` literals. Use `VineTheme.*` colors;
+  apply transparency via `.withValues(alpha: x)` on a theme color.
+- [ ] No inline `TextStyle(...)`. Use a `VineTheme.*Font()` helper.
+  If the design needs a style that doesn't exist, **add it to
+  `VineTheme`** with a matching test (see coverage note below). See
+  [`ui_theming.md`](ui_theming.md).
+- [ ] No raw `Image.network` / `NetworkImage`. Use `VineCachedImage`.
+- [ ] No raw `Icons.*` / `SvgPicture.asset(...)`. Use `DivineIcon` or
+  `DivineIconButton`. Icon colors are picked automatically from the
+  button variant — never pass color manually to icon-in-button cases.
+- [ ] Uniform gaps between children in a `Row`/`Column` → use
+  `spacing: N`, not manual `SizedBox` spacers. `SizedBox` is fine when
+  gaps differ.
+- [ ] Interactive tap targets (`GestureDetector`, `InkWell`, custom) are
+  wrapped in `Semantics(button: true, label: ...)`. Decorative images
+  use `ExcludeSemantics`. See [`accessibility.md`](accessibility.md).
+
+Composition and style:
+
+- [ ] No methods returning `Widget`. Extract to a widget class (private
+  `_Xxx` inside the same file is fine). See
+  [`code_style.md`](code_style.md).
+- [ ] No `Future.delayed()` for UI timing. Use `AnimatedSwitcher`,
+  animation controllers, stream listeners.
+- [ ] Build methods stay small — a high-level composition of widget
+  classes.
+- [ ] Check `context.mounted` after every `await` before using
+  `BuildContext`.
+
+Scroll and navigation:
+
+- [ ] `NestedScrollView` with a pinned `SliverPersistentHeader` needs a
+  `topInset` in the delegate when the outer layout is edge-to-edge (no
+  `SafeArea`). See
+  [`ui_theming.md`](ui_theming.md#nestedscrollview-edge-to-edge-and-pinned-headers).
+
+State management:
+
+- [ ] Every `BlocProvider<X>(create: ...)` has a descendant that reads
+  `X` via `context.read/watch/select<X>`, `BlocBuilder<X,`,
+  `BlocListener<X,`, `BlocConsumer<X,`, or `BlocSelector<X,`. If not,
+  either add `lazy: false` with a justification or delete the wrapper
+  entirely — side effects in `create:` never fire without a consumer.
+- [ ] No error strings / exception objects in BLoC `state`. Use status
+  enums + `addError`. See [`state_management.md`](state_management.md).
+- [ ] No mutable instance variables on a BLoC class. All state lives in
+  the state object.
+
+Testing:
+
+- [ ] Any widget test that pumps code calling `context.l10n` includes
+  `localizationsDelegates: AppLocalizations.localizationsDelegates` and
+  `supportedLocales: AppLocalizations.supportedLocales` on its
+  `MaterialApp`.
+- [ ] New public method on a strict-coverage package (currently
+  `mobile/packages/divine_ui`) has a matching test **in the same PR**.
+  See [`testing.md`](testing.md#strict-coverage-packages).
+
+---
+
+## Before committing
+
+Run the verification sequence from `mobile/`:
+
+```
+dart format <changed files>
+flutter analyze lib test integration_test
+flutter test <scoped tests for your change>
+```
+
+Then:
+
+- [ ] No debug `print` / `developer.log` / red-background markers /
+  emoji TODOs left behind.
+- [ ] No unused imports, unused locals, dead code from a removed
+  approach.
+- [ ] Format, analyze, and scoped tests all pass locally.
+- [ ] Generated files (Riverpod, Freezed, JSON, Mockito, Drift) are
+  regenerated and staged if you touched inputs.
+- [ ] `pubspec.lock` churn from a different SDK/pub-resolver run is
+  **discarded**, not committed — only commit lockfile changes that come
+  from an explicit `flutter pub get` tied to a `pubspec.yaml` change.
+- [ ] Commit message explains the *why* (1–2 sentence body), not just
+  the *what*.
+
+---
+
+## Before opening or updating a PR
+
+- [ ] PR description follows `pull_request_template.md` (use
+  `/pr-summary` to regenerate from commits).
+- [ ] Deferred work is tracked in linked follow-up issues — not left
+  implicit in the PR body.
+- [ ] Screenshots or screen recordings attached for UI changes.
+- [ ] Manual test plan covers both own-profile and other-profile paths
+  (or equivalent primary vs secondary code paths) where relevant.
+- [ ] CI: `build / build` (divine_ui coverage), `Analyze`, `Tests`,
+  `Format`, `Generated Files` all green before requesting review.
+
+## Responding to review
+
+- [ ] Fetch **all** unresolved threads (including `isOutdated`) via
+  GraphQL before triaging — comments on outdated lines still need a
+  reply and a resolve.
+- [ ] Categorize: blocking / nit / superseded / deferred.
+- [ ] Sort by complexity; batch related fixes into one commit per
+  workstream; post one reply per thread citing the commit SHA.
+- [ ] Leave a single summary comment on the review tagging the reviewer
+  when all their blockers are addressed; don't expect them to
+  reconstruct it from 20 inline replies.

--- a/.claude/rules/state_management.md
+++ b/.claude/rules/state_management.md
@@ -201,6 +201,101 @@ emit(state.copyWith(
 
 ---
 
+## BlocProvider is lazy by default
+
+`BlocProvider(create:)` defaults to `lazy: true` (inherited from
+`provider`). The `create:` factory only runs the **first time** a
+descendant reads the bloc — via `context.read<X>()`, `context.watch<X>()`,
+`context.select((X b) => ...)`, `BlocBuilder<X, Y>`, `BlocListener<X, Y>`,
+`BlocConsumer<X, Y>`, or `BlocSelector<X, Y, S>`.
+
+**Consequence:** side effects inside the `create:` factory — a classic
+example being `..add(const LoadRequested())` to warm a cache — **do not
+run** unless something in the subtree consumes the bloc. A
+`BlocProvider` with no consumer in its subtree is dead code.
+
+**Bad — looks like cache warming, actually does nothing:**
+```dart
+// profile_grid.dart: there is no context.read<MyFollowersBloc> or
+// BlocBuilder<MyFollowersBloc, ...> anywhere under `content`, so the
+// factory — and therefore the load event — never fires.
+return BlocProvider<MyFollowersBloc>(
+  create: (_) => MyFollowersBloc(
+    followRepository: followRepository,
+  )..add(const MyFollowersListLoadRequested()),
+  child: content,
+);
+```
+
+**Before adding or keeping a `BlocProvider<X>`, verify a consumer
+exists.** A quick grep across the subtree's files:
+
+```
+grep -rn "context.read<X>\|context.watch<X>\|context.select((X\|BlocBuilder<X,\|BlocListener<X,\|BlocConsumer<X,\|BlocSelector<X,"
+```
+
+If the grep returns nothing, choose one:
+
+1. **Delete the wrapper.** If the work is "just cache warming," push it
+   to the repository layer where it belongs — the repository owns
+   composition, fallback, and pre-fetch strategies
+   (see `architecture.md`).
+2. **Add `lazy: false`** with a code comment justifying why the factory
+   must run eagerly, and add a test that covers the eager effect.
+
+This also applies to `MultiBlocProvider` and to nested providers — each
+bloc needs its own consumer; one consumer does not wake the others.
+
+---
+
+## Persisting state across shell-route transitions
+
+Screens inside a `ShellRoute` whose content is gated on the current URL
+(e.g. `_ProfileContentView` returning `SizedBox.shrink()` when
+`routeContext.type != RouteType.profile`) will **unmount** the content
+subtree whenever the URL briefly leaves the route — including during
+`context.push(...)` to a route defined outside the shell.
+
+Consequences:
+
+- `TabController`, `ScrollController`, animation controllers, and any
+  other state living in a widget `State` are **disposed** and
+  re-created on return.
+- The user sees the screen "reset" (e.g. selected tab → Videos, scroll
+  position → top) after closing the pushed route.
+
+**Fix:** persist the state externally, keyed by a stable identifier.
+For per-screen state like "active tab index," a simple
+`StateProvider<Map<String, int>>` keyed by `userIdHex` is enough:
+
+```dart
+// lib/providers/profile_tab_index_provider.dart
+import 'package:flutter_riverpod/legacy.dart';
+
+final profileTabIndexProvider = StateProvider<Map<String, int>>(
+  (ref) => <String, int>{},
+);
+```
+
+Read in `initState` to seed `TabController.initialIndex`; write in the
+tab listener. Lazy-sync side effects (e.g. loading a tab's data on
+first view) must also be re-dispatched when the restored index is not
+zero, since the controller's listener doesn't fire for the initial
+index.
+
+See `profile_grid.dart` + `profile_tab_index_provider.dart` for the
+pattern.
+
+### Riverpod 3.x gotcha
+
+`StateProvider` lives in **`package:flutter_riverpod/legacy.dart`** in
+Riverpod 3 — it's not exported from the main `flutter_riverpod.dart`
+entry. `StateProvider.family` type inference has sharp edges; prefer a
+plain `StateProvider<Map<K, V>>` for per-key state unless you
+specifically need independent cache scopes per key.
+
+---
+
 ## No Mutable Instance Variables in BLoC
 
 All mutable data must live in the BLoC's state object, never as private fields on the BLoC class. Private fields bypass the state stream, making them invisible to the UI, untestable via `blocTest`, and prone to desyncing from the actual state.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -354,3 +354,46 @@ Aim for 100% coverage. Use:
 ```bash
 flutter test --coverage
 ```
+
+### Strict-coverage packages
+
+Some packages enforce **100% line coverage as a CI gate** — not a
+target, a gate. The PR fails with a very specific message:
+
+> `Expected coverage >= 100.00% but actual is 99.xx%.`
+> `Lines not covered: lib/…: N, M, …`
+
+Current strict-coverage packages in this repo:
+
+- `mobile/packages/divine_ui`
+
+When adding a new public method / getter / constructor on a strict
+package (e.g. a new `VineTheme.xxxFont()` helper, a new enum case
+surfaced by a public method, a new widget variant), **add a matching
+test in the same PR**. Mirror the style of neighbouring tests —
+typically an assertion on the returned style / computed size.
+
+If a line is genuinely unreachable, exclude it from coverage with a
+justified `// coverage:ignore-line` (or block) comment rather than
+leaving the gate red.
+
+---
+
+## Widget tests that use `context.l10n`
+
+Any widget test that pumps a widget which calls `context.l10n.xxx` (or
+its generated getters) must include the localization delegates on the
+test's `MaterialApp`, or the l10n lookup fails at runtime:
+
+```dart
+MaterialApp(
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: ...
+)
+```
+
+A common symptom of the missing setup is an assertion that passes when
+the string is hardcoded but fails after an l10n migration with
+`Found 0 widgets with text "…"`. The widget tree built correctly; only
+the text child failed to resolve.

--- a/.claude/rules/ui_theming.md
+++ b/.claude/rules/ui_theming.md
@@ -380,6 +380,97 @@ SingleChildScrollView(
 
 ---
 
+## NestedScrollView edge-to-edge and pinned headers
+
+When building a screen with an edge-to-edge layout (banner extends
+behind the status bar, no outer `SafeArea`) plus a
+`NestedScrollView` with a pinned `SliverPersistentHeader`, the pinned
+header will sit **under the status bar** by default — icons/labels get
+clipped by the notch / Dynamic Island.
+
+**Fix:** the delegate must take a `topInset` that contributes to both
+`minExtent` and `maxExtent`, and render a matching `Padding(top:
+topInset)` above its content:
+
+```dart
+class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
+  _SliverAppBarDelegate(this._tabBar, {required this.topInset});
+
+  final TabBar _tabBar;
+  final double topInset;
+
+  @override
+  double get minExtent => _tabBar.preferredSize.height + topInset;
+
+  @override
+  double get maxExtent => _tabBar.preferredSize.height + topInset;
+
+  @override
+  Widget build(BuildContext context, double shrinkOffset, bool _) =>
+      DecoratedBox(
+        decoration: const BoxDecoration(color: VineTheme.surfaceBackground),
+        child: Padding(
+          padding: EdgeInsets.only(top: topInset),
+          child: _tabBar,
+        ),
+      );
+
+  @override
+  bool shouldRebuild(_SliverAppBarDelegate oldDelegate) =>
+      topInset != oldDelegate.topInset || _tabBar != oldDelegate._tabBar;
+}
+```
+
+### Prefer a dynamic topInset over a static one
+
+Setting `topInset = safeAreaTop` unconditionally leaves a permanent
+safe-area-sized gap above the pinned header when the user is at scroll
+offset 0 — visually loose. Drive the inset from scroll position so it
+only grows when the header is actually about to pin under the status
+bar:
+
+```dart
+// In the enclosing State (scroll listener):
+void _onScroll() {
+  final safeAreaTop = MediaQuery.paddingOf(context).top;
+  final triggerScroll = _headerHeight + _spacerHeight - safeAreaTop;
+  final newInset =
+      (scrollOffset - triggerScroll).clamp(0.0, safeAreaTop);
+  if (newInset != _tabBarTopInset) {
+    setState(() => _tabBarTopInset = newInset);
+  }
+}
+```
+
+### Pitfall: pinned-header height inflates outer maxScrollExtent
+
+`NestedScrollView` includes the pinned header's height in the outer
+`maxScrollExtent`. After the header and any scrolling action-buttons
+row are fully scrolled off, the outer can still scroll past that point
+by `pinnedHeaderHeight` before the inner scroll takes over — producing
+a visible "dead zone" at the top when scrolling back up (action
+buttons or other overlay widgets remain offscreen for that extra
+distance before reappearing). Options:
+
+1. Accept the gap and document it as a known issue.
+2. Use `SliverOverlapAbsorber`/`SliverOverlapInjector` (standard
+   Flutter pattern — doesn't fully solve, adjusts where the transition
+   happens).
+3. Restructure to a non-`NestedScrollView` architecture
+   (e.g. a single `CustomScrollView` whose pinned header is the only
+   scroll coordinator).
+
+### Pitfall: body subtree is rendered under pinned headers
+
+`NestedScrollView`'s body is laid out from y=0 of its own viewport, not
+from the pinned header's bottom edge. Decorations on the body's top
+edge (top borders, top-rounded `ClipRRect`, foreground `BorderSide`)
+are painted **behind** the pinned header and invisible. Put such
+decorations **inside the pinned header's delegate**, not on the body,
+so they live in the always-visible sliver region.
+
+---
+
 ## Accessibility
 
 See `accessibility.md` for the full accessibility guide (semantic labels, announcements, traversal order, contrast, font responsiveness, motion, and testing).


### PR DESCRIPTION
Closes #3201

## Summary

Codify the durable architectural lessons surfaced during review of #2571 as auto-read rules under `.claude/rules/`. Each rule is cross-linked from a new top-level `self_review_checklist.md` so that Claude-Code sessions are primed with this knowledge at session start, without anyone having to invoke a skill. Nothing under `lib/` or `test/` is touched — this is documentation that governs how the assistant self-checks before committing.

The goal is that the next time this kind of feedback would have fired, it fires in my head instead of in a reviewer's mouth.

## What's new

### 1. `rules/self_review_checklist.md` (new, 157 lines)

Single-page checklist organized by gate:

- **Before planning a feature** — architecture & ownership, routing, l10n planning
- **While implementing** — design-system compliance, widget composition, scroll/navigation, state management, testing setup
- **Before committing** — verification sequence, cleanup, lockfile discipline
- **Before opening or updating a PR** — description, manual test plan, CI gates
- **Responding to review** — thread triage, phasing, reply discipline

Every bullet links to the detailed rule it summarizes, so this doubles as a table of contents for the rest of `rules/`.

### 2. Extensions to existing rule files

#### `rules/state_management.md` (+95 lines)

**"BlocProvider is lazy by default"** — closes the exact anti-pattern from the dead follower-prefetch wrapping on #2571.

- `BlocProvider(create:)` defaults to `lazy: true`; the factory only runs when a descendant reads the bloc.
- Side effects like `..add(LoadRequested())` inside `create:` **do not fire** without a consumer.
- Grep recipe to verify a consumer exists (`context.read/watch/select<X>`, `BlocBuilder<X,`, `BlocListener<X,`, `BlocConsumer<X,`, `BlocSelector<X,`).
- Two acceptable remediations: delete the wrapper and push the work to the repository layer, or add `lazy: false` with a code comment + coverage test.

Sourced from:
- [Oscar's original diagnosis (thread #3)](https://github.com/divinevideo/divine-mobile/pull/2571#discussion_r3045773857)
- [Yliana's code-walkthrough verification](https://github.com/divinevideo/divine-mobile/pull/2571#discussion_r3045773857)
- [Dr Liz's blocking review](https://github.com/divinevideo/divine-mobile/pull/2571#pullrequestreview-4122738196) marking this as one of three merge blockers
- Fix on `new-profile`: `ee4416f79`

**"Persisting state across shell-route transitions"** — prevents the "tab resets to Videos after closing a fullscreen video" regression I had to fix live during the redesign.

- Screens inside a `ShellRoute` whose content is gated on the current URL can be unmounted during `context.push(...)` to an out-of-shell route.
- `TabController` / `ScrollController` state is disposed and re-created on return.
- Fix pattern: `StateProvider<Map<String, int>>` keyed by a stable identifier, read in `initState` to seed the controller, written back on change.
- Riverpod 3.x footnote: `StateProvider` lives in `package:flutter_riverpod/legacy.dart`, not the main export; `.family` type inference has sharp edges — use a plain `StateProvider<Map<K, V>>` for per-key state.

Sourced from: investigation during the new-profile PR when I noticed tab state was being dropped on return from fullscreen videos (not a reviewer catch — this one was a self-find during QA, but worth codifying).

#### `rules/ui_theming.md` (+91 lines)

**"NestedScrollView edge-to-edge and pinned headers"** — the pattern that resolves hm21's tab-bar-under-the-status-bar blocker.

- Delegate `topInset` that contributes to both `minExtent` / `maxExtent` and is rendered as `Padding(top: topInset)` above the header content.
- Prefer a dynamic topInset (animated from 0 → safeAreaTop as the layout triggers pinning) over a static one, so there's no permanent safe-area-sized gap at scroll offset 0.
- Pitfall: `NestedScrollView` includes the pinned header's height in the outer `maxScrollExtent`, creating a visible "dead zone" when scrolling back up.
- Pitfall: the body subtree is rendered *under* pinned headers; top-edge decorations on the body (top borders, top-rounded `ClipRRect`) are painted behind the pinned header and invisible. Put those decorations inside the pinned delegate instead.

Sourced from:
- [hm21's suggestion (thread #17)](https://github.com/divinevideo/divine-mobile/pull/2571#discussion_r3093904286)
- [Dr Liz's blocker](https://github.com/divinevideo/divine-mobile/pull/2571#pullrequestreview-4122738196) restating #17 as merge-blocking
- Fix on `new-profile`: `dde8ccc35` (the new scroll architecture)
- "Body rendered under pinned headers" pitfall: discovered during the outer-radius / divider-position iteration where a `ClipRRect(topLeft: 4, topRight: 4)` on the `CustomScrollView` disappeared entirely, forcing me to move the divider into the pinned sliver

#### `rules/testing.md` (+43 lines)

**"Strict-coverage packages"** — catches the exact CI failure signature from `50fd803e9`.

- `mobile/packages/divine_ui` enforces 100% line coverage; missing coverage on a new public method is a hard merge block.
- The failure message is very specific (`Expected coverage >= 100.00% but actual is 99.xx%. Lines not covered: lib/…: N, M`), so it can be recognized at a glance.
- Rule: any new public method / getter / constructor on a strict package needs a matching test in the same PR.

**"Widget tests that use `context.l10n`"** — the exact symptom that bit me during the Phase 2 l10n migration.

- Tests pumping widgets that call `context.l10n` need `AppLocalizations.localizationsDelegates` + `supportedLocales` on their `MaterialApp`, or the lookup fails at runtime.
- Symptom: `Found 0 widgets with text "…"` on a test that passed when the string was hardcoded.

Sourced from:
- Divine UI CI failure after `50fd803e9` ([run](https://github.com/divinevideo/divine-mobile/actions/runs/24682859227/job/72184402943)) — fixed in `4e710299b`
- Phase 2 l10n migration test failures: the 31 failing tests in `profile_header_widget_test.dart` / `profile_actions_sheet_content_test.dart` that only passed once delegates were added

#### `rules/localization.md` (+55 lines)

**"Running an l10n pass over existing code"** — the migration procedure I executed in Phase 2, now written down.

1. Inventory hardcoded strings (excluding logs, asset paths, test fixtures).
2. Check `app_en.arb` first — keys are often scaffolded in anticipation of a migration and sit unused.
3. Prefer reuse over adding near-duplicates.
4. Add missing keys with `@description` metadata when the meaning isn't obvious from the name.
5. Regenerate via `flutter gen-l10n`.
6. Swap call sites; thread `BuildContext` into helpers that don't already take it.
7. Update tests with localization delegates.

**"Copy-alignment policy"** — align code to the ARB value, not the other way around.

- ARB values are already translated into 16+ locales; changing an English value silently drifts every translation.
- Copy changes belong in product-reviewed commits, not as a side effect of an l10n migration.

Sourced from:
- [realmeylisdev #5 — stats row labels](https://github.com/divinevideo/divine-mobile/pull/2571#discussion_r3093647086)
- [realmeylisdev #6 — session-expired sheet](https://github.com/divinevideo/divine-mobile/pull/2571#discussion_r3093647399)
- [realmeylisdev #7 — action buttons](https://github.com/divinevideo/divine-mobile/pull/2571#discussion_r3093647625)
- [realmeylisdev #9 — actions sheet](https://github.com/divinevideo/divine-mobile/pull/2571#discussion_r3093652559)
- [Dr Liz's top-level blocker](https://github.com/divinevideo/divine-mobile/pull/2571#pullrequestreview-4122738196) requiring a complete l10n pass
- Fix on `new-profile`: `04c7d52f7`

### 3. `CLAUDE.md` (+18 / -4)

Adds a prominent "Read before every change" section pointing to the new `self_review_checklist.md`, and extends the reference list so each rule's summary mentions the new sub-topics.

## Why these and not others

The review surface on #2571 was large, but most inline threads were enforcing *rules that already exist* (no hardcoded strings, no raw Colors, use VineTheme, no `Image.network`) — I just failed to self-check against them. For those, there was nothing to add; the fix is behavioral, and `self_review_checklist.md` is the explicit hook to trigger that behavior.

The five extensions above capture knowledge that was **not** in the rules when #2571 was reviewed:

| Extension | Why it belongs in rules |
|---|---|
| BlocProvider lazy + dead-code risk | Subtle — requires knowing `provider` defaults to `lazy: true`; the grep recipe is non-obvious. |
| State persistence across shell-route transitions | Non-obvious unmount behavior specific to this router structure. |
| NestedScrollView edge-to-edge + topInset | Very specific to the banner-edge-to-edge design pattern. |
| Strict-coverage packages | The 100% gate failure signature is unique to divine_ui and worth recognizing on sight. |
| l10n-pass procedure + copy alignment | There's an "adding a new string" section but no "migrating a prototype" procedure. |

## Test plan

- [x] Rules files render correctly on GitHub (markdown links, fenced code blocks).
- [x] `self_review_checklist.md` cross-links point to existing sections (`architecture.md`, `state_management.md#…`, etc.).
- [x] `CLAUDE.md` still parses as markdown; reference list is alphabetical-adjacent to the other `rules/*.md` entries.
- [x] No code changes, so no CI impact beyond `Analyze` passing cleanly (it does — nothing in `lib/`).
- [ ] Future: next PR I open on this branch, sanity-check that the assistant actually reads the checklist at session start (I'll confirm this the next time I start a feature).

## Related

- Source PR where the lessons came from: #2571
- Dr Liz's blocking review: [pullrequestreview-4122738196](https://github.com/divinevideo/divine-mobile/pull/2571#pullrequestreview-4122738196)
- Follow-up issues already filed: #3119 (pull-to-refresh for redesigned profile), #3120 (moving follower-list cache warming to the repository layer)
