### PR TITLE
feat(l10n): honor 24h-override and thread locale into remaining DateFormat sites

### DIFF
--- a/mobile/lib/l10n/localized_time_formatter.dart
+++ b/mobile/lib/l10n/localized_time_formatter.dart
@@ -117,10 +117,17 @@ abstract class LocalizedTimeFormatter {
 
   /// Formats a Unix timestamp (seconds) for message bubble
   /// timestamps with localized labels.
+  ///
+  /// When [use24Hour] is true, same-day timestamps render with a
+  /// 24-hour clock (`DateFormat.Hm`). Otherwise they use the locale's
+  /// preferred 12h/24h style via `DateFormat.jm`. Pass
+  /// `MediaQuery.of(context).alwaysUse24HourFormat` from the callsite
+  /// so the OS-level clock override is honoured.
   static String formatMessageTime(
     AppLocalizations l10n,
     int unixSeconds, {
     String? locale,
+    bool use24Hour = false,
   }) {
     final now = DateTime.now();
     final date = DateTime.fromMillisecondsSinceEpoch(
@@ -132,7 +139,11 @@ abstract class LocalizedTimeFormatter {
     if (diff.inSeconds < 60) return l10n.timeVerboseNow;
 
     final dayDiff = _calendarDayDiff(now, date);
-    if (dayDiff == 0) return DateFormat.jm(locale).format(date);
+    if (dayDiff == 0) {
+      return use24Hour
+          ? DateFormat.Hm(locale).format(date)
+          : DateFormat.jm(locale).format(date);
+    }
     return _formatByDayDiff(l10n, dayDiff, date, now, locale: locale);
   }
 

--- a/mobile/lib/screens/creator_analytics_screen.dart
+++ b/mobile/lib/screens/creator_analytics_screen.dart
@@ -1001,6 +1001,7 @@ class _DailyTrendCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final points = summary.dailyInteractions;
+    final locale = Localizations.localeOf(context).toLanguageTag();
     final maxValue = points.fold<int>(
       0,
       (maxInteractions, point) => point.interactions > maxInteractions
@@ -1043,7 +1044,7 @@ class _DailyTrendCard extends StatelessWidget {
                         SizedBox(
                           width: 68,
                           child: Text(
-                            point.axisLabel,
+                            point.axisLabel(locale),
                             style: VineTheme.bodySmallFont(
                               color: VineTheme.onSurfaceMuted,
                             ),
@@ -1357,8 +1358,9 @@ class _DailyInteractionPoint {
   final DateTime day;
   final int interactions;
 
-  String get axisLabel =>
-      '${DateFormat.E().format(day)} ${DateFormat.Md().format(day)}';
+  String axisLabel(String locale) =>
+      '${DateFormat.E(locale).format(day)} '
+      '${DateFormat.Md(locale).format(day)}';
 }
 
 DateTime _videoTimestamp(VideoEvent video) {

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -283,6 +283,7 @@ class _MessageList extends StatelessWidget {
             context.l10n,
             message.createdAt,
             locale: Localizations.localeOf(context).toLanguageTag(),
+            use24Hour: MediaQuery.of(context).alwaysUse24HourFormat,
           ),
           isSent: isSent,
           isFirstInGroup: isFirstInGroup,

--- a/mobile/lib/widgets/library/drafts_tab.dart
+++ b/mobile/lib/widgets/library/drafts_tab.dart
@@ -271,6 +271,16 @@ class DraftsTab extends ConsumerWidget {
   }
 }
 
+String _formatDraftSubtitle(BuildContext context, DateTime lastModified) {
+  final locale = Localizations.localeOf(context).toLanguageTag();
+  final date = DateFormat.yMMMEd(locale).format(lastModified);
+  final time = MaterialLocalizations.of(context).formatTimeOfDay(
+    TimeOfDay.fromDateTime(lastModified),
+    alwaysUse24HourFormat: MediaQuery.of(context).alwaysUse24HourFormat,
+  );
+  return '$date $time';
+}
+
 /// List tile widget displaying a single draft.
 class DraftListTile extends StatelessWidget {
   /// Creates a draft list tile.
@@ -340,7 +350,7 @@ class DraftListTile extends StatelessWidget {
         overflow: TextOverflow.ellipsis,
       ),
       subtitle: Text(
-        DateFormat.yMMMEd().add_jm().format(draft.lastModified),
+        _formatDraftSubtitle(context, draft.lastModified),
         style: VineTheme.bodySmallFont(),
       ),
       trailing: onOpenMore == null

--- a/mobile/test/l10n/localized_time_formatter_test.dart
+++ b/mobile/test/l10n/localized_time_formatter_test.dart
@@ -289,6 +289,45 @@ void main() {
         expect(result, matches(RegExp(r'^\d{1,2}:\d{2}\s?(AM|PM)?$')));
       });
 
+      testWidgets(
+        'use24Hour: true renders 24-hour clock regardless of locale',
+        (tester) async {
+          final en = await _loadL10n(tester, const Locale('en'));
+          final now = DateTime.now();
+          final earlierToday = now.subtract(const Duration(hours: 2));
+          if (earlierToday.day != now.day) return;
+          final ts = earlierToday.millisecondsSinceEpoch ~/ 1000;
+
+          final result = LocalizedTimeFormatter.formatMessageTime(
+            en,
+            ts,
+            locale: 'en',
+            use24Hour: true,
+          );
+          expect(result, matches(RegExp(r'^\d{1,2}:\d{2}$')));
+          expect(result, isNot(contains('AM')));
+          expect(result, isNot(contains('PM')));
+        },
+      );
+
+      testWidgets(
+        'use24Hour: false keeps locale-default 12h in en',
+        (tester) async {
+          final en = await _loadL10n(tester, const Locale('en'));
+          final now = DateTime.now();
+          final earlierToday = now.subtract(const Duration(hours: 2));
+          if (earlierToday.day != now.day) return;
+          final ts = earlierToday.millisecondsSinceEpoch ~/ 1000;
+
+          final result = LocalizedTimeFormatter.formatMessageTime(
+            en,
+            ts,
+            locale: 'en',
+          );
+          expect(result, anyOf(contains('AM'), contains('PM')));
+        },
+      );
+
       testWidgets('returns "Yesterday" for previous day', (tester) async {
         final en = await _loadL10n(tester, const Locale('en'));
         final de = await _loadL10n(tester, const Locale('de'));


### PR DESCRIPTION
## Merge order

**Merge after #3253.** Sibling of #3256. Once #3253 lands, rebase this
onto `main` and merge; it can land **before or after #3256**.

Note on the git base: this PR is physically branched on top of
`feat/332-l10n-remove-model-english-getters` (the #3256 branch) so it
could share the test file that #3253 creates, but the actual code
dependency is only on #3253. #3256 and #3257 touch different methods
in `localized_time_formatter.dart` and different groups in the test
file, so rebasing one after the other is straightforward.

## Summary

Third and final slice of #332. Directly resolves the issue's explicit
"12-hour vs 24-hour" ask and cleans up the last three bare `DateFormat`
callsites that weren't threading a locale.

### What changes

1. **`LocalizedTimeFormatter.formatMessageTime` gains `bool use24Hour`**

   - `use24Hour: true` → same-day timestamps use `DateFormat.Hm(locale)`
     (24-hour clock).
   - `use24Hour: false` (default) → `DateFormat.jm(locale)` (locale's
     preferred clock style).
   - Callers pass `MediaQuery.of(context).alwaysUse24HourFormat`, so a
     user who flipped "24-Hour Time" ON in iOS/Android settings sees
     `21:41` in message bubbles even on `en_US` (which defaults to
     12h). Change is backward-compatible — parameter defaults to
     `false`.

2. **`conversation_view.dart:281`** — threads the MediaQuery override
   into the `formatMessageTime` call.

3. **`drafts_tab.dart:343`** — replaces
   `DateFormat.yMMMEd().add_jm().format(...)` (no locale + forced 12h)
   with a threaded-locale `DateFormat.yMMMEd(locale)` for the date
   portion plus `MaterialLocalizations.formatTimeOfDay(...,
   alwaysUse24HourFormat: ...)` for the time portion. Extracted to a
   small private `_formatDraftSubtitle` helper for readability.

4. **`creator_analytics_screen.dart:1361`** —
   `_DailyInteractionPoint.axisLabel` was a `String get` on a
   BuildContext-less data class. Now a method `axisLabel(String locale)`.
   The consuming widget `_DailyTrendCard` resolves
   `Localizations.localeOf(context).toLanguageTag()` once and passes it
   in at render time. Same layout, now locale-aware.

5. **Tests**: added two `formatMessageTime` tests verifying
   `use24Hour: true` produces `HH:mm` with no AM/PM marker, and that
   the default keeps locale-default 12h in `en`.

## Test plan
- [x] `flutter analyze lib test integration_test` → clean
- [x] `dart format --set-exit-if-changed` → 0 changes
- [x] `flutter test test/l10n/` → 33 passed (31 from stack + 2 new use24Hour)
- [x] `flutter test test/widgets/library/drafts_tab_test.dart` → 12 pass
- [x] `flutter test test/screens/inbox/conversation/conversation_view_test.dart` → 7 pass
- [ ] Manual: on iOS, toggle Settings → General → Date & Time →
      24-Hour Time → confirm conversation bubble timestamps and draft
      subtitle time portion flip between `9:41 PM` / `21:41` without
      restart.
- [ ] Manual: switch in-app locale to `de` → confirm drafts subtitle
      renders `Mi., 22. Apr. 2026 21:41` (German compact-date + 24h).

## Related
- Part of #332 — this PR closes the issue when the stack lands.
- Stacked on #3256 in git; functionally a sibling.