### PR TITLE
test(video-volume): inject fake system volume listener in SharedPreferences test

### DIFF
--- a/mobile/test/blocs/video_volume/video_volume_cubit_test.dart
+++ b/mobile/test/blocs/video_volume/video_volume_cubit_test.dart
@@ -54,7 +54,10 @@ void main() {
         });
         final prefsWithValue = await SharedPreferences.getInstance();
 
-        final cubit = VideoVolumeCubit(sharedPreferences: prefsWithValue);
+        final cubit = VideoVolumeCubit(
+          sharedPreferences: prefsWithValue,
+          systemVolumeListener: fakeVolumeListener,
+        );
         addTearDown(cubit.close);
 
         expect(cubit.state.volume, equals(0.0));


### PR DESCRIPTION
## Summary

Unblocks CI on Linux runners. The `VideoVolumeCubit` test `reads persisted volume from SharedPreferences` was the only test in `mobile/test/blocs/video_volume/video_volume_cubit_test.dart` that constructed the cubit directly instead of via the `buildCubit()` helper — it needs a fresh `SharedPreferences` seeded with a specific value, which `buildCubit()` doesn't support. Without the `systemVolumeListener` injection, the cubit falls through to `_PluginVolumeListener()` on non-web platforms, which calls `VolumeController.addListener` on `com.kurenai7968.volume_controller.volume_listener_event`. That channel has no Linux platform implementation, so an async `MissingPluginException` fires after the test body returns and fails the test on CI.

Fix: inject the `_FakeSystemVolumeListener` that's already in scope from `setUp` (line 34), matching every other test in the file.

No production code change.

Closes #3218.
Refs #3166 — commit `a7aa1fa3c` added this test file.
Refs #3172 — currently blocked by this test on CI; will be synced with main once this lands.

## Test plan

- [x] `cd mobile && flutter test test/blocs/video_volume/video_volume_cubit_test.dart` → 12/12 pass locally
- [x] `flutter analyze` on the touched test file → no issues (pre-commit hook)
- [x] `dart format` → no changes (pre-commit hook)
- [ ] Full `Mobile CI` passes on this branch