### PR TITLE
test(notification): untag notification_service_enhanced test

### DIFF
--- a/mobile/test/services/notification_service_enhanced_test.dart
+++ b/mobile/test/services/notification_service_enhanced_test.dart
@@ -5,7 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/services/notification_service_enhanced.dart';
 
-@Tags(['skip_very_good_optimization'])
 void main() {
   group('NotificationServiceEnhanced Race Condition Tests', () {
     late NotificationServiceEnhanced service;


### PR DESCRIPTION
## Description

Removes `@Tags(['skip_very_good_optimization'])` from `notification_service_enhanced_test.dart`. The file already had the correct `resetInstance()` + `setUp`/`tearDown` pattern shipped in PR #3082 — two test groups, each calling `NotificationServiceEnhanced.resetInstance()` at the top of `setUp` before creating the service. Earlier batch-verification attempts had grouped this file with leakier ones and attributed a cascade to the bundle; single-file verification under the VGV optimizer proves it passes on its own.

No source-code changes required. Verify-and-untag only.

**Tag count**: 61 → 60. The baseline file update is intentionally NOT in this PR — #3288's gate is loose (count must not exceed baseline), so a decrease passes without touching the baseline. This keeps the PR free of merge-order conflicts with the other four open untag PRs.

**Related Issue:** Part of #3137.

**Sibling PRs:** #3282, #3284, #3287, #3290. Companion to #3288 (the baseline gate).

## Type of Change

- [ ] ✨ New feature
- [ ] 🛠️ Bug fix
- [ ] ❌ Breaking change
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore (removing test-isolation opt-out after confirming the underlying fix holds)

## Test plan

- [x] `flutter analyze` clean
- [x] `dart format` clean
- [x] `flutter test test/services/notification_service_enhanced_test.dart` — all tests pass in isolation
- [x] VGV full-suite verification, 4 seeds, all green. Seed 12345's first attempt hit an `Unhandled exception` late-run flake (test 7211/7532); retry was clean and subsequent runs confirmed stability:

  | Seed | Pass | Fail | Skip | Exit |
  |---:|---:|---:|---:|---:|
  | 42 | 7532 | 0 | 368 | 0 |
  | 12345 (retry) | 7532 | 0 | 368 | 0 |
  | 99999 | 7532 | 0 | 368 | 0 |
  | 455121988 (random) | 7532 | 0 | 368 | 0 |

  Command: `very_good test --optimization --concurrency=2 --exclude-tags integration --test-randomize-ordering-seed <seed>`

- [x] No cascade into `test/widgets/video_editor/timeline_editor/*` (the earlier v3 cascade victim) — clean across all 4 seeds.