### PR TITLE
chore(l10n): translate Phase 3 inbox keys to non-English locales

### DIFF
--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2193,6 +2193,32 @@
     "featureRequestCancel": "إلغاء",
     "followersFailedToLoadList": "فشل تحميل قائمة المتابعين",
     "followingFailedToLoadList": "فشل تحميل قائمة المتابَعين",
+    "inboxActionBlock": "حظر {displayName}",
+    "@inboxActionBlock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionMute": "كتم المحادثة",
+    "inboxActionRemove": "إزالة المحادثة",
+    "inboxActionReport": "الإبلاغ عن {displayName}",
+    "@inboxActionReport": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionUnblock": "إلغاء حظر {displayName}",
+    "@inboxActionUnblock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "inboxBlockedUser": "تم حظر {displayName}",
     "@inboxBlockedUser": {
         "placeholders": {
@@ -2201,6 +2227,20 @@
             }
         }
     },
+    "inboxConversationMuted": "تم كتم المحادثة",
+    "inboxConversationUnmuted": "تم إلغاء كتم المحادثة",
+    "inboxEmptySubtitle": "زر + لن يعضّك.",
+    "inboxEmptyTitle": "لا توجد رسائل بعد",
+    "inboxRemoveConfirmBody": "سيؤدي هذا إلى حذف محادثتك مع {displayName}. لا يمكن التراجع عن هذا الإجراء.",
+    "@inboxRemoveConfirmBody": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxRemoveConfirmConfirm": "إزالة",
+    "inboxRemoveConfirmTitle": "إزالة المحادثة؟",
     "inboxRemovedConversation": "تمت إزالة المحادثة",
     "inboxReportedUser": "تم الإبلاغ عن {displayName}",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2193,6 +2193,32 @@
     "featureRequestCancel": "Abbrechen",
     "followersFailedToLoadList": "Follower-Liste konnte nicht geladen werden",
     "followingFailedToLoadList": "Folge-ich-Liste konnte nicht geladen werden",
+    "inboxActionBlock": "{displayName} blockieren",
+    "@inboxActionBlock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionMute": "Unterhaltung stummschalten",
+    "inboxActionRemove": "Unterhaltung entfernen",
+    "inboxActionReport": "{displayName} melden",
+    "@inboxActionReport": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionUnblock": "{displayName} entblocken",
+    "@inboxActionUnblock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "inboxBlockedUser": "{displayName} blockiert",
     "@inboxBlockedUser": {
         "placeholders": {
@@ -2201,6 +2227,20 @@
             }
         }
     },
+    "inboxConversationMuted": "Unterhaltung stummgeschaltet",
+    "inboxConversationUnmuted": "Unterhaltung nicht mehr stummgeschaltet",
+    "inboxEmptySubtitle": "Der + Button beißt nicht.",
+    "inboxEmptyTitle": "Noch keine Nachrichten",
+    "inboxRemoveConfirmBody": "Dadurch wird deine Unterhaltung mit {displayName} gelöscht. Dieser Vorgang kann nicht rückgängig gemacht werden.",
+    "@inboxRemoveConfirmBody": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxRemoveConfirmConfirm": "Entfernen",
+    "inboxRemoveConfirmTitle": "Unterhaltung entfernen?",
     "inboxRemovedConversation": "Unterhaltung entfernt",
     "inboxReportedUser": "{displayName} gemeldet",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2193,6 +2193,32 @@
     "featureRequestCancel": "Cancelar",
     "followersFailedToLoadList": "No se pudo cargar la lista de seguidores",
     "followingFailedToLoadList": "No se pudo cargar la lista de seguidos",
+    "inboxActionBlock": "Bloquear a {displayName}",
+    "@inboxActionBlock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionMute": "Silenciar conversación",
+    "inboxActionRemove": "Eliminar conversación",
+    "inboxActionReport": "Reportar a {displayName}",
+    "@inboxActionReport": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionUnblock": "Desbloquear a {displayName}",
+    "@inboxActionUnblock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "inboxBlockedUser": "Bloqueaste a {displayName}",
     "@inboxBlockedUser": {
         "placeholders": {
@@ -2201,6 +2227,20 @@
             }
         }
     },
+    "inboxConversationMuted": "Conversación silenciada",
+    "inboxConversationUnmuted": "Conversación sin silenciar",
+    "inboxEmptySubtitle": "El botón + no muerde.",
+    "inboxEmptyTitle": "Aún no hay mensajes",
+    "inboxRemoveConfirmBody": "Esto eliminará tu conversación con {displayName}. Esta acción no se puede deshacer.",
+    "@inboxRemoveConfirmBody": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxRemoveConfirmConfirm": "Eliminar",
+    "inboxRemoveConfirmTitle": "¿Eliminar conversación?",
     "inboxRemovedConversation": "Conversación eliminada",
     "inboxReportedUser": "Reportaste a {displayName}",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2193,6 +2193,32 @@
     "featureRequestCancel": "Annuler",
     "followersFailedToLoadList": "Impossible de charger la liste des abonnés",
     "followingFailedToLoadList": "Impossible de charger la liste des abonnements",
+    "inboxActionBlock": "Bloquer {displayName}",
+    "@inboxActionBlock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionMute": "Mettre la conversation en sourdine",
+    "inboxActionRemove": "Supprimer la conversation",
+    "inboxActionReport": "Signaler {displayName}",
+    "@inboxActionReport": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionUnblock": "Débloquer {displayName}",
+    "@inboxActionUnblock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "inboxBlockedUser": "{displayName} bloqué(e)",
     "@inboxBlockedUser": {
         "placeholders": {
@@ -2201,6 +2227,20 @@
             }
         }
     },
+    "inboxConversationMuted": "Conversation mise en sourdine",
+    "inboxConversationUnmuted": "Conversation réactivée",
+    "inboxEmptySubtitle": "Le bouton + ne mord pas.",
+    "inboxEmptyTitle": "Aucun message pour le moment",
+    "inboxRemoveConfirmBody": "Cela supprimera votre conversation avec {displayName}. Cette action est irréversible.",
+    "@inboxRemoveConfirmBody": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxRemoveConfirmConfirm": "Supprimer",
+    "inboxRemoveConfirmTitle": "Supprimer la conversation ?",
     "inboxRemovedConversation": "Conversation supprimée",
     "inboxReportedUser": "{displayName} signalé(e)",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2193,6 +2193,32 @@
     "featureRequestCancel": "Batal",
     "followersFailedToLoadList": "Gagal memuat daftar pengikut",
     "followingFailedToLoadList": "Gagal memuat daftar mengikuti",
+    "inboxActionBlock": "Blokir {displayName}",
+    "@inboxActionBlock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionMute": "Bisukan percakapan",
+    "inboxActionRemove": "Hapus percakapan",
+    "inboxActionReport": "Laporkan {displayName}",
+    "@inboxActionReport": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionUnblock": "Buka blokir {displayName}",
+    "@inboxActionUnblock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "inboxBlockedUser": "{displayName} diblokir",
     "@inboxBlockedUser": {
         "placeholders": {
@@ -2201,6 +2227,20 @@
             }
         }
     },
+    "inboxConversationMuted": "Percakapan dibisukan",
+    "inboxConversationUnmuted": "Bisu percakapan dibatalkan",
+    "inboxEmptySubtitle": "Tombol + tidak menggigit kok.",
+    "inboxEmptyTitle": "Belum ada pesan",
+    "inboxRemoveConfirmBody": "Ini akan menghapus percakapanmu dengan {displayName}. Tindakan ini tidak bisa dibatalkan.",
+    "@inboxRemoveConfirmBody": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxRemoveConfirmConfirm": "Hapus",
+    "inboxRemoveConfirmTitle": "Hapus percakapan?",
     "inboxRemovedConversation": "Percakapan dihapus",
     "inboxReportedUser": "{displayName} dilaporkan",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2193,6 +2193,32 @@
     "featureRequestCancel": "Annulla",
     "followersFailedToLoadList": "Impossibile caricare la lista dei follower",
     "followingFailedToLoadList": "Impossibile caricare la lista dei seguiti",
+    "inboxActionBlock": "Blocca {displayName}",
+    "@inboxActionBlock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionMute": "Silenzia conversazione",
+    "inboxActionRemove": "Rimuovi conversazione",
+    "inboxActionReport": "Segnala {displayName}",
+    "@inboxActionReport": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionUnblock": "Sblocca {displayName}",
+    "@inboxActionUnblock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "inboxBlockedUser": "{displayName} bloccato/a",
     "@inboxBlockedUser": {
         "placeholders": {
@@ -2201,6 +2227,20 @@
             }
         }
     },
+    "inboxConversationMuted": "Conversazione silenziata",
+    "inboxConversationUnmuted": "Conversazione riattivata",
+    "inboxEmptySubtitle": "Il pulsante + non morde.",
+    "inboxEmptyTitle": "Ancora nessun messaggio",
+    "inboxRemoveConfirmBody": "Questo eliminerà la tua conversazione con {displayName}. Questa azione non può essere annullata.",
+    "@inboxRemoveConfirmBody": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxRemoveConfirmConfirm": "Rimuovi",
+    "inboxRemoveConfirmTitle": "Rimuovere la conversazione?",
     "inboxRemovedConversation": "Conversazione rimossa",
     "inboxReportedUser": "{displayName} segnalato/a",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2193,6 +2193,32 @@
     "featureRequestCancel": "キャンセル",
     "followersFailedToLoadList": "フォロワーリストの読み込みがうまくいかなかった",
     "followingFailedToLoadList": "フォロー中リストの読み込みがうまくいかなかった",
+    "inboxActionBlock": "{displayName}をブロック",
+    "@inboxActionBlock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionMute": "会話をミュート",
+    "inboxActionRemove": "会話を削除",
+    "inboxActionReport": "{displayName}を報告",
+    "@inboxActionReport": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionUnblock": "{displayName}のブロックを解除",
+    "@inboxActionUnblock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "inboxBlockedUser": "{displayName}をブロックしたよ",
     "@inboxBlockedUser": {
         "placeholders": {
@@ -2201,6 +2227,20 @@
             }
         }
     },
+    "inboxConversationMuted": "会話をミュートしたよ",
+    "inboxConversationUnmuted": "会話のミュートを解除したよ",
+    "inboxEmptySubtitle": "この+ボタン、噛まないよ。",
+    "inboxEmptyTitle": "まだメッセージはないよ",
+    "inboxRemoveConfirmBody": "{displayName}との会話が削除されます。この操作は取り消せません。",
+    "@inboxRemoveConfirmBody": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxRemoveConfirmConfirm": "削除",
+    "inboxRemoveConfirmTitle": "会話を削除する？",
     "inboxRemovedConversation": "会話を削除したよ",
     "inboxReportedUser": "{displayName}を報告したよ",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1503,6 +1503,32 @@
     "featureRequestCancel": "취소",
     "followersFailedToLoadList": "팔로워 목록을 불러오지 못했어요",
     "followingFailedToLoadList": "팔로잉 목록을 불러오지 못했어요",
+    "inboxActionBlock": "{displayName} 차단",
+    "@inboxActionBlock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionMute": "대화 알림 끄기",
+    "inboxActionRemove": "대화 삭제",
+    "inboxActionReport": "{displayName} 신고",
+    "@inboxActionReport": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionUnblock": "{displayName} 차단 해제",
+    "@inboxActionUnblock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "inboxBlockedUser": "{displayName}을(를) 차단했어요",
     "@inboxBlockedUser": {
         "placeholders": {
@@ -1511,6 +1537,20 @@
             }
         }
     },
+    "inboxConversationMuted": "대화 알림을 껐어요",
+    "inboxConversationUnmuted": "대화 알림을 다시 켰어요",
+    "inboxEmptySubtitle": "+ 버튼, 물지 않아요.",
+    "inboxEmptyTitle": "아직 메시지가 없어요",
+    "inboxRemoveConfirmBody": "{displayName}와의 대화가 삭제돼요. 이 작업은 되돌릴 수 없어요.",
+    "@inboxRemoveConfirmBody": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxRemoveConfirmConfirm": "삭제",
+    "inboxRemoveConfirmTitle": "대화를 삭제할까요?",
     "inboxRemovedConversation": "대화를 삭제했어요",
     "inboxReportedUser": "{displayName}을(를) 신고했어요",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2193,6 +2193,32 @@
     "featureRequestCancel": "Annuleren",
     "followersFailedToLoadList": "Volgerlijst kon niet worden geladen",
     "followingFailedToLoadList": "Volglijst kon niet worden geladen",
+    "inboxActionBlock": "{displayName} blokkeren",
+    "@inboxActionBlock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionMute": "Gesprek dempen",
+    "inboxActionRemove": "Gesprek verwijderen",
+    "inboxActionReport": "{displayName} rapporteren",
+    "@inboxActionReport": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionUnblock": "{displayName} deblokkeren",
+    "@inboxActionUnblock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "inboxBlockedUser": "{displayName} geblokkeerd",
     "@inboxBlockedUser": {
         "placeholders": {
@@ -2201,6 +2227,20 @@
             }
         }
     },
