### PR TITLE
fix(video-editor): localize copy and harden macos recording

### DIFF
--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2930,5 +2930,7 @@
     "shareMenuDeleteFailedNotOwner": "يمكنك حذف مقاطع الفيديو الخاصة بك فقط.",
     "videoEditorLayers": "الطبقات",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{تكرار} other{تكرارات}}",
-    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again."
+    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
+  "videoEditorAudioSegmentInstruction": "حدّد مقطع الصوت لفيديوك",
+  "videoEditorClipGalleryInstruction": "اضغط للتعديل. اضغط مطولاً واسحب لإعادة الترتيب."
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2928,7 +2928,6 @@
     "shareMenuDeleteFailedNotAuthenticated": "سجّل الدخول مرة أخرى، ثم حاول الحذف.",
     "shareMenuDeleteFailedNotInitialized": "الحذف غير جاهز بعد. حاول مرة أخرى بعد لحظة.",
     "shareMenuDeleteFailedNotOwner": "يمكنك حذف مقاطع الفيديو الخاصة بك فقط.",
-    "videoEditorLayers": "الطبقات",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{تكرار} other{تكرارات}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "حدّد مقطع الصوت لفيديوك",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2930,5 +2930,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{Loop} other{Loops}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Wähle den Audiobereich für dein Video aus",
-  "videoEditorClipGalleryInstruction": "Tippen zum Bearbeiten. Halten und ziehen zum Neuordnen."
+  "videoEditorClipGalleryInstruction": "Tippen zum Bearbeiten. Halten und ziehen zum Neuordnen.",
+  "navSearch": "Suche",
+  "navSearchTooltip": "Suchen"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2926,7 +2926,6 @@
     "shareMenuDeleteFailedNotAuthenticated": "Melde dich erneut an und versuch es nochmal.",
     "shareMenuDeleteFailedNotInitialized": "Löschen ist noch nicht bereit. Versuch es gleich noch einmal.",
     "shareMenuDeleteFailedNotOwner": "Du kannst nur deine eigenen Videos löschen.",
-    "videoEditorLayers": "Ebenen",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{Loop} other{Loops}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Wähle den Audiobereich für dein Video aus",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2928,5 +2928,7 @@
     "shareMenuDeleteFailedNotOwner": "Du kannst nur deine eigenen Videos löschen.",
     "videoEditorLayers": "Ebenen",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{Loop} other{Loops}}",
-    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again."
+    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
+  "videoEditorAudioSegmentInstruction": "Wähle den Audiobereich für dein Video aus",
+  "videoEditorClipGalleryInstruction": "Tippen zum Bearbeiten. Halten und ziehen zum Neuordnen."
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -425,6 +425,14 @@
   "videoGridDeleteConfirm": "Delete",
   "videoGridDeletingContent": "Deleting content...",
   "videoGridDeleteSuccess": "Delete request sent successfully",
+  "videoGridDeleteFailure": "Failed to delete content: {error}",
+  "@videoGridDeleteFailure": {
+    "placeholders": {
+      "error": {
+        "type": "Object"
+      }
+    }
+  },
   "exploreTabClassics": "Classics",
   "exploreTabNew": "New",
   "exploreTabPopular": "Popular",
@@ -1532,6 +1540,7 @@
   "shareMenuEditVideoSubtitle": "Update title, description, and hashtags",
   "shareMenuDeleteVideo": "Delete Video",
   "shareMenuDeleteVideoSubtitle": "Remove this video from Divine. It may still appear on other Nostr clients.",
+  "shareMenuDeleteWarning": "This sends a delete request (NIP-09) to all relays. Some relays may still keep the content.",
   "shareMenuVideoInTheseLists": "Video is in these lists:",
   "shareMenuVideoCount": "{count} videos",
   "@shareMenuVideoCount": {
@@ -1546,6 +1555,14 @@
   "shareMenuCancel": "Cancel",
   "shareMenuDelete": "Delete",
   "shareMenuDeletingContent": "Deleting content...",
+  "shareMenuFailedToDeleteContent": "Failed to delete content: {error}",
+  "@shareMenuFailedToDeleteContent": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "shareMenuDeleteRequestSent": "Video deleted",
   "shareMenuDeleteFailedNotInitialized": "Deletion isn't ready yet. Try again in a moment.",
   "shareMenuDeleteFailedNotOwner": "You can only delete your own videos.",
@@ -1578,6 +1595,14 @@
   "shareMenuVideoUpdated": "Video updated successfully",
   "shareMenuFailedToUpdateVideo": "Failed to update video: {error}",
   "@shareMenuFailedToUpdateVideo": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "shareMenuFailedToDeleteVideo": "Failed to delete video: {error}",
+  "@shareMenuFailedToDeleteVideo": {
     "placeholders": {
       "error": {
         "type": "String"
@@ -1851,6 +1876,8 @@
   "navExplore": "Explore",
   "navInbox": "Inbox",
   "navProfile": "Profile",
+  "navSearch": "Search",
+  "navSearchTooltip": "Search",
   "navMyProfile": "My Profile",
   "navNotifications": "Notifications",
   "navOpenCamera": "Open camera",
@@ -2769,6 +2796,7 @@
   "videoEditorAudioNoSoundsFoundTitle": "No sounds found",
   "videoEditorAudioNoSoundsFoundSubtitle": "Try a different search term",
   "videoEditorAudioFailedToLoadTitle": "Failed to load sounds",
+  "videoEditorAudioSegmentInstruction": "Select the audio segment for your video",
   "videoEditorDrawToolArrowSemanticLabel": "Arrow tool",
   "videoEditorDrawToolEraserSemanticLabel": "Eraser tool",
   "videoEditorDrawToolMarkerSemanticLabel": "Marker tool",
@@ -2782,6 +2810,7 @@
     }
   },
   "videoEditorLayerReorderHint": "Hold to reorder",
+  "videoEditorLayers": "Layers",
   "videoEditorShowTimelineSemanticLabel": "Show timeline",
   "videoEditorHideTimelineSemanticLabel": "Hide timeline",
   "videoEditorFeedPreviewContent": "Avoid placing content behind these areas.",
@@ -2824,6 +2853,7 @@
     }
   },
   "videoEditorTimelineClipReorderHint": "Long press to reorder",
+  "videoEditorClipGalleryInstruction": "Tap to edit. Hold and drag to reorder.",
   "videoEditorTimelineClipMoveLeft": "Move left",
   "videoEditorTimelineClipMoveRight": "Move right",
   "videoEditorTimelineLongPressToDragHint": "Long press to drag",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2810,7 +2810,6 @@
     }
   },
   "videoEditorLayerReorderHint": "Hold to reorder",
-  "videoEditorLayers": "Layers",
   "videoEditorShowTimelineSemanticLabel": "Show timeline",
   "videoEditorHideTimelineSemanticLabel": "Hide timeline",
   "videoEditorFeedPreviewContent": "Avoid placing content behind these areas.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2926,7 +2926,6 @@
     "shareMenuDeleteFailedNotAuthenticated": "Volvé a iniciar sesión y probá borrar de nuevo.",
     "shareMenuDeleteFailedNotInitialized": "El borrado no está listo todavía. Probá de nuevo en un momento.",
     "shareMenuDeleteFailedNotOwner": "Solo podés borrar tus propios videos.",
-    "videoEditorLayers": "Capas",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{bucle} other{bucles}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Selecciona el segmento de audio para tu video",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2930,5 +2930,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{bucle} other{bucles}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Selecciona el segmento de audio para tu video",
-  "videoEditorClipGalleryInstruction": "Toca para editar. Mantén presionado y arrastra para reordenar."
+  "videoEditorClipGalleryInstruction": "Toca para editar. Mantén presionado y arrastra para reordenar.",
+  "navSearch": "Buscar",
+  "navSearchTooltip": "Buscar"
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2928,5 +2928,7 @@
     "shareMenuDeleteFailedNotOwner": "Solo podés borrar tus propios videos.",
     "videoEditorLayers": "Capas",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{bucle} other{bucles}}",
-    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again."
+    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
+  "videoEditorAudioSegmentInstruction": "Selecciona el segmento de audio para tu video",
+  "videoEditorClipGalleryInstruction": "Toca para editar. Mantén presionado y arrastra para reordenar."
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2930,5 +2930,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{boucle} other{boucles}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Sélectionne le segment audio de ta vidéo",
-  "videoEditorClipGalleryInstruction": "Appuie pour modifier. Maintiens appuyé et fais glisser pour réorganiser."
+  "videoEditorClipGalleryInstruction": "Appuie pour modifier. Maintiens appuyé et fais glisser pour réorganiser.",
+  "navSearch": "Recherche",
+  "navSearchTooltip": "Rechercher"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2926,7 +2926,6 @@
     "shareMenuDeleteFailedNotAuthenticated": "Reconnecte-toi, puis réessaie de supprimer.",
     "shareMenuDeleteFailedNotInitialized": "La suppression n'est pas prête. Réessaie dans un instant.",
     "shareMenuDeleteFailedNotOwner": "Tu peux supprimer uniquement tes propres vidéos.",
-    "videoEditorLayers": "Calques",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{boucle} other{boucles}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Sélectionne le segment audio de ta vidéo",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2928,5 +2928,7 @@
     "shareMenuDeleteFailedNotOwner": "Tu peux supprimer uniquement tes propres vidéos.",
     "videoEditorLayers": "Calques",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{boucle} other{boucles}}",
-    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again."
+    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
+  "videoEditorAudioSegmentInstruction": "Sélectionne le segment audio de ta vidéo",
+  "videoEditorClipGalleryInstruction": "Appuie pour modifier. Maintiens appuyé et fais glisser pour réorganiser."
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2930,5 +2930,7 @@
     "shareMenuDeleteFailedNotOwner": "Kamu cuma bisa menghapus video milikmu sendiri.",
     "videoEditorLayers": "Lapisan",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loop}}",
-    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again."
+    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
+  "videoEditorAudioSegmentInstruction": "Pilih segmen audio untuk videomu",
+  "videoEditorClipGalleryInstruction": "Ketuk untuk mengedit. Tekan lama dan seret untuk mengurutkan ulang."
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2928,7 +2928,6 @@
     "shareMenuDeleteFailedNotAuthenticated": "Masuk lagi, lalu coba hapus.",
     "shareMenuDeleteFailedNotInitialized": "Penghapusan belum siap. Coba lagi sebentar lagi.",
     "shareMenuDeleteFailedNotOwner": "Kamu cuma bisa menghapus video milikmu sendiri.",
-    "videoEditorLayers": "Lapisan",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loop}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Pilih segmen audio untuk videomu",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2926,7 +2926,6 @@
     "shareMenuDeleteFailedNotAuthenticated": "Accedi di nuovo, poi riprova a eliminare.",
     "shareMenuDeleteFailedNotInitialized": "L'eliminazione non è ancora pronta. Riprova tra un attimo.",
     "shareMenuDeleteFailedNotOwner": "Puoi eliminare solo i tuoi video.",
-    "videoEditorLayers": "Livelli",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loop}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Seleziona il segmento audio per il tuo video",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2928,5 +2928,7 @@
     "shareMenuDeleteFailedNotOwner": "Puoi eliminare solo i tuoi video.",
     "videoEditorLayers": "Livelli",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loop}}",
-    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again."
+    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
+  "videoEditorAudioSegmentInstruction": "Seleziona il segmento audio per il tuo video",
+  "videoEditorClipGalleryInstruction": "Tocca per modificare. Tieni premuto e trascina per riordinare."
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2930,5 +2930,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loop}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Seleziona il segmento audio per il tuo video",
-  "videoEditorClipGalleryInstruction": "Tocca per modificare. Tieni premuto e trascina per riordinare."
+  "videoEditorClipGalleryInstruction": "Tocca per modificare. Tieni premuto e trascina per riordinare.",
+  "navSearch": "Cerca",
+  "navSearchTooltip": "Cerca"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2928,7 +2928,6 @@
     "shareMenuDeleteFailedNotAuthenticated": "もう一度ログインしてから削除してね。",
     "shareMenuDeleteFailedNotInitialized": "削除の準備がまだだよ。少し待ってからもう一度試してね。",
     "shareMenuDeleteFailedNotOwner": "自分の動画だけ削除できるよ。",
-    "videoEditorLayers": "レイヤー",
     "videoFeedLoopCountLine": "{compactCount}{count, plural, other{ループ}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "動画に使うオーディオ範囲を選択",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2930,5 +2930,7 @@
     "shareMenuDeleteFailedNotOwner": "自分の動画だけ削除できるよ。",
     "videoEditorLayers": "レイヤー",
     "videoFeedLoopCountLine": "{compactCount}{count, plural, other{ループ}}",
-    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again."
+    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
+  "videoEditorAudioSegmentInstruction": "動画に使うオーディオ範囲を選択",
+  "videoEditorClipGalleryInstruction": "タップして編集。長押ししてドラッグで並べ替え。"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2219,5 +2219,7 @@
     "shareMenuDeleteFailedNotOwner": "내가 올린 영상만 삭제할 수 있어요.",
     "videoEditorLayers": "레이어",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, other{루프}}",
-    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again."
+    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
+  "videoEditorAudioSegmentInstruction": "동영상에 사용할 오디오 구간을 선택하세요",
+  "videoEditorClipGalleryInstruction": "탭해서 편집하세요. 길게 누르고 드래그해 순서를 바꾸세요."
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2217,7 +2217,6 @@
     "shareMenuDeleteFailedNotAuthenticated": "다시 로그인한 뒤 삭제를 시도해요.",
     "shareMenuDeleteFailedNotInitialized": "삭제 준비가 아직 안 됐어요. 잠시 뒤에 다시 시도해요.",
     "shareMenuDeleteFailedNotOwner": "내가 올린 영상만 삭제할 수 있어요.",
-    "videoEditorLayers": "레이어",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, other{루프}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "동영상에 사용할 오디오 구간을 선택하세요",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2928,5 +2928,7 @@
     "shareMenuDeleteFailedNotOwner": "Je kunt alleen je eigen video's verwijderen.",
     "videoEditorLayers": "Lagen",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loops}}",
-    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again."
+    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
+  "videoEditorAudioSegmentInstruction": "Selecteer het audiofragment voor je video",
+  "videoEditorClipGalleryInstruction": "Tik om te bewerken. Houd vast en sleep om te herordenen."
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2926,7 +2926,6 @@
     "shareMenuDeleteFailedNotAuthenticated": "Log opnieuw in en probeer te verwijderen.",
     "shareMenuDeleteFailedNotInitialized": "Verwijderen is nog niet klaar. Probeer het zo meteen opnieuw.",
     "shareMenuDeleteFailedNotOwner": "Je kunt alleen je eigen video's verwijderen.",
-    "videoEditorLayers": "Lagen",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loops}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Selecteer het audiofragment voor je video",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2930,5 +2930,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loops}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Selecteer het audiofragment voor je video",
-  "videoEditorClipGalleryInstruction": "Tik om te bewerken. Houd vast en sleep om te herordenen."
+  "videoEditorClipGalleryInstruction": "Tik om te bewerken. Houd vast en sleep om te herordenen.",
+  "navSearch": "Zoeken",
+  "navSearchTooltip": "Zoeken"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2930,5 +2930,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{pętla} few{pętle} many{pętli} other{pętli}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Wybierz fragment audio dla swojego filmu",
-  "videoEditorClipGalleryInstruction": "Dotknij, aby edytować. Przytrzymaj i przeciągnij, aby zmienić kolejność."
+  "videoEditorClipGalleryInstruction": "Dotknij, aby edytować. Przytrzymaj i przeciągnij, aby zmienić kolejność.",
+  "navSearch": "Szukaj",
+  "navSearchTooltip": "Szukaj"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2928,5 +2928,7 @@
     "shareMenuDeleteFailedNotOwner": "Możesz usuwać tylko własne filmy.",
     "videoEditorLayers": "Warstwy",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{pętla} few{pętle} many{pętli} other{pętli}}",
-    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again."
+    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
+  "videoEditorAudioSegmentInstruction": "Wybierz fragment audio dla swojego filmu",
+  "videoEditorClipGalleryInstruction": "Dotknij, aby edytować. Przytrzymaj i przeciągnij, aby zmienić kolejność."
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2926,7 +2926,6 @@
     "shareMenuDeleteFailedNotAuthenticated": "Zaloguj się ponownie i spróbuj usunąć.",
     "shareMenuDeleteFailedNotInitialized": "Usuwanie nie jest jeszcze gotowe. Spróbuj ponownie za chwilę.",
     "shareMenuDeleteFailedNotOwner": "Możesz usuwać tylko własne filmy.",
-    "videoEditorLayers": "Warstwy",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{pętla} few{pętle} many{pętli} other{pętli}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Wybierz fragment audio dla swojego filmu",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2928,5 +2928,7 @@
     "shareMenuDeleteFailedNotOwner": "Só podes apagar os teus próprios vídeos.",
     "videoEditorLayers": "Camadas",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loops}}",
-    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again."
+    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
+  "videoEditorAudioSegmentInstruction": "Selecione o trecho de áudio para seu vídeo",
+  "videoEditorClipGalleryInstruction": "Toque para editar. Pressione e arraste para reordenar."
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2926,7 +2926,6 @@
     "shareMenuDeleteFailedNotAuthenticated": "Inicia sessão outra vez e tenta apagar.",
     "shareMenuDeleteFailedNotInitialized": "A exclusão ainda não está pronta. Tenta de novo daqui a pouco.",
     "shareMenuDeleteFailedNotOwner": "Só podes apagar os teus próprios vídeos.",
-    "videoEditorLayers": "Camadas",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loops}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Selecione o trecho de áudio para seu vídeo",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2930,5 +2930,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loops}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Selecione o trecho de áudio para seu vídeo",
-  "videoEditorClipGalleryInstruction": "Toque para editar. Pressione e arraste para reordenar."
+  "videoEditorClipGalleryInstruction": "Toque para editar. Pressione e arraste para reordenar.",
+  "navSearch": "Pesquisar",
+  "navSearchTooltip": "Pesquisar"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2926,7 +2926,6 @@
     "shareMenuDeleteFailedNotAuthenticated": "Autentifică-te din nou, apoi încearcă să ștergi.",
     "shareMenuDeleteFailedNotInitialized": "Ștergerea nu e încă gata. Încearcă din nou peste un moment.",
     "shareMenuDeleteFailedNotOwner": "Poți șterge doar propriile videoclipuri.",
-    "videoEditorLayers": "Straturi",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{buclă} other{bucle}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Alege segmentul audio pentru videoclipul tău",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2930,5 +2930,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{buclă} other{bucle}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Alege segmentul audio pentru videoclipul tău",
-  "videoEditorClipGalleryInstruction": "Atinge pentru editare. Ține apăsat și trage pentru reordonare."
+  "videoEditorClipGalleryInstruction": "Atinge pentru editare. Ține apăsat și trage pentru reordonare.",
+  "navSearch": "Caută",
+  "navSearchTooltip": "Caută"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2928,5 +2928,7 @@
     "shareMenuDeleteFailedNotOwner": "Poți șterge doar propriile videoclipuri.",
     "videoEditorLayers": "Straturi",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{buclă} other{bucle}}",
-    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again."
+    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
+  "videoEditorAudioSegmentInstruction": "Alege segmentul audio pentru videoclipul tău",
+  "videoEditorClipGalleryInstruction": "Atinge pentru editare. Ține apăsat și trage pentru reordonare."
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2928,5 +2928,7 @@
     "shareMenuDeleteFailedNotOwner": "Du kan bara ta bort dina egna videor.",
     "videoEditorLayers": "Lager",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loopar}}",
