### PR TITLE
test(video-thumbnail): untag after stubbing ProVideoEditor.instance in setUp

### DIFF
--- a/mobile/test/services/video_thumbnail_service_test.dart
+++ b/mobile/test/services/video_thumbnail_service_test.dart
@@ -1,13 +1,30 @@
 // ABOUTME: Unit tests for video thumbnail extraction service
 // ABOUTME: Tests thumbnail generation, error handling, and edge cases
 
-@Tags(['skip_very_good_optimization'])
 import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
+// Not exported from pro_video_editor's barrel — imported via path so we can
+// subclass MethodChannelProVideoEditor and skip its EventChannel subscription.
+// May need updating on pro_video_editor upgrades.
+import 'package:pro_video_editor/core/platform/native_method_channel.dart';
+import 'package:pro_video_editor/core/platform/platform_interface.dart';
+
+/// Fresh ProVideoEditor-compatible instance for tests.
+///
+/// Extends [MethodChannelProVideoEditor] so method calls route through the
+/// per-test mocked `MethodChannel('pro_video_editor')`. Overrides
+/// [initializeStream] to skip subscribing to the `pro_video_editor_progress`
+/// and `pro_video_editor_waveform_stream` EventChannels — without this
+/// override, the constructor throws `MissingPluginException` in the VGV
+/// shared isolate where those EventChannels aren't mocked.
+class _NoopInitProVideoEditor extends MethodChannelProVideoEditor {
+  @override
+  Stream<dynamic> initializeStream() => const Stream.empty();
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -29,6 +46,14 @@ void main() {
     });
 
     setUp(() {
+      // Reset the pro_video_editor platform singleton to a test-mode instance
+      // whose constructor does NOT subscribe to EventChannels. Without this,
+      // whichever file ran before ours in the VGV shared isolate may have left
+      // `ProVideoEditor.instance` pointing at a foreign mock that overrides
+      // only its own methods, causing our method calls to throw
+      // `UnimplementedError` instead of routing through the MethodChannel.
+      ProVideoEditor.instance = _NoopInitProVideoEditor();
+
       testVideoPath = '${tempDir.path}/test_video.mp4';
 
       // Mock the pro_video_editor platform channel per-test so it does not
@@ -292,6 +317,14 @@ void main() {
     });
 
     setUp(() {
+      // Reset the pro_video_editor platform singleton to a test-mode instance
+      // whose constructor does NOT subscribe to EventChannels. Without this,
+      // whichever file ran before ours in the VGV shared isolate may have left
+      // `ProVideoEditor.instance` pointing at a foreign mock that overrides
+      // only its own methods, causing our method calls to throw
+      // `UnimplementedError` instead of routing through the MethodChannel.
+      ProVideoEditor.instance = _NoopInitProVideoEditor();
+
       getThumbnailsReturnsBytes = false;
       getMetadataSucceeds = true;
 


### PR DESCRIPTION
## Description

Removes `@Tags(['skip_very_good_optimization'])` from `video_thumbnail_service_test.dart` by resetting `ProVideoEditor.instance` in each group's `setUp` to a local test-mode subclass.

### Root cause

Other test files in the repo (`sound_waveform_bloc_test`, `video_recorder_provider_test`, `video_editor_split_service_test`) each define their own `_MockProVideoEditor` and assign it to `ProVideoEditor.instance` without ever restoring it. Under VGV's shared isolate, whichever of those runs before this file leaves the singleton pointing at a foreign mock that only overrides the methods its own tests need. Calls from `extractLastFrame` to `_proVideoEditor.getSingleThumbnail(...)`, `.getMetadata(...)`, and `.getThumbnails(...)` then resolve to the foreign mock's un-overridden inherited methods and either throw `UnimplementedError` or return empty/null values. The existing `setMockMethodCallHandler` in `setUp` is irrelevant because the foreign mock never routes through the platform channel.

### Fix

Assign `ProVideoEditor.instance = _NoopInitProVideoEditor()` at the top of each `setUp`. `_NoopInitProVideoEditor` extends `MethodChannelProVideoEditor` (so method calls route through the mocked platform channel) and overrides `initializeStream()` to return an empty stream — mirrors the pattern from [`mobile/test/blocs/sound_waveform/sound_waveform_bloc_test.dart:11-44`](mobile/test/blocs/sound_waveform/sound_waveform_bloc_test.dart).

Without the `initializeStream` override, constructing a fresh `MethodChannelProVideoEditor` subscribes to the `pro_video_editor_progress` and `pro_video_editor_waveform_stream` EventChannels and throws `MissingPluginException` under test. An earlier attempt at a naive reset (without the override) regressed the file from 3 failures to 31; this PR's variant skips that pitfall.

### Import note

`native_method_channel.dart` isn't exported from `pro_video_editor`'s public barrel; imported via path (`package:pro_video_editor/core/platform/native_method_channel.dart`) with an adjacent comment explaining the tradeoff and flagging it for review on package upgrades.

**Tag count**: 61 → 60. Compatible with #3288 (loose gate) without a baseline update.

**Related Issue:** Part of #3137.

**Sibling PRs:** #3282, #3284, #3287, #3289, #3290. Companion to #3288 (the baseline gate).

## Type of Change

- [ ] ✨ New feature
- [x] 🛠️ Bug fix (test-isolation fix, source-code change in service-class-under-test is nil)
- [ ] ❌ Breaking change
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Test plan

- [x] `flutter analyze` clean
- [x] `dart format` clean
- [x] `flutter test test/services/video_thumbnail_service_test.dart` — all 23 tests pass in isolation
- [x] VGV full-suite verification, 4 seeds, all green:

  | Seed | Pass | Fail | Skip | Exit |
  |---:|---:|---:|---:|---:|
  | 42 (retry) | 7560 | 0 | 368 | 0 |
  | 12345 (retry) | 7560 | 0 | 368 | 0 |
  | 99999 | 7560 | 0 | 368 | 0 |
  | 179580515 (random) | 7560 | 0 | 368 | 0 |

  Command: `very_good test --optimization --concurrency=2 --exclude-tags integration --test-randomize-ordering-seed <seed>`

- [x] Seed 42's first attempt hit an unrelated VGV CLI null-check flake (`test_cli_runner.dart:574`, same pattern as #3289's seed-12345 flake); retry clean.
- [x] Seed 12345's first attempt hit an unrelated `NativeProofData` performance-benchmark timing flake (passed in every other run); retry clean.
- [x] No cascade into `video_editor_timeline_test` or `video_editor_timeline_clip_strip_test` across any seed.
- [x] No regression in the 20 non-`extractLastFrame` tests in the file.