### PR TITLE
refactor: migrate to package:clock to unblock fakeAsync virtualization

### DIFF
--- a/mobile/lib/features/app/startup/startup_metrics.dart
+++ b/mobile/lib/features/app/startup/startup_metrics.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tracks startup performance metrics and identifies bottlenecks
 // ABOUTME: Provides data for optimizing initialization sequence
 
+import 'package:clock/clock.dart';
+
 /// Metrics collected during app startup
 class StartupMetrics {
   StartupMetrics({
@@ -113,7 +115,7 @@ class ServiceMetrics {
   }) => ServiceMetrics(
     name: name,
     startTime: startTime,
-    endTime: DateTime.now(),
+    endTime: clock.now(),
     success: success,
     error: error,
     stackTrace: stackTrace,
@@ -127,7 +129,7 @@ class StartupError {
     required this.error,
     this.stackTrace,
     DateTime? timestamp,
-  }) : timestamp = timestamp ?? DateTime.now();
+  }) : timestamp = timestamp ?? clock.now();
   final String serviceName;
   final Object error;
   final StackTrace? stackTrace;
@@ -136,13 +138,13 @@ class StartupError {
 
 /// Tracks metrics during startup
 class MetricsCollector {
-  final DateTime _startTime = DateTime.now();
+  final DateTime _startTime = clock.now();
   final Map<String, ServiceMetrics> _services = {};
   final List<StartupError> _errors = [];
 
   /// Start tracking a service
   void startService(String name) {
-    _services[name] = ServiceMetrics(name: name, startTime: DateTime.now());
+    _services[name] = ServiceMetrics(name: name, startTime: clock.now());
   }
 
   /// Mark service as complete
@@ -170,7 +172,7 @@ class MetricsCollector {
 
   /// Generate final metrics
   StartupMetrics generateMetrics() {
-    final endTime = DateTime.now();
+    final endTime = clock.now();
     final serviceTimings = <String, Duration>{};
 
     for (final entry in _services.entries) {

--- a/mobile/lib/features/app/startup/startup_profiler.dart
+++ b/mobile/lib/features/app/startup/startup_profiler.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Profiles actual startup times and identifies bottlenecks
 // ABOUTME: Analyzes provider initialization to optimize startup sequence
 
+import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:openvine/features/app/startup/startup_metrics.dart';
 import 'package:openvine/features/app/startup/startup_phase.dart';
@@ -79,12 +80,12 @@ class ProviderInitTracker {
     isProxy = name.contains('Proxy');
   }
   final String name;
-  final DateTime startTime = DateTime.now();
+  final DateTime startTime = clock.now();
   DateTime? endTime;
   bool isProxy = false;
 
   void complete() {
-    endTime = DateTime.now();
+    endTime = clock.now();
   }
 
   Duration? get duration => endTime?.difference(startTime);
@@ -102,7 +103,7 @@ class StartupProfiler {
 
   /// Mark app start
   void markAppStart() {
-    _appStartTime = DateTime.now();
+    _appStartTime = clock.now();
     Log.info('📱 App startup initiated', name: 'StartupProfiler');
     CrashReportingService.instance.logInitializationStep(
       'App startup initiated',
@@ -121,7 +122,7 @@ class StartupProfiler {
 
   /// Mark app ready (UI responsive)
   void markAppReady() {
-    _appReadyTime = DateTime.now();
+    _appReadyTime = clock.now();
     Log.info('✅ App ready for interaction', name: 'StartupProfiler');
 
     final startupTime = _appReadyTime!

--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
@@ -1257,7 +1258,7 @@ class VideoFeedController extends ChangeNotifier {
       final hadExistingPlayer = pool.hasPlayer(video.url);
       final loadStopwatch = _loadStopwatches.putIfAbsent(
         index,
-        () => Stopwatch()..start(),
+        () => clock.stopwatch()..start(),
       );
       _logDebug(
         'load_start ${_videoDebugDetails(index)} '
@@ -1940,7 +1941,7 @@ class VideoFeedController extends ChangeNotifier {
       return;
     }
 
-    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    final nowMs = clock.now().millisecondsSinceEpoch;
 
     if (_rateCheckWallStartMs == null) {
       _rateCheckWallStartMs = nowMs;
@@ -1991,7 +1992,7 @@ class VideoFeedController extends ChangeNotifier {
   /// tick, passed in so we don't read `player.state.position` a
   /// second time.
   void _emitStateSnapshotIfDue(int index, Player player, int positionMs) {
-    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    final nowMs = clock.now().millisecondsSinceEpoch;
     if (_lastStateSnapshotWallMs != null &&
         nowMs - _lastStateSnapshotWallMs! < _stateSnapshotIntervalMs) {
       return;

--- a/mobile/packages/pooled_video_player/pubspec.yaml
+++ b/mobile/packages/pooled_video_player/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   audio_session: ^0.2.2
+  clock: ^1.1.2
   device_info_plus: ^10.1.2
   equatable: ^2.0.7
   flutter:

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -3817,16 +3817,8 @@ void main() {
     });
 
     group('slow-load detection', () {
-      // NOTE: This test cannot use `fakeAsync` because the slow-load
-      // watchdog reads `Stopwatch.elapsedMilliseconds` (see
-      // `VideoFeedController._loadStopwatches`), which is bound to the OS
-      // clock and is not affected by `fakeAsync`'s virtual time. Converting
-      // the test would require migrating production code to `package:clock`
-      // first. Tracked alongside the startup_diagnostics deferrals in
-      // #3233 / #3237.
-      test(
-        'current video gives up with error when load exceeds threshold',
-        () async {
+      test('current video gives up with error when load exceeds threshold', () {
+        fakeAsync((async) {
           final videos = createTestVideos(count: 1);
 
           // Use isBuffering: true so the video stays in loading state
@@ -3849,17 +3841,18 @@ void main() {
           final notifier = controller.getIndexNotifier(0);
 
           // Initially loading.
-          await Future<void>.delayed(const Duration(milliseconds: 100));
+          async.elapse(const Duration(milliseconds: 100));
           expect(notifier.value.hasError, isFalse);
 
           // After threshold, watchdog gives up for stuck current video.
-          await Future<void>.delayed(const Duration(milliseconds: 1200));
+          async.elapse(const Duration(milliseconds: 1200));
           expect(notifier.value.hasError, isTrue);
 
           controller.dispose();
-          await slowPool.dispose();
-        },
-      );
+          unawaited(slowPool.dispose());
+          async.flushMicrotasks();
+        });
+      });
 
       test(
         'isSlowLoad is cleared when video becomes ready before threshold',
@@ -4965,16 +4958,8 @@ void main() {
     });
 
     group('stuck playback with no fallback sources', () {
-      // NOTE: This test cannot use `fakeAsync` because the slow-load
-      // watchdog reads `Stopwatch.elapsedMilliseconds` (see
-      // `VideoFeedController._loadStopwatches`), which is bound to the OS
-      // clock and is not affected by `fakeAsync`'s virtual time. Converting
-      // the test would require migrating production code to `package:clock`
-      // first. Tracked alongside the startup_diagnostics deferrals in
-      // #3233 follow-up.
-      test(
-        'marks error when stuck and no fallback sources available',
-        () async {
+      test('marks error when stuck and no fallback sources available', () {
+        fakeAsync((async) {
           // Create a pool where players start buffering (never become ready).
           final stuckSetups = <String, MockPlayerSetup>{};
           final stuckPool = TestablePlayerPool(
@@ -5004,11 +4989,11 @@ void main() {
             slowLoadThreshold: const Duration(milliseconds: 100),
           );
 
-          await Future<void>.delayed(const Duration(milliseconds: 50));
-
           // Watchdog fires every 1s; after 1s elapsed exceeds 100ms
           // threshold and retries — no fallback sources → marks error.
-          await Future<void>.delayed(const Duration(seconds: 2));
+          async
+            ..elapse(const Duration(milliseconds: 50))
+            ..elapse(const Duration(seconds: 2));
 
           expect(
             controller.getLoadState(0),
@@ -5017,11 +5002,12 @@ void main() {
 
           controller.dispose();
           for (final s in stuckSetups.values) {
-            await s.dispose();
+            unawaited(s.dispose());
           }
-          await stuckPool.dispose();
-        },
-      );
+          unawaited(stuckPool.dispose());
+          async.flushMicrotasks();
+        });
+      });
     });
 
     group('retryLoad', () {
@@ -5673,172 +5659,169 @@ void main() {
       await pool.dispose();
     });
 
-    // NOTE: The three tests below cannot use `fakeAsync` because the
-    // playback-rate / state-snapshot diagnostics read
-    // `DateTime.now().millisecondsSinceEpoch` directly (see
-    // `VideoFeedController._checkPlaybackRate` and
-    // `_emitStateSnapshotIfDue` at `video_feed_controller.dart:1943,1994`).
-    // Under `fakeAsync`, `DateTime.now()` returns real wall-clock time,
-    // so `wallDelta` is always ~0 and the detection logic either never
-    // fires (breaking the positive test) or passes tautologically
-    // (hiding real regressions in the negative tests). Converting these
-    // requires migrating the wall-clock reads to `package:clock`'s
-    // injectable `clock.now()`. Tracked alongside the startup_diagnostics
-    // and stuck-playback deferrals in #3233 / #3237.
     test(
       'slow_playback_detected fires when position advances at '
       'well below real-time rate',
-      () async {
-        final logs = <String>[];
-        final controller = VideoFeedController(
-          videos: createTestVideos(count: 1),
-          pool: pool,
-          onLog: (level, message) => logs.add(message),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 100));
+      () {
+        fakeAsync((async) {
+          final logs = <String>[];
+          final controller = VideoFeedController(
+            videos: createTestVideos(count: 1),
+            pool: pool,
+            onLog: (level, message) => logs.add(message),
+          );
+          async.elapse(const Duration(milliseconds: 100));
 
-        final url = createTestVideos()[0].url;
-        final setup = playerSetups[url]!;
+          final url = createTestVideos()[0].url;
+          final setup = playerSetups[url]!;
 
-        when(() => setup.state.playing).thenReturn(true);
-        when(() => setup.state.buffering).thenReturn(false);
-        when(
-          () => setup.state.position,
-        ).thenReturn(const Duration(milliseconds: 1000));
+          when(() => setup.state.playing).thenReturn(true);
+          when(() => setup.state.buffering).thenReturn(false);
+          when(
+            () => setup.state.position,
+          ).thenReturn(const Duration(milliseconds: 1000));
 
-        // Trigger buffer ready to start the heartbeat timer. The first
-        // rate-check tick will anchor the window at positionStart=1000,
-        // wallStart=now.
-        setup.bufferingController.add(false);
+          // Trigger buffer ready to start the heartbeat timer. The first
+          // rate-check tick will anchor the window at positionStart=1000,
+          // wallStart=now.
+          setup.bufferingController.add(false);
 
-        // After ~1s of wall time with the same position (1000), nudge
-        // position forward by only 100ms. This means the 2s rate-check
-        // window that fires around T+2.2s will see:
-        //   positionDelta ≈ 100ms over wallDelta ≈ 2100ms
-        //   ratePct ≈ 4–5 (well under the 50% threshold)
-        // Simulates the iOS "position crawls at ~4% real-time" bug.
-        await Future<void>.delayed(const Duration(milliseconds: 1000));
-        when(
-          () => setup.state.position,
-        ).thenReturn(const Duration(milliseconds: 1100));
+          // After ~1s of wall time with the same position (1000), nudge
+          // position forward by only 100ms. This means the 2s rate-check
+          // window that fires around T+2.2s will see:
+          //   positionDelta ≈ 100ms over wallDelta ≈ 2100ms
+          //   ratePct ≈ 4–5 (well under the 50% threshold)
+          // Simulates the iOS "position crawls at ~4% real-time" bug.
+          async.elapse(const Duration(milliseconds: 1000));
+          when(
+            () => setup.state.position,
+          ).thenReturn(const Duration(milliseconds: 1100));
 
-        // Wait past the 2s rate-check window boundary so the heartbeat
-        // tick that evaluates the window sees position=1100.
-        await Future<void>.delayed(const Duration(milliseconds: 1400));
+          // Wait past the 2s rate-check window boundary so the heartbeat
+          // tick that evaluates the window sees position=1100.
+          async.elapse(const Duration(milliseconds: 1400));
 
-        final slowLogs = logs
-            .where((m) => m.startsWith('slow_playback_detected'))
-            .toList();
+          final slowLogs = logs
+              .where((m) => m.startsWith('slow_playback_detected'))
+              .toList();
 
-        expect(
-          slowLogs,
-          isNotEmpty,
-          reason:
-              'Expected slow_playback_detected when position advanced '
-              'only ~100ms over ~2.4s of wall time (~4% real-time). '
-              'All logs: $logs',
-        );
-        // Sanity: the log line should include the rate so we can grep
-        // for it in production and filter by severity.
-        expect(slowLogs.first, contains('ratePct='));
-        expect(slowLogs.first, contains('positionDeltaMs='));
-        expect(slowLogs.first, contains('wallDeltaMs='));
+          expect(
+            slowLogs,
+            isNotEmpty,
+            reason:
+                'Expected slow_playback_detected when position advanced '
+                'only ~100ms over ~2.4s of wall time (~4% real-time). '
+                'All logs: $logs',
+          );
+          // Sanity: the log line should include the rate so we can grep
+          // for it in production and filter by severity.
+          expect(slowLogs.first, contains('ratePct='));
+          expect(slowLogs.first, contains('positionDeltaMs='));
+          expect(slowLogs.first, contains('wallDeltaMs='));
 
-        controller.dispose();
+          controller.dispose();
+          async.flushMicrotasks();
+        });
       },
     );
 
     test(
       'slow_playback_detected does NOT fire at normal real-time rate',
-      () async {
-        final logs = <String>[];
-        final controller = VideoFeedController(
-          videos: createTestVideos(count: 1),
-          pool: pool,
-          onLog: (level, message) => logs.add(message),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 100));
+      () {
+        fakeAsync((async) {
+          final logs = <String>[];
+          final controller = VideoFeedController(
+            videos: createTestVideos(count: 1),
+            pool: pool,
+            onLog: (level, message) => logs.add(message),
+          );
+          async.elapse(const Duration(milliseconds: 100));
 
-        final url = createTestVideos()[0].url;
-        final setup = playerSetups[url]!;
+          final url = createTestVideos()[0].url;
+          final setup = playerSetups[url]!;
 
-        when(() => setup.state.playing).thenReturn(true);
-        when(() => setup.state.buffering).thenReturn(false);
-        when(
-          () => setup.state.position,
-        ).thenReturn(const Duration(milliseconds: 1000));
-        setup.bufferingController.add(false);
+          when(() => setup.state.playing).thenReturn(true);
+          when(() => setup.state.buffering).thenReturn(false);
+          when(
+            () => setup.state.position,
+          ).thenReturn(const Duration(milliseconds: 1000));
+          setup.bufferingController.add(false);
 
-        // Advance position by 2000ms in ~1.5s of wall time (~133%
-        // real-time — a bit fast but comfortably above the 50%
-        // slow-playback threshold).
-        await Future<void>.delayed(const Duration(milliseconds: 1500));
-        when(
-          () => setup.state.position,
-        ).thenReturn(const Duration(milliseconds: 3000));
+          // Advance position by 2000ms in ~1.5s of wall time (~133%
+          // real-time — a bit fast but comfortably above the 50%
+          // slow-playback threshold).
+          async.elapse(const Duration(milliseconds: 1500));
+          when(
+            () => setup.state.position,
+          ).thenReturn(const Duration(milliseconds: 3000));
 
-        // Wait past the 2s rate-check window boundary so the check
-        // evaluates with positionDelta ≈ 2000, wallDelta ≈ 2100,
-        // ratePct ≈ 95.
-        await Future<void>.delayed(const Duration(milliseconds: 800));
+          // Wait past the 2s rate-check window boundary so the check
+          // evaluates with positionDelta ≈ 2000, wallDelta ≈ 2100,
+          // ratePct ≈ 95.
+          async.elapse(const Duration(milliseconds: 800));
 
-        expect(
-          logs.where((m) => m.startsWith('slow_playback_detected')),
-          isEmpty,
-          reason:
-              'slow_playback_detected should only fire when playback is '
-              'measurably slower than real-time, not for normal speed. '
-              'All logs: $logs',
-        );
+          expect(
+            logs.where((m) => m.startsWith('slow_playback_detected')),
+            isEmpty,
+            reason:
+                'slow_playback_detected should only fire when playback is '
+                'measurably slower than real-time, not for normal speed. '
+                'All logs: $logs',
+          );
 
-        controller.dispose();
+          controller.dispose();
+          async.flushMicrotasks();
+        });
       },
     );
 
     test(
       'player_state_snapshot fires periodically for current video',
-      () async {
-        final logs = <String>[];
-        final controller = VideoFeedController(
-          videos: createTestVideos(count: 1),
-          pool: pool,
-          onLog: (level, message) => logs.add(message),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 100));
+      () {
+        fakeAsync((async) {
+          final logs = <String>[];
+          final controller = VideoFeedController(
+            videos: createTestVideos(count: 1),
+            pool: pool,
+            onLog: (level, message) => logs.add(message),
+          );
+          async.elapse(const Duration(milliseconds: 100));
 
-        final url = createTestVideos()[0].url;
-        final setup = playerSetups[url]!;
+          final url = createTestVideos()[0].url;
+          final setup = playerSetups[url]!;
 
-        when(() => setup.state.playing).thenReturn(true);
-        when(() => setup.state.buffering).thenReturn(false);
-        when(
-          () => setup.state.position,
-        ).thenReturn(const Duration(milliseconds: 500));
-        setup.bufferingController.add(false);
+          when(() => setup.state.playing).thenReturn(true);
+          when(() => setup.state.buffering).thenReturn(false);
+          when(
+            () => setup.state.position,
+          ).thenReturn(const Duration(milliseconds: 500));
+          setup.bufferingController.add(false);
 
-        // Wait longer than the snapshot interval (2s) to guarantee at
-        // least one snapshot fires.
-        await Future<void>.delayed(const Duration(milliseconds: 2300));
+          // Wait longer than the snapshot interval (2s) to guarantee at
+          // least one snapshot fires.
+          async.elapse(const Duration(milliseconds: 2300));
 
-        final snapshotLogs = logs
-            .where((m) => m.startsWith('player_state_snapshot'))
-            .toList();
+          final snapshotLogs = logs
+              .where((m) => m.startsWith('player_state_snapshot'))
+              .toList();
 
-        expect(
-          snapshotLogs,
-          isNotEmpty,
-          reason:
-              'Expected player_state_snapshot to fire at least once '
-              'within ~2.3s. All logs: $logs',
-        );
-        // The snapshot should include enough fields to diagnose mpv
-        // state divergence in production logs.
-        expect(snapshotLogs.first, contains('playing='));
-        expect(snapshotLogs.first, contains('buffering='));
-        expect(snapshotLogs.first, contains('positionMs='));
-        expect(snapshotLogs.first, contains('index=0'));
+          expect(
+            snapshotLogs,
+            isNotEmpty,
+            reason:
+                'Expected player_state_snapshot to fire at least once '
+                'within ~2.3s. All logs: $logs',
+          );
+          // The snapshot should include enough fields to diagnose mpv
+          // state divergence in production logs.
+          expect(snapshotLogs.first, contains('playing='));
+          expect(snapshotLogs.first, contains('buffering='));
+          expect(snapshotLogs.first, contains('positionMs='));
+          expect(snapshotLogs.first, contains('index=0'));
 
-        controller.dispose();
+          controller.dispose();
+          async.flushMicrotasks();
+        });
       },
     );
   });

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -354,7 +354,7 @@ packages:
     source: hosted
     version: "0.4.2"
   clock:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: clock
       sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -82,6 +82,10 @@ dependencies:
 
   blossom_upload_service:
 
+  # Testable time source — wraps DateTime.now/Stopwatch so fakeAsync can
+  # virtualize them in tests.
+  clock: ^1.1.2
+
   # State management
   flutter_riverpod: ^3.0.0
   riverpod_annotation: ^3.0.0

--- a/mobile/test/startup/startup_diagnostics_test.dart
+++ b/mobile/test/startup/startup_diagnostics_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Validates timing logs, breadcrumbs, and timeout detection
 
 import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/features/app/startup/startup_coordinator.dart';
@@ -199,55 +201,55 @@ void main() {
       expect(report, contains('DeferredService'));
     });
 
-    test('should detect and warn about slow initialization', () async {
-      // Arrange
-      final completer = Completer<void>();
-      final warnings = <String>[];
-      Timer? timeoutTimer;
+    test('should detect and warn about slow initialization', () {
+      fakeAsync((async) {
+        final completer = Completer<void>();
+        final warnings = <String>[];
+        Timer? timeoutTimer;
 
-      coordinator.registerService(
-        name: 'SlowService',
-        phase: StartupPhase.critical,
-        initialize: () async {
-          // Start timeout detection
-          timeoutTimer = Timer(const Duration(seconds: 2), () {
-            warnings.add(
-              'WARNING: SlowService initialization taking > 2 seconds',
-            );
-            CrashReportingService.instance.log(
-              'Startup timeout detected for SlowService',
-            );
-          });
+        coordinator.registerService(
+          name: 'SlowService',
+          phase: StartupPhase.critical,
+          initialize: () async {
+            // Start timeout detection
+            timeoutTimer = Timer(const Duration(seconds: 2), () {
+              warnings.add(
+                'WARNING: SlowService initialization taking > 2 seconds',
+              );
+              CrashReportingService.instance.log(
+                'Startup timeout detected for SlowService',
+              );
+            });
 
-          // Simulate slow initialization
-          await Future.delayed(const Duration(seconds: 3));
-          timeoutTimer?.cancel();
-          completer.complete();
-        },
-      );
+            // Simulate slow initialization
+            await Future.delayed(const Duration(seconds: 3));
+            timeoutTimer?.cancel();
+            completer.complete();
+          },
+        );
 
-      // Act
-      final initFuture = coordinator.initialize();
+        // Kick off initialization (fire-and-forget; we'll elapse past it).
+        unawaited(coordinator.initialize());
 
-      // Wait for timeout warning
-      await Future.delayed(const Duration(seconds: 2, milliseconds: 100));
+        // After 2.1s, the 2s Timer should have fired.
+        async.elapse(const Duration(seconds: 2, milliseconds: 100));
+        expect(
+          warnings,
+          contains('WARNING: SlowService initialization taking > 2 seconds'),
+        );
 
-      // Assert - should have timeout warning
-      expect(
-        warnings,
-        contains('WARNING: SlowService initialization taking > 2 seconds'),
-      );
+        // Elapse past the 3s simulated work so the service — and the
+        // whole coordinator — complete.
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
 
-      // Wait for completion
-      await initFuture;
-      await completer.future;
-
-      // Service should still complete
-      final metrics = coordinator.metrics;
-      expect(
-        metrics.serviceTimings['SlowService']!.inMilliseconds,
-        greaterThanOrEqualTo(3000),
-      );
+        expect(completer.isCompleted, isTrue);
+        final metrics = coordinator.metrics;
+        expect(
+          metrics.serviceTimings['SlowService']!.inMilliseconds,
+          greaterThanOrEqualTo(3000),
+        );
+      });
     });
 
     test('should handle initialization failures with proper logging', () async {


### PR DESCRIPTION
## Summary

Completes the fakeAsync sweep chain (#3233 → #3236 → #3238) by
migrating production code to `package:clock`, unblocking the 6 tests
that were previously deferred for reading the OS clock directly.

> **Stacked on #3238** (which is stacked on #3236). Base branch is
> `task/3237-fakeasync-audit-gap`. Merge order: #3236 → #3238 → this PR.

## Why this migration is safe

`package:clock` provides `clock.now()` and `clock.stopwatch()` that
read from a zoned clock. Outside tests, there is no zoned override
— `clock.now()` returns `DateTime.now()`, `clock.stopwatch()` returns
a system-clock-backed `Stopwatch`. **Production behavior is identical.**

Inside `fakeAsync`, the `fake_async` package automatically wraps its
callback in `withClock(...)` (see `fake_async-1.3.3/lib/fake_async.dart:181`),
so `clock.now()` and `clock.stopwatch()` both respect the fake clock
— no manual `withClock` wrapping needed in tests.

## Changes

### Production (3 files)

| File | Change |
|------|--------|
| `mobile/lib/features/app/startup/startup_metrics.dart` | 5× `DateTime.now()` → `clock.now()` + import |
| `mobile/lib/features/app/startup/startup_profiler.dart` | 4× `DateTime.now()` → `clock.now()` + import |
| `mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart` | `Stopwatch()` → `clock.stopwatch()` (`_loadStopwatches`), 2× `DateTime.now()` → `clock.now()` (`_checkPlaybackRate`, `_emitStateSnapshotIfDue`) + import |

### Dependencies

- `mobile/pubspec.yaml`: add `clock: ^1.1.2`
- `mobile/packages/pooled_video_player/pubspec.yaml`: add `clock: ^1.1.2`
- `mobile/pubspec.lock`: promotes `clock` from transitive to direct main (version unchanged)

### Tests converted (6 — all now `00:00`)

| Test | File | Before |
|------|------|--------|
| `should detect and warn about slow initialization` | `startup_diagnostics_test.dart` | ~5.1s |
| `current video gives up with error when load exceeds threshold` | `video_feed_controller_test.dart` | ~1.3s |
| `marks error when stuck and no fallback sources available` | `video_feed_controller_test.dart` | ~2s |
| `slow_playback_detected fires when position advances at well below real-time rate` | `video_feed_controller_test.dart` | ~2.5s |
| `slow_playback_detected does NOT fire at normal real-time rate` | `video_feed_controller_test.dart` | ~2.3s |
| `player_state_snapshot fires periodically for current video` | `video_feed_controller_test.dart` | ~2.4s |

Also removes the `// NOTE:` blocks in `video_feed_controller_test.dart`
added by #3236 and #3238 documenting the blocker.

## Verification

- [x] `flutter analyze` full mobile — clean (0 issues).
- [x] `flutter test packages/pooled_video_player/test/controllers/video_feed_controller_test.dart` — 190 pass.
- [x] Full `pooled_video_player` package suite — 455 tests pass in `00:17`.
- [x] All startup-related mobile tests (`startup_coordinator_test.dart`, `app_first_frame_startup_test.dart`, `startup_diagnostics_test.dart`) — 16 pass in `00:01`.
- [x] Pre-commit hooks (format + analyze) pass.
- [ ] Per-package CI green on the PR.

## Residual scan

- Other `Stopwatch()` usages in mobile/ are UI-level elapsed-time
  displays (`clip_manager_provider.dart`, `relay_diagnostic_screen.dart`,
  `nostr_connect_screen.dart`) — intentionally not migrated.
- `_loadStopwatches`, `_rateCheckWallStartMs`, `_lastStateSnapshotWallMs`
  are only referenced in `video_feed_controller.dart`; no other
  production code affected.

## Chain recap

- PR #3236 — 4 tests from the #3233 audit converted, 3 deferred.
- PR #3238 — 12 audit-gap tests converted, 3 more deferred (same root cause).
- PR #3237 → filed during #3238 investigation, tracks audit-gap sites.
- **This PR** — unblocks all 6 deferred sites via a single production change.

Closes #3233 (the remaining deferred sites), #3237 (audit-gap follow-up).