+    "inboxConversationMuted": "Gesprek gedempt",
+    "inboxConversationUnmuted": "Gesprek niet meer gedempt",
+    "inboxEmptySubtitle": "Die +-knop bijt niet.",
+    "inboxEmptyTitle": "Nog geen berichten",
+    "inboxRemoveConfirmBody": "Dit verwijdert je gesprek met {displayName}. Deze actie kan niet ongedaan worden gemaakt.",
+    "@inboxRemoveConfirmBody": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxRemoveConfirmConfirm": "Verwijderen",
+    "inboxRemoveConfirmTitle": "Gesprek verwijderen?",
     "inboxRemovedConversation": "Gesprek verwijderd",
     "inboxReportedUser": "{displayName} gerapporteerd",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2193,6 +2193,32 @@
     "featureRequestCancel": "Anuluj",
     "followersFailedToLoadList": "Nie udało się załadować listy obserwujących",
     "followingFailedToLoadList": "Nie udało się załadować listy obserwowanych",
+    "inboxActionBlock": "Zablokuj {displayName}",
+    "@inboxActionBlock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionMute": "Wycisz rozmowę",
+    "inboxActionRemove": "Usuń rozmowę",
+    "inboxActionReport": "Zgłoś {displayName}",
+    "@inboxActionReport": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionUnblock": "Odblokuj {displayName}",
+    "@inboxActionUnblock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "inboxBlockedUser": "Zablokowano {displayName}",
     "@inboxBlockedUser": {
         "placeholders": {
@@ -2201,6 +2227,20 @@
             }
         }
     },
+    "inboxConversationMuted": "Wyciszono rozmowę",
+    "inboxConversationUnmuted": "Wyłączono wyciszenie rozmowy",
+    "inboxEmptySubtitle": "Ten przycisk + nie gryzie.",
+    "inboxEmptyTitle": "Brak wiadomości",
+    "inboxRemoveConfirmBody": "Spowoduje to usunięcie rozmowy z {displayName}. Tej operacji nie można cofnąć.",
+    "@inboxRemoveConfirmBody": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxRemoveConfirmConfirm": "Usuń",
+    "inboxRemoveConfirmTitle": "Usunąć rozmowę?",
     "inboxRemovedConversation": "Usunięto rozmowę",
     "inboxReportedUser": "Zgłoszono {displayName}",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2193,6 +2193,32 @@
     "featureRequestCancel": "Cancelar",
     "followersFailedToLoadList": "Falha ao carregar lista de seguidores",
     "followingFailedToLoadList": "Falha ao carregar lista de seguindo",
+    "inboxActionBlock": "Bloquear {displayName}",
+    "@inboxActionBlock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionMute": "Silenciar conversa",
+    "inboxActionRemove": "Remover conversa",
+    "inboxActionReport": "Denunciar {displayName}",
+    "@inboxActionReport": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionUnblock": "Desbloquear {displayName}",
+    "@inboxActionUnblock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "inboxBlockedUser": "{displayName} bloqueado(a)",
     "@inboxBlockedUser": {
         "placeholders": {
@@ -2201,6 +2227,20 @@
             }
         }
     },
+    "inboxConversationMuted": "Conversa silenciada",
+    "inboxConversationUnmuted": "Conversa com som ativado",
+    "inboxEmptySubtitle": "O botão + não morde.",
+    "inboxEmptyTitle": "Ainda sem mensagens",
+    "inboxRemoveConfirmBody": "Isso apagará sua conversa com {displayName}. Esta ação não pode ser desfeita.",
+    "@inboxRemoveConfirmBody": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxRemoveConfirmConfirm": "Remover",
+    "inboxRemoveConfirmTitle": "Remover conversa?",
     "inboxRemovedConversation": "Conversa removida",
     "inboxReportedUser": "{displayName} denunciado(a)",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2193,6 +2193,32 @@
     "featureRequestCancel": "Anulează",
     "followersFailedToLoadList": "Nu s-a putut încărca lista de urmăritori",
     "followingFailedToLoadList": "Nu s-a putut încărca lista de urmăriți",
+    "inboxActionBlock": "Blochează {displayName}",
+    "@inboxActionBlock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionMute": "Dezactivează sunetul conversației",
+    "inboxActionRemove": "Elimină conversația",
+    "inboxActionReport": "Raportează {displayName}",
+    "@inboxActionReport": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionUnblock": "Deblochează {displayName}",
+    "@inboxActionUnblock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "inboxBlockedUser": "{displayName} a fost blocat(ă)",
     "@inboxBlockedUser": {
         "placeholders": {
@@ -2201,6 +2227,20 @@
             }
         }
     },
+    "inboxConversationMuted": "Conversație dezactivată",
+    "inboxConversationUnmuted": "Conversație reactivată",
+    "inboxEmptySubtitle": "Butonul + nu mușcă.",
+    "inboxEmptyTitle": "Încă niciun mesaj",
+    "inboxRemoveConfirmBody": "Astfel, conversația ta cu {displayName} va fi ștearsă. Această acțiune nu poate fi anulată.",
+    "@inboxRemoveConfirmBody": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxRemoveConfirmConfirm": "Elimină",
+    "inboxRemoveConfirmTitle": "Elimini conversația?",
     "inboxRemovedConversation": "Conversație eliminată",
     "inboxReportedUser": "{displayName} a fost raportat(ă)",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2193,6 +2193,32 @@
     "featureRequestCancel": "Avbryt",
     "followersFailedToLoadList": "Kunde inte ladda följarlistan",
     "followingFailedToLoadList": "Kunde inte ladda följer-listan",
+    "inboxActionBlock": "Blockera {displayName}",
+    "@inboxActionBlock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionMute": "Tysta konversation",
+    "inboxActionRemove": "Ta bort konversation",
+    "inboxActionReport": "Rapportera {displayName}",
+    "@inboxActionReport": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionUnblock": "Avblockera {displayName}",
+    "@inboxActionUnblock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "inboxBlockedUser": "{displayName} blockerad",
     "@inboxBlockedUser": {
         "placeholders": {
@@ -2201,6 +2227,20 @@
             }
         }
     },
