### PR TITLE
fix(video-recorder): ensure the recording button is correctly centered

### DIFF
--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
@@ -91,6 +91,7 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
                       child: DivineIconButton(
                         icon: .arrowCounterClockwise,
                         type: .ghostSecondary,
+                        size: .small,
                         onPressed: null,
                       ),
                     ),

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_stack_test.dart
@@ -172,8 +172,9 @@ void main() {
         await tester.pumpWidget(buildWidget());
         await tester.pumpAndSettle();
 
-        final stackRect =
-            tester.getRect(find.byType(VideoRecorderCaptureStack));
+        final stackRect = tester.getRect(
+          find.byType(VideoRecorderCaptureStack),
+        );
         final recordButtonRect = tester.getRect(find.byType(RecordButton));
 
         expect(

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_stack_test.dart
@@ -167,6 +167,20 @@ void main() {
 
         expect(find.byType(Stack), findsWidgets);
       });
+
+      testWidgets('$RecordButton is horizontally centered', (tester) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        final stackRect =
+            tester.getRect(find.byType(VideoRecorderCaptureStack));
+        final recordButtonRect = tester.getRect(find.byType(RecordButton));
+
+        expect(
+          recordButtonRect.center.dx,
+          closeTo(stackRect.center.dx, 2.0),
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
Closes #3286

 ## Description

Ensure the recording button is correctly centered.

**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore