### PR TITLE
refactor: migrate throttle/rate-limit helpers to package:clock

### DIFF
--- a/mobile/lib/features/app/startup/startup_metrics.dart
+++ b/mobile/lib/features/app/startup/startup_metrics.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tracks startup performance metrics and identifies bottlenecks
 // ABOUTME: Provides data for optimizing initialization sequence
 
+import 'package:clock/clock.dart';
+
 /// Metrics collected during app startup
 class StartupMetrics {
   StartupMetrics({
@@ -113,7 +115,7 @@ class ServiceMetrics {
   }) => ServiceMetrics(
     name: name,
     startTime: startTime,
-    endTime: DateTime.now(),
+    endTime: clock.now(),
     success: success,
     error: error,
     stackTrace: stackTrace,
@@ -127,7 +129,7 @@ class StartupError {
     required this.error,
     this.stackTrace,
     DateTime? timestamp,
-  }) : timestamp = timestamp ?? DateTime.now();
+  }) : timestamp = timestamp ?? clock.now();
   final String serviceName;
   final Object error;
   final StackTrace? stackTrace;
@@ -136,13 +138,13 @@ class StartupError {
 
 /// Tracks metrics during startup
 class MetricsCollector {
-  final DateTime _startTime = DateTime.now();
+  final DateTime _startTime = clock.now();
   final Map<String, ServiceMetrics> _services = {};
   final List<StartupError> _errors = [];
 
   /// Start tracking a service
   void startService(String name) {
-    _services[name] = ServiceMetrics(name: name, startTime: DateTime.now());
+    _services[name] = ServiceMetrics(name: name, startTime: clock.now());
   }
 
   /// Mark service as complete
@@ -170,7 +172,7 @@ class MetricsCollector {
 
   /// Generate final metrics
   StartupMetrics generateMetrics() {
-    final endTime = DateTime.now();
+    final endTime = clock.now();
     final serviceTimings = <String, Duration>{};
 
     for (final entry in _services.entries) {

--- a/mobile/lib/features/app/startup/startup_profiler.dart
+++ b/mobile/lib/features/app/startup/startup_profiler.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Profiles actual startup times and identifies bottlenecks
 // ABOUTME: Analyzes provider initialization to optimize startup sequence
 
+import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:openvine/features/app/startup/startup_metrics.dart';
 import 'package:openvine/features/app/startup/startup_phase.dart';
@@ -79,12 +80,12 @@ class ProviderInitTracker {
     isProxy = name.contains('Proxy');
   }
   final String name;
-  final DateTime startTime = DateTime.now();
+  final DateTime startTime = clock.now();
   DateTime? endTime;
   bool isProxy = false;
 
   void complete() {
-    endTime = DateTime.now();
+    endTime = clock.now();
   }
 
   Duration? get duration => endTime?.difference(startTime);
@@ -102,7 +103,7 @@ class StartupProfiler {
 
   /// Mark app start
   void markAppStart() {
-    _appStartTime = DateTime.now();
+    _appStartTime = clock.now();
     Log.info('📱 App startup initiated', name: 'StartupProfiler');
     CrashReportingService.instance.logInitializationStep(
       'App startup initiated',
@@ -121,7 +122,7 @@ class StartupProfiler {
 
   /// Mark app ready (UI responsive)
   void markAppReady() {
-    _appReadyTime = DateTime.now();
+    _appReadyTime = clock.now();
     Log.info('✅ App ready for interaction', name: 'StartupProfiler');
 
     final startupTime = _appReadyTime!

--- a/mobile/lib/mixins/pagination_mixin.dart
+++ b/mobile/lib/mixins/pagination_mixin.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Reusable pagination mixin with throttling for PageView widgets
 // ABOUTME: Prevents duplicate loadMore() calls with configurable threshold and throttle
 
+import 'package:clock/clock.dart';
 import 'package:flutter/widgets.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -43,7 +44,7 @@ mixin PaginationMixin<T extends StatefulWidget> on State<T> {
     }
 
     // Rate limit pagination calls to prevent spam
-    final now = DateTime.now();
+    final now = clock.now();
     if (_lastPaginationCall != null &&
         now.difference(_lastPaginationCall!).inSeconds < throttleSeconds) {
       Log.debug(

--- a/mobile/lib/mixins/video_prefetch_mixin.dart
+++ b/mobile/lib/mixins/video_prefetch_mixin.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Reusable video prefetch mixin for PageView-based video feeds
 // ABOUTME: Handles both file caching and controller pre-initialization for instant playback
 
+import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:media_cache/media_cache.dart';
@@ -73,7 +74,7 @@ mixin VideoPrefetchMixin {
     }
 
     // Throttle prefetch calls to avoid excessive network activity
-    final now = DateTime.now();
+    final now = clock.now();
     if (_lastPrefetchCall != null &&
         now.difference(_lastPrefetchCall!).inSeconds <
             prefetchThrottleSeconds) {

--- a/mobile/lib/utils/async_utils.dart
+++ b/mobile/lib/utils/async_utils.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 import 'dart:math' as math;
+import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -352,7 +353,7 @@ class AsyncUtils {
     DateTime? lastCall;
 
     return () {
-      final now = DateTime.now();
+      final now = clock.now();
       if (lastCall == null || now.difference(lastCall!) >= interval) {
         lastCall = now;
         operation();
@@ -391,7 +392,7 @@ class AsyncUtils {
     for (var i = 0; i < operations.length; i++) {
       // Calculate delay needed
       if (lastExecutionTime != null) {
-        final elapsed = DateTime.now().difference(lastExecutionTime);
+        final elapsed = clock.now().difference(lastExecutionTime);
         final remaining = minInterval - elapsed;
 
         if (!remaining.isNegative && remaining.inMicroseconds > 0) {
@@ -404,7 +405,7 @@ class AsyncUtils {
 
       // Execute operation
       try {
-        lastExecutionTime = DateTime.now();
+        lastExecutionTime = clock.now();
         final result = await operations[i]();
         results.add(result);
 

--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
@@ -1257,7 +1258,7 @@ class VideoFeedController extends ChangeNotifier {
       final hadExistingPlayer = pool.hasPlayer(video.url);
       final loadStopwatch = _loadStopwatches.putIfAbsent(
         index,
-        () => Stopwatch()..start(),
+        () => clock.stopwatch()..start(),
       );
       _logDebug(
         'load_start ${_videoDebugDetails(index)} '
@@ -1940,7 +1941,7 @@ class VideoFeedController extends ChangeNotifier {
       return;
     }
 
-    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    final nowMs = clock.now().millisecondsSinceEpoch;
 
     if (_rateCheckWallStartMs == null) {
       _rateCheckWallStartMs = nowMs;
@@ -1991,7 +1992,7 @@ class VideoFeedController extends ChangeNotifier {
   /// tick, passed in so we don't read `player.state.position` a
   /// second time.
   void _emitStateSnapshotIfDue(int index, Player player, int positionMs) {
-    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    final nowMs = clock.now().millisecondsSinceEpoch;
     if (_lastStateSnapshotWallMs != null &&
         nowMs - _lastStateSnapshotWallMs! < _stateSnapshotIntervalMs) {
       return;

--- a/mobile/packages/pooled_video_player/pubspec.yaml
+++ b/mobile/packages/pooled_video_player/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   audio_session: ^0.2.2
+  clock: ^1.1.2
   device_info_plus: ^10.1.2
   equatable: ^2.0.7
   flutter:

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -3817,16 +3817,8 @@ void main() {
     });
 
     group('slow-load detection', () {
-      // NOTE: This test cannot use `fakeAsync` because the slow-load
-      // watchdog reads `Stopwatch.elapsedMilliseconds` (see
-      // `VideoFeedController._loadStopwatches`), which is bound to the OS
-      // clock and is not affected by `fakeAsync`'s virtual time. Converting
-      // the test would require migrating production code to `package:clock`
-      // first. Tracked alongside the startup_diagnostics deferrals in
-      // #3233 / #3237.
-      test(
-        'current video gives up with error when load exceeds threshold',
-        () async {
+      test('current video gives up with error when load exceeds threshold', () {
+        fakeAsync((async) {
           final videos = createTestVideos(count: 1);
 
           // Use isBuffering: true so the video stays in loading state
@@ -3849,17 +3841,18 @@ void main() {
           final notifier = controller.getIndexNotifier(0);
 
           // Initially loading.
-          await Future<void>.delayed(const Duration(milliseconds: 100));
+          async.elapse(const Duration(milliseconds: 100));
           expect(notifier.value.hasError, isFalse);
 
           // After threshold, watchdog gives up for stuck current video.
-          await Future<void>.delayed(const Duration(milliseconds: 1200));
+          async.elapse(const Duration(milliseconds: 1200));
           expect(notifier.value.hasError, isTrue);
 
           controller.dispose();
-          await slowPool.dispose();
-        },
-      );
+          unawaited(slowPool.dispose());
+          async.flushMicrotasks();
+        });
+      });
 
       test(
         'isSlowLoad is cleared when video becomes ready before threshold',
@@ -4965,16 +4958,8 @@ void main() {
     });
 
     group('stuck playback with no fallback sources', () {
-      // NOTE: This test cannot use `fakeAsync` because the slow-load
-      // watchdog reads `Stopwatch.elapsedMilliseconds` (see
-      // `VideoFeedController._loadStopwatches`), which is bound to the OS
-      // clock and is not affected by `fakeAsync`'s virtual time. Converting
-      // the test would require migrating production code to `package:clock`
-      // first. Tracked alongside the startup_diagnostics deferrals in
-      // #3233 follow-up.
-      test(
-        'marks error when stuck and no fallback sources available',
-        () async {
+      test('marks error when stuck and no fallback sources available', () {
+        fakeAsync((async) {
           // Create a pool where players start buffering (never become ready).
           final stuckSetups = <String, MockPlayerSetup>{};
           final stuckPool = TestablePlayerPool(
@@ -5004,11 +4989,11 @@ void main() {
             slowLoadThreshold: const Duration(milliseconds: 100),
           );
 
-          await Future<void>.delayed(const Duration(milliseconds: 50));
-
           // Watchdog fires every 1s; after 1s elapsed exceeds 100ms
           // threshold and retries — no fallback sources → marks error.
-          await Future<void>.delayed(const Duration(seconds: 2));
+          async
+            ..elapse(const Duration(milliseconds: 50))
+            ..elapse(const Duration(seconds: 2));
 
           expect(
             controller.getLoadState(0),
@@ -5017,11 +5002,12 @@ void main() {
 
           controller.dispose();
           for (final s in stuckSetups.values) {
-            await s.dispose();
+            unawaited(s.dispose());
           }
-          await stuckPool.dispose();
-        },
-      );
+          unawaited(stuckPool.dispose());
+          async.flushMicrotasks();
+        });
+      });
     });
 
     group('retryLoad', () {
@@ -5673,172 +5659,169 @@ void main() {
       await pool.dispose();
     });
 
-    // NOTE: The three tests below cannot use `fakeAsync` because the
-    // playback-rate / state-snapshot diagnostics read
-    // `DateTime.now().millisecondsSinceEpoch` directly (see
-    // `VideoFeedController._checkPlaybackRate` and
-    // `_emitStateSnapshotIfDue` at `video_feed_controller.dart:1943,1994`).
-    // Under `fakeAsync`, `DateTime.now()` returns real wall-clock time,
-    // so `wallDelta` is always ~0 and the detection logic either never
-    // fires (breaking the positive test) or passes tautologically
-    // (hiding real regressions in the negative tests). Converting these
-    // requires migrating the wall-clock reads to `package:clock`'s
-    // injectable `clock.now()`. Tracked alongside the startup_diagnostics
-    // and stuck-playback deferrals in #3233 / #3237.
     test(
       'slow_playback_detected fires when position advances at '
       'well below real-time rate',
-      () async {
-        final logs = <String>[];
-        final controller = VideoFeedController(
-          videos: createTestVideos(count: 1),
-          pool: pool,
-          onLog: (level, message) => logs.add(message),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 100));
+      () {
+        fakeAsync((async) {
+          final logs = <String>[];
+          final controller = VideoFeedController(
+            videos: createTestVideos(count: 1),
+            pool: pool,
+            onLog: (level, message) => logs.add(message),
+          );
+          async.elapse(const Duration(milliseconds: 100));
 
-        final url = createTestVideos()[0].url;
-        final setup = playerSetups[url]!;
+          final url = createTestVideos()[0].url;
+          final setup = playerSetups[url]!;
 
-        when(() => setup.state.playing).thenReturn(true);
-        when(() => setup.state.buffering).thenReturn(false);
-        when(
-          () => setup.state.position,
-        ).thenReturn(const Duration(milliseconds: 1000));
+          when(() => setup.state.playing).thenReturn(true);
+          when(() => setup.state.buffering).thenReturn(false);
+          when(
+            () => setup.state.position,
+          ).thenReturn(const Duration(milliseconds: 1000));
 
-        // Trigger buffer ready to start the heartbeat timer. The first
-        // rate-check tick will anchor the window at positionStart=1000,
-        // wallStart=now.
-        setup.bufferingController.add(false);
+          // Trigger buffer ready to start the heartbeat timer. The first
+          // rate-check tick will anchor the window at positionStart=1000,
+          // wallStart=now.
+          setup.bufferingController.add(false);
 
-        // After ~1s of wall time with the same position (1000), nudge
-        // position forward by only 100ms. This means the 2s rate-check
-        // window that fires around T+2.2s will see:
-        //   positionDelta ≈ 100ms over wallDelta ≈ 2100ms
-        //   ratePct ≈ 4–5 (well under the 50% threshold)
-        // Simulates the iOS "position crawls at ~4% real-time" bug.
-        await Future<void>.delayed(const Duration(milliseconds: 1000));
-        when(
-          () => setup.state.position,
-        ).thenReturn(const Duration(milliseconds: 1100));
+          // After ~1s of wall time with the same position (1000), nudge
+          // position forward by only 100ms. This means the 2s rate-check
+          // window that fires around T+2.2s will see:
+          //   positionDelta ≈ 100ms over wallDelta ≈ 2100ms
+          //   ratePct ≈ 4–5 (well under the 50% threshold)
+          // Simulates the iOS "position crawls at ~4% real-time" bug.
+          async.elapse(const Duration(milliseconds: 1000));
+          when(
+            () => setup.state.position,
+          ).thenReturn(const Duration(milliseconds: 1100));
 
-        // Wait past the 2s rate-check window boundary so the heartbeat
-        // tick that evaluates the window sees position=1100.
-        await Future<void>.delayed(const Duration(milliseconds: 1400));
+          // Wait past the 2s rate-check window boundary so the heartbeat
+          // tick that evaluates the window sees position=1100.
+          async.elapse(const Duration(milliseconds: 1400));
 
-        final slowLogs = logs
-            .where((m) => m.startsWith('slow_playback_detected'))
-            .toList();
+          final slowLogs = logs
+              .where((m) => m.startsWith('slow_playback_detected'))
+              .toList();
 
-        expect(
-          slowLogs,
-          isNotEmpty,
-          reason:
-              'Expected slow_playback_detected when position advanced '
-              'only ~100ms over ~2.4s of wall time (~4% real-time). '
-              'All logs: $logs',
-        );
-        // Sanity: the log line should include the rate so we can grep
-        // for it in production and filter by severity.
-        expect(slowLogs.first, contains('ratePct='));
-        expect(slowLogs.first, contains('positionDeltaMs='));
-        expect(slowLogs.first, contains('wallDeltaMs='));
+          expect(
+            slowLogs,
+            isNotEmpty,
+            reason:
+                'Expected slow_playback_detected when position advanced '
+                'only ~100ms over ~2.4s of wall time (~4% real-time). '
+                'All logs: $logs',
+          );
+          // Sanity: the log line should include the rate so we can grep
+          // for it in production and filter by severity.
+          expect(slowLogs.first, contains('ratePct='));
+          expect(slowLogs.first, contains('positionDeltaMs='));
+          expect(slowLogs.first, contains('wallDeltaMs='));
 
-        controller.dispose();
+          controller.dispose();
+          async.flushMicrotasks();
+        });
       },
     );
 
     test(
       'slow_playback_detected does NOT fire at normal real-time rate',
-      () async {
-        final logs = <String>[];
-        final controller = VideoFeedController(
-          videos: createTestVideos(count: 1),
-          pool: pool,
-          onLog: (level, message) => logs.add(message),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 100));
+      () {
+        fakeAsync((async) {
+          final logs = <String>[];
+          final controller = VideoFeedController(
+            videos: createTestVideos(count: 1),
+            pool: pool,
+            onLog: (level, message) => logs.add(message),
+          );
+          async.elapse(const Duration(milliseconds: 100));
 
-        final url = createTestVideos()[0].url;
-        final setup = playerSetups[url]!;
+          final url = createTestVideos()[0].url;
+          final setup = playerSetups[url]!;
 
-        when(() => setup.state.playing).thenReturn(true);
-        when(() => setup.state.buffering).thenReturn(false);
-        when(
-          () => setup.state.position,
-        ).thenReturn(const Duration(milliseconds: 1000));
-        setup.bufferingController.add(false);
+          when(() => setup.state.playing).thenReturn(true);
+          when(() => setup.state.buffering).thenReturn(false);
+          when(
+            () => setup.state.position,
+          ).thenReturn(const Duration(milliseconds: 1000));
+          setup.bufferingController.add(false);
 
-        // Advance position by 2000ms in ~1.5s of wall time (~133%
-        // real-time — a bit fast but comfortably above the 50%
-        // slow-playback threshold).
-        await Future<void>.delayed(const Duration(milliseconds: 1500));
-        when(
-          () => setup.state.position,
-        ).thenReturn(const Duration(milliseconds: 3000));
+          // Advance position by 2000ms in ~1.5s of wall time (~133%
+          // real-time — a bit fast but comfortably above the 50%
+          // slow-playback threshold).
+          async.elapse(const Duration(milliseconds: 1500));
+          when(
+            () => setup.state.position,
+          ).thenReturn(const Duration(milliseconds: 3000));
 
-        // Wait past the 2s rate-check window boundary so the check
-        // evaluates with positionDelta ≈ 2000, wallDelta ≈ 2100,
-        // ratePct ≈ 95.
-        await Future<void>.delayed(const Duration(milliseconds: 800));
+          // Wait past the 2s rate-check window boundary so the check
+          // evaluates with positionDelta ≈ 2000, wallDelta ≈ 2100,
+          // ratePct ≈ 95.
+          async.elapse(const Duration(milliseconds: 800));
 
-        expect(
-          logs.where((m) => m.startsWith('slow_playback_detected')),
-          isEmpty,
-          reason:
-              'slow_playback_detected should only fire when playback is '
-              'measurably slower than real-time, not for normal speed. '
-              'All logs: $logs',
-        );
+          expect(
+            logs.where((m) => m.startsWith('slow_playback_detected')),
+            isEmpty,
+            reason:
+                'slow_playback_detected should only fire when playback is '
+                'measurably slower than real-time, not for normal speed. '
+                'All logs: $logs',
+          );
 
-        controller.dispose();
+          controller.dispose();
+          async.flushMicrotasks();
+        });
       },
     );
 
     test(
       'player_state_snapshot fires periodically for current video',
-      () async {
-        final logs = <String>[];
-        final controller = VideoFeedController(
-          videos: createTestVideos(count: 1),
-          pool: pool,
-          onLog: (level, message) => logs.add(message),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 100));
+      () {
+        fakeAsync((async) {
+          final logs = <String>[];
+          final controller = VideoFeedController(
+            videos: createTestVideos(count: 1),
+            pool: pool,
+            onLog: (level, message) => logs.add(message),
+          );
+          async.elapse(const Duration(milliseconds: 100));
 
-        final url = createTestVideos()[0].url;
-        final setup = playerSetups[url]!;
+          final url = createTestVideos()[0].url;
+          final setup = playerSetups[url]!;
 
-        when(() => setup.state.playing).thenReturn(true);
-        when(() => setup.state.buffering).thenReturn(false);
-        when(
-          () => setup.state.position,
-        ).thenReturn(const Duration(milliseconds: 500));
-        setup.bufferingController.add(false);
+          when(() => setup.state.playing).thenReturn(true);
+          when(() => setup.state.buffering).thenReturn(false);
+          when(
+            () => setup.state.position,
+          ).thenReturn(const Duration(milliseconds: 500));
+          setup.bufferingController.add(false);
 
-        // Wait longer than the snapshot interval (2s) to guarantee at
-        // least one snapshot fires.
-        await Future<void>.delayed(const Duration(milliseconds: 2300));
+          // Wait longer than the snapshot interval (2s) to guarantee at
+          // least one snapshot fires.
+          async.elapse(const Duration(milliseconds: 2300));
 
-        final snapshotLogs = logs
-            .where((m) => m.startsWith('player_state_snapshot'))
-            .toList();
+          final snapshotLogs = logs
+              .where((m) => m.startsWith('player_state_snapshot'))
+              .toList();
 
-        expect(
-          snapshotLogs,
-          isNotEmpty,
-          reason:
-              'Expected player_state_snapshot to fire at least once '
-              'within ~2.3s. All logs: $logs',
-        );
-        // The snapshot should include enough fields to diagnose mpv
-        // state divergence in production logs.
-        expect(snapshotLogs.first, contains('playing='));
-        expect(snapshotLogs.first, contains('buffering='));
-        expect(snapshotLogs.first, contains('positionMs='));
-        expect(snapshotLogs.first, contains('index=0'));
+          expect(
+            snapshotLogs,
+            isNotEmpty,
+            reason:
+                'Expected player_state_snapshot to fire at least once '
+                'within ~2.3s. All logs: $logs',
+          );
+          // The snapshot should include enough fields to diagnose mpv
+          // state divergence in production logs.
+          expect(snapshotLogs.first, contains('playing='));
+          expect(snapshotLogs.first, contains('buffering='));
+          expect(snapshotLogs.first, contains('positionMs='));
+          expect(snapshotLogs.first, contains('index=0'));
 
-        controller.dispose();
+          controller.dispose();
+          async.flushMicrotasks();
+        });
       },
     );
   });

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -354,7 +354,7 @@ packages:
     source: hosted
     version: "0.4.2"
   clock:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: clock
       sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -82,6 +82,10 @@ dependencies:
 
   blossom_upload_service:
 
+  # Testable time source — wraps DateTime.now/Stopwatch so fakeAsync can
+  # virtualize them in tests.
+  clock: ^1.1.2
+
   # State management
   flutter_riverpod: ^3.0.0
   riverpod_annotation: ^3.0.0

--- a/mobile/test/mixins/video_prefetch_mixin_test.dart
+++ b/mobile/test/mixins/video_prefetch_mixin_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: TDD tests for VideoPrefetchMixin
 // ABOUTME: Verifies video prefetching behavior in PageView-based feeds
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -310,42 +311,44 @@ void main() {
       );
     });
 
-    test('SPEC: should allow prefetch after throttle period', () async {
-      final videos = _createMockVideos(10);
+    test('SPEC: should allow prefetch after throttle period', () {
+      fakeAsync((async) {
+        final videos = _createMockVideos(10);
 
-      final mixin = TestVideoPrefetchMixin(mockCache);
+        final mixin = TestVideoPrefetchMixin(mockCache);
 
-      // First call
-      mixin.checkForPrefetch(currentIndex: 3, videos: videos);
-      verify(
-        () => mockCache.preCacheFiles(
-          any(),
-          batchSize: any(named: 'batchSize'),
-          authHeadersProvider: any(named: 'authHeadersProvider'),
-        ),
-      ).called(1);
+        // First call
+        mixin.checkForPrefetch(currentIndex: 3, videos: videos);
+        verify(
+          () => mockCache.preCacheFiles(
+            any(),
+            batchSize: any(named: 'batchSize'),
+            authHeadersProvider: any(named: 'authHeadersProvider'),
+          ),
+        ).called(1);
 
-      reset(mockCache);
-      when(
-        () => mockCache.preCacheFiles(
-          any(),
-          batchSize: any(named: 'batchSize'),
-          authHeadersProvider: any(named: 'authHeadersProvider'),
-        ),
-      ).thenAnswer((_) async {});
+        reset(mockCache);
+        when(
+          () => mockCache.preCacheFiles(
+            any(),
+            batchSize: any(named: 'batchSize'),
+            authHeadersProvider: any(named: 'authHeadersProvider'),
+          ),
+        ).thenAnswer((_) async {});
 
-      // Wait for throttle period (default 1 second in test)
-      await Future.delayed(const Duration(milliseconds: 1100));
+        // Wait for throttle period (default 1 second in test)
+        async.elapse(const Duration(milliseconds: 1100));
 
-      // Second call should work now
-      mixin.checkForPrefetch(currentIndex: 4, videos: videos);
-      verify(
-        () => mockCache.preCacheFiles(
-          any(),
-          batchSize: any(named: 'batchSize'),
-          authHeadersProvider: any(named: 'authHeadersProvider'),
-        ),
-      ).called(1);
+        // Second call should work now
+        mixin.checkForPrefetch(currentIndex: 4, videos: videos);
+        verify(
+          () => mockCache.preCacheFiles(
+            any(),
+            batchSize: any(named: 'batchSize'),
+            authHeadersProvider: any(named: 'authHeadersProvider'),
+          ),
+        ).called(1);
+      });
     });
 
     test('SPEC: should handle prefetch errors gracefully', () {

--- a/mobile/test/startup/startup_diagnostics_test.dart
+++ b/mobile/test/startup/startup_diagnostics_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Validates timing logs, breadcrumbs, and timeout detection
 
 import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/features/app/startup/startup_coordinator.dart';
@@ -199,55 +201,55 @@ void main() {
       expect(report, contains('DeferredService'));
     });
 
-    test('should detect and warn about slow initialization', () async {
-      // Arrange
-      final completer = Completer<void>();
-      final warnings = <String>[];
-      Timer? timeoutTimer;
+    test('should detect and warn about slow initialization', () {
+      fakeAsync((async) {
+        final completer = Completer<void>();
+        final warnings = <String>[];
+        Timer? timeoutTimer;
 
-      coordinator.registerService(
-        name: 'SlowService',
-        phase: StartupPhase.critical,
-        initialize: () async {
-          // Start timeout detection
-          timeoutTimer = Timer(const Duration(seconds: 2), () {
-            warnings.add(
-              'WARNING: SlowService initialization taking > 2 seconds',
-            );
-            CrashReportingService.instance.log(
-              'Startup timeout detected for SlowService',
-            );
-          });
+        coordinator.registerService(
+          name: 'SlowService',
+          phase: StartupPhase.critical,
+          initialize: () async {
+            // Start timeout detection
+            timeoutTimer = Timer(const Duration(seconds: 2), () {
+              warnings.add(
+                'WARNING: SlowService initialization taking > 2 seconds',
+              );
+              CrashReportingService.instance.log(
+                'Startup timeout detected for SlowService',
+              );
+            });
 
-          // Simulate slow initialization
-          await Future.delayed(const Duration(seconds: 3));
-          timeoutTimer?.cancel();
-          completer.complete();
-        },
-      );
+            // Simulate slow initialization
+            await Future.delayed(const Duration(seconds: 3));
+            timeoutTimer?.cancel();
+            completer.complete();
+          },
+        );
 
-      // Act
-      final initFuture = coordinator.initialize();
+        // Kick off initialization (fire-and-forget; we'll elapse past it).
+        unawaited(coordinator.initialize());
 
-      // Wait for timeout warning
-      await Future.delayed(const Duration(seconds: 2, milliseconds: 100));
+        // After 2.1s, the 2s Timer should have fired.
+        async.elapse(const Duration(seconds: 2, milliseconds: 100));
+        expect(
+          warnings,
+          contains('WARNING: SlowService initialization taking > 2 seconds'),
+        );
 
-      // Assert - should have timeout warning
-      expect(
-        warnings,
-        contains('WARNING: SlowService initialization taking > 2 seconds'),
-      );
+        // Elapse past the 3s simulated work so the service — and the
+        // whole coordinator — complete.
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
 
-      // Wait for completion
-      await initFuture;
-      await completer.future;
-
-      // Service should still complete
-      final metrics = coordinator.metrics;
-      expect(
-        metrics.serviceTimings['SlowService']!.inMilliseconds,
-        greaterThanOrEqualTo(3000),
-      );
+        expect(completer.isCompleted, isTrue);
+        final metrics = coordinator.metrics;
+        expect(
+          metrics.serviceTimings['SlowService']!.inMilliseconds,
+          greaterThanOrEqualTo(3000),
+        );
+      });
     });
 
     test('should handle initialization failures with proper logging', () async {


### PR DESCRIPTION
Closes #3241

## Summary

Extends the #3239 migration to the three remaining production utilities
that read the OS clock for throttle / rate-limit logic. Unblocks the
last `≥1s` `Future.delayed` site flagged during the post-chain backlog
survey and makes the corresponding production paths test-virtualizable
for any future test that needs to exercise throttle windows.

> **Stacked on #3239** (which stacks #3238 → #3236). Base branch is
> `refactor/package-clock-migration`. Merge order: #3236 → #3238 →
> #3239 → this PR.

## Why this migration is safe

Same reasoning as #3239 — `clock.now()` returns `DateTime.now()`
outside a `withClock(...)` zone override, so production behavior is
unchanged. Inside `fakeAsync`, the fake clock is installed automatically
by the `fake_async` package.

## Changes

### Production (3 files)

| File | Change |
|------|--------|
| `mobile/lib/utils/async_utils.dart` | `AsyncUtils.throttle()` + `AsyncUtils.executeWithRateLimit()` read `clock.now()` (3 call sites) + import |
| `mobile/lib/mixins/video_prefetch_mixin.dart` | Prefetch throttle reads `clock.now()` (1 call site) + import |
| `mobile/lib/mixins/pagination_mixin.dart` | Pagination throttle reads `clock.now()` (1 call site) + import |

### Test (1 file)

- `mobile/test/mixins/video_prefetch_mixin_test.dart` "should allow
  prefetch after throttle period" wrapped in `fakeAsync`. The
  `await Future.delayed(1100ms)` is now `async.elapse(1100ms)`.

No pubspec changes — `clock` is already a direct dep from #3239.

## Test results

- `video_prefetch_mixin_test.dart` — 11 tests `00:00` (was ~1.1s).
- `pagination_mixin_test.dart` + `scroll_pagination_mixin_test.dart` —
  7 tests `00:00`, no regressions from the throttle production change.
- `flutter analyze` full mobile — clean.

## Forward-looking wins

This is the largest still-latent win because `async_utils.dart`'s
throttle + rate-limit helpers are a shared utility. Any future test
that needs to exercise throttle/rate-limit timing can now do so via
`fakeAsync` without burning real wall-clock time. The three explicit
consumers today:

- `pagination_mixin` (used by feed screens)
- `video_prefetch_mixin` (used by feed screens)
- Any direct callers of `AsyncUtils.throttle` / `AsyncUtils.executeWithRateLimit`

## Chain context

- PR #3236 — 4 test sites converted, 3 deferred for OS-clock reads.
- PR #3238 — 12 audit-gap sites converted, 3 more deferred.
- PR #3239 — production `package:clock` migration unblocks those 6 deferrals.
- **This PR** — extends the migration to throttle/rate-limit helpers and
  converts the one remaining `≥1s` test found in the backlog survey.