+    "inboxConversationMuted": "Konversation tystad",
+    "inboxConversationUnmuted": "Konversation inte tystad",
+    "inboxEmptySubtitle": "+-knappen bits inte.",
+    "inboxEmptyTitle": "Inga meddelanden än",
+    "inboxRemoveConfirmBody": "Detta tar bort din konversation med {displayName}. Denna åtgärd kan inte ångras.",
+    "@inboxRemoveConfirmBody": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxRemoveConfirmConfirm": "Ta bort",
+    "inboxRemoveConfirmTitle": "Ta bort konversation?",
     "inboxRemovedConversation": "Konversation borttagen",
     "inboxReportedUser": "{displayName} rapporterad",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2193,6 +2193,32 @@
     "featureRequestCancel": "İptal",
     "followersFailedToLoadList": "Takipçi listesi yüklenemedi",
     "followingFailedToLoadList": "Takip edilen listesi yüklenemedi",
+    "inboxActionBlock": "{displayName} kullanıcısını engelle",
+    "@inboxActionBlock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionMute": "Sohbeti sessize al",
+    "inboxActionRemove": "Sohbeti kaldır",
+    "inboxActionReport": "{displayName} kullanıcısını bildir",
+    "@inboxActionReport": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxActionUnblock": "{displayName} kullanıcısının engelini kaldır",
+    "@inboxActionUnblock": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "inboxBlockedUser": "{displayName} engellendi",
     "@inboxBlockedUser": {
         "placeholders": {
@@ -2201,6 +2227,20 @@
             }
         }
     },