-    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again."
+    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
+  "videoEditorAudioSegmentInstruction": "Välj ljudsegmentet för din video",
+  "videoEditorClipGalleryInstruction": "Tryck för att redigera. Håll ned och dra för att ändra ordning."
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2926,7 +2926,6 @@
     "shareMenuDeleteFailedNotAuthenticated": "Logga in igen och försök ta bort.",
     "shareMenuDeleteFailedNotInitialized": "Borttagningen är inte redo än. Försök igen om en stund.",
     "shareMenuDeleteFailedNotOwner": "Du kan bara ta bort dina egna videor.",
-    "videoEditorLayers": "Lager",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loopar}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Välj ljudsegmentet för din video",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2930,5 +2930,7 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loopar}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Välj ljudsegmentet för din video",
-  "videoEditorClipGalleryInstruction": "Tryck för att redigera. Håll ned och dra för att ändra ordning."
+  "videoEditorClipGalleryInstruction": "Tryck för att redigera. Håll ned och dra för att ändra ordning.",
+  "navSearch": "Sök",
+  "navSearchTooltip": "Sök"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2930,5 +2930,7 @@
     "shareMenuDeleteFailedNotOwner": "Yalnızca kendi videolarını silebilirsin.",
     "videoEditorLayers": "Katmanlar",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{döngü} other{döngüler}}",
-    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again."
+    "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
+  "videoEditorAudioSegmentInstruction": "Videon için ses bölümünü seç",
+  "videoEditorClipGalleryInstruction": "Düzenlemek için dokun. Yeniden sıralamak için basılı tutup sürükle."
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2928,7 +2928,6 @@
     "shareMenuDeleteFailedNotAuthenticated": "Tekrar giriş yap, sonra silmeyi dene.",
     "shareMenuDeleteFailedNotInitialized": "Silme henüz hazır değil. Birazdan tekrar dene.",
     "shareMenuDeleteFailedNotOwner": "Yalnızca kendi videolarını silebilirsin.",
-    "videoEditorLayers": "Katmanlar",
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{döngü} other{döngüler}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Videon için ses bölümünü seç",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9578,12 +9578,6 @@ abstract class AppLocalizations {
   /// **'Hold to reorder'**
   String get videoEditorLayerReorderHint;
 
-  /// No description provided for @videoEditorLayers.
-  ///
-  /// In en, this message translates to:
-  /// **'Layers'**
-  String get videoEditorLayers;
-
   /// No description provided for @videoEditorShowTimelineSemanticLabel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -1612,6 +1612,12 @@ abstract class AppLocalizations {
   /// **'Delete request sent successfully'**
   String get videoGridDeleteSuccess;
 
+  /// No description provided for @videoGridDeleteFailure.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to delete content: {error}'**
+  String videoGridDeleteFailure(Object error);
+
   /// No description provided for @exploreTabClassics.
   ///
   /// In en, this message translates to:
@@ -5318,6 +5324,12 @@ abstract class AppLocalizations {
   /// **'Remove this video from Divine. It may still appear on other Nostr clients.'**
   String get shareMenuDeleteVideoSubtitle;
 
+  /// No description provided for @shareMenuDeleteWarning.
+  ///
+  /// In en, this message translates to:
+  /// **'This sends a delete request (NIP-09) to all relays. Some relays may still keep the content.'**
+  String get shareMenuDeleteWarning;
+
   /// No description provided for @shareMenuVideoInTheseLists.
   ///
   /// In en, this message translates to:
@@ -5359,6 +5371,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Deleting content...'**
   String get shareMenuDeletingContent;
+
+  /// No description provided for @shareMenuFailedToDeleteContent.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to delete content: {error}'**
+  String shareMenuFailedToDeleteContent(String error);
 
   /// No description provided for @shareMenuDeleteRequestSent.
   ///
@@ -5503,6 +5521,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Failed to update video: {error}'**
   String shareMenuFailedToUpdateVideo(String error);
+
+  /// No description provided for @shareMenuFailedToDeleteVideo.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to delete video: {error}'**
+  String shareMenuFailedToDeleteVideo(String error);
 
   /// No description provided for @shareMenuDeleteVideoQuestion.
   ///
@@ -6433,6 +6457,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Profile'**
   String get navProfile;
+
+  /// No description provided for @navSearch.
+  ///
+  /// In en, this message translates to:
+  /// **'Search'**
+  String get navSearch;
+
+  /// No description provided for @navSearchTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Search'**
+  String get navSearchTooltip;
 
   /// No description provided for @navMyProfile.
   ///
@@ -9500,6 +9536,12 @@ abstract class AppLocalizations {
   /// **'Failed to load sounds'**
   String get videoEditorAudioFailedToLoadTitle;
 
+  /// No description provided for @videoEditorAudioSegmentInstruction.
+  ///
+  /// In en, this message translates to:
+  /// **'Select the audio segment for your video'**
+  String get videoEditorAudioSegmentInstruction;
+
   /// No description provided for @videoEditorDrawToolArrowSemanticLabel.
   ///
   /// In en, this message translates to:
@@ -9535,6 +9577,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Hold to reorder'**
   String get videoEditorLayerReorderHint;
+
+  /// No description provided for @videoEditorLayers.
+  ///
+  /// In en, this message translates to:
+  /// **'Layers'**
+  String get videoEditorLayers;
 
   /// No description provided for @videoEditorShowTimelineSemanticLabel.
   ///
@@ -9623,6 +9671,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Long press to reorder'**
   String get videoEditorTimelineClipReorderHint;
+
+  /// No description provided for @videoEditorClipGalleryInstruction.
+  ///
+  /// In en, this message translates to:
+  /// **'Tap to edit. Hold and drag to reorder.'**
+  String get videoEditorClipGalleryInstruction;
 
   /// No description provided for @videoEditorTimelineClipMoveLeft.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5349,9 +5349,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoEditorLayerReorderHint => 'اضغط مطولاً لإعادة الترتيب';
 
   @override
-  String get videoEditorLayers => 'الطبقات';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => 'إظهار الجدول الزمني';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -854,6 +854,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoGridDeleteSuccess => 'تم إرسال طلب الحذف بنجاح';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return 'فشل حذف المحتوى: $error';
+  }
+
+  @override
   String get exploreTabClassics => 'الكلاسيكيات';
 
   @override
@@ -2984,6 +2989,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get shareMenuDeleteVideoSubtitle => 'إزالة هذا المحتوى نهائيًا';
 
   @override
+  String get shareMenuDeleteWarning =>
+      'سيرسل هذا طلب حذف (NIP-09) إلى جميع المحولات. قد تحتفظ بعض المحولات بالمحتوى.';
+
+  @override
   String get shareMenuVideoInTheseLists => 'الفيديو في هذه القوائم:';
 
   @override
@@ -3006,6 +3015,11 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => 'جاري حذف المحتوى...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return 'فشل حذف المحتوى: $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent => 'تم إرسال طلب الحذف بنجاح';
@@ -3088,6 +3102,11 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return 'فشل تحديث الفيديو: $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return 'فشل حذف الفيديو: $error';
   }
 
   @override
@@ -3605,6 +3624,12 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get navProfile => 'الملف الشخصي';
+
+  @override
+  String get navSearch => 'بحث';
+
+  @override
+  String get navSearchTooltip => 'بحث';
 
   @override
   String get navMyProfile => 'ملفي الشخصي';
@@ -5301,6 +5326,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoEditorAudioFailedToLoadTitle => 'فشل تحميل الأصوات';
 
   @override
+  String get videoEditorAudioSegmentInstruction => 'حدّد مقطع الصوت لفيديوك';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => 'أداة السهم';
 
   @override
@@ -5319,6 +5347,9 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get videoEditorLayerReorderHint => 'اضغط مطولاً لإعادة الترتيب';
+
+  @override
+  String get videoEditorLayers => 'الطبقات';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => 'إظهار الجدول الزمني';
@@ -5371,6 +5402,10 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get videoEditorTimelineClipReorderHint => 'اضغط مطولاً لإعادة الترتيب';
+
+  @override
+  String get videoEditorClipGalleryInstruction =>
+      'اضغط للتعديل. اضغط مطولاً واسحب لإعادة الترتيب.';
 
   @override
   String get videoEditorTimelineClipMoveLeft => 'تحريك لليسار';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -890,6 +890,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoGridDeleteSuccess => 'Löschanfrage erfolgreich gesendet';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return 'Inhalt konnte nicht gelöscht werden: $error';
+  }
+
+  @override
   String get exploreTabClassics => 'Klassiker';
 
   @override
@@ -3055,6 +3060,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Diesen Inhalt dauerhaft entfernen';
 
   @override
+  String get shareMenuDeleteWarning =>
+      'Damit wird eine Löschanfrage (NIP-09) an alle Relays gesendet. Manche Relays behalten die Inhalte möglicherweise trotzdem.';
+
+  @override
   String get shareMenuVideoInTheseLists => 'Video ist in diesen Listen:';
 
   @override
@@ -3077,6 +3086,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => 'Inhalt wird gelöscht...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return 'Inhalt konnte nicht gelöscht werden: $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent => 'Löschanfrage erfolgreich gesendet';
@@ -3159,6 +3173,11 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return 'Video konnte nicht aktualisiert werden: $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return 'Video konnte nicht gelöscht werden: $error';
   }
 
   @override
@@ -3688,6 +3707,12 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get navProfile => 'Profil';
+
+  @override
+  String get navSearch => 'Search';
+
+  @override
+  String get navSearchTooltip => 'Search';
 
   @override
   String get navMyProfile => 'Mein Profil';
@@ -5417,6 +5442,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Sounds konnten nicht geladen werden';
 
   @override
+  String get videoEditorAudioSegmentInstruction =>
+      'Wähle den Audiobereich für dein Video aus';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => 'Pfeil-Werkzeug';
 
   @override
@@ -5435,6 +5464,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get videoEditorLayerReorderHint => 'Zum Neuordnen halten';
+
+  @override
+  String get videoEditorLayers => 'Ebenen';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => 'Timeline anzeigen';
@@ -5489,6 +5521,10 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get videoEditorTimelineClipReorderHint =>
       'Lange drücken zum Neuordnen';
+
+  @override
+  String get videoEditorClipGalleryInstruction =>
+      'Tippen zum Bearbeiten. Halten und ziehen zum Neuordnen.';
 
   @override
   String get videoEditorTimelineClipMoveLeft => 'Nach links verschieben';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3709,10 +3709,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get navProfile => 'Profil';
 
   @override
-  String get navSearch => 'Search';
+  String get navSearch => 'Suche';
 
   @override
-  String get navSearchTooltip => 'Search';
+  String get navSearchTooltip => 'Suchen';
 
   @override
   String get navMyProfile => 'Mein Profil';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5466,9 +5466,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoEditorLayerReorderHint => 'Zum Neuordnen halten';
 
   @override
-  String get videoEditorLayers => 'Ebenen';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => 'Timeline anzeigen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -881,6 +881,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoGridDeleteSuccess => 'Delete request sent successfully';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return 'Failed to delete content: $error';
+  }
+
+  @override
   String get exploreTabClassics => 'Classics';
 
   @override
@@ -3018,6 +3023,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Remove this video from Divine. It may still appear on other Nostr clients.';
 
   @override
+  String get shareMenuDeleteWarning =>
+      'This sends a delete request (NIP-09) to all relays. Some relays may still keep the content.';
+
+  @override
   String get shareMenuVideoInTheseLists => 'Video is in these lists:';
 
   @override
@@ -3040,6 +3049,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => 'Deleting content...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return 'Failed to delete content: $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent => 'Video deleted';
@@ -3123,6 +3137,11 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return 'Failed to update video: $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return 'Failed to delete video: $error';
   }
 
   @override
@@ -3647,6 +3666,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get navProfile => 'Profile';
+
+  @override
+  String get navSearch => 'Search';
+
+  @override
+  String get navSearchTooltip => 'Search';
 
   @override
   String get navMyProfile => 'My Profile';
@@ -5353,6 +5378,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoEditorAudioFailedToLoadTitle => 'Failed to load sounds';
 
   @override
+  String get videoEditorAudioSegmentInstruction =>
+      'Select the audio segment for your video';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => 'Arrow tool';
 
   @override
@@ -5371,6 +5400,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get videoEditorLayerReorderHint => 'Hold to reorder';
+
+  @override
+  String get videoEditorLayers => 'Layers';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => 'Show timeline';
@@ -5424,6 +5456,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get videoEditorTimelineClipReorderHint => 'Long press to reorder';
+
+  @override
+  String get videoEditorClipGalleryInstruction =>
+      'Tap to edit. Hold and drag to reorder.';
 
   @override
   String get videoEditorTimelineClipMoveLeft => 'Move left';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5402,9 +5402,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoEditorLayerReorderHint => 'Hold to reorder';
 
   @override
-  String get videoEditorLayers => 'Layers';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => 'Show timeline';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3706,10 +3706,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get navProfile => 'Perfil';
 
   @override
-  String get navSearch => 'Search';
+  String get navSearch => 'Buscar';
 
   @override
-  String get navSearchTooltip => 'Search';
+  String get navSearchTooltip => 'Buscar';
 
   @override
   String get navMyProfile => 'Mi perfil';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5462,9 +5462,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videoEditorLayerReorderHint => 'Mantén presionado para reordenar';
 
   @override
-  String get videoEditorLayers => 'Capas';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => 'Mostrar línea de tiempo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -892,6 +892,11 @@ class AppLocalizationsEs extends AppLocalizations {
       'Pedido de eliminación enviado con éxito';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return 'No se pudo eliminar el contenido: $error';
+  }
+
+  @override
   String get exploreTabClassics => 'Clásicos';
 
   @override
@@ -3054,6 +3059,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get shareMenuDeleteVideoSubtitle => 'Sacá este contenido para siempre';
 
   @override
+  String get shareMenuDeleteWarning =>
+      'Esto envía un pedido de eliminación (NIP-09) a todos los relays. Algunos relays todavía pueden mantener el contenido.';
+
+  @override
   String get shareMenuVideoInTheseLists => 'El video está en estas listas:';
 
   @override
@@ -3076,6 +3085,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => 'Eliminando contenido...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return 'No se pudo eliminar el contenido: $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent =>
@@ -3160,6 +3174,11 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return 'No se pudo actualizar el video: $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return 'No se pudo eliminar el video: $error';
   }
 
   @override
@@ -3685,6 +3704,12 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get navProfile => 'Perfil';
+
+  @override
+  String get navSearch => 'Search';
+
+  @override
+  String get navSearchTooltip => 'Search';
 
   @override
   String get navMyProfile => 'Mi perfil';
@@ -5413,6 +5438,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se pudieron cargar los sonidos';
 
   @override
+  String get videoEditorAudioSegmentInstruction =>
+      'Selecciona el segmento de audio para tu video';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => 'Herramienta flecha';
 
   @override
@@ -5431,6 +5460,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get videoEditorLayerReorderHint => 'Mantén presionado para reordenar';
+
+  @override
+  String get videoEditorLayers => 'Capas';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => 'Mostrar línea de tiempo';
@@ -5485,6 +5517,10 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get videoEditorTimelineClipReorderHint =>
       'Mantén presionado para reordenar';
+
+  @override
+  String get videoEditorClipGalleryInstruction =>
+      'Toca para editar. Mantén presionado y arrastra para reordenar.';
 
   @override
   String get videoEditorTimelineClipMoveLeft => 'Mover a la izquierda';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5480,9 +5480,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get videoEditorLayerReorderHint => 'Maintenez appuyé pour réorganiser';
 
   @override
-  String get videoEditorLayers => 'Calques';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => 'Afficher la timeline';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -902,6 +902,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Demande de suppression envoyée avec succès';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return 'Échec de la suppression : $error';
+  }
+
+  @override
   String get exploreTabClassics => 'Classiques';
 
   @override
@@ -3059,6 +3064,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Retirer ce contenu définitivement';
 
   @override
+  String get shareMenuDeleteWarning =>
+      'Cette action envoie une requête de suppression (NIP-09) à tous les relays. Certains relays peuvent garder le contenu.';
+
+  @override
   String get shareMenuVideoInTheseLists => 'La vidéo est dans ces listes :';
 
   @override
@@ -3081,6 +3090,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => 'Suppression du contenu...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return 'Échec de la suppression du contenu : $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent =>
@@ -3165,6 +3179,11 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return 'Échec de la mise à jour de la vidéo : $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return 'Échec de la suppression de la vidéo : $error';
   }
 
   @override
@@ -3695,6 +3714,12 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get navProfile => 'Profil';
+
+  @override
+  String get navSearch => 'Search';
+
+  @override
+  String get navSearchTooltip => 'Search';
 
   @override
   String get navMyProfile => 'Mon profil';
@@ -5431,6 +5456,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Échec du chargement des sons';
 
   @override
+  String get videoEditorAudioSegmentInstruction =>
+      'Sélectionne le segment audio de ta vidéo';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => 'Outil flèche';
 
   @override
@@ -5449,6 +5478,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get videoEditorLayerReorderHint => 'Maintenez appuyé pour réorganiser';
+
+  @override
+  String get videoEditorLayers => 'Calques';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => 'Afficher la timeline';
@@ -5502,6 +5534,10 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get videoEditorTimelineClipReorderHint => 'Appui long pour déplacer';
+
+  @override
+  String get videoEditorClipGalleryInstruction =>
+      'Appuie pour modifier. Maintiens appuyé et fais glisser pour réorganiser.';
 
   @override
   String get videoEditorTimelineClipMoveLeft => 'Déplacer vers la gauche';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3716,10 +3716,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get navProfile => 'Profil';
 
   @override
-  String get navSearch => 'Search';
+  String get navSearch => 'Recherche';
 
   @override
-  String get navSearchTooltip => 'Search';
+  String get navSearchTooltip => 'Rechercher';
 
   @override
   String get navMyProfile => 'Mon profil';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5377,9 +5377,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoEditorLayerReorderHint => 'Tahan untuk mengurutkan ulang';
 
   @override
-  String get videoEditorLayers => 'Lapisan';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => 'Tampilkan timeline';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -862,6 +862,11 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoGridDeleteSuccess => 'Permintaan hapus berhasil dikirim';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return 'Gagal menghapus konten: $error';
+  }
+
+  @override
   String get exploreTabClassics => 'Klasik';
 
   @override
@@ -2990,6 +2995,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get shareMenuDeleteVideoSubtitle => 'Hapus konten ini secara permanen';
 
   @override
+  String get shareMenuDeleteWarning =>
+      'Ini akan mengirim permintaan hapus (NIP-09) ke semua relay. Beberapa relay mungkin masih menyimpan kontennya.';
+
+  @override
   String get shareMenuVideoInTheseLists => 'Video ada di daftar ini:';
 
   @override
@@ -3011,6 +3020,11 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => 'Menghapus konten...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return 'Gagal menghapus konten: $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent => 'Permintaan hapus berhasil dikirim';
@@ -3094,6 +3108,11 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return 'Gagal memperbarui video: $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return 'Gagal menghapus video: $error';
   }
 
   @override
@@ -3617,6 +3636,12 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get navProfile => 'Profil';
+
+  @override
+  String get navSearch => 'Cari';
+
+  @override
+  String get navSearchTooltip => 'Cari';
 
   @override
   String get navMyProfile => 'Profilku';
@@ -5328,6 +5353,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoEditorAudioFailedToLoadTitle => 'Gagal memuat suara';
 
   @override
+  String get videoEditorAudioSegmentInstruction =>
+      'Pilih segmen audio untuk videomu';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => 'Alat panah';
 
   @override
@@ -5346,6 +5375,9 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get videoEditorLayerReorderHint => 'Tahan untuk mengurutkan ulang';
+
+  @override
+  String get videoEditorLayers => 'Lapisan';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => 'Tampilkan timeline';
@@ -5400,6 +5432,10 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get videoEditorTimelineClipReorderHint =>
       'Tekan lama untuk mengurutkan ulang';
