### PR TITLE
feat(search): add people list search support behind feature flag

### DIFF
--- a/mobile/lib/blocs/list_search/list_search_bloc.dart
+++ b/mobile/lib/blocs/list_search/list_search_bloc.dart
@@ -1,23 +1,47 @@
-// ABOUTME: BLoC for searching curated video lists (kind 30005).
-// ABOUTME: Streams local + relay results progressively via CuratedListRepository.
+// ABOUTME: BLoC for searching curated video lists (kind 30005) and people lists (kind 30000).
+// ABOUTME: Merges both streams via a tagged union and uses emit.forEach for safe lifecycle.
 
 import 'package:curated_list_repository/curated_list_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart';
 import 'package:openvine/constants/search_constants.dart';
+import 'package:rxdart/rxdart.dart';
 
 part 'list_search_event.dart';
 part 'list_search_state.dart';
 
-/// BLoC for searching curated video lists (kind 30005).
+/// Tagged union emitted by the merged search stream.
+sealed class _SearchResult {
+  const _SearchResult();
+}
+
+final class _VideoSearchResult extends _SearchResult {
+  const _VideoSearchResult(this.lists);
+  final List<CuratedList> lists;
+}
+
+final class _PeopleSearchResult extends _SearchResult {
+  const _PeopleSearchResult(this.lists);
+  final List<UserList> lists;
+}
+
+/// BLoC for searching curated video lists (kind 30005) and people lists
+/// (kind 30000).
 ///
