### PR TITLE
feat(video-editor): add outside area overlays

### DIFF
--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -107,6 +109,12 @@ class VideoEditorTimelineBody extends StatelessWidget {
         fit: .passthrough,
         clipBehavior: .none,
         children: [
+          // Keep stack slots stable during drag-reorder to avoid gesture drops.
+          _TimelineMaxDurationStripeOverlay(
+            pixelsPerSecond: pixelsPerSecond,
+            visible: !isReordering,
+          ),
+
           Column(
             crossAxisAlignment: .start,
             mainAxisSize: .min,
@@ -177,21 +185,26 @@ class VideoEditorTimelineBody extends StatelessWidget {
               ),
             ],
           ),
-          // Semi-transparent overlay from 6.3s to the end.
-          if (!isReordering)
-            _TimelineMaxDurationOverlay(pixelsPerSecond: pixelsPerSecond),
+          _TimelineMaxDurationDimOverlay(
+            pixelsPerSecond: pixelsPerSecond,
+            visible: !isReordering,
+          ),
         ],
       ),
     );
   }
 }
 
-class _TimelineMaxDurationOverlay extends StatelessWidget {
-  const _TimelineMaxDurationOverlay({
+class _TimelineMaxDurationStripeOverlay extends StatelessWidget {
+  const _TimelineMaxDurationStripeOverlay({
     required this.pixelsPerSecond,
+    required this.visible,
   });
 
+  static const _outsideExtendWidth = 200.0;
+
   final double pixelsPerSecond;
+  final bool visible;
 
   @override
   Widget build(BuildContext context) {
@@ -202,12 +215,99 @@ class _TimelineMaxDurationOverlay extends StatelessWidget {
           pixelsPerSecond,
       top: 0,
       bottom: 0,
-      right: -200,
+      right: -_outsideExtendWidth,
       child: IgnorePointer(
-        child: ColoredBox(
-          color: VineTheme.surfaceContainerHigh.withValues(alpha: 0.6),
+        child: Visibility(
+          visible: visible,
+          maintainState: true,
+          child: const CustomPaint(
+            painter: _TimelineOutsideAreaPainter(
+              stripeColor: VineTheme.onSurfaceDisabled,
+            ),
+            child: SizedBox.expand(),
+          ),
         ),
       ),
     );
+  }
+}
+
+class _TimelineMaxDurationDimOverlay extends StatelessWidget {
+  const _TimelineMaxDurationDimOverlay({
+    required this.pixelsPerSecond,
+    required this.visible,
+  });
+
+  static const _outsideExtendWidth = 200.0;
+
+  final double pixelsPerSecond;
+  final bool visible;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      left:
+          VideoEditorConstants.maxDuration.inMilliseconds /
+          1000 *
+          pixelsPerSecond,
+      top: 0,
+      bottom: 0,
+      right: -_outsideExtendWidth,
+      child: IgnorePointer(
+        child: Visibility(
+          visible: visible,
+          maintainState: true,
+          child: ColoredBox(
+            color: VineTheme.surfaceContainerHigh.withValues(alpha: 0.3),
+            child: const SizedBox.expand(),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _TimelineOutsideAreaPainter extends CustomPainter {
+  const _TimelineOutsideAreaPainter({
+    required this.stripeColor,
+  });
+
+  static const _stripeRotationRadians = 1.05;
+  static const double _stripeWidth = 5;
+  static const double _stripeGap = 10;
+  static final Float64List _stripeTransformStorage =
+      (Matrix4.identity()..rotateZ(_stripeRotationRadians)).storage;
+
+  final Color stripeColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final stripePaint = Paint()
+      ..color = stripeColor
+      ..strokeWidth = _stripeWidth
+      ..strokeCap = StrokeCap.butt
+      ..isAntiAlias = false;
+
+    canvas.save();
+    canvas.clipRect(Offset.zero & size);
+    canvas.transform(_stripeTransformStorage);
+
+    final drawHeight = (size.height * 3).ceilToDouble();
+    final drawWidth = (size.width * 3).ceilToDouble();
+    final startX = -drawWidth - ((-drawWidth) % _stripeGap);
+    for (var x = startX; x <= drawWidth; x += _stripeGap) {
+      canvas.drawLine(
+        Offset(x, -drawHeight),
+        Offset(x, drawHeight),
+        stripePaint,
+      );
+    }
+
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(covariant _TimelineOutsideAreaPainter oldDelegate) {
+    return oldDelegate.stripeColor != stripeColor;
   }
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_body_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_body_test.dart
@@ -1,13 +1,86 @@
 // ABOUTME: Unit tests for VideoEditorTimelineBody.
 // ABOUTME: Verifies constructor wiring for core timeline body dependencies.
 
+import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
+import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart';
 
+class _MockVideoEditorMainBloc
+    extends MockBloc<VideoEditorMainEvent, VideoEditorMainState>
+    implements VideoEditorMainBloc {}
+
+class _MockTimelineOverlayBloc
+    extends MockBloc<TimelineOverlayEvent, TimelineOverlayState>
+    implements TimelineOverlayBloc {}
+
 void main() {
   group(VideoEditorTimelineBody, () {
+    late _MockVideoEditorMainBloc mainBloc;
+    late _MockTimelineOverlayBloc overlayBloc;
+
+    setUp(() {
+      mainBloc = _MockVideoEditorMainBloc();
+      overlayBloc = _MockTimelineOverlayBloc();
+
+      when(
+        () => mainBloc.stream,
+      ).thenAnswer((_) => const Stream<VideoEditorMainState>.empty());
+      when(
+        () => overlayBloc.stream,
+      ).thenAnswer((_) => const Stream<TimelineOverlayState>.empty());
+      when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
+    });
+
+    Future<void> pumpBody(
+      WidgetTester tester, {
+      bool isReordering = false,
+    }) async {
+      when(
+        () => mainBloc.state,
+      ).thenReturn(VideoEditorMainState(isReordering: isReordering));
+
+        final scrollController = ScrollController();
+        final playhead = ValueNotifier(Duration.zero);
+        addTearDown(scrollController.dispose);
+        addTearDown(playhead.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<VideoEditorMainBloc>.value(value: mainBloc),
+              BlocProvider<TimelineOverlayBloc>.value(value: overlayBloc),
+            ],
+              child: SizedBox(
+                height: 120000,
+                child: VideoEditorTimelineBody(
+                  totalDuration: const Duration(seconds: 12),
+                  pixelsPerSecond: 80,
+                  scrollController: scrollController,
+                  scrollPadding: 16,
+                  clips: const <DivineVideoClip>[],
+                  totalWidth: 960,
+                  isInteracting: false,
+                  onReorder: (_) {},
+                  onReorderChanged: (_) {},
+                  playheadPosition: playhead,
+                ),
+            ),
+          ),
+        ),
+      );
+    }
+
     test('stores constructor parameters', () {
       final scrollController = ScrollController();
       final playhead = ValueNotifier(Duration.zero);
@@ -36,6 +109,78 @@ void main() {
 
       scrollController.dispose();
       playhead.dispose();
+    });
+
+    testWidgets('shows outside-area overlays when not reordering', (
+      tester,
+    ) async {
+      await pumpBody(tester);
+
+      final dimOverlayFinder = find.byWidgetPredicate(
+        (widget) =>
+            widget is ColoredBox &&
+            widget.color ==
+                VineTheme.surfaceContainerHigh.withValues(alpha: 0.3),
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is CustomPaint &&
+              widget.painter.runtimeType.toString() ==
+                  '_TimelineOutsideAreaPainter',
+        ),
+        findsOneWidget,
+      );
+      expect(dimOverlayFinder, findsOneWidget);
+    });
+
+    testWidgets('hides outside-area overlays when reordering', (tester) async {
+      await pumpBody(tester, isReordering: true);
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is CustomPaint &&
+              widget.painter.runtimeType.toString() ==
+                  '_TimelineOutsideAreaPainter',
+        ),
+        findsNothing,
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is ColoredBox &&
+              widget.color ==
+                  VineTheme.surfaceContainerHigh.withValues(alpha: 0.3),
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('renders dim overlay with updated alpha', (tester) async {
+      await pumpBody(tester);
+
+      final expectedColor = VineTheme.surfaceContainerHigh.withValues(
+        alpha: 0.3,
+      );
+      final unexpectedColor = VineTheme.surfaceContainerHigh.withValues(
+        alpha: 0.6,
+      );
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget is ColoredBox && widget.color == expectedColor,
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byWidgetPredicate(
+          (widget) => widget is ColoredBox && widget.color == unexpectedColor,
+        ),
+        findsNothing,
+      );
     });
   });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_body_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_body_test.dart
@@ -47,34 +47,34 @@ void main() {
         () => mainBloc.state,
       ).thenReturn(VideoEditorMainState(isReordering: isReordering));
 
-        final scrollController = ScrollController();
-        final playhead = ValueNotifier(Duration.zero);
-        addTearDown(scrollController.dispose);
-        addTearDown(playhead.dispose);
+      final scrollController = ScrollController();
+      final playhead = ValueNotifier(Duration.zero);
+      addTearDown(scrollController.dispose);
+      addTearDown(playhead.dispose);
 
       await tester.pumpWidget(
         MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: MultiBlocProvider(
             providers: [
               BlocProvider<VideoEditorMainBloc>.value(value: mainBloc),
               BlocProvider<TimelineOverlayBloc>.value(value: overlayBloc),
             ],
-              child: SizedBox(
-                height: 120000,
-                child: VideoEditorTimelineBody(
-                  totalDuration: const Duration(seconds: 12),
-                  pixelsPerSecond: 80,
-                  scrollController: scrollController,
-                  scrollPadding: 16,
-                  clips: const <DivineVideoClip>[],
-                  totalWidth: 960,
-                  isInteracting: false,
-                  onReorder: (_) {},
-                  onReorderChanged: (_) {},
-                  playheadPosition: playhead,
-                ),
+            child: SizedBox(
+              height: 120000,
+              child: VideoEditorTimelineBody(
+                totalDuration: const Duration(seconds: 12),
+                pixelsPerSecond: 80,
+                scrollController: scrollController,
+                scrollPadding: 16,
+                clips: const <DivineVideoClip>[],
+                totalWidth: 960,
+                isInteracting: false,
+                onReorder: (_) {},
+                onReorderChanged: (_) {},
+                playheadPosition: playhead,
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
Closes #3296

## Description

Add the outside area overlays same like in figma.

<img width="322" alt="Bildschirmfoto 2026-04-23 um 14 52 18" src="https://github.com/user-attachments/assets/bb2d1a1d-1671-4deb-af2f-858a9d43ce44" />



**Related Issue:** 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore