### PR TITLE
chore(l10n): update localization rules for widget test assertions

### DIFF
--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -42,6 +42,28 @@ When creating new UI, add strings to the ARB file first:
 - **`divine_ui` package stays l10n-free** — its widgets accept string params with English defaults
 - **Plurals use ICU syntax** in ARB files, not conditional logic in Dart
 - **Every `MaterialApp` in tests needs delegates** — use `localizationsDelegates: AppLocalizations.localizationsDelegates` and `supportedLocales: AppLocalizations.supportedLocales`
+- **Never hardcode English strings in widget test assertions** — resolve the key from `AppLocalizations` instead, so the test survives copy changes and breaks loudly if the widget stops reading from l10n. Pick whichever lookup fits the test:
+
+```dart
+// Option A — direct lookup by locale (no BuildContext needed)
+final l10n = lookupAppLocalizations(const Locale('en'));
+expect(find.text(l10n.videoEditorAudioSegmentInstruction), findsOneWidget);
+
+// Option B — via the pumped widget's BuildContext
+final l10n = AppLocalizations.of(
+  tester.element(find.byType(VideoAudioEditorTimingScreen)),
+);
+expect(find.text(l10n.videoEditorAudioSegmentInstruction), findsOneWidget);
+
+// Optional but recommended — prove the widget actually reads from l10n
+expect(
+  find.text(lookupAppLocalizations(const Locale('de')).videoEditorAudioSegmentInstruction),
+  findsNothing,
+);
+
+// Bad — hardcoded string breaks when copy changes and hides missing l10n
+expect(find.text('Select the audio segment for your video'), findsOneWidget);
+```
 
 ## Key Files
 


### PR DESCRIPTION
Closes #3283

## Description

Add a new rule that test files also correctly use l10n instant of hardcoded strings

**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore