### PR TITLE
refactor(video-editor): convert old text-style values to VineTheme

### DIFF
--- a/mobile/lib/widgets/library/clips_tab.dart
+++ b/mobile/lib/widgets/library/clips_tab.dart
@@ -134,18 +134,20 @@ class ClipsTab extends StatelessWidget {
         backgroundColor: VineTheme.cardBackground,
         title: Text(
           context.l10n.libraryDeleteClipTitle,
-          style: const TextStyle(color: VineTheme.whiteText),
+          style: VineTheme.titleSmallFont(),
         ),
         content: Text(
           context.l10n.libraryDeleteClipMessage,
-          style: const TextStyle(color: VineTheme.whiteText),
+          style: VineTheme.bodyMediumFont(),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(dialogContext).pop(false),
             child: Text(
               context.l10n.commonCancel,
-              style: const TextStyle(color: VineTheme.secondaryText),
+              style: VineTheme.bodyMediumFont(
+                color: VineTheme.secondaryText,
+              ),
             ),
           ),
           ElevatedButton(

--- a/mobile/lib/widgets/library/drafts_tab.dart
+++ b/mobile/lib/widgets/library/drafts_tab.dart
@@ -223,20 +223,22 @@ class DraftsTab extends ConsumerWidget {
         backgroundColor: VineTheme.cardBackground,
         title: Text(
           context.l10n.libraryDeleteDraftTitle,
-          style: const TextStyle(color: VineTheme.whiteText),
+          style: VineTheme.titleSmallFont(),
         ),
         content: Text(
           context.l10n.libraryDeleteDraftMessage(
             draft.title.isEmpty ? context.l10n.draftUntitled : draft.title,
           ),
-          style: const TextStyle(color: VineTheme.whiteText),
+          style: VineTheme.bodyMediumFont(),
         ),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(dialogContext).pop(false),
             child: Text(
               context.l10n.commonCancel,
-              style: const TextStyle(color: VineTheme.secondaryText),
+              style: VineTheme.bodyMediumFont(
+                color: VineTheme.secondaryText,
+              ),
             ),
           ),
           ElevatedButton(

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -332,18 +332,13 @@ class _EmptyState extends StatelessWidget {
           const SizedBox(height: 16),
           Text(
             context.l10n.videoEditorAudioNoSoundsAvailableTitle,
-            style: const TextStyle(
-              color: VineTheme.whiteText,
-              fontSize: 18,
-              fontWeight: FontWeight.w500,
-            ),
+            style: VineTheme.bodyLargeFont(),
           ),
           const SizedBox(height: 8),
           Text(
             context.l10n.videoEditorAudioNoSoundsAvailableSubtitle,
-            style: const TextStyle(
+            style: VineTheme.bodyMediumFont(
               color: VineTheme.secondaryText,
-              fontSize: 14,
             ),
             textAlign: TextAlign.center,
           ),
@@ -370,18 +365,13 @@ class _NoResultsState extends StatelessWidget {
           const SizedBox(height: 16),
           Text(
             context.l10n.videoEditorAudioNoSoundsFoundTitle,
-            style: const TextStyle(
-              color: VineTheme.whiteText,
-              fontSize: 18,
-              fontWeight: FontWeight.w500,
-            ),
+            style: VineTheme.bodyLargeFont().copyWith(),
           ),
           const SizedBox(height: 8),
           Text(
             context.l10n.videoEditorAudioNoSoundsFoundSubtitle,
-            style: const TextStyle(
+            style: VineTheme.bodyMediumFont(
               color: VineTheme.secondaryText,
-              fontSize: 14,
             ),
           ),
         ],
@@ -407,18 +397,13 @@ class _ErrorState extends ConsumerWidget {
             const SizedBox(height: 16),
             Text(
               context.l10n.videoEditorAudioFailedToLoadTitle,
-              style: const TextStyle(
-                color: VineTheme.whiteText,
-                fontSize: 18,
-                fontWeight: FontWeight.w500,
-              ),
+              style: VineTheme.bodyLargeFont(),
             ),
             const SizedBox(height: 8),
             Text(
               error.toString(),
-              style: const TextStyle(
+              style: VineTheme.bodySmallFont(
                 color: VineTheme.secondaryText,
-                fontSize: 12,
               ),
               textAlign: TextAlign.center,
               maxLines: 3,

--- a/mobile/lib/widgets/video_editor/clip_editor/video_time_display.dart
+++ b/mobile/lib/widgets/video_editor/clip_editor/video_time_display.dart
@@ -47,14 +47,8 @@ class VideoTimeDisplay extends StatelessWidget {
   Widget build(BuildContext context) {
     final defaultCurrentStyle =
         currentStyle ??
-        const TextStyle(
-          color: VineTheme.whiteText,
-          fontSize: 18,
-          fontFamily: VineTheme.fontFamilyBricolage,
-          fontWeight: .w800,
-          height: 1.33,
-          letterSpacing: 0.15,
-          fontFeatures: [.tabularFigures()],
+        VineTheme.titleMediumFont().copyWith(
+          fontFeatures: const [.tabularFigures()],
         );
 
     final defaultSeparatorStyle =

--- a/mobile/lib/widgets/video_metadata/video_metadata_content_warning_selector.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_content_warning_selector.dart
@@ -152,9 +152,8 @@ class _ContentWarningMultiSelectState
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
             child: Text(
               context.l10n.videoMetadataContentWarningSelectAllThatApply,
-              style: const TextStyle(
+              style: VineTheme.bodySmallFont(
                 color: VineTheme.secondaryText,
-                fontSize: 13,
               ),
             ),
           ),
@@ -173,10 +172,7 @@ class _ContentWarningMultiSelectState
                       context.l10n,
                       label,
                     ),
-                    style: const TextStyle(
-                      color: VineTheme.whiteText,
-                      fontSize: 15,
-                    ),
+                    style: VineTheme.bodyLargeFont(),
                   ),
                   activeColor: VineTheme.vineGreen,
                   checkColor: VineTheme.whiteText,

--- a/mobile/lib/widgets/video_recorder/video_recorder_camera_placeholder.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_camera_placeholder.dart
@@ -34,9 +34,8 @@ class VideoRecorderCameraPlaceholder extends StatelessWidget {
                 child: Text(
                   errorMessage!,
                   textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    color: Color(0xB3FFFFFF),
-                    fontSize: 14,
+                  style: VineTheme.bodyMediumFont(
+                    color: VineTheme.onSurfaceVariant,
                   ),
                 ),
               ),

--- a/mobile/lib/widgets/video_recorder/video_recorder_countdown_overlay.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_countdown_overlay.dart
@@ -31,12 +31,8 @@ class VideoRecorderCountdownOverlay extends ConsumerWidget {
           child: Center(
             child: Text(
               countdownValue.toString(),
-              style: const TextStyle(
-                color: VineTheme.primaryText,
+              style: VineTheme.displayLargeFont().copyWith(
                 fontSize: 114,
-                fontFamily: VineTheme.fontFamilyBricolage,
-                fontWeight: .w700,
-                height: 1.12,
               ),
             ),
           ),


### PR DESCRIPTION
Closes #3255



## Description

Use the VineTheme font across the different widgets in the video creation flow instead of the old TextStyle.

**Related Issue:** Closes #3148


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore