### PR TITLE
feat(l10n): wire Intl locale sync and migrate 6 timestamp callsites

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -21,6 +21,8 @@ import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart' show Intl;
 import 'package:invite_api_client/invite_api_client.dart';
 import 'package:openvine/app_update/app_update.dart';
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
@@ -760,6 +762,8 @@ Future<void> _startOpenVineApp() async {
   );
   StartupPerformanceService.instance.checkpoint('pre_app_launch');
 
+  await initializeDateFormatting();
+
   runApp(
     UncontrolledProviderScope(
       container: container,
@@ -1484,6 +1488,9 @@ class _DivineAppState extends ConsumerState<DivineApp> {
     // The BlocBuilder is used because the cubit is provided further down
     // in the widget tree by MultiBlocProvider.
     Widget buildApp(Locale? locale) {
+      if (locale != null) {
+        Intl.defaultLocale = locale.toLanguageTag();
+      }
       if (!kIsWeb && io.Platform.isAndroid) {
         return AnnotatedRegion<SystemUiOverlayStyle>(
           value: VineTheme.statusBarStyle,

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
 import 'package:openvine/notifications/widgets/widgets.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -16,7 +17,6 @@ import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/services/notification_target_resolver.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
-import 'package:time_formatter/time_formatter.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// The notification list UI.
@@ -396,8 +396,10 @@ class _NotificationList extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
                 child: Text(
-                  TimeFormatter.formatDateLabel(
+                  LocalizedTimeFormatter.formatDateLabel(
+                    context.l10n,
                     notification.timestamp.millisecondsSinceEpoch ~/ 1000,
+                    locale: Localizations.localeOf(context).toLanguageTag(),
                   ),
                   style: const TextStyle(
                     fontSize: 14,

--- a/mobile/lib/notifications/widgets/notification_list_item.dart
+++ b/mobile/lib/notifications/widgets/notification_list_item.dart
@@ -7,8 +7,8 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/notifications/widgets/notification_avatar_stack.dart';
-import 'package:time_formatter/time_formatter.dart';
 
 /// Displays a single notification row in the notifications list.
 ///
@@ -414,7 +414,7 @@ class _Timestamp extends StatelessWidget {
   Widget build(BuildContext context) {
     final unixSeconds = timestamp.millisecondsSinceEpoch ~/ 1000;
     return Text(
-      TimeFormatter.formatRelativeVerbose(unixSeconds),
+      LocalizedTimeFormatter.formatRelativeVerbose(context.l10n, unixSeconds),
       style: VineTheme.bodySmallFont(color: VineTheme.lightText),
     );
   }

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -8,6 +8,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/widgets.dart';
@@ -16,7 +18,6 @@ import 'package:openvine/utils/clipboard_utils.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_content.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_result.dart';
-import 'package:time_formatter/time_formatter.dart';
 
 /// View for a single DM conversation.
 ///
@@ -278,7 +279,11 @@ class _MessageList extends StatelessWidget {
 
         return MessageBubble(
           message: message.content,
-          timestamp: TimeFormatter.formatMessageTime(message.createdAt),
+          timestamp: LocalizedTimeFormatter.formatMessageTime(
+            context.l10n,
+            message.createdAt,
+            locale: Localizations.localeOf(context).toLanguageTag(),
+          ),
           isSent: isSent,
           isFirstInGroup: isFirstInGroup,
           isLastInGroup: isLastInGroup,

--- a/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
+++ b/mobile/lib/screens/inbox/message_requests/widgets/request_tile.dart
@@ -5,10 +5,11 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/user_avatar.dart';
-import 'package:time_formatter/time_formatter.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// A conversation row in the message requests list.
@@ -48,8 +49,10 @@ class RequestTile extends ConsumerWidget {
     );
 
     final relativeTime = conversation.lastMessageTimestamp != null
-        ? TimeFormatter.formatConversationTimestamp(
+        ? LocalizedTimeFormatter.formatConversationTimestamp(
+            context.l10n,
             conversation.lastMessageTimestamp!,
+            locale: Localizations.localeOf(context).toLanguageTag(),
           )
         : '';
 

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -6,10 +6,11 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/user_avatar.dart';
-import 'package:time_formatter/time_formatter.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// A single conversation row in the DM conversation list.
@@ -58,8 +59,10 @@ class ConversationTile extends ConsumerWidget {
     );
 
     final relativeTime = conversation.lastMessageTimestamp != null
-        ? TimeFormatter.formatConversationTimestamp(
+        ? LocalizedTimeFormatter.formatConversationTimestamp(
+            context.l10n,
             conversation.lastMessageTimestamp!,
+            locale: Localizations.localeOf(context).toLanguageTag(),
           )
         : '';
 

--- a/mobile/lib/screens/notifications_screen.dart
+++ b/mobile/lib/screens/notifications_screen.dart
@@ -12,6 +12,7 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -23,7 +24,6 @@ import 'package:openvine/services/notification_target_resolver.dart';
 import 'package:openvine/services/screen_analytics_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/notification_list_item.dart';
-import 'package:time_formatter/time_formatter.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 class NotificationsScreen extends ConsumerStatefulWidget {
@@ -412,9 +412,13 @@ class _NotificationTabContentState
                           Padding(
                             padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
                             child: Text(
-                              TimeFormatter.formatDateLabel(
+                              LocalizedTimeFormatter.formatDateLabel(
+                                context.l10n,
                                 notification.timestamp.millisecondsSinceEpoch ~/
                                     1000,
+                                locale: Localizations.localeOf(
+                                  context,
+                                ).toLanguageTag(),
                               ),
                               style: const TextStyle(
                                 fontSize: 14,

--- a/mobile/test/l10n/localized_time_formatter_test.dart
+++ b/mobile/test/l10n/localized_time_formatter_test.dart
@@ -1,0 +1,433 @@
+// ABOUTME: Tests for LocalizedTimeFormatter — locale-aware wrapper around
+// ABOUTME: TimeFormatter that maps to AppLocalizations strings.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/l10n/localized_time_formatter.dart';
+
+Future<AppLocalizations> _loadL10n(WidgetTester tester, Locale locale) async {
+  late AppLocalizations l10n;
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: locale,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Builder(
+        builder: (context) {
+          l10n = context.l10n;
+          return const SizedBox.shrink();
+        },
+      ),
+    ),
+  );
+  return l10n;
+}
+
+int _unixSecondsAgo(Duration duration) {
+  return DateTime.now().subtract(duration).millisecondsSinceEpoch ~/ 1000;
+}
+
+void main() {
+  setUpAll(initializeDateFormatting);
+
+  group(LocalizedTimeFormatter, () {
+    group('formatRelative', () {
+      testWidgets('returns localized "now" for <1 minute', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final de = await _loadL10n(tester, const Locale('de'));
+        final ts = _unixSecondsAgo(const Duration(seconds: 30));
+
+        expect(LocalizedTimeFormatter.formatRelative(en, ts), equals('now'));
+        expect(LocalizedTimeFormatter.formatRelative(de, ts), equals('jetzt'));
+      });
+
+      testWidgets('returns minutes for <1 hour', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final de = await _loadL10n(tester, const Locale('de'));
+        final ts = _unixSecondsAgo(const Duration(minutes: 5));
+
+        expect(LocalizedTimeFormatter.formatRelative(en, ts), equals('5m'));
+        expect(LocalizedTimeFormatter.formatRelative(de, ts), equals('5 Min'));
+      });
+
+      testWidgets('returns hours for <1 day', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final ts = _unixSecondsAgo(const Duration(hours: 14));
+
+        expect(LocalizedTimeFormatter.formatRelative(en, ts), equals('14h'));
+      });
+
+      testWidgets('returns days for <1 week', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final ts = _unixSecondsAgo(const Duration(days: 3));
+
+        expect(LocalizedTimeFormatter.formatRelative(en, ts), equals('3d'));
+      });
+
+      testWidgets('returns weeks for <60 days', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final ts = _unixSecondsAgo(const Duration(days: 14));
+
+        expect(LocalizedTimeFormatter.formatRelative(en, ts), equals('2w'));
+      });
+
+      testWidgets('returns months for <1 year', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final ts = _unixSecondsAgo(const Duration(days: 90));
+
+        expect(LocalizedTimeFormatter.formatRelative(en, ts), equals('3mo'));
+      });
+
+      testWidgets('returns years for >=1 year', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final ts = _unixSecondsAgo(const Duration(days: 400));
+
+        expect(LocalizedTimeFormatter.formatRelative(en, ts), equals('1y'));
+      });
+    });
+
+    group('formatRelativeVerbose', () {
+      testWidgets('returns localized "Now" for <1 minute', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final de = await _loadL10n(tester, const Locale('de'));
+        final ts = _unixSecondsAgo(const Duration(seconds: 10));
+
+        expect(
+          LocalizedTimeFormatter.formatRelativeVerbose(en, ts),
+          equals('Now'),
+        );
+        expect(
+          LocalizedTimeFormatter.formatRelativeVerbose(de, ts),
+          equals('Jetzt'),
+        );
+      });
+
+      testWidgets('returns localized "{time} ago" for older', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final de = await _loadL10n(tester, const Locale('de'));
+        final ts = _unixSecondsAgo(const Duration(minutes: 3));
+
+        expect(
+          LocalizedTimeFormatter.formatRelativeVerbose(en, ts),
+          equals('3m ago'),
+        );
+        expect(
+          LocalizedTimeFormatter.formatRelativeVerbose(de, ts),
+          equals('vor 3 Min'),
+        );
+      });
+    });
+
+    group('formatDateLabel', () {
+      testWidgets('returns localized "Today" for current day', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final de = await _loadL10n(tester, const Locale('de'));
+        final now = DateTime.now();
+        final earlierToday = DateTime(now.year, now.month, now.day, 12);
+        final safeTime = earlierToday.isAfter(now)
+            ? DateTime(now.year, now.month, now.day, 0, 1)
+            : earlierToday;
+        final ts = safeTime.millisecondsSinceEpoch ~/ 1000;
+
+        expect(
+          LocalizedTimeFormatter.formatDateLabel(en, ts),
+          equals('Today'),
+        );
+        expect(
+          LocalizedTimeFormatter.formatDateLabel(de, ts),
+          equals('Heute'),
+        );
+      });
+
+      testWidgets('returns localized "Yesterday"', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final de = await _loadL10n(tester, const Locale('de'));
+        final now = DateTime.now();
+        final yesterday = DateTime(now.year, now.month, now.day - 1, 12);
+        final ts = yesterday.millisecondsSinceEpoch ~/ 1000;
+
+        expect(
+          LocalizedTimeFormatter.formatDateLabel(en, ts),
+          equals('Yesterday'),
+        );
+        expect(
+          LocalizedTimeFormatter.formatDateLabel(de, ts),
+          equals('Gestern'),
+        );
+      });
+
+      testWidgets('returns weekday name for 2-6 days ago', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final ts = _unixSecondsAgo(const Duration(days: 3));
+
+        final result = LocalizedTimeFormatter.formatDateLabel(
+          en,
+          ts,
+          locale: 'en',
+        );
+        const weekdays = {
+          'Monday',
+          'Tuesday',
+          'Wednesday',
+          'Thursday',
+          'Friday',
+          'Saturday',
+          'Sunday',
+        };
+        expect(weekdays.contains(result), isTrue, reason: 'got: $result');
+      });
+
+      testWidgets('uses passed locale for older dates', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final ts = _unixSecondsAgo(const Duration(days: 30));
+
+        final enResult = LocalizedTimeFormatter.formatDateLabel(
+          en,
+          ts,
+          locale: 'en',
+        );
+        final deResult = LocalizedTimeFormatter.formatDateLabel(
+          en,
+          ts,
+          locale: 'de',
+        );
+        expect(enResult, isNotEmpty);
+        expect(deResult, isNotEmpty);
+        expect(enResult, isNot(equals(deResult)));
+      });
+    });
+
+    group('formatConversationTimestamp', () {
+      testWidgets('returns localized "now" for <1 minute', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final de = await _loadL10n(tester, const Locale('de'));
+        final ts = _unixSecondsAgo(const Duration(seconds: 10));
+
+        expect(
+          LocalizedTimeFormatter.formatConversationTimestamp(en, ts),
+          equals('now'),
+        );
+        expect(
+          LocalizedTimeFormatter.formatConversationTimestamp(de, ts),
+          equals('jetzt'),
+        );
+      });
+
+      testWidgets('returns minutes for <1 hour', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final ts = _unixSecondsAgo(const Duration(minutes: 30));
+
+        expect(
+          LocalizedTimeFormatter.formatConversationTimestamp(en, ts),
+          equals('30m'),
+        );
+      });
+
+      testWidgets('returns hours for same day', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final now = DateTime.now();
+        final earlierToday = now.copyWith(hour: 1, minute: 0);
+        if (now.difference(earlierToday).inMinutes < 60) return;
+        final ts = earlierToday.millisecondsSinceEpoch ~/ 1000;
+
+        final result = LocalizedTimeFormatter.formatConversationTimestamp(
+          en,
+          ts,
+        );
+        expect(result, endsWith('h'));
+      });
+
+      testWidgets('returns "Yesterday" for previous day', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final de = await _loadL10n(tester, const Locale('de'));
+        final now = DateTime.now();
+        final yesterday = DateTime(now.year, now.month, now.day - 1, 12);
+        final ts = yesterday.millisecondsSinceEpoch ~/ 1000;
+
+        expect(
+          LocalizedTimeFormatter.formatConversationTimestamp(en, ts),
+          equals('Yesterday'),
+        );
+        expect(
+          LocalizedTimeFormatter.formatConversationTimestamp(de, ts),
+          equals('Gestern'),
+        );
+      });
+    });
+
+    group('formatMessageTime', () {
+      testWidgets('returns localized "Now" for <60 seconds', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final de = await _loadL10n(tester, const Locale('de'));
+        final ts = _unixSecondsAgo(const Duration(seconds: 30));
+
+        expect(
+          LocalizedTimeFormatter.formatMessageTime(en, ts),
+          equals('Now'),
+        );
+        expect(
+          LocalizedTimeFormatter.formatMessageTime(de, ts),
+          equals('Jetzt'),
+        );
+      });
+
+      testWidgets('renders time-of-day for same calendar day', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final now = DateTime.now();
+        final earlierToday = now.subtract(const Duration(hours: 2));
+        if (earlierToday.day != now.day) return;
+        final ts = earlierToday.millisecondsSinceEpoch ~/ 1000;
+
+        final result = LocalizedTimeFormatter.formatMessageTime(
+          en,
+          ts,
+          locale: 'en',
+        );
+        expect(result, matches(RegExp(r'^\d{1,2}:\d{2}\s?(AM|PM)?$')));
+      });
+
+      testWidgets('returns "Yesterday" for previous day', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final de = await _loadL10n(tester, const Locale('de'));
+        final now = DateTime.now();
+        final yesterday = DateTime(now.year, now.month, now.day - 1, 12);
+        final ts = yesterday.millisecondsSinceEpoch ~/ 1000;
+
+        expect(
+          LocalizedTimeFormatter.formatMessageTime(en, ts),
+          equals('Yesterday'),
+        );
+        expect(
+          LocalizedTimeFormatter.formatMessageTime(de, ts),
+          equals('Gestern'),
+        );
+      });
+    });
+
+    group('formatDurationAgo', () {
+      testWidgets('returns localized "just now" for <1 minute', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final de = await _loadL10n(tester, const Locale('de'));
+
+        expect(
+          LocalizedTimeFormatter.formatDurationAgo(
+            en,
+            const Duration(seconds: 30),
+          ),
+          equals('just now'),
+        );
+        expect(
+          LocalizedTimeFormatter.formatDurationAgo(
+            de,
+            const Duration(seconds: 30),
+          ),
+          equals('gerade eben'),
+        );
+      });
+
+      testWidgets('returns minutes for <1 hour', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final de = await _loadL10n(tester, const Locale('de'));
+
+        expect(
+          LocalizedTimeFormatter.formatDurationAgo(
+            en,
+            const Duration(minutes: 5),
+          ),
+          equals('5m ago'),
+        );
+        expect(
+          LocalizedTimeFormatter.formatDurationAgo(
+            de,
+            const Duration(minutes: 5),
+          ),
+          equals('vor 5 Min'),
+        );
+      });
+
+      testWidgets('returns hours for <1 day', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+
+        expect(
+          LocalizedTimeFormatter.formatDurationAgo(
+            en,
+            const Duration(hours: 3),
+          ),
+          equals('3h ago'),
+        );
+      });
+
+      testWidgets('returns days for >=1 day', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+
+        expect(
+          LocalizedTimeFormatter.formatDurationAgo(
+            en,
+            const Duration(days: 2),
+          ),
+          equals('2d ago'),
+        );
+      });
+    });
+
+    group('formatDraftAge', () {
+      testWidgets('returns localized "Just now" for <1 minute', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+        final de = await _loadL10n(tester, const Locale('de'));
+
+        expect(
+          LocalizedTimeFormatter.formatDraftAge(
+            en,
+            const Duration(seconds: 30),
+          ),
+          equals('Just now'),
+        );
+        expect(
+          LocalizedTimeFormatter.formatDraftAge(
+            de,
+            const Duration(seconds: 30),
+          ),
+          equals('Gerade eben'),
+        );
+      });
+
+      testWidgets('returns minutes for <1 hour', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+
+        expect(
+          LocalizedTimeFormatter.formatDraftAge(
+            en,
+            const Duration(minutes: 7),
+          ),
+          equals('7m ago'),
+        );
+      });
+
+      testWidgets('returns hours for <1 day', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+
+        expect(
+          LocalizedTimeFormatter.formatDraftAge(
+            en,
+            const Duration(hours: 5),
+          ),
+          equals('5h ago'),
+        );
+      });
+
+      testWidgets('returns days for >=1 day', (tester) async {
+        final en = await _loadL10n(tester, const Locale('en'));
+
+        expect(
+          LocalizedTimeFormatter.formatDraftAge(
+            en,
+            const Duration(days: 4),
+          ),
+          equals('4d ago'),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Merge order

**Merge this first.** Both PR #3256 and PR #3257 depend on this
foundation — they add tests to the file this PR creates
(`test/l10n/localized_time_formatter_test.dart`) and PR #3257 further
modifies a line this PR also modifies in `conversation_view.dart`.
After this lands, PR #3256 and PR #3257 can be rebased onto `main`
and merged **in either order** — they touch different methods in the
formatter and different test groups, so they're siblings rather than
a chain.

## Summary

Foundation PR for #332 (locale-aware date/time formatting). Finishes the
stalled migration started in #2095 and #2930 by wiring the app-init step
that was missing, and routing six UI timestamp sites through the l10n-aware
`LocalizedTimeFormatter` wrapper that already exists in the repo.

### What changes

1. **App init (`lib/main.dart`)**
   - `await initializeDateFormatting()` before `runApp` loads locale data
     for all supported locales. Without this, `DateFormat.yMMMd('de')` would
     throw `LocaleDataException` at runtime for non-`en` users.
   - `Intl.defaultLocale = locale.toLanguageTag()` inside `buildApp(Locale?)`
     so bare `DateFormat.*()` calls (e.g. in models) follow the in-app locale
     rather than the system locale.
   - `intl` is imported with `show Intl` to avoid a clash with Flutter's
     `TextDirection`.

2. **Six callsite migrations** — swapped `TimeFormatter.*` (l10n-free) for
   `LocalizedTimeFormatter.*` (ARB-backed), threading `context.l10n` and
   `locale: Localizations.localeOf(context).toLanguageTag()`:
   - `lib/screens/notifications_screen.dart` (date labels)
   - `lib/notifications/view/notifications_view.dart` (date labels)
   - `lib/notifications/widgets/notification_list_item.dart` (relative time)
   - `lib/screens/inbox/message_requests/widgets/request_tile.dart` (conversation timestamps)
   - `lib/screens/inbox/widgets/conversation_tile.dart` (conversation timestamps)
   - `lib/screens/inbox/conversation/conversation_view.dart` (message bubble time)

3. **New test file `test/l10n/localized_time_formatter_test.dart`** — the
   audit flagged zero coverage on the wrapper. Added 28 tests covering all
   seven public methods with both `en` and `de` assertions, proving locale
   threading reaches the ARB layer and the `DateFormat` layer.

### What still breaks (follow-up PRs)

This is deliberately scoped to unblock non-English timestamp rendering on
the listed surfaces. Still in scope of #332, tracked for follow-up PRs:

- Hardcoded English getters on `VideoEvent.relativeTime`,
  `Comment.relativeTime`, `NotificationModel.formattedTimestamp` (violates
  `rules/localization.md`, consumed by 3 widgets) — handled by #3256.
- 24h-override via `MediaQuery.alwaysUse24HourFormat` for message-bubble
  time-of-day (the issue's explicit "12-hour vs 24-hour" ask) — handled by #3257.
- Remaining direct `DateFormat.*()` calls without a locale arg
  (`drafts_tab.dart`, `creator_analytics_screen.dart`) — handled by #3257.

Related: supersedes the QA tracker duplicate #518, closed via bulk cleanup
rather than implementation.

## Test plan
- [x] `flutter analyze lib test integration_test` → clean
- [x] `dart format --set-exit-if-changed` on 8 changed files → 0 changes
- [x] `flutter test test/l10n/` → 44 passed (16 existing + 28 new)
- [x] `flutter test` on the 6 migrated widget tests → 52 passed, 0 failed
- [x] Repo-wide grep confirms no stray `TimeFormatter.*` calls outside the
      legitimate numeric-duration formatter in
      `video_editor_timeline_header.dart`
- [ ] Manual smoke: switch in-app locale to `de` and verify German
      timestamp strings render on notifications / inbox / conversation
      screens (planned after merge — depends on where `LocaleCubit`
      exposes its switcher UI)

## Related
- Part of #332
- Closes duplicate-by-scope QA item #518
- Builds on #2095 (2026-03-10) and #2930 (2026-04-12)