### PR TITLE
test(draft-storage): untag after restoring PathProviderPlatform in tearDown

### DIFF
--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -1,7 +1,6 @@
 // ABOUTME: TDD tests for DraftStorageService - persistent storage for vine drafts
 // ABOUTME: Tests save, load, delete, clear, and migration operations using Drift
 
-@Tags(['skip_very_good_optimization'])
 import 'dart:convert';
 
 import 'package:db_client/db_client.dart';
@@ -638,17 +637,28 @@ void main() {
 
     group('migrateOldDrafts', () {
       const documentsPath = '/tmp/documents';
+      late PathProviderPlatform originalPathProviderInstance;
 
       setUp(() {
         TestWidgetsFlutterBinding.ensureInitialized();
 
+        // Save the current PathProviderPlatform.instance so tearDown can
+        // restore it. Without this, the `MockPathProviderPlatform` installed
+        // below leaks into subsequent test files in the VGV shared isolate;
+        // any test that transitively calls `getApplicationDocumentsDirectory`
+        // (e.g. `VideoThumbnailService.extractThumbnail`) gets the mock's
+        // `/tmp/documents` path and fails with I/O errors.
+        originalPathProviderInstance = PathProviderPlatform.instance;
         final mockPlatform = MockPathProviderPlatform()
           ..setApplicationDocumentsPath(documentsPath);
         PathProviderPlatform.instance = mockPlatform;
         SharedPreferences.setMockInitialValues({});
       });
 
-      tearDown(SharedPreferences.resetStatic);
+      tearDown(() {
+        PathProviderPlatform.instance = originalPathProviderInstance;
+        SharedPreferences.resetStatic();
+      });
 
       Map<String, dynamic> buildClipJson({
         required String id,


### PR DESCRIPTION
## Description

Removes `@Tags(['skip_very_good_optimization'])` from `draft_storage_service_test.dart` by fixing a path-provider leak in the nested `migrateOldDrafts` group.

### Root cause

The `migrateOldDrafts` group's `setUp` (lines 642-648) replaced `PathProviderPlatform.instance` with a `MockPathProviderPlatform` but the `tearDown` (line 651) only reset `SharedPreferences`. The mock persisted into subsequent test files in the VGV shared isolate. Any test that transitively called `getApplicationDocumentsDirectory()` — notably `video_editor_timeline_clip_strip_test.dart` via `VideoThumbnailService.extractThumbnail` at `lib/services/video_thumbnail_service.dart:67` — received the mock's `/tmp/documents` path (a directory that doesn't exist in the test environment) and failed with `[ERROR]` on file I/O.

An earlier batch-verification attempt documented this cascade (17 errors in `video_editor_timeline_clip_strip_test`) in the #3280 addendum but couldn't identify the mechanism at the time.

### Fix

Save the original `PathProviderPlatform.instance` in a `late` variable at the top of the group's `setUp`, then restore it in the `tearDown`. Mirrors the proven pattern in `mobile/test/services/upload_initialization_helper_test.dart:27-55`.

**Tag count**: 61 → 60. Compatible with #3288 (loose gate) without a baseline update.

**Related Issue:** Part of #3137.

**Sibling PRs:** #3282, #3284, #3287, #3289, #3290, #3291. Companion to #3288 (the baseline gate).

## Type of Change

- [ ] ✨ New feature
- [x] 🛠️ Bug fix
- [ ] ❌ Breaking change
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Test plan

- [x] `flutter analyze` clean
- [x] `dart format` clean
- [x] `flutter test test/services/draft_storage_service_test.dart` — all 27 tests pass in isolation
- [x] VGV full-suite verification, 4 seeds, all green. **No cascade into `video_editor_timeline_clip_strip_test` across any seed** — this is the primary check for this PR:

  | Seed | Pass | Fail | Skip | Exit |
  |---:|---:|---:|---:|---:|
  | 42 | 7560 | 0 | 368 | 0 |
  | 12345 | 7560 | 0 | 368 | 0 |
  | 99999 | 7560 | 0 | 368 | 0 |
  | 2196170051 (random) | 7560 | 0 | 368 | 0 |

  Command: `very_good test --optimization --concurrency=2 --exclude-tags integration --test-randomize-ordering-seed <seed>`

## Follow-up worth noting

Other test files in the repo likely have the same latent `PathProviderPlatform.instance = …` without restore pattern. They don't cascade today because their files stay tagged (so they run in isolated processes). If future untag work uncovers similar cascades, this PR's pattern is the template.