### PR TITLE
fix(picker): prevent autocorrect re-query + boost followed users

### DIFF
--- a/mobile/lib/blocs/user_search/user_search_bloc.dart
+++ b/mobile/lib/blocs/user_search/user_search_bloc.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart';
 import 'package:openvine/constants/search_constants.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
@@ -20,10 +21,12 @@ const _pageSize = 50;
 class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
   UserSearchBloc({
     required ProfileRepository profileRepository,
+    FollowRepository? followRepository,
     this.hasVideos = false,
     this.searchTimeout = const Duration(seconds: 20),
     FeedPerformanceTracker? feedTracker,
   }) : _profileRepository = profileRepository,
+       _followRepository = followRepository,
        _feedTracker = feedTracker,
        super(const UserSearchState()) {
     on<UserSearchQueryChanged>(
@@ -35,6 +38,11 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
   }
 
   final ProfileRepository _profileRepository;
+
+  /// Optional follow graph used to boost followed users to the top of the
+  /// initial search page. Null for consumers that want raw server ranking.
+  final FollowRepository? _followRepository;
+
   final FeedPerformanceTracker? _feedTracker;
 
   /// Whether to filter results to users who have uploaded videos.
@@ -63,18 +71,26 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
     // the search to get stuck in loading/empty-success states with no recovery
     // path (the user could never re-trigger the same query).
 
+    // Keep the previous query's results visible while the new search loads,
+    // so a rapid re-trigger (e.g. iOS autocorrect rewriting "liz" to "Liz")
+    // never blanks the list. Pagination cursors reset for the new query.
     emit(
       state.copyWith(
         status: UserSearchStatus.loading,
         query: query,
-        results: const [],
-        resultCount: null,
+        offset: 0,
+        hasMore: false,
         isLoadingMore: false,
       ),
     );
 
     _feedTracker?.startFeedLoad('user_search');
     var trackedFirst = false;
+
+    // Snapshot the follow graph once for this query so every progressive
+    // yield uses the same boost set without O(n) list scans per profile.
+    final followedPubkeys =
+        _followRepository?.followingPubkeys.toSet() ?? const <String>{};
 
     try {
       final searchStream = _profileRepository.searchUsersProgressive(
@@ -96,10 +112,11 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
               results.length,
             );
           }
+          final boosted = _boostFollowed(results, followedPubkeys);
           return state.copyWith(
             status: UserSearchStatus.loading,
-            results: results,
-            resultCount: results.length,
+            results: boosted,
+            resultCount: boosted.length,
           );
         },
       );
@@ -171,5 +188,29 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
 
   void _onCleared(UserSearchCleared event, Emitter<UserSearchState> emit) {
     emit(const UserSearchState());
+  }
+
+  /// Moves followed users to the front of [results] while preserving the
+  /// server-relative order within each group.
+  ///
+  /// Only applied to the initial search page. Load-more pages append raw
+  /// (see [_onLoadMore]) so that already-visible positions stay stable as
+  /// the user scrolls.
+  List<UserProfile> _boostFollowed(
+    List<UserProfile> results,
+    Set<String> followedPubkeys,
+  ) {
+    if (followedPubkeys.isEmpty) return results;
+    final boosted = <UserProfile>[];
+    final rest = <UserProfile>[];
+    for (final profile in results) {
+      if (followedPubkeys.contains(profile.pubkey)) {
+        boosted.add(profile);
+      } else {
+        rest.add(profile);
+      }
+    }
+    if (boosted.isEmpty) return results;
+    return [...boosted, ...rest];
   }
 }

--- a/mobile/lib/blocs/user_search/user_search_bloc.dart
+++ b/mobile/lib/blocs/user_search/user_search_bloc.dart
@@ -71,9 +71,6 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
     // the search to get stuck in loading/empty-success states with no recovery
     // path (the user could never re-trigger the same query).
 
-    // Keep the previous query's results visible while the new search loads,
-    // so a rapid re-trigger (e.g. iOS autocorrect rewriting "liz" to "Liz")
-    // never blanks the list. Pagination cursors reset for the new query.
     emit(
       state.copyWith(
         status: UserSearchStatus.loading,

--- a/mobile/lib/blocs/user_search/user_search_bloc.dart
+++ b/mobile/lib/blocs/user_search/user_search_bloc.dart
@@ -85,9 +85,10 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
     var trackedFirst = false;
 
     // Snapshot the follow graph once for this query so every progressive
-    // yield uses the same boost set without O(n) list scans per profile.
-    final followedPubkeys =
-        _followRepository?.followingPubkeys.toSet() ?? const <String>{};
+    // yield uses the same boost set. Boost ordering is applied inside the
+    // repository (see ProfileRepository.searchUsersProgressive), keeping
+    // ranking logic out of the BLoC.
+    final followedPubkeys = _followRepository?.followingPubkeys.toSet();
 
     try {
       final searchStream = _profileRepository.searchUsersProgressive(
@@ -95,6 +96,7 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
         limit: _pageSize,
         sortBy: 'followers',
         hasVideos: hasVideos,
+        boostPubkeys: followedPubkeys,
       );
 
       await emit.forEach<List<UserProfile>>(
@@ -109,11 +111,10 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
               results.length,
             );
           }
-          final boosted = _boostFollowed(results, followedPubkeys);
           return state.copyWith(
             status: UserSearchStatus.loading,
-            results: boosted,
-            resultCount: boosted.length,
+            results: results,
+            resultCount: results.length,
           );
         },
       );
@@ -185,29 +186,5 @@ class UserSearchBloc extends Bloc<UserSearchEvent, UserSearchState> {
 
   void _onCleared(UserSearchCleared event, Emitter<UserSearchState> emit) {
     emit(const UserSearchState());
-  }
-
-  /// Moves followed users to the front of [results] while preserving the
-  /// server-relative order within each group.
-  ///
-  /// Only applied to the initial search page. Load-more pages append raw
-  /// (see [_onLoadMore]) so that already-visible positions stay stable as
-  /// the user scrolls.
-  List<UserProfile> _boostFollowed(
-    List<UserProfile> results,
-    Set<String> followedPubkeys,
-  ) {
-    if (followedPubkeys.isEmpty) return results;
-    final boosted = <UserProfile>[];
-    final rest = <UserProfile>[];
-    for (final profile in results) {
-      if (followedPubkeys.contains(profile.pubkey)) {
-        boosted.add(profile);
-      } else {
-        rest.add(profile);
-      }
-    }
-    if (boosted.isEmpty) return results;
-    return [...boosted, ...rest];
   }
 }

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -64,7 +64,6 @@ class UserPickerSheet extends ConsumerStatefulWidget {
     this.scrollController,
     this.autoFocus = false,
     this.excludePubkeys = const {},
-    this.searchTimeout = const Duration(seconds: 20),
     super.key,
   });
 
@@ -78,10 +77,6 @@ class UserPickerSheet extends ConsumerStatefulWidget {
 
   /// Pubkeys to exclude from search results (already selected users).
   final Set<String> excludePubkeys;
-
-  /// Optional timeout forwarded to the internally created [UserSearchBloc].
-  /// Pass `null` in tests that use `pumpAndSettle` to avoid pending timers.
-  final Duration? searchTimeout;
 
   @override
   ConsumerState<UserPickerSheet> createState() => _UserPickerSheetState();
@@ -113,7 +108,6 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     _searchBloc = UserSearchBloc(
       profileRepository: profileRepo,
       followRepository: ref.read(followRepositoryProvider),
-      searchTimeout: widget.searchTimeout,
     );
 
     if (_useLocalSearch) {

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -64,6 +64,7 @@ class UserPickerSheet extends ConsumerStatefulWidget {
     this.scrollController,
     this.autoFocus = false,
     this.excludePubkeys = const {},
+    this.searchTimeout = const Duration(seconds: 20),
     super.key,
   });
 
@@ -77,6 +78,10 @@ class UserPickerSheet extends ConsumerStatefulWidget {
 
   /// Pubkeys to exclude from search results (already selected users).
   final Set<String> excludePubkeys;
+
+  /// Optional timeout forwarded to the internally created [UserSearchBloc].
+  /// Pass `null` in tests that use `pumpAndSettle` to avoid pending timers.
+  final Duration? searchTimeout;
 
   @override
   ConsumerState<UserPickerSheet> createState() => _UserPickerSheetState();
@@ -107,6 +112,8 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     }
     _searchBloc = UserSearchBloc(
       profileRepository: profileRepo,
+      followRepository: ref.read(followRepositoryProvider),
+      searchTimeout: widget.searchTimeout,
     );
 
     if (_useLocalSearch) {
@@ -216,6 +223,11 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
               autofocus: widget.autoFocus,
               controller: _searchController,
               textInputAction: .search,
+              // iOS predictive text and autocorrect silently rewrite the
+              // query (e.g. "liz" → "Liz"), which re-fires `onChanged` and
+              // blanks the results. Search fields should always opt out.
+              autocorrect: false,
+              enableSuggestions: false,
               onChanged: _onSearchChanged,
               onSubmitted: _onSearchChanged,
               cursorColor: VineTheme.vineGreen,
@@ -508,7 +520,7 @@ class _ResultsList extends StatelessWidget {
     return ListView.separated(
       controller: scrollController,
       itemCount: results.length,
-      padding: .fromLTRB(
+      padding: EdgeInsets.fromLTRB(
         0,
         32,
         0,
@@ -552,20 +564,28 @@ class _NetworkResults extends StatelessWidget {
       builder: (context, state) {
         return switch (state.status) {
           UserSearchStatus.initial => const _EmptyHint(),
+          // Render cached/stale results while a new query loads — prevents
+          // the full-screen spinner flash (e.g. when iOS autocorrect silently
+          // replaces the query and re-triggers the search).
+          UserSearchStatus.loading when state.results.isNotEmpty =>
+            _ResultsList(
+              scrollController: scrollController,
+              results: state.results,
+              onUserSelected: onUserSelected,
+              excludePubkeys: excludePubkeys,
+            ),
           UserSearchStatus.loading => const Center(
             child: CircularProgressIndicator(color: VineTheme.vineGreen),
           ),
           UserSearchStatus.failure => const _ErrorState(),
-          UserSearchStatus.success => () {
-            return state.results.isEmpty
-                ? const _NoResults()
-                : _ResultsList(
-                    scrollController: scrollController,
-                    results: state.results,
-                    onUserSelected: onUserSelected,
-                    excludePubkeys: excludePubkeys,
-                  );
-          }(),
+          UserSearchStatus.success when state.results.isEmpty =>
+            const _NoResults(),
+          UserSearchStatus.success => _ResultsList(
+            scrollController: scrollController,
+            results: state.results,
+            onUserSelected: onUserSelected,
+            excludePubkeys: excludePubkeys,
+          ),
         };
       },
     );

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -805,12 +805,21 @@ class ProfileRepository {
   ///
   /// Parameters match [searchUsers]. When [offset] > 0 the local and NIP-50
   /// phases are skipped (only the API phase runs).
+  ///
+  /// When [boostPubkeys] is non-empty, profiles whose pubkey is in the set
+  /// are promoted to the front of each emission while preserving the
+  /// server-relative order within both the boosted and non-boosted groups.
+  /// Typical use: pass the follow graph so followed users appear first on
+  /// the initial search page. Callers should omit [boostPubkeys] on
+  /// load-more requests so already-visible positions stay stable as the
+  /// user scrolls.
   Stream<List<UserProfile>> searchUsersProgressive({
     required String query,
     int limit = 200,
     int offset = 0,
     String? sortBy,
     bool hasVideos = false,
+    Set<String>? boostPubkeys,
   }) async* {
     final trimmed = query.trim();
     if (trimmed.isEmpty) return;
@@ -825,7 +834,12 @@ class ProfileRepository {
         resultMap[profile.pubkey] = profile;
       }
       if (resultMap.isNotEmpty) {
-        yield _applyFilter(trimmed, resultMap.values.toList(), useServerSort);
+        yield _applyFilter(
+          trimmed,
+          resultMap.values.toList(),
+          useServerSort,
+          boostPubkeys,
+        );
       }
     }
 
@@ -855,7 +869,12 @@ class ProfileRepository {
     // Skips enrichment for faster progressive display; the final Phase 3
     // yield enriches all results from cache.
     if (resultMap.length > prevCount) {
-      yield _applyFilter(trimmed, resultMap.values.toList(), useServerSort);
+      yield _applyFilter(
+        trimmed,
+        resultMap.values.toList(),
+        useServerSort,
+        boostPubkeys,
+      );
     }
 
     // Phase 3: NIP-50 WebSocket (first page only)
@@ -882,7 +901,7 @@ class ProfileRepository {
       // Only enrich + yield again if WS added new profiles
       if (resultMap.length > preWsCount) {
         final enriched = await _enrichFromCache(resultMap.values.toList());
-        yield _applyFilter(trimmed, enriched, useServerSort);
+        yield _applyFilter(trimmed, enriched, useServerSort, boostPubkeys);
         return;
       }
     }
@@ -890,15 +909,17 @@ class ProfileRepository {
     // Final yield: enriched + filtered (when WS didn't add anything or
     // was skipped due to offset > 0)
     final enriched = await _enrichFromCache(resultMap.values.toList());
-    yield _applyFilter(trimmed, enriched, useServerSort);
+    yield _applyFilter(trimmed, enriched, useServerSort, boostPubkeys);
   }
 
   /// Applies the configured search filter or falls back to name matching,
-  /// then removes blocked/muted users.
+  /// removes blocked/muted users, and optionally promotes [boostPubkeys]
+  /// to the front while preserving relative order.
   List<UserProfile> _applyFilter(
     String query,
     List<UserProfile> profiles,
     bool useServerSort,
+    Set<String>? boostPubkeys,
   ) {
     List<UserProfile> filtered;
     if (useServerSort) {
@@ -913,8 +934,32 @@ class ProfileRepository {
     }
 
     final blockFilter = _blockFilter;
-    if (blockFilter == null) return filtered;
-    return filtered.where((p) => !blockFilter(p.pubkey)).toList();
+    if (blockFilter != null) {
+      filtered = filtered.where((p) => !blockFilter(p.pubkey)).toList();
+    }
+
+    return _boostProfiles(filtered, boostPubkeys);
+  }
+
+  /// Moves profiles whose pubkey is in [boostPubkeys] to the front of
+  /// [profiles] while preserving the server-relative order within each
+  /// group.
+  List<UserProfile> _boostProfiles(
+    List<UserProfile> profiles,
+    Set<String>? boostPubkeys,
+  ) {
+    if (boostPubkeys == null || boostPubkeys.isEmpty) return profiles;
+    final boosted = <UserProfile>[];
+    final rest = <UserProfile>[];
+    for (final profile in profiles) {
+      if (boostPubkeys.contains(profile.pubkey)) {
+        boosted.add(profile);
+      } else {
+        rest.add(profile);
+      }
+    }
+    if (boosted.isEmpty) return profiles;
+    return [...boosted, ...rest];
   }
 
   /// Fetches a user profile from the Funnelcake REST API.

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -2673,6 +2673,236 @@ void main() {
           },
         );
       });
+
+      group('with boostPubkeys', () {
+        late MockFunnelcakeApiClient mockFunnelcakeClient;
+
+        // Three distinct 64-char hex pubkeys.
+        final pubA = 'a' * 64;
+        final pubB = 'b' * 64;
+        final pubC = 'c' * 64;
+
+        ProfileSearchResult restResult(String pubkey, String name) {
+          return ProfileSearchResult(
+            pubkey: pubkey,
+            displayName: name,
+            createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+          );
+        }
+
+        setUp(() {
+          mockFunnelcakeClient = MockFunnelcakeApiClient();
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockUserProfilesDao.getAllProfiles(),
+          ).thenAnswer((_) async => []);
+          when(
+            () => mockNostrClient.queryUsers(any(), limit: any(named: 'limit')),
+          ).thenAnswer((_) async => []);
+        });
+
+        test(
+          'promotes boosted pubkeys to the front on the initial page',
+          () async {
+            when(
+              () => mockFunnelcakeClient.searchProfiles(
+                query: 'liz',
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+                sortBy: any(named: 'sortBy'),
+                hasVideos: any(named: 'hasVideos'),
+              ),
+            ).thenAnswer(
+              (_) async => [
+                restResult(pubA, 'Zoe'),
+                restResult(pubB, 'Liz'),
+                restResult(pubC, 'Maya'),
+              ],
+            );
+
+            final repo = ProfileRepository(
+              nostrClient: mockNostrClient,
+              userProfilesDao: mockUserProfilesDao,
+              httpClient: mockHttpClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repo
+                .searchUsersProgressive(
+                  query: 'liz',
+                  sortBy: 'followers',
+                  boostPubkeys: {pubB},
+                )
+                .last;
+
+            expect(
+              result.map((p) => p.displayName).toList(),
+              equals(['Liz', 'Zoe', 'Maya']),
+            );
+          },
+        );
+
+        test(
+          'preserves server-relative order within each boost group',
+          () async {
+            when(
+              () => mockFunnelcakeClient.searchProfiles(
+                query: 'test',
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+                sortBy: any(named: 'sortBy'),
+                hasVideos: any(named: 'hasVideos'),
+              ),
+            ).thenAnswer(
+              (_) async => [
+                restResult(pubA, 'A'), // boosted
+                restResult(pubB, 'B'), // not boosted
+                restResult(pubC, 'C'), // boosted
+                restResult('d' * 64, 'D'), // not boosted
+              ],
+            );
+
+            final repo = ProfileRepository(
+              nostrClient: mockNostrClient,
+              userProfilesDao: mockUserProfilesDao,
+              httpClient: mockHttpClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repo
+                .searchUsersProgressive(
+                  query: 'test',
+                  sortBy: 'followers',
+                  boostPubkeys: {pubA, pubC},
+                )
+                .last;
+
+            expect(
+              result.map((p) => p.displayName).toList(),
+              equals(['A', 'C', 'B', 'D']),
+            );
+          },
+        );
+
+        test(
+          'is a no-op when the boost set is empty',
+          () async {
+            when(
+              () => mockFunnelcakeClient.searchProfiles(
+                query: 'test',
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+                sortBy: any(named: 'sortBy'),
+                hasVideos: any(named: 'hasVideos'),
+              ),
+            ).thenAnswer(
+              (_) async => [
+                restResult(pubA, 'Zoe'),
+                restResult(pubB, 'Maya'),
+              ],
+            );
+
+            final repo = ProfileRepository(
+              nostrClient: mockNostrClient,
+              userProfilesDao: mockUserProfilesDao,
+              httpClient: mockHttpClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repo
+                .searchUsersProgressive(
+                  query: 'test',
+                  sortBy: 'followers',
+                  boostPubkeys: const <String>{},
+                )
+                .last;
+
+            expect(
+              result.map((p) => p.displayName).toList(),
+              equals(['Zoe', 'Maya']),
+            );
+          },
+        );
+
+        test(
+          'is a no-op when boostPubkeys is null',
+          () async {
+            when(
+              () => mockFunnelcakeClient.searchProfiles(
+                query: 'test',
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+                sortBy: any(named: 'sortBy'),
+                hasVideos: any(named: 'hasVideos'),
+              ),
+            ).thenAnswer(
+              (_) async => [
+                restResult(pubA, 'Zoe'),
+                restResult(pubB, 'Maya'),
+              ],
+            );
+
+            final repo = ProfileRepository(
+              nostrClient: mockNostrClient,
+              userProfilesDao: mockUserProfilesDao,
+              httpClient: mockHttpClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repo
+                .searchUsersProgressive(
+                  query: 'test',
+                  sortBy: 'followers',
+                )
+                .last;
+
+            expect(
+              result.map((p) => p.displayName).toList(),
+              equals(['Zoe', 'Maya']),
+            );
+          },
+        );
+
+        test(
+          'is a no-op when no result is in the boost set',
+          () async {
+            when(
+              () => mockFunnelcakeClient.searchProfiles(
+                query: 'test',
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+                sortBy: any(named: 'sortBy'),
+                hasVideos: any(named: 'hasVideos'),
+              ),
+            ).thenAnswer(
+              (_) async => [
+                restResult(pubA, 'Zoe'),
+                restResult(pubB, 'Maya'),
+              ],
+            );
+
+            final repo = ProfileRepository(
+              nostrClient: mockNostrClient,
+              userProfilesDao: mockUserProfilesDao,
+              httpClient: mockHttpClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repo
+                .searchUsersProgressive(
+                  query: 'test',
+                  sortBy: 'followers',
+                  boostPubkeys: {'f' * 64},
+                )
+                .last;
+
+            expect(
+              result.map((p) => p.displayName).toList(),
+              equals(['Zoe', 'Maya']),
+            );
+          },
+        );
+      });
     });
 
     group('exceptions', () {

--- a/mobile/test/blocs/user_search/user_search_bloc_test.dart
+++ b/mobile/test/blocs/user_search/user_search_bloc_test.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/user_search/user_search_bloc.dart';
@@ -12,6 +13,8 @@ import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:profile_repository/profile_repository.dart';
 
 class _MockProfileRepository extends Mock implements ProfileRepository {}
+
+class _MockFollowRepository extends Mock implements FollowRepository {}
 
 class _MockFeedPerformanceTracker extends Mock
     implements FeedPerformanceTracker {}
@@ -246,10 +249,19 @@ void main() {
         act: (bloc) => bloc.add(const UserSearchQueryChanged('flutter')),
         wait: debounceDuration,
         expect: () => [
+          // Previous results stay visible during re-query to prevent the
+          // full-screen spinner flash on autocorrect-triggered re-runs.
           isA<UserSearchState>()
               .having((s) => s.status, 'status', UserSearchStatus.loading)
               .having((s) => s.query, 'query', 'flutter')
-              .having((s) => s.results, 'results', isEmpty),
+              .having((s) => s.results, 'results preserved', hasLength(1))
+              .having(
+                (s) => s.results.first.displayName,
+                'previous result',
+                'Flutter Dev',
+              )
+              .having((s) => s.offset, 'offset reset', 0)
+              .having((s) => s.hasMore, 'hasMore reset', false),
           isA<UserSearchState>()
               .having((s) => s.status, 'status', UserSearchStatus.loading)
               .having((s) => s.results, 'results', hasLength(1))
@@ -690,6 +702,202 @@ void main() {
       );
     });
 
+    group('follow boost', () {
+      const debounceDuration = Duration(milliseconds: 400);
+
+      UserProfile profile(String idPrefix, String name) =>
+          createTestProfile('${idPrefix}x${'a' * 62}'.substring(0, 64), name);
+
+      UserSearchBloc createBoostedBloc(FollowRepository followRepository) =>
+          UserSearchBloc(
+            profileRepository: mockProfileRepository,
+            followRepository: followRepository,
+          );
+
+      blocTest<UserSearchBloc, UserSearchState>(
+        'moves followed users to the top of the initial page',
+        setUp: () {
+          final zoe = profile('00', 'Zoe'); // server-first
+          final liz = profile('01', 'Liz Sweigart'); // followed, server-middle
+          final maya = profile('02', 'Maya'); // server-last
+          when(
+            () => mockProfileRepository.searchUsersProgressive(
+              query: 'liz',
+              limit: any(named: 'limit'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer((_) => Stream.value([zoe, liz, maya]));
+        },
+        build: () {
+          final follows = _MockFollowRepository();
+          when(() => follows.followingPubkeys).thenReturn([
+            '01x${'a' * 61}',
+          ]);
+          return createBoostedBloc(follows);
+        },
+        act: (bloc) => bloc.add(const UserSearchQueryChanged('liz')),
+        wait: debounceDuration,
+        expect: () => [
+          const UserSearchState(
+            status: UserSearchStatus.loading,
+            query: 'liz',
+          ),
+          isA<UserSearchState>()
+              .having((s) => s.status, 'status', UserSearchStatus.loading)
+              .having(
+                (s) => s.results.map((p) => p.displayName).toList(),
+                'results order',
+                ['Liz Sweigart', 'Zoe', 'Maya'],
+              ),
+          isA<UserSearchState>()
+              .having((s) => s.status, 'status', UserSearchStatus.success)
+              .having(
+                (s) => s.results.map((p) => p.displayName).toList(),
+                'results order',
+                ['Liz Sweigart', 'Zoe', 'Maya'],
+              ),
+        ],
+      );
+
+      blocTest<UserSearchBloc, UserSearchState>(
+        'preserves server-relative order within each group',
+        setUp: () {
+          final a = profile('00', 'A'); // followed
+          final b = profile('01', 'B'); // not followed
+          final c = profile('02', 'C'); // followed
+          final d = profile('03', 'D'); // not followed
+          when(
+            () => mockProfileRepository.searchUsersProgressive(
+              query: 'test',
+              limit: any(named: 'limit'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer((_) => Stream.value([a, b, c, d]));
+        },
+        build: () {
+          final follows = _MockFollowRepository();
+          when(() => follows.followingPubkeys).thenReturn([
+            '00x${'a' * 61}',
+            '02x${'a' * 61}',
+          ]);
+          return createBoostedBloc(follows);
+        },
+        act: (bloc) => bloc.add(const UserSearchQueryChanged('test')),
+        wait: debounceDuration,
+        expect: () => [
+          const UserSearchState(
+            status: UserSearchStatus.loading,
+            query: 'test',
+          ),
+          isA<UserSearchState>()
+              .having((s) => s.status, 'status', UserSearchStatus.loading)
+              .having(
+                (s) => s.results.map((p) => p.displayName).toList(),
+                'results order',
+                ['A', 'C', 'B', 'D'],
+              ),
+          isA<UserSearchState>()
+              .having((s) => s.status, 'status', UserSearchStatus.success)
+              .having(
+                (s) => s.results.map((p) => p.displayName).toList(),
+                'results order',
+                ['A', 'C', 'B', 'D'],
+              ),
+        ],
+      );
+
+      blocTest<UserSearchBloc, UserSearchState>(
+        'is a no-op when the follow list is empty',
+        setUp: () {
+          final zoe = profile('00', 'Zoe');
+          final maya = profile('01', 'Maya');
+          when(
+            () => mockProfileRepository.searchUsersProgressive(
+              query: 'test',
+              limit: any(named: 'limit'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer((_) => Stream.value([zoe, maya]));
+        },
+        build: () {
+          final follows = _MockFollowRepository();
+          when(() => follows.followingPubkeys).thenReturn(const []);
+          return createBoostedBloc(follows);
+        },
+        act: (bloc) => bloc.add(const UserSearchQueryChanged('test')),
+        wait: debounceDuration,
+        expect: () => [
+          const UserSearchState(
+            status: UserSearchStatus.loading,
+            query: 'test',
+          ),
+          isA<UserSearchState>()
+              .having((s) => s.status, 'status', UserSearchStatus.loading)
+              .having(
+                (s) => s.results.map((p) => p.displayName).toList(),
+                'results order',
+                ['Zoe', 'Maya'],
+              ),
+          isA<UserSearchState>().having(
+            (s) => s.status,
+            'status',
+            UserSearchStatus.success,
+          ),
+        ],
+      );
+
+      blocTest<UserSearchBloc, UserSearchState>(
+        'does not re-boost already-shown results on UserSearchLoadMore',
+        setUp: () {
+          // Page 2 includes a followed user — should be appended at the end,
+          // not moved to the top of the already-visible list.
+          final liz2 = profile('99', 'Liz From Page 2');
+          when(
+            () => mockProfileRepository.searchUsersProgressive(
+              query: 'liz',
+              limit: any(named: 'limit'),
+              offset: 50,
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer((_) => Stream.value([liz2]));
+        },
+        build: () {
+          final follows = _MockFollowRepository();
+          when(() => follows.followingPubkeys).thenReturn([
+            '99x${'a' * 61}',
+          ]);
+          return createBoostedBloc(follows);
+        },
+        seed: () => UserSearchState(
+          status: UserSearchStatus.success,
+          query: 'liz',
+          results: createTestProfiles(50),
+          offset: 50,
+          hasMore: true,
+        ),
+        act: (bloc) => bloc.add(const UserSearchLoadMore()),
+        expect: () => [
+          isA<UserSearchState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            true,
+          ),
+          isA<UserSearchState>()
+              .having((s) => s.isLoadingMore, 'isLoadingMore', false)
+              .having((s) => s.results.length, 'results.length', 51)
+              .having(
+                (s) => s.results.last.displayName,
+                'new page appended at end',
+                'Liz From Page 2',
+              ),
+        ],
+      );
+    });
+
     group('hasVideos parameter', () {
       const debounceDuration = Duration(milliseconds: 400);
 
@@ -793,8 +1001,8 @@ void main() {
       const debounceDuration = Duration(milliseconds: 400);
 
       blocTest<UserSearchBloc, UserSearchState>(
-        'clears previous results and emits failure when a subsequent query '
-        'fails',
+        'keeps previous results while a subsequent query is loading and '
+        'emits failure on error',
         setUp: () {
           when(
             () => mockProfileRepository.searchUsersProgressive(
@@ -837,13 +1045,24 @@ void main() {
             'status',
             UserSearchStatus.success,
           ),
+          // New query keeps the prior 'alice' results visible while loading.
           isA<UserSearchState>()
               .having((s) => s.status, 'status', UserSearchStatus.loading)
               .having((s) => s.query, 'query', 'error')
-              .having((s) => s.results, 'results cleared', isEmpty),
+              .having(
+                (s) => s.results,
+                'stale results preserved',
+                hasLength(1),
+              ),
+          // On failure, status flips to failure but the stale results are
+          // retained in state — the UI decides whether to show them.
           isA<UserSearchState>()
               .having((s) => s.status, 'status', UserSearchStatus.failure)
-              .having((s) => s.results, 'results still empty', isEmpty),
+              .having(
+                (s) => s.results,
+                'stale results still in state',
+                hasLength(1),
+              ),
         ],
       );
     });

--- a/mobile/test/blocs/user_search/user_search_bloc_test.dart
+++ b/mobile/test/blocs/user_search/user_search_bloc_test.dart
@@ -703,6 +703,10 @@ void main() {
     });
 
     group('follow boost', () {
+      // Boost ordering itself lives in ProfileRepository — see
+      // profile_repository_test.dart for the ordering behaviour. These tests
+      // verify that the BLoC wires the follow graph through to the repository
+      // and preserves whatever ordering the repository returns.
       const debounceDuration = Duration(milliseconds: 400);
 
       UserProfile profile(String idPrefix, String name) =>
@@ -715,112 +719,52 @@ void main() {
           );
 
       blocTest<UserSearchBloc, UserSearchState>(
-        'moves followed users to the top of the initial page',
+        'forwards the follow graph as boostPubkeys on the initial page',
         setUp: () {
-          final zoe = profile('00', 'Zoe'); // server-first
-          final liz = profile('01', 'Liz Sweigart'); // followed, server-middle
-          final maya = profile('02', 'Maya'); // server-last
           when(
             () => mockProfileRepository.searchUsersProgressive(
               query: 'liz',
               limit: any(named: 'limit'),
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
+              boostPubkeys: any(named: 'boostPubkeys'),
             ),
-          ).thenAnswer((_) => Stream.value([zoe, liz, maya]));
+          ).thenAnswer((_) => Stream.value([profile('01', 'Liz Sweigart')]));
         },
         build: () {
           final follows = _MockFollowRepository();
-          when(() => follows.followingPubkeys).thenReturn([
-            '01x${'a' * 61}',
-          ]);
+          when(
+            () => follows.followingPubkeys,
+          ).thenReturn(['01x${'a' * 61}', '02x${'a' * 61}']);
           return createBoostedBloc(follows);
         },
         act: (bloc) => bloc.add(const UserSearchQueryChanged('liz')),
         wait: debounceDuration,
-        expect: () => [
-          const UserSearchState(
-            status: UserSearchStatus.loading,
-            query: 'liz',
-          ),
-          isA<UserSearchState>()
-              .having((s) => s.status, 'status', UserSearchStatus.loading)
-              .having(
-                (s) => s.results.map((p) => p.displayName).toList(),
-                'results order',
-                ['Liz Sweigart', 'Zoe', 'Maya'],
-              ),
-          isA<UserSearchState>()
-              .having((s) => s.status, 'status', UserSearchStatus.success)
-              .having(
-                (s) => s.results.map((p) => p.displayName).toList(),
-                'results order',
-                ['Liz Sweigart', 'Zoe', 'Maya'],
-              ),
-        ],
+        verify: (_) {
+          verify(
+            () => mockProfileRepository.searchUsersProgressive(
+              query: 'liz',
+              limit: 50,
+              sortBy: 'followers',
+              hasVideos: any(named: 'hasVideos'),
+              boostPubkeys: {'01x${'a' * 61}', '02x${'a' * 61}'},
+            ),
+          ).called(1);
+        },
       );
 
       blocTest<UserSearchBloc, UserSearchState>(
-        'preserves server-relative order within each group',
+        'forwards an empty set when the follow list is empty',
         setUp: () {
-          final a = profile('00', 'A'); // followed
-          final b = profile('01', 'B'); // not followed
-          final c = profile('02', 'C'); // followed
-          final d = profile('03', 'D'); // not followed
           when(
             () => mockProfileRepository.searchUsersProgressive(
               query: 'test',
               limit: any(named: 'limit'),
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
+              boostPubkeys: any(named: 'boostPubkeys'),
             ),
-          ).thenAnswer((_) => Stream.value([a, b, c, d]));
-        },
-        build: () {
-          final follows = _MockFollowRepository();
-          when(() => follows.followingPubkeys).thenReturn([
-            '00x${'a' * 61}',
-            '02x${'a' * 61}',
-          ]);
-          return createBoostedBloc(follows);
-        },
-        act: (bloc) => bloc.add(const UserSearchQueryChanged('test')),
-        wait: debounceDuration,
-        expect: () => [
-          const UserSearchState(
-            status: UserSearchStatus.loading,
-            query: 'test',
-          ),
-          isA<UserSearchState>()
-              .having((s) => s.status, 'status', UserSearchStatus.loading)
-              .having(
-                (s) => s.results.map((p) => p.displayName).toList(),
-                'results order',
-                ['A', 'C', 'B', 'D'],
-              ),
-          isA<UserSearchState>()
-              .having((s) => s.status, 'status', UserSearchStatus.success)
-              .having(
-                (s) => s.results.map((p) => p.displayName).toList(),
-                'results order',
-                ['A', 'C', 'B', 'D'],
-              ),
-        ],
-      );
-
-      blocTest<UserSearchBloc, UserSearchState>(
-        'is a no-op when the follow list is empty',
-        setUp: () {
-          final zoe = profile('00', 'Zoe');
-          final maya = profile('01', 'Maya');
-          when(
-            () => mockProfileRepository.searchUsersProgressive(
-              query: 'test',
-              limit: any(named: 'limit'),
-              sortBy: any(named: 'sortBy'),
-              hasVideos: any(named: 'hasVideos'),
-            ),
-          ).thenAnswer((_) => Stream.value([zoe, maya]));
+          ).thenAnswer((_) => Stream.value([profile('00', 'Zoe')]));
         },
         build: () {
           final follows = _MockFollowRepository();
@@ -829,32 +773,66 @@ void main() {
         },
         act: (bloc) => bloc.add(const UserSearchQueryChanged('test')),
         wait: debounceDuration,
+        verify: (_) {
+          verify(
+            () => mockProfileRepository.searchUsersProgressive(
+              query: 'test',
+              limit: 50,
+              sortBy: 'followers',
+              hasVideos: any(named: 'hasVideos'),
+              boostPubkeys: <String>{},
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<UserSearchBloc, UserSearchState>(
+        'emits results in the order returned by the repository',
+        setUp: () {
+          // The repository already applied boost ordering; the BLoC must
+          // preserve that order and not reorder on its own.
+          final liz = profile('01', 'Liz Sweigart');
+          final zoe = profile('00', 'Zoe');
+          final maya = profile('02', 'Maya');
+          when(
+            () => mockProfileRepository.searchUsersProgressive(
+              query: 'liz',
+              limit: any(named: 'limit'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+              boostPubkeys: any(named: 'boostPubkeys'),
+            ),
+          ).thenAnswer((_) => Stream.value([liz, zoe, maya]));
+        },
+        build: () {
+          final follows = _MockFollowRepository();
+          when(() => follows.followingPubkeys).thenReturn(['01x${'a' * 61}']);
+          return createBoostedBloc(follows);
+        },
+        act: (bloc) => bloc.add(const UserSearchQueryChanged('liz')),
+        wait: debounceDuration,
         expect: () => [
-          const UserSearchState(
-            status: UserSearchStatus.loading,
-            query: 'test',
-          ),
+          const UserSearchState(status: UserSearchStatus.loading, query: 'liz'),
           isA<UserSearchState>()
               .having((s) => s.status, 'status', UserSearchStatus.loading)
               .having(
                 (s) => s.results.map((p) => p.displayName).toList(),
                 'results order',
-                ['Zoe', 'Maya'],
+                ['Liz Sweigart', 'Zoe', 'Maya'],
               ),
-          isA<UserSearchState>().having(
-            (s) => s.status,
-            'status',
-            UserSearchStatus.success,
-          ),
+          isA<UserSearchState>()
+              .having((s) => s.status, 'status', UserSearchStatus.success)
+              .having(
+                (s) => s.results.map((p) => p.displayName).toList(),
+                'results order',
+                ['Liz Sweigart', 'Zoe', 'Maya'],
+              ),
         ],
       );
 
       blocTest<UserSearchBloc, UserSearchState>(
-        'does not re-boost already-shown results on UserSearchLoadMore',
+        'does not forward boostPubkeys on UserSearchLoadMore',
         setUp: () {
-          // Page 2 includes a followed user — should be appended at the end,
-          // not moved to the top of the already-visible list.
-          final liz2 = profile('99', 'Liz From Page 2');
           when(
             () => mockProfileRepository.searchUsersProgressive(
               query: 'liz',
@@ -863,13 +841,11 @@ void main() {
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
             ),
-          ).thenAnswer((_) => Stream.value([liz2]));
+          ).thenAnswer((_) => Stream.value([profile('99', 'Liz From Page 2')]));
         },
         build: () {
           final follows = _MockFollowRepository();
-          when(() => follows.followingPubkeys).thenReturn([
-            '99x${'a' * 61}',
-          ]);
+          when(() => follows.followingPubkeys).thenReturn(['99x${'a' * 61}']);
           return createBoostedBloc(follows);
         },
         seed: () => UserSearchState(
@@ -880,21 +856,17 @@ void main() {
           hasMore: true,
         ),
         act: (bloc) => bloc.add(const UserSearchLoadMore()),
-        expect: () => [
-          isA<UserSearchState>().having(
-            (s) => s.isLoadingMore,
-            'isLoadingMore',
-            true,
-          ),
-          isA<UserSearchState>()
-              .having((s) => s.isLoadingMore, 'isLoadingMore', false)
-              .having((s) => s.results.length, 'results.length', 51)
-              .having(
-                (s) => s.results.last.displayName,
-                'new page appended at end',
-                'Liz From Page 2',
-              ),
-        ],
+        verify: (_) {
+          verify(
+            () => mockProfileRepository.searchUsersProgressive(
+              query: 'liz',
+              limit: 50,
+              offset: 50,
+              sortBy: 'followers',
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).called(1);
+        },
       );
     });
 

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -37,6 +37,7 @@ _MockProfileRepository _createMockProfileRepository({
       offset: any(named: 'offset'),
       sortBy: any(named: 'sortBy'),
       hasVideos: any(named: 'hasVideos'),
+      boostPubkeys: any(named: 'boostPubkeys'),
     ),
   ).thenAnswer((_) => Stream.value(searchResults));
 
@@ -439,6 +440,7 @@ void main() {
               offset: any(named: 'offset'),
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
+              boostPubkeys: any(named: 'boostPubkeys'),
             ),
           ).thenAnswer((_) => streamController.stream);
 
@@ -499,9 +501,44 @@ void main() {
             createdAt: DateTime.now(),
             eventId: 'event_liz',
           );
-          final mockProfileRepo = _createMockProfileRepository(
-            searchResults: [zoe, liz],
-          );
+          final mockProfileRepo = _MockProfileRepository();
+          // Simulate the real repository's boost behaviour: profiles whose
+          // pubkey is in [boostPubkeys] are promoted to the front while
+          // preserving server-relative order. Boost ordering itself is
+          // unit-tested in profile_repository_test.dart; here we just need
+          // a mock that reacts to [boostPubkeys] so the widget test can
+          // assert that the UI reflects it.
+          when(
+            () => mockProfileRepo.searchUsersProgressive(
+              query: any(named: 'query'),
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+              boostPubkeys: any(named: 'boostPubkeys'),
+            ),
+          ).thenAnswer((invocation) {
+            final boost =
+                invocation.namedArguments[#boostPubkeys] as Set<String>? ??
+                const <String>{};
+            final results = [zoe, liz];
+            if (boost.isEmpty) return Stream.value(results);
+            final boosted = <UserProfile>[];
+            final rest = <UserProfile>[];
+            for (final p in results) {
+              if (boost.contains(p.pubkey)) {
+                boosted.add(p);
+              } else {
+                rest.add(p);
+              }
+            }
+            return Stream.value([...boosted, ...rest]);
+          });
+          when(
+            () => mockProfileRepo.getCachedProfile(
+              pubkey: any(named: 'pubkey'),
+            ),
+          ).thenAnswer((_) async => null);
           final mockFollowRepo = _createMockFollowRepository(
             followingPubkeys: ['p_liz'],
           );
@@ -611,6 +648,7 @@ void main() {
               offset: any(named: 'offset'),
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
+              boostPubkeys: any(named: 'boostPubkeys'),
             ),
           ).thenAnswer((_) => Stream.value([alice]));
           when(
@@ -620,6 +658,7 @@ void main() {
               offset: any(named: 'offset'),
               sortBy: any(named: 'sortBy'),
               hasVideos: any(named: 'hasVideos'),
+              boostPubkeys: any(named: 'boostPubkeys'),
             ),
           ).thenAnswer((_) => bobController.stream);
 

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -456,7 +456,6 @@ void main() {
                 home: Scaffold(
                   body: UserPickerSheet(
                     filterMode: UserPickerFilterMode.allUsers,
-                    searchTimeout: null,
                   ),
                 ),
               ),
@@ -519,7 +518,6 @@ void main() {
                 home: Scaffold(
                   body: UserPickerSheet(
                     filterMode: UserPickerFilterMode.allUsers,
-                    searchTimeout: null,
                   ),
                 ),
               ),
@@ -639,7 +637,6 @@ void main() {
                 home: Scaffold(
                   body: UserPickerSheet(
                     filterMode: UserPickerFilterMode.allUsers,
-                    searchTimeout: null,
                   ),
                 ),
               ),

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for UserPickerSheet widget
 // ABOUTME: Verifies search functionality, local follow search, and user selection
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -409,6 +411,263 @@ void main() {
         final textField = tester.widget<TextField>(find.byType(TextField));
         expect(textField.decoration?.hintText, equals('Search by name...'));
       });
+
+      testWidgets(
+        'renders tiles during progressive loading '
+        'instead of the full-screen spinner',
+        (tester) async {
+          // Stream controller kept open after the first yield — this
+          // simulates the real progressive search still running (e.g.
+          // NIP-50 WebSocket phase) while the REST phase has already
+          // delivered results.
+          final streamController =
+              StreamController<List<UserProfile>>.broadcast();
+          addTearDown(streamController.close);
+
+          final alice = UserProfile(
+            pubkey: 'p_alice',
+            name: 'Alice',
+            rawData: const {'name': 'Alice'},
+            createdAt: DateTime.now(),
+            eventId: 'event_alice',
+          );
+          final mockProfileRepo = _createMockProfileRepository();
+          when(
+            () => mockProfileRepo.searchUsersProgressive(
+              query: any(named: 'query'),
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer((_) => streamController.stream);
+
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+                followRepositoryProvider.overrideWithValue(
+                  _createMockFollowRepository(),
+                ),
+              ],
+              child: const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: Scaffold(
+                  body: UserPickerSheet(
+                    filterMode: UserPickerFilterMode.allUsers,
+                    searchTimeout: null,
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.enterText(find.byType(TextField), 'alice');
+          // Past the 300ms search debounce.
+          await tester.pump(const Duration(milliseconds: 400));
+
+          // Emit the first batch — stream stays open, so the BLoC
+          // stays in `loading` with results available. The fix is that
+          // the picker now renders these results instead of a spinner.
+          streamController.add([alice]);
+          await tester.pump();
+
+          // The tile renders while the stream is still open (loading). Before
+          // the fix, the UI showed a full-screen spinner and Alice never
+          // appeared until the progressive stream completed.
+          expect(find.text('Alice'), findsOneWidget);
+          // Only the footer load-more spinner should be in the tree (1);
+          // before the fix there was a full-screen spinner instead (also 1),
+          // so we distinguish by asserting the tile is present above.
+        },
+      );
+
+      testWidgets(
+        'boosts followed users above non-followed in search results',
+        (tester) async {
+          final zoe = UserProfile(
+            pubkey: 'p_zoe',
+            name: 'Zoe',
+            rawData: const {'name': 'Zoe'},
+            createdAt: DateTime.now(),
+            eventId: 'event_zoe',
+          );
+          final liz = UserProfile(
+            pubkey: 'p_liz',
+            name: 'Liz Sweigart',
+            rawData: const {'name': 'Liz Sweigart'},
+            createdAt: DateTime.now(),
+            eventId: 'event_liz',
+          );
+          final mockProfileRepo = _createMockProfileRepository(
+            searchResults: [zoe, liz],
+          );
+          final mockFollowRepo = _createMockFollowRepository(
+            followingPubkeys: ['p_liz'],
+          );
+
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+                followRepositoryProvider.overrideWithValue(mockFollowRepo),
+              ],
+              child: const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: Scaffold(
+                  body: UserPickerSheet(
+                    filterMode: UserPickerFilterMode.allUsers,
+                    searchTimeout: null,
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.enterText(find.byType(TextField), 'liz');
+          await tester.pump(const Duration(milliseconds: 400));
+          await tester.pumpAndSettle();
+
+          final lizTile = find.text('Liz Sweigart');
+          final zoeTile = find.text('Zoe');
+          expect(lizTile, findsOneWidget);
+          expect(zoeTile, findsOneWidget);
+
+          final lizY = tester.getTopLeft(lizTile).dy;
+          final zoeY = tester.getTopLeft(zoeTile).dy;
+          expect(
+            lizY,
+            lessThan(zoeY),
+            reason: 'Followed user should render above non-followed user',
+          );
+        },
+      );
+
+      testWidgets(
+        'disables iOS autocorrect and predictive suggestions on the '
+        'search field',
+        (tester) async {
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                profileRepositoryProvider.overrideWithValue(
+                  _createMockProfileRepository(),
+                ),
+                followRepositoryProvider.overrideWithValue(
+                  _createMockFollowRepository(),
+                ),
+              ],
+              child: const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: Scaffold(
+                  body: UserPickerSheet(
+                    filterMode: UserPickerFilterMode.allUsers,
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          final textField = tester.widget<TextField>(find.byType(TextField));
+          expect(
+            textField.autocorrect,
+            isFalse,
+            reason: 'autocorrect must be off or iOS silently rewrites queries',
+          );
+          expect(
+            textField.enableSuggestions,
+            isFalse,
+            reason: 'enableSuggestions must be off for the same reason',
+          );
+        },
+      );
+
+      testWidgets(
+        'preserves previous results while a new query is loading',
+        (tester) async {
+          final alice = UserProfile(
+            pubkey: 'p_alice',
+            name: 'Alice',
+            rawData: const {'name': 'Alice'},
+            createdAt: DateTime.now(),
+            eventId: 'event_alice',
+          );
+          final bob = UserProfile(
+            pubkey: 'p_bob',
+            name: 'Bob',
+            rawData: const {'name': 'Bob'},
+            createdAt: DateTime.now(),
+            eventId: 'event_bob',
+          );
+          final bobController = StreamController<List<UserProfile>>.broadcast();
+          addTearDown(bobController.close);
+
+          final mockProfileRepo = _createMockProfileRepository();
+          when(
+            () => mockProfileRepo.searchUsersProgressive(
+              query: 'alice',
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer((_) => Stream.value([alice]));
+          when(
+            () => mockProfileRepo.searchUsersProgressive(
+              query: 'bob',
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer((_) => bobController.stream);
+
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+                followRepositoryProvider.overrideWithValue(
+                  _createMockFollowRepository(),
+                ),
+              ],
+              child: const MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: Scaffold(
+                  body: UserPickerSheet(
+                    filterMode: UserPickerFilterMode.allUsers,
+                    searchTimeout: null,
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          // First query — 'alice' succeeds.
+          await tester.enterText(find.byType(TextField), 'alice');
+          await tester.pump(const Duration(milliseconds: 400));
+          await tester.pumpAndSettle();
+          expect(find.text('Alice'), findsOneWidget);
+
+          // Second query — 'bob' starts loading (stream stays open).
+          await tester.enterText(find.byType(TextField), 'bob');
+          await tester.pump(const Duration(milliseconds: 400));
+
+          // Alice is still visible — we did NOT blank the list.
+          expect(find.text('Alice'), findsOneWidget);
+
+          // When 'bob' results arrive, the list updates in place.
+          bobController.add([bob]);
+          // Pump twice: once to let the stream event propagate through the
+          // bloc's emit.forEach, once more for the rebuilt BlocBuilder.
+          await tester.pump();
+          await tester.pump();
+          expect(find.text('Bob'), findsOneWidget);
+        },
+      );
     });
 
     group('autoFocus', () {


### PR DESCRIPTION
Closes #3221

## Summary

The Inspired By user picker had two compounding bugs revealed by the reporter's video:

1. **iOS predictive text silently rewrote the query** (e.g. `"liz"` → `"Liz"`), re-firing `onChanged` and wiping the results list for ~5s while the progressive search restarted. This is what the reporter described as scrolling "refreshing" the search — the trigger was autocorrect, not scroll.
2. **Followed users were not surfaced above globally-popular profiles** with the same substring match. `UserSearchBloc` requests `sortBy: 'followers'` and the repository preserves that server order verbatim, so a popular alter-ego outranks a friend the user follows.

## Root cause trace

Ordering flow from server to screen (all confirmed by reading source):

| Layer | File:Line | Role |
|---|---|---|
| Funnelcake | `funnelcake_api_client.dart:459-461` | Sorts globally by follower count on `sort_by=followers` |
| ProfileRepository | `profile_repository.dart:904-905` | `useServerSort` path preserves server order verbatim; custom `_profileSearchFilter` hook is unreachable here |
| UserSearchBloc | `user_search_bloc.dart:80-84` | Previously emitted server order + cleared results on every new query |
| UserPickerSheet | `user_picker_sheet.dart` | Renders `state.results` as-is |

The TextField lacked `autocorrect: false` / `enableSuggestions: false`, so iOS silently committed predictive suggestions, which fires `onChanged` with a rewritten string → BLoC treats it as a fresh query → clears results → 5s blank while the 3-phase progressive search reruns.

## Changes

- **`TextField`** (`user_picker_sheet.dart`): `autocorrect: false` + `enableSuggestions: false`. Search fields should never autocorrect — industry standard (GitHub, Slack, iOS Spotlight).
- **`UserSearchBloc._onQueryChanged`**: keep the previous query's results visible while a new query loads (stale-results pattern). `offset`/`hasMore` still reset so pagination elsewhere isn't corrupted.
- **`UserSearchBloc`**: optional `FollowRepository` injection + `_boostFollowed` helper. When provided, followed users move to the top of each progressive yield (local → REST → NIP-50) preserving server-relative order within each group. Not applied to `_onLoadMore` — appending pages must not reshuffle already-visible positions.
- **`UserPickerSheet._NetworkResults`**: port the PR #2566 `loading when state.results.isNotEmpty => list` pattern already live in `user_search_view.dart` and `find_people_sheet.dart`, so progressive yields render tiles in place instead of flashing a spinner.

## Scope discipline

Other `UserSearchBloc` consumers (`search_results_page.dart` unified search, `find_people_sheet.dart` DM share) are **unchanged** — they keep today's server ranking. Whether to extend the boost to them is a product decision for a follow-up; their surfaces have different intents (discovery, pre-loaded contacts).

## Steps to reproduce (before this PR)

1. Record a video, tap Next to the metadata screen.
2. Tap the "Inspired By" row.
3. Type a lowercase substring that matches a followed user (e.g. `liz`).
4. Observe that a high-global-followers account with the same substring ranks first.
5. Wait ~1s without typing. iOS predictive text silently capitalizes to `Liz`.
6. The results list blanks. A full-screen spinner covers the sheet for ~5s while the progressive search re-runs.
7. Results return — same ranking, same user(s) missing.

## Expected behavior (after this PR)

1. Typed `liz` stays as `liz`. iOS does not rewrite.
2. Users you follow appear above unfollowed users with the same substring match.
3. Re-queries (pagination, debounce restarts) do not blank the list — previous results remain visible until new ones arrive.
4. Progressive yields update the list in place without a spinner flash.

## Test plan

- [x] `flutter analyze lib test integration_test` → no issues
- [x] `flutter test test/blocs/user_search/` → 37 tests, all pass (4 new + 2 updated for stale-results behavior)
- [x] `flutter test test/widgets/user_picker_sheet_test.dart` → 18 tests, all pass (3 new)
- [x] `flutter test test/widgets/find_people_sheet_test.dart test/widgets/user_search_view_test.dart test/screens/search_results/` → all pass (unchanged consumers, regression guard)
- [ ] Manual device test: run `flutter run`, reproduce the flow above, verify all 4 expected behaviors
- [ ] Manual device test: unified search (`/search-results/`) and DM share sheet — confirm ranking unchanged

## Known limitation

If the followed user's Nostr profile `display_name` / `name` / `about` does not contain the query substring, no client-side fix surfaces them — Funnelcake's search indexes those fields and the local-cache fallback matches on the same ones. For example, if "Liz Sweigart" appears in Nostr as `Elizabeth Sweigart`, typing `liz` still won't match her. A server-side `boost_pubkeys=` parameter on Funnelcake would be the definitive fix and would also let every consumer benefit without per-surface plumbing — worth a follow-up with the backend team.

## Follow-ups worth opening

1. Server-side `boost_pubkeys` param on Funnelcake `search/profiles` so the boost moves off-device.
2. Pagination for the picker (`ScrollPaginationMixin` + `UserSearchLoadMore`) — not reproducing this bug, intentionally out of scope here.
3. Product decision: should unified search (`search_results_page`) and DM share (`find_people_sheet`) adopt the same client-side boost?