+
+  @override
+  String get videoEditorClipGalleryInstruction =>
+      'Ketuk untuk mengedit. Tekan lama dan seret untuk mengurutkan ulang.';
 
   @override
   String get videoEditorTimelineClipMoveLeft => 'Geser ke kiri';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5458,9 +5458,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoEditorLayerReorderHint => 'Tieni premuto per riordinare';
 
   @override
-  String get videoEditorLayers => 'Livelli';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => 'Mostra timeline';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3704,10 +3704,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get navProfile => 'Profilo';
 
   @override
-  String get navSearch => 'Search';
+  String get navSearch => 'Cerca';
 
   @override
-  String get navSearchTooltip => 'Search';
+  String get navSearchTooltip => 'Cerca';
 
   @override
   String get navMyProfile => 'Il mio profilo';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -892,6 +892,11 @@ class AppLocalizationsIt extends AppLocalizations {
       'Richiesta di eliminazione inviata con successo';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return 'Impossibile eliminare il contenuto: $error';
+  }
+
+  @override
   String get exploreTabClassics => 'Classici';
 
   @override
@@ -3050,6 +3055,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Rimuovi definitivamente questo contenuto';
 
   @override
+  String get shareMenuDeleteWarning =>
+      'Verrà inviata una richiesta di eliminazione (NIP-09) a tutti i relay. Alcuni relay potrebbero comunque conservare il contenuto.';
+
+  @override
   String get shareMenuVideoInTheseLists => 'Il video è in queste liste:';
 
   @override
@@ -3072,6 +3081,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => 'Eliminazione contenuto...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return 'Impossibile eliminare il contenuto: $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent =>
@@ -3157,6 +3171,11 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return 'Impossibile aggiornare il video: $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return 'Impossibile eliminare il video: $error';
   }
 
   @override
@@ -3683,6 +3702,12 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get navProfile => 'Profilo';
+
+  @override
+  String get navSearch => 'Search';
+
+  @override
+  String get navSearchTooltip => 'Search';
 
   @override
   String get navMyProfile => 'Il mio profilo';
@@ -5408,6 +5433,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Impossibile caricare i suoni';
 
   @override
+  String get videoEditorAudioSegmentInstruction =>
+      'Seleziona il segmento audio per il tuo video';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => 'Strumento freccia';
 
   @override
@@ -5427,6 +5456,9 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get videoEditorLayerReorderHint => 'Tieni premuto per riordinare';
+
+  @override
+  String get videoEditorLayers => 'Livelli';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => 'Mostra timeline';
@@ -5481,6 +5513,10 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get videoEditorTimelineClipReorderHint =>
       'Tieni premuto per riordinare';
+
+  @override
+  String get videoEditorClipGalleryInstruction =>
+      'Tocca per modificare. Tieni premuto e trascina per riordinare.';
 
   @override
   String get videoEditorTimelineClipMoveLeft => 'Sposta a sinistra';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -815,6 +815,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoGridDeleteSuccess => '削除リクエストを送ったよ';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return 'コンテンツの削除がうまくいかなかった: $error';
+  }
+
+  @override
   String get exploreTabClassics => 'クラシック';
 
   @override
@@ -2861,6 +2866,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get shareMenuDeleteVideoSubtitle => 'このコンテンツを完全に削除';
 
   @override
+  String get shareMenuDeleteWarning =>
+      'すべてのリレーに削除リクエスト (NIP-09) を送るよ。一部のリレーではキャッシュが残ることもあるよ。';
+
+  @override
   String get shareMenuVideoInTheseLists => 'この動画が入ってるリスト:';
 
   @override
@@ -2882,6 +2891,11 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => 'コンテンツを削除中...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return 'コンテンツの削除がうまくいかなかった: $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent => '削除リクエストを送ったよ';
@@ -2959,6 +2973,11 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return '動画の更新がうまくいかなかった: $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return '動画の削除がうまくいかなかった: $error';
   }
 
   @override
@@ -3465,6 +3484,12 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get navProfile => 'プロフィール';
+
+  @override
+  String get navSearch => '検索';
+
+  @override
+  String get navSearchTooltip => '検索';
 
   @override
   String get navMyProfile => 'マイプロフィール';
@@ -5128,6 +5153,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoEditorAudioFailedToLoadTitle => 'サウンドの読み込みに失敗';
 
   @override
+  String get videoEditorAudioSegmentInstruction => '動画に使うオーディオ範囲を選択';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => '矢印ツール';
 
   @override
@@ -5146,6 +5174,9 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get videoEditorLayerReorderHint => '長押しして並べ替え';
+
+  @override
+  String get videoEditorLayers => 'レイヤー';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => 'タイムラインを表示';
@@ -5197,6 +5228,9 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get videoEditorTimelineClipReorderHint => '長押しして並べ替え';
+
+  @override
+  String get videoEditorClipGalleryInstruction => 'タップして編集。長押ししてドラッグで並べ替え。';
 
   @override
   String get videoEditorTimelineClipMoveLeft => '左に移動';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5176,9 +5176,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoEditorLayerReorderHint => '長押しして並べ替え';
 
   @override
-  String get videoEditorLayers => 'レイヤー';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => 'タイムラインを表示';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5198,9 +5198,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoEditorLayerReorderHint => '길게 눌러 순서 변경';
 
   @override
-  String get videoEditorLayers => '레이어';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => '타임라인 표시';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -817,6 +817,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoGridDeleteSuccess => '삭제 요청을 보냈어요';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return '콘텐츠를 삭제하지 못했어요: $error';
+  }
+
+  @override
   String get exploreTabClassics => '클래식';
 
   @override
@@ -2873,6 +2878,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get shareMenuDeleteVideoSubtitle => '이 콘텐츠를 완전히 지워요';
 
   @override
+  String get shareMenuDeleteWarning =>
+      '모든 릴레이에 삭제 요청(NIP-09)을 보내요. 일부 릴레이에는 콘텐츠가 남아 있을 수 있어요.';
+
+  @override
   String get shareMenuVideoInTheseLists => '영상이 다음 리스트에 있어요:';
 
   @override
@@ -2894,6 +2903,11 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => '콘텐츠 삭제 중...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return '콘텐츠 삭제에 실패했어요: $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent => '삭제 요청을 보냈어요';
@@ -2972,6 +2986,11 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return '영상 업데이트에 실패했어요: $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return '영상 삭제에 실패했어요: $error';
   }
 
   @override
@@ -3478,6 +3497,12 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get navProfile => '프로필';
+
+  @override
+  String get navSearch => '검색';
+
+  @override
+  String get navSearchTooltip => '검색';
 
   @override
   String get navMyProfile => '내 프로필';
@@ -5150,6 +5175,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoEditorAudioFailedToLoadTitle => '사운드 로드 실패';
 
   @override
+  String get videoEditorAudioSegmentInstruction => '동영상에 사용할 오디오 구간을 선택하세요';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => '화살표 도구';
 
   @override
@@ -5168,6 +5196,9 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get videoEditorLayerReorderHint => '길게 눌러 순서 변경';
+
+  @override
+  String get videoEditorLayers => '레이어';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => '타임라인 표시';
@@ -5219,6 +5250,10 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get videoEditorTimelineClipReorderHint => '길게 눌러 순서 변경';
+
+  @override
+  String get videoEditorClipGalleryInstruction =>
+      '탭해서 편집하세요. 길게 누르고 드래그해 순서를 바꾸세요.';
 
   @override
   String get videoEditorTimelineClipMoveLeft => '왼쪽으로 이동';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3678,10 +3678,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get navProfile => 'Profiel';
 
   @override
-  String get navSearch => 'Search';
+  String get navSearch => 'Zoeken';
 
   @override
-  String get navSearchTooltip => 'Search';
+  String get navSearchTooltip => 'Zoeken';
 
   @override
   String get navMyProfile => 'Mijn profiel';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5425,9 +5425,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoEditorLayerReorderHint => 'Vasthouden om te herordenen';
 
   @override
-  String get videoEditorLayers => 'Lagen';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => 'Tijdlijn tonen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -883,6 +883,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoGridDeleteSuccess => 'Verwijderverzoek succesvol verstuurd';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return 'Inhoud verwijderen mislukt: $error';
+  }
+
+  @override
   String get exploreTabClassics => 'Klassiekers';
 
   @override
@@ -3027,6 +3032,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Deze inhoud definitief verwijderen';
 
   @override
+  String get shareMenuDeleteWarning =>
+      'Dit stuurt een verwijderverzoek (NIP-09) naar alle relays. Sommige relays kunnen de inhoud alsnog bewaren.';
+
+  @override
   String get shareMenuVideoInTheseLists => 'Video staat in deze lijsten:';
 
   @override
@@ -3049,6 +3058,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => 'Inhoud verwijderen...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return 'Inhoud verwijderen mislukt: $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent =>
@@ -3133,6 +3147,11 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return 'Video bijwerken mislukt: $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return 'Video verwijderen mislukt: $error';
   }
 
   @override
@@ -3657,6 +3676,12 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get navProfile => 'Profiel';
+
+  @override
+  String get navSearch => 'Search';
+
+  @override
+  String get navSearchTooltip => 'Search';
 
   @override
   String get navMyProfile => 'Mijn profiel';
@@ -5376,6 +5401,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoEditorAudioFailedToLoadTitle => 'Geluiden laden mislukt';
 
   @override
+  String get videoEditorAudioSegmentInstruction =>
+      'Selecteer het audiofragment voor je video';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => 'Pijlgereedschap';
 
   @override
@@ -5394,6 +5423,9 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get videoEditorLayerReorderHint => 'Vasthouden om te herordenen';
+
+  @override
+  String get videoEditorLayers => 'Lagen';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => 'Tijdlijn tonen';
@@ -5448,6 +5480,10 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get videoEditorTimelineClipReorderHint =>
       'Lang indrukken om te slepen';
+
+  @override
+  String get videoEditorClipGalleryInstruction =>
+      'Tik om te bewerken. Houd vast en sleep om te herordenen.';
 
   @override
   String get videoEditorTimelineClipMoveLeft => 'Naar links verplaatsen';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -893,6 +893,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoGridDeleteSuccess => 'Żądanie usunięcia wysłane pomyślnie';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return 'Nie udało się usunąć treści: $error';
+  }
+
+  @override
   String get exploreTabClassics => 'Klasyki';
 
   @override
@@ -3104,6 +3109,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get shareMenuDeleteVideoSubtitle => 'Trwale usuń tę treść';
 
   @override
+  String get shareMenuDeleteWarning =>
+      'To wyślе żądanie usunięcia (NIP-09) do wszystkich przekaźników. Niektóre przekaźniki mogą nadal zachować treść.';
+
+  @override
   String get shareMenuVideoInTheseLists => 'Film jest na tych listach:';
 
   @override
@@ -3133,6 +3142,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => 'Usuwanie treści...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return 'Nie udało się usunąć treści: $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent =>
@@ -3216,6 +3230,11 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return 'Nie udało się zaktualizować filmu: $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return 'Nie udało się usunąć filmu: $error';
   }
 
   @override
@@ -3748,6 +3767,12 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get navProfile => 'Profil';
+
+  @override
+  String get navSearch => 'Search';
+
+  @override
+  String get navSearchTooltip => 'Search';
 
   @override
   String get navMyProfile => 'Mój profil';
@@ -5491,6 +5516,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Nie udało się wczytać dźwięków';
 
   @override
+  String get videoEditorAudioSegmentInstruction =>
+      'Wybierz fragment audio dla swojego filmu';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => 'Narzędzie strzałki';
 
   @override
@@ -5510,6 +5539,9 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get videoEditorLayerReorderHint =>
       'Przytrzymaj, aby zmienić kolejność';
+
+  @override
+  String get videoEditorLayers => 'Warstwy';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => 'Pokaż oś czasu';
@@ -5564,6 +5596,10 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get videoEditorTimelineClipReorderHint =>
       'Przytrzymaj, aby zmienić kolejność';
+
+  @override
+  String get videoEditorClipGalleryInstruction =>
+      'Dotknij, aby edytować. Przytrzymaj i przeciągnij, aby zmienić kolejność.';
 
   @override
   String get videoEditorTimelineClipMoveLeft => 'Przesuń w lewo';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3769,10 +3769,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get navProfile => 'Profil';
 
   @override
-  String get navSearch => 'Search';
+  String get navSearch => 'Szukaj';
 
   @override
-  String get navSearchTooltip => 'Search';
+  String get navSearchTooltip => 'Szukaj';
 
   @override
   String get navMyProfile => 'Mój profil';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5541,9 +5541,6 @@ class AppLocalizationsPl extends AppLocalizations {
       'Przytrzymaj, aby zmienić kolejność';
 
   @override
-  String get videoEditorLayers => 'Warstwy';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => 'Pokaż oś czasu';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3688,10 +3688,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get navProfile => 'Perfil';
 
   @override
-  String get navSearch => 'Search';
+  String get navSearch => 'Pesquisar';
 
   @override
-  String get navSearchTooltip => 'Search';
+  String get navSearchTooltip => 'Pesquisar';
 
   @override
   String get navMyProfile => 'Meu perfil';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -895,6 +895,11 @@ class AppLocalizationsPt extends AppLocalizations {
       'Solicitação de exclusão enviada com sucesso';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return 'Falha ao excluir conteúdo: $error';
+  }
+
+  @override
   String get exploreTabClassics => 'Clássicos';
 
   @override
@@ -3039,6 +3044,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Remover este conteúdo permanentemente';
 
   @override
+  String get shareMenuDeleteWarning =>
+      'Isso vai enviar uma solicitação de exclusão (NIP-09) para todos os relays. Alguns relays podem manter o conteúdo mesmo assim.';
+
+  @override
   String get shareMenuVideoInTheseLists => 'O vídeo está nestas listas:';
 
   @override
@@ -3061,6 +3070,11 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => 'Excluindo conteúdo...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return 'Falha ao excluir conteúdo: $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent =>
@@ -3145,6 +3159,11 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return 'Falha ao atualizar vídeo: $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return 'Falha ao excluir vídeo: $error';
   }
 
   @override
@@ -3667,6 +3686,12 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get navProfile => 'Perfil';
+
+  @override
+  String get navSearch => 'Search';
+
+  @override
+  String get navSearchTooltip => 'Search';
 
   @override
   String get navMyProfile => 'Meu perfil';
@@ -5386,6 +5411,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoEditorAudioFailedToLoadTitle => 'Falha ao carregar sons';
 
   @override
+  String get videoEditorAudioSegmentInstruction =>
+      'Selecione o trecho de áudio para seu vídeo';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => 'Ferramenta seta';
 
   @override
@@ -5404,6 +5433,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get videoEditorLayerReorderHint => 'Pressione e segure para reordenar';
+
+  @override
+  String get videoEditorLayers => 'Camadas';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => 'Mostrar linha do tempo';
@@ -5458,6 +5490,10 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get videoEditorTimelineClipReorderHint =>
       'Pressione e segure para reordenar';
+
+  @override
+  String get videoEditorClipGalleryInstruction =>
+      'Toque para editar. Pressione e arraste para reordenar.';
 
   @override
   String get videoEditorTimelineClipMoveLeft => 'Mover para a esquerda';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5435,9 +5435,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoEditorLayerReorderHint => 'Pressione e segure para reordenar';
 
   @override
-  String get videoEditorLayers => 'Camadas';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => 'Mostrar linha do tempo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3774,10 +3774,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get navProfile => 'Profil';
 
   @override
-  String get navSearch => 'Search';
+  String get navSearch => 'Caută';
 
   @override
-  String get navSearchTooltip => 'Search';
+  String get navSearchTooltip => 'Caută';
 
   @override
   String get navMyProfile => 'Profilul meu';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5545,9 +5545,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoEditorLayerReorderHint => 'Ține apăsat pentru a reordona';
 
   @override
-  String get videoEditorLayers => 'Straturi';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => 'Afișează cronologia';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -910,6 +910,11 @@ class AppLocalizationsRo extends AppLocalizations {
       'Cererea de ștergere a fost trimisă cu succes';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return 'N-am putut șterge conținutul: $error';
+  }
+
+  @override
   String get exploreTabClassics => 'Clasice';
 
   @override
@@ -3104,6 +3109,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get shareMenuDeleteVideoSubtitle => 'Elimină definitiv acest conținut';
 
   @override
+  String get shareMenuDeleteWarning =>
+      'Asta va trimite o cerere de ștergere (NIP-09) către toate relay-urile. Unele relay-uri pot păstra totuși conținutul.';
+
+  @override
   String get shareMenuVideoInTheseLists => 'Videoclipul e în aceste liste:';
 
   @override
@@ -3133,6 +3142,11 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => 'Se șterge conținutul...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return 'N-am putut șterge conținutul: $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent =>
@@ -3217,6 +3231,11 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return 'N-am putut actualiza videoclipul: $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return 'N-am putut șterge videoclipul: $error';
   }
 
   @override
@@ -3753,6 +3772,12 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get navProfile => 'Profil';
+
+  @override
+  String get navSearch => 'Search';
+
+  @override
+  String get navSearchTooltip => 'Search';
 
   @override
   String get navMyProfile => 'Profilul meu';
@@ -5496,6 +5521,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Nu s-au putut încărca sunetele';
 
   @override
+  String get videoEditorAudioSegmentInstruction =>
+      'Alege segmentul audio pentru videoclipul tău';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => 'Instrument săgeată';
 
   @override
@@ -5514,6 +5543,9 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get videoEditorLayerReorderHint => 'Ține apăsat pentru a reordona';
+
+  @override
+  String get videoEditorLayers => 'Straturi';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => 'Afișează cronologia';
@@ -5568,6 +5600,10 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get videoEditorTimelineClipReorderHint =>
       'Apăsare lungă pentru reordonare';
+
+  @override
+  String get videoEditorClipGalleryInstruction =>
+      'Atinge pentru editare. Ține apăsat și trage pentru reordonare.';
 
   @override
   String get videoEditorTimelineClipMoveLeft => 'Mută la stânga';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3659,10 +3659,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get navProfile => 'Profil';
 
   @override
-  String get navSearch => 'Search';
+  String get navSearch => 'Sök';
 
   @override
-  String get navSearchTooltip => 'Search';
+  String get navSearchTooltip => 'Sök';
 
   @override
   String get navMyProfile => 'Min profil';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -869,6 +869,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoGridDeleteSuccess => 'Borttagningsbegäran skickad';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return 'Kunde inte ta bort innehåll: $error';
+  }
+
+  @override
   String get exploreTabClassics => 'Klassiker';
 
   @override
@@ -3012,6 +3017,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Ta bort det här innehållet permanent';
 
   @override
+  String get shareMenuDeleteWarning =>
+      'Detta skickar en borttagningsbegäran (NIP-09) till alla reler. Vissa reler kan fortfarande behålla innehållet.';
+
+  @override
   String get shareMenuVideoInTheseLists => 'Videon finns i de här listorna:';
 
   @override
@@ -3034,6 +3043,11 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => 'Tar bort innehåll...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return 'Kunde inte ta bort innehåll: $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent => 'Borttagningsbegäran skickad';
@@ -3116,6 +3130,11 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return 'Kunde inte uppdatera videon: $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return 'Kunde inte ta bort videon: $error';
   }
 
   @override
@@ -3638,6 +3657,12 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get navProfile => 'Profil';
+
+  @override
+  String get navSearch => 'Search';
+
+  @override
+  String get navSearchTooltip => 'Search';
 
   @override
   String get navMyProfile => 'Min profil';
@@ -5345,6 +5370,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Det gick inte att ladda ljud';
 
   @override
+  String get videoEditorAudioSegmentInstruction =>
+      'Välj ljudsegmentet för din video';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => 'Pilverktyg';
 
   @override
@@ -5363,6 +5392,9 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get videoEditorLayerReorderHint => 'Håll ned för att ordna om';
+
+  @override
+  String get videoEditorLayers => 'Lager';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => 'Visa tidslinje';
@@ -5416,6 +5448,10 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get videoEditorTimelineClipReorderHint => 'Håll ned för att ordna om';
+
+  @override
+  String get videoEditorClipGalleryInstruction =>
+      'Tryck för att redigera. Håll ned och dra för att ändra ordning.';
 
   @override
   String get videoEditorTimelineClipMoveLeft => 'Flytta vänster';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5394,9 +5394,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoEditorLayerReorderHint => 'Håll ned för att ordna om';
 
   @override
-  String get videoEditorLayers => 'Lager';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => 'Visa tidslinje';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -863,6 +863,11 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoGridDeleteSuccess => 'Silme isteği başarıyla gönderildi';
 
   @override
+  String videoGridDeleteFailure(Object error) {
+    return 'İçerik silinemedi: $error';
+  }
+
+  @override
   String get exploreTabClassics => 'Klasikler';
 
   @override
@@ -3000,6 +3005,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get shareMenuDeleteVideoSubtitle => 'Bu içeriği kalıcı olarak kaldır';
 
   @override
+  String get shareMenuDeleteWarning =>
+      'Bu işlem tüm rölelere bir silme isteği (NIP-09) gönderir. Bazı röleler içeriği saklamaya devam edebilir.';
+
+  @override
   String get shareMenuVideoInTheseLists => 'Video şu listelerde:';
 
   @override
@@ -3022,6 +3031,11 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get shareMenuDeletingContent => 'İçerik siliniyor...';
+
+  @override
+  String shareMenuFailedToDeleteContent(String error) {
+    return 'İçerik silinemedi: $error';
+  }
 
   @override
   String get shareMenuDeleteRequestSent => 'Silme isteği başarıyla gönderildi';
@@ -3105,6 +3119,11 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String shareMenuFailedToUpdateVideo(String error) {
     return 'Video güncellenemedi: $error';
+  }
+
+  @override
+  String shareMenuFailedToDeleteVideo(String error) {
+    return 'Video silinemedi: $error';
   }
 
   @override
@@ -3629,6 +3648,12 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get navProfile => 'Profil';
+
+  @override
+  String get navSearch => 'Ara';
+
+  @override
+  String get navSearchTooltip => 'Ara';
 
   @override
   String get navMyProfile => 'Profilim';
@@ -5330,6 +5355,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoEditorAudioFailedToLoadTitle => 'Sesler yüklenemedi';
 
   @override
+  String get videoEditorAudioSegmentInstruction =>
+      'Videon için ses bölümünü seç';
+
+  @override
   String get videoEditorDrawToolArrowSemanticLabel => 'Ok aracı';
 
   @override
@@ -5348,6 +5377,9 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get videoEditorLayerReorderHint => 'Yeniden sıralamak için basılı tut';
+
+  @override
+  String get videoEditorLayers => 'Katmanlar';
 
   @override
   String get videoEditorShowTimelineSemanticLabel => 'Zaman çizelgesini göster';
@@ -5402,6 +5434,10 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get videoEditorTimelineClipReorderHint =>
       'Yeniden sıralamak için uzun basın';
+
+  @override
+  String get videoEditorClipGalleryInstruction =>
+      'Düzenlemek için dokun. Yeniden sıralamak için basılı tutup sürükle.';
 
   @override
   String get videoEditorTimelineClipMoveLeft => 'Sola taşı';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5379,9 +5379,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoEditorLayerReorderHint => 'Yeniden sıralamak için basılı tut';
 
   @override
-  String get videoEditorLayers => 'Katmanlar';
-
-  @override
   String get videoEditorShowTimelineSemanticLabel => 'Zaman çizelgesini göster';
 
   @override

--- a/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
+++ b/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
@@ -13,6 +13,7 @@ import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/blocs/sound_waveform/sound_waveform_bloc.dart';
 import 'package:openvine/blocs/video_editor/audio_timing/audio_timing_cubit.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/widgets/stereo_waveform_painter.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/video_editor_audio_chip.dart';
 import 'package:openvine/widgets/video_editor/video_editor_toolbar.dart';
@@ -325,8 +326,7 @@ class _BottomControls extends StatelessWidget {
         Padding(
           padding: const .symmetric(horizontal: 16),
           child: Text(
-            // TODO(l10n): Replace with context.l10n when localization is added.
-            'Select the audio segment for your video',
+            context.l10n.videoEditorAudioSegmentInstruction,
             style: VineTheme.bodySmallFont(),
             textAlign: .center,
           ),

--- a/mobile/lib/widgets/video_metadata/video_metadata_collaborators_input.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_collaborators_input.dart
@@ -62,8 +62,6 @@ class VideoMetadataCollaboratorsInput extends ConsumerWidget {
                       ),
                       const SizedBox(width: 4),
                       VideoMetadataHelpButton(
-                        // TODO(l10n): Replace with context.l10n
-                        //   when localization is added.
                         onTap: () => _showHelpDialog(context),
                         tooltip:
                             context.l10n.videoMetadataCollaboratorsHelpTooltip,

--- a/mobile/lib/widgets/video_metadata/video_metadata_inspired_by_input.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_inspired_by_input.dart
@@ -41,7 +41,6 @@ class VideoMetadataInspiredByInput extends ConsumerWidget {
 
     return Semantics(
       button: true,
-      // TODO(l10n): Replace with context.l10n when localization is added.
       label: context.l10n.videoMetadataSetInspiredBySemanticLabel,
       child: InkWell(
         onTap: hasInspiredBy

--- a/mobile/lib/widgets/video_metadata/video_metadata_tags_input.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_tags_input.dart
@@ -183,7 +183,6 @@ class _VideoMetadataTagsInputState
                   DivineTextField(
                     controller: _controller,
                     focusNode: _focusNode,
-                    // TODO(l10n): Replace with context.l10n when localization is added.
                     labelText: tags.isEmpty
                         ? context.l10n.videoMetadataTagsLabel
                         : null,

--- a/mobile/packages/divine_camera/lib/divine_camera.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera.dart
@@ -269,10 +269,12 @@ class DivineCamera {
   /// Returns the recorded video result, or null if recording failed.
   Future<VideoRecordingResult?> stopRecording() async {
     if (!_state.isRecording) return null;
-    final result = await _platform.stopRecording();
-    _state = _state.copyWith(isRecording: false);
-    _notifyStateChanged();
-    return result;
+    try {
+      return await _platform.stopRecording();
+    } finally {
+      _state = _state.copyWith(isRecording: false);
+      _notifyStateChanged();
+    }
   }
 
   /// Handles app lifecycle changes (pause, resume, etc.).

--- a/mobile/packages/divine_camera/macos/Classes/CameraController+Capture.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController+Capture.swift
@@ -76,15 +76,25 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
                 if !isWriterSessionStarted && writer.status == .writing {
                     writer.startSession(atSourceTime: timestamp)
                     isWriterSessionStarted = true
+                    print(
+                        "DivineCamera macOS: Writer session started at "
+                            + "\(timestamp.seconds)"
+                    )
                 }
 
                 if writer.status == .writing
                     && videoInput.isReadyForMoreMediaData
                 {
-                    adaptor.append(
+                    let appended = adaptor.append(
                         pixelBuffer,
                         withPresentationTime: timestamp
                     )
+                    if !appended {
+                        print(
+                            "DivineCamera macOS: Failed to append video frame: "
+                                + "\(writer.error?.localizedDescription ?? "Unknown error")"
+                        )
+                    }
                 }
             }
         } else if output == audioOutput {
@@ -94,7 +104,13 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
                 if isWriterSessionStarted && writer.status == .writing
                     && audioInput.isReadyForMoreMediaData
                 {
-                    audioInput.append(sampleBuffer)
+                    let appended = audioInput.append(sampleBuffer)
+                    if !appended {
+                        print(
+                            "DivineCamera macOS: Failed to append audio frame: "
+                                + "\(writer.error?.localizedDescription ?? "Unknown error")"
+                        )
+                    }
                 }
             }
         }

--- a/mobile/packages/divine_camera/macos/Classes/CameraController+Recording.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController+Recording.swift
@@ -27,6 +27,16 @@ extension CameraController {
         videoOutputQueue.async { [weak self] in
             guard let self = self else { return }
 
+            guard self.hasReceivedPreviewFrame() else {
+                self.disableAutoFlash()
+                DispatchQueue.main.async {
+                    completion(
+                        "Camera preview has not produced a video frame yet"
+                    )
+                }
+                return
+            }
+
             let outputDir: URL
             if let customDir = outputDirectory {
                 outputDir = URL(fileURLWithPath: customDir)
@@ -108,19 +118,44 @@ extension CameraController {
                 )
                 audioInput.expectsMediaDataInRealTime = true
 
-                if writer.canAdd(videoInput) {
-                    writer.add(videoInput)
+                guard writer.canAdd(videoInput) else {
+                    self.cleanupRecordingState(deleteOutputFile: true)
+                    DispatchQueue.main.async {
+                        completion("Cannot add video input to asset writer")
+                    }
+                    return
                 }
+                writer.add(videoInput)
+
+                let addedAudioInput: AVAssetWriterInput?
                 if writer.canAdd(audioInput) {
                     writer.add(audioInput)
+                    addedAudioInput = audioInput
+                } else {
+                    addedAudioInput = nil
+                    print(
+                        "DivineCamera macOS: Cannot add audio input "
+                            + "to asset writer"
+                    )
                 }
 
                 self.assetWriter = writer
                 self.videoWriterInput = videoInput
-                self.audioWriterInput = audioInput
+                self.audioWriterInput = addedAudioInput
                 self.pixelBufferAdaptor = adaptor
 
-                writer.startWriting()
+                guard writer.startWriting() else {
+                    let message =
+                        writer.error?.localizedDescription ?? "Unknown error"
+                    writer.cancelWriting()
+                    self.cleanupRecordingState(deleteOutputFile: true)
+                    DispatchQueue.main.async {
+                        completion(
+                            "Failed to start asset writer: \(message)"
+                        )
+                    }
+                    return
+                }
 
                 // Switch to the preferred audio device if specified.
                 // The audio input/output stay in the session for its
@@ -201,6 +236,18 @@ extension CameraController {
         videoOutputQueue.async { [weak self] in
             guard let self = self else { return }
 
+            if !self.isWriterSessionStarted {
+                writer.cancelWriting()
+                self.cleanupRecordingState(deleteOutputFile: true)
+                DispatchQueue.main.async {
+                    completion(
+                        nil,
+                        "Recording stopped before first video frame"
+                    )
+                }
+                return
+            }
+
             self.videoWriterInput?.markAsFinished()
             self.audioWriterInput?.markAsFinished()
 
@@ -273,5 +320,23 @@ extension CameraController {
                 }
             }
         }
+    }
+
+    /// Clears recording-only state after completion, cancellation, or failure.
+    func cleanupRecordingState(deleteOutputFile: Bool) {
+        disableAutoFlash()
+
+        if deleteOutputFile, let outputURL = currentRecordingURL {
+            try? FileManager.default.removeItem(at: outputURL)
+        }
+
+        assetWriter = nil
+        videoWriterInput = nil
+        audioWriterInput = nil
+        pixelBufferAdaptor = nil
+        currentRecordingURL = nil
+        recordingStartTime = nil
+        isWriterSessionStarted = false
+        isRecording = false
     }
 }

--- a/mobile/packages/divine_camera/macos/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController.swift
@@ -337,6 +337,10 @@ class CameraController: NSObject {
         if session.canAddOutput(videoOutput) {
             session.addOutput(videoOutput)
             self.videoOutput = videoOutput
+        } else {
+            session.commitConfiguration()
+            completion(nil, "Cannot add video output")
+            return
         }
 
         // Setup audio output for recording
@@ -345,6 +349,8 @@ class CameraController: NSObject {
         if session.canAddOutput(audioOutput) {
             session.addOutput(audioOutput)
             self.audioOutput = audioOutput
+        } else {
+            print("DivineCamera macOS: Cannot add audio output")
         }
 
         session.commitConfiguration()
@@ -355,6 +361,12 @@ class CameraController: NSObject {
         // Start session
         session.startRunning()
         self.captureSession = session
+
+        guard session.isRunning else {
+            self.captureSession = nil
+            completion(nil, "Camera session failed to start")
+            return
+        }
 
         // Register texture
         textureId = textureRegistry.register(self)
@@ -400,6 +412,13 @@ class CameraController: NSObject {
             state["textureId"] = self.textureId
             completion(state, nil)
         }
+    }
+
+    /// Whether preview frames have started flowing from AVFoundation.
+    func hasReceivedPreviewFrame() -> Bool {
+        pixelBufferLock.lock()
+        defer { pixelBufferLock.unlock() }
+        return latestSampleBuffer != nil
     }
 
     /// Updates camera properties from the device.

--- a/mobile/packages/divine_camera/test/divine_camera_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_test.dart
@@ -11,6 +11,7 @@ class MockDivineCameraPlatform
     implements DivineCameraPlatform {
   CameraState _state = const CameraState();
   bool _isRecording = false;
+  bool throwOnStopRecording = false;
   void Function(VideoRecordingResult result)? _onRecordingAutoStopped;
   void Function(RemoteRecordTrigger trigger)? _onRemoteRecordTrigger;
 
@@ -133,6 +134,10 @@ class MockDivineCameraPlatform
   @override
   Future<VideoRecordingResult?> stopRecording() async {
     if (!_isRecording) return null;
+    if (throwOnStopRecording) {
+      _isRecording = false;
+      throw PlatformException(code: 'RECORD_STOP_ERROR');
+    }
     _isRecording = false;
     return const VideoRecordingResult(
       filePath: '/test/video.mp4',
@@ -507,6 +512,20 @@ void main() {
         expect(result.width, 1080);
         expect(result.height, 1920);
         expect(DivineCamera.instance.isRecording, isFalse);
+      });
+
+      test('clears recording state when native stop fails', () async {
+        await DivineCamera.instance.initialize();
+        await DivineCamera.instance.startRecording();
+        mockPlatform.throwOnStopRecording = true;
+
+        await expectLater(
+          DivineCamera.instance.stopRecording(),
+          throwsA(isA<PlatformException>()),
+        );
+
+        expect(DivineCamera.instance.isRecording, isFalse);
+        expect(DivineCamera.instance.canRecord, isTrue);
       });
 
       test('canRecord returns true when initialized', () async {

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -1,0 +1,49 @@
+// ABOUTME: Tests that ARB locale files stay in sync with the English template.
+// ABOUTME: Prevents generated l10n APIs from drifting from translated files.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  group('ARB consistency', () {
+    test('all locales define the same message keys as app_en.arb', () {
+      final l10nDir = Directory('lib/l10n');
+      final arbFiles =
+          l10nDir
+              .listSync()
+              .whereType<File>()
+              .where((file) => file.path.endsWith('.arb'))
+              .toList()
+            ..sort((a, b) => a.path.compareTo(b.path));
+
+      final template = _readArb(File('lib/l10n/app_en.arb'));
+      final templateKeys = _messageKeys(template);
+
+      for (final file in arbFiles) {
+        final arb = _readArb(file);
+        final keys = _messageKeys(arb);
+
+        expect(
+          keys.difference(templateKeys),
+          isEmpty,
+          reason: '${file.path} has keys missing from app_en.arb',
+        );
+        expect(
+          templateKeys.difference(keys),
+          isEmpty,
+          reason: '${file.path} is missing keys from app_en.arb',
+        );
+      }
+    });
+  });
+}
+
+Map<String, Object?> _readArb(File file) {
+  return (jsonDecode(file.readAsStringSync()) as Map).cast<String, Object?>();
+}
+
+Set<String> _messageKeys(Map<String, Object?> arb) {
+  return arb.keys.where((key) => !key.startsWith('@')).toSet();
+}

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -52,6 +52,13 @@ const _knownUntranslatedDebt = {
   'profileMyLibraryLabel',
   'profileMessageLabel',
   'profileUserFallback',
+  'videoActionLikeLabel',
+  'videoActionReplyLabel',
+  'videoActionRepostLabel',
+  'videoActionShareLabel',
+  'videoActionAboutLabel',
+  'videoOverlayOpenMetadataFromTitle',
+  'videoOverlayOpenMetadataFromDescription',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -31,7 +31,7 @@ void main() {
           reason: '${file.path} has keys missing from app_en.arb',
         );
         expect(
-          templateKeys.difference(keys),
+          templateKeys.difference(keys).difference(_knownUntranslatedDebt),
           isEmpty,
           reason: '${file.path} is missing keys from app_en.arb',
         );
@@ -39,6 +39,20 @@ void main() {
     });
   });
 }
+
+const _knownUntranslatedDebt = {
+  'profileNoSavedVideosTitle',
+  'profileSavedOwnEmpty',
+  'profileErrorLoadingSaved',
+  'profileMaybeLaterLabel',
+  'profileSecurePrimaryButton',
+  'profileCompletePrimaryButton',
+  'profileLoopsLabel',
+  'profileLikesLabel',
+  'profileMyLibraryLabel',
+  'profileMessageLabel',
+  'profileUserFallback',
+};
 
 Map<String, Object?> _readArb(File file) {
   return (jsonDecode(file.readAsStringSync()) as Map).cast<String, Object?>();

--- a/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
+++ b/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
@@ -148,7 +148,7 @@ void main() {
       ProVideoEditor.instance = mockEditor;
     });
 
-    Widget buildWidget({AudioEvent? sound}) {
+    Widget buildWidget({AudioEvent? sound, Locale? locale}) {
       final testSound =
           sound ??
           _createTestAudioEvent(
@@ -158,6 +158,7 @@ void main() {
 
       return ProviderScope(
         child: MaterialApp(
+          locale: locale,
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: VideoAudioEditorTimingScreen(sound: testSound),
@@ -182,6 +183,20 @@ void main() {
       expect(
         find.text('Select the audio segment for your video'),
         findsOneWidget,
+      );
+    });
+
+    testWidgets('renders localized instruction text', (tester) async {
+      await tester.pumpWidget(buildWidget(locale: const Locale('de')));
+      await tester.pump();
+
+      expect(
+        find.text('Wähle den Audiobereich für dein Video aus'),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Select the audio segment for your video'),
+        findsNothing,
       );
     });
 

--- a/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
+++ b/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
@@ -181,7 +181,11 @@ void main() {
       await tester.pump();
 
       expect(
-        find.text('Select the audio segment for your video'),
+        find.text(
+          lookupAppLocalizations(
+            const Locale('en'),
+          ).videoEditorAudioSegmentInstruction,
+        ),
         findsOneWidget,
       );
     });
@@ -191,11 +195,19 @@ void main() {
       await tester.pump();
 
       expect(
-        find.text('Wähle den Audiobereich für dein Video aus'),
+        find.text(
+          lookupAppLocalizations(
+            const Locale('de'),
+          ).videoEditorAudioSegmentInstruction,
+        ),
         findsOneWidget,
       );
       expect(
-        find.text('Select the audio segment for your video'),
+        find.text(
+          lookupAppLocalizations(
+            const Locale('en'),
+          ).videoEditorAudioSegmentInstruction,
+        ),
         findsNothing,
       );
     });


### PR DESCRIPTION
Closes #3250

## Summary
- localize remaining video editor instruction copy and regenerate l10n output
- add ARB coverage for the PR 3142 follow-up keys while allowing existing profile translation debt
- harden macOS camera recording cleanup when preview frames or first writer frames never arrive

## Test Plan
- [x] dart test test/l10n/arb_consistency_test.dart
- [x] flutter test test/widgets/video_clip_editor/gallery/video_editor_gallery_instruction_text_test.dart test/screens/video_editor/video_audio_editor_timing_screen_test.dart
- [x] flutter test test/divine_camera_test.dart from mobile/packages/divine_camera
- [x] repo pre-push selected tests, 181 passed
- [x] flutter analyze --no-pub via pre-commit hook
- [x] flutter build macos --debug