### PR TITLE
test(screen-analytics): untag after bypassing Firebase in testInstance

### DIFF
--- a/mobile/lib/services/screen_analytics_service.dart
+++ b/mobile/lib/services/screen_analytics_service.dart
@@ -16,7 +16,7 @@ const _maxScreenSessionAge = Duration(seconds: 60);
 /// Service for tracking screen navigation, performance, and user engagement
 class ScreenAnalyticsService {
   factory ScreenAnalyticsService() => _instance ??= ScreenAnalyticsService._();
-  ScreenAnalyticsService._();
+  ScreenAnalyticsService._() : _bypassAnalytics = false;
 
   static ScreenAnalyticsService? _instance;
 
@@ -34,13 +34,18 @@ class ScreenAnalyticsService {
   /// Creates a testable instance that does not touch [FirebaseAnalytics].
   @visibleForTesting
   ScreenAnalyticsService.testInstance({FirebaseAnalytics? analytics})
-    : _analyticsOverride = analytics;
+    : _analyticsOverride = analytics,
+      _bypassAnalytics = true;
 
   // Lazy-init to avoid crashing when Firebase isn't initialized (e.g. tests).
   FirebaseAnalytics? _analyticsOverride;
   FirebaseAnalytics? _analyticsInstance;
-  FirebaseAnalytics? get _analytics =>
-      _analyticsOverride ?? (_analyticsInstance ??= _initAnalytics());
+  final bool _bypassAnalytics;
+
+  FirebaseAnalytics? get _analytics {
+    if (_bypassAnalytics) return _analyticsOverride;
+    return _analyticsOverride ?? (_analyticsInstance ??= _initAnalytics());
+  }
 
   static FirebaseAnalytics? _initAnalytics() {
     try {

--- a/mobile/test/services/screen_analytics_service_test.dart
+++ b/mobile/test/services/screen_analytics_service_test.dart
@@ -2,7 +2,6 @@
 // ABOUTME: Verifies sessions older than 60s are discarded and resetAllSessions
 // ABOUTME: clears all active sessions on app resume.
 
-@Tags(['skip_very_good_optimization'])
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/screen_analytics_service.dart';
 
@@ -11,6 +10,9 @@ void main() {
     late ScreenAnalyticsService service;
 
     setUp(() {
+      // Reset to discard any stale singleton left by a previous test or test
+      // file when running in a shared isolate (VGV optimized runner).
+      ScreenAnalyticsService.resetInstance();
       service = ScreenAnalyticsService.testInstance();
     });
 


### PR DESCRIPTION
## Description

Second application of the `_bypassAnalytics` pattern from PR #3282 (`FeedPerformanceTracker`), now on `ScreenAnalyticsService`. Same root cause, same fix, no divergence.

**Root cause** — `ScreenAnalyticsService.testInstance()` only sets `_analyticsOverride` to `null`. The `_analytics` getter then falls back to `_initAnalytics()` on first access. In a file-isolated run this is harmless — `FirebaseAnalytics.instance` throws, the `try/catch` returns null, and `_analytics?.logEvent(...)` is a no-op. In the VGV shared isolate, another test leaves the Firebase platform channel partially initialised, so `FirebaseAnalytics.instance` returns a live instance and subsequent `logEvent`/`logScreenView` calls throw async `PlatformException(channel-error, ...)` that the test cannot suppress.

**Fix** — `testInstance()` now sets a `_bypassAnalytics = true` flag; the `_analytics` getter short-circuits on that flag and never reaches `_initAnalytics()`. Additive and `@visibleForTesting` — no production behaviour change (the default `_()` constructor initialises the flag to `false`).

**Test-side change** — adds `ScreenAnalyticsService.resetInstance()` at the top of `setUp` before `testInstance()`, mirroring the `notification_service_enhanced_test` / `feed_performance_tracker_stale_session_test` patterns. Belt-and-suspenders for anything that inadvertently touches the singleton via the factory.

### Why `page_load_observer_test.dart` remains untagged and unchanged

`mobile/lib/services/page_load_observer.dart:9` holds `final ScreenAnalyticsService _analytics = ScreenAnalyticsService();` — the *production* factory singleton, not `testInstance`. Its test at `mobile/test/services/page_load_observer_test.dart` installs a `_FakeFirebaseCore` so the factory path works. Our `_bypassAnalytics` flag is only true when constructed via `testInstance()`; the production factory continues to initialise `_analytics` normally. No change needed on that side.

**Tag count**: 61 → 60.

**Related Issue:** Part of #3137.

**Template source:** #3282. **Direction:** #3280 (brainstorm).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Test plan

- [x] `dart format` clean (no-op on touched files)
- [x] `flutter analyze lib/services/screen_analytics_service.dart test/services/screen_analytics_service_test.dart` — No issues found
- [x] VGV full-suite verification, 4 seeds (3 fixed + 1 fresh random), all green. The fresh random seed captures adjacency orderings the fixed seeds may miss:

  | Seed | Pass | Fail | Skip | Exit |
  |---:|---:|---:|---:|---:|
  | 42 | 7532 | 0 | 368 | 0 |
  | 12345 | 7532 | 0 | 368 | 0 |
  | 99999 | 7532 | 0 | 368 | 0 |
  | 21156759 (random) | 7532 | 0 | 368 | 0 |

  Command: `very_good test --optimization --concurrency=2 --exclude-tags integration --test-randomize-ordering-seed <seed>`

- [x] No cascade into unrelated tests (specifically `test/widgets/video_editor/timeline_editor/*` which cascaded in earlier 2-file verifications — clean across all 4 seeds here).