### PR TITLE
docs: content policy layer design + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-04-23-content-policy-layer.md
+++ b/docs/superpowers/plans/2026-04-23-content-policy-layer.md
@@ -1,0 +1,2161 @@
+# Content Policy Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace three overlapping moderation services with a single pure-Dart `ContentPolicyEngine` that gates every parse boundary, so blocked/muted content never becomes an in-memory object on any feed.
+
+**Architecture:** A new `content_policy` package exposes a stateless engine composed of ordered `PolicyRule`s, plus an immutable `ContentPolicyState` value type. `ContentBlocklistService` gains `currentState` / `stream` accessors. The engine is injected into every `fromJson` / relay-event-handler boundary and at affordance-gate call sites (Follow, DM, mention, share/tag pickers). Ships behind a `content_policy_v2` feature flag until Phase 3.
+
+**Tech Stack:** Dart 3 sealed classes, `flutter_riverpod` (legacy glue), existing `FeatureFlag` enum, `shared_preferences`, `bloc_test`, `mocktail`.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-content-policy-layer-design.md`
+
+---
+
+## Orientation for the implementer
+
+You likely do not have context for this codebase. Before starting any task:
+
+- **Monorepo layout** — the app lives at `mobile/`. Feature-level code is in `mobile/lib/`. Shared packages live at `mobile/packages/<name>/` and are referenced from `mobile/pubspec.yaml` using implicit path deps (e.g. `  count_formatter:` with no version — the workspace `resolution: workspace` setting handles pathing). Use `mobile/packages/count_formatter/` as your template for any new package in this plan.
+- **All Flutter commands run from `mobile/`**, never from the repo root. `cd mobile && flutter test …`.
+- **Mise pinning** — the repo uses `mise exec --` for pinned Flutter. If you hit tool-version drift, prefix with `mise exec -- flutter …`.
+- **Codegen** — if you touch Riverpod, Freezed, JSON, Mockito, or Drift annotations, you must run `cd mobile && dart run build_runner build --delete-conflicting-outputs` and commit the generated files.
+- **Never truncate Nostr IDs** anywhere — code, logs, tests, analytics, debug output. Full hex pubkeys always.
+- **Disclosure invariant is a hard rule** — the app must never tell a user they have been blocked by another user. No ruleId string, no pubkey, no "MutualMute" token in any user-visible copy, snackbar, release log, analytics event, or Crashlytics breadcrumb. This affects test design (negative assertions) and logging choices throughout the plan.
+- **Existing feature flags** live at `mobile/lib/features/feature_flags/`. The enum is `mobile/lib/features/feature_flags/models/feature_flag.dart`; the service is `mobile/lib/features/feature_flags/services/feature_flag_service.dart`. Defaults are declared in `build_configuration.dart` in the same directory.
+- **Two names to reconcile** — the spec uses `ContentBlocklistRepository` (as of a rename referenced in #3227); the current code still uses `ContentBlocklistService` at `mobile/lib/services/content_blocklist_service.dart`. This plan uses the **current** name (`ContentBlocklistService`) because the rename has not yet landed. If #3227 lands before this plan is executed, globally swap `ContentBlocklistService` → `ContentBlocklistRepository` in the task text below.
+- **Existing block-filter hook** — `mobile/packages/videos_repository/lib/src/video_content_filter.dart` defines `typedef BlockedVideoFilter = bool Function(String pubkey);` and `videos_repository.dart` already calls it at four parse points (lines 787, 826, 860, 900 of the current file). The engine-injection work in Phase 1 preserves this callback shape — we replace the callback's **implementation** with `engine.evaluate(...) is Block`, not the callback's position in the code. Other repositories (comments, profile, hashtag, notifications) do **not** yet have an equivalent hook; the plan adds one.
+
+---
+
+## Chunk 1: Phase 0 — Build the engine package
+
+Everything in this chunk is pure Dart, no Flutter, no IO, trivially unit-testable. When this chunk is done, the engine exists and has 100% unit coverage; nothing in the app calls it yet.
+
+### Task 0.1: Scaffold the `content_policy` package
+
+**Files:**
+- Create: `mobile/packages/content_policy/pubspec.yaml`
+- Create: `mobile/packages/content_policy/analysis_options.yaml`
+- Create: `mobile/packages/content_policy/lib/content_policy.dart`
+- Modify: `mobile/pubspec.yaml` (add to `workspace:` list and as implicit dep)
+
+- [ ] **Step 1: Create the package pubspec**
+
+Write `mobile/packages/content_policy/pubspec.yaml`:
+
+```yaml
+name: content_policy
+description: Pure Dart content policy engine. Ingress filter + affordance gate.
+version: 0.1.0+1
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.11.0
+
+dev_dependencies:
+  test: ^1.26.3
+  very_good_analysis: ^10.0.0
+```
+
+- [ ] **Step 2: Create the analysis_options**
+
+Write `mobile/packages/content_policy/analysis_options.yaml`:
+
+```yaml
+include: package:very_good_analysis/analysis_options.yaml
+```
+
+- [ ] **Step 3: Create the barrel file**
+
+Write `mobile/packages/content_policy/lib/content_policy.dart`:
+
+```dart
+// Content policy engine — ingress filter + affordance gate.
+export 'src/content_policy_engine.dart';
+export 'src/content_policy_state.dart';
+export 'src/policy_decision.dart';
+export 'src/policy_input.dart';
+export 'src/policy_rule.dart';
+export 'src/rules/mutual_mute_rule.dart';
+export 'src/rules/pubkey_block_rule.dart';
+export 'src/rules/pubkey_mute_rule.dart';
+export 'src/rules/self_reference_rule.dart';
+```
+
+- [ ] **Step 4: Register the package in the monorepo**
+
+Modify `mobile/pubspec.yaml`. In the `workspace:` block (around line 26–57, alphabetical after `comments_repository`), add:
+
+```yaml
+  - packages/content_policy
+```
+
+And in the `dependencies:` block (near other implicit path deps like `videos_repository:`), add:
+
+```yaml
+  # Content Policy — parse-gate ingress filter
+  content_policy:
+```
+
+- [ ] **Step 5: Verify the package resolves**
+
+Run: `cd mobile && flutter pub get`
+Expected: no errors, `content_policy` listed in resolved packages.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/packages/content_policy mobile/pubspec.yaml
+git commit -m "feat(content_policy): scaffold pure-Dart policy engine package"
+```
+
+### Task 0.2: Define `PolicyInput`
+
+**Files:**
+- Create: `mobile/packages/content_policy/lib/src/policy_input.dart`
+- Create: `mobile/packages/content_policy/test/src/policy_input_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Write `mobile/packages/content_policy/test/src/policy_input_test.dart`:
+
+```dart
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(PolicyInput, () {
+    test('constructs with only pubkey', () {
+      const input = PolicyInput(pubkey: 'abc');
+      expect(input.pubkey, equals('abc'));
+      expect(input.kind, isNull);
+      expect(input.content, isNull);
+      expect(input.tags, isNull);
+    });
+
+    test('constructs with all fields', () {
+      const input = PolicyInput(
+        pubkey: 'abc',
+        kind: 34236,
+        content: 'hello',
+        tags: [
+          ['d', 'video-1'],
+        ],
+      );
+      expect(input.pubkey, equals('abc'));
+      expect(input.kind, equals(34236));
+      expect(input.content, equals('hello'));
+      expect(input.tags, hasLength(1));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/policy_input_test.dart`
+Expected: compile error — `PolicyInput` is undefined.
+
+- [ ] **Step 3: Implement `PolicyInput`**
+
+Write `mobile/packages/content_policy/lib/src/policy_input.dart`:
+
+```dart
+/// Minimal input the policy engine needs to evaluate a single event.
+///
+/// Parsers construct this from the raw JSON envelope of a Nostr event
+/// (or a REST response row that carries the same fields). Only [pubkey]
+/// is consulted by the Phase 1 rules; the remaining fields are part of
+/// the contract so future rules (hashtag, keyword) can be added without
+/// changing every call site.
+class PolicyInput {
+  const PolicyInput({
+    required this.pubkey,
+    this.kind,
+    this.content,
+    this.tags,
+  });
+
+  /// Event author's hex pubkey. Required.
+  final String pubkey;
+
+  /// Event kind (NIP-01 integer). Optional — not all REST responses carry it.
+  final int? kind;
+
+  /// Event content string. Optional.
+  final String? content;
+
+  /// Event tags, as the standard `List<List<String>>` NIP-01 shape. Optional.
+  final List<List<String>>? tags;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/policy_input_test.dart`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/packages/content_policy/lib/src/policy_input.dart mobile/packages/content_policy/test/src/policy_input_test.dart
+git commit -m "feat(content_policy): add PolicyInput value type"
+```
+
+### Task 0.3: Define `PolicyDecision` sealed hierarchy
+
+**Files:**
+- Create: `mobile/packages/content_policy/lib/src/policy_decision.dart`
+- Create: `mobile/packages/content_policy/test/src/policy_decision_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Write `mobile/packages/content_policy/test/src/policy_decision_test.dart`:
+
+```dart
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(PolicyDecision, () {
+    test('Allow is a PolicyDecision', () {
+      const decision = Allow();
+      expect(decision, isA<PolicyDecision>());
+    });
+
+    test('Block carries a ruleId', () {
+      const decision = Block(ruleId: 'PubkeyMuteRule');
+      expect(decision.ruleId, equals('PubkeyMuteRule'));
+      expect(decision, isA<PolicyDecision>());
+    });
+
+    test('pattern matches exhaustively', () {
+      PolicyDecision decision = const Allow();
+      final label = switch (decision) {
+        Allow() => 'allow',
+        Block() => 'block',
+      };
+      expect(label, equals('allow'));
+
+      decision = const Block(ruleId: 'r');
+      final label2 = switch (decision) {
+        Allow() => 'allow',
+        Block() => 'block',
+      };
+      expect(label2, equals('block'));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/policy_decision_test.dart`
+Expected: compile error — `Allow`, `Block`, `PolicyDecision` undefined.
+
+- [ ] **Step 3: Implement the sealed hierarchy**
+
+Write `mobile/packages/content_policy/lib/src/policy_decision.dart`:
+
+```dart
+/// Outcome of evaluating a single [PolicyInput] against the engine.
+///
+/// The sealed hierarchy lets callers pattern-match exhaustively without
+/// default cases. New decision variants (SoftHide, Warn) can be added
+/// later; Phase 1 ships only Allow and Block.
+sealed class PolicyDecision {
+  const PolicyDecision();
+}
+
+/// Content is permitted to be parsed into an in-app model.
+final class Allow extends PolicyDecision {
+  const Allow();
+}
+
+/// Content must be dropped. [ruleId] is for local diagnostics only —
+/// it must never appear in user-visible copy, release logs, remote
+/// telemetry, Crashlytics breadcrumbs, or analytics events.
+final class Block extends PolicyDecision {
+  const Block({required this.ruleId});
+
+  /// Identifier of the rule that produced this decision. Debug-only.
+  final String ruleId;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/policy_decision_test.dart`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/packages/content_policy/lib/src/policy_decision.dart mobile/packages/content_policy/test/src/policy_decision_test.dart
+git commit -m "feat(content_policy): add PolicyDecision sealed hierarchy"
+```
+
+### Task 0.4: Define `ContentPolicyState`
+
+**Files:**
+- Create: `mobile/packages/content_policy/lib/src/content_policy_state.dart`
+- Create: `mobile/packages/content_policy/test/src/content_policy_state_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Write `mobile/packages/content_policy/test/src/content_policy_state_test.dart`:
+
+```dart
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(ContentPolicyState, () {
+    const me = 'me-pubkey';
+
+    test('empty state has no filtered authors', () {
+      final state = ContentPolicyState.empty();
+      expect(state.currentUserPubkey, isNull);
+      expect(state.isAuthorFiltered('anyone'), isFalse);
+      expect(state.isBlockedBy('anyone'), isFalse);
+    });
+
+    test('mutedPubkeys filters author', () {
+      final state = ContentPolicyState(
+        currentUserPubkey: me,
+        mutedPubkeys: const {'muted'},
+        blockedPubkeys: const {},
+        pubkeysBlockingUs: const {},
+        pubkeysMutingUs: const {},
+      );
+      expect(state.isAuthorFiltered('muted'), isTrue);
+      expect(state.isAuthorFiltered('other'), isFalse);
+    });
+
+    test('blockedPubkeys filters author', () {
+      final state = ContentPolicyState(
+        currentUserPubkey: me,
+        mutedPubkeys: const {},
+        blockedPubkeys: const {'blocked'},
+        pubkeysBlockingUs: const {},
+        pubkeysMutingUs: const {},
+      );
+      expect(state.isAuthorFiltered('blocked'), isTrue);
+    });
+
+    test('pubkeysBlockingUs filters author and reports blockedBy', () {
+      final state = ContentPolicyState(
+        currentUserPubkey: me,
+        mutedPubkeys: const {},
+        blockedPubkeys: const {},
+        pubkeysBlockingUs: const {'blocker'},
+        pubkeysMutingUs: const {},
+      );
+      expect(state.isAuthorFiltered('blocker'), isTrue);
+      expect(state.isBlockedBy('blocker'), isTrue);
+      expect(state.isBlockedBy('someone-else'), isFalse);
+    });
+
+    test('pubkeysMutingUs filters author and reports blockedBy', () {
+      final state = ContentPolicyState(
+        currentUserPubkey: me,
+        mutedPubkeys: const {},
+        blockedPubkeys: const {},
+        pubkeysBlockingUs: const {},
+        pubkeysMutingUs: const {'muter'},
+      );
+      expect(state.isAuthorFiltered('muter'), isTrue);
+      expect(state.isBlockedBy('muter'), isTrue);
+    });
+
+    test('isBlockedBy excludes authors that we muted/blocked but not vice versa', () {
+      final state = ContentPolicyState(
+        currentUserPubkey: me,
+        mutedPubkeys: const {'someone-we-muted'},
+        blockedPubkeys: const {'someone-we-blocked'},
+        pubkeysBlockingUs: const {},
+        pubkeysMutingUs: const {},
+      );
+      expect(state.isBlockedBy('someone-we-muted'), isFalse);
+      expect(state.isBlockedBy('someone-we-blocked'), isFalse);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/content_policy_state_test.dart`
+Expected: compile error — `ContentPolicyState` undefined.
+
+- [ ] **Step 3: Implement `ContentPolicyState`**
+
+Write `mobile/packages/content_policy/lib/src/content_policy_state.dart`:
+
+```dart
+/// Immutable snapshot of all state the policy engine needs to evaluate.
+///
+/// Rebuilt by [ContentBlocklistService] whenever the underlying source
+/// data changes. The engine never mutates it; it is replaced wholesale.
+class ContentPolicyState {
+  const ContentPolicyState({
+    required this.currentUserPubkey,
+    required this.mutedPubkeys,
+    required this.blockedPubkeys,
+    required this.pubkeysBlockingUs,
+    required this.pubkeysMutingUs,
+  });
+
+  /// Empty state — used pre-hydration or when no user is authenticated.
+  ///
+  /// With an empty state, every rule short-circuits to Allow. This is
+  /// the documented startup window; the bootstrap sequence is responsible
+  /// for hydrating before any parse-gate call fires.
+  factory ContentPolicyState.empty() => const ContentPolicyState(
+        currentUserPubkey: null,
+        mutedPubkeys: {},
+        blockedPubkeys: {},
+        pubkeysBlockingUs: {},
+        pubkeysMutingUs: {},
+      );
+
+  /// The hex pubkey of the currently authenticated user, or null.
+  final String? currentUserPubkey;
+
+  /// Authors the user muted via their own kind 10000 event.
+  final Set<String> mutedPubkeys;
+
+  /// Authors the user blocked via their own kind 30000 d=block event.
+  final Set<String> blockedPubkeys;
+
+  /// Authors whose kind 30000 d=block event names the current user.
+  final Set<String> pubkeysBlockingUs;
+
+  /// Authors whose kind 10000 event names the current user.
+  final Set<String> pubkeysMutingUs;
+
+  /// True when content from [pubkey] must be filtered from feeds.
+  bool isAuthorFiltered(String pubkey) =>
+      mutedPubkeys.contains(pubkey) ||
+      blockedPubkeys.contains(pubkey) ||
+      pubkeysBlockingUs.contains(pubkey) ||
+      pubkeysMutingUs.contains(pubkey);
+
+  /// True when [pubkey] has a mute/block entry naming the current user.
+  ///
+  /// This is the query that [ContentPolicyEngine.canTarget] uses — it
+  /// answers "does the recipient want to hear from us?" without leaking
+  /// the reason. Callers MUST NOT surface the return value as copy.
+  bool isBlockedBy(String pubkey) =>
+      pubkeysBlockingUs.contains(pubkey) ||
+      pubkeysMutingUs.contains(pubkey);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/content_policy_state_test.dart`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/packages/content_policy/lib/src/content_policy_state.dart mobile/packages/content_policy/test/src/content_policy_state_test.dart
+git commit -m "feat(content_policy): add immutable ContentPolicyState"
+```
+
+### Task 0.5: Define `PolicyRule` interface
+
+**Files:**
+- Create: `mobile/packages/content_policy/lib/src/policy_rule.dart`
+
+- [ ] **Step 1: Write the interface**
+
+Write `mobile/packages/content_policy/lib/src/policy_rule.dart`:
+
+```dart
+import 'package:content_policy/src/content_policy_state.dart';
+import 'package:content_policy/src/policy_decision.dart';
+import 'package:content_policy/src/policy_input.dart';
+
+/// A single, pure, synchronous check in the policy pipeline.
+///
+/// Rules must be deterministic: same input + same state always produces
+/// the same decision. No IO, no async, no mutation.
+abstract interface class PolicyRule {
+  /// Stable identifier used in [Block.ruleId] and in the engine's
+  /// ordering assertion. Must match the class name by convention.
+  String get id;
+
+  /// Evaluate the rule. Return [Allow] to let the pipeline continue,
+  /// [Block] to short-circuit with a drop decision.
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state);
+}
+```
+
+- [ ] **Step 2: Run analyzer on the package**
+
+Run: `cd mobile/packages/content_policy && dart analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/packages/content_policy/lib/src/policy_rule.dart
+git commit -m "feat(content_policy): add PolicyRule interface"
+```
+
+### Task 0.6: Implement `SelfReferenceRule`
+
+**Files:**
+- Create: `mobile/packages/content_policy/lib/src/rules/self_reference_rule.dart`
+- Create: `mobile/packages/content_policy/test/src/rules/self_reference_rule_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Write `mobile/packages/content_policy/test/src/rules/self_reference_rule_test.dart`:
+
+```dart
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(SelfReferenceRule, () {
+    const rule = SelfReferenceRule();
+    const me = 'me-pubkey';
+
+    final stateWithMeInEveryList = ContentPolicyState(
+      currentUserPubkey: me,
+      mutedPubkeys: const {me},
+      blockedPubkeys: const {me},
+      pubkeysBlockingUs: const {me},
+      pubkeysMutingUs: const {me},
+    );
+
+    test('id matches class name', () {
+      expect(rule.id, equals('SelfReferenceRule'));
+    });
+
+    test('allows the current user even if every list contains them', () {
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: me),
+        stateWithMeInEveryList,
+      );
+      expect(decision, isA<Allow>());
+    });
+
+    test('allows any author when no user is authenticated', () {
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'anyone'),
+        ContentPolicyState.empty(),
+      );
+      expect(decision, isA<Allow>());
+    });
+
+    test('returns Allow (not short-circuit Block) for a different pubkey', () {
+      // Self rule only handles the self case. Other rules decide for others.
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'someone-else'),
+        stateWithMeInEveryList,
+      );
+      expect(decision, isA<Allow>());
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/rules/self_reference_rule_test.dart`
+Expected: compile error — `SelfReferenceRule` undefined.
+
+- [ ] **Step 3: Implement `SelfReferenceRule`**
+
+Write `mobile/packages/content_policy/lib/src/rules/self_reference_rule.dart`:
+
+```dart
+import 'package:content_policy/src/content_policy_state.dart';
+import 'package:content_policy/src/policy_decision.dart';
+import 'package:content_policy/src/policy_input.dart';
+import 'package:content_policy/src/policy_rule.dart';
+
+/// Guarantees the user's own content is never filtered, even if a
+/// malformed mute/block list contains the user's own pubkey.
+///
+/// Must be first in the rule pipeline — the engine asserts this.
+///
+/// Why: a self-referential mute list reproduced issue #2192 where the
+/// user's own events disappeared from their feed.
+class SelfReferenceRule implements PolicyRule {
+  const SelfReferenceRule();
+
+  @override
+  String get id => 'SelfReferenceRule';
+
+  @override
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    // This rule only handles the self case. For any other pubkey, we
+    // return Allow and let the subsequent rules decide.
+    return const Allow();
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/rules/self_reference_rule_test.dart`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/packages/content_policy/lib/src/rules/self_reference_rule.dart mobile/packages/content_policy/test/src/rules/self_reference_rule_test.dart
+git commit -m "feat(content_policy): add SelfReferenceRule"
+```
+
+### Task 0.7: Implement `PubkeyMuteRule`
+
+**Files:**
+- Create: `mobile/packages/content_policy/lib/src/rules/pubkey_mute_rule.dart`
+- Create: `mobile/packages/content_policy/test/src/rules/pubkey_mute_rule_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Write `mobile/packages/content_policy/test/src/rules/pubkey_mute_rule_test.dart`:
+
+```dart
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(PubkeyMuteRule, () {
+    const rule = PubkeyMuteRule();
+
+    test('id is stable', () {
+      expect(rule.id, equals('PubkeyMuteRule'));
+    });
+
+    test('blocks authors present in mutedPubkeys', () {
+      final state = ContentPolicyState(
+        currentUserPubkey: 'me',
+        mutedPubkeys: const {'muted'},
+        blockedPubkeys: const {},
+        pubkeysBlockingUs: const {},
+        pubkeysMutingUs: const {},
+      );
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'muted'),
+        state,
+      );
+      expect(decision, isA<Block>());
+      expect((decision as Block).ruleId, equals('PubkeyMuteRule'));
+    });
+
+    test('allows authors not in mutedPubkeys', () {
+      final state = ContentPolicyState(
+        currentUserPubkey: 'me',
+        mutedPubkeys: const {'muted'},
+        blockedPubkeys: const {},
+        pubkeysBlockingUs: const {},
+        pubkeysMutingUs: const {},
+      );
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'not-muted'),
+        state,
+      );
+      expect(decision, isA<Allow>());
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/rules/pubkey_mute_rule_test.dart`
+Expected: compile error.
+
+- [ ] **Step 3: Implement `PubkeyMuteRule`**
+
+Write `mobile/packages/content_policy/lib/src/rules/pubkey_mute_rule.dart`:
+
+```dart
+import 'package:content_policy/src/content_policy_state.dart';
+import 'package:content_policy/src/policy_decision.dart';
+import 'package:content_policy/src/policy_input.dart';
+import 'package:content_policy/src/policy_rule.dart';
+
+/// Blocks content from authors the user muted via kind 10000.
+class PubkeyMuteRule implements PolicyRule {
+  const PubkeyMuteRule();
+
+  @override
+  String get id => 'PubkeyMuteRule';
+
+  @override
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    if (state.mutedPubkeys.contains(input.pubkey)) {
+      return Block(ruleId: id);
+    }
+    return const Allow();
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/rules/pubkey_mute_rule_test.dart`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/packages/content_policy/lib/src/rules/pubkey_mute_rule.dart mobile/packages/content_policy/test/src/rules/pubkey_mute_rule_test.dart
+git commit -m "feat(content_policy): add PubkeyMuteRule"
+```
+
+### Task 0.8: Implement `PubkeyBlockRule`
+
+**Files:**
+- Create: `mobile/packages/content_policy/lib/src/rules/pubkey_block_rule.dart`
+- Create: `mobile/packages/content_policy/test/src/rules/pubkey_block_rule_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Write `mobile/packages/content_policy/test/src/rules/pubkey_block_rule_test.dart`:
+
+```dart
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(PubkeyBlockRule, () {
+    const rule = PubkeyBlockRule();
+
+    test('id is stable', () {
+      expect(rule.id, equals('PubkeyBlockRule'));
+    });
+
+    test('blocks authors present in blockedPubkeys', () {
+      final state = ContentPolicyState(
+        currentUserPubkey: 'me',
+        mutedPubkeys: const {},
+        blockedPubkeys: const {'blocked'},
+        pubkeysBlockingUs: const {},
+        pubkeysMutingUs: const {},
+      );
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'blocked'),
+        state,
+      );
+      expect(decision, isA<Block>());
+      expect((decision as Block).ruleId, equals('PubkeyBlockRule'));
+    });
+
+    test('allows authors not in blockedPubkeys', () {
+      final state = ContentPolicyState.empty();
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'anyone'),
+        state,
+      );
+      expect(decision, isA<Allow>());
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/rules/pubkey_block_rule_test.dart`
+Expected: compile error.
+
+- [ ] **Step 3: Implement `PubkeyBlockRule`**
+
+Write `mobile/packages/content_policy/lib/src/rules/pubkey_block_rule.dart`:
+
+```dart
+import 'package:content_policy/src/content_policy_state.dart';
+import 'package:content_policy/src/policy_decision.dart';
+import 'package:content_policy/src/policy_input.dart';
+import 'package:content_policy/src/policy_rule.dart';
+
+/// Blocks content from authors the user blocked via kind 30000 d=block.
+class PubkeyBlockRule implements PolicyRule {
+  const PubkeyBlockRule();
+
+  @override
+  String get id => 'PubkeyBlockRule';
+
+  @override
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    if (state.blockedPubkeys.contains(input.pubkey)) {
+      return Block(ruleId: id);
+    }
+    return const Allow();
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/rules/pubkey_block_rule_test.dart`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/packages/content_policy/lib/src/rules/pubkey_block_rule.dart mobile/packages/content_policy/test/src/rules/pubkey_block_rule_test.dart
+git commit -m "feat(content_policy): add PubkeyBlockRule"
+```
+
+### Task 0.9: Implement `MutualMuteRule`
+
+**Files:**
+- Create: `mobile/packages/content_policy/lib/src/rules/mutual_mute_rule.dart`
+- Create: `mobile/packages/content_policy/test/src/rules/mutual_mute_rule_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Write `mobile/packages/content_policy/test/src/rules/mutual_mute_rule_test.dart`:
+
+```dart
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(MutualMuteRule, () {
+    const rule = MutualMuteRule();
+
+    test('id is stable', () {
+      expect(rule.id, equals('MutualMuteRule'));
+    });
+
+    test('blocks authors in pubkeysBlockingUs', () {
+      final state = ContentPolicyState(
+        currentUserPubkey: 'me',
+        mutedPubkeys: const {},
+        blockedPubkeys: const {},
+        pubkeysBlockingUs: const {'blocker'},
+        pubkeysMutingUs: const {},
+      );
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'blocker'),
+        state,
+      );
+      expect(decision, isA<Block>());
+      expect((decision as Block).ruleId, equals('MutualMuteRule'));
+    });
+
+    test('blocks authors in pubkeysMutingUs', () {
+      final state = ContentPolicyState(
+        currentUserPubkey: 'me',
+        mutedPubkeys: const {},
+        blockedPubkeys: const {},
+        pubkeysBlockingUs: const {},
+        pubkeysMutingUs: const {'muter'},
+      );
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'muter'),
+        state,
+      );
+      expect(decision, isA<Block>());
+    });
+
+    test('allows authors not in either mutual-mute set', () {
+      final state = ContentPolicyState.empty();
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'stranger'),
+        state,
+      );
+      expect(decision, isA<Allow>());
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/rules/mutual_mute_rule_test.dart`
+Expected: compile error.
+
+- [ ] **Step 3: Implement `MutualMuteRule`**
+
+Write `mobile/packages/content_policy/lib/src/rules/mutual_mute_rule.dart`:
+
+```dart
+import 'package:content_policy/src/content_policy_state.dart';
+import 'package:content_policy/src/policy_decision.dart';
+import 'package:content_policy/src/policy_input.dart';
+import 'package:content_policy/src/policy_rule.dart';
+
+/// Blocks content from authors whose own mute/block list names the
+/// current user. Enforces the mutual-mute guarantee: if they don't
+/// want our content, we don't show theirs.
+class MutualMuteRule implements PolicyRule {
+  const MutualMuteRule();
+
+  @override
+  String get id => 'MutualMuteRule';
+
+  @override
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    if (state.isBlockedBy(input.pubkey)) {
+      return Block(ruleId: id);
+    }
+    return const Allow();
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/rules/mutual_mute_rule_test.dart`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/packages/content_policy/lib/src/rules/mutual_mute_rule.dart mobile/packages/content_policy/test/src/rules/mutual_mute_rule_test.dart
+git commit -m "feat(content_policy): add MutualMuteRule"
+```
+
+### Task 0.10: Implement `ContentPolicyEngine`
+
+The engine composes rules, short-circuits on first `Block`, and asserts `SelfReferenceRule` is at position 0 when constructed from the default rule set. It also exposes `canTarget`, a simple wrapper over `state.isBlockedBy` that does not run the rule pipeline.
+
+**Files:**
+- Create: `mobile/packages/content_policy/lib/src/content_policy_engine.dart`
+- Create: `mobile/packages/content_policy/test/src/content_policy_engine_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Write `mobile/packages/content_policy/test/src/content_policy_engine_test.dart`:
+
+```dart
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(ContentPolicyEngine, () {
+    const me = 'me';
+
+    group('evaluate', () {
+      test('returns Allow when no rule blocks', () {
+        final engine = ContentPolicyEngine.defaultRules();
+        final decision = engine.evaluate(
+          const PolicyInput(pubkey: 'stranger'),
+          ContentPolicyState.empty(),
+        );
+        expect(decision, isA<Allow>());
+      });
+
+      test('returns Block when the first applicable rule blocks', () {
+        final engine = ContentPolicyEngine.defaultRules();
+        final state = ContentPolicyState(
+          currentUserPubkey: me,
+          mutedPubkeys: const {'muted'},
+          blockedPubkeys: const {},
+          pubkeysBlockingUs: const {},
+          pubkeysMutingUs: const {},
+        );
+        final decision = engine.evaluate(
+          const PolicyInput(pubkey: 'muted'),
+          state,
+        );
+        expect(decision, isA<Block>());
+        expect((decision as Block).ruleId, equals('PubkeyMuteRule'));
+      });
+
+      test('short-circuits on first Block — later rules do not run', () {
+        var secondRuleRan = false;
+        final engine = ContentPolicyEngine([
+          const SelfReferenceRule(),
+          _AlwaysBlockRule('first'),
+          _SpyRule(() => secondRuleRan = true),
+        ]);
+        final decision = engine.evaluate(
+          const PolicyInput(pubkey: 'x'),
+          ContentPolicyState.empty(),
+        );
+        expect(decision, isA<Block>());
+        expect((decision as Block).ruleId, equals('first'));
+        expect(secondRuleRan, isFalse);
+      });
+
+      test(
+          'SelfReferenceRule short-circuits even when a later rule would block',
+          () {
+        final engine = ContentPolicyEngine.defaultRules();
+        // The user's own pubkey is in every filter list (malformed state).
+        final state = ContentPolicyState(
+          currentUserPubkey: me,
+          mutedPubkeys: const {me},
+          blockedPubkeys: const {me},
+          pubkeysBlockingUs: const {me},
+          pubkeysMutingUs: const {me},
+        );
+        final decision = engine.evaluate(
+          const PolicyInput(pubkey: me),
+          state,
+        );
+        expect(decision, isA<Allow>());
+      });
+    });
+
+    group('construction invariants', () {
+      test('defaultRules places SelfReferenceRule first', () {
+        final engine = ContentPolicyEngine.defaultRules();
+        expect(engine.rules.first, isA<SelfReferenceRule>());
+      });
+
+      test('asserts when SelfReferenceRule is not first', () {
+        expect(
+          () => ContentPolicyEngine([
+            const PubkeyMuteRule(),
+            const SelfReferenceRule(),
+          ]),
+          throwsA(isA<AssertionError>()),
+        );
+      });
+
+      test('allows custom rule lists so long as SelfReferenceRule leads', () {
+        expect(
+          () => ContentPolicyEngine([
+            const SelfReferenceRule(),
+            _AlwaysBlockRule('custom'),
+          ]),
+          returnsNormally,
+        );
+      });
+    });
+
+    group('canTarget', () {
+      test('returns true when pubkey is not in isBlockedBy', () {
+        final engine = ContentPolicyEngine.defaultRules();
+        expect(
+          engine.canTarget('stranger', ContentPolicyState.empty()),
+          isTrue,
+        );
+      });
+
+      test('returns false when pubkey blocks us', () {
+        final engine = ContentPolicyEngine.defaultRules();
+        final state = ContentPolicyState(
+          currentUserPubkey: me,
+          mutedPubkeys: const {},
+          blockedPubkeys: const {},
+          pubkeysBlockingUs: const {'blocker'},
+          pubkeysMutingUs: const {},
+        );
+        expect(engine.canTarget('blocker', state), isFalse);
+      });
+
+      test('returns false when pubkey muted us', () {
+        final engine = ContentPolicyEngine.defaultRules();
+        final state = ContentPolicyState(
+          currentUserPubkey: me,
+          mutedPubkeys: const {},
+          blockedPubkeys: const {},
+          pubkeysBlockingUs: const {},
+          pubkeysMutingUs: const {'muter'},
+        );
+        expect(engine.canTarget('muter', state), isFalse);
+      });
+
+      test('does not run the full rule pipeline', () {
+        // canTarget must not invoke custom rules at all. Using a rule
+        // that would throw if called proves it's bypassed.
+        final engine = ContentPolicyEngine([
+          const SelfReferenceRule(),
+          _ExplodingRule(),
+        ]);
+        expect(
+          () => engine.canTarget('anyone', ContentPolicyState.empty()),
+          returnsNormally,
+        );
+      });
+    });
+  });
+}
+
+class _AlwaysBlockRule implements PolicyRule {
+  const _AlwaysBlockRule(this._id);
+  final String _id;
+  @override
+  String get id => _id;
+  @override
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) =>
+      Block(ruleId: id);
+}
+
+class _SpyRule implements PolicyRule {
+  _SpyRule(this.onEvaluate);
+  final void Function() onEvaluate;
+  @override
+  String get id => 'SpyRule';
+  @override
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    onEvaluate();
+    return const Allow();
+  }
+}
+
+class _ExplodingRule implements PolicyRule {
+  @override
+  String get id => 'ExplodingRule';
+  @override
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    throw StateError('should not run');
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/content_policy_engine_test.dart`
+Expected: compile error — `ContentPolicyEngine` undefined.
+
+- [ ] **Step 3: Implement the engine**
+
+Write `mobile/packages/content_policy/lib/src/content_policy_engine.dart`:
+
+```dart
+import 'package:content_policy/src/content_policy_state.dart';
+import 'package:content_policy/src/policy_decision.dart';
+import 'package:content_policy/src/policy_input.dart';
+import 'package:content_policy/src/policy_rule.dart';
+import 'package:content_policy/src/rules/mutual_mute_rule.dart';
+import 'package:content_policy/src/rules/pubkey_block_rule.dart';
+import 'package:content_policy/src/rules/pubkey_mute_rule.dart';
+import 'package:content_policy/src/rules/self_reference_rule.dart';
+
+/// Evaluates content against an ordered pipeline of [PolicyRule]s and
+/// answers interaction-gating queries via [canTarget].
+///
+/// The engine is stateless. [evaluate] takes a fresh [ContentPolicyState]
+/// snapshot on every call; rebuild the snapshot upstream, don't mutate.
+class ContentPolicyEngine {
+  /// Construct with an explicit rule list. [SelfReferenceRule] must be
+  /// at position 0 or an [AssertionError] is thrown.
+  ContentPolicyEngine(this.rules)
+      : assert(
+          rules.isNotEmpty && rules.first is SelfReferenceRule,
+          'SelfReferenceRule must be first in the pipeline. '
+          'It guarantees the user is never filtered by a malformed list.',
+        );
+
+  /// The canonical Phase 1 rule set.
+  factory ContentPolicyEngine.defaultRules() => ContentPolicyEngine(const [
+        SelfReferenceRule(),
+        PubkeyMuteRule(),
+        PubkeyBlockRule(),
+        MutualMuteRule(),
+      ]);
+
+  final List<PolicyRule> rules;
+
+  /// Runs [input] through the pipeline and returns the first [Block]
+  /// decision, or [Allow] if no rule blocks.
+  ///
+  /// Short-circuits on first [Block]; later rules do not run.
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    for (final rule in rules) {
+      final decision = rule.evaluate(input, state);
+      if (decision is Block) return decision;
+    }
+    return const Allow();
+  }
+
+  /// Answers: should the UI offer an interaction that targets [pubkey]?
+  ///
+  /// Returns `false` when [pubkey] has a mute/block entry naming the
+  /// current user. Callers MUST translate this to *absence* of the
+  /// affordance, not a disabled state with explanation.
+  ///
+  /// This query bypasses the full rule pipeline. It's a specific
+  /// question with a specific answer; routing it through `evaluate`
+  /// would give the caller a `ruleId` they must not expose.
+  bool canTarget(String pubkey, ContentPolicyState state) {
+    return !state.isBlockedBy(pubkey);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mobile/packages/content_policy && dart test test/src/content_policy_engine_test.dart`
+Expected: PASS, all tests.
+
+- [ ] **Step 5: Run the full package test suite**
+
+Run: `cd mobile/packages/content_policy && dart test`
+Expected: PASS, all tests across all files.
+
+- [ ] **Step 6: Run package analyzer**
+
+Run: `cd mobile/packages/content_policy && dart analyze`
+Expected: `No issues found!`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mobile/packages/content_policy/lib/src/content_policy_engine.dart mobile/packages/content_policy/test/src/content_policy_engine_test.dart
+git commit -m "feat(content_policy): add ContentPolicyEngine with rule-order assertion"
+```
+
+### Task 0.11: Coverage verification
+
+- [ ] **Step 1: Run package tests with coverage**
+
+Run:
+```bash
+cd mobile/packages/content_policy
+dart pub global run coverage:test_with_coverage
+```
+
+(If `coverage` is not installed globally, install: `dart pub global activate coverage`.)
+
+- [ ] **Step 2: Verify coverage is 100%**
+
+Inspect `coverage/lcov.info`. Every line of every `lib/src/**` file should be hit. If not, add a targeted test for the uncovered branch before proceeding. This package ships the invariant-bearing logic of the whole feature — coverage gaps here are invariant gaps.
+
+- [ ] **Step 3: Commit coverage config (if added)**
+
+```bash
+git add -A mobile/packages/content_policy
+git commit -m "test(content_policy): verify 100% coverage on engine package"
+```
+
+---
+
+## Chunk 2: Phase 1 — Parse-gate integration
+
+This chunk wires the engine into the app, under the `content_policy_v2` feature flag. When the flag is OFF the app behaves exactly as before. When ON, the engine gates every parse boundary.
+
+### Task 1.1: Add `contentPolicyV2` feature flag
+
+**Files:**
+- Modify: `mobile/lib/features/feature_flags/models/feature_flag.dart`
+- Modify: `mobile/lib/features/feature_flags/services/build_configuration.dart`
+- Test: `mobile/test/models/feature_flag_state_test.dart` (pattern exists; add coverage)
+
+- [ ] **Step 1: Add the enum entry**
+
+Modify `mobile/lib/features/feature_flags/models/feature_flag.dart`. Add before the closing `;`:
+
+```dart
+  contentPolicyV2(
+    'Content Policy v2',
+    'Parse-gated policy engine — filter blocked/muted authors at ingress',
+  )
+```
+
+Remove the trailing `,` from the previous entry (`integratedApps`) and ensure syntax remains valid.
+
+- [ ] **Step 2: Wire the default**
+
+Modify `mobile/lib/features/feature_flags/services/build_configuration.dart`. Inspect the file — it has a `getDefault(FeatureFlag flag)` method. Add a case:
+
+```dart
+case FeatureFlag.contentPolicyV2:
+  return false; // Off in Phase 1; flipped to true in Phase 3.
+```
+
+- [ ] **Step 3: Run existing feature-flag tests**
+
+Run: `cd mobile && flutter test test/models/feature_flag_state_test.dart test/services/feature_flag_service_test.dart test/screens/feature_flag_screen_test.dart`
+Expected: PASS (or one adjustment needed for the exhaustive enum assertion — fix by adding the new flag to expected test inputs).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/lib/features/feature_flags
+git commit -m "feat(feature_flags): add contentPolicyV2 flag (default off)"
+```
+
+### Task 1.2: Extend `ContentBlocklistService` to expose `ContentPolicyState`
+
+`ContentBlocklistService` (at `mobile/lib/services/content_blocklist_service.dart`) already holds four sets internally: `_runtimeBlocklist` + `_internalBlocklist` (= user's blocks), `_mutualMuteBlocklist` (= users muting us), `_blockedByOthers` (= users blocking us via kind 30000). This task adds the mapping to `ContentPolicyState` without changing the existing sets or publishing paths.
+
+We introduce two new accessors: `currentState` (synchronous snapshot) and `stateStream` (broadcast stream that emits when `_notifyChanged()` fires). Phase 1 has no separate `mutedPubkeys` set in the service — kind 10000 of *our own* mute list is not yet read locally. We surface an empty `mutedPubkeys` set for now; the spec's `PubkeyMuteRule` will simply never block from this path until a later PR plumbs own-kind-10000 reading. The `MutualMuteRule` and `PubkeyBlockRule` paths do all current work.
+
+> **Note for the implementer:** the spec assumes kind 10000 personal-mute reading exists. Today the service only reads kind 10000 events that *name us*. Do not introduce personal-mute reading in this task — that is a follow-up PR (out of scope per the spec's "Deferred" section's own-profile mute list tracking). Just leave `mutedPubkeys` empty in the mapping and add a `TODO(#XXXX)` comment naming the follow-up.
+
+**Files:**
+- Modify: `mobile/lib/services/content_blocklist_service.dart`
+- Test: `mobile/test/services/content_blocklist_service_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mobile/test/services/content_blocklist_service_test.dart` (inside the existing `main() { group(...) }`):
+
+```dart
+group('ContentPolicyState exposure', () {
+  test('currentState reflects blocked, mutual-mute and blocked-by sets',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final service = ContentBlocklistService(prefs: prefs);
+
+    const me = 'my-full-hex-pubkey';
+    const blockedByUs = 'blocked-by-us-hex';
+    await service.blockUser(blockedByUs, ourPubkey: me);
+
+    final state = service.currentState;
+    expect(state.blockedPubkeys, contains(blockedByUs));
+    expect(state.mutedPubkeys, isEmpty); // Phase 1: own-kind-10000 not wired
+    expect(state.pubkeysBlockingUs, isEmpty);
+    expect(state.pubkeysMutingUs, isEmpty);
+  });
+
+  test('stateStream emits a new snapshot after block/unblock', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final service = ContentBlocklistService(prefs: prefs);
+
+    const blocked = 'some-hex';
+    final snapshots = <ContentPolicyState>[];
+    final sub = service.stateStream.listen(snapshots.add);
+
+    await service.blockUser(blocked, ourPubkey: 'me');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(snapshots, hasLength(greaterThanOrEqualTo(1)));
+    expect(snapshots.last.blockedPubkeys, contains(blocked));
+
+    await sub.cancel();
+  });
+});
+```
+
+Make sure to add the import at the top of the file if not present:
+
+```dart
+import 'package:content_policy/content_policy.dart';
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile && flutter test test/services/content_blocklist_service_test.dart -n "ContentPolicyState exposure"`
+Expected: FAIL — `currentState` and `stateStream` undefined on `ContentBlocklistService`.
+
+- [ ] **Step 3: Add dep and implement**
+
+Modify `mobile/lib/services/content_blocklist_service.dart`:
+
+3a. Add import:
+```dart
+import 'package:content_policy/content_policy.dart';
+```
+
+3b. Add a field (near the other subscription fields, ~line 70):
+```dart
+final _stateController = StreamController<ContentPolicyState>.broadcast();
+```
+
+3c. Add methods (after `blockingStats` ~line 424):
+```dart
+/// Synchronous snapshot of the current policy state.
+///
+/// Safe to call from any context, including build methods. Reads the
+/// service's internal sets and projects them into the immutable
+/// [ContentPolicyState] shape the engine consumes.
+ContentPolicyState get currentState => ContentPolicyState(
+      currentUserPubkey: _ourPubkey,
+      // TODO(#content-policy-own-mute): wire own kind 10000 reading so
+      // we can populate this set. Until then, PubkeyMuteRule is dormant.
+      mutedPubkeys: const {},
+      blockedPubkeys: Set.unmodifiable({
+        ..._internalBlocklist,
+        ..._runtimeBlocklist,
+      }),
+      pubkeysBlockingUs: Set.unmodifiable(_blockedByOthers),
+      pubkeysMutingUs: Set.unmodifiable(_mutualMuteBlocklist),
+    );
+
+/// Broadcast stream of [ContentPolicyState] snapshots.
+///
+/// Emits whenever the underlying sets change. The first event is not
+/// the initial state — call [currentState] for that and use this
+/// stream for subsequent updates.
+Stream<ContentPolicyState> get stateStream => _stateController.stream;
+```
+
+3d. Modify `_notifyChanged` to emit:
+```dart
+void _notifyChanged() {
+  _onChanged?.call();
+  if (!_stateController.isClosed) {
+    _stateController.add(currentState);
+  }
+}
+```
+
+3e. Modify `dispose()` to close the controller:
+```dart
+void dispose() {
+  _mutualMuteSyncStarted = false;
+  _mutualMuteSubscriptionId = null;
+  _blockListSyncStarted = false;
+  _stateController.close();
+}
+```
+
+3f. Update `pubspec.yaml` of the `mobile` app to ensure `content_policy:` is a dep (done in Chunk 1 Task 0.1 if you added it correctly — verify).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mobile && flutter test test/services/content_blocklist_service_test.dart`
+Expected: PASS (full file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/services/content_blocklist_service.dart mobile/test/services/content_blocklist_service_test.dart
+git commit -m "feat(blocklist): expose ContentPolicyState snapshot and stream"
+```
+
+### Task 1.3: Add `contentPolicyEngineProvider` Riverpod provider
+
+**Files:**
+- Modify: `mobile/lib/providers/app_providers.dart`
+- Test: `mobile/test/providers/app_providers_test.dart` (or create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Create or append to `mobile/test/providers/content_policy_engine_provider_test.dart`:
+
+```dart
+import 'package:content_policy/content_policy.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/providers/app_providers.dart';
+
+void main() {
+  test('contentPolicyEngineProvider exposes the default rule set', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final engine = container.read(contentPolicyEngineProvider);
+    expect(engine.rules.first, isA<SelfReferenceRule>());
+    expect(engine.rules, hasLength(4));
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile && flutter test test/providers/content_policy_engine_provider_test.dart`
+Expected: FAIL — `contentPolicyEngineProvider` undefined.
+
+- [ ] **Step 3: Implement the provider**
+
+Modify `mobile/lib/providers/app_providers.dart`. Near the `contentBlocklistService` provider (around line 806), add:
+
+```dart
+import 'package:content_policy/content_policy.dart';
+
+/// The singleton policy engine. Stateless — safe to share across the app.
+@Riverpod(keepAlive: true)
+ContentPolicyEngine contentPolicyEngine(Ref ref) {
+  return ContentPolicyEngine.defaultRules();
+}
+```
+
+- [ ] **Step 4: Run codegen**
+
+Run: `cd mobile && dart run build_runner build --delete-conflicting-outputs`
+Expected: `app_providers.g.dart` updated with `contentPolicyEngineProvider`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd mobile && flutter test test/providers/content_policy_engine_provider_test.dart`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/lib/providers/app_providers.dart mobile/lib/providers/app_providers.g.dart mobile/test/providers/content_policy_engine_provider_test.dart
+git commit -m "feat(providers): add contentPolicyEngineProvider"
+```
+
+### Task 1.4: Bootstrap hydration — block state ready before first subscription
+
+The spec's "State hydration" section requires the policy state to be fully hydrated from local storage before the parse-gate accepts its first call. Today, `ContentBlocklistService`'s constructor already loads from `SharedPreferences` synchronously (see `_loadBlockedUsers` called from the constructor). What's missing is an explicit assertion: the `blocklistSyncBridge` (app_providers.dart:838) must not start relay subscriptions until the service's local hydration is done.
+
+Local hydration is synchronous today. This task adds a test that asserts `currentState` is populated from prefs *before* any `syncBlockListsInBackground` call, so future refactors can't regress the order.
+
+**Files:**
+- Test: `mobile/test/services/content_blocklist_service_hydration_test.dart` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Write `mobile/test/services/content_blocklist_service_hydration_test.dart`:
+
+```dart
+import 'package:content_policy/content_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/content_blocklist_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  group('ContentBlocklistService hydration', () {
+    test('currentState reflects persisted blocks before any sync call',
+        () async {
+      // Simulate an app restart with persisted state.
+      SharedPreferences.setMockInitialValues({
+        'blocked_users_list': '["persisted-pubkey-hex"]',
+      });
+      final prefs = await SharedPreferences.getInstance();
+
+      final service = ContentBlocklistService(prefs: prefs);
+
+      // No relay sync has happened — currentState must already include
+      // the persisted block.
+      final state = service.currentState;
+      expect(state.blockedPubkeys, contains('persisted-pubkey-hex'));
+    });
+
+    test('empty prefs yields empty state (Allow-by-default window)', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+
+      final service = ContentBlocklistService(prefs: prefs);
+
+      final state = service.currentState;
+      expect(state.blockedPubkeys, isEmpty);
+      expect(state.pubkeysBlockingUs, isEmpty);
+      expect(state.pubkeysMutingUs, isEmpty);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes**
+
+Run: `cd mobile && flutter test test/services/content_blocklist_service_hydration_test.dart`
+Expected: likely PASSES already because constructor hydration exists. The value of this test is documenting the invariant — future refactors that break synchronous hydration will fail here.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/test/services/content_blocklist_service_hydration_test.dart
+git commit -m "test(blocklist): pin synchronous prefs hydration invariant"
+```
+
+### Task 1.5: Parse-gate at `videos_repository` — engine behind flag
+
+The repository already accepts a `BlockedVideoFilter` callback. We replace its *source* (still a callback — `BlockedVideoFilter`'s shape doesn't change), so the repository stays decoupled from the engine. The provider factory at `app_providers.dart` is the injection seam. When `contentPolicyV2` is ON, the callback consults the engine; when OFF, it consults `shouldFilterFromFeeds` exactly as before.
+
+**Files:**
+- Modify: `mobile/lib/services/blocklist_content_filter.dart`
+- Modify: `mobile/lib/providers/app_providers.dart` (the provider that constructs the filter)
+- Test: `mobile/test/services/blocklist_content_filter_test.dart` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Write `mobile/test/services/blocklist_content_filter_test.dart`:
+
+```dart
+import 'package:content_policy/content_policy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/blocklist_content_filter.dart';
+
+void main() {
+  group('createPolicyEngineFilter', () {
+    test('blocks pubkey when engine.evaluate returns Block', () {
+      final engine = ContentPolicyEngine.defaultRules();
+      ContentPolicyState state() => ContentPolicyState(
+            currentUserPubkey: 'me',
+            mutedPubkeys: const {},
+            blockedPubkeys: const {'blocked-hex'},
+            pubkeysBlockingUs: const {},
+            pubkeysMutingUs: const {},
+          );
+
+      final filter = createPolicyEngineFilter(engine, state);
+      expect(filter('blocked-hex'), isTrue);
+      expect(filter('allowed-hex'), isFalse);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile && flutter test test/services/blocklist_content_filter_test.dart`
+Expected: FAIL — `createPolicyEngineFilter` undefined.
+
+- [ ] **Step 3: Implement the new factory**
+
+Modify `mobile/lib/services/blocklist_content_filter.dart`. Append (do not remove `createBlocklistFilter` — we keep both until Phase 3):
+
+```dart
+import 'package:content_policy/content_policy.dart';
+
+/// Creates a [BlockedVideoFilter] backed by [engine].
+///
+/// [stateProvider] is invoked on every call so the filter always reads
+/// the freshest [ContentPolicyState] snapshot without capturing a stale
+/// copy.
+BlockedVideoFilter createPolicyEngineFilter(
+  ContentPolicyEngine engine,
+  ContentPolicyState Function() stateProvider,
+) {
+  return (String pubkey) {
+    final decision = engine.evaluate(
+      PolicyInput(pubkey: pubkey),
+      stateProvider(),
+    );
+    return decision is Block;
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mobile && flutter test test/services/blocklist_content_filter_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Route the repository provider through the flag**
+
+Find where `videos_repository` is constructed — in `mobile/lib/providers/app_providers.dart` there is a provider that constructs `VideosRepository` with a `blockFilter:` argument. Locate by searching for `blockFilter:` in that file. Update the provider to switch based on the flag:
+
+```dart
+import 'package:content_policy/content_policy.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+
+// Inside the videos_repository provider:
+final flagService = ref.watch(featureFlagServiceProvider);
+final useV2 = flagService.isEnabled(FeatureFlag.contentPolicyV2);
+
+final blocklistService = ref.watch(contentBlocklistServiceProvider);
+
+final blockFilter = useV2
+    ? createPolicyEngineFilter(
+        ref.watch(contentPolicyEngineProvider),
+        () => blocklistService.currentState,
+      )
+    : createBlocklistFilter(blocklistService);
+
+// Pass blockFilter into the VideosRepository constructor as before.
+```
+
+> **Pre-flight**: exact provider path in `app_providers.dart` varies — search for the `VideosRepository(` constructor call. The line numbers shift across commits. If a `videos_repository:` provider doesn't exist in `app_providers.dart`, search for the constructor across `mobile/lib/` with `rg "VideosRepository\(" mobile/lib`.
+
+- [ ] **Step 6: Run affected tests**
+
+Run: `cd mobile && flutter test test/providers/video_events_provider_blocklist_test.dart`
+Expected: PASS. The flag defaults OFF, so behavior is unchanged.
+
+- [ ] **Step 7: Write a flag-ON test for the provider wiring**
+
+Create `mobile/test/providers/video_events_provider_policy_engine_test.dart` that overrides `featureFlagServiceProvider` to return `contentPolicyV2: true`, seeds a blocked pubkey via the blocklist service, and asserts the engine-backed filter drops its events. Pattern-match existing tests (`video_events_provider_blocklist_test.dart`) for setup.
+
+- [ ] **Step 8: Run the new test**
+
+Run: `cd mobile && flutter test test/providers/video_events_provider_policy_engine_test.dart`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add mobile/lib/services/blocklist_content_filter.dart \
+        mobile/lib/providers/app_providers.dart \
+        mobile/test/services/blocklist_content_filter_test.dart \
+        mobile/test/providers/video_events_provider_policy_engine_test.dart
+git commit -m "feat(videos_repository): route block filter through engine when flag on"
+```
+
+### Task 1.6: Parse-gate at other repositories (comments, profile, hashtag, likes, reposts, notifications)
+
+Each repository under `mobile/packages/<name>_repository/` that converts relay events or REST rows into app models needs the same hook. Pattern:
+
+1. Add (if missing) a `BlockedAuthorFilter = bool Function(String pubkey)` typedef in that repository's `lib/src/`, mirroring `video_content_filter.dart`.
+2. Accept an optional filter in the repository constructor.
+3. At every `fromJson` / `fromEvent` / row-to-model conversion, return `null` or skip when the filter returns `true`.
+4. Wire the filter at the repository's Riverpod provider in `mobile/lib/providers/app_providers.dart`, routing through the flag exactly as Task 1.5.
+
+> **Important**: each of these repositories currently has **no** author filter. The spec's audit calls out comments, profile feeds, hashtag feeds, notifications, search as leak surfaces. This task is where those leaks get closed. Do one repository at a time, each as its own test-first sub-commit.
+
+**Repository sub-tasks** (each its own TDD cycle and commit):
+
+- [ ] **Sub-task 1.6.a — `comments_repository`**
+  - Files: `mobile/packages/comments_repository/lib/src/{comments_repository.dart, blocked_author_filter.dart}`, corresponding test file.
+  - Find every `Comment.fromJson` / `Comment` construction site in `comments_repository.dart` — gate each one with `if (_blockFilter?.call(authorPubkey) ?? false) continue;` (or `return null` for single-item paths).
+  - Integration test: seed a blocked author in the test engine's state; publish a comment event into the repository's stream; assert the state has no matching comment.
+  - Commit: `feat(comments_repository): engine-gate comment parsing`.
+
+- [ ] **Sub-task 1.6.b — `profile_repository`**
+  - Files: `mobile/packages/profile_repository/lib/src/profile_repository.dart` + test.
+  - Profile repository handles both own and other profiles. Important: **do not** filter the current user's own profile fetch (SelfReferenceRule already handles that, but the repository may have a direct path that bypasses the engine). Manually audit: `ProfileRepository.getProfile(pubkey)` should still return the user's own profile unconditionally.
+  - Gate at the `Profile.fromJson`/`fromEvent` boundary. For the list-shaped endpoints (follower/following lists), filter the list before returning.
+  - Commit: `feat(profile_repository): engine-gate profile parsing`.
+
+- [ ] **Sub-task 1.6.c — `hashtag_repository`**
+  - Files: `mobile/packages/hashtag_repository/lib/src/*.dart` + test.
+  - Filter at the hashtag search / hashtag-feed response parse boundary.
+  - Commit: `feat(hashtag_repository): engine-gate hashtag feed parsing`.
+
+- [ ] **Sub-task 1.6.d — `likes_repository`** / `reposts_repository`
+  - Files: `mobile/packages/likes_repository/lib/src/*.dart`, `mobile/packages/reposts_repository/lib/src/*.dart`, plus tests.
+  - Each produces events authored by third parties. Gate at parse.
+  - Commits: `feat(likes_repository): engine-gate like parsing`, `feat(reposts_repository): engine-gate repost parsing`.
+
+- [ ] **Sub-task 1.6.e — `notification_repository`**
+  - Files: `mobile/packages/notification_repository/lib/src/*.dart` + test.
+  - Notifications are generated from third-party events naming the current user. Gate at the parse boundary that ingests those events, so a muted author cannot generate a notification.
+  - Commit: `feat(notification_repository): engine-gate notification parsing`.
+
+Each sub-task follows the exact TDD structure shown in Task 1.5 (failing test, minimal implementation, passing test, commit). The reviewing agent should verify that after each sub-task, the file's existing tests still pass.
+
+### Task 1.7: Parse-gate at the Nostr envelope — `relay_pool.dart`
+
+The videos repository already has a parse seam at the event level. Other surfaces route through the Nostr SDK's `Event.fromJson` (at `mobile/packages/nostr_sdk/lib/event.dart:46`) and downstream handlers in `relay_pool.dart` (line 268), `nostr_connect_session.dart` (line 373), and `relay_isolate_worker.dart` (line 90). A blocked author's event gets to `Event.fromJson`, then flows through the relay pool to every subscriber.
+
+The spec's ingress invariant says: no Dart object for blocked content. Perfect enforcement requires gating at `Event.fromJson` or at every relay subscription delivery point. Gating inside `Event.fromJson` is invasive and couples the Nostr SDK package to the app-level policy engine — unacceptable. Instead, we gate at each subscription delivery seam.
+
+The existing videos-repo seam handles the highest-volume path. This task adds a second seam at the relay-pool dispatcher that is used by the Nostr client's low-level subscribers (used by `ContentBlocklistService` itself and other services that don't go through repositories).
+
+**Files:**
+- Modify: `mobile/packages/nostr_client/lib/src/nostr_client.dart`
+- Test: `mobile/packages/nostr_client/test/src/nostr_client_test.dart`
+
+- [ ] **Step 1: Audit the subscribe pathway**
+
+Read `mobile/packages/nostr_client/lib/src/nostr_client.dart` end-to-end and identify the single point where incoming events are dispatched to subscribers (likely a `.map` or `_emit` on the returned `Stream<Event>`). Record the line number.
+
+- [ ] **Step 2: Add an optional filter hook**
+
+Extend `NostrClient`'s constructor (or its `subscribe` method — whichever is least disruptive) to accept an optional `bool Function(String pubkey)? authorFilter`. Skip emission when the filter returns `true`.
+
+Mirror `BlockedVideoFilter`'s shape so the wiring at the app_providers layer is identical.
+
+- [ ] **Step 3: Write failing tests**
+
+Add to `mobile/packages/nostr_client/test/src/nostr_client_test.dart`:
+
+```dart
+test('subscribe drops events whose author the filter blocks', () async {
+  // Use the existing mock NostrClient test harness (see file's setUp).
+  // Arrange: filter blocks 'blocked-hex'.
+  // Act: push two events through the mock relay — one from 'blocked-hex',
+  //   one from 'allowed-hex'.
+  // Assert: only the 'allowed-hex' event is delivered to the subscriber.
+});
+```
+
+- [ ] **Step 4: Implement minimal change and verify test passes**
+
+Run: `cd mobile/packages/nostr_client && dart test`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the filter at the provider**
+
+In `mobile/lib/providers/app_providers.dart`, the `NostrClient` / `NostrService` provider: pass the engine-backed filter (behind the flag). Keep OFF-path behavior unchanged.
+
+- [ ] **Step 6: Run the full relay integration test suite**
+
+Run: `cd mobile && flutter test test/integration/`
+Expected: existing integration tests still pass (flag is off in those tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mobile/packages/nostr_client mobile/lib/providers/app_providers.dart
+git commit -m "feat(nostr_client): author filter hook at subscription dispatcher"
+```
+
+### Task 1.8: Surface regression tests under flag-ON
+
+These are the regression tests that would have caught #948 staying fixed. Each mirrors a content surface; each seeds a muted/blocked pubkey into the blocklist service, pushes events or REST rows through the repository, and asserts the resulting BLoC/Provider state never contains the blocked author.
+
+Create under `mobile/test/content_policy/surfaces/` (new directory):
+
+- [ ] **Sub-task 1.8.a — `home_feed_blocked_author_test.dart`** — blocked author never reaches `video_events_provider` state.
+- [ ] **Sub-task 1.8.b — `search_blocked_author_test.dart`** — video search results filter blocked authors.
+- [ ] **Sub-task 1.8.c — `hashtag_feed_blocked_author_test.dart`** — hashtag feeds filter blocked authors.
+- [ ] **Sub-task 1.8.d — `other_profile_feed_blocked_author_test.dart`** — a third party's profile grid filters blocked-by-us content.
+- [ ] **Sub-task 1.8.e — `comments_blocked_author_test.dart`** — comments from blocked authors are absent.
+- [ ] **Sub-task 1.8.f — `notifications_blocked_author_test.dart`** — no notification is generated from a blocked author.
+
+Each test:
+1. Overrides `featureFlagServiceProvider` to enable `contentPolicyV2`.
+2. Seeds a blocked pubkey via `contentBlocklistServiceProvider`.
+3. Pumps the relevant BLoC/Provider.
+4. Asserts the blocked author's content/event/notification is absent from the final state.
+
+Commit each as: `test(content_policy): assert <surface> filters blocked authors`.
+
+### Task 1.9: Disclosure tests — negative assertions
+
+The spec requires: (a) no user-visible copy reveals a block relationship, (b) release-build logs must not contain `MutualMuteRule` or pubkey literals.
+
+**Files:**
+- Test: `mobile/test/content_policy/disclosure/copy_grep_test.dart` (new)
+- Test: `mobile/test/content_policy/disclosure/logging_test.dart` (new)
+
+- [ ] **Step 1: Copy-grep CI guard**
+
+Write `mobile/test/content_policy/disclosure/copy_grep_test.dart`:
+
+```dart
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('no user-visible copy reveals block relationship', () async {
+    final forbidden = [
+      RegExp(r'blocked you', caseSensitive: false),
+      RegExp(r'blocked by', caseSensitive: false),
+      RegExp(r'not accepting', caseSensitive: false),
+      RegExp(r'user has muted you', caseSensitive: false),
+    ];
+
+    final libDir = Directory('lib');
+    final arb = Directory('lib/l10n'); // Adjust to actual l10n path
+    final dirs = [libDir, if (arb.existsSync()) arb];
+
+    for (final dir in dirs) {
+      await for (final entity in dir.list(recursive: true, followLinks: false)) {
+        if (entity is! File) continue;
+        if (!entity.path.endsWith('.dart') && !entity.path.endsWith('.arb')) {
+          continue;
+        }
+        final content = await entity.readAsString();
+        for (final pattern in forbidden) {
+          final match = pattern.firstMatch(content);
+          expect(
+            match,
+            isNull,
+            reason: '${entity.path} contains forbidden copy '
+                'matching ${pattern.pattern}',
+          );
+        }
+      }
+    }
+  });
+}
+```
+
+- [ ] **Step 2: Logging assertion**
+
+Write `mobile/test/content_policy/disclosure/logging_test.dart` that pumps a widget tree with the engine enabled, routes a blocked event through it, and asserts no logger output contains `'MutualMuteRule'` or the blocked pubkey literal. Use `dart:developer` log capture via `debugPrint` override.
+
+- [ ] **Step 3: Run both tests**
+
+Run: `cd mobile && flutter test test/content_policy/disclosure/`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/test/content_policy/disclosure/
+git commit -m "test(content_policy): disclosure invariant guards (copy + logs)"
+```
+
+### Task 1.10: Cache invalidation on mute/unmute
+
+When `blockUser` / `unblockUser` is called, the state stream emits; any session cache holding content from the now-blocked pubkey must invalidate so next reads go through the parse-gate.
+
+For Riverpod: watch the blocklist version counter (already exists: `blocklistVersionProvider`) in the relevant feed providers, so they rebuild on change. This is the *existing* pattern — we verify it still holds under the engine path. Audit each feed provider identified in Chunk 1 Task 1.5/1.6 to confirm it invalidates when `blocklistVersionProvider` bumps.
+
+For BLoCs: each feed BLoC that holds its own cache (e.g. `VideoFeedBloc`, `CommentsBloc`) must subscribe to `contentBlocklistService.stateStream` and dispatch a refresh event.
+
+**Files:**
+- Modify: BLoCs in `mobile/lib/blocs/*/` that cache third-party content.
+
+- [ ] **Step 1: Audit**
+
+Run a grep: `rg "contentBlocklistServiceProvider|contentBlocklistService" mobile/lib/blocs` and list every hit.
+
+- [ ] **Step 2: Add stream subscription + refresh for each identified BLoC**
+
+Pattern (example for `VideoFeedBloc`):
+
+```dart
+VideoFeedBloc(..., ContentBlocklistService blocklist) : ... {
+  _stateSub = blocklist.stateStream.listen(
+    (_) => add(const VideoFeedPolicyStateChanged()),
+  );
+}
+
+@override
+Future<void> close() async {
+  await _stateSub.cancel();
+  return super.close();
+}
+```
+
+And add an event handler that re-runs the current fetch via the engine-gated repository.
+
+- [ ] **Step 3: Write bloc_tests**
+
+For each BLoC that got the new subscription, add a `blocTest` that seeds blocked data, adds a block, and expects a refreshed state without the blocked content.
+
+- [ ] **Step 4: Commit each BLoC change separately**
+
+Commits like `feat(video_feed_bloc): refresh on policy state change`.
+
+### Task 1.11: Phase 1 end-of-chunk verification
+
+- [ ] **Step 1: Run the full Flutter test suite**
+
+Run: `cd mobile && flutter test`
+Expected: all tests pass. Any failures block chunk close.
+
+- [ ] **Step 2: Run analyzer**
+
+Run: `cd mobile && flutter analyze lib test integration_test`
+Expected: `No issues found!`
+
+- [ ] **Step 3: Integration smoke test, flag OFF (default)**
+
+Boot the app against the local Docker stack and confirm feeds, search, comments, profile grids all still work.
+
+- [ ] **Step 4: Integration smoke test, flag ON**
+
+Toggle `contentPolicyV2` on in the feature flag screen. Block a test user. Confirm their content disappears from every surface audited. Record a short manual-QA checklist in the PR description.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit --allow-empty -m "chore(content_policy): Phase 1 ready for review"
+```
+
+---
+
+## Chunk 3: Phase 2 — Interaction gating (`canTarget`)
+
+All affordances targeting a specific pubkey consult `engine.canTarget(pubkey, state)`. When it returns `false`, the affordance is **absent** — no disabled state, no tooltip, no copy.
+
+### Task 2.1: Provider helpers for `canTarget`
+
+**Files:**
+- Modify: `mobile/lib/providers/app_providers.dart`
+- Test: `mobile/test/providers/can_target_provider_test.dart` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Write `mobile/test/providers/can_target_provider_test.dart` that uses `ProviderContainer` with overrides for engine + blocklist, asserts `canTargetProvider('target-hex')` returns expected bool for various states.
+
+- [ ] **Step 2: Add the provider**
+
+Inside `app_providers.dart`:
+
+```dart
+/// Reactive bool provider that answers canTarget for a given pubkey.
+///
+/// Rebuilds when the blocklist state stream emits.
+@riverpod
+bool canTarget(CanTargetRef ref, String pubkey) {
+  final flagService = ref.watch(featureFlagServiceProvider);
+  final engine = ref.watch(contentPolicyEngineProvider);
+  final blocklist = ref.watch(contentBlocklistServiceProvider);
+  // Also re-read on state changes:
+  ref.watch(blocklistVersionProvider);
+
+  if (!flagService.isEnabled(FeatureFlag.contentPolicyV2)) return true;
+  return engine.canTarget(pubkey, blocklist.currentState);
+}
+```
+
+- [ ] **Step 3: Codegen + test pass**
+
+Run: `cd mobile && dart run build_runner build --delete-conflicting-outputs`
+Run: `cd mobile && flutter test test/providers/can_target_provider_test.dart`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/lib/providers/app_providers.dart mobile/lib/providers/app_providers.g.dart mobile/test/providers/can_target_provider_test.dart
+git commit -m "feat(providers): canTargetProvider for affordance gating"
+```
+
+### Task 2.2: Gate Follow/Unfollow affordance
+
+**Files:**
+- Modify: `mobile/lib/widgets/profile/follow_from_profile_button.dart`
+- Modify: `mobile/lib/widgets/video_feed_item/video_follow_button.dart`
+- Test: widget tests at `mobile/test/widgets/profile/follow_from_profile_button_test.dart` and analogue for `video_follow_button`.
+
+- [ ] **Step 1: Write failing widget tests**
+
+For each follow-button widget, write a widget test that pumps the widget inside a `ProviderScope` with an override making `canTargetProvider(targetPubkey)` return `false`, and asserts `find.byType(FollowFromProfileButton)` / analogue renders nothing visible (zero-sized, or conditional to not build). Add a positive-case test with `true`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd mobile && flutter test test/widgets/profile/follow_from_profile_button_test.dart`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement gating**
+
+Convert the widget to `ConsumerWidget`; early-return `const SizedBox.shrink()` when `ref.watch(canTargetProvider(targetPubkey))` is `false`. No text, no icon, no tooltip.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run again — PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/widgets/profile/follow_from_profile_button.dart \
+        mobile/lib/widgets/video_feed_item/video_follow_button.dart \
+        mobile/test/widgets/profile/follow_from_profile_button_test.dart \
+        mobile/test/widgets/video_feed_item/video_follow_button_test.dart
+git commit -m "feat(ui): hide follow affordance when target blocks us"
+```
+
+### Task 2.3: Gate Send DM affordance
+
+**Files:**
+- Find the send-DM entry point (profile screen, conversation screen). Search: `rg "sendDm\|SendDirectMessage\|DmComposer" mobile/lib`.
+- Modify each entry point.
+- Add widget tests asserting absence.
+
+Pattern identical to Task 2.2: early return shrink when `canTarget` is false. One commit per site.
+
+### Task 2.4: Gate reply compose
+
+**Files:** `mobile/lib/screens/comments/widgets/comment_input.dart` and reply flows under `mobile/lib/blocs/comments/`.
+
+If the event is reachable in the UI (filtering may miss a transient), reply compose must still be hidden. Gate the compose button's build.
+
+### Task 2.5: Gate @-mention autocomplete
+
+**Files:**
+- Modify: `mobile/lib/screens/comments/widgets/mention_overlay.dart`
+- Modify: the underlying suggestion source (grep for `mentionAutocomplete` / `@` handling in the feature flags widget list).
+
+- [ ] **Step 1:** Filter the suggestion list to exclude pubkeys for which `canTarget == false`.
+- [ ] **Step 2:** Widget test: seed one target that blocks us + one that does not, confirm only one appears in suggestions.
+- [ ] **Step 3:** Commit: `feat(mentions): exclude blocked-by targets from autocomplete`.
+
+### Task 2.6: Gate share-to-user and tag-in-video pickers
+
+**Files:** search `rg "share.*user.*picker\|TagInVideoPicker" mobile/lib`.
+
+Filter the candidate list in the picker view. Widget tests and per-picker commits.
+
+### Task 2.7: Phase 2 verification
+
+- [ ] **Step 1:** Run all widget tests.
+- [ ] **Step 2:** Manual QA walkthrough: for every affordance (Follow, DM, reply, mention, share, tag) seed a pubkey that blocks us, open the UI, confirm the affordance does not render. Confirm there is no tooltip, no disabled state, no copy, no snackbar.
+- [ ] **Step 3:** Disclosure test pass: re-run the copy-grep and logging tests from Task 1.9.
+- [ ] **Step 4:** Commit: `chore(content_policy): Phase 2 ready for review`.
+
+---
+
+## Chunk 4: Phase 3 & 4 — Flag flip, removal of scattered filters, cleanup
+
+This chunk is the actual behavior change. Up to this point, the app runs unchanged for all users (flag is off by default). Here we flip the flag, remove the per-surface `.where(!shouldFilterFromFeeds(...))` calls, and delete dead code.
+
+### Task 3.1: Flip `contentPolicyV2` default to `true`
+
+**Files:** `mobile/lib/features/feature_flags/services/build_configuration.dart`
+
+- [ ] **Step 1:** Change the default for `FeatureFlag.contentPolicyV2` from `false` to `true`.
+- [ ] **Step 2:** Run full test suite — expect some tests to fail because they rely on flag-off behavior. Migrate them to the flag-on expectation (or delete if redundant with Phase 1 surface tests).
+- [ ] **Step 3:** Commit: `feat(content_policy): enable v2 engine by default`.
+
+### Task 3.2: Remove scattered `.where(!shouldFilterFromFeeds(...))` calls
+
+Per the audit in Chunk 1, callers live at (from the earlier grep):
+
+- `mobile/lib/providers/for_you_provider.dart:127, 192`
+- `mobile/lib/providers/classic_vines_provider.dart:92, 131, 182, 233`
+- `mobile/lib/providers/popular_now_feed_provider.dart:111, 247, 407, 491`
+- `mobile/lib/providers/popular_videos_feed_provider.dart:223`
+- `mobile/lib/providers/video_events_providers.dart:312, 410`
+- `mobile/lib/services/video_event_service.dart:2113, 2403, 4053`
+- `mobile/lib/screens/video_detail_screen.dart:202`
+
+For each:
+
+- [ ] Delete the `.where(...)` call (or the `if (...shouldFilterFromFeeds)` branch).
+- [ ] Delete any now-dead `final blocklistService = ref.read(contentBlocklistServiceProvider);` locals.
+- [ ] Re-run the surface regression test from Task 1.8 for that surface. It must still pass — the engine is doing the filtering now.
+- [ ] Commit per file: `refactor(<surface>): remove redundant blocklist filter, engine owns it`.
+
+### Task 3.3: Remove the `BlockedVideoFilter` "legacy" factory
+
+**Files:** `mobile/lib/services/blocklist_content_filter.dart`
+
+- [ ] **Step 1:** Delete `createBlocklistFilter` (the legacy factory). All callers now use `createPolicyEngineFilter`.
+- [ ] **Step 2:** Run: `rg "createBlocklistFilter" mobile/` — should be empty.
+- [ ] **Step 3:** Run full test suite.
+- [ ] **Step 4:** Commit: `chore(blocklist): remove legacy filter factory`.
+
+### Task 3.4: Mark `ContentBlocklistService.shouldFilterFromFeeds` deprecated
+
+**Files:** `mobile/lib/services/content_blocklist_service.dart`
+
+- [ ] **Step 1:** Annotate `shouldFilterFromFeeds` with `@Deprecated('Use ContentPolicyEngine. Removal tracked in #<issue>.')`.
+- [ ] **Step 2:** Run analyzer — tests that still call it will get deprecation warnings. Migrate or suppress the warning in each test.
+- [ ] **Step 3:** Commit: `chore(blocklist): deprecate shouldFilterFromFeeds`.
+
+### Task 3.5: Delete dead code — `mute_service.dart` and `content_moderation_service.dart`
+
+**Files:**
+- Delete: `mobile/lib/services/mute_service.dart`
+- Delete: `mobile/lib/services/content_moderation_service.dart`
+- Delete: corresponding Riverpod providers in `mobile/lib/providers/app_providers.dart` / `.g.dart`.
+
+- [ ] **Step 1:** Run: `rg "MuteService|ContentModerationService" mobile/lib` — list every usage. Confirm every site is either (a) dead code itself, or (b) a no-op path. If any active caller remains, stop and surface to the implementer.
+- [ ] **Step 2:** Delete the files.
+- [ ] **Step 3:** Codegen: `cd mobile && dart run build_runner build --delete-conflicting-outputs`.
+- [ ] **Step 4:** Run full test suite.
+- [ ] **Step 5:** File a follow-up issue: "Add `SubscribedListRule` to port ContentModerationService's subscribe-to-external-mute-list intent". Link to the spec's deferred section.
+- [ ] **Step 6:** Commit: `chore: remove dead MuteService and ContentModerationService`.
+
+### Task 3.6: Remove the feature flag
+
+Once Phase 3 has been in production for one release cycle and no rollback has been needed, the flag is safe to remove. Treat this as a separate small PR after verification.
+
+**Files:**
+- Modify: `mobile/lib/features/feature_flags/models/feature_flag.dart` — delete `contentPolicyV2`.
+- Modify: `mobile/lib/features/feature_flags/services/build_configuration.dart` — delete the case.
+- Modify: every provider that checks `flagService.isEnabled(FeatureFlag.contentPolicyV2)` — delete the branch, keep the ON-path unconditionally.
+
+- [ ] **Step 1:** Grep for `contentPolicyV2` and migrate every site.
+- [ ] **Step 2:** Delete the enum entry and default case.
+- [ ] **Step 3:** Delete any tests that toggle the flag explicitly (the engine path is now the only path).
+- [ ] **Step 4:** Run full test suite + analyzer.
+- [ ] **Step 5:** Commit: `chore(content_policy): remove v2 feature flag`.
+
+### Task 3.7: Close the loop
+
+- [ ] **Step 1:** Close #948 with a link to the surface regression tests from Task 1.8 — those are the tests that enforce the fix stays fixed.
+- [ ] **Step 2:** Update the umbrella Content Moderation epic (#604) with the completed scope.
+- [ ] **Step 3:** Post the disclosure test (Task 1.9) behavior as a CI gate, so future copy changes that try to reveal a block relationship fail the build.
+
+---
+
+## Verification before declaring done
+
+Before the plan is considered complete, the implementing agent must be able to answer **yes** to each:
+
+1. Does `cd mobile && flutter test` pass with zero failures on `main`?
+2. Does `cd mobile && flutter analyze lib test integration_test` report zero issues?
+3. Does `cd mobile/packages/content_policy && dart test` pass with 100% line coverage on every `lib/src/**` file?
+4. Is there a surface regression test (Task 1.8) for every content surface named in the spec's audit (home, explore/for-you, popular, search, hashtag, profile-by-others, comments, notifications)?
+5. Do the disclosure tests (Task 1.9) pass, and do they run on every CI build?
+6. Does a manual QA pass with the flag ON confirm: (a) blocked author's content absent from every surface, (b) affordances absent for blockees, (c) no copy or tooltip reveals the block relationship?
+7. Is the `content_policy_v2` flag removed after one release's worth of bake-in, per Task 3.6?
+
+When every answer is yes, the Content Policy Layer is complete and #948 is closed for good.
+
+---
+
+## Task index (for reviewers)
+
+**Chunk 1 — Phase 0, engine package:** 0.1 scaffold; 0.2 PolicyInput; 0.3 PolicyDecision; 0.4 ContentPolicyState; 0.5 PolicyRule; 0.6 SelfReferenceRule; 0.7 PubkeyMuteRule; 0.8 PubkeyBlockRule; 0.9 MutualMuteRule; 0.10 ContentPolicyEngine; 0.11 coverage.
+
+**Chunk 2 — Phase 1, parse-gate:** 1.1 flag; 1.2 ContentPolicyState exposure; 1.3 engine provider; 1.4 hydration pin; 1.5 videos_repository; 1.6 comments/profile/hashtag/likes/reposts/notifications; 1.7 nostr_client; 1.8 surface regression tests; 1.9 disclosure tests; 1.10 cache invalidation; 1.11 chunk verification.
+
+**Chunk 3 — Phase 2, interaction gating:** 2.1 canTarget provider; 2.2 follow; 2.3 DM; 2.4 reply compose; 2.5 mention autocomplete; 2.6 share/tag pickers; 2.7 chunk verification.
+
+**Chunk 4 — Phase 3 & 4, flag flip + cleanup:** 3.1 flip default; 3.2 remove scattered filters; 3.3 remove legacy factory; 3.4 deprecate shouldFilterFromFeeds; 3.5 delete dead services; 3.6 remove flag; 3.7 close issue.

--- a/docs/superpowers/plans/2026-04-23-content-policy-layer.md
+++ b/docs/superpowers/plans/2026-04-23-content-policy-layer.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace three overlapping moderation services with a single pure-Dart `ContentPolicyEngine` that gates every parse boundary, so blocked/muted content never becomes an in-memory object on any feed.
+**Goal:** Replace three overlapping moderation services with a single pure-Dart `ContentPolicyEngine` that gates every repository and relay-dispatch ingress boundary, so blocked/muted content never reaches app state on any feed.
 
-**Architecture:** A new `content_policy` package exposes a stateless engine composed of ordered `PolicyRule`s, plus an immutable `ContentPolicyState` value type. `ContentBlocklistService` gains `currentState` / `stream` accessors. The engine is injected into every `fromJson` / relay-event-handler boundary and at affordance-gate call sites (Follow, DM, mention, share/tag pickers). Ships behind a `content_policy_v2` feature flag until Phase 3.
+**Architecture:** A new `content_policy` package exposes a stateless engine composed of ordered `PolicyRule`s, plus an immutable `ContentPolicyState` value type. `ContentBlocklistRepository` gains `currentState` / `stateStream` accessors. The engine is injected into repository parse boundaries, REST model-construction paths, relay-event dispatch seams, and affordance-gate call sites (Follow, DM, mention, share/tag pickers). Ships behind a `content_policy_v2` feature flag until Phase 3.
 
 **Tech Stack:** Dart 3 sealed classes, `flutter_riverpod` (legacy glue), existing `FeatureFlag` enum, `shared_preferences`, `bloc_test`, `mocktail`.
 
@@ -23,8 +23,8 @@ You likely do not have context for this codebase. Before starting any task:
 - **Never truncate Nostr IDs** anywhere — code, logs, tests, analytics, debug output. Full hex pubkeys always.
 - **Disclosure invariant is a hard rule** — the app must never tell a user they have been blocked by another user. No ruleId string, no pubkey, no "MutualMute" token in any user-visible copy, snackbar, release log, analytics event, or Crashlytics breadcrumb. This affects test design (negative assertions) and logging choices throughout the plan.
 - **Existing feature flags** live at `mobile/lib/features/feature_flags/`. The enum is `mobile/lib/features/feature_flags/models/feature_flag.dart`; the service is `mobile/lib/features/feature_flags/services/feature_flag_service.dart`. Defaults are declared in `build_configuration.dart` in the same directory.
-- **Two names to reconcile** — the spec uses `ContentBlocklistRepository` (as of a rename referenced in #3227); the current code still uses `ContentBlocklistService` at `mobile/lib/services/content_blocklist_service.dart`. This plan uses the **current** name (`ContentBlocklistService`) because the rename has not yet landed. If #3227 lands before this plan is executed, globally swap `ContentBlocklistService` → `ContentBlocklistRepository` in the task text below.
-- **Existing block-filter hook** — `mobile/packages/videos_repository/lib/src/video_content_filter.dart` defines `typedef BlockedVideoFilter = bool Function(String pubkey);` and `videos_repository.dart` already calls it at four parse points (lines 787, 826, 860, 900 of the current file). The engine-injection work in Phase 1 preserves this callback shape — we replace the callback's **implementation** with `engine.evaluate(...) is Block`, not the callback's position in the code. Other repositories (comments, profile, hashtag, notifications) do **not** yet have an equivalent hook; the plan adds one.
+- **Current naming** — the blocklist rename has already landed. Use `ContentBlocklistRepository` from `mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart` and the Riverpod provider `contentBlocklistRepositoryProvider` in `mobile/lib/providers/app_providers.dart`.
+- **Existing block-filter hook** — `mobile/packages/videos_repository/lib/src/video_content_filter.dart` defines `typedef BlockedVideoFilter = bool Function(String pubkey);` and `videos_repository.dart` already calls it at four parse points (lines 787, 826, 860, 900 of the current file). The engine-injection work in Phase 1 preserves this callback shape — we replace the callback's **implementation** with `engine.evaluate(...) is Block`, not the callback's position in the code. Equivalent hooks already exist for comments, profile, and notifications; the remaining new hook work is for hashtag, likes, and reposts.
 
 ---
 
@@ -397,7 +397,7 @@ Write `mobile/packages/content_policy/lib/src/content_policy_state.dart`:
 ```dart
 /// Immutable snapshot of all state the policy engine needs to evaluate.
 ///
-/// Rebuilt by [ContentBlocklistService] whenever the underlying source
+/// Rebuilt by [ContentBlocklistRepository] whenever the underlying source
 /// data changes. The engine never mutates it; it is replaced wholesale.
 class ContentPolicyState {
   const ContentPolicyState({
@@ -1274,21 +1274,21 @@ git add mobile/lib/features/feature_flags
 git commit -m "feat(feature_flags): add contentPolicyV2 flag (default off)"
 ```
 
-### Task 1.2: Extend `ContentBlocklistService` to expose `ContentPolicyState`
+### Task 1.2: Extend `ContentBlocklistRepository` to expose `ContentPolicyState`
 
-`ContentBlocklistService` (at `mobile/lib/services/content_blocklist_service.dart`) already holds four sets internally: `_runtimeBlocklist` + `_internalBlocklist` (= user's blocks), `_mutualMuteBlocklist` (= users muting us), `_blockedByOthers` (= users blocking us via kind 30000). This task adds the mapping to `ContentPolicyState` without changing the existing sets or publishing paths.
+`ContentBlocklistRepository` (at `mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart`) already holds four sets internally: `_runtimeBlocklist` + `_internalBlocklist` (= user's blocks), `_mutualMuteBlocklist` (= users muting us), `_blockedByOthers` (= users blocking us via kind 30000). This task adds the mapping to `ContentPolicyState` without changing the existing sets or publishing paths.
 
-We introduce two new accessors: `currentState` (synchronous snapshot) and `stateStream` (broadcast stream that emits when `_notifyChanged()` fires). Phase 1 has no separate `mutedPubkeys` set in the service — kind 10000 of *our own* mute list is not yet read locally. We surface an empty `mutedPubkeys` set for now; the spec's `PubkeyMuteRule` will simply never block from this path until a later PR plumbs own-kind-10000 reading. The `MutualMuteRule` and `PubkeyBlockRule` paths do all current work.
+We introduce two new accessors: `currentState` (synchronous snapshot) and `stateStream` (broadcast stream that emits when `_notifyChanged()` fires). Phase 1 has no separate `mutedPubkeys` set in the repository — kind 10000 of *our own* mute list is not yet read locally. We surface an empty `mutedPubkeys` set for now; the spec's `PubkeyMuteRule` will simply never block from this path until a later PR plumbs own-kind-10000 reading. The `MutualMuteRule` and `PubkeyBlockRule` paths do all current work.
 
-> **Note for the implementer:** the spec assumes kind 10000 personal-mute reading exists. Today the service only reads kind 10000 events that *name us*. Do not introduce personal-mute reading in this task — that is a follow-up PR (out of scope per the spec's "Deferred" section's own-profile mute list tracking). Just leave `mutedPubkeys` empty in the mapping and add a `TODO(#XXXX)` comment naming the follow-up.
+> **Note for the implementer:** the spec assumes kind 10000 personal-mute reading exists. Today the repository only reads kind 10000 events that *name us*. Do not introduce personal-mute reading in this task — that is a follow-up PR (out of scope per the spec's "Deferred" section's own-profile mute list tracking). Just leave `mutedPubkeys` empty in the mapping and add a `TODO(#XXXX)` comment naming the follow-up.
 
 **Files:**
-- Modify: `mobile/lib/services/content_blocklist_service.dart`
-- Test: `mobile/test/services/content_blocklist_service_test.dart`
+- Modify: `mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart`
+- Test: `mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart`
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `mobile/test/services/content_blocklist_service_test.dart` (inside the existing `main() { group(...) }`):
+Add to `mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart` (inside the existing `main() { group(...) }`):
 
 ```dart
 group('ContentPolicyState exposure', () {
@@ -1296,7 +1296,7 @@ group('ContentPolicyState exposure', () {
       () async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
-    final service = ContentBlocklistService(prefs: prefs);
+    final service = ContentBlocklistRepository(prefs: prefs);
 
     const me = 'my-full-hex-pubkey';
     const blockedByUs = 'blocked-by-us-hex';
@@ -1312,7 +1312,7 @@ group('ContentPolicyState exposure', () {
   test('stateStream emits a new snapshot after block/unblock', () async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();
-    final service = ContentBlocklistService(prefs: prefs);
+    final service = ContentBlocklistRepository(prefs: prefs);
 
     const blocked = 'some-hex';
     final snapshots = <ContentPolicyState>[];
@@ -1337,12 +1337,12 @@ import 'package:content_policy/content_policy.dart';
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `cd mobile && flutter test test/services/content_blocklist_service_test.dart -n "ContentPolicyState exposure"`
-Expected: FAIL — `currentState` and `stateStream` undefined on `ContentBlocklistService`.
+Run: `cd mobile && flutter test packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart -n "ContentPolicyState exposure"`
+Expected: FAIL — `currentState` and `stateStream` undefined on `ContentBlocklistRepository`.
 
 - [ ] **Step 3: Add dep and implement**
 
-Modify `mobile/lib/services/content_blocklist_service.dart`:
+Modify `mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart`:
 
 3a. Add import:
 ```dart
@@ -1359,7 +1359,7 @@ final _stateController = StreamController<ContentPolicyState>.broadcast();
 /// Synchronous snapshot of the current policy state.
 ///
 /// Safe to call from any context, including build methods. Reads the
-/// service's internal sets and projects them into the immutable
+/// repository's internal sets and projects them into the immutable
 /// [ContentPolicyState] shape the engine consumes.
 ContentPolicyState get currentState => ContentPolicyState(
       currentUserPubkey: _ourPubkey,
@@ -1402,17 +1402,17 @@ void dispose() {
 }
 ```
 
-3f. Update `pubspec.yaml` of the `mobile` app to ensure `content_policy:` is a dep (done in Chunk 1 Task 0.1 if you added it correctly — verify).
+3f. Update `mobile/packages/content_blocklist_repository/pubspec.yaml` to ensure `content_policy:` is a dependency if it is not already inherited via workspace config.
 
 - [ ] **Step 4: Run test to verify it passes**
 
-Run: `cd mobile && flutter test test/services/content_blocklist_service_test.dart`
+Run: `cd mobile && flutter test packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart`
 Expected: PASS (full file).
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add mobile/lib/services/content_blocklist_service.dart mobile/test/services/content_blocklist_service_test.dart
+git add mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
 git commit -m "feat(blocklist): expose ContentPolicyState snapshot and stream"
 ```
 
@@ -1451,7 +1451,7 @@ Expected: FAIL — `contentPolicyEngineProvider` undefined.
 
 - [ ] **Step 3: Implement the provider**
 
-Modify `mobile/lib/providers/app_providers.dart`. Near the `contentBlocklistService` provider (around line 806), add:
+Modify `mobile/lib/providers/app_providers.dart`. Near the `contentBlocklistRepository` provider (around line 800), add:
 
 ```dart
 import 'package:content_policy/content_policy.dart';
@@ -1482,25 +1482,25 @@ git commit -m "feat(providers): add contentPolicyEngineProvider"
 
 ### Task 1.4: Bootstrap hydration — block state ready before first subscription
 
-The spec's "State hydration" section requires the policy state to be fully hydrated from local storage before the parse-gate accepts its first call. Today, `ContentBlocklistService`'s constructor already loads from `SharedPreferences` synchronously (see `_loadBlockedUsers` called from the constructor). What's missing is an explicit assertion: the `blocklistSyncBridge` (app_providers.dart:838) must not start relay subscriptions until the service's local hydration is done.
+The spec's "State hydration" section requires the policy state to be fully hydrated from local storage before the parse-gate accepts its first call. Today, `ContentBlocklistRepository`'s constructor already loads from `SharedPreferences` synchronously (see `_loadBlockedUsers` called from the constructor). What's missing is an explicit assertion: the `blocklistSyncBridge` (app_providers.dart:832) must not start relay subscriptions until the repository's local hydration is done.
 
 Local hydration is synchronous today. This task adds a test that asserts `currentState` is populated from prefs *before* any `syncBlockListsInBackground` call, so future refactors can't regress the order.
 
 **Files:**
-- Test: `mobile/test/services/content_blocklist_service_hydration_test.dart` (new)
+- Test: `mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_hydration_test.dart` (new)
 
 - [ ] **Step 1: Write the failing test**
 
-Write `mobile/test/services/content_blocklist_service_hydration_test.dart`:
+Write `mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_hydration_test.dart`:
 
 ```dart
 import 'package:content_policy/content_policy.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:openvine/services/content_blocklist_service.dart';
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  group('ContentBlocklistService hydration', () {
+  group('ContentBlocklistRepository hydration', () {
     test('currentState reflects persisted blocks before any sync call',
         () async {
       // Simulate an app restart with persisted state.
@@ -1509,7 +1509,7 @@ void main() {
       });
       final prefs = await SharedPreferences.getInstance();
 
-      final service = ContentBlocklistService(prefs: prefs);
+      final service = ContentBlocklistRepository(prefs: prefs);
 
       // No relay sync has happened — currentState must already include
       // the persisted block.
@@ -1521,7 +1521,7 @@ void main() {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
 
-      final service = ContentBlocklistService(prefs: prefs);
+      final service = ContentBlocklistRepository(prefs: prefs);
 
       final state = service.currentState;
       expect(state.blockedPubkeys, isEmpty);
@@ -1534,19 +1534,21 @@ void main() {
 
 - [ ] **Step 2: Run test to verify it fails or passes**
 
-Run: `cd mobile && flutter test test/services/content_blocklist_service_hydration_test.dart`
+Run: `cd mobile && flutter test packages/content_blocklist_repository/test/src/content_blocklist_repository_hydration_test.dart`
 Expected: likely PASSES already because constructor hydration exists. The value of this test is documenting the invariant — future refactors that break synchronous hydration will fail here.
 
 - [ ] **Step 3: Commit**
 
 ```bash
-git add mobile/test/services/content_blocklist_service_hydration_test.dart
+git add mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_hydration_test.dart
 git commit -m "test(blocklist): pin synchronous prefs hydration invariant"
 ```
 
 ### Task 1.5: Parse-gate at `videos_repository` — engine behind flag
 
 The repository already accepts a `BlockedVideoFilter` callback. We replace its *source* (still a callback — `BlockedVideoFilter`'s shape doesn't change), so the repository stays decoupled from the engine. The provider factory at `app_providers.dart` is the injection seam. When `contentPolicyV2` is ON, the callback consults the engine; when OFF, it consults `shouldFilterFromFeeds` exactly as before.
+
+This task also covers the Funnelcake REST paths that `videos_repository` already funnels through `BlockedVideoFilter` (for example `getVideosByAuthor`, feed/search transformations, and other REST response loops inside the repository). No separate Funnelcake task is needed for video content as long as those paths keep using the same filter seam.
 
 **Files:**
 - Modify: `mobile/lib/services/blocklist_content_filter.dart`
@@ -1630,14 +1632,14 @@ import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 final flagService = ref.watch(featureFlagServiceProvider);
 final useV2 = flagService.isEnabled(FeatureFlag.contentPolicyV2);
 
-final blocklistService = ref.watch(contentBlocklistServiceProvider);
+final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
 
 final blockFilter = useV2
     ? createPolicyEngineFilter(
         ref.watch(contentPolicyEngineProvider),
-        () => blocklistService.currentState,
+        () => blocklistRepository.currentState,
       )
-    : createBlocklistFilter(blocklistService);
+    : createBlocklistFilter(blocklistRepository);
 
 // Pass blockFilter into the VideosRepository constructor as before.
 ```
@@ -1677,35 +1679,33 @@ Each repository under `mobile/packages/<name>_repository/` that converts relay e
 3. At every `fromJson` / `fromEvent` / row-to-model conversion, return `null` or skip when the filter returns `true`.
 4. Wire the filter at the repository's Riverpod provider in `mobile/lib/providers/app_providers.dart`, routing through the flag exactly as Task 1.5.
 
-> **Important**: each of these repositories currently has **no** author filter. The spec's audit calls out comments, profile feeds, hashtag feeds, notifications, search as leak surfaces. This task is where those leaks get closed. Do one repository at a time, each as its own test-first sub-commit.
+> **Important**: not every repository here starts from the same place. Comments, profile, and notifications already have pubkey-filter hooks; hashtag, likes, and reposts still need new ones. This task closes the remaining leak surfaces one repository at a time, each as its own test-first sub-commit.
 
 **Repository sub-tasks** (each its own TDD cycle and commit):
 
 - [ ] **Sub-task 1.6.a — `comments_repository`**
-  - Files: `mobile/packages/comments_repository/lib/src/{comments_repository.dart, blocked_author_filter.dart}`, corresponding test file.
-  - Find every `Comment.fromJson` / `Comment` construction site in `comments_repository.dart` — gate each one with `if (_blockFilter?.call(authorPubkey) ?? false) continue;` (or `return null` for single-item paths).
-  - Integration test: seed a blocked author in the test engine's state; publish a comment event into the repository's stream; assert the state has no matching comment.
+  - Files: `mobile/packages/comments_repository/lib/src/{comments_repository.dart, blocked_comment_filter.dart}`, corresponding test file.
+  - The hook already exists. Replace the provider wiring so `BlockedCommentFilter` is engine-backed when `contentPolicyV2` is ON, then add a regression test proving blocked authors never surface through the repository.
   - Commit: `feat(comments_repository): engine-gate comment parsing`.
 
 - [ ] **Sub-task 1.6.b — `profile_repository`**
-  - Files: `mobile/packages/profile_repository/lib/src/profile_repository.dart` + test.
-  - Profile repository handles both own and other profiles. Important: **do not** filter the current user's own profile fetch (SelfReferenceRule already handles that, but the repository may have a direct path that bypasses the engine). Manually audit: `ProfileRepository.getProfile(pubkey)` should still return the user's own profile unconditionally.
-  - Gate at the `Profile.fromJson`/`fromEvent` boundary. For the list-shaped endpoints (follower/following lists), filter the list before returning.
+  - Files: `mobile/packages/profile_repository/lib/src/{profile_repository.dart, blocked_profile_filter.dart}` + test.
+  - The hook already exists. Replace the provider wiring so `BlockedProfileFilter` is engine-backed when `contentPolicyV2` is ON, then verify the current user's own profile still survives via `SelfReferenceRule`.
   - Commit: `feat(profile_repository): engine-gate profile parsing`.
 
 - [ ] **Sub-task 1.6.c — `hashtag_repository`**
   - Files: `mobile/packages/hashtag_repository/lib/src/*.dart` + test.
-  - Filter at the hashtag search / hashtag-feed response parse boundary.
+  - Add a new pubkey-based filter hook at the hashtag search / hashtag-feed response parse boundary, then wire it from the provider layer.
   - Commit: `feat(hashtag_repository): engine-gate hashtag feed parsing`.
 
 - [ ] **Sub-task 1.6.d — `likes_repository`** / `reposts_repository`
   - Files: `mobile/packages/likes_repository/lib/src/*.dart`, `mobile/packages/reposts_repository/lib/src/*.dart`, plus tests.
-  - Each produces events authored by third parties. Gate at parse.
+  - Each produces events authored by third parties. Add a new pubkey-based filter hook and gate at parse.
   - Commits: `feat(likes_repository): engine-gate like parsing`, `feat(reposts_repository): engine-gate repost parsing`.
 
 - [ ] **Sub-task 1.6.e — `notification_repository`**
-  - Files: `mobile/packages/notification_repository/lib/src/*.dart` + test.
-  - Notifications are generated from third-party events naming the current user. Gate at the parse boundary that ingests those events, so a muted author cannot generate a notification.
+  - Files: `mobile/packages/notification_repository/lib/src/{notification_repository.dart, blocked_notification_filter.dart}`, `mobile/lib/notifications/providers/notification_repository_provider.dart`, plus test.
+  - The hook already exists. Replace the provider wiring so `BlockedNotificationFilter` is engine-backed when `contentPolicyV2` is ON, then verify a blocked author cannot generate a notification.
   - Commit: `feat(notification_repository): engine-gate notification parsing`.
 
 Each sub-task follows the exact TDD structure shown in Task 1.5 (failing test, minimal implementation, passing test, commit). The reviewing agent should verify that after each sub-task, the file's existing tests still pass.
@@ -1716,7 +1716,7 @@ The videos repository already has a parse seam at the event level. Other surface
 
 The spec's ingress invariant says: no Dart object for blocked content. Perfect enforcement requires gating at `Event.fromJson` or at every relay subscription delivery point. Gating inside `Event.fromJson` is invasive and couples the Nostr SDK package to the app-level policy engine — unacceptable. Instead, we gate at each subscription delivery seam.
 
-The existing videos-repo seam handles the highest-volume path. This task adds a second seam at the relay-pool dispatcher that is used by the Nostr client's low-level subscribers (used by `ContentBlocklistService` itself and other services that don't go through repositories).
+The existing videos-repo seam handles the highest-volume path. This task adds a second seam at the relay-pool dispatcher that is used by the Nostr client's low-level subscribers (used by `ContentBlocklistRepository` itself and other services that don't go through repositories).
 
 **Files:**
 - Modify: `mobile/packages/nostr_client/lib/src/nostr_client.dart`
@@ -1782,7 +1782,7 @@ Create under `mobile/test/content_policy/surfaces/` (new directory):
 
 Each test:
 1. Overrides `featureFlagServiceProvider` to enable `contentPolicyV2`.
-2. Seeds a blocked pubkey via `contentBlocklistServiceProvider`.
+2. Seeds a blocked pubkey via `contentBlocklistRepositoryProvider`.
 3. Pumps the relevant BLoC/Provider.
 4. Asserts the blocked author's content/event/notification is absent from the final state.
 
@@ -1862,21 +1862,21 @@ When `blockUser` / `unblockUser` is called, the state stream emits; any session 
 
 For Riverpod: watch the blocklist version counter (already exists: `blocklistVersionProvider`) in the relevant feed providers, so they rebuild on change. This is the *existing* pattern — we verify it still holds under the engine path. Audit each feed provider identified in Chunk 1 Task 1.5/1.6 to confirm it invalidates when `blocklistVersionProvider` bumps.
 
-For BLoCs: each feed BLoC that holds its own cache (e.g. `VideoFeedBloc`, `CommentsBloc`) must subscribe to `contentBlocklistService.stateStream` and dispatch a refresh event.
+For BLoCs: each feed BLoC that holds its own cache (e.g. `VideoFeedBloc`, `CommentsBloc`) must subscribe to `contentBlocklistRepository.stateStream` and dispatch a refresh event.
 
 **Files:**
 - Modify: BLoCs in `mobile/lib/blocs/*/` that cache third-party content.
 
 - [ ] **Step 1: Audit**
 
-Run a grep: `rg "contentBlocklistServiceProvider|contentBlocklistService" mobile/lib/blocs` and list every hit.
+Run a grep: `rg "contentBlocklistRepositoryProvider|contentBlocklistRepository" mobile/lib/blocs` and list every hit.
 
 - [ ] **Step 2: Add stream subscription + refresh for each identified BLoC**
 
 Pattern (example for `VideoFeedBloc`):
 
 ```dart
-VideoFeedBloc(..., ContentBlocklistService blocklist) : ... {
+VideoFeedBloc(..., ContentBlocklistRepository blocklist) : ... {
   _stateSub = blocklist.stateStream.listen(
     (_) => add(const VideoFeedPolicyStateChanged()),
   );
@@ -1953,7 +1953,7 @@ Inside `app_providers.dart`:
 bool canTarget(CanTargetRef ref, String pubkey) {
   final flagService = ref.watch(featureFlagServiceProvider);
   final engine = ref.watch(contentPolicyEngineProvider);
-  final blocklist = ref.watch(contentBlocklistServiceProvider);
+  final blocklist = ref.watch(contentBlocklistRepositoryProvider);
   // Also re-read on state changes:
   ref.watch(blocklistVersionProvider);
 
@@ -2076,7 +2076,7 @@ Per the audit in Chunk 1, callers live at (from the earlier grep):
 For each:
 
 - [ ] Delete the `.where(...)` call (or the `if (...shouldFilterFromFeeds)` branch).
-- [ ] Delete any now-dead `final blocklistService = ref.read(contentBlocklistServiceProvider);` locals.
+- [ ] Delete any now-dead `final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);` locals.
 - [ ] Re-run the surface regression test from Task 1.8 for that surface. It must still pass — the engine is doing the filtering now.
 - [ ] Commit per file: `refactor(<surface>): remove redundant blocklist filter, engine owns it`.
 
@@ -2089,9 +2089,9 @@ For each:
 - [ ] **Step 3:** Run full test suite.
 - [ ] **Step 4:** Commit: `chore(blocklist): remove legacy filter factory`.
 
-### Task 3.4: Mark `ContentBlocklistService.shouldFilterFromFeeds` deprecated
+### Task 3.4: Mark `ContentBlocklistRepository.shouldFilterFromFeeds` deprecated
 
-**Files:** `mobile/lib/services/content_blocklist_service.dart`
+**Files:** `mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart`
 
 - [ ] **Step 1:** Annotate `shouldFilterFromFeeds` with `@Deprecated('Use ContentPolicyEngine. Removal tracked in #<issue>.')`.
 - [ ] **Step 2:** Run analyzer — tests that still call it will get deprecation warnings. Migrate or suppress the warning in each test.
@@ -2103,6 +2103,7 @@ For each:
 - Delete: `mobile/lib/services/mute_service.dart`
 - Delete: `mobile/lib/services/content_moderation_service.dart`
 - Delete: corresponding Riverpod providers in `mobile/lib/providers/app_providers.dart` / `.g.dart`.
+- Keep `ContentBlocklistRepository` in `mobile/packages/content_blocklist_repository/`; it is the long-term state source and is not part of this cleanup.
 
 - [ ] **Step 1:** Run: `rg "MuteService|ContentModerationService" mobile/lib` — list every usage. Confirm every site is either (a) dead code itself, or (b) a no-op path. If any active caller remains, stop and surface to the implementer.
 - [ ] **Step 2:** Delete the files.

--- a/docs/superpowers/specs/2026-04-23-content-policy-layer-design.md
+++ b/docs/superpowers/specs/2026-04-23-content-policy-layer-design.md
@@ -1,0 +1,423 @@
+# Content Policy Layer — Design
+
+## Problem
+
+Users are seeing content from authors they have blocked or muted. The pattern is recurring — issue #948 reported exactly this for search in February, was closed, and the leak has returned. A full audit (see the expanded comment on #948) found that blocked-author content leaks in comments, video search, user search, hashtag feeds, other-user profile feeds, and likely notifications. Only the primary feeds, video detail screen, and DM conversations apply filtering.
+
+The root cause is architectural. The app has **three overlapping content-moderation services** — `MuteService` (dead code, `lib/services/mute_service.dart`), `ContentModerationService` (dead code, `lib/services/content_moderation_service.dart`), and `ContentBlocklistService` (the only one wired up). Filtering is applied at the presentation layer on a per-surface basis via `.where(!shouldFilterFromFeeds(...))` calls in feeds and providers. Every new feed has to remember to call the filter, and most don't.
+
+Patching each surface one-at-a-time is how #948 reopened. The fix is to move the policy boundary down, not sideways.
+
+## Goals
+
+- Make filtering a property of the system, not a convention every feature must re-apply.
+- Consolidate the three overlapping services into one policy engine + one state source.
+- Leave room for hashtag/keyword filters, subscribed moderation lists, NSFW/age gates, and future rules without re-architecting.
+- Preserve a hard invariant: the app must never tell a user they have been blocked by someone else.
+- Avoid churn — scope Phase 1 tightly enough to ship with confidence, design the interface broadly enough that the deferred features don't require rework.
+
+## Non-Goals
+
+- Admin/moderator view of unfiltered content. Handled in a separate tool; nothing in this app bypasses the policy layer.
+- Write-time cache-invalidation framework. The dominant content caches are session-scoped (Riverpod/BLoC state); the only persistent event cache is `PersonalEventCacheService` which holds the current user's own events by definition.
+- Retroactive disk scrubbing on new mute. Nothing on disk stores third-party event content.
+- Server-side filtering. Funnelcake and relays remain unaware. All filtering is client-side.
+- Relay-side NIP-42 auth / protected subscription handling. Orthogonal.
+- Hashtag/keyword/subscribed-list rules. Interface supports them; implementation deferred.
+
+## Invariants
+
+Four invariants that every component in the design must uphold.
+
+### 1. Ingress invariant
+
+Blocked content must not become a Dart object in the app's memory. The filter runs at parse time — at the boundary where raw JSON becomes `NostrEvent` or `VideoEvent`. If the policy engine says block, no object is constructed, no signature is verified, no downstream code runs.
+
+### 2. Interaction invariant
+
+The app must not offer UI affordances for interactions the recipient has blocked. When the current user's local state indicates a target pubkey has blocked us (via that pubkey's published kind 10000 or kind 30000 block list), UI affordances targeting that pubkey — follow, DM, reply, mention, tag, share-to — must be hidden, not greyed-out with an explanation, not disabled with a tooltip. Absent, full stop.
+
+### 3. Disclosure invariant
+
+The app must never tell a user they have been blocked by another user. No badge, no error message, no empty-state copy, no tooltip, no remote log, no analytics event that reveals the block relationship to the blocked user or to third parties. Plausible deniability: absence of an affordance may be inferred as many things; we never confirm.
+
+### 4. Cross-app honesty
+
+These invariants describe the behavior of *this* app. They do not prevent the user from publishing mentions, replies, or DMs via any other Nostr client. The spec is honest that this is UX policy, not protocol-level enforcement. Any "we prevent X" language in code comments or user-facing copy must be accurate about this boundary.
+
+## Architecture
+
+```
+                    ┌──────────────────────────────────┐
+                    │     ContentPolicyEngine          │
+                    │     (pure Dart, no Flutter)      │
+                    │                                  │
+                    │   evaluate(PolicyInput,          │
+                    │            ContentPolicyState)   │
+                    │     → PolicyDecision             │
+                    │                                  │
+                    │   canTarget(pubkey,              │
+                    │             ContentPolicyState)  │
+                    │     → bool                       │
+                    │                                  │
+                    │   composed of ordered            │
+                    │     List<PolicyRule>             │
+                    └──────────────────────────────────┘
+                               ▲
+                               │
+                 ┌─────────────┼─────────────┐
+                 │                           │
+      ┌──────────┴────────┐       ┌──────────┴────────┐
+      │ parse-gated       │       │   canTarget()     │
+      │ NostrEventParser  │       │   queried by UI   │
+      │ VideoEvent.fromJson│      │   affordance gates │
+      │ etc.              │       │                   │
+      │                   │       │                   │
+      │ JSON → Event?     │       │                   │
+      │ (null = dropped)  │       │                   │
+      └───────────────────┘       └───────────────────┘
+                ▲
+                │
+      ┌─────────┴──────────┐
+      │ NostrClient /      │
+      │ FunnelcakeClient   │
+      │ receive raw JSON,  │
+      │ never see Events   │
+      │ that don't parse   │
+      └────────────────────┘
+```
+
+**ContentBlocklistRepository** (already extracted per #3227) owns persistence, Nostr publish, and relay sync of mute/block state. It exposes a synchronously-hydrated `ContentPolicyState` snapshot plus a `Stream<ContentPolicyState>` for updates. The engine reads state on every evaluation; it is itself stateless.
+
+The architecture has **two query shapes** on one engine:
+
+- `evaluate(input, state) → PolicyDecision` — ingress filtering. Used by parsers.
+- `canTarget(pubkey, state) → bool` — affordance gating. Used by UI code deciding whether to render a Follow/DM/mention control.
+
+These are distinct surfaces with distinct call sites and distinct failure modes. Combining them into one API that returns a rich decision object was considered and rejected because callers in the UI don't need (and must not leak) the reason.
+
+## Components
+
+### 1. `content_policy` package
+
+New package at `mobile/packages/content_policy/`. No Flutter deps. 100% unit-testable.
+
+#### `PolicyInput`
+
+```dart
+class PolicyInput {
+  const PolicyInput({
+    required this.pubkey,
+    this.kind,
+    this.content,
+    this.tags,
+  });
+
+  final String pubkey;
+  final int? kind;
+  final String? content;
+  final List<List<String>>? tags;
+}
+```
+
+Minimal contract. Parsers construct this from the parts of the JSON they already need to read (pubkey is at a fixed key in the Nostr envelope). For Phase 1, only `pubkey` is consulted by rules.
+
+#### `PolicyDecision`
+
+```dart
+sealed class PolicyDecision {
+  const PolicyDecision();
+}
+
+final class Allow extends PolicyDecision {
+  const Allow();
+}
+
+final class Block extends PolicyDecision {
+  const Block({required this.ruleId});
+  final String ruleId;  // diagnostics only, release builds never surface
+}
+
+// Reserved for later; not implemented in Phase 1:
+// final class SoftHide extends PolicyDecision { ... }
+// final class Warn    extends PolicyDecision { ... }
+```
+
+`Block` carries a `ruleId` for local diagnostics only. Must not appear in user-visible copy, release-build logs, remote telemetry, Crashlytics breadcrumbs, or analytics events.
+
+#### `PolicyRule`
+
+```dart
+abstract interface class PolicyRule {
+  String get id;
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state);
+}
+```
+
+Rules are pure functions. No IO, no async. They read from the `ContentPolicyState` snapshot passed into each call.
+
+#### `ContentPolicyEngine`
+
+```dart
+class ContentPolicyEngine {
+  const ContentPolicyEngine(this.rules);
+  final List<PolicyRule> rules;
+
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    for (final rule in rules) {
+      final d = rule.evaluate(input, state);
+      if (d is Block) return d;
+    }
+    return const Allow();
+  }
+
+  bool canTarget(String pubkey, ContentPolicyState state) {
+    return !state.isBlockedBy(pubkey);
+  }
+}
+```
+
+- Rules are evaluated in order. Short-circuits on first `Block`.
+- `canTarget` is a simple read from `ContentPolicyState` — the mutual-mute list. It does not run the full rule pipeline; it answers one specific question.
+
+#### Rule ordering is load-bearing
+
+`SelfReferenceRule` must be first. A malformed mute list that includes the current user's own pubkey would otherwise filter the user's own content, reproducing #2192. The engine constructor asserts `SelfReferenceRule` is at position 0 when constructed from the default rule set.
+
+### 2. `ContentPolicyState`
+
+Immutable value type. The engine never mutates it; it is rebuilt by `ContentBlocklistRepository` when source data changes.
+
+```dart
+class ContentPolicyState {
+  const ContentPolicyState({
+    required this.currentUserPubkey,
+    required this.mutedPubkeys,           // user muted these (kind 10000)
+    required this.blockedPubkeys,         // user blocked these (kind 30000 d=block)
+    required this.pubkeysBlockingUs,      // from kind 30000 events naming us
+    required this.pubkeysMutingUs,        // from kind 10000 events naming us
+  });
+
+  bool isAuthorFiltered(String pubkey) =>
+      mutedPubkeys.contains(pubkey) ||
+      blockedPubkeys.contains(pubkey) ||
+      pubkeysBlockingUs.contains(pubkey) ||
+      pubkeysMutingUs.contains(pubkey);
+
+  bool isBlockedBy(String pubkey) =>
+      pubkeysBlockingUs.contains(pubkey) ||
+      pubkeysMutingUs.contains(pubkey);
+}
+```
+
+All four sets are `Set<String>` of hex pubkeys. O(1) lookup.
+
+An empty `ContentPolicyState` (no current user, empty sets) is the default during pre-hydration. See "State hydration" below for why this is a correctness concern.
+
+### 3. Phase 1 rules
+
+All ship with the engine. All consult only `PolicyInput.pubkey` plus `ContentPolicyState`.
+
+| Rule | Behavior |
+|---|---|
+| `SelfReferenceRule` | If `input.pubkey == state.currentUserPubkey`, returns `Allow` and short-circuits. Must be at position 0. |
+| `PubkeyMuteRule` | `Block` if `state.mutedPubkeys.contains(input.pubkey)`. |
+| `PubkeyBlockRule` | `Block` if `state.blockedPubkeys.contains(input.pubkey)`. |
+| `MutualMuteRule` | `Block` if `state.pubkeysBlockingUs.contains(input.pubkey)` or `state.pubkeysMutingUs.contains(input.pubkey)`. |
+
+### 4. Parse-gate integration
+
+The parse-gate is **direct integration**, not a wrapper class. The engine is injected into the existing parser constructor. There is no "raw parser" API surface.
+
+Affected parse boundaries (to be audited and mapped in the implementation plan):
+
+- `NostrEvent.fromJson` / the app's Nostr event parsing entry point.
+- `VideoEvent.fromJson` and related model `fromJson` constructors in `mobile/packages/models/`.
+- Funnelcake REST response deserialization paths (e.g. `getVideosByAuthor`, `search`, `getFeed`, `getHashtagVideos`, profile lookups).
+
+At each boundary:
+
+```dart
+Event? parse(Map<String, dynamic> json) {
+  final pubkey = json['pubkey'] as String?;
+  if (pubkey == null) return null;
+
+  final decision = _engine.evaluate(
+    PolicyInput(pubkey: pubkey, kind: json['kind'] as int?),
+    _stateProvider(),
+  );
+  if (decision is Block) {
+    _dropCounter.increment(decision.ruleId);  // dev builds only
+    return null;
+  }
+
+  // ... existing parse + signature verification
+  return Event(...);
+}
+```
+
+For list-valued REST responses, iterate the raw items, short-circuit on blocked pubkeys, skip without constructing the model.
+
+Blocked events are **never** constructed, never signature-verified, never written to any cache, never dispatched to any subscriber.
+
+### 5. Interaction gating (`canTarget`)
+
+UI surfaces that target a specific pubkey consult `engine.canTarget(pubkey, state)` to decide whether to render the affordance.
+
+Gated affordances (non-exhaustive; the implementation plan audits all):
+
+| Surface | Behavior when `canTarget` returns false |
+|---|---|
+| Follow / Unfollow button on profile | Hidden |
+| Send DM action on profile | Hidden |
+| Reply compose on any event from them | Hidden (rarely reachable since content is filtered) |
+| @-mention autocomplete | Excluded from suggestion list |
+| Share-to-user picker | Excluded |
+| Tag-in-video picker | Excluded |
+
+Gating is **absence**, not a disabled state with explanation. No copy, no tooltip, no reason.
+
+### 6. State source — `ContentBlocklistRepository`
+
+Already exists (extracted per #3227). No rewrite. Adjustments:
+
+- Expose `ContentPolicyState get currentState` — synchronous snapshot.
+- Expose `Stream<ContentPolicyState> get stream` — emits on change.
+- Ensure local-storage hydration is synchronous at app bootstrap (see "State hydration").
+- Keep publishing responsibilities (kind 10000 mute publish, kind 30000 block publish, mutual-mute sync from relays) unchanged. PR #3188 already made these reliable; no change needed.
+
+The `MutualMuteRule` reads from `pubkeysBlockingUs` / `pubkeysMutingUs`, which `ContentBlocklistRepository` already populates from subscribed kind 10000 / kind 30000 events.
+
+## State hydration
+
+**Invariant**: Policy state must be fully hydrated from local storage *before* the parse-gate accepts its first call.
+
+The app bootstrap sequence must:
+
+1. Open SharedPreferences / Hive boxes that persist the user's own mute and block lists.
+2. Construct `ContentPolicyState` from those.
+3. Register the engine with that state.
+4. Only then open WebSocket subscriptions or kick off REST fetches.
+
+Relay sync of mutual-mute data happens asynchronously after bootstrap. Until relay sync completes, the app knows *our own* mutes/blocks but not what other users have published about us. That's acceptable — during that window, the leak case is narrower (we would see content from users who blocked us until we fetch their kind 30000). This is a recognized and accepted window, not an invariant violation.
+
+Relay sync emitting a new `ContentPolicyState` on the engine's stream is what triggers cache invalidation (below).
+
+## Mute / unmute — cache invalidation
+
+When the user adds a pubkey to their mute or block list:
+
+1. `ContentBlocklistRepository` persists to local storage and publishes the updated kind 10000 / kind 30000 event (existing behavior from PR #3188).
+2. `ContentPolicyState` stream emits a new snapshot.
+3. Any in-memory session cache that could hold content from the newly-muted pubkey is invalidated:
+   - Riverpod providers: `ref.invalidate(...)` on the relevant providers; they refetch through the parse-gate.
+   - BLoCs: emit a `Refresh` event or equivalent; repositories refetch through the parse-gate.
+
+Invalidation targets the dominant surfaces: home feeds, search, hashtag feeds, profile feeds, comments, notifications.
+
+**What is *not* done:**
+
+- No sweep of `PersonalEventCacheService` (it only holds the current user's own events).
+- No sweep of image/video caches (content-addressed by URL; unreferenced media evicts via normal LRU).
+- No scan of SharedPreferences / Hive for content fields (we don't persist third-party content anywhere).
+
+Unmute works identically — state changes, caches invalidate, next fetch re-populates through the gate.
+
+## Migration plan
+
+Four phases, each independently shippable. Feature-flagged under `content_policy_v2` until Phase 3.
+
+### Phase 0 — Build the engine
+
+- Create `content_policy` package with engine, rule interface, the four Phase 1 rules, `PolicyInput`, `PolicyDecision`, `ContentPolicyState`.
+- 100% unit test coverage on the package (pure Dart, trivial to test).
+- No integration with app yet. No surfaces routed.
+
+### Phase 1 — Parse-gate integration
+
+- Inject the engine into the Nostr event parser and model `fromJson` parsers under the `content_policy_v2` flag.
+- When the flag is on, parse-gate applies. When off, parsers behave unchanged.
+- `ContentBlocklistRepository` exposes `currentState` / `stream`.
+- Bootstrap sequence hydrates policy state synchronously before any subscription or fetch opens.
+- Integration tests: publish events from a muted pubkey through a fake NostrClient; assert they never reach any BLoC/Provider state.
+
+### Phase 2 — Interaction gating
+
+- Implement `canTarget` call sites in UI: follow, DM, mention autocomplete, share/tag pickers.
+- Still feature-flagged.
+- Widget tests assert affordances are absent when mutual-mute state names the target.
+- Manual QA pass: walk through every known interaction surface, confirm invariants hold.
+
+### Phase 3 — Enable and delete scattered filters
+
+- Enable `content_policy_v2` in all builds.
+- Remove every `.where(!shouldFilterFromFeeds(...))` call in feeds, providers, and BLoCs. The parse-gate now owns that work.
+- Remove the `ContentBlocklistService` → `shouldFilterFromFeeds` call sites. Keep the method on the repository for a deprecation window; mark `@Deprecated`.
+- Close #948.
+
+### Phase 4 — Cleanup
+
+- Delete `lib/services/mute_service.dart` (dead code).
+- Delete `lib/services/content_moderation_service.dart` (dead code). File a follow-up issue to implement its subscribe-to-external-mute-list feature as a future `SubscribedListRule`.
+- Delete `shouldFilterFromFeeds` from `ContentBlocklistRepository`.
+- Remove the `content_policy_v2` flag.
+
+## Testing strategy
+
+Every layer has a clear test shape.
+
+**Engine** (`content_policy` package): pure unit tests, table-driven per rule. No mocks. No Flutter. Assertions on input → output mapping for each `PolicyDecision` branch.
+
+**Rule ordering**: test that `SelfReferenceRule` short-circuits even when later rules would block the pubkey. Test that engine construction asserts when `SelfReferenceRule` is not first.
+
+**Parsers**: integration tests with a test engine whose rules are configurable. Publish synthetic events / decode synthetic JSON; assert `null` for blocked inputs, constructed model for allowed inputs.
+
+**State hydration**: bootstrap test that constructs the app with a pre-populated mute list in SharedPreferences, asserts the engine state is ready before any subscription opens. Failure mode covered: engine queried during pre-hydration must return `Allow` (empty state) — we accept this as the documented startup window, not a bug.
+
+**Cache invalidation**: test that emitting a new `ContentPolicyState` via the repository's stream causes the relevant providers / BLoCs to refetch.
+
+**Surface regression tests** — the tests that would have caught #948 staying fixed:
+
+- For each content surface (home, popular, for-you, search, hashtag, profile, comments, notifications), a widget/integration test that seeds a muted pubkey into repository state, asserts that pubkey's content is absent from the emitted BLoC/Provider state.
+
+**Affordance gating tests**: widget tests that seed `pubkeysBlockingUs`, render the relevant UI, assert the affordance is absent. Do **not** assert on error copy, tooltip text, or any surface that would reveal the reason.
+
+**Disclosure tests** (negative assertions):
+
+- No copy string anywhere contains "blocked you", "blocked by", "not accepting" or equivalent — enforced by a source grep in CI.
+- Release-build logs do not contain `MutualMuteRule` or pubkey literals from policy decisions — enforced by test harness.
+
+## What this design deliberately rejects
+
+- **Admin/unfiltered view** — moderation happens in separate tooling. No part of this app sees unfiltered content.
+- **Stream-transformer / adapter pattern** — rejected in favor of parse-gate. Same guarantees, earlier application, no allocation of blocked objects, no signature-verify cost on blocked events.
+- **Write-time filter at the cache boundary** — rejected in favor of parse-time. Blocked content never becomes an object.
+- **Purge-on-mute disk sweep** — not needed. Session caches invalidate via provider refresh; no persistent third-party-content store exists.
+- **Separate raw parser + `PolicyGatedParser` wrapper** — rejected. Bypass becomes a public type, DI gets ambiguous, drift risk. Single parser with engine injected.
+- **`isBlockedByUser` exposed to BLoCs / UI** — rejected. `canTarget` returns a bool with no reason; `isBlockedBy` is private to the state class.
+- **Rich failure reasons on blocked interactions** — rejected. Interaction attempts that would fail due to being-blocked must appear to succeed locally (optimistic UI) or fail with a generic network-style error.
+
+## Open questions (resolve in implementation plan)
+
+1. **Exact parse boundaries to route.** The implementation plan must audit every `fromJson` that converts remote data to an in-app model, plus every WebSocket event-handler entry point. A complete list goes in the plan, not the spec.
+2. **How BLoCs currently invalidate on state change.** The plan picks a uniform invalidation signal (BLoC event vs. repository-owned stream the BLoC listens to). Existing patterns in the repo should drive this.
+3. **Feature flag plumbing.** The app has an existing feature-flag mechanism (see `2026-04-02-feature-flags-entry-design.md`); the plan wires `content_policy_v2` into it.
+4. **Whether `personal_event_cache_service.dart` needs any guard.** Per its ABOUTME it only holds the current user's own events; `SelfReferenceRule` covers that case. The plan confirms this by reading the code rather than the comment.
+
+## Deferred — future work on this layer
+
+Each of these is a follow-up issue, not in scope for Phase 1. The interface is designed so they fit without re-architecting.
+
+- **`HashtagRule`** — check event tags for muted hashtags.
+- **`KeywordRule`** — substring match on `content`. Needs its own performance budget (O(m) per event).
+- **`SubscribedListRule`** — subscribe to external curators' kind 10000 / kind 30000 events, aggregate into policy state. Folds in `ContentModerationService`'s original intent.
+- **NSFW / content-warning integration** — the existing `ContentFilterService` and moderated-content pipeline (see `2026-04-05-moderated-content-filter-design.md`) become additional rules or a sibling engine; scoping tbd.
+- **Age-gate integration** — tie into the age-restricted viewer auth work (see `2026-04-17-age-restricted-viewer-auth-parity.md`).
+
+## Related work and context
+
+- **#948** (reopened 2026-04-23) — the recurring user report. This design closes it on Phase 3.
+- **PR #3188** (merged 2026-04-20) — made mute/block publishing reliable. Upstream of this design. No overlap in scope.
+- **#3227** (closed 2026-04-22) — renamed `ContentBlocklistService` → `ContentBlocklistRepository`. This design builds on that positioning.
+- **Epic #604** — the umbrella "Content Moderation" epic. A new tracking issue for this design will link to #604.
+- **`MuteService`**, **`ContentModerationService`** — deleted in Phase 4 per this design.

--- a/docs/superpowers/specs/2026-04-23-content-policy-layer-design.md
+++ b/docs/superpowers/specs/2026-04-23-content-policy-layer-design.md
@@ -4,7 +4,7 @@
 
 Users are seeing content from authors they have blocked or muted. The pattern is recurring — issue #948 reported exactly this for search in February, was closed, and the leak has returned. A full audit (see the expanded comment on #948) found that blocked-author content leaks in comments, video search, user search, hashtag feeds, other-user profile feeds, and likely notifications. Only the primary feeds, video detail screen, and DM conversations apply filtering.
 
-The root cause is architectural. The app has **three overlapping content-moderation services** — `MuteService` (dead code, `lib/services/mute_service.dart`), `ContentModerationService` (dead code, `lib/services/content_moderation_service.dart`), and `ContentBlocklistService` (the only one wired up). Filtering is applied at the presentation layer on a per-surface basis via `.where(!shouldFilterFromFeeds(...))` calls in feeds and providers. Every new feed has to remember to call the filter, and most don't.
+The root cause is architectural. The app has **three overlapping content-moderation services** — `MuteService` (dead code, `lib/services/mute_service.dart`), `ContentModerationService` (dead code, `lib/services/content_moderation_service.dart`), and `ContentBlocklistRepository` (the only one wired up). Filtering is applied at the presentation layer on a per-surface basis via `.where(!shouldFilterFromFeeds(...))` calls in feeds and providers. Every new feed has to remember to call the filter, and most don't.
 
 Patching each surface one-at-a-time is how #948 reopened. The fix is to move the policy boundary down, not sideways.
 
@@ -31,7 +31,7 @@ Four invariants that every component in the design must uphold.
 
 ### 1. Ingress invariant
 
-Blocked content must not become a Dart object in the app's memory. The filter runs at parse time — at the boundary where raw JSON becomes `NostrEvent` or `VideoEvent`. If the policy engine says block, no object is constructed, no signature is verified, no downstream code runs.
+Blocked content must not cross an app ingress boundary into app state. The filter runs at repository parse boundaries, REST model-construction loops, and relay-subscription delivery seams. If the policy engine says block, the event or model is dropped before it is cached, exposed to app subscribers, or rendered by downstream features.
 
 ### 2. Interaction invariant
 
@@ -73,7 +73,8 @@ These invariants describe the behavior of *this* app. They do not prevent the us
       │ VideoEvent.fromJson│      │   affordance gates │
       │ etc.              │       │                   │
       │                   │       │                   │
-      │ JSON → Event?     │       │                   │
+      │ JSON/relay event  │       │                   │
+      │ → app model?      │       │                   │
       │ (null = dropped)  │       │                   │
       └───────────────────┘       └───────────────────┘
                 ▲
@@ -81,9 +82,11 @@ These invariants describe the behavior of *this* app. They do not prevent the us
       ┌─────────┴──────────┐
       │ NostrClient /      │
       │ FunnelcakeClient   │
-      │ receive raw JSON,  │
-      │ never see Events   │
-      │ that don't parse   │
+      │ receive raw JSON / │
+      │ raw relay events;  │
+      │ blocked content is │
+      │ dropped at app     │
+      │ ingress seams      │
       └────────────────────┘
 ```
 
@@ -235,6 +238,8 @@ Affected parse boundaries (to be audited and mapped in the implementation plan):
 - `VideoEvent.fromJson` and related model `fromJson` constructors in `mobile/packages/models/`.
 - Funnelcake REST response deserialization paths (e.g. `getVideosByAuthor`, `search`, `getFeed`, `getHashtagVideos`, profile lookups).
 
+For video content, the existing `videos_repository` `BlockedVideoFilter` seam is the intended enforcement point for both relay and Funnelcake REST responses. The implementation plan should treat that as the coverage mechanism for video REST paths rather than inventing a second video-only hook.
+
 At each boundary:
 
 ```dart
@@ -258,7 +263,7 @@ Event? parse(Map<String, dynamic> json) {
 
 For list-valued REST responses, iterate the raw items, short-circuit on blocked pubkeys, skip without constructing the model.
 
-Blocked events are **never** constructed, never signature-verified, never written to any cache, never dispatched to any subscriber.
+Blocked content is **never** allowed past the app ingress seam into app state, caches, or subscribers. Some low-level SDK objects may still exist transiently before the app-level seam decides to drop them; that is an accepted tradeoff to keep app policy out of the SDK.
 
 ### 5. Interaction gating (`canTarget`)
 
@@ -352,7 +357,7 @@ Four phases, each independently shippable. Feature-flagged under `content_policy
 
 - Enable `content_policy_v2` in all builds.
 - Remove every `.where(!shouldFilterFromFeeds(...))` call in feeds, providers, and BLoCs. The parse-gate now owns that work.
-- Remove the `ContentBlocklistService` → `shouldFilterFromFeeds` call sites. Keep the method on the repository for a deprecation window; mark `@Deprecated`.
+- Remove the `ContentBlocklistRepository` → `shouldFilterFromFeeds` call sites. Keep the method on the repository for a deprecation window; mark `@Deprecated`.
 - Close #948.
 
 ### Phase 4 — Cleanup


### PR DESCRIPTION
## Summary

- Adds `docs/superpowers/specs/2026-04-23-content-policy-layer-design.md` — design spec for consolidating three overlapping moderation services (`ContentBlocklistService`, dead `MuteService`, dead `ContentModerationService`) into a single parse-gated `ContentPolicyEngine` so blocked/muted content can never become an in-memory object on any feed.
- Adds `docs/superpowers/plans/2026-04-23-content-policy-layer.md` — TDD-structured implementation plan across four chunks matching the spec's phases: engine package, parse-gate, interaction gating, flag flip, and cleanup.

Relates to #948.

## Why

- Users are still seeing content from authors they've blocked. #948 was closed in February, and the leak pattern has returned.
- The pattern is architectural: filtering is applied per surface via `.where(!shouldFilterFromFeeds(...))` calls, so every new feed has to remember to reapply the rule.
- The fix moves the policy boundary down to the parse layer. Blocked events never become Dart objects.
- Four invariants are made load-bearing: ingress, interaction, disclosure, and cross-app honesty.

## Scope

Docs only. No code changes. Implementation PRs per chunk will follow.

## Test plan

- [x] Spec reviewed against current code: `ContentBlocklistService` at `mobile/lib/services/content_blocklist_service.dart`, existing `BlockedVideoFilter` seam at `mobile/packages/videos_repository/lib/src/video_content_filter.dart`, and feature flag infra at `mobile/lib/features/feature_flags/`.
- [x] Naming reconciled: spec uses `ContentBlocklistRepository` per #3227, while live code still uses `ContentBlocklistService`; the plan calls out the swap if #3227 lands first.
- [x] Phase 1 gap documented: own-kind-10000 mute-list reading does not exist yet; the plan leaves `mutedPubkeys` empty with a `TODO` and notes `PubkeyMuteRule` is dormant on that path until follow-up work.
- [x] Rebased onto current `origin/main`; PR diff is docs-only.
- [x] `cd mobile && flutter test test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart`