+    "inboxConversationMuted": "Sohbet sessize alındı",
+    "inboxConversationUnmuted": "Sohbet sessizden çıkarıldı",
+    "inboxEmptySubtitle": "+ tuşu ısırmaz.",
+    "inboxEmptyTitle": "Henüz mesaj yok",
+    "inboxRemoveConfirmBody": "Bu işlem, {displayName} ile olan sohbetini siler. Bu işlem geri alınamaz.",
+    "@inboxRemoveConfirmBody": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxRemoveConfirmConfirm": "Kaldır",
+    "inboxRemoveConfirmTitle": "Sohbet kaldırılsın mı?",
     "inboxRemovedConversation": "Sohbet kaldırıldı",
     "inboxReportedUser": "{displayName} bildirildi",
     "@inboxReportedUser": {

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4329,48 +4329,48 @@ class AppLocalizationsAr extends AppLocalizations {
   String get inboxRemovedConversation => 'تمت إزالة المحادثة';
 
   @override
-  String get inboxEmptyTitle => 'No messages yet';
+  String get inboxEmptyTitle => 'لا توجد رسائل بعد';
 
   @override
-  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+  String get inboxEmptySubtitle => 'زر + لن يعضّك.';
 
   @override
-  String get inboxActionMute => 'Mute conversation';
+  String get inboxActionMute => 'كتم المحادثة';
 
   @override
   String inboxActionReport(String displayName) {
-    return 'Report $displayName';
+    return 'الإبلاغ عن $displayName';
   }
 
   @override
   String inboxActionBlock(String displayName) {
-    return 'Block $displayName';
+    return 'حظر $displayName';
   }
 
   @override
   String inboxActionUnblock(String displayName) {
-    return 'Unblock $displayName';
+    return 'إلغاء حظر $displayName';
   }
 
   @override
-  String get inboxActionRemove => 'Remove conversation';
+  String get inboxActionRemove => 'إزالة المحادثة';
 
   @override
-  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+  String get inboxRemoveConfirmTitle => 'إزالة المحادثة؟';
 
   @override
   String inboxRemoveConfirmBody(String displayName) {
-    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+    return 'سيؤدي هذا إلى حذف محادثتك مع $displayName. لا يمكن التراجع عن هذا الإجراء.';
   }
 
   @override
-  String get inboxRemoveConfirmConfirm => 'Remove';
+  String get inboxRemoveConfirmConfirm => 'إزالة';
 
   @override
-  String get inboxConversationMuted => 'Conversation muted';
+  String get inboxConversationMuted => 'تم كتم المحادثة';
 
   @override
-  String get inboxConversationUnmuted => 'Conversation unmuted';
+  String get inboxConversationUnmuted => 'تم إلغاء كتم المحادثة';
 
   @override
   String get reportDialogCancel => 'إلغاء';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4423,48 +4423,49 @@ class AppLocalizationsDe extends AppLocalizations {
   String get inboxRemovedConversation => 'Unterhaltung entfernt';
 
   @override
-  String get inboxEmptyTitle => 'No messages yet';
+  String get inboxEmptyTitle => 'Noch keine Nachrichten';
 
   @override
-  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+  String get inboxEmptySubtitle => 'Der + Button beißt nicht.';
 
   @override
-  String get inboxActionMute => 'Mute conversation';
+  String get inboxActionMute => 'Unterhaltung stummschalten';
 
   @override
   String inboxActionReport(String displayName) {
-    return 'Report $displayName';
+    return '$displayName melden';
   }
 
   @override
   String inboxActionBlock(String displayName) {
-    return 'Block $displayName';
+    return '$displayName blockieren';
   }
 
   @override
   String inboxActionUnblock(String displayName) {
-    return 'Unblock $displayName';
+    return '$displayName entblocken';
   }
 
   @override
-  String get inboxActionRemove => 'Remove conversation';
+  String get inboxActionRemove => 'Unterhaltung entfernen';
 
   @override
-  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+  String get inboxRemoveConfirmTitle => 'Unterhaltung entfernen?';
 
   @override
   String inboxRemoveConfirmBody(String displayName) {
-    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+    return 'Dadurch wird deine Unterhaltung mit $displayName gelöscht. Dieser Vorgang kann nicht rückgängig gemacht werden.';
   }
 
   @override
-  String get inboxRemoveConfirmConfirm => 'Remove';
+  String get inboxRemoveConfirmConfirm => 'Entfernen';
 
   @override
-  String get inboxConversationMuted => 'Conversation muted';
+  String get inboxConversationMuted => 'Unterhaltung stummgeschaltet';
 
   @override
-  String get inboxConversationUnmuted => 'Conversation unmuted';
+  String get inboxConversationUnmuted =>
+      'Unterhaltung nicht mehr stummgeschaltet';
 
   @override
   String get reportDialogCancel => 'Abbrechen';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4415,48 +4415,48 @@ class AppLocalizationsEs extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversación eliminada';
 
   @override
-  String get inboxEmptyTitle => 'No messages yet';
+  String get inboxEmptyTitle => 'Aún no hay mensajes';
 
   @override
-  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+  String get inboxEmptySubtitle => 'El botón + no muerde.';
 
   @override
-  String get inboxActionMute => 'Mute conversation';
+  String get inboxActionMute => 'Silenciar conversación';
 
   @override
   String inboxActionReport(String displayName) {
-    return 'Report $displayName';
+    return 'Reportar a $displayName';
   }
 
   @override
   String inboxActionBlock(String displayName) {
-    return 'Block $displayName';
+    return 'Bloquear a $displayName';
   }
 
   @override
   String inboxActionUnblock(String displayName) {
-    return 'Unblock $displayName';
+    return 'Desbloquear a $displayName';
   }
 
   @override
-  String get inboxActionRemove => 'Remove conversation';
+  String get inboxActionRemove => 'Eliminar conversación';
 
   @override
-  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+  String get inboxRemoveConfirmTitle => '¿Eliminar conversación?';
 
   @override
   String inboxRemoveConfirmBody(String displayName) {
-    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+    return 'Esto eliminará tu conversación con $displayName. Esta acción no se puede deshacer.';
   }
 
   @override
-  String get inboxRemoveConfirmConfirm => 'Remove';
+  String get inboxRemoveConfirmConfirm => 'Eliminar';
 
   @override
-  String get inboxConversationMuted => 'Conversation muted';
+  String get inboxConversationMuted => 'Conversación silenciada';
 
   @override
-  String get inboxConversationUnmuted => 'Conversation unmuted';
+  String get inboxConversationUnmuted => 'Conversación sin silenciar';
 
   @override
   String get reportDialogCancel => 'Cancelar';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4428,48 +4428,48 @@ class AppLocalizationsFr extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversation supprimée';
 
   @override
-  String get inboxEmptyTitle => 'No messages yet';
+  String get inboxEmptyTitle => 'Aucun message pour le moment';
 
   @override
-  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+  String get inboxEmptySubtitle => 'Le bouton + ne mord pas.';
 
   @override
-  String get inboxActionMute => 'Mute conversation';
+  String get inboxActionMute => 'Mettre la conversation en sourdine';
 
   @override
   String inboxActionReport(String displayName) {
-    return 'Report $displayName';
+    return 'Signaler $displayName';
   }
 
   @override
   String inboxActionBlock(String displayName) {
-    return 'Block $displayName';
+    return 'Bloquer $displayName';
   }
 
   @override
   String inboxActionUnblock(String displayName) {
-    return 'Unblock $displayName';
+    return 'Débloquer $displayName';
   }
 
   @override
-  String get inboxActionRemove => 'Remove conversation';
+  String get inboxActionRemove => 'Supprimer la conversation';
 
   @override
-  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+  String get inboxRemoveConfirmTitle => 'Supprimer la conversation ?';
 
   @override
   String inboxRemoveConfirmBody(String displayName) {
-    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+    return 'Cela supprimera votre conversation avec $displayName. Cette action est irréversible.';
   }
 
   @override
-  String get inboxRemoveConfirmConfirm => 'Remove';
+  String get inboxRemoveConfirmConfirm => 'Supprimer';
 
   @override
-  String get inboxConversationMuted => 'Conversation muted';
+  String get inboxConversationMuted => 'Conversation mise en sourdine';
 
   @override
-  String get inboxConversationUnmuted => 'Conversation unmuted';
+  String get inboxConversationUnmuted => 'Conversation réactivée';
 
   @override
   String get reportDialogCancel => 'Annuler';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4349,48 +4349,48 @@ class AppLocalizationsId extends AppLocalizations {
   String get inboxRemovedConversation => 'Percakapan dihapus';
 
   @override
-  String get inboxEmptyTitle => 'No messages yet';
+  String get inboxEmptyTitle => 'Belum ada pesan';
 
   @override
-  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+  String get inboxEmptySubtitle => 'Tombol + tidak menggigit kok.';
 
   @override
-  String get inboxActionMute => 'Mute conversation';
+  String get inboxActionMute => 'Bisukan percakapan';
 
   @override
   String inboxActionReport(String displayName) {
-    return 'Report $displayName';
+    return 'Laporkan $displayName';
   }
 
   @override
   String inboxActionBlock(String displayName) {
-    return 'Block $displayName';
+    return 'Blokir $displayName';
   }
 
   @override
   String inboxActionUnblock(String displayName) {
-    return 'Unblock $displayName';
+    return 'Buka blokir $displayName';
   }
 
   @override
-  String get inboxActionRemove => 'Remove conversation';
+  String get inboxActionRemove => 'Hapus percakapan';
 
   @override
-  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+  String get inboxRemoveConfirmTitle => 'Hapus percakapan?';
 
   @override
   String inboxRemoveConfirmBody(String displayName) {
-    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+    return 'Ini akan menghapus percakapanmu dengan $displayName. Tindakan ini tidak bisa dibatalkan.';
   }
 
   @override
-  String get inboxRemoveConfirmConfirm => 'Remove';
+  String get inboxRemoveConfirmConfirm => 'Hapus';
 
   @override
-  String get inboxConversationMuted => 'Conversation muted';
+  String get inboxConversationMuted => 'Percakapan dibisukan';
 
   @override
-  String get inboxConversationUnmuted => 'Conversation unmuted';
+  String get inboxConversationUnmuted => 'Bisu percakapan dibatalkan';
 
   @override
   String get reportDialogCancel => 'Batal';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4414,48 +4414,48 @@ class AppLocalizationsIt extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversazione rimossa';
 
   @override
-  String get inboxEmptyTitle => 'No messages yet';
+  String get inboxEmptyTitle => 'Ancora nessun messaggio';
 
   @override
-  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+  String get inboxEmptySubtitle => 'Il pulsante + non morde.';
 
   @override
-  String get inboxActionMute => 'Mute conversation';
+  String get inboxActionMute => 'Silenzia conversazione';
 
   @override
   String inboxActionReport(String displayName) {
-    return 'Report $displayName';
+    return 'Segnala $displayName';
   }
 
   @override
   String inboxActionBlock(String displayName) {
-    return 'Block $displayName';
+    return 'Blocca $displayName';
   }
 
   @override
   String inboxActionUnblock(String displayName) {
-    return 'Unblock $displayName';
+    return 'Sblocca $displayName';
   }
 
   @override
-  String get inboxActionRemove => 'Remove conversation';
+  String get inboxActionRemove => 'Rimuovi conversazione';
 
   @override
-  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+  String get inboxRemoveConfirmTitle => 'Rimuovere la conversazione?';
 
   @override
   String inboxRemoveConfirmBody(String displayName) {
-    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+    return 'Questo eliminerà la tua conversazione con $displayName. Questa azione non può essere annullata.';
   }
 
   @override
-  String get inboxRemoveConfirmConfirm => 'Remove';
+  String get inboxRemoveConfirmConfirm => 'Rimuovi';
 
   @override
-  String get inboxConversationMuted => 'Conversation muted';
+  String get inboxConversationMuted => 'Conversazione silenziata';
 
   @override
-  String get inboxConversationUnmuted => 'Conversation unmuted';
+  String get inboxConversationUnmuted => 'Conversazione riattivata';
 
   @override
   String get reportDialogCancel => 'Annulla';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4183,48 +4183,48 @@ class AppLocalizationsJa extends AppLocalizations {
   String get inboxRemovedConversation => '会話を削除したよ';
 
   @override
-  String get inboxEmptyTitle => 'No messages yet';
+  String get inboxEmptyTitle => 'まだメッセージはないよ';
 
   @override
-  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+  String get inboxEmptySubtitle => 'この+ボタン、噛まないよ。';
 
   @override
-  String get inboxActionMute => 'Mute conversation';
+  String get inboxActionMute => '会話をミュート';
 
   @override
   String inboxActionReport(String displayName) {
-    return 'Report $displayName';
+    return '$displayNameを報告';
   }
 
   @override
   String inboxActionBlock(String displayName) {
-    return 'Block $displayName';
+    return '$displayNameをブロック';
   }
 
   @override
   String inboxActionUnblock(String displayName) {
-    return 'Unblock $displayName';
+    return '$displayNameのブロックを解除';
   }
 
   @override
-  String get inboxActionRemove => 'Remove conversation';
+  String get inboxActionRemove => '会話を削除';
 
   @override
-  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+  String get inboxRemoveConfirmTitle => '会話を削除する？';
 
   @override
   String inboxRemoveConfirmBody(String displayName) {
-    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+    return '$displayNameとの会話が削除されます。この操作は取り消せません。';
   }
 
   @override
-  String get inboxRemoveConfirmConfirm => 'Remove';
+  String get inboxRemoveConfirmConfirm => '削除';
 
   @override
-  String get inboxConversationMuted => 'Conversation muted';
+  String get inboxConversationMuted => '会話をミュートしたよ';
 
   @override
-  String get inboxConversationUnmuted => 'Conversation unmuted';
+  String get inboxConversationUnmuted => '会話のミュートを解除したよ';
 
   @override
   String get reportDialogCancel => 'キャンセル';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4199,48 +4199,48 @@ class AppLocalizationsKo extends AppLocalizations {
   String get inboxRemovedConversation => '대화를 삭제했어요';
 
   @override
-  String get inboxEmptyTitle => 'No messages yet';
+  String get inboxEmptyTitle => '아직 메시지가 없어요';
 
   @override
-  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+  String get inboxEmptySubtitle => '+ 버튼, 물지 않아요.';
 
   @override
-  String get inboxActionMute => 'Mute conversation';
+  String get inboxActionMute => '대화 알림 끄기';
 
   @override
   String inboxActionReport(String displayName) {
-    return 'Report $displayName';
+    return '$displayName 신고';
   }
 
   @override
   String inboxActionBlock(String displayName) {
-    return 'Block $displayName';
+    return '$displayName 차단';
   }
 
   @override
   String inboxActionUnblock(String displayName) {
-    return 'Unblock $displayName';
+    return '$displayName 차단 해제';
   }
 
   @override
-  String get inboxActionRemove => 'Remove conversation';
+  String get inboxActionRemove => '대화 삭제';
 
   @override
-  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+  String get inboxRemoveConfirmTitle => '대화를 삭제할까요?';
 
   @override
   String inboxRemoveConfirmBody(String displayName) {
-    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+    return '$displayName와의 대화가 삭제돼요. 이 작업은 되돌릴 수 없어요.';
   }
 
   @override
-  String get inboxRemoveConfirmConfirm => 'Remove';
+  String get inboxRemoveConfirmConfirm => '삭제';
 
   @override
-  String get inboxConversationMuted => 'Conversation muted';
+  String get inboxConversationMuted => '대화 알림을 껐어요';
 
   @override
-  String get inboxConversationUnmuted => 'Conversation unmuted';
+  String get inboxConversationUnmuted => '대화 알림을 다시 켰어요';
 
   @override
   String get reportDialogCancel => '취소';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4385,48 +4385,48 @@ class AppLocalizationsNl extends AppLocalizations {
   String get inboxRemovedConversation => 'Gesprek verwijderd';
 
   @override
-  String get inboxEmptyTitle => 'No messages yet';
+  String get inboxEmptyTitle => 'Nog geen berichten';
 
   @override
-  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+  String get inboxEmptySubtitle => 'Die +-knop bijt niet.';
 
   @override
-  String get inboxActionMute => 'Mute conversation';
+  String get inboxActionMute => 'Gesprek dempen';
 
   @override
   String inboxActionReport(String displayName) {
-    return 'Report $displayName';
+    return '$displayName rapporteren';
   }
 
   @override
   String inboxActionBlock(String displayName) {
-    return 'Block $displayName';
+    return '$displayName blokkeren';
   }
 
   @override
   String inboxActionUnblock(String displayName) {
-    return 'Unblock $displayName';
+    return '$displayName deblokkeren';
   }
 
   @override
-  String get inboxActionRemove => 'Remove conversation';
+  String get inboxActionRemove => 'Gesprek verwijderen';
 
   @override
-  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+  String get inboxRemoveConfirmTitle => 'Gesprek verwijderen?';
 
   @override
   String inboxRemoveConfirmBody(String displayName) {
-    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+    return 'Dit verwijdert je gesprek met $displayName. Deze actie kan niet ongedaan worden gemaakt.';
   }
 
   @override
-  String get inboxRemoveConfirmConfirm => 'Remove';
+  String get inboxRemoveConfirmConfirm => 'Verwijderen';
 
   @override
-  String get inboxConversationMuted => 'Conversation muted';
+  String get inboxConversationMuted => 'Gesprek gedempt';
 
   @override
-  String get inboxConversationUnmuted => 'Conversation unmuted';
+  String get inboxConversationUnmuted => 'Gesprek niet meer gedempt';
 
   @override
   String get reportDialogCancel => 'Annuleren';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4499,48 +4499,48 @@ class AppLocalizationsPl extends AppLocalizations {
   String get inboxRemovedConversation => 'Usunięto rozmowę';
 
   @override
-  String get inboxEmptyTitle => 'No messages yet';
+  String get inboxEmptyTitle => 'Brak wiadomości';
 
   @override
-  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+  String get inboxEmptySubtitle => 'Ten przycisk + nie gryzie.';
 
   @override
-  String get inboxActionMute => 'Mute conversation';
+  String get inboxActionMute => 'Wycisz rozmowę';
 
   @override
   String inboxActionReport(String displayName) {
-    return 'Report $displayName';
+    return 'Zgłoś $displayName';
   }
 
   @override
   String inboxActionBlock(String displayName) {
-    return 'Block $displayName';
+    return 'Zablokuj $displayName';
   }
 
   @override
   String inboxActionUnblock(String displayName) {
-    return 'Unblock $displayName';
+    return 'Odblokuj $displayName';
   }
 
   @override
-  String get inboxActionRemove => 'Remove conversation';
+  String get inboxActionRemove => 'Usuń rozmowę';
 
   @override
-  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+  String get inboxRemoveConfirmTitle => 'Usunąć rozmowę?';
 
   @override
   String inboxRemoveConfirmBody(String displayName) {
-    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+    return 'Spowoduje to usunięcie rozmowy z $displayName. Tej operacji nie można cofnąć.';
   }
 
   @override
-  String get inboxRemoveConfirmConfirm => 'Remove';
+  String get inboxRemoveConfirmConfirm => 'Usuń';
 
   @override
-  String get inboxConversationMuted => 'Conversation muted';
+  String get inboxConversationMuted => 'Wyciszono rozmowę';
 
   @override
-  String get inboxConversationUnmuted => 'Conversation unmuted';
+  String get inboxConversationUnmuted => 'Wyłączono wyciszenie rozmowy';
 
   @override
   String get reportDialogCancel => 'Anuluj';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4399,48 +4399,48 @@ class AppLocalizationsPt extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversa removida';
 
   @override
-  String get inboxEmptyTitle => 'No messages yet';
+  String get inboxEmptyTitle => 'Ainda sem mensagens';
 
   @override
-  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+  String get inboxEmptySubtitle => 'O botão + não morde.';
 
   @override
-  String get inboxActionMute => 'Mute conversation';
+  String get inboxActionMute => 'Silenciar conversa';
 
   @override
   String inboxActionReport(String displayName) {
-    return 'Report $displayName';
+    return 'Denunciar $displayName';
   }
 
   @override
   String inboxActionBlock(String displayName) {
-    return 'Block $displayName';
+    return 'Bloquear $displayName';
   }
 
   @override
   String inboxActionUnblock(String displayName) {
-    return 'Unblock $displayName';
+    return 'Desbloquear $displayName';
   }
 
   @override
-  String get inboxActionRemove => 'Remove conversation';
+  String get inboxActionRemove => 'Remover conversa';
 
   @override
-  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+  String get inboxRemoveConfirmTitle => 'Remover conversa?';
 
   @override
   String inboxRemoveConfirmBody(String displayName) {
-    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+    return 'Isso apagará sua conversa com $displayName. Esta ação não pode ser desfeita.';
   }
 
   @override
-  String get inboxRemoveConfirmConfirm => 'Remove';
+  String get inboxRemoveConfirmConfirm => 'Remover';
 
   @override
-  String get inboxConversationMuted => 'Conversation muted';
+  String get inboxConversationMuted => 'Conversa silenciada';
 
   @override
-  String get inboxConversationUnmuted => 'Conversation unmuted';
+  String get inboxConversationUnmuted => 'Conversa com som ativado';
 
   @override
   String get reportDialogCancel => 'Cancelar';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4501,48 +4501,48 @@ class AppLocalizationsRo extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversație eliminată';
 
   @override
-  String get inboxEmptyTitle => 'No messages yet';
+  String get inboxEmptyTitle => 'Încă niciun mesaj';
 
   @override
-  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+  String get inboxEmptySubtitle => 'Butonul + nu mușcă.';
 
   @override
-  String get inboxActionMute => 'Mute conversation';
+  String get inboxActionMute => 'Dezactivează sunetul conversației';
 
   @override
   String inboxActionReport(String displayName) {
-    return 'Report $displayName';
+    return 'Raportează $displayName';
   }
 
   @override
   String inboxActionBlock(String displayName) {
-    return 'Block $displayName';
+    return 'Blochează $displayName';
   }
 
   @override
   String inboxActionUnblock(String displayName) {
-    return 'Unblock $displayName';
+    return 'Deblochează $displayName';
   }
 
   @override
-  String get inboxActionRemove => 'Remove conversation';
+  String get inboxActionRemove => 'Elimină conversația';
 
   @override
-  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+  String get inboxRemoveConfirmTitle => 'Elimini conversația?';
 
   @override
   String inboxRemoveConfirmBody(String displayName) {
-    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+    return 'Astfel, conversația ta cu $displayName va fi ștearsă. Această acțiune nu poate fi anulată.';
   }
 
   @override
-  String get inboxRemoveConfirmConfirm => 'Remove';
+  String get inboxRemoveConfirmConfirm => 'Elimină';
 
   @override
-  String get inboxConversationMuted => 'Conversation muted';
+  String get inboxConversationMuted => 'Conversație dezactivată';
 
   @override
-  String get inboxConversationUnmuted => 'Conversation unmuted';
+  String get inboxConversationUnmuted => 'Conversație reactivată';
 
   @override
   String get reportDialogCancel => 'Anulează';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4365,48 +4365,48 @@ class AppLocalizationsSv extends AppLocalizations {
   String get inboxRemovedConversation => 'Konversation borttagen';
 
   @override
-  String get inboxEmptyTitle => 'No messages yet';
+  String get inboxEmptyTitle => 'Inga meddelanden än';
 
   @override
-  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+  String get inboxEmptySubtitle => '+-knappen bits inte.';
 
   @override
-  String get inboxActionMute => 'Mute conversation';
+  String get inboxActionMute => 'Tysta konversation';
 
   @override
   String inboxActionReport(String displayName) {
-    return 'Report $displayName';
+    return 'Rapportera $displayName';
   }
 
   @override
   String inboxActionBlock(String displayName) {
-    return 'Block $displayName';
+    return 'Blockera $displayName';
   }
 
   @override
   String inboxActionUnblock(String displayName) {
-    return 'Unblock $displayName';
+    return 'Avblockera $displayName';
   }
 
   @override
-  String get inboxActionRemove => 'Remove conversation';
+  String get inboxActionRemove => 'Ta bort konversation';
 
   @override
-  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+  String get inboxRemoveConfirmTitle => 'Ta bort konversation?';
 
   @override
   String inboxRemoveConfirmBody(String displayName) {
-    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+    return 'Detta tar bort din konversation med $displayName. Denna åtgärd kan inte ångras.';
   }
 
   @override
-  String get inboxRemoveConfirmConfirm => 'Remove';
+  String get inboxRemoveConfirmConfirm => 'Ta bort';
 
   @override
-  String get inboxConversationMuted => 'Conversation muted';
+  String get inboxConversationMuted => 'Konversation tystad';
 
   @override
-  String get inboxConversationUnmuted => 'Conversation unmuted';
+  String get inboxConversationUnmuted => 'Konversation inte tystad';
 
   @override
   String get reportDialogCancel => 'Avbryt';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4356,48 +4356,48 @@ class AppLocalizationsTr extends AppLocalizations {
   String get inboxRemovedConversation => 'Sohbet kaldırıldı';
 
   @override
-  String get inboxEmptyTitle => 'No messages yet';
+  String get inboxEmptyTitle => 'Henüz mesaj yok';
 
   @override
-  String get inboxEmptySubtitle => 'That + button won\'t bite.';
+  String get inboxEmptySubtitle => '+ tuşu ısırmaz.';
 
   @override
-  String get inboxActionMute => 'Mute conversation';
+  String get inboxActionMute => 'Sohbeti sessize al';
 
   @override
   String inboxActionReport(String displayName) {
-    return 'Report $displayName';
+    return '$displayName kullanıcısını bildir';
   }
 
   @override
   String inboxActionBlock(String displayName) {
-    return 'Block $displayName';
+    return '$displayName kullanıcısını engelle';
   }
 
   @override
   String inboxActionUnblock(String displayName) {
-    return 'Unblock $displayName';
+    return '$displayName kullanıcısının engelini kaldır';
   }
 
   @override
-  String get inboxActionRemove => 'Remove conversation';
+  String get inboxActionRemove => 'Sohbeti kaldır';
 
   @override
-  String get inboxRemoveConfirmTitle => 'Remove conversation?';
+  String get inboxRemoveConfirmTitle => 'Sohbet kaldırılsın mı?';
 
   @override
   String inboxRemoveConfirmBody(String displayName) {
-    return 'This will delete your conversation with $displayName. This action cannot be undone.';
+    return 'Bu işlem, $displayName ile olan sohbetini siler. Bu işlem geri alınamaz.';
   }
 
   @override
-  String get inboxRemoveConfirmConfirm => 'Remove';
+  String get inboxRemoveConfirmConfirm => 'Kaldır';
 
   @override
-  String get inboxConversationMuted => 'Conversation muted';
+  String get inboxConversationMuted => 'Sohbet sessize alındı';
 
   @override
-  String get inboxConversationUnmuted => 'Conversation unmuted';
+  String get inboxConversationUnmuted => 'Sohbet sessizden çıkarıldı';
 
   @override
   String get reportDialogCancel => 'İptal';


### PR DESCRIPTION
Closes #3215. Follow-up to #3212.

## Description

PR #3212 added 12 new `inbox*` keys to `app_en.arb` only. This PR translates those keys into the 14 non-English locales so the `Generated Files` fallback no longer serves English in every non-English UI.

Translations were drafted to match the tone, register, and grammatical pattern of the `inbox*` keys already shipped in each locale:
- **de, fr, it, nl, sv, tr, id, ro, pt** — past participle / passive register, matching `inboxBlockedUser: "{displayName} blockiert"`-style entries.
- **es** — personal 2nd-person informal, matching `inboxBlockedUser: "Bloqueaste a {displayName}"`.
- **pl** — impersonal past, matching `Zablokowano {displayName}`.
- **ja** — casual `〜したよ` ending on action snackbars, matching `{displayName}をブロックしたよ`.
- **ko** — polite `〜어요`, matching `{displayName}을(를) 차단했어요`.
- **ar** — `تم + verb` passive construction, matching `تم حظر {displayName}`.

Korean is included. Every existing `inbox*` key is already translated in `app_ko.arb`; the partial coverage in that file is in unrelated areas and out of scope here.

## Type of Change

- [x] 🗑️ Chore

## What's in this PR

### `mobile/lib/l10n/app_{ar,de,es,fr,id,it,ja,ko,nl,pl,pt,ro,sv,tr}.arb`

Inserted the 12 new keys + 4 `@placeholder` metadata blocks in alphabetical position within each file's existing `inbox*` block (between `followingFailedToLoadList` and `invitesTitle`). Preserves each file's 4-space indentation.

Keys translated (plain + parameterized):

| Key | Notes |
|-----|-------|
| `inboxEmptyTitle` | Empty-state title |
| `inboxEmptySubtitle` | Playful "+ button won't bite" line — culturally adapted per locale |
| `inboxActionMute` | Sheet row label |
| `inboxActionReport` | Parameterized (`{displayName}`) |
| `inboxActionBlock` | Parameterized |
| `inboxActionUnblock` | Parameterized |
| `inboxActionRemove` | Sheet row label |
| `inboxRemoveConfirmTitle` | Confirm dialog title |
| `inboxRemoveConfirmBody` | Parameterized |
| `inboxRemoveConfirmConfirm` | Confirm button label |
| `inboxConversationMuted` | Snackbar |
| `inboxConversationUnmuted` | Snackbar |

### `mobile/lib/l10n/generated/app_localizations_*.dart` (14 files)

Regenerated via `cd mobile && flutter gen-l10n`. No manual edits.

## Verification

- `cd mobile && flutter analyze lib test integration_test` — clean (`No issues found!`).
- `cd mobile && flutter test test/screens/inbox/` — 145 tests pass. Existing tests compare against English literals under the default locale and remain green.
- All 14 ARB files validated as JSON before commit.
- `flutter gen-l10n` completes successfully. Pre-existing "untranslated message(s)" warnings for other key families are unchanged — not introduced here.
- CI `Generated Files` job will rerun `flutter gen-l10n` and require the committed generated files to match (they do).

## How to review

- The `app_en.arb` is intentionally untouched — source of truth was fixed in #3212.
- To sanity-check one locale, diff the ARB file and look at the 12 new keys between `@inboxActionUnblock` (end of Action block) and `inboxRemovedConversation` (existing).
- Native-speaker eyes on a line or two are welcome — I'm happy to amend any translation that feels off.

## Out of scope / follow-ups

- Korean partial coverage in other feature areas (auth, settings, feed) — tracked separately; not addressed here.
- Any future `inbox*` keys should be added to all 14 locales in the same commit, matching the cadence of #3091, #3117, and #3139.