### PR TITLE
test(feed-performance): untag after bypassing Firebase in testInstance

### DIFF
--- a/mobile/lib/services/feed_performance_tracker.dart
+++ b/mobile/lib/services/feed_performance_tracker.dart
@@ -16,7 +16,7 @@ const _maxSessionAge = Duration(seconds: 60);
 /// Service for tracking feed performance and user engagement
 class FeedPerformanceTracker {
   factory FeedPerformanceTracker() => _instance ??= FeedPerformanceTracker._();
-  FeedPerformanceTracker._();
+  FeedPerformanceTracker._() : _bypassAnalytics = false;
 
   static FeedPerformanceTracker? _instance;
 
@@ -32,13 +32,18 @@ class FeedPerformanceTracker {
   /// Creates a testable instance that does not touch [FirebaseAnalytics].
   @visibleForTesting
   FeedPerformanceTracker.testInstance({FirebaseAnalytics? analytics})
-    : _analyticsOverride = analytics;
+    : _analyticsOverride = analytics,
+      _bypassAnalytics = true;
 
   // Lazy-init to avoid crashing when Firebase isn't initialized (e.g. tests).
   FirebaseAnalytics? _analyticsOverride;
   FirebaseAnalytics? _analyticsInstance;
-  FirebaseAnalytics? get _analytics =>
-      _analyticsOverride ?? (_analyticsInstance ??= _initAnalytics());
+  final bool _bypassAnalytics;
+
+  FirebaseAnalytics? get _analytics {
+    if (_bypassAnalytics) return _analyticsOverride;
+    return _analyticsOverride ?? (_analyticsInstance ??= _initAnalytics());
+  }
 
   static FirebaseAnalytics? _initAnalytics() {
     try {

--- a/mobile/test/services/feed_performance_tracker_stale_session_test.dart
+++ b/mobile/test/services/feed_performance_tracker_stale_session_test.dart
@@ -2,7 +2,6 @@
 // ABOUTME: Verifies sessions older than 60s are discarded and resetAllSessions
 // ABOUTME: clears all active sessions on app resume.
 
-@Tags(['skip_very_good_optimization'])
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 
@@ -11,6 +10,9 @@ void main() {
     late FeedPerformanceTracker tracker;
 
     setUp(() {
+      // Reset to discard any stale singleton left by a previous test or test
+      // file when running in a shared isolate (VGV optimized runner).
+      FeedPerformanceTracker.resetInstance();
       tracker = FeedPerformanceTracker.testInstance();
     });
 


### PR DESCRIPTION
## Description

Unwinds `@Tags(['skip_very_good_optimization'])` on `feed_performance_tracker_stale_session_test.dart` by fixing the actual leak rather than papering over it.

**Root cause found via local verification:** `FeedPerformanceTracker.testInstance()` only sets `_analyticsOverride` to `null`. The `_analytics` getter then falls back to `_initAnalytics()` on first access. In a file-isolated run this was harmless — `FirebaseAnalytics.instance` threw, the `try/catch` returned null, and `_analytics?.logEvent(...)` was a no-op. In the VGV shared isolate, another test leaves the Firebase platform channel partially initialised, so `FirebaseAnalytics.instance` returns a live instance and `logEvent` throws an async `PlatformException(channel-error, ...)` that the test cannot suppress.

**Fix:** `testInstance()` now sets a `_bypassAnalytics = true` flag; the `_analytics` getter short-circuits on that flag and never reaches `_initAnalytics()`. Additive and `@visibleForTesting` — no production behaviour change (the default `_()` constructor initialises the flag to `false`).

**Test-side change:** adds `FeedPerformanceTracker.resetInstance()` at the top of `setUp` before `testInstance()`, mirroring the `notification_service_enhanced_test` pattern. Belt-and-suspenders for anything that inadvertently touches the singleton via the factory.

**Tag count:** 61 → 60.

**Related Issue:** Part of #3137

**Follows the direction in** #3280 (brainstorm doc + 2026-04-23 verification findings). The brainstorm addendum's original fix template (reset-before-testInstance) was insufficient on its own — this PR captures the full root cause and the working fix.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Test plan

- [x] `dart format` clean
- [x] `flutter analyze lib/services/feed_performance_tracker.dart test/services/feed_performance_tracker_stale_session_test.dart` — No issues found
- [x] VGV full-suite verification, 3× random seeds, all green:
  | Seed | Pass | Fail | Skip | Exit |
  |---:|---:|---:|---:|---:|
  | 42 | 7532 | 0 | 368 | 0 |
  | 12345 | 7532 | 0 | 368 | 0 |
  | 99999 | 7532 | 0 | 368 | 0 |

  Command: `very_good test --optimization --concurrency=2 --exclude-tags integration --test-randomize-ordering-seed <seed>`