### PR TITLE
fix(test): override soundLibraryServiceProvider in SoundsScreen no-URL snackbar test

### DIFF
--- a/mobile/test/screens/sounds_screen_test.dart
+++ b/mobile/test/screens/sounds_screen_test.dart
@@ -768,6 +768,13 @@ void main() {
               trendingSoundsProvider.overrideWith(
                 () => MockTrendingSoundsNotifier(sounds: testSounds),
               ),
+              // Force empty bundled sounds so only the Trending Sounds
+              // horizontal list renders; otherwise rootBundle loads the
+              // bundled manifest and the Featured Sounds section adds a
+              // second horizontal ListView.
+              soundLibraryServiceProvider.overrideWith(
+                (_) async => SoundLibraryService(),
+              ),
               audioPlaybackServiceProvider.overrideWithValue(mockAudioService),
             ],
           ),


### PR DESCRIPTION
Closes #3278.

## Summary

One test in `mobile/test/screens/sounds_screen_test.dart` has been failing reliably on `origin/main` and blocking CI on unrelated PRs (surfaced by CI on [#3243](https://github.com/divinevideo/divine-mobile/pull/3243)).

## Root cause

`SoundsScreen` renders the Featured Sounds section (53 bundled sounds from the asset manifest, each with a valid URL) before Trending Sounds (`mobile/lib/screens/sounds_screen.dart:338-345`). The failing test overrides `trendingSoundsProvider` with one URL-less `AudioEvent`, then taps `find.byIcon(Icons.play_arrow).first` — which hits a Featured Sounds tile, not the trending one. `_onPreviewTap` (`sounds_screen.dart:108`) goes down the `loadAudio` path, the no-URL snackbar branch at `:128-143` never runs, and the expected text isn't in the tree.

## Fix

Add `soundLibraryServiceProvider.overrideWith((_) async => SoundLibraryService())` to the failing test's `overrides` list, forcing the Featured Sounds section to render empty. Four sibling tests in the same file already use this pattern (lines 210, 308, 387, 508); the comment on line 206 explains why. Copied the same comment verbatim so the rationale is visible at both sites.

No source changes.

## Test plan

- [x] `flutter test test/screens/sounds_screen_test.dart --plain-name "shows snackbar when sound has no URL"` — was failing on main, now passes.
- [x] `flutter test test/screens/sounds_screen_test.dart` — 24 passed, 3 skipped.
- [x] `flutter test test/screens/sounds_screen_test.dart --test-randomize-ordering-seed random` — 24 passed, 3 skipped, stable under random order.
- [x] `flutter analyze test/screens/sounds_screen_test.dart` — No issues found.
- [x] `dart format --output=none --set-exit-if-changed test/screens/sounds_screen_test.dart` — clean.

## Follow-up candidate (not in this PR)

The `tapping different sound stops current and plays new` test at line 705 also omits the `soundLibraryServiceProvider` override. It passes today because its only assertion is `verify(loadAudio).called(1)` — any tap on a Featured Sounds tile satisfies that, so the bug is masked, not absent. Worth tightening in a separate PR if the file gets more attention.