### PR TITLE
feat(inbox): phase 3 Figma alignment for messages tab

### DIFF
--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2167,6 +2167,50 @@
   },
   "inboxRemovedConversation": "Removed conversation",
 
+  "inboxEmptyTitle": "No messages yet",
+  "inboxEmptySubtitle": "That + button won't bite.",
+
+  "inboxActionMute": "Mute conversation",
+  "inboxActionReport": "Report {displayName}",
+  "@inboxActionReport": {
+    "placeholders": {
+      "displayName": {
+        "type": "String"
+      }
+    }
+  },
+  "inboxActionBlock": "Block {displayName}",
+  "@inboxActionBlock": {
+    "placeholders": {
+      "displayName": {
+        "type": "String"
+      }
+    }
+  },
+  "inboxActionUnblock": "Unblock {displayName}",
+  "@inboxActionUnblock": {
+    "placeholders": {
+      "displayName": {
+        "type": "String"
+      }
+    }
+  },
+  "inboxActionRemove": "Remove conversation",
+
+  "inboxRemoveConfirmTitle": "Remove conversation?",
+  "inboxRemoveConfirmBody": "This will delete your conversation with {displayName}. This action cannot be undone.",
+  "@inboxRemoveConfirmBody": {
+    "placeholders": {
+      "displayName": {
+        "type": "String"
+      }
+    }
+  },
+  "inboxRemoveConfirmConfirm": "Remove",
+
+  "inboxConversationMuted": "Conversation muted",
+  "inboxConversationUnmuted": "Conversation unmuted",
+
   "reportDialogCancel": "Cancel",
   "reportDialogReport": "Report",
 

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7778,6 +7778,78 @@ abstract class AppLocalizations {
   /// **'Removed conversation'**
   String get inboxRemovedConversation;
 
+  /// No description provided for @inboxEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No messages yet'**
+  String get inboxEmptyTitle;
+
+  /// No description provided for @inboxEmptySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'That + button won\'t bite.'**
+  String get inboxEmptySubtitle;
+
+  /// No description provided for @inboxActionMute.
+  ///
+  /// In en, this message translates to:
+  /// **'Mute conversation'**
+  String get inboxActionMute;
+
+  /// No description provided for @inboxActionReport.
+  ///
+  /// In en, this message translates to:
+  /// **'Report {displayName}'**
+  String inboxActionReport(String displayName);
+
+  /// No description provided for @inboxActionBlock.
+  ///
+  /// In en, this message translates to:
+  /// **'Block {displayName}'**
+  String inboxActionBlock(String displayName);
+
+  /// No description provided for @inboxActionUnblock.
+  ///
+  /// In en, this message translates to:
+  /// **'Unblock {displayName}'**
+  String inboxActionUnblock(String displayName);
+
+  /// No description provided for @inboxActionRemove.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove conversation'**
+  String get inboxActionRemove;
+
+  /// No description provided for @inboxRemoveConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove conversation?'**
+  String get inboxRemoveConfirmTitle;
+
+  /// No description provided for @inboxRemoveConfirmBody.
+  ///
+  /// In en, this message translates to:
+  /// **'This will delete your conversation with {displayName}. This action cannot be undone.'**
+  String inboxRemoveConfirmBody(String displayName);
+
+  /// No description provided for @inboxRemoveConfirmConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove'**
+  String get inboxRemoveConfirmConfirm;
+
+  /// No description provided for @inboxConversationMuted.
+  ///
+  /// In en, this message translates to:
+  /// **'Conversation muted'**
+  String get inboxConversationMuted;
+
+  /// No description provided for @inboxConversationUnmuted.
+  ///
+  /// In en, this message translates to:
+  /// **'Conversation unmuted'**
+  String get inboxConversationUnmuted;
+
   /// No description provided for @reportDialogCancel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4323,6 +4323,50 @@ class AppLocalizationsAr extends AppLocalizations {
   String get inboxRemovedConversation => 'تمت إزالة المحادثة';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => 'إلغاء';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4417,6 +4417,50 @@ class AppLocalizationsDe extends AppLocalizations {
   String get inboxRemovedConversation => 'Unterhaltung entfernt';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => 'Abbrechen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4360,6 +4360,50 @@ class AppLocalizationsEn extends AppLocalizations {
   String get inboxRemovedConversation => 'Removed conversation';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => 'Cancel';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4409,6 +4409,50 @@ class AppLocalizationsEs extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversación eliminada';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4422,6 +4422,50 @@ class AppLocalizationsFr extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversation supprimée';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => 'Annuler';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4343,6 +4343,50 @@ class AppLocalizationsId extends AppLocalizations {
   String get inboxRemovedConversation => 'Percakapan dihapus';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => 'Batal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4408,6 +4408,50 @@ class AppLocalizationsIt extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversazione rimossa';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => 'Annulla';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4177,6 +4177,50 @@ class AppLocalizationsJa extends AppLocalizations {
   String get inboxRemovedConversation => '会話を削除したよ';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => 'キャンセル';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4193,6 +4193,50 @@ class AppLocalizationsKo extends AppLocalizations {
   String get inboxRemovedConversation => '대화를 삭제했어요';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => '취소';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4379,6 +4379,50 @@ class AppLocalizationsNl extends AppLocalizations {
   String get inboxRemovedConversation => 'Gesprek verwijderd';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => 'Annuleren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4493,6 +4493,50 @@ class AppLocalizationsPl extends AppLocalizations {
   String get inboxRemovedConversation => 'Usunięto rozmowę';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => 'Anuluj';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4393,6 +4393,50 @@ class AppLocalizationsPt extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversa removida';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4495,6 +4495,50 @@ class AppLocalizationsRo extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversație eliminată';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => 'Anulează';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4359,6 +4359,50 @@ class AppLocalizationsSv extends AppLocalizations {
   String get inboxRemovedConversation => 'Konversation borttagen';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => 'Avbryt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4350,6 +4350,50 @@ class AppLocalizationsTr extends AppLocalizations {
   String get inboxRemovedConversation => 'Sohbet kaldırıldı';
 
   @override
+  String get inboxEmptyTitle => 'No messages yet';
+
+  @override
+  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+
+  @override
+  String get inboxActionMute => 'Mute conversation';
+
+  @override
+  String inboxActionReport(String displayName) {
+    return 'Report $displayName';
+  }
+
+  @override
+  String inboxActionBlock(String displayName) {
+    return 'Block $displayName';
+  }
+
+  @override
+  String inboxActionUnblock(String displayName) {
+    return 'Unblock $displayName';
+  }
+
+  @override
+  String get inboxActionRemove => 'Remove conversation';
+
+  @override
+  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+
+  @override
+  String inboxRemoveConfirmBody(String displayName) {
+    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+  }
+
+  @override
+  String get inboxRemoveConfirmConfirm => 'Remove';
+
+  @override
+  String get inboxConversationMuted => 'Conversation muted';
+
+  @override
+  String get inboxConversationUnmuted => 'Conversation unmuted';
+
+  @override
   String get reportDialogCancel => 'İptal';
 
   @override

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -430,7 +430,9 @@ class _ConversationListState extends ConsumerState<_ConversationList>
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
               content: Text(
-                nowMuted ? 'Conversation muted' : 'Conversation unmuted',
+                nowMuted
+                    ? context.l10n.inboxConversationMuted
+                    : context.l10n.inboxConversationUnmuted,
               ),
             ),
           );
@@ -491,26 +493,25 @@ class _ConversationListState extends ConsumerState<_ConversationList>
       builder: (context) => AlertDialog(
         backgroundColor: VineTheme.cardBackground,
         title: Text(
-          'Remove conversation?',
+          context.l10n.inboxRemoveConfirmTitle,
           style: VineTheme.titleLargeFont(),
         ),
         content: Text(
-          'This will delete your conversation with $displayName. '
-          'This action cannot be undone.',
+          context.l10n.inboxRemoveConfirmBody(displayName),
           style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
             child: Text(
-              'Cancel',
+              context.l10n.commonCancel,
               style: VineTheme.bodyMediumFont(color: VineTheme.onSurface),
             ),
           ),
           TextButton(
             onPressed: () => Navigator.pop(context, true),
             child: Text(
-              'Remove',
+              context.l10n.inboxRemoveConfirmConfirm,
               style: VineTheme.bodyMediumFont(color: VineTheme.error),
             ),
           ),

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -265,6 +265,11 @@ class _ConversationListState extends ConsumerState<_ConversationList>
     with ScrollPaginationMixin {
   final ScrollController _scrollController = ScrollController();
 
+  /// ID of the conversation whose long-press action sheet is currently open.
+  /// Drives the [ConversationTile] highlight so the user can see which row
+  /// the sheet refers to. Cleared in a `finally` block after the sheet closes.
+  String? _highlightedConversationId;
+
   @override
   ScrollController get paginationScrollController => _scrollController;
 
@@ -360,6 +365,7 @@ class _ConversationListState extends ConsumerState<_ConversationList>
         return ConversationTile(
           conversation: conversation,
           currentUserPubkey: widget.currentUserPubkey,
+          highlighted: conversation.id == _highlightedConversationId,
           onTap: () => _onConversationTapped(context, conversation),
           onLongPress: () => _onConversationLongPressed(
             context,
@@ -414,73 +420,80 @@ class _ConversationListState extends ConsumerState<_ConversationList>
     final actionsCubit = context.read<ConversationActionsCubit>();
     final isBlocked = actionsCubit.isBlocked(otherPubkey);
 
-    final action = await ConversationActionsSheet.show(
-      context,
-      displayName: displayName,
-      isMuted: isMuted,
-      isBlocked: isBlocked,
-    );
+    setState(() => _highlightedConversationId = conversation.id);
+    try {
+      final action = await ConversationActionsSheet.show(
+        context,
+        displayName: displayName,
+        isMuted: isMuted,
+        isBlocked: isBlocked,
+      );
 
-    if (action == null || !context.mounted) return;
+      if (action == null || !context.mounted) return;
 
-    switch (action) {
-      case ConversationAction.toggleMute:
-        final nowMuted = await muteCubit.toggleMute(conversation.id);
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(
-                nowMuted
-                    ? context.l10n.inboxConversationMuted
-                    : context.l10n.inboxConversationUnmuted,
-              ),
-            ),
-          );
-        }
-
-      case ConversationAction.report:
-        final reported = await actionsCubit.reportUser(otherPubkey);
-        if (context.mounted && reported) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(context.l10n.inboxReportedUser(displayName)),
-            ),
-          );
-        }
-
-      case ConversationAction.block:
-        if (isBlocked) {
-          actionsCubit.unblockUser(otherPubkey);
-        } else {
-          actionsCubit.blockUser(otherPubkey);
-        }
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(
-                isBlocked
-                    ? context.l10n.inboxUnblockedUser(displayName)
-                    : context.l10n.inboxBlockedUser(displayName),
-              ),
-            ),
-          );
-        }
-
-      case ConversationAction.remove:
-        if (!context.mounted) return;
-        final confirmed = await _confirmRemove(context, displayName);
-        if (confirmed && context.mounted) {
-          final removed = await actionsCubit.removeConversation(
-            conversation.id,
-          );
-          if (context.mounted && removed) {
+      switch (action) {
+        case ConversationAction.toggleMute:
+          final nowMuted = await muteCubit.toggleMute(conversation.id);
+          if (context.mounted) {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
-                content: Text(context.l10n.inboxRemovedConversation),
+                content: Text(
+                  nowMuted
+                      ? context.l10n.inboxConversationMuted
+                      : context.l10n.inboxConversationUnmuted,
+                ),
               ),
             );
           }
-        }
+
+        case ConversationAction.report:
+          final reported = await actionsCubit.reportUser(otherPubkey);
+          if (context.mounted && reported) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(context.l10n.inboxReportedUser(displayName)),
+              ),
+            );
+          }
+
+        case ConversationAction.block:
+          if (isBlocked) {
+            actionsCubit.unblockUser(otherPubkey);
+          } else {
+            actionsCubit.blockUser(otherPubkey);
+          }
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(
+                  isBlocked
+                      ? context.l10n.inboxUnblockedUser(displayName)
+                      : context.l10n.inboxBlockedUser(displayName),
+                ),
+              ),
+            );
+          }
+
+        case ConversationAction.remove:
+          if (!context.mounted) return;
+          final confirmed = await _confirmRemove(context, displayName);
+          if (confirmed && context.mounted) {
+            final removed = await actionsCubit.removeConversation(
+              conversation.id,
+            );
+            if (context.mounted && removed) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(context.l10n.inboxRemovedConversation),
+                ),
+              );
+            }
+          }
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _highlightedConversationId = null);
+      }
     }
   }
 

--- a/mobile/lib/screens/inbox/widgets/conversation_actions_sheet.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_actions_sheet.dart
@@ -3,6 +3,7 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
 
 /// Actions available from the conversation long-press sheet.
 enum ConversationAction {
@@ -42,18 +43,20 @@ class ConversationActionsSheet {
             _MuteActionTile(isMuted: isMuted),
             _ActionTile(
               icon: DivineIconName.flag,
-              label: 'Report $displayName',
+              label: context.l10n.inboxActionReport(displayName),
               result: ConversationAction.report,
             ),
             _ActionTile(
               icon: DivineIconName.eyeSlash,
-              label: isBlocked ? 'Unblock $displayName' : 'Block $displayName',
+              label: isBlocked
+                  ? context.l10n.inboxActionUnblock(displayName)
+                  : context.l10n.inboxActionBlock(displayName),
               isDestructive: !isBlocked,
               result: ConversationAction.block,
             ),
-            const _ActionTile(
+            _ActionTile(
               icon: DivineIconName.trash,
-              label: 'Remove conversation',
+              label: context.l10n.inboxActionRemove,
               isDestructive: true,
               showDivider: false,
               result: ConversationAction.remove,
@@ -74,7 +77,7 @@ class _MuteActionTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       toggled: isMuted,
-      label: 'Mute conversation',
+      label: context.l10n.inboxActionMute,
       child: DecoratedBox(
         decoration: const BoxDecoration(
           border: Border(
@@ -90,7 +93,7 @@ class _MuteActionTile extends StatelessWidget {
           onChanged: (_) =>
               Navigator.of(context).pop(ConversationAction.toggleMute),
           title: Text(
-            'Mute conversation',
+            context.l10n.inboxActionMute,
             style: VineTheme.titleMediumFont(),
           ),
           secondary: const DivineIcon(

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -23,6 +23,7 @@ class ConversationTile extends ConsumerWidget {
     required this.currentUserPubkey,
     required this.onTap,
     this.onLongPress,
+    this.highlighted = false,
     super.key,
   });
 
@@ -30,6 +31,10 @@ class ConversationTile extends ConsumerWidget {
   final String currentUserPubkey;
   final VoidCallback onTap;
   final VoidCallback? onLongPress;
+
+  /// When true, applies a [VineTheme.containerLow] background tint to
+  /// indicate this row is the target of an open long-press action sheet.
+  final bool highlighted;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -74,8 +79,9 @@ class ConversationTile extends ConsumerWidget {
         onLongPress: onLongPress,
         behavior: HitTestBehavior.opaque,
         child: DecoratedBox(
-          decoration: const BoxDecoration(
-            border: Border(
+          decoration: BoxDecoration(
+            color: highlighted ? VineTheme.containerLow : null,
+            border: const Border(
               bottom: BorderSide(color: VineTheme.outlineDisabled),
             ),
           ),

--- a/mobile/lib/screens/inbox/widgets/inbox_empty_state.dart
+++ b/mobile/lib/screens/inbox/widgets/inbox_empty_state.dart
@@ -3,6 +3,7 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
 
 /// Empty state shown when there are no DM conversations.
 ///
@@ -21,12 +22,12 @@ class InboxEmptyState extends StatelessWidget {
           spacing: 8,
           children: [
             Text(
-              'No messages yet',
+              context.l10n.inboxEmptyTitle,
               style: VineTheme.titleMediumFont(color: VineTheme.onSurfaceMuted),
               textAlign: TextAlign.center,
             ),
             Text(
-              "That + button won't bite.",
+              context.l10n.inboxEmptySubtitle,
               style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted),
               textAlign: TextAlign.center,
             ),

--- a/mobile/packages/time_formatter/lib/src/time_formatter.dart
+++ b/mobile/packages/time_formatter/lib/src/time_formatter.dart
@@ -57,7 +57,7 @@ abstract class TimeFormatter {
 
   /// Formats a Unix timestamp (seconds) for conversation list timestamps.
   ///
-  /// - Under 1 minute: "now"
+  /// - Under 1 minute: "1m" (floor — never "0m" or "now")
   /// - Under 1 hour: relative minutes — "1m", "5m", "59m"
   /// - Same calendar day: relative hours — "1h", "3h", "23h"
   /// - Yesterday: "Yesterday"
@@ -72,7 +72,7 @@ abstract class TimeFormatter {
     ).toLocal();
     final diff = now.difference(date);
 
-    if (diff.inMinutes < 1) return 'now';
+    if (diff.inMinutes < 1) return '1m';
     if (diff.inMinutes < 60) return '${diff.inMinutes}m';
 
     final dayDiff = _calendarDayDiff(now, date);

--- a/mobile/packages/time_formatter/test/src/time_formatter_test.dart
+++ b/mobile/packages/time_formatter/test/src/time_formatter_test.dart
@@ -104,11 +104,11 @@ void main() {
     });
 
     group('formatConversationTimestamp', () {
-      test('returns "now" for less than a minute ago', () {
+      test('returns "1m" floor for less than a minute ago', () {
         final ts = unixSecondsAgo(const Duration(seconds: 30));
         expect(
           TimeFormatter.formatConversationTimestamp(ts),
-          equals('now'),
+          equals('1m'),
         );
       });
 

--- a/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
+++ b/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Widget tests for ConversationTile.
 // ABOUTME: Verifies avatar, display name, last message, unread dot, and tap.
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
@@ -260,6 +261,83 @@ void main() {
 
         expect(longPressed, isTrue);
       });
+    });
+
+    group('highlight', () {
+      testWidgets(
+        'applies $VineTheme.containerLow background when highlighted',
+        (tester) async {
+          final testProfile = createTestProfile(displayName: 'Alice');
+          final testConversation = createTestConversation();
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              additionalOverrides: [
+                fetchUserProfileProvider(otherPubkey).overrideWith(
+                  (ref) async => testProfile,
+                ),
+              ],
+              home: Scaffold(
+                body: ConversationTile(
+                  conversation: testConversation,
+                  currentUserPubkey: currentPubkey,
+                  highlighted: true,
+                  onTap: () {},
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final decoratedBox = tester.widget<DecoratedBox>(
+            find
+                .descendant(
+                  of: find.byType(ConversationTile),
+                  matching: find.byType(DecoratedBox),
+                )
+                .first,
+          );
+          final decoration = decoratedBox.decoration as BoxDecoration;
+          expect(decoration.color, equals(VineTheme.containerLow));
+        },
+      );
+
+      testWidgets(
+        'has no background color when not highlighted',
+        (tester) async {
+          final testProfile = createTestProfile(displayName: 'Alice');
+          final testConversation = createTestConversation();
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              additionalOverrides: [
+                fetchUserProfileProvider(otherPubkey).overrideWith(
+                  (ref) async => testProfile,
+                ),
+              ],
+              home: Scaffold(
+                body: ConversationTile(
+                  conversation: testConversation,
+                  currentUserPubkey: currentPubkey,
+                  onTap: () {},
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final decoratedBox = tester.widget<DecoratedBox>(
+            find
+                .descendant(
+                  of: find.byType(ConversationTile),
+                  matching: find.byType(DecoratedBox),
+                )
+                .first,
+          );
+          final decoration = decoratedBox.decoration as BoxDecoration;
+          expect(decoration.color, isNull);
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #3213

## Description

Phase 3 Figma alignment for the DM Messages tab. Brings the inbox in line with six new Figma screens (file `rp1DsDEUuCaicW0lk6I2aZ`, nodes `10165:115255`, `10165:114421`, `10165:114188`, `10165:113961`, `10165:82443`, `10183:132451`) that together specify the full empty-and-populated state matrix plus the long-press action sheet.

Three verified gaps, each shipped as its own commit.

**Related Issue:** None — continuation of Phase 3 Figma alignment work.

## Type of Change

- [x] ✨ New feature — long-press target highlight
- [x] 🛠️ Bug fix — timestamp `"now"` floored to `"1m"` per design spec
- [x] 🗑️ Chore — localized all inbox-tab hardcoded strings

## What's in this PR

1. `chore(inbox): localize messages tab strings` — 12 new `inbox*` ARB keys. Empty-state copy, long-press sheet labels (Mute/Report/Block/Unblock/Remove), mute snackbars, and the remove-confirm dialog all route through `context.l10n.*`. Reuses `commonCancel`.
2. `fix(inbox): show "1m" floor instead of "now"` — scoped to `TimeFormatter.formatConversationTimestamp`; `formatRelative` unchanged.
3. `feat(inbox): highlight conversation tile during long-press action sheet` — `ConversationTile` gets a `highlighted` bool prop that paints the row with `VineTheme.containerLow` (#0E2B21, Figma `bg/surface-container-low`). `InboxView` tracks the highlighted id in local widget state; set before the sheet `await`, cleared in a `finally` so the tint persists through the ~300 ms close animation and clears on any exit path.

## How to test (manual smoke)

Run on a simulator. Build the app (`cd mobile && flutter run`) and sign into any Nostr account.

### Prerequisite setup (to see all states)

- **Account A:** brand-new account, nobody followed, no DMs ever — gives you the "no following, no messages" state.
- **Account B:** same account after following 3+ people and having 5+ active conversations — gives you the populated states.
- To surface a message request, have a non-followed account send account B a DM via any Nostr client.

### 1. Empty state — "not following" (Figma `10165:115255`)

**Preconditions:** Account A, no following, no conversations, no requests.

**Steps:** Open the app → tap the inbox tab in the bottom bar → tap the `Messages` pill.

**Expected:**
- Screen shows `No messages yet` (ExtraBold 16) centered, with `That + button won't bite.` (Regular 14) directly below in muted white.
- No bar people row.
- No "Message requests" row.
- Green `+` FAB visible bottom-right.

### 2. Empty state + message requests (Figma `10165:114421`)

**Preconditions:** Account A with at least one pending DM from a stranger, still no sent messages.

**Steps:** Open inbox → Messages tab.

**Expected:**
- `Message requests` row visible at the top with a red pill badge showing the request count (or `99+`) and a `>` caret.
- Same `No messages yet` / `That + button won't bite.` copy centered below.
- No bar people row.

### 3. Following + empty (Figma `10165:114188`)

**Preconditions:** Account B follows 3+ users, no DMs started yet.

**Steps:** Open inbox → Messages tab.

**Expected:**
- Horizontal bar people row at the top showing the followed accounts (48 px avatars, 72 px columns).
- `No messages yet` / `That + button won't bite.` centered below the bar.

### 4. Following + full list, no requests (Figma `10165:113961`)

**Preconditions:** Account B with ≥5 active DM conversations and zero pending requests.

**Steps:** Open inbox → Messages tab → scroll the conversation list.

**Expected:**
- Bar people row at top.
- Conversation list below with 40 px avatars, display names in ExtraBold white, last-message preview in Regular white (75 %), timestamp in muted white, red unread dot when applicable.
- No "Message requests" row.

### 5. Following + requests + full list (Figma `10165:82443`)

**Preconditions:** Account B with active conversations AND pending requests.

**Expected:** Same as state 4 plus a `Message requests` row with a `99+` pill directly below the bar people, above the first conversation.

### 6. Long-press action sheet (Figma `10183:132451`)

**Preconditions:** State 4 or 5.

**Steps:** Long-press any conversation row. Observe the tile and the sheet as it opens and during interactions below.

**Expected:**
- The long-pressed row tints to a subtle dark-green (`#0E2B21`) immediately and holds that tint for the entire time the sheet is visible.
- Bottom sheet opens from the bottom with rounded top corners, scrim dims the rest of the screen.
- Four rows in order with dividers between them:
  1. Bell icon — `Mute conversation` — trailing green `Switch` (toggled according to current state).
  2. Flag icon — `Report <name>` (white text).
  3. Eye-slash icon — `Block <name>` (red text) or `Unblock <name>` (white text) depending on current state.
  4. Trash icon — `Remove conversation` (red text, no divider under it).
- Dismiss the sheet by tapping the scrim → tile tint clears immediately.

### 7. Individual action outcomes

From state 6, verify each action independently:

- **Toggle mute:** flip the switch → sheet closes → snackbar at the bottom reads `Conversation muted` or `Conversation unmuted`. Tile tint clears after the sheet closes.
- **Report <name>:** tap the row → sheet closes → snackbar reads `Reported <name>`.
- **Block <name>:** tap the row → sheet closes → snackbar reads `Blocked <name>`. Re-open the sheet and confirm the middle row now reads `Unblock <name>` in white text. Tap it → snackbar reads `Unblocked <name>`.
- **Remove conversation:** tap the row → confirmation dialog appears. Title `Remove conversation?`, body `This will delete your conversation with <name>. This action cannot be undone.`, `Cancel` button (white), `Remove` button (red).
  - Tap `Cancel` → dialog dismisses, nothing else changes.
  - Tap `Remove` → dialog dismisses, conversation disappears from the list, snackbar reads `Removed conversation`.

### 8. Timestamp floor

From state 4: send a DM from another account to account B, or refresh a conversation so `lastMessageTimestamp` is fresh (<60 s).

**Expected:** The timestamp next to the conversation name reads `1m`, never `0m` and never `now`.

### 9. Accessibility & scaling

- Enable iOS "Larger Accessibility Text" (or Android font scale max). Re-open inbox and verify the empty-state copy does not clip. Re-open the long-press sheet and verify all four rows remain legible.
- Turn on VoiceOver/TalkBack, swipe through a populated inbox, and confirm each row is announced as `<name> conversation`. Long-press a row and verify the sheet items read in order (Mute / Report / Block / Remove).

## Automated test coverage

- `time_formatter_test.dart` — updated; all 27 tests pass (`cd mobile/packages/time_formatter && dart test`).
- `inbox_empty_state_test.dart` — unchanged; localized values match literals for `en` so existing assertions still pass.
- `conversation_actions_sheet_test.dart` — unchanged; same rationale.
- `conversation_tile_test.dart` — 2 new tests under a `highlight` group that verify the prop applies/removes `VineTheme.containerLow` as the decoration color.
- Full inbox suite: 145 tests pass (`cd mobile && flutter test test/screens/inbox/`).
- Analyzer clean (`flutter analyze lib test integration_test`).

## Out of scope / follow-ups

- `ConversationListStatus.error` still renders the localized "No messages yet" copy — pre-existing misleading-UX bug, not introduced here. Separate fix recommended.
- Figma annotation on node `10165:115331` is phrased backwards (says "only appears if a user does not have any message requests" but the screen shows the module when requests exist). Current code matches the visual intent (`requestConversations.isNotEmpty`). Flagged to the designer; no code change.
- Translations for the 12 new `inbox*` keys will ship in an immediate follow-up (tracked in #3215). Recent l10n PRs (#3091, #3117, #3139) add translations for every locale in the same commit; the follow-up brings this PR in line.