-/// Delegates to [CuratedListRepository.searchAllLists] which yields local
-/// results first, then progressively merges relay results.
+/// Merges [CuratedListRepository.searchAllLists] and
+/// [CuratedListRepository.searchAllPeopleLists] into a single stream via
+/// [Rx.merge] and processes it with [emit.forEach] so that
+/// [debounceRestartable] correctly cancels in-flight subscriptions.
+///
+/// The [peopleListSearchEnabled] flag controls whether the people list stream
+/// is included. When `false`, only video lists are searched.
 class ListSearchBloc extends Bloc<ListSearchEvent, ListSearchState> {
   ListSearchBloc({
     required CuratedListRepository curatedListRepository,
+    bool peopleListSearchEnabled = false,
   }) : _curatedListRepository = curatedListRepository,
+       _peopleListSearchEnabled = peopleListSearchEnabled,
        super(const ListSearchState()) {
     on<ListSearchQueryChanged>(
       _onQueryChanged,
@@ -27,6 +51,7 @@ class ListSearchBloc extends Bloc<ListSearchEvent, ListSearchState> {
   }
 
   final CuratedListRepository _curatedListRepository;
+  final bool _peopleListSearchEnabled;
 
   Future<void> _onQueryChanged(
     ListSearchQueryChanged event,
@@ -45,25 +70,45 @@ class ListSearchBloc extends Bloc<ListSearchEvent, ListSearchState> {
       return;
     }
 
-    emit(state.copyWith(status: ListSearchStatus.loading, query: query));
+    emit(
+      state.copyWith(
+        status: ListSearchStatus.loading,
+        query: query,
+        videoResults: const [],
+        peopleResults: const [],
+      ),
+    );
 
     try {
-      await emit.forEach(
-        _curatedListRepository.searchAllLists(query),
-        onData: (results) => state.copyWith(
-          status: ListSearchStatus.success,
-          results: results,
-        ),
+      final videoStream = _curatedListRepository
+          .searchAllLists(query)
+          .map<_SearchResult>(_VideoSearchResult.new);
+
+      final streams = [
+        videoStream,
+        if (_peopleListSearchEnabled)
+          _curatedListRepository
+              .searchAllPeopleLists(query)
+              .map<_SearchResult>(_PeopleSearchResult.new),
+      ];
+
+      await emit.forEach<_SearchResult>(
+        Rx.merge(streams),
+        onData: (result) => switch (result) {
+          _VideoSearchResult(:final lists) => state.copyWith(
+            status: ListSearchStatus.success,
+            videoResults: lists,
+          ),
+          _PeopleSearchResult(:final lists) => state.copyWith(
+            status: ListSearchStatus.success,
+            peopleResults: lists,
+          ),
+        },
       );
 
-      // If stream completes without emitting, still emit success
+      // If stream completes without emitting, still emit success.
       if (state.status == ListSearchStatus.loading) {
-        emit(
-          state.copyWith(
-            status: ListSearchStatus.success,
-            results: const [],
-          ),
-        );
+        emit(state.copyWith(status: ListSearchStatus.success));
       }
     } on Exception catch (e, stackTrace) {
       addError(e, stackTrace);

--- a/mobile/lib/blocs/list_search/list_search_state.dart
+++ b/mobile/lib/blocs/list_search/list_search_state.dart
@@ -1,5 +1,5 @@
 // ABOUTME: State class for the ListSearchBloc.
-// ABOUTME: Holds status, query, and curated video list search results.
+// ABOUTME: Holds status, query, curated video list results, and people list results.
 
 part of 'list_search_bloc.dart';
 
@@ -23,7 +23,8 @@ final class ListSearchState extends Equatable {
   const ListSearchState({
     this.status = ListSearchStatus.initial,
     this.query = '',
-    this.results = const [],
+    this.videoResults = const [],
+    this.peopleResults = const [],
   });
 
   /// The current status of the search.
@@ -32,23 +33,27 @@ final class ListSearchState extends Equatable {
   /// The current search query.
   final String query;
 
-  /// Curated video lists matching the search.
-  // TODO(#2853): Add people list results field.
-  final List<CuratedList> results;
+  /// Curated video lists (kind 30005) matching the search.
+  final List<CuratedList> videoResults;
+
+  /// People lists (kind 30000) matching the search.
+  final List<UserList> peopleResults;
 
   /// Create a copy with updated values.
   ListSearchState copyWith({
     ListSearchStatus? status,
     String? query,
-    List<CuratedList>? results,
+    List<CuratedList>? videoResults,
+    List<UserList>? peopleResults,
   }) {
     return ListSearchState(
       status: status ?? this.status,
       query: query ?? this.query,
-      results: results ?? this.results,
+      videoResults: videoResults ?? this.videoResults,
+      peopleResults: peopleResults ?? this.peopleResults,
     );
   }
 
   @override
-  List<Object> get props => [status, query, results];
+  List<Object> get props => [status, query, videoResults, peopleResults];
 }

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -51,6 +51,10 @@ enum FeatureFlag {
     'HLS + NIP-98 Web Player',
     'Route web video playback through hls.js with NIP-98 auth headers so '
         'age-gated and other 401-protected media can be viewed on web',
+  ),
+  peopleListSearch(
+    'People List Search',
+    'Show people list (kind 30000) results alongside video lists in search',
   )
   ;
 

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -43,6 +43,8 @@ class BuildConfiguration {
         return const bool.fromEnvironment('FF_FEED_AUTO_ADVANCE');
       case FeatureFlag.hlsAuthWebPlayer:
         return const bool.fromEnvironment('FF_HLS_AUTH_WEB_PLAYER');
+      case FeatureFlag.peopleListSearch:
+        return const bool.fromEnvironment('FF_PEOPLE_LIST_SEARCH');
     }
   }
 
@@ -85,6 +87,8 @@ class BuildConfiguration {
         return 'FF_FEED_AUTO_ADVANCE';
       case FeatureFlag.hlsAuthWebPlayer:
         return 'FF_HLS_AUTH_WEB_PLAYER';
+      case FeatureFlag.peopleListSearch:
+        return 'FF_PEOPLE_LIST_SEARCH';
     }
   }
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2368,6 +2368,8 @@
     "searchDiscoverSomethingInteresting": "اكتشف شيئًا مثيرًا للاهتمام",
     "searchEnterQuery": "أدخل استعلام البحث",
     "searchFindCuratedVideoLists": "ابحث عن قوائم فيديو مختارة",
+  "searchListsSectionHeader": "القوائم",
+  "searchListsLoadingLabel": "جارٍ تحميل نتائج القوائم",
     "searchForLists": "البحث عن قوائم",
     "searchSomethingWentWrong": "حدث خطأ ما",
     "searchTryAgain": "حاول مجددًا",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2368,6 +2368,8 @@
     "searchDiscoverSomethingInteresting": "Entdecke etwas Interessantes",
     "searchEnterQuery": "Suchbegriff eingeben",
     "searchFindCuratedVideoLists": "Kuratierte Videolisten finden",
+  "searchListsSectionHeader": "Listen",
+  "searchListsLoadingLabel": "Listenergebnisse werden geladen",
     "searchForLists": "Nach Listen suchen",
     "searchSomethingWentWrong": "Etwas ist schiefgelaufen",
     "searchTryAgain": "Erneut versuchen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2400,6 +2400,8 @@
   "@searchDiscoverSomethingInteresting": {
     "description": "Subtitle of the empty-query placeholder shown on the search results screen before the user has entered a query."
   },
+  "searchListsSectionHeader": "Lists",
+  "searchListsLoadingLabel": "Loading list results",
 
   "contentWarningViewAnyway": "View Anyway",
 

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2368,6 +2368,8 @@
     "searchDiscoverSomethingInteresting": "Descubrí algo interesante",
     "searchEnterQuery": "Ingresá una búsqueda",
     "searchFindCuratedVideoLists": "Encontrá listas de videos curadas",
+  "searchListsSectionHeader": "Listas",
+  "searchListsLoadingLabel": "Cargando resultados de listas",
     "searchForLists": "Buscar listas",
     "searchSomethingWentWrong": "Algo salió mal",
     "searchTryAgain": "Reintentar",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2368,6 +2368,8 @@
     "searchDiscoverSomethingInteresting": "Découvre quelque chose d'intéressant",
     "searchEnterQuery": "Saisis une recherche",
     "searchFindCuratedVideoLists": "Trouve des listes de vidéos sélectionnées",
+  "searchListsSectionHeader": "Listes",
+  "searchListsLoadingLabel": "Chargement des résultats de listes",
     "searchForLists": "Rechercher des listes",
     "searchSomethingWentWrong": "Quelque chose s'est mal passé",
     "searchTryAgain": "Réessayer",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2368,6 +2368,8 @@
     "searchDiscoverSomethingInteresting": "Temukan sesuatu yang menarik",
     "searchEnterQuery": "Masukkan kata pencarian",
     "searchFindCuratedVideoLists": "Temukan daftar video pilihan",
+  "searchListsSectionHeader": "Daftar",
+  "searchListsLoadingLabel": "Memuat hasil daftar",
     "searchForLists": "Cari daftar",
     "searchSomethingWentWrong": "Terjadi kesalahan",
     "searchTryAgain": "Coba lagi",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2368,6 +2368,8 @@
     "searchDiscoverSomethingInteresting": "Scopri qualcosa di interessante",
     "searchEnterQuery": "Inserisci una ricerca",
     "searchFindCuratedVideoLists": "Trova liste di video curate",
+  "searchListsSectionHeader": "Liste",
+  "searchListsLoadingLabel": "Caricamento risultati liste",
     "searchForLists": "Cerca liste",
     "searchSomethingWentWrong": "Qualcosa è andato storto",
     "searchTryAgain": "Riprova",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2368,6 +2368,8 @@
     "searchDiscoverSomethingInteresting": "面白いものを見つけよう",
     "searchEnterQuery": "検索キーワードを入力",
     "searchFindCuratedVideoLists": "キュレーションされた動画リストを探そう",
+  "searchListsSectionHeader": "リスト",
+  "searchListsLoadingLabel": "リスト結果を読み込み中",
     "searchForLists": "リストを検索",
     "searchSomethingWentWrong": "なんかうまくいかなかった",
     "searchTryAgain": "もう一回",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1678,6 +1678,8 @@
     "searchDiscoverSomethingInteresting": "흥미로운 것을 발견해보세요",
     "searchEnterQuery": "검색어를 입력하세요",
     "searchFindCuratedVideoLists": "큐레이션된 동영상 목록 찾기",
+  "searchListsSectionHeader": "목록",
+  "searchListsLoadingLabel": "목록 결과 불러오는 중",
     "searchForLists": "목록 검색",
     "searchSomethingWentWrong": "문제가 발생했어요",
     "searchTryAgain": "다시 시도",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2368,6 +2368,8 @@
     "searchDiscoverSomethingInteresting": "Ontdek iets interessants",
     "searchEnterQuery": "Voer een zoekopdracht in",
     "searchFindCuratedVideoLists": "Vind samengestelde videolijsten",
+  "searchListsSectionHeader": "Lijsten",
+  "searchListsLoadingLabel": "Lijstresultaten laden",
     "searchForLists": "Zoek naar lijsten",
     "searchSomethingWentWrong": "Er ging iets mis",
     "searchTryAgain": "Opnieuw proberen",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2368,6 +2368,8 @@
     "searchDiscoverSomethingInteresting": "Odkryj coś ciekawego",
     "searchEnterQuery": "Wpisz zapytanie",
     "searchFindCuratedVideoLists": "Znajdź wyselekcjonowane listy filmów",
+  "searchListsSectionHeader": "Listy",
+  "searchListsLoadingLabel": "Ładowanie wyników list",
     "searchForLists": "Szukaj list",
     "searchSomethingWentWrong": "Coś poszło nie tak",
     "searchTryAgain": "Spróbuj ponownie",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2368,6 +2368,8 @@
     "searchDiscoverSomethingInteresting": "Descubra algo interessante",
     "searchEnterQuery": "Digite uma busca",
     "searchFindCuratedVideoLists": "Encontre listas de vídeos selecionados",
+  "searchListsSectionHeader": "Listas",
+  "searchListsLoadingLabel": "Carregando resultados de listas",
     "searchForLists": "Buscar listas",
     "searchSomethingWentWrong": "Algo deu errado",
     "searchTryAgain": "Tentar novamente",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2368,6 +2368,8 @@
     "searchDiscoverSomethingInteresting": "Descoperă ceva interesant",
     "searchEnterQuery": "Introdu un termen de căutare",
     "searchFindCuratedVideoLists": "Găsește liste de videoclipuri selectate",
+  "searchListsSectionHeader": "Liste",
+  "searchListsLoadingLabel": "Se încarcă rezultatele listelor",
     "searchForLists": "Caută liste",
     "searchSomethingWentWrong": "Ceva nu a mers bine",
     "searchTryAgain": "Încearcă din nou",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2368,6 +2368,8 @@
     "searchDiscoverSomethingInteresting": "Upptäck något intressant",
     "searchEnterQuery": "Skriv en sökterm",
     "searchFindCuratedVideoLists": "Hitta kurerade videolistor",
+  "searchListsSectionHeader": "Listor",
+  "searchListsLoadingLabel": "Laddar listresultat",
     "searchForLists": "Sök efter listor",
     "searchSomethingWentWrong": "Något gick fel",
     "searchTryAgain": "Försök igen",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2368,6 +2368,8 @@
     "searchDiscoverSomethingInteresting": "İlginç bir şey keşfet",
     "searchEnterQuery": "Bir arama terimi girin",
     "searchFindCuratedVideoLists": "Küratörlü video listelerini bul",
+  "searchListsSectionHeader": "Listeler",
+  "searchListsLoadingLabel": "Liste sonuçları yükleniyor",
     "searchForLists": "Liste ara",
     "searchSomethingWentWrong": "Bir şeyler ters gitti",
     "searchTryAgain": "Tekrar dene",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -8276,6 +8276,18 @@ abstract class AppLocalizations {
   /// **'Discover something interesting'**
   String get searchDiscoverSomethingInteresting;
 
+  /// No description provided for @searchListsSectionHeader.
+  ///
+  /// In en, this message translates to:
+  /// **'Lists'**
+  String get searchListsSectionHeader;
+
+  /// No description provided for @searchListsLoadingLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Loading list results'**
+  String get searchListsLoadingLabel;
+
   /// No description provided for @cameraAgeRestriction.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4629,6 +4629,12 @@ class AppLocalizationsAr extends AppLocalizations {
       'اكتشف شيئًا مثيرًا للاهتمام';
 
   @override
+  String get searchListsSectionHeader => 'القوائم';
+
+  @override
+  String get searchListsLoadingLabel => 'جارٍ تحميل نتائج القوائم';
+
+  @override
   String get cameraAgeRestriction =>
       'يجب أن يكون عمرك 16 عامًا أو أكثر لإنشاء محتوى';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4731,6 +4731,12 @@ class AppLocalizationsDe extends AppLocalizations {
       'Entdecke etwas Interessantes';
 
   @override
+  String get searchListsSectionHeader => 'Listen';
+
+  @override
+  String get searchListsLoadingLabel => 'Listenergebnisse werden geladen';
+
+  @override
   String get cameraAgeRestriction =>
       'Du musst mindestens 16 Jahre alt sein, um Inhalte zu erstellen';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4668,6 +4668,12 @@ class AppLocalizationsEn extends AppLocalizations {
       'Discover something interesting';
 
   @override
+  String get searchListsSectionHeader => 'Lists';
+
+  @override
+  String get searchListsLoadingLabel => 'Loading list results';
+
+  @override
   String get cameraAgeRestriction =>
       'You must be 16 or older to create content';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4723,6 +4723,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get searchDiscoverSomethingInteresting => 'Descubrí algo interesante';
 
   @override
+  String get searchListsSectionHeader => 'Listas';
+
+  @override
+  String get searchListsLoadingLabel => 'Cargando resultados de listas';
+
+  @override
   String get cameraAgeRestriction =>
       'Tenés que tener 16 años o más para crear contenido';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4737,6 +4737,12 @@ class AppLocalizationsFr extends AppLocalizations {
       'Découvre quelque chose d\'intéressant';
 
   @override
+  String get searchListsSectionHeader => 'Listes';
+
+  @override
+  String get searchListsLoadingLabel => 'Chargement des résultats de listes';
+
+  @override
   String get cameraAgeRestriction =>
       'Tu dois avoir 16 ans ou plus pour créer du contenu';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4650,6 +4650,12 @@ class AppLocalizationsId extends AppLocalizations {
       'Temukan sesuatu yang menarik';
 
   @override
+  String get searchListsSectionHeader => 'Daftar';
+
+  @override
+  String get searchListsLoadingLabel => 'Memuat hasil daftar';
+
+  @override
   String get cameraAgeRestriction =>
       'Kamu harus berusia 16 tahun atau lebih untuk membuat konten';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4718,6 +4718,12 @@ class AppLocalizationsIt extends AppLocalizations {
       'Scopri qualcosa di interessante';
 
   @override
+  String get searchListsSectionHeader => 'Liste';
+
+  @override
+  String get searchListsLoadingLabel => 'Caricamento risultati liste';
+
+  @override
   String get cameraAgeRestriction =>
       'Devi avere almeno 16 anni per creare contenuti';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4470,6 +4470,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get searchDiscoverSomethingInteresting => '面白いものを見つけよう';
 
   @override
+  String get searchListsSectionHeader => 'リスト';
+
+  @override
+  String get searchListsLoadingLabel => 'リスト結果を読み込み中';
+
+  @override
   String get cameraAgeRestriction => 'コンテンツを作るには16歳以上である必要があるよ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4493,6 +4493,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get searchDiscoverSomethingInteresting => '흥미로운 것을 발견해보세요';
 
   @override
+  String get searchListsSectionHeader => '목록';
+
+  @override
+  String get searchListsLoadingLabel => '목록 결과 불러오는 중';
+
+  @override
   String get cameraAgeRestriction => '콘텐츠를 만들려면 16세 이상이어야 해요';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4690,6 +4690,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get searchDiscoverSomethingInteresting => 'Ontdek iets interessants';
 
   @override
+  String get searchListsSectionHeader => 'Lijsten';
+
+  @override
+  String get searchListsLoadingLabel => 'Lijstresultaten laden';
+
+  @override
   String get cameraAgeRestriction =>
       'Je moet 16 jaar of ouder zijn om content te maken';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4812,6 +4812,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get searchDiscoverSomethingInteresting => 'Odkryj coś ciekawego';
 
   @override
+  String get searchListsSectionHeader => 'Listy';
+
+  @override
+  String get searchListsLoadingLabel => 'Ładowanie wyników list';
+
+  @override
   String get cameraAgeRestriction =>
       'Musisz mieć co najmniej 16 lat, aby tworzyć treści';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4703,6 +4703,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get searchDiscoverSomethingInteresting => 'Descubra algo interessante';
 
   @override
+  String get searchListsSectionHeader => 'Listas';
+
+  @override
+  String get searchListsLoadingLabel => 'Carregando resultados de listas';
+
+  @override
   String get cameraAgeRestriction =>
       'Você precisa ter 16 anos ou mais para criar conteúdo';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4805,6 +4805,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get searchDiscoverSomethingInteresting => 'Descoperă ceva interesant';
 
   @override
+  String get searchListsSectionHeader => 'Liste';
+
+  @override
+  String get searchListsLoadingLabel => 'Se încarcă rezultatele listelor';
+
+  @override
   String get cameraAgeRestriction =>
       'Trebuie să ai cel puțin 16 ani pentru a crea conținut';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4664,6 +4664,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get searchDiscoverSomethingInteresting => 'Upptäck något intressant';
 
   @override
+  String get searchListsSectionHeader => 'Listor';
+
+  @override
+  String get searchListsLoadingLabel => 'Laddar listresultat';
+
+  @override
   String get cameraAgeRestriction =>
       'Du måste vara 16 år eller äldre för att skapa innehåll';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4655,6 +4655,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get searchDiscoverSomethingInteresting => 'İlginç bir şey keşfet';
 
   @override
+  String get searchListsSectionHeader => 'Listeler';
+
+  @override
+  String get searchListsLoadingLabel => 'Liste sonuçları yükleniyor';
+
+  @override
   String get cameraAgeRestriction =>
       'İçerik oluşturmak için 16 yaşında veya daha büyük olmalısın';
 

--- a/mobile/lib/screens/search_results/view/search_results_page.dart
+++ b/mobile/lib/screens/search_results/view/search_results_page.dart
@@ -6,6 +6,8 @@ import 'package:openvine/blocs/list_search/list_search_bloc.dart';
 import 'package:openvine/blocs/search_results_filter/search_results_filter.dart';
 import 'package:openvine/blocs/user_search/user_search_bloc.dart';
 import 'package:openvine/blocs/video_search/video_search_bloc.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/search_results/view/search_results_view.dart';
 import 'package:openvine/screens/search_results/widgets/search_results_app_bar.dart';
@@ -52,6 +54,9 @@ class SearchResultsPage extends ConsumerWidget {
         BlocProvider(
           create: (_) => ListSearchBloc(
             curatedListRepository: ref.read(curatedListRepositoryProvider),
+            peopleListSearchEnabled: ref.read(
+              isFeatureEnabledProvider(FeatureFlag.peopleListSearch),
+            ),
           ),
         ),
       ],

--- a/mobile/lib/screens/search_results/widgets/lists_section.dart
+++ b/mobile/lib/screens/search_results/widgets/lists_section.dart
@@ -57,7 +57,10 @@ class ListsSection extends StatelessWidget {
       slivers: [
         if (!showAll)
           SliverToBoxAdapter(
-            child: SectionHeader(title: 'Lists', onTap: onSeeAll),
+            child: SectionHeader(
+              title: context.l10n.searchListsSectionHeader,
+              onTap: onSeeAll,
+            ),
           ),
         _ListsContent(showAll: showAll),
       ],
@@ -269,7 +272,7 @@ class _ListsSkeletonLoader extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       identifier: 'lists_loading_indicator',
-      label: 'Loading list results',
+      label: context.l10n.searchListsLoadingLabel,
       child: const Skeletonizer(
         effect: vineSkeletonEffect,
         child: Padding(

--- a/mobile/lib/screens/search_results/widgets/lists_section.dart
+++ b/mobile/lib/screens/search_results/widgets/lists_section.dart
@@ -1,5 +1,8 @@
 // ABOUTME: Lists section for search results, used in both "All" preview
 // ABOUTME: and the dedicated "Lists" tab (showAll: true).
+// ABOUTME: Shows curated video lists (kind 30005) and, when the
+// ABOUTME: peopleListSearch feature flag is enabled (injected via BLoC),
+// ABOUTME: people lists (kind 30000).
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -7,12 +10,14 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide AspectRatio;
 import 'package:openvine/blocs/list_search/list_search_bloc.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/router/routes/route_extras.dart';
 import 'package:openvine/screens/curated_list_feed_screen.dart';
 import 'package:openvine/screens/search_results/widgets/search_section_empty_state.dart';
 import 'package:openvine/screens/search_results/widgets/search_section_error_state.dart';
 import 'package:openvine/screens/search_results/widgets/section_header.dart';
 import 'package:openvine/widgets/list_search_card.dart';
+import 'package:openvine/widgets/people_list_search_card.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 /// Always-visible Lists section with a "Lists" header.
@@ -34,12 +39,17 @@ class ListsSection extends StatelessWidget {
     final status = context.select(
       (ListSearchBloc bloc) => bloc.state.status,
     );
-    final results = context.select(
-      (ListSearchBloc bloc) => bloc.state.results,
+    final videoResults = context.select(
+      (ListSearchBloc bloc) => bloc.state.videoResults,
+    );
+    final peopleResults = context.select(
+      (ListSearchBloc bloc) => bloc.state.peopleResults,
     );
 
+    final hasAnyResults = videoResults.isNotEmpty || peopleResults.isNotEmpty;
+
     // In the All tab, hide entire section when results are empty and loaded.
-    if (!showAll && status == .success && results.isEmpty) {
+    if (!showAll && status == .success && !hasAnyResults) {
       return const SliverToBoxAdapter(child: SizedBox.shrink());
     }
 
@@ -63,10 +73,21 @@ class _ListsContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final status = context.select((ListSearchBloc bloc) => bloc.state.status);
-    final results = context.select((ListSearchBloc bloc) => bloc.state.results);
+    final videoResults = context.select(
+      (ListSearchBloc bloc) => bloc.state.videoResults,
+    );
+    final peopleResults = context.select(
+      (ListSearchBloc bloc) => bloc.state.peopleResults,
+    );
     final query = context.select((ListSearchBloc bloc) => bloc.state.query);
 
-    if ((status == .initial || status == .loading) && results.isEmpty) {
+    if (status == .initial && showAll) {
+      return const _InitialState();
+    }
+
+    if ((status == .initial || status == .loading) &&
+        videoResults.isEmpty &&
+        peopleResults.isEmpty) {
       return const _LoadingState();
     }
 
@@ -78,38 +99,39 @@ class _ListsContent extends StatelessWidget {
       );
     }
 
-    if (results.isEmpty) {
+    final hasAnyResults = videoResults.isNotEmpty || peopleResults.isNotEmpty;
+
+    if (!hasAnyResults) {
       if (showAll && status == .success) {
         return SearchSectionEmptyState(query: query);
       }
       return const SliverToBoxAdapter(child: SizedBox.shrink());
     }
 
-    final displayCount = showAll ? results.length : results.take(2).length;
-
     return _ResultsGrid(
-      results: results,
-      displayCount: displayCount,
+      videoResults: videoResults,
+      peopleResults: peopleResults,
       showAll: showAll,
     );
   }
 }
 
-// TODO(#2853): Display both video and people list cards in the grid.
 class _ResultsGrid extends StatelessWidget {
   const _ResultsGrid({
-    required this.results,
-    required this.displayCount,
+    required this.videoResults,
+    required this.peopleResults,
     required this.showAll,
   });
 
-  final List<CuratedList> results;
-  final int displayCount;
+  final List<CuratedList> videoResults;
+  final List<UserList> peopleResults;
   final bool showAll;
 
   @override
   Widget build(BuildContext context) {
     if (showAll) {
+      // In the full grid, show all video results followed by all people results.
+      final totalCount = videoResults.length + peopleResults.length;
       return SliverPadding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         sliver: SliverGrid(
@@ -120,17 +142,28 @@ class _ResultsGrid extends StatelessWidget {
             childAspectRatio: 0.85,
           ),
           delegate: SliverChildBuilderDelegate((context, index) {
-            final list = results[index];
-            return CuratedListSearchCard(
-              curatedList: list,
-              onTap: () => _navigateToCuratedList(context, list),
+            if (index < videoResults.length) {
+              final list = videoResults[index];
+              return _ListCard(
+                curatedList: list,
+                onTap: () => _navigateToCuratedList(context, list),
+              );
+            }
+            final peopleList = peopleResults[index - videoResults.length];
+            return _PeopleListCard(
+              userList: peopleList,
+              // TODO(#2853-view): Navigate to people list detail screen.
+              onTap: () {},
             );
-          }, childCount: displayCount),
+          }, childCount: totalCount),
         ),
       );
     }
-
-    final displayResults = results.take(displayCount).toList();
+    // In the preview (All tab), show at most 1 video card + 1 people card.
+    final previewVideo = videoResults.isNotEmpty ? videoResults.first : null;
+    final previewPeople = peopleResults.isNotEmpty ? peopleResults.first : null;
+    final previewCount =
+        (previewVideo != null ? 1 : 0) + (previewPeople != null ? 1 : 0);
 
     return SliverToBoxAdapter(
       child: Padding(
@@ -139,14 +172,80 @@ class _ResultsGrid extends StatelessWidget {
           spacing: 12,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            for (final list in displayResults)
+            if (previewVideo != null)
               Expanded(
-                child: CuratedListSearchCard(
-                  curatedList: list,
-                  onTap: () => _navigateToCuratedList(context, list),
+                child: _ListCard(
+                  curatedList: previewVideo,
+                  onTap: () => _navigateToCuratedList(context, previewVideo),
                 ),
               ),
-            if (displayResults.length == 1) const Expanded(child: SizedBox()),
+            if (previewPeople != null)
+              Expanded(
+                child: _PeopleListCard(
+                  userList: previewPeople,
+                  onTap: () {},
+                ),
+              ),
+            // If only one item, fill the second slot with empty space.
+            if (previewCount == 1) const Expanded(child: SizedBox()),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Card widget for a curated video list result.
+class _ListCard extends StatelessWidget {
+  const _ListCard({required this.curatedList, required this.onTap});
+
+  final CuratedList curatedList;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return CuratedListSearchCard(curatedList: curatedList, onTap: onTap);
+  }
+}
+
+/// Card widget for a people list result.
+class _PeopleListCard extends StatelessWidget {
+  const _PeopleListCard({required this.userList, required this.onTap});
+
+  final UserList userList;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return PeopleListSearchCard(userList: userList, onTap: onTap);
+  }
+}
+
+class _InitialState extends StatelessWidget {
+  const _InitialState();
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverFillRemaining(
+      hasScrollBody: false,
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const DivineIcon(
+              icon: DivineIconName.search,
+              color: VineTheme.secondaryText,
+              size: 64,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              context.l10n.searchForLists,
+              style: VineTheme.titleSmallFont(),
+            ),
+            Text(
+              context.l10n.searchFindCuratedVideoLists,
+              style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
+            ),
           ],
         ),
       ),

--- a/mobile/lib/widgets/people_list_search_card.dart
+++ b/mobile/lib/widgets/people_list_search_card.dart
@@ -1,0 +1,210 @@
+// ABOUTME: Card widget for displaying people list (kind 30000) search results.
+// ABOUTME: Shows an avatar collage with member count badge,
+// ABOUTME: plus title and description below. Designed for 2-column grid layout.
+
+import 'package:count_formatter/count_formatter.dart';
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:models/models.dart' hide AspectRatio;
+import 'package:openvine/widgets/user_avatar.dart';
+
+/// Number of avatar slots to display in the collage.
+const _avatarSlotCount = 4;
+
+/// Corner radius for the collage container.
+const _collageRadius = 16.0;
+
+/// Border width around each avatar.
+const _avatarBorder = 2.0;
+
+/// Search card for a people list (kind 30000).
+///
+/// Shows a 2×2 avatar collage with a member count badge,
+/// plus title and description below. Designed for 2-column grid layout.
+class PeopleListSearchCard extends StatelessWidget {
+  const PeopleListSearchCard({
+    required this.userList,
+    required this.onTap,
+    super.key,
+  });
+
+  final UserList userList;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: userList.name,
+      button: true,
+      container: true,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _AvatarCollage(
+              pubkeys: userList.pubkeys,
+              memberCount: userList.pubkeys.length,
+            ),
+            const SizedBox(height: 8),
+            _ListTitle(title: userList.name),
+            if (userList.description != null &&
+                userList.description!.isNotEmpty) ...[
+              const SizedBox(height: 2),
+              _ListDescription(description: userList.description!),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ListTitle extends StatelessWidget {
+  const _ListTitle({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      title,
+      style: VineTheme.titleSmallFont(),
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+    );
+  }
+}
+
+class _ListDescription extends StatelessWidget {
+  const _ListDescription({required this.description});
+
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      description,
+      style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+    );
+  }
+}
+
+/// 2×2 grid of avatar thumbnails with a member count badge.
+///
+/// Renders up to [_avatarSlotCount] avatars. Slots without a resolved
+/// avatar URL show a coloured placeholder.
+class _AvatarCollage extends StatelessWidget {
+  const _AvatarCollage({
+    required this.pubkeys,
+    required this.memberCount,
+  });
+
+  final List<String> pubkeys;
+  final int memberCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return AspectRatio(
+      aspectRatio: 1,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final totalSize = constraints.maxWidth;
+          final cellSize = (totalSize - _avatarBorder) / 2;
+
+          return DecoratedBox(
+            decoration: BoxDecoration(
+              color: VineTheme.containerLow,
+              borderRadius: BorderRadius.circular(_collageRadius),
+            ),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(_collageRadius),
+              child: Stack(
+                children: [
+                  // 2×2 grid of avatar cells
+                  for (int i = 0; i < _avatarSlotCount; i++)
+                    Positioned(
+                      left: (i % 2) * (cellSize + _avatarBorder),
+                      top: (i ~/ 2) * (cellSize + _avatarBorder),
+                      width: cellSize,
+                      height: cellSize,
+                      child: _AvatarCell(
+                        pubkey: i < pubkeys.length ? pubkeys[i] : null,
+                        tone:
+                            UserAvatarPlaceholderTone.values[(i + 1) %
+                                UserAvatarPlaceholderTone.values.length],
+                      ),
+                    ),
+                  // Member count badge
+                  Positioned(
+                    left: 8,
+                    bottom: 9,
+                    child: _MemberCountBadge(count: memberCount),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// A single avatar cell in the collage.
+class _AvatarCell extends StatelessWidget {
+  const _AvatarCell({required this.tone, this.pubkey});
+
+  final UserAvatarPlaceholderTone tone;
+  final String? pubkey;
+
+  @override
+  Widget build(BuildContext context) {
+    // We only have pubkeys here, not resolved picture URLs.
+    // The avatar widget handles placeholder rendering when imageUrl is null.
+    return UserAvatar(
+      name: pubkey,
+      size: double.infinity,
+      placeholderTone: tone,
+    );
+  }
+}
+
+class _MemberCountBadge extends StatelessWidget {
+  const _MemberCountBadge({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    return MediaQuery.withNoTextScaling(
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: VineTheme.backgroundColor.withValues(alpha: 0.65),
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            spacing: 4,
+            children: [
+              const DivineIcon(
+                icon: DivineIconName.user,
+                color: VineTheme.whiteText,
+                size: 16,
+              ),
+              Text(
+                CountFormatter.formatCompact(count),
+                style: VineTheme.labelSmallFont(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/packages/curated_list_repository/lib/curated_list_repository.dart
+++ b/mobile/packages/curated_list_repository/lib/curated_list_repository.dart
@@ -3,3 +3,4 @@ library;
 
 export 'src/curated_list_converter.dart';
 export 'src/curated_list_repository.dart';
+export 'src/user_list_converter.dart';

--- a/mobile/packages/curated_list_repository/lib/src/curated_list_repository.dart
+++ b/mobile/packages/curated_list_repository/lib/src/curated_list_repository.dart
@@ -349,7 +349,7 @@ class CuratedListRepository {
         error: e,
         stackTrace: stackTrace,
       );
-      return;
+      rethrow;
     }
 
     final seen = <String, UserList>{};

--- a/mobile/packages/curated_list_repository/lib/src/curated_list_repository.dart
+++ b/mobile/packages/curated_list_repository/lib/src/curated_list_repository.dart
@@ -3,7 +3,10 @@
 // ABOUTME(WIP): read-only query methods, and in-memory state populated by the
 // ABOUTME(WIP): Page layer. Persistence and relay sync come in later phases.
 
+import 'dart:developer';
+
 import 'package:curated_list_repository/src/curated_list_converter.dart';
+import 'package:curated_list_repository/src/user_list_converter.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
@@ -13,6 +16,9 @@ import 'package:rxdart/rxdart.dart';
 
 /// NIP-51 kind for curated video lists.
 const _curatedListKind = 30005;
+
+/// NIP-51 kind for people/user lists.
+const _peopleListKind = 30000;
 
 /// Well-known d-tag for the user's default "My List".
 const defaultListId = 'my_vine_list';
@@ -314,6 +320,59 @@ class CuratedListRepository {
       merged[list.id] = list;
     }
     yield List.unmodifiable(merged.values.toList());
+  }
+
+  /// Searches Nostr relays for people lists (kind 30000) matching [query].
+  ///
+  /// Yields results progressively:
+  /// 1. Relay results without avatar URLs
+  /// 2. (Future: avatar resolution — deferred until profile lookup is wired)
+  ///
+  /// Deduplicates by list ID (d-tag), keeping the newest version.
+  /// Empty lists (no pubkeys) are excluded.
+  Stream<List<UserList>> searchAllPeopleLists(String query) async* {
+    if (query.trim().isEmpty) return;
+
+    final lowerQuery = query.toLowerCase();
+
+    List<Event> events;
+    try {
+      events = await _nostrClient.queryEvents(
+        [
+          Filter(kinds: [_peopleListKind], limit: 50),
+        ],
+      );
+    } on Exception catch (e) {
+      log(
+        'searchAllPeopleLists: relay query failed for "$query": $e',
+        name: 'CuratedListRepository',
+      );
+      return;
+    }
+
+    final seen = <String, UserList>{};
+    for (final event in events) {
+      final list = UserListConverter.fromEvent(event);
+      if (list == null) continue;
+      if (list.pubkeys.isEmpty) continue;
+
+      // Client-side query filter
+      final matches =
+          list.name.toLowerCase().contains(lowerQuery) ||
+          (list.description?.toLowerCase().contains(lowerQuery) ?? false);
+      if (!matches) continue;
+
+      // Dedup by d-tag, keep newest
+      final existing = seen[list.id];
+      if (existing != null && existing.updatedAt.isAfter(list.updatedAt)) {
+        continue;
+      }
+      seen[list.id] = list;
+    }
+
+    if (seen.isNotEmpty) {
+      yield List.unmodifiable(seen.values.toList());
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/mobile/packages/curated_list_repository/lib/src/curated_list_repository.dart
+++ b/mobile/packages/curated_list_repository/lib/src/curated_list_repository.dart
@@ -342,10 +342,12 @@ class CuratedListRepository {
           Filter(kinds: [_peopleListKind], limit: 50),
         ],
       );
-    } on Exception catch (e) {
+    } on Exception catch (e, stackTrace) {
       log(
         'searchAllPeopleLists: relay query failed for "$query": $e',
         name: 'CuratedListRepository',
+        error: e,
+        stackTrace: stackTrace,
       );
       return;
     }

--- a/mobile/packages/curated_list_repository/lib/src/user_list_converter.dart
+++ b/mobile/packages/curated_list_repository/lib/src/user_list_converter.dart
@@ -1,0 +1,83 @@
+// ABOUTME: Converts between Nostr events and UserList models.
+// ABOUTME: Handles NIP-51 kind 30000 parsing including p-tags for pubkeys.
+
+import 'package:models/models.dart';
+import 'package:nostr_sdk/nostr_sdk.dart' show Event;
+
+/// Utility for converting between Nostr events and [UserList] models.
+///
+/// Handles NIP-51 kind 30000 event parsing, including:
+/// - `p` tags for pubkey members
+/// - Metadata tags: title, description, image
+abstract final class UserListConverter {
+  /// Parses a Nostr [Event] into a [UserList].
+  ///
+  /// Returns `null` if the event cannot be parsed (e.g. missing d-tag).
+  static UserList? fromEvent(Event event) {
+    try {
+      final dTag = _extractDTag(event);
+      if (dTag == null) return null;
+
+      String? title;
+      String? description;
+      String? imageUrl;
+      final pubkeys = <String>[];
+
+      for (final dynamic rawTag in event.tags) {
+        final tag = (rawTag as List<dynamic>).cast<String>();
+        if (tag.isEmpty) continue;
+
+        switch (tag[0]) {
+          case 'title':
+            if (tag.length > 1) title = tag[1];
+          case 'name':
+            // Some clients use 'name' instead of 'title'
+            if (tag.length > 1) title ??= tag[1];
+          case 'description':
+            if (tag.length > 1) description = tag[1];
+          case 'image':
+            if (tag.length > 1) imageUrl = tag[1];
+          case 'p':
+            if (tag.length > 1) pubkeys.add(tag[1]);
+        }
+      }
+
+      // Use title, fall back to first line of content, then default.
+      final contentFirstLine = event.content.split('\n').first;
+      final name =
+          title ??
+          (contentFirstLine.isNotEmpty ? contentFirstLine : 'Untitled List');
+
+      final timestamp = DateTime.fromMillisecondsSinceEpoch(
+        event.createdAt * 1000,
+      );
+
+      return UserList(
+        id: dTag,
+        name: name,
+        pubkeys: pubkeys,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        description:
+            description ?? (event.content.isNotEmpty ? event.content : null),
+        imageUrl: imageUrl,
+        nostrEventId: event.id,
+      );
+    } on Object catch (_) {
+      return null;
+    }
+  }
+
+  /// Extracts the `d` tag value from an [event].
+  ///
+  /// Returns `null` if no d-tag is present.
+  static String? _extractDTag(Event event) {
+    for (final dynamic rawTag in event.tags) {
+      final tag = (rawTag as List<dynamic>).cast<String>();
+      if (tag.length >= 2 && tag[0] == 'd') {
+        return tag[1];
+      }
+    }
+    return null;
+  }
+}

--- a/mobile/packages/curated_list_repository/test/src/curated_list_repository_test.dart
+++ b/mobile/packages/curated_list_repository/test/src/curated_list_repository_test.dart
@@ -1296,13 +1296,15 @@ void main() {
         expect(results, isEmpty);
       });
 
-      test('returns empty stream on relay exception', () async {
+      test('propagates relay exception', () async {
         when(
           () => nostrClient.queryEvents(any()),
         ).thenThrow(Exception('relay error'));
 
-        final results = await repository.searchAllPeopleLists('vine').toList();
-        expect(results, isEmpty);
+        expect(
+          repository.searchAllPeopleLists('vine').toList(),
+          throwsA(isA<Exception>()),
+        );
       });
 
       test('returns matching people list', () async {

--- a/mobile/packages/curated_list_repository/test/src/curated_list_repository_test.dart
+++ b/mobile/packages/curated_list_repository/test/src/curated_list_repository_test.dart
@@ -1256,5 +1256,162 @@ void main() {
         );
       });
     });
+
+    group('searchAllPeopleLists', () {
+      Event makePeopleEvent({
+        required String dTag,
+        required String title,
+        List<String> pubkeys = const [],
+        int createdAt = 1718400000,
+      }) {
+        return Event(
+          _testPubkey,
+          30000,
+          [
+            ['d', dTag],
+            ['title', title],
+            for (final pk in pubkeys) ['p', pk],
+          ],
+          '',
+          createdAt: createdAt,
+        );
+      }
+
+      test('returns empty stream for blank query', () async {
+        final results = await repository.searchAllPeopleLists('').toList();
+        expect(results, isEmpty);
+      });
+
+      test('returns empty stream for whitespace-only query', () async {
+        final results = await repository.searchAllPeopleLists('   ').toList();
+        expect(results, isEmpty);
+      });
+
+      test('returns empty stream when relay returns no events', () async {
+        when(
+          () => nostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => []);
+
+        final results = await repository.searchAllPeopleLists('vine').toList();
+        expect(results, isEmpty);
+      });
+
+      test('returns empty stream on relay exception', () async {
+        when(
+          () => nostrClient.queryEvents(any()),
+        ).thenThrow(Exception('relay error'));
+
+        final results = await repository.searchAllPeopleLists('vine').toList();
+        expect(results, isEmpty);
+      });
+
+      test('returns matching people list', () async {
+        final event = makePeopleEvent(
+          dTag: 'pl1',
+          title: 'Vine Creators',
+          pubkeys: ['pk1', 'pk2'],
+        );
+        when(
+          () => nostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final results = await repository.searchAllPeopleLists('vine').toList();
+
+        expect(results, hasLength(1));
+        expect(results.first, hasLength(1));
+        expect(results.first.first.id, equals('pl1'));
+        expect(results.first.first.name, equals('Vine Creators'));
+        expect(results.first.first.pubkeys, equals(['pk1', 'pk2']));
+      });
+
+      test('excludes lists with no pubkeys', () async {
+        final emptyList = makePeopleEvent(
+          dTag: 'empty',
+          title: 'Vine Empty',
+          pubkeys: [],
+        );
+        final nonEmpty = makePeopleEvent(
+          dTag: 'full',
+          title: 'Vine Full',
+          pubkeys: ['pk1'],
+        );
+        when(
+          () => nostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [emptyList, nonEmpty]);
+
+        final results = await repository.searchAllPeopleLists('vine').toList();
+
+        expect(results, hasLength(1));
+        expect(results.first.first.id, equals('full'));
+      });
+
+      test('excludes lists that do not match query', () async {
+        final matching = makePeopleEvent(
+          dTag: 'match',
+          title: 'Vine Stars',
+          pubkeys: ['pk1'],
+        );
+        final nonMatching = makePeopleEvent(
+          dTag: 'other',
+          title: 'Unrelated List',
+          pubkeys: ['pk2'],
+        );
+        when(
+          () => nostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [matching, nonMatching]);
+
+        final results = await repository.searchAllPeopleLists('vine').toList();
+
+        expect(results, hasLength(1));
+        expect(results.first.first.id, equals('match'));
+      });
+
+      test('deduplicates by d-tag keeping newest', () async {
+        final older = makePeopleEvent(
+          dTag: 'pl1',
+          title: 'Vine List',
+          pubkeys: ['pk1'],
+        );
+        final newer = makePeopleEvent(
+          dTag: 'pl1',
+          title: 'Vine List Updated',
+          pubkeys: ['pk1', 'pk2'],
+          createdAt: 1718400001,
+        );
+        when(
+          () => nostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [older, newer]);
+
+        final results = await repository.searchAllPeopleLists('vine').toList();
+
+        expect(results, hasLength(1));
+        expect(results.first, hasLength(1));
+        expect(results.first.first.name, equals('Vine List Updated'));
+        expect(results.first.first.pubkeys, hasLength(2));
+      });
+
+      test('matches query against description', () async {
+        final withDesc = Event(
+          _testPubkey,
+          30000,
+          [
+            ['d', 'pl1'],
+            ['title', 'My List'],
+            ['description', 'Top vine creators'],
+            ['p', 'pk1'],
+          ],
+          '',
+          createdAt: 1718400000,
+        );
+        when(
+          () => nostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [withDesc]);
+
+        final results = await repository.searchAllPeopleLists('vine').toList();
+
+        expect(results, hasLength(1));
+        expect(results.first.first.description, contains('vine'));
+      });
+    });
   });
 }

--- a/mobile/packages/curated_list_repository/test/src/user_list_converter_test.dart
+++ b/mobile/packages/curated_list_repository/test/src/user_list_converter_test.dart
@@ -1,0 +1,296 @@
+// ABOUTME: Unit tests for UserListConverter — kind 30000 Nostr event parsing.
+
+import 'package:curated_list_repository/curated_list_repository.dart';
+import 'package:models/models.dart';
+import 'package:nostr_sdk/nostr_sdk.dart' show Event;
+import 'package:test/test.dart';
+
+/// 64-char hex pubkey for test events.
+const _testPubkey =
+    'aabbccddaabbccddaabbccddaabbccdd'
+    'aabbccddaabbccddaabbccddaabbccdd';
+
+/// Creates a kind 30000 Nostr event with the given [tags] and [content].
+Event _makeEvent({
+  List<List<String>> tags = const [],
+  String content = '',
+  int? createdAt,
+}) {
+  return Event(
+    _testPubkey,
+    30000,
+    tags.map(List<String>.from).toList(),
+    content,
+    createdAt: createdAt ?? 1718400000,
+  );
+}
+
+void main() {
+  group(UserListConverter, () {
+    group('fromEvent', () {
+      test('returns null when d-tag is missing', () {
+        final event = _makeEvent(
+          tags: [
+            ['title', 'No D Tag'],
+          ],
+        );
+
+        expect(UserListConverter.fromEvent(event), isNull);
+      });
+
+      test('parses minimal event with only d-tag', () {
+        final event = _makeEvent(
+          tags: [
+            ['d', 'my-list'],
+          ],
+        );
+
+        final list = UserListConverter.fromEvent(event);
+
+        expect(list, isNotNull);
+        expect(list!.id, equals('my-list'));
+        expect(list.name, equals('Untitled List'));
+        expect(list.pubkeys, isEmpty);
+        expect(list.isPublic, isTrue);
+      });
+
+      test('uses title tag for name', () {
+        final event = _makeEvent(
+          tags: [
+            ['d', 'my-list'],
+            ['title', 'My People'],
+          ],
+        );
+
+        final list = UserListConverter.fromEvent(event);
+
+        expect(list!.name, equals('My People'));
+      });
+
+      test('falls back to name tag when title is absent', () {
+        final event = _makeEvent(
+          tags: [
+            ['d', 'my-list'],
+            ['name', 'Named List'],
+          ],
+        );
+
+        final list = UserListConverter.fromEvent(event);
+
+        expect(list!.name, equals('Named List'));
+      });
+
+      test('title tag takes precedence over name tag', () {
+        final event = _makeEvent(
+          tags: [
+            ['d', 'my-list'],
+            ['name', 'Name Tag'],
+            ['title', 'Title Tag'],
+          ],
+        );
+
+        final list = UserListConverter.fromEvent(event);
+
+        expect(list!.name, equals('Title Tag'));
+      });
+
+      test('falls back to first line of content when no title or name', () {
+        final event = _makeEvent(
+          tags: [
+            ['d', 'my-list'],
+          ],
+          content: 'Content Title\nSecond line',
+        );
+
+        final list = UserListConverter.fromEvent(event);
+
+        expect(list!.name, equals('Content Title'));
+      });
+
+      test('parses p-tags as pubkeys', () {
+        final event = _makeEvent(
+          tags: [
+            ['d', 'my-list'],
+            ['p', 'pubkey1'],
+            ['p', 'pubkey2'],
+            ['p', 'pubkey3'],
+          ],
+        );
+
+        final list = UserListConverter.fromEvent(event);
+
+        expect(list!.pubkeys, equals(['pubkey1', 'pubkey2', 'pubkey3']));
+      });
+
+      test('parses description tag', () {
+        final event = _makeEvent(
+          tags: [
+            ['d', 'my-list'],
+            ['description', 'A great list of people'],
+          ],
+        );
+
+        final list = UserListConverter.fromEvent(event);
+
+        expect(list!.description, equals('A great list of people'));
+      });
+
+      test('parses image tag', () {
+        final event = _makeEvent(
+          tags: [
+            ['d', 'my-list'],
+            ['image', 'https://example.com/cover.jpg'],
+          ],
+        );
+
+        final list = UserListConverter.fromEvent(event);
+
+        expect(list!.imageUrl, equals('https://example.com/cover.jpg'));
+      });
+
+      test('sets createdAt and updatedAt from event timestamp', () {
+        const ts = 1718400000;
+        final event = _makeEvent(
+          tags: [
+            ['d', 'my-list'],
+          ],
+          createdAt: ts,
+        );
+
+        final list = UserListConverter.fromEvent(event);
+
+        final expected = DateTime.fromMillisecondsSinceEpoch(ts * 1000);
+        expect(list!.createdAt, equals(expected));
+        expect(list.updatedAt, equals(expected));
+      });
+
+      test('sets nostrEventId from event id', () {
+        final event = _makeEvent(
+          tags: [
+            ['d', 'my-list'],
+          ],
+        );
+
+        final list = UserListConverter.fromEvent(event);
+
+        expect(list!.nostrEventId, equals(event.id));
+      });
+
+      test('ignores unrecognised tags without throwing', () {
+        final event = _makeEvent(
+          tags: [
+            ['d', 'my-list'],
+            ['unknown', 'value'],
+            ['e', 'some-event-id'],
+          ],
+        );
+
+        expect(() => UserListConverter.fromEvent(event), returnsNormally);
+        final list = UserListConverter.fromEvent(event);
+        expect(list, isNotNull);
+        expect(list!.pubkeys, isEmpty);
+      });
+
+      test('returns null on malformed event (empty tags list entry)', () {
+        // An event where a tag entry is completely empty should not crash.
+        final event = _makeEvent(
+          tags: [
+            ['d', 'my-list'],
+            [], // empty tag — should be skipped
+          ],
+        );
+
+        expect(() => UserListConverter.fromEvent(event), returnsNormally);
+      });
+
+      test('parses full event with all fields', () {
+        final event = _makeEvent(
+          tags: [
+            ['d', 'full-list'],
+            ['title', 'Full List'],
+            ['description', 'All fields present'],
+            ['image', 'https://example.com/img.jpg'],
+            ['p', 'pk1'],
+            ['p', 'pk2'],
+          ],
+          content: 'ignored when title present',
+          createdAt: 1718400000,
+        );
+
+        final list = UserListConverter.fromEvent(event);
+
+        expect(list, isNotNull);
+        expect(list!.id, equals('full-list'));
+        expect(list.name, equals('Full List'));
+        expect(list.description, equals('All fields present'));
+        expect(list.imageUrl, equals('https://example.com/img.jpg'));
+        expect(list.pubkeys, equals(['pk1', 'pk2']));
+        expect(list.isPublic, isTrue);
+        expect(list.isEditable, isTrue);
+      });
+    });
+  });
+
+  group('UserList model', () {
+    final now = DateTime(2024, 6, 15);
+
+    test('copyWith preserves all fields', () {
+      final original = UserList(
+        id: 'id1',
+        name: 'Original',
+        pubkeys: const ['pk1'],
+        createdAt: now,
+        updatedAt: now,
+        description: 'desc',
+        imageUrl: 'https://img.com',
+        nostrEventId: 'event1',
+      );
+
+      final copy = original.copyWith(name: 'Updated');
+
+      expect(copy.id, equals('id1'));
+      expect(copy.name, equals('Updated'));
+      expect(copy.pubkeys, equals(['pk1']));
+      expect(copy.description, equals('desc'));
+      expect(copy.imageUrl, equals('https://img.com'));
+    });
+
+    test('equality is value-based', () {
+      final a = UserList(
+        id: 'id1',
+        name: 'List',
+        pubkeys: const ['pk1'],
+        createdAt: now,
+        updatedAt: now,
+      );
+      final b = UserList(
+        id: 'id1',
+        name: 'List',
+        pubkeys: const ['pk1'],
+        createdAt: now,
+        updatedAt: now,
+      );
+
+      expect(a, equals(b));
+    });
+
+    test('lists with different pubkeys are not equal', () {
+      final a = UserList(
+        id: 'id1',
+        name: 'List',
+        pubkeys: const ['pk1'],
+        createdAt: now,
+        updatedAt: now,
+      );
+      final b = UserList(
+        id: 'id1',
+        name: 'List',
+        pubkeys: const ['pk2'],
+        createdAt: now,
+        updatedAt: now,
+      );
+
+      expect(a, isNot(equals(b)));
+    });
+  });
+}

--- a/mobile/test/blocs/list_search/list_search_bloc_test.dart
+++ b/mobile/test/blocs/list_search/list_search_bloc_test.dart
@@ -220,6 +220,32 @@ void main() {
       );
 
       blocTest<ListSearchBloc, ListSearchState>(
+        'emits failure on exception from people stream',
+        setUp: () {
+          when(
+            () => curatedListRepository.searchAllLists(any()),
+          ).thenAnswer((_) => const Stream.empty());
+          when(
+            () => curatedListRepository.searchAllPeopleLists(any()),
+          ).thenAnswer((_) => Stream.error(Exception('relay down')));
+        },
+        build: () => buildBloc(peopleEnabled: true),
+        act: (bloc) => bloc.add(const ListSearchQueryChanged('test')),
+        wait: const Duration(milliseconds: 400),
+        expect: () => [
+          const ListSearchState(
+            status: ListSearchStatus.loading,
+            query: 'test',
+          ),
+          const ListSearchState(
+            status: ListSearchStatus.failure,
+            query: 'test',
+          ),
+        ],
+        errors: () => [isA<Exception>()],
+      );
+
+      blocTest<ListSearchBloc, ListSearchState>(
         're-searches when same query is dispatched in failure state',
         setUp: () {
           when(

--- a/mobile/test/blocs/list_search/list_search_bloc_test.dart
+++ b/mobile/test/blocs/list_search/list_search_bloc_test.dart
@@ -22,16 +22,29 @@ void main() {
       updatedAt: now,
     );
 
+    final testUserList = UserList(
+      id: 'ul1',
+      name: 'Cool People',
+      pubkeys: const ['pk1', 'pk2'],
+      createdAt: now,
+      updatedAt: now,
+    );
+
     setUp(() {
       curatedListRepository = _MockCuratedListRepository();
 
       when(
         () => curatedListRepository.searchAllLists(any()),
       ).thenAnswer((_) => const Stream.empty());
+
+      when(
+        () => curatedListRepository.searchAllPeopleLists(any()),
+      ).thenAnswer((_) => const Stream.empty());
     });
 
-    ListSearchBloc buildBloc() => ListSearchBloc(
+    ListSearchBloc buildBloc({bool peopleEnabled = false}) => ListSearchBloc(
       curatedListRepository: curatedListRepository,
+      peopleListSearchEnabled: peopleEnabled,
     );
 
     test('initial state is $ListSearchState', () {
@@ -40,7 +53,7 @@ void main() {
 
     group(ListSearchQueryChanged, () {
       blocTest<ListSearchBloc, ListSearchState>(
-        'emits loading then success when query matches',
+        'emits loading then success when video query matches',
         setUp: () {
           when(
             () => curatedListRepository.searchAllLists('videos'),
@@ -54,12 +67,94 @@ void main() {
             status: ListSearchStatus.loading,
             query: 'videos',
           ),
-          ListSearchState(
-            status: ListSearchStatus.success,
-            query: 'videos',
-            results: [testCuratedList],
+          isA<ListSearchState>()
+              .having((s) => s.status, 'status', ListSearchStatus.success)
+              .having((s) => s.query, 'query', 'videos')
+              .having(
+                (s) => s.videoResults,
+                'videoResults',
+                [testCuratedList],
+              ),
+        ],
+      );
+
+      blocTest<ListSearchBloc, ListSearchState>(
+        'emits people results when people list search is enabled',
+        setUp: () {
+          when(
+            () => curatedListRepository.searchAllPeopleLists('people'),
+          ).thenAnswer((_) => Stream.value([testUserList]));
+        },
+        build: () => buildBloc(peopleEnabled: true),
+        act: (bloc) => bloc.add(const ListSearchQueryChanged('people')),
+        wait: const Duration(milliseconds: 400),
+        expect: () => [
+          const ListSearchState(
+            status: ListSearchStatus.loading,
+            query: 'people',
+          ),
+          isA<ListSearchState>()
+              .having((s) => s.status, 'status', ListSearchStatus.success)
+              .having(
+                (s) => s.peopleResults,
+                'peopleResults',
+                [testUserList],
+              ),
+        ],
+      );
+
+      blocTest<ListSearchBloc, ListSearchState>(
+        'does not search people lists when flag is disabled',
+        setUp: () {
+          when(
+            () => curatedListRepository.searchAllLists('mixed'),
+          ).thenAnswer((_) => Stream.value([testCuratedList]));
+        },
+        build: buildBloc, // peopleEnabled: false by default
+        act: (bloc) => bloc.add(const ListSearchQueryChanged('mixed')),
+        wait: const Duration(milliseconds: 400),
+        verify: (bloc) {
+          verifyNever(
+            () => curatedListRepository.searchAllPeopleLists(any()),
+          );
+          expect(bloc.state.peopleResults, isEmpty);
+        },
+      );
+
+      blocTest<ListSearchBloc, ListSearchState>(
+        'merges video and people results when both enabled',
+        setUp: () {
+          when(
+            () => curatedListRepository.searchAllLists('mixed'),
+          ).thenAnswer((_) => Stream.value([testCuratedList]));
+          when(
+            () => curatedListRepository.searchAllPeopleLists('mixed'),
+          ).thenAnswer((_) => Stream.value([testUserList]));
+        },
+        build: () => buildBloc(peopleEnabled: true),
+        act: (bloc) => bloc.add(const ListSearchQueryChanged('mixed')),
+        wait: const Duration(milliseconds: 400),
+        expect: () => [
+          const ListSearchState(
+            status: ListSearchStatus.loading,
+            query: 'mixed',
+          ),
+          // Two success states: one per stream emission.
+          isA<ListSearchState>().having(
+            (s) => s.status,
+            'status',
+            ListSearchStatus.success,
+          ),
+          isA<ListSearchState>().having(
+            (s) => s.status,
+            'status',
+            ListSearchStatus.success,
           ),
         ],
+        verify: (bloc) {
+          expect(bloc.state.videoResults, contains(testCuratedList));
+          expect(bloc.state.peopleResults, contains(testUserList));
+        },
       );
 
       blocTest<ListSearchBloc, ListSearchState>(
@@ -84,7 +179,8 @@ void main() {
         seed: () => ListSearchState(
           status: ListSearchStatus.success,
           query: 'old',
-          results: [testCuratedList],
+          videoResults: [testCuratedList],
+          peopleResults: [testUserList],
         ),
         build: buildBloc,
         act: (bloc) => bloc.add(const ListSearchQueryChanged('')),
@@ -101,7 +197,7 @@ void main() {
       );
 
       blocTest<ListSearchBloc, ListSearchState>(
-        'emits failure on exception',
+        'emits failure on exception from video stream',
         setUp: () {
           when(
             () => curatedListRepository.searchAllLists(any()),
@@ -142,16 +238,18 @@ void main() {
             status: ListSearchStatus.loading,
             query: 'test',
           ),
-          ListSearchState(
-            status: ListSearchStatus.success,
-            query: 'test',
-            results: [testCuratedList],
-          ),
+          isA<ListSearchState>()
+              .having((s) => s.status, 'status', ListSearchStatus.success)
+              .having(
+                (s) => s.videoResults,
+                'videoResults',
+                [testCuratedList],
+              ),
         ],
       );
 
       blocTest<ListSearchBloc, ListSearchState>(
-        'yields progressive results as relay stream emits',
+        'yields progressive video results as relay stream emits',
         setUp: () {
           final list2 = CuratedList(
             id: 'cl2',
@@ -178,14 +276,14 @@ void main() {
             status: ListSearchStatus.loading,
             query: 'vid',
           ),
-          ListSearchState(
-            status: ListSearchStatus.success,
-            query: 'vid',
-            results: [testCuratedList],
+          isA<ListSearchState>().having(
+            (s) => s.videoResults.length,
+            'videoResults.length',
+            1,
           ),
           isA<ListSearchState>().having(
-            (s) => s.results.length,
-            'results.length',
+            (s) => s.videoResults.length,
+            'videoResults.length',
             2,
           ),
         ],
@@ -198,12 +296,40 @@ void main() {
         seed: () => ListSearchState(
           status: ListSearchStatus.success,
           query: 'test',
-          results: [testCuratedList],
+          videoResults: [testCuratedList],
+          peopleResults: [testUserList],
         ),
         build: buildBloc,
         act: (bloc) => bloc.add(const ListSearchCleared()),
         expect: () => [const ListSearchState()],
       );
+    });
+
+    group('ListSearchState', () {
+      test('copyWith preserves peopleResults when not specified', () {
+        final state = ListSearchState(
+          status: ListSearchStatus.success,
+          query: 'q',
+          videoResults: [testCuratedList],
+          peopleResults: [testUserList],
+        );
+        final updated = state.copyWith(query: 'q2');
+        expect(updated.peopleResults, equals([testUserList]));
+      });
+
+      test('props includes videoResults and peopleResults', () {
+        final state1 = ListSearchState(
+          videoResults: [testCuratedList],
+          peopleResults: [testUserList],
+        );
+        final state2 = ListSearchState(
+          videoResults: [testCuratedList],
+          peopleResults: [testUserList],
+        );
+        const state3 = ListSearchState();
+        expect(state1, equals(state2));
+        expect(state1, isNot(equals(state3)));
+      });
     });
   });
 }

--- a/mobile/test/screens/search_results/widgets/lists_section_test.dart
+++ b/mobile/test/screens/search_results/widgets/lists_section_test.dart
@@ -76,7 +76,7 @@ void main() {
             ListSearchState(
               status: ListSearchStatus.success,
               query: 'test',
-              results: [testList],
+              videoResults: [testList],
             ),
           );
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Added kind-30000 converter, searchAllPeopleLists stream, peopleResults state field, parallel bloc streams, PeopleListSearchCard widget, updated ListsSection, peopleListSearch feature flag, and unit tests.

Note: PeopleListSearchCard UI is intentionally placeholder-level — pixel-perfect Figma implementation will land in the "Create list" ticket alongside the full people list creation flow. This PR only wires up the data layer (kind-30000 converter, relay search stream, BLoC state) and a functional card so the feature can be tested end-to-end once the backend ships.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #2853

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore