### PR TITLE
feat(content-policy): Phase 1a foundation — flag, state, engine provider

### DIFF
--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -55,6 +55,10 @@ enum FeatureFlag {
   peopleListSearch(
     'People List Search',
     'Show people list (kind 30000) results alongside video lists in search',
+  ),
+  contentPolicyV2(
+    'Content Policy v2',
+    'Parse-gated policy engine — filter blocked/muted authors at ingress',
   )
   ;
 

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -45,6 +45,8 @@ class BuildConfiguration {
         return const bool.fromEnvironment('FF_HLS_AUTH_WEB_PLAYER');
       case FeatureFlag.peopleListSearch:
         return const bool.fromEnvironment('FF_PEOPLE_LIST_SEARCH');
+      case FeatureFlag.contentPolicyV2:
+        return const bool.fromEnvironment('FF_CONTENT_POLICY_V2');
     }
   }
 
@@ -89,6 +91,8 @@ class BuildConfiguration {
         return 'FF_HLS_AUTH_WEB_PLAYER';
       case FeatureFlag.peopleListSearch:
         return 'FF_PEOPLE_LIST_SEARCH';
+      case FeatureFlag.contentPolicyV2:
+        return 'FF_CONTENT_POLICY_V2';
     }
   }
 }

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -9,6 +9,7 @@ import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:categories_repository/categories_repository.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:content_policy/content_policy.dart';
 import 'package:curated_list_repository/curated_list_repository.dart';
 import 'package:curation_repository/curation_repository.dart';
 import 'package:dm_repository/dm_repository.dart';
@@ -115,6 +116,11 @@ import 'package:unified_logger/unified_logger.dart';
 import 'package:videos_repository/videos_repository.dart';
 
 part 'app_providers.g.dart';
+
+@Riverpod(keepAlive: true)
+ContentPolicyEngine contentPolicyEngine(Ref ref) {
+  return ContentPolicyEngine.defaultRules();
+}
 
 final nostrAppDirectoryServiceProvider = Provider<NostrAppDirectoryService>((
   ref,

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -8,6 +8,55 @@ part of 'app_providers.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
+
+@ProviderFor(contentPolicyEngine)
+const contentPolicyEngineProvider = ContentPolicyEngineProvider._();
+
+final class ContentPolicyEngineProvider
+    extends
+        $FunctionalProvider<
+          ContentPolicyEngine,
+          ContentPolicyEngine,
+          ContentPolicyEngine
+        >
+    with $Provider<ContentPolicyEngine> {
+  const ContentPolicyEngineProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'contentPolicyEngineProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$contentPolicyEngineHash();
+
+  @$internal
+  @override
+  $ProviderElement<ContentPolicyEngine> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  ContentPolicyEngine create(Ref ref) {
+    return contentPolicyEngine(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ContentPolicyEngine value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ContentPolicyEngine>(value),
+    );
+  }
+}
+
+String _$contentPolicyEngineHash() =>
+    r'3e6e0f8415da251057c220f5873bd5359c6ce9f1';
+
 /// Connection status service for monitoring network connectivity
 
 @ProviderFor(connectionStatusService)

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:content_blocklist_repository/src/block_list_signer.dart';
+import 'package:content_policy/content_policy.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
@@ -73,6 +74,8 @@ class ContentBlocklistRepository {
   // followers list until they explicitly re-follow.
   final Set<String> _severedFollowers = <String>{};
 
+  final _stateController = StreamController<ContentPolicyState>.broadcast();
+
   // Subscription tracking for mutual mutes
   String? _mutualMuteSubscriptionId;
   bool _mutualMuteSyncStarted = false;
@@ -85,8 +88,30 @@ class ContentBlocklistRepository {
   BlockListSigner? _signer;
   NostrClient? _nostrClient;
 
+  /// A synchronous snapshot of the current policy state.
+  ContentPolicyState get currentState => _buildCurrentState();
+
+  /// Emits a new [ContentPolicyState] snapshot whenever the policy changes.
+  Stream<ContentPolicyState> get stateStream => _stateController.stream;
+
+  ContentPolicyState _buildCurrentState() => ContentPolicyState(
+    currentUserPubkey: _ourPubkey,
+    // TODO(rabble): populate from our own kind 10000 once personal-mute
+    // reading is wired; tracking in follow-up to the content-policy epic.
+    mutedPubkeys: const {},
+    blockedPubkeys: Set.unmodifiable({
+      ..._internalBlocklist,
+      ..._runtimeBlocklist,
+    }),
+    pubkeysBlockingUs: Set.unmodifiable(_blockedByOthers),
+    pubkeysMutingUs: Set.unmodifiable(_mutualMuteBlocklist),
+  );
+
   void _notifyChanged() {
     _onChanged?.call();
+    if (!_stateController.isClosed) {
+      _stateController.add(_buildCurrentState());
+    }
   }
 
   void _addInitialBlockedContent() {
@@ -721,5 +746,6 @@ class ContentBlocklistRepository {
     _mutualMuteSyncStarted = false;
     _mutualMuteSubscriptionId = null;
     _blockListSyncStarted = false;
+    unawaited(_stateController.close());
   }
 }

--- a/mobile/packages/content_blocklist_repository/pubspec.yaml
+++ b/mobile/packages/content_blocklist_repository/pubspec.yaml
@@ -13,6 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  content_policy:
   models:
     path: ../models
   nostr_client:

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_hydration_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_hydration_test.dart
@@ -1,0 +1,48 @@
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+// Invariant: ContentBlocklistRepository.currentState must already reflect
+// persisted data immediately after construction — no async init step.
+// Tests here pin that guarantee so a future refactor cannot accidentally
+// break synchronous hydration.
+void main() {
+  group('ContentBlocklistRepository synchronous hydration invariant', () {
+    test(
+      'currentState reflects persisted blocks synchronously at construction',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'blocked_users_list': '["persisted-hex-pubkey"]',
+        });
+        final prefs = await SharedPreferences.getInstance();
+        final repo = ContentBlocklistRepository(prefs: prefs);
+
+        // No await, no pump — currentState must be ready immediately.
+        final state = repo.currentState;
+        expect(
+          state.blockedPubkeys,
+          contains('persisted-hex-pubkey'),
+          reason:
+              'persisted block must appear in currentState without any async '
+              'step after construction',
+        );
+      },
+    );
+
+    test('empty prefs yield empty state at construction', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final repo = ContentBlocklistRepository(prefs: prefs);
+
+      final state = repo.currentState;
+      expect(
+        state.blockedPubkeys,
+        isEmpty,
+        reason: 'no persisted blocks should produce an empty blocked set',
+      );
+      expect(state.mutedPubkeys, isEmpty);
+      expect(state.pubkeysBlockingUs, isEmpty);
+      expect(state.pubkeysMutingUs, isEmpty);
+    });
+  });
+}

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:content_policy/content_policy.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -1294,6 +1295,52 @@ void main() {
       );
 
       verify(() => mockClient.subscribe(any())).called(4);
+    });
+  });
+
+  group('ContentPolicyState exposure', () {
+    test('currentState reflects blocked set after blockUser', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final repo = ContentBlocklistRepository(prefs: prefs);
+
+      const me = 'my-hex-pubkey';
+      const blockedByUs = 'blocked-hex';
+      await repo.blockUser(blockedByUs, ourPubkey: me);
+
+      final state = repo.currentState;
+      expect(state.blockedPubkeys, contains(blockedByUs));
+      expect(state.mutedPubkeys, isEmpty);
+      expect(state.pubkeysBlockingUs, isEmpty);
+      expect(state.pubkeysMutingUs, isEmpty);
+    });
+
+    test('stateStream emits a new snapshot when blocks change', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final repo = ContentBlocklistRepository(prefs: prefs);
+
+      const blocked = 'some-hex';
+      final snapshots = <ContentPolicyState>[];
+      final sub = repo.stateStream.listen(snapshots.add);
+
+      await repo.blockUser(blocked, ourPubkey: 'me');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(snapshots, hasLength(greaterThanOrEqualTo(1)));
+      expect(snapshots.last.blockedPubkeys, contains(blocked));
+
+      await sub.cancel();
+    });
+
+    test('currentState reflects persisted blocks at construction', () async {
+      SharedPreferences.setMockInitialValues({
+        'blocked_users_list': '["persisted-hex"]',
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final repo = ContentBlocklistRepository(prefs: prefs);
+
+      expect(repo.currentState.blockedPubkeys, contains('persisted-hex'));
     });
   });
 }

--- a/mobile/packages/content_policy/analysis_options.yaml
+++ b/mobile/packages/content_policy/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:very_good_analysis/analysis_options.yaml

--- a/mobile/packages/content_policy/lib/content_policy.dart
+++ b/mobile/packages/content_policy/lib/content_policy.dart
@@ -6,4 +6,5 @@ export 'src/content_policy_state.dart';
 export 'src/policy_decision.dart';
 export 'src/policy_input.dart';
 export 'src/policy_rule.dart';
+export 'src/rules/pubkey_mute_rule.dart';
 export 'src/rules/self_reference_rule.dart';

--- a/mobile/packages/content_policy/lib/content_policy.dart
+++ b/mobile/packages/content_policy/lib/content_policy.dart
@@ -2,6 +2,7 @@
 //
 // Subsequent tasks will populate this barrel with src/ exports.
 
+export 'src/content_policy_engine.dart';
 export 'src/content_policy_state.dart';
 export 'src/policy_decision.dart';
 export 'src/policy_input.dart';

--- a/mobile/packages/content_policy/lib/content_policy.dart
+++ b/mobile/packages/content_policy/lib/content_policy.dart
@@ -1,3 +1,5 @@
 // Content policy engine — ingress filter + affordance gate.
 //
 // Subsequent tasks will populate this barrel with src/ exports.
+
+export 'src/policy_input.dart';

--- a/mobile/packages/content_policy/lib/content_policy.dart
+++ b/mobile/packages/content_policy/lib/content_policy.dart
@@ -5,3 +5,4 @@
 export 'src/content_policy_state.dart';
 export 'src/policy_decision.dart';
 export 'src/policy_input.dart';
+export 'src/policy_rule.dart';

--- a/mobile/packages/content_policy/lib/content_policy.dart
+++ b/mobile/packages/content_policy/lib/content_policy.dart
@@ -6,3 +6,4 @@ export 'src/content_policy_state.dart';
 export 'src/policy_decision.dart';
 export 'src/policy_input.dart';
 export 'src/policy_rule.dart';
+export 'src/rules/self_reference_rule.dart';

--- a/mobile/packages/content_policy/lib/content_policy.dart
+++ b/mobile/packages/content_policy/lib/content_policy.dart
@@ -2,5 +2,6 @@
 //
 // Subsequent tasks will populate this barrel with src/ exports.
 
+export 'src/content_policy_state.dart';
 export 'src/policy_decision.dart';
 export 'src/policy_input.dart';

--- a/mobile/packages/content_policy/lib/content_policy.dart
+++ b/mobile/packages/content_policy/lib/content_policy.dart
@@ -6,5 +6,6 @@ export 'src/content_policy_state.dart';
 export 'src/policy_decision.dart';
 export 'src/policy_input.dart';
 export 'src/policy_rule.dart';
+export 'src/rules/pubkey_block_rule.dart';
 export 'src/rules/pubkey_mute_rule.dart';
 export 'src/rules/self_reference_rule.dart';

--- a/mobile/packages/content_policy/lib/content_policy.dart
+++ b/mobile/packages/content_policy/lib/content_policy.dart
@@ -2,4 +2,5 @@
 //
 // Subsequent tasks will populate this barrel with src/ exports.
 
+export 'src/policy_decision.dart';
 export 'src/policy_input.dart';

--- a/mobile/packages/content_policy/lib/content_policy.dart
+++ b/mobile/packages/content_policy/lib/content_policy.dart
@@ -1,0 +1,3 @@
+// Content policy engine — ingress filter + affordance gate.
+//
+// Subsequent tasks will populate this barrel with src/ exports.

--- a/mobile/packages/content_policy/lib/content_policy.dart
+++ b/mobile/packages/content_policy/lib/content_policy.dart
@@ -6,6 +6,7 @@ export 'src/content_policy_state.dart';
 export 'src/policy_decision.dart';
 export 'src/policy_input.dart';
 export 'src/policy_rule.dart';
+export 'src/rules/mutual_mute_rule.dart';
 export 'src/rules/pubkey_block_rule.dart';
 export 'src/rules/pubkey_mute_rule.dart';
 export 'src/rules/self_reference_rule.dart';

--- a/mobile/packages/content_policy/lib/src/content_policy_engine.dart
+++ b/mobile/packages/content_policy/lib/src/content_policy_engine.dart
@@ -1,0 +1,71 @@
+import 'package:content_policy/src/content_policy_state.dart';
+import 'package:content_policy/src/policy_decision.dart';
+import 'package:content_policy/src/policy_input.dart';
+import 'package:content_policy/src/policy_rule.dart';
+import 'package:content_policy/src/rules/mutual_mute_rule.dart';
+import 'package:content_policy/src/rules/pubkey_block_rule.dart';
+import 'package:content_policy/src/rules/pubkey_mute_rule.dart';
+import 'package:content_policy/src/rules/self_reference_rule.dart';
+
+/// Evaluates content against an ordered pipeline of [PolicyRule]s and
+/// answers interaction-gating queries via [canTarget].
+///
+/// The engine is stateless. [evaluate] takes a fresh [ContentPolicyState]
+/// snapshot on every call; rebuild the snapshot upstream, don't mutate.
+class ContentPolicyEngine {
+  /// Construct with an explicit rule list. [SelfReferenceRule] must be
+  /// at position 0 or an [AssertionError] is thrown.
+  ContentPolicyEngine(this.rules)
+    : assert(
+        rules.isNotEmpty && rules.first is SelfReferenceRule,
+        'SelfReferenceRule must be first in the pipeline. '
+        'It guarantees the user is never filtered by a malformed list.',
+      );
+
+  /// The canonical Phase 1 rule set.
+  factory ContentPolicyEngine.defaultRules() => ContentPolicyEngine(const [
+    SelfReferenceRule(),
+    PubkeyMuteRule(),
+    PubkeyBlockRule(),
+    MutualMuteRule(),
+  ]);
+
+  /// Ordered list of rules the engine evaluates on every call.
+  final List<PolicyRule> rules;
+
+  /// Runs [input] through the pipeline and returns the first [Block]
+  /// decision, or [Allow] if no rule blocks.
+  ///
+  /// Short-circuits on first [Block]; later rules do not run.
+  /// [SelfReferenceRule] (always first) also short-circuits to [Allow]
+  /// when the input pubkey matches the current user, preventing any
+  /// subsequent rule from filtering the user's own content.
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    for (final rule in rules) {
+      final decision = rule.evaluate(input, state);
+      if (decision is Block) return decision;
+      // SelfReferenceRule is first and returns Allow for the user's own
+      // pubkey. When it does, no further rules should run — self-content
+      // is unconditionally permitted even if later rules would block it.
+      if (rule is SelfReferenceRule &&
+          state.currentUserPubkey != null &&
+          input.pubkey == state.currentUserPubkey) {
+        return const Allow();
+      }
+    }
+    return const Allow();
+  }
+
+  /// Answers: should the UI offer an interaction that targets [pubkey]?
+  ///
+  /// Returns `false` when [pubkey] has a mute/block entry naming the
+  /// current user. Callers MUST translate this to *absence* of the
+  /// affordance, not a disabled state with explanation.
+  ///
+  /// This query bypasses the full rule pipeline. It's a specific
+  /// question with a specific answer; routing it through [evaluate]
+  /// would give the caller a [Block.ruleId] they must not expose.
+  bool canTarget(String pubkey, ContentPolicyState state) {
+    return !state.isBlockedBy(pubkey);
+  }
+}

--- a/mobile/packages/content_policy/lib/src/content_policy_state.dart
+++ b/mobile/packages/content_policy/lib/src/content_policy_state.dart
@@ -1,0 +1,58 @@
+/// Immutable snapshot of all state the policy engine needs to evaluate.
+///
+/// Rebuilt by ContentBlocklistService whenever the underlying source
+/// data changes. The engine never mutates it; it is replaced wholesale.
+class ContentPolicyState {
+  /// Creates a [ContentPolicyState] from the four source sets plus the
+  /// currently authenticated user's pubkey (null when not authenticated).
+  const ContentPolicyState({
+    required this.currentUserPubkey,
+    required this.mutedPubkeys,
+    required this.blockedPubkeys,
+    required this.pubkeysBlockingUs,
+    required this.pubkeysMutingUs,
+  });
+
+  /// Empty state — used pre-hydration or when no user is authenticated.
+  ///
+  /// With an empty state, every rule short-circuits to Allow. This is
+  /// the documented startup window; the bootstrap sequence is responsible
+  /// for hydrating before any parse-gate call fires.
+  factory ContentPolicyState.empty() => const ContentPolicyState(
+    currentUserPubkey: null,
+    mutedPubkeys: {},
+    blockedPubkeys: {},
+    pubkeysBlockingUs: {},
+    pubkeysMutingUs: {},
+  );
+
+  /// The hex pubkey of the currently authenticated user, or null.
+  final String? currentUserPubkey;
+
+  /// Authors the user muted via their own kind 10000 event.
+  final Set<String> mutedPubkeys;
+
+  /// Authors the user blocked via their own kind 30000 d=block event.
+  final Set<String> blockedPubkeys;
+
+  /// Authors whose kind 30000 d=block event names the current user.
+  final Set<String> pubkeysBlockingUs;
+
+  /// Authors whose kind 10000 event names the current user.
+  final Set<String> pubkeysMutingUs;
+
+  /// True when content from [pubkey] must be filtered from feeds.
+  bool isAuthorFiltered(String pubkey) =>
+      mutedPubkeys.contains(pubkey) ||
+      blockedPubkeys.contains(pubkey) ||
+      pubkeysBlockingUs.contains(pubkey) ||
+      pubkeysMutingUs.contains(pubkey);
+
+  /// True when [pubkey] has a mute/block entry naming the current user.
+  ///
+  /// This is the query ContentPolicyEngine.canTarget uses — it answers
+  /// "does the recipient want to hear from us?" without leaking the
+  /// reason. Callers MUST NOT surface the return value as copy.
+  bool isBlockedBy(String pubkey) =>
+      pubkeysBlockingUs.contains(pubkey) || pubkeysMutingUs.contains(pubkey);
+}

--- a/mobile/packages/content_policy/lib/src/policy_decision.dart
+++ b/mobile/packages/content_policy/lib/src/policy_decision.dart
@@ -1,0 +1,28 @@
+/// Outcome of evaluating a single policy input against the engine.
+///
+/// The sealed hierarchy lets callers pattern-match exhaustively without
+/// default cases. New decision variants (SoftHide, Warn) can be added
+/// later; Phase 1 ships only Allow and Block.
+sealed class PolicyDecision {
+  /// Const base constructor for the sealed hierarchy.
+  const PolicyDecision();
+}
+
+/// Content is permitted to be parsed into an in-app model.
+final class Allow extends PolicyDecision {
+  /// Creates an [Allow] decision.
+  const Allow();
+}
+
+/// Content must be dropped.
+///
+/// [ruleId] is for local diagnostics only — it must never appear in
+/// user-visible copy, release logs, remote telemetry, Crashlytics
+/// breadcrumbs, or analytics events.
+final class Block extends PolicyDecision {
+  /// Creates a [Block] decision with a diagnostic [ruleId].
+  const Block({required this.ruleId});
+
+  /// Identifier of the rule that produced this decision. Debug-only.
+  final String ruleId;
+}

--- a/mobile/packages/content_policy/lib/src/policy_input.dart
+++ b/mobile/packages/content_policy/lib/src/policy_input.dart
@@ -1,0 +1,28 @@
+/// Minimal input the policy engine needs to evaluate a single event.
+///
+/// Parsers construct this from the raw JSON envelope of a Nostr event
+/// (or a REST response row that carries the same fields). Only [pubkey]
+/// is consulted by the Phase 1 rules; the remaining fields are part of
+/// the contract so future rules (hashtag, keyword) can be added without
+/// changing every call site.
+class PolicyInput {
+  /// Creates a [PolicyInput] with the given event fields.
+  const PolicyInput({
+    required this.pubkey,
+    this.kind,
+    this.content,
+    this.tags,
+  });
+
+  /// Event author's hex pubkey. Required.
+  final String pubkey;
+
+  /// Event kind (NIP-01 integer). Optional — not all REST responses carry it.
+  final int? kind;
+
+  /// Event content string. Optional.
+  final String? content;
+
+  /// Event tags, as the standard `List<List<String>>` NIP-01 shape. Optional.
+  final List<List<String>>? tags;
+}

--- a/mobile/packages/content_policy/lib/src/policy_rule.dart
+++ b/mobile/packages/content_policy/lib/src/policy_rule.dart
@@ -1,0 +1,17 @@
+import 'package:content_policy/src/content_policy_state.dart';
+import 'package:content_policy/src/policy_decision.dart';
+import 'package:content_policy/src/policy_input.dart';
+
+/// A single, pure, synchronous check in the policy pipeline.
+///
+/// Rules must be deterministic: same input + same state always produces
+/// the same decision. No IO, no async, no mutation.
+abstract interface class PolicyRule {
+  /// Stable identifier used in [Block.ruleId] and in the engine's
+  /// ordering assertion. Must match the class name by convention.
+  String get id;
+
+  /// Evaluate the rule. Return [Allow] to let the pipeline continue,
+  /// [Block] to short-circuit with a drop decision.
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state);
+}

--- a/mobile/packages/content_policy/lib/src/rules/mutual_mute_rule.dart
+++ b/mobile/packages/content_policy/lib/src/rules/mutual_mute_rule.dart
@@ -1,0 +1,23 @@
+import 'package:content_policy/src/content_policy_state.dart';
+import 'package:content_policy/src/policy_decision.dart';
+import 'package:content_policy/src/policy_input.dart';
+import 'package:content_policy/src/policy_rule.dart';
+
+/// Blocks content from authors whose own mute/block list names the
+/// current user. Enforces the mutual-mute guarantee: if they don't
+/// want our content, we don't show theirs.
+class MutualMuteRule implements PolicyRule {
+  /// Creates a [MutualMuteRule].
+  const MutualMuteRule();
+
+  @override
+  String get id => 'MutualMuteRule';
+
+  @override
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    if (state.isBlockedBy(input.pubkey)) {
+      return Block(ruleId: id);
+    }
+    return const Allow();
+  }
+}

--- a/mobile/packages/content_policy/lib/src/rules/pubkey_block_rule.dart
+++ b/mobile/packages/content_policy/lib/src/rules/pubkey_block_rule.dart
@@ -1,0 +1,21 @@
+import 'package:content_policy/src/content_policy_state.dart';
+import 'package:content_policy/src/policy_decision.dart';
+import 'package:content_policy/src/policy_input.dart';
+import 'package:content_policy/src/policy_rule.dart';
+
+/// Blocks content from authors the user blocked via kind 30000 d=block.
+class PubkeyBlockRule implements PolicyRule {
+  /// Creates a [PubkeyBlockRule].
+  const PubkeyBlockRule();
+
+  @override
+  String get id => 'PubkeyBlockRule';
+
+  @override
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    if (state.blockedPubkeys.contains(input.pubkey)) {
+      return Block(ruleId: id);
+    }
+    return const Allow();
+  }
+}

--- a/mobile/packages/content_policy/lib/src/rules/pubkey_mute_rule.dart
+++ b/mobile/packages/content_policy/lib/src/rules/pubkey_mute_rule.dart
@@ -1,0 +1,21 @@
+import 'package:content_policy/src/content_policy_state.dart';
+import 'package:content_policy/src/policy_decision.dart';
+import 'package:content_policy/src/policy_input.dart';
+import 'package:content_policy/src/policy_rule.dart';
+
+/// Blocks content from authors the user muted via kind 10000.
+class PubkeyMuteRule implements PolicyRule {
+  /// Creates a [PubkeyMuteRule].
+  const PubkeyMuteRule();
+
+  @override
+  String get id => 'PubkeyMuteRule';
+
+  @override
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    if (state.mutedPubkeys.contains(input.pubkey)) {
+      return Block(ruleId: id);
+    }
+    return const Allow();
+  }
+}

--- a/mobile/packages/content_policy/lib/src/rules/self_reference_rule.dart
+++ b/mobile/packages/content_policy/lib/src/rules/self_reference_rule.dart
@@ -1,0 +1,26 @@
+import 'package:content_policy/src/content_policy_state.dart';
+import 'package:content_policy/src/policy_decision.dart';
+import 'package:content_policy/src/policy_input.dart';
+import 'package:content_policy/src/policy_rule.dart';
+
+/// Guarantees the user's own content is never filtered, even if a
+/// malformed mute/block list contains the user's own pubkey.
+///
+/// Must be first in the rule pipeline — the engine asserts this.
+///
+/// Why: a self-referential mute list reproduced issue #2192 where the
+/// user's own events disappeared from their feed.
+class SelfReferenceRule implements PolicyRule {
+  /// Creates a [SelfReferenceRule].
+  const SelfReferenceRule();
+
+  @override
+  String get id => 'SelfReferenceRule';
+
+  @override
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    // This rule only handles the self case. For any other pubkey, we
+    // return Allow and let subsequent rules decide.
+    return const Allow();
+  }
+}

--- a/mobile/packages/content_policy/pubspec.yaml
+++ b/mobile/packages/content_policy/pubspec.yaml
@@ -1,0 +1,12 @@
+name: content_policy
+description: Pure Dart content policy engine. Ingress filter + affordance gate.
+version: 0.1.0+1
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.11.0
+
+dev_dependencies:
+  test: ^1.26.3
+  very_good_analysis: ^10.0.0

--- a/mobile/packages/content_policy/test/src/content_policy_engine_test.dart
+++ b/mobile/packages/content_policy/test/src/content_policy_engine_test.dart
@@ -1,0 +1,179 @@
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(ContentPolicyEngine, () {
+    const me = 'me';
+
+    group('evaluate', () {
+      test('returns Allow when no rule blocks', () {
+        final engine = ContentPolicyEngine.defaultRules();
+        final decision = engine.evaluate(
+          const PolicyInput(pubkey: 'stranger'),
+          ContentPolicyState.empty(),
+        );
+        expect(decision, isA<Allow>());
+      });
+
+      test('returns Block when the first applicable rule blocks', () {
+        final engine = ContentPolicyEngine.defaultRules();
+        const state = ContentPolicyState(
+          currentUserPubkey: me,
+          mutedPubkeys: {'muted'},
+          blockedPubkeys: {},
+          pubkeysBlockingUs: {},
+          pubkeysMutingUs: {},
+        );
+        final decision = engine.evaluate(
+          const PolicyInput(pubkey: 'muted'),
+          state,
+        );
+        expect(decision, isA<Block>());
+        expect((decision as Block).ruleId, equals('PubkeyMuteRule'));
+      });
+
+      test('short-circuits on first Block — later rules do not run', () {
+        var secondRuleRan = false;
+        final engine = ContentPolicyEngine([
+          const SelfReferenceRule(),
+          const _AlwaysBlockRule('first'),
+          _SpyRule(() => secondRuleRan = true),
+        ]);
+        final decision = engine.evaluate(
+          const PolicyInput(pubkey: 'x'),
+          ContentPolicyState.empty(),
+        );
+        expect(decision, isA<Block>());
+        expect((decision as Block).ruleId, equals('first'));
+        expect(secondRuleRan, isFalse);
+      });
+
+      test(
+        'SelfReferenceRule short-circuits even when a later rule would block',
+        () {
+          final engine = ContentPolicyEngine.defaultRules();
+          const state = ContentPolicyState(
+            currentUserPubkey: me,
+            mutedPubkeys: {me},
+            blockedPubkeys: {me},
+            pubkeysBlockingUs: {me},
+            pubkeysMutingUs: {me},
+          );
+          final decision = engine.evaluate(
+            const PolicyInput(pubkey: me),
+            state,
+          );
+          expect(decision, isA<Allow>());
+        },
+      );
+    });
+
+    group('construction invariants', () {
+      test('defaultRules places SelfReferenceRule first', () {
+        final engine = ContentPolicyEngine.defaultRules();
+        expect(engine.rules.first, isA<SelfReferenceRule>());
+      });
+
+      test('asserts when SelfReferenceRule is not first', () {
+        expect(
+          () => ContentPolicyEngine([
+            const PubkeyMuteRule(),
+            const SelfReferenceRule(),
+          ]),
+          throwsA(isA<AssertionError>()),
+        );
+      });
+
+      test('allows custom rule lists so long as SelfReferenceRule leads', () {
+        expect(
+          () => ContentPolicyEngine([
+            const SelfReferenceRule(),
+            const _AlwaysBlockRule('custom'),
+          ]),
+          returnsNormally,
+        );
+      });
+    });
+
+    group('canTarget', () {
+      test('returns true when pubkey is not in isBlockedBy', () {
+        final engine = ContentPolicyEngine.defaultRules();
+        expect(
+          engine.canTarget('stranger', ContentPolicyState.empty()),
+          isTrue,
+        );
+      });
+
+      test('returns false when pubkey blocks us', () {
+        final engine = ContentPolicyEngine.defaultRules();
+        const state = ContentPolicyState(
+          currentUserPubkey: me,
+          mutedPubkeys: {},
+          blockedPubkeys: {},
+          pubkeysBlockingUs: {'blocker'},
+          pubkeysMutingUs: {},
+        );
+        expect(engine.canTarget('blocker', state), isFalse);
+      });
+
+      test('returns false when pubkey muted us', () {
+        final engine = ContentPolicyEngine.defaultRules();
+        const state = ContentPolicyState(
+          currentUserPubkey: me,
+          mutedPubkeys: {},
+          blockedPubkeys: {},
+          pubkeysBlockingUs: {},
+          pubkeysMutingUs: {'muter'},
+        );
+        expect(engine.canTarget('muter', state), isFalse);
+      });
+
+      test('does not run the full rule pipeline', () {
+        final engine = ContentPolicyEngine([
+          const SelfReferenceRule(),
+          _ExplodingRule(),
+        ]);
+        expect(
+          () => engine.canTarget('anyone', ContentPolicyState.empty()),
+          returnsNormally,
+        );
+      });
+    });
+  });
+}
+
+class _AlwaysBlockRule implements PolicyRule {
+  const _AlwaysBlockRule(this._id);
+  final String _id;
+
+  @override
+  String get id => _id;
+
+  @override
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) =>
+      Block(ruleId: id);
+}
+
+class _SpyRule implements PolicyRule {
+  _SpyRule(this.onEvaluate);
+  final void Function() onEvaluate;
+
+  @override
+  String get id => 'SpyRule';
+
+  @override
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    onEvaluate();
+    return const Allow();
+  }
+}
+
+class _ExplodingRule implements PolicyRule {
+  @override
+  String get id => 'ExplodingRule';
+
+  @override
+  PolicyDecision evaluate(PolicyInput input, ContentPolicyState state) {
+    throw StateError('should not run');
+  }
+}

--- a/mobile/packages/content_policy/test/src/content_policy_state_test.dart
+++ b/mobile/packages/content_policy/test/src/content_policy_state_test.dart
@@ -1,0 +1,78 @@
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(ContentPolicyState, () {
+    const me = 'me-pubkey';
+
+    test('empty state has no filtered authors', () {
+      final state = ContentPolicyState.empty();
+      expect(state.currentUserPubkey, isNull);
+      expect(state.isAuthorFiltered('anyone'), isFalse);
+      expect(state.isBlockedBy('anyone'), isFalse);
+    });
+
+    test('mutedPubkeys filters author', () {
+      const state = ContentPolicyState(
+        currentUserPubkey: me,
+        mutedPubkeys: {'muted'},
+        blockedPubkeys: {},
+        pubkeysBlockingUs: {},
+        pubkeysMutingUs: {},
+      );
+      expect(state.isAuthorFiltered('muted'), isTrue);
+      expect(state.isAuthorFiltered('other'), isFalse);
+    });
+
+    test('blockedPubkeys filters author', () {
+      const state = ContentPolicyState(
+        currentUserPubkey: me,
+        mutedPubkeys: {},
+        blockedPubkeys: {'blocked'},
+        pubkeysBlockingUs: {},
+        pubkeysMutingUs: {},
+      );
+      expect(state.isAuthorFiltered('blocked'), isTrue);
+    });
+
+    test('pubkeysBlockingUs filters author and reports blockedBy', () {
+      const state = ContentPolicyState(
+        currentUserPubkey: me,
+        mutedPubkeys: {},
+        blockedPubkeys: {},
+        pubkeysBlockingUs: {'blocker'},
+        pubkeysMutingUs: {},
+      );
+      expect(state.isAuthorFiltered('blocker'), isTrue);
+      expect(state.isBlockedBy('blocker'), isTrue);
+      expect(state.isBlockedBy('someone-else'), isFalse);
+    });
+
+    test('pubkeysMutingUs filters author and reports blockedBy', () {
+      const state = ContentPolicyState(
+        currentUserPubkey: me,
+        mutedPubkeys: {},
+        blockedPubkeys: {},
+        pubkeysBlockingUs: {},
+        pubkeysMutingUs: {'muter'},
+      );
+      expect(state.isAuthorFiltered('muter'), isTrue);
+      expect(state.isBlockedBy('muter'), isTrue);
+    });
+
+    test(
+      'isBlockedBy excludes authors that we muted/blocked but not vice versa',
+      () {
+        const state = ContentPolicyState(
+          currentUserPubkey: me,
+          mutedPubkeys: {'someone-we-muted'},
+          blockedPubkeys: {'someone-we-blocked'},
+          pubkeysBlockingUs: {},
+          pubkeysMutingUs: {},
+        );
+        expect(state.isBlockedBy('someone-we-muted'), isFalse);
+        expect(state.isBlockedBy('someone-we-blocked'), isFalse);
+      },
+    );
+  });
+}

--- a/mobile/packages/content_policy/test/src/policy_decision_test.dart
+++ b/mobile/packages/content_policy/test/src/policy_decision_test.dart
@@ -1,6 +1,3 @@
-// The exhaustiveness test intentionally switches on a narrowed Block value to
-// verify both arms compile. The Allow arm is unreachable by design.
-// ignore_for_file: pattern_never_matches_value_type
 import 'package:content_policy/content_policy.dart';
 import 'package:test/test.dart';
 
@@ -17,20 +14,22 @@ void main() {
       expect(decision, isA<PolicyDecision>());
     });
 
-    test('pattern matches exhaustively', () {
-      PolicyDecision decision = const Allow();
+    test('pattern matches exhaustively on Allow', () {
+      const PolicyDecision decision = Allow();
       final label = switch (decision) {
         Allow() => 'allow',
         Block() => 'block',
       };
       expect(label, equals('allow'));
+    });
 
-      decision = const Block(ruleId: 'r');
-      final label2 = switch (decision) {
+    test('pattern matches exhaustively on Block', () {
+      const PolicyDecision decision = Block(ruleId: 'r');
+      final label = switch (decision) {
         Allow() => 'allow',
         Block() => 'block',
       };
-      expect(label2, equals('block'));
+      expect(label, equals('block'));
     });
   });
 }

--- a/mobile/packages/content_policy/test/src/policy_decision_test.dart
+++ b/mobile/packages/content_policy/test/src/policy_decision_test.dart
@@ -1,0 +1,36 @@
+// The exhaustiveness test intentionally switches on a narrowed Block value to
+// verify both arms compile. The Allow arm is unreachable by design.
+// ignore_for_file: pattern_never_matches_value_type
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(PolicyDecision, () {
+    test('Allow is a PolicyDecision', () {
+      const decision = Allow();
+      expect(decision, isA<PolicyDecision>());
+    });
+
+    test('Block carries a ruleId', () {
+      const decision = Block(ruleId: 'PubkeyMuteRule');
+      expect(decision.ruleId, equals('PubkeyMuteRule'));
+      expect(decision, isA<PolicyDecision>());
+    });
+
+    test('pattern matches exhaustively', () {
+      PolicyDecision decision = const Allow();
+      final label = switch (decision) {
+        Allow() => 'allow',
+        Block() => 'block',
+      };
+      expect(label, equals('allow'));
+
+      decision = const Block(ruleId: 'r');
+      final label2 = switch (decision) {
+        Allow() => 'allow',
+        Block() => 'block',
+      };
+      expect(label2, equals('block'));
+    });
+  });
+}

--- a/mobile/packages/content_policy/test/src/policy_input_test.dart
+++ b/mobile/packages/content_policy/test/src/policy_input_test.dart
@@ -1,0 +1,29 @@
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(PolicyInput, () {
+    test('constructs with only pubkey', () {
+      const input = PolicyInput(pubkey: 'abc');
+      expect(input.pubkey, equals('abc'));
+      expect(input.kind, isNull);
+      expect(input.content, isNull);
+      expect(input.tags, isNull);
+    });
+
+    test('constructs with all fields', () {
+      const input = PolicyInput(
+        pubkey: 'abc',
+        kind: 34236,
+        content: 'hello',
+        tags: [
+          ['d', 'video-1'],
+        ],
+      );
+      expect(input.pubkey, equals('abc'));
+      expect(input.kind, equals(34236));
+      expect(input.content, equals('hello'));
+      expect(input.tags, hasLength(1));
+    });
+  });
+}

--- a/mobile/packages/content_policy/test/src/rules/mutual_mute_rule_test.dart
+++ b/mobile/packages/content_policy/test/src/rules/mutual_mute_rule_test.dart
@@ -1,0 +1,52 @@
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(MutualMuteRule, () {
+    const rule = MutualMuteRule();
+
+    test('id is stable', () {
+      expect(rule.id, equals('MutualMuteRule'));
+    });
+
+    test('blocks authors in pubkeysBlockingUs', () {
+      const state = ContentPolicyState(
+        currentUserPubkey: 'me',
+        mutedPubkeys: {},
+        blockedPubkeys: {},
+        pubkeysBlockingUs: {'blocker'},
+        pubkeysMutingUs: {},
+      );
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'blocker'),
+        state,
+      );
+      expect(decision, isA<Block>());
+      expect((decision as Block).ruleId, equals('MutualMuteRule'));
+    });
+
+    test('blocks authors in pubkeysMutingUs', () {
+      const state = ContentPolicyState(
+        currentUserPubkey: 'me',
+        mutedPubkeys: {},
+        blockedPubkeys: {},
+        pubkeysBlockingUs: {},
+        pubkeysMutingUs: {'muter'},
+      );
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'muter'),
+        state,
+      );
+      expect(decision, isA<Block>());
+    });
+
+    test('allows authors not in either mutual-mute set', () {
+      final state = ContentPolicyState.empty();
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'stranger'),
+        state,
+      );
+      expect(decision, isA<Allow>());
+    });
+  });
+}

--- a/mobile/packages/content_policy/test/src/rules/pubkey_block_rule_test.dart
+++ b/mobile/packages/content_policy/test/src/rules/pubkey_block_rule_test.dart
@@ -1,0 +1,37 @@
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(PubkeyBlockRule, () {
+    const rule = PubkeyBlockRule();
+
+    test('id is stable', () {
+      expect(rule.id, equals('PubkeyBlockRule'));
+    });
+
+    test('blocks authors present in blockedPubkeys', () {
+      const state = ContentPolicyState(
+        currentUserPubkey: 'me',
+        mutedPubkeys: {},
+        blockedPubkeys: {'blocked'},
+        pubkeysBlockingUs: {},
+        pubkeysMutingUs: {},
+      );
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'blocked'),
+        state,
+      );
+      expect(decision, isA<Block>());
+      expect((decision as Block).ruleId, equals('PubkeyBlockRule'));
+    });
+
+    test('allows authors not in blockedPubkeys', () {
+      final state = ContentPolicyState.empty();
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'anyone'),
+        state,
+      );
+      expect(decision, isA<Allow>());
+    });
+  });
+}

--- a/mobile/packages/content_policy/test/src/rules/pubkey_mute_rule_test.dart
+++ b/mobile/packages/content_policy/test/src/rules/pubkey_mute_rule_test.dart
@@ -1,0 +1,43 @@
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(PubkeyMuteRule, () {
+    const rule = PubkeyMuteRule();
+
+    test('id is stable', () {
+      expect(rule.id, equals('PubkeyMuteRule'));
+    });
+
+    test('blocks authors present in mutedPubkeys', () {
+      const state = ContentPolicyState(
+        currentUserPubkey: 'me',
+        mutedPubkeys: {'muted'},
+        blockedPubkeys: {},
+        pubkeysBlockingUs: {},
+        pubkeysMutingUs: {},
+      );
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'muted'),
+        state,
+      );
+      expect(decision, isA<Block>());
+      expect((decision as Block).ruleId, equals('PubkeyMuteRule'));
+    });
+
+    test('allows authors not in mutedPubkeys', () {
+      const state = ContentPolicyState(
+        currentUserPubkey: 'me',
+        mutedPubkeys: {'muted'},
+        blockedPubkeys: {},
+        pubkeysBlockingUs: {},
+        pubkeysMutingUs: {},
+      );
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'not-muted'),
+        state,
+      );
+      expect(decision, isA<Allow>());
+    });
+  });
+}

--- a/mobile/packages/content_policy/test/src/rules/self_reference_rule_test.dart
+++ b/mobile/packages/content_policy/test/src/rules/self_reference_rule_test.dart
@@ -1,0 +1,46 @@
+import 'package:content_policy/content_policy.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(SelfReferenceRule, () {
+    const rule = SelfReferenceRule();
+    const me = 'me-pubkey';
+
+    const stateWithMeInEveryList = ContentPolicyState(
+      currentUserPubkey: me,
+      mutedPubkeys: {me},
+      blockedPubkeys: {me},
+      pubkeysBlockingUs: {me},
+      pubkeysMutingUs: {me},
+    );
+
+    test('id matches class name', () {
+      expect(rule.id, equals('SelfReferenceRule'));
+    });
+
+    test('allows the current user even if every list contains them', () {
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: me),
+        stateWithMeInEveryList,
+      );
+      expect(decision, isA<Allow>());
+    });
+
+    test('allows any author when no user is authenticated', () {
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'anyone'),
+        ContentPolicyState.empty(),
+      );
+      expect(decision, isA<Allow>());
+    });
+
+    test('returns Allow (not short-circuit Block) for a different pubkey', () {
+      // Self rule only handles the self case. Other rules decide for others.
+      final decision = rule.evaluate(
+        const PolicyInput(pubkey: 'someone-else'),
+        stateWithMeInEveryList,
+      );
+      expect(decision, isA<Allow>());
+    });
+  });
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -30,6 +30,7 @@ workspace:
   - packages/categories_repository
   - packages/comments_repository
   - packages/content_blocklist_repository
+  - packages/content_policy
   - packages/count_formatter
   - packages/curated_list_repository
   - packages/curation_repository
@@ -208,6 +209,9 @@ dependencies:
 
   # TV static noise effect
   tv_static_effect:
+
+  # Content Policy — parse-gate ingress filter
+  content_policy:
 
   # Count Formatter - Compact number formatting
   count_formatter:

--- a/mobile/test/providers/content_policy_engine_provider_test.dart
+++ b/mobile/test/providers/content_policy_engine_provider_test.dart
@@ -1,0 +1,15 @@
+import 'package:content_policy/content_policy.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/providers/app_providers.dart';
+
+void main() {
+  test('contentPolicyEngineProvider exposes default rule set', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final engine = container.read(contentPolicyEngineProvider);
+    expect(engine.rules.first, isA<SelfReferenceRule>());
+    expect(engine.rules, hasLength(4));
+  });
+}


### PR DESCRIPTION
Closes #3262

## Summary

Phase 1a of the Content Policy Layer design. Wires the engine into the app as a dormant provider, behind a default-off feature flag. No repository parse-gates yet — those land in Phase 1b.

Four commits, one per task:

1. **feat(feature_flags)** — add \`contentPolicyV2\` flag (default off). Gates Phase 1 integration; flipped true in a later chunk.
2. **feat(content_blocklist_repository)** — expose \`currentState\` synchronous snapshot + \`stateStream\` broadcast. Projects the repository's internal blocked / mutual-mute / blocked-by sets into the \`ContentPolicyState\` shape the engine consumes, without coupling to repository internals. \`mutedPubkeys\` intentionally left empty with a \`TODO(rabble):\` — personal-kind-10000 reading is a follow-up; \`MutualMuteRule\` + \`PubkeyBlockRule\` carry current work.
3. **feat(providers)** — add \`contentPolicyEngineProvider\` (keepAlive Riverpod provider exposing \`ContentPolicyEngine.defaultRules()\`).
4. **test(content_blocklist_repository)** — pin synchronous hydration invariant so future refactors can't silently make hydration async.

## Stacked on

PR #3251 (\`feat/content-policy-engine\`). Merge the engine PR first; this will auto-rebase. If #3251 needs changes, re-stack this one.

## Scope

No parse-gates. No interaction gates. Flag stays off. The engine is reachable via Riverpod but nothing queries it yet. Phase 1b will wire it into \`videos_repository\`, \`comments_repository\`, \`profile_repository\`, \`hashtag_repository\`, \`likes_repository\`, \`reposts_repository\`, \`notification_repository\`, plus the \`nostr_client\` WebSocket seam.

Spec: \`docs/superpowers/specs/2026-04-23-content-policy-layer-design.md\`
Plan: \`docs/superpowers/plans/2026-04-23-content-policy-layer.md\` (PR #3248)

## Test plan

- [x] \`flutter analyze lib test\` clean.
- [x] \`dart test\` in \`content_blocklist_repository\` — 58 pass (3 new for \`currentState\` / \`stateStream\`).
- [x] \`dart test\` in \`content_policy\` — 37 pass, unchanged.
- [x] Hydration test file exists and passes.
- [x] \`contentPolicyEngineProvider\` test asserts \`SelfReferenceRule\` first and rule count 4.
- [x] Rebased onto latest \`origin/main\`; resolves cleanly with concurrent \`peopleListSearch\` feature flag landing.
- [ ] Manual smoke: flag is off by default; app behavior unchanged. The engine is visible but not wired to any filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)