### PR TITLE
feat(bug-report): add image attachment support (#3094)

### DIFF
--- a/docs/superpowers/plans/2026-04-23-bug-report-image-attachments.md
+++ b/docs/superpowers/plans/2026-04-23-bug-report-image-attachments.md
@@ -1,0 +1,1371 @@
+# Bug Report Image Attachments Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add image attachment support (up to 3 gallery images) to the mobile in-app bug report dialog, uploading them as Zendesk ticket attachments via the native SDK.
+
+**Architecture:** New `ImageAttachmentPicker` widget handles selection/preview/removal. `BugReportDialog` hosts it and passes file paths through `ZendeskSupportService.createStructuredBugReport()` → `createTicket()` → native platform channel. Native iOS (Swift) and Android (Kotlin) handlers upload files via `ZDKUploadProvider`/`UploadProvider` before attaching tokens to the `CreateRequest`. Desktop hides the picker entirely.
+
+**Tech Stack:** Flutter (Dart), `image_picker` ^1.2.0 (already in pubspec), ZendeskSupportSDK ~9.0 (iOS), com.zendesk:support:5.1.2 (Android), platform channels via `MethodChannel('com.openvine/zendesk_support')`.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-bug-report-image-attachments-design.md`
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `mobile/lib/widgets/image_attachment_picker.dart` | Stateful widget: gallery picker, thumbnail previews, remove buttons, platform guard |
+| Create | `mobile/test/widgets/image_attachment_picker_test.dart` | Widget tests for picker behavior |
+| Modify | `mobile/lib/l10n/app_en.arb` | Add 4 ARB keys for picker strings |
+| Modify | `mobile/lib/widgets/bug_report_dialog.dart` | Host picker, pass attachment paths to service |
+| Modify | `mobile/test/widgets/bug_report_dialog_test.dart` | Test attachment passthrough and zero-attachment regression |
+| Modify | `mobile/lib/services/zendesk_support_service.dart` | Add `attachmentPaths` param to `createStructuredBugReport()` and `createTicket()` |
+| Modify | `mobile/test/services/zendesk_support_service_test.dart` | Test platform channel includes/omits `attachmentPaths` |
+| Modify | `mobile/ios/Runner/AppDelegate.swift` | Upload files via `ZDKUploadProvider`, attach tokens to `ZDKCreateRequest` |
+| Modify | `mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt` | Upload files via `UploadProvider`, attach tokens to `CreateRequest` |
+
+---
+
+## Task 1: Add Localization Keys
+
+**Files:**
+- Modify: `mobile/lib/l10n/app_en.arb` (append before closing `}`)
+
+- [ ] **Step 1: Add ARB keys**
+
+Open `mobile/lib/l10n/app_en.arb`. Before the final closing `}`, add a comma after the last entry and append:
+
+```json
+  "bugReportAttachImages": "Attach images",
+  "@bugReportAttachImages": {
+    "description": "Tooltip and semantics label for the add-images button in bug report dialog"
+  },
+  "bugReportRemoveImage": "Remove image",
+  "@bugReportRemoveImage": {
+    "description": "Semantics label for the remove button on an attached image thumbnail"
+  },
+  "bugReportImagesCount": "{count} of {max} images",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "max": { "type": "int" }
+    },
+    "description": "Screen reader announcement after adding or removing an image attachment"
+  },
+  "bugReportUploadFailed": "Image upload failed. Please try again.",
+  "@bugReportUploadFailed": {
+    "description": "Error message when image attachment upload fails during bug report submission"
+  }
+```
+
+- [ ] **Step 2: Generate l10n code**
+
+Run from `mobile/`:
+
+```bash
+flutter gen-l10n
+```
+
+Expected: no errors, files regenerated under `mobile/lib/l10n/generated/`.
+
+- [ ] **Step 3: Verify the keys are accessible**
+
+Run from `mobile/`:
+
+```bash
+grep 'bugReportAttachImages\|bugReportRemoveImage\|bugReportImagesCount\|bugReportUploadFailed' lib/l10n/generated/app_localizations_en.dart
+```
+
+Expected: 4 getter methods visible.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/l10n/app_en.arb lib/l10n/generated/
+git commit -m "feat(l10n): add ARB keys for bug report image attachments"
+```
+
+---
+
+## Task 2: Create ImageAttachmentPicker Widget
+
+**Files:**
+- Create: `mobile/lib/widgets/image_attachment_picker.dart`
+
+- [ ] **Step 1: Create the widget file**
+
+Create `mobile/lib/widgets/image_attachment_picker.dart`:
+
+```dart
+import 'dart:io';
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+class ImageAttachmentPicker extends StatefulWidget {
+  const ImageAttachmentPicker({
+    required this.onChanged,
+    super.key,
+    this.maxImages = 3,
+    this.enabled = true,
+  });
+
+  final int maxImages;
+  final ValueChanged<List<XFile>> onChanged;
+  final bool enabled;
+
+  @override
+  State<ImageAttachmentPicker> createState() => _ImageAttachmentPickerState();
+}
+
+class _ImageAttachmentPickerState extends State<ImageAttachmentPicker> {
+  final List<XFile> _images = [];
+
+  @visibleForTesting
+  static ImagePicker imagePicker = ImagePicker();
+
+  bool get _isMobile =>
+      defaultTargetPlatform == TargetPlatform.iOS ||
+      defaultTargetPlatform == TargetPlatform.android;
+
+  Future<void> _pickImages() async {
+    if (!widget.enabled) return;
+
+    final remaining = widget.maxImages - _images.length;
+    if (remaining <= 0) return;
+
+    final picked = await imagePicker.pickMultiImage(
+      maxWidth: 1920,
+      imageQuality: 80,
+    );
+
+    if (picked.isEmpty) return;
+
+    setState(() {
+      final toAdd = picked.take(remaining).toList();
+      _images.addAll(toAdd);
+    });
+    widget.onChanged(List.unmodifiable(_images));
+
+    if (mounted) {
+      SemanticsService.announce(
+        context.l10n.bugReportImagesCount(_images.length, widget.maxImages),
+        TextDirection.ltr,
+      );
+    }
+  }
+
+  void _removeImage(int index) {
+    if (!widget.enabled) return;
+
+    setState(() {
+      _images.removeAt(index);
+    });
+    widget.onChanged(List.unmodifiable(_images));
+
+    if (mounted) {
+      SemanticsService.announce(
+        context.l10n.bugReportImagesCount(_images.length, widget.maxImages),
+        TextDirection.ltr,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isMobile) return const SizedBox.shrink();
+
+    final l10n = context.l10n;
+    final showAddButton = _images.length < widget.maxImages;
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        for (var i = 0; i < _images.length; i++)
+          _Thumbnail(
+            file: _images[i],
+            enabled: widget.enabled,
+            semanticsLabel: l10n.bugReportRemoveImage,
+            onRemove: () => _removeImage(i),
+          ),
+        if (showAddButton)
+          _AddButton(
+            enabled: widget.enabled,
+            semanticsLabel: l10n.bugReportAttachImages,
+            onTap: _pickImages,
+          ),
+      ],
+    );
+  }
+}
+
+class _Thumbnail extends StatelessWidget {
+  const _Thumbnail({
+    required this.file,
+    required this.enabled,
+    required this.semanticsLabel,
+    required this.onRemove,
+  });
+
+  final XFile file;
+  final bool enabled;
+  final String semanticsLabel;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 64,
+      height: 64,
+      child: Stack(
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: Image.file(
+              File(file.path),
+              width: 64,
+              height: 64,
+              fit: BoxFit.cover,
+              semanticLabel: file.name,
+            ),
+          ),
+          if (enabled)
+            Positioned(
+              top: 0,
+              right: 0,
+              child: Semantics(
+                button: true,
+                label: semanticsLabel,
+                child: GestureDetector(
+                  onTap: onRemove,
+                  child: ExcludeSemantics(
+                    child: Container(
+                      width: 20,
+                      height: 20,
+                      decoration: const BoxDecoration(
+                        color: VineTheme.cardBackground,
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        Icons.close,
+                        size: 14,
+                        color: VineTheme.whiteText,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AddButton extends StatelessWidget {
+  const _AddButton({
+    required this.enabled,
+    required this.semanticsLabel,
+    required this.onTap,
+  });
+
+  final bool enabled;
+  final String semanticsLabel;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: semanticsLabel,
+      child: GestureDetector(
+        onTap: enabled ? onTap : null,
+        child: ExcludeSemantics(
+          child: Container(
+            width: 64,
+            height: 64,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: Colors.grey),
+            ),
+            child: Icon(
+              Icons.add_photo_alternate_outlined,
+              color: enabled ? VineTheme.vineGreen : Colors.grey,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run from `mobile/`:
+
+```bash
+flutter analyze lib/widgets/image_attachment_picker.dart
+```
+
+Expected: no issues.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/widgets/image_attachment_picker.dart
+git commit -m "feat: add ImageAttachmentPicker widget for bug report attachments"
+```
+
+---
+
+## Task 3: Test ImageAttachmentPicker Widget
+
+**Files:**
+- Create: `mobile/test/widgets/image_attachment_picker_test.dart`
+
+- [ ] **Step 1: Write the test file**
+
+Create `mobile/test/widgets/image_attachment_picker_test.dart`:
+
+```dart
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/image_attachment_picker.dart';
+
+class _MockImagePicker extends Mock implements ImagePicker {}
+
+void main() {
+  late _MockImagePicker mockPicker;
+  late AppLocalizations l10n;
+
+  setUp(() {
+    mockPicker = _MockImagePicker();
+    ImageAttachmentPicker.imagePicker = mockPicker;
+    l10n = lookupAppLocalizations(const Locale('en'));
+  });
+
+  tearDown(() {
+    ImageAttachmentPicker.imagePicker = ImagePicker();
+  });
+
+  Widget buildTestWidget({
+    int maxImages = 3,
+    bool enabled = true,
+    ValueChanged<List<XFile>>? onChanged,
+  }) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: ImageAttachmentPicker(
+          maxImages: maxImages,
+          enabled: enabled,
+          onChanged: onChanged ?? (_) {},
+        ),
+      ),
+    );
+  }
+
+  group('ImageAttachmentPicker', () {
+    testWidgets('renders add button on mobile', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.byIcon(Icons.add_photo_alternate_outlined), findsOneWidget);
+    });
+
+    testWidgets('renders SizedBox.shrink on non-mobile', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.byIcon(Icons.add_photo_alternate_outlined), findsNothing);
+      expect(find.byType(SizedBox), findsOneWidget);
+    });
+
+    testWidgets('calls onChanged when images are picked', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final pickedFiles = [XFile('/tmp/img1.jpg')];
+      when(
+        () => mockPicker.pickMultiImage(
+          maxWidth: any(named: 'maxWidth'),
+          imageQuality: any(named: 'imageQuality'),
+        ),
+      ).thenAnswer((_) async => pickedFiles);
+
+      List<XFile>? result;
+      await tester.pumpWidget(
+        buildTestWidget(onChanged: (files) => result = files),
+      );
+
+      await tester.tap(find.byIcon(Icons.add_photo_alternate_outlined));
+      await tester.pumpAndSettle();
+
+      expect(result, isNotNull);
+      expect(result!.length, 1);
+      expect(result!.first.path, '/tmp/img1.jpg');
+    });
+
+    testWidgets('truncates selection to remaining slots', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final fourFiles = [
+        XFile('/tmp/a.jpg'),
+        XFile('/tmp/b.jpg'),
+        XFile('/tmp/c.jpg'),
+        XFile('/tmp/d.jpg'),
+      ];
+      when(
+        () => mockPicker.pickMultiImage(
+          maxWidth: any(named: 'maxWidth'),
+          imageQuality: any(named: 'imageQuality'),
+        ),
+      ).thenAnswer((_) async => fourFiles);
+
+      List<XFile>? result;
+      await tester.pumpWidget(
+        buildTestWidget(
+          maxImages: 3,
+          onChanged: (files) => result = files,
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.add_photo_alternate_outlined));
+      await tester.pumpAndSettle();
+
+      expect(result!.length, 3);
+    });
+
+    testWidgets('hides add button at max count', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final threeFiles = [
+        XFile('/tmp/a.jpg'),
+        XFile('/tmp/b.jpg'),
+        XFile('/tmp/c.jpg'),
+      ];
+      when(
+        () => mockPicker.pickMultiImage(
+          maxWidth: any(named: 'maxWidth'),
+          imageQuality: any(named: 'imageQuality'),
+        ),
+      ).thenAnswer((_) async => threeFiles);
+
+      await tester.pumpWidget(buildTestWidget(maxImages: 3));
+
+      // Pick 3 images
+      await tester.tap(find.byIcon(Icons.add_photo_alternate_outlined));
+      await tester.pumpAndSettle();
+
+      // Add button should be gone
+      expect(find.byIcon(Icons.add_photo_alternate_outlined), findsNothing);
+    });
+
+    testWidgets('remove button removes correct image', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final twoFiles = [XFile('/tmp/a.jpg'), XFile('/tmp/b.jpg')];
+      when(
+        () => mockPicker.pickMultiImage(
+          maxWidth: any(named: 'maxWidth'),
+          imageQuality: any(named: 'imageQuality'),
+        ),
+      ).thenAnswer((_) async => twoFiles);
+
+      List<XFile>? lastResult;
+      await tester.pumpWidget(
+        buildTestWidget(onChanged: (files) => lastResult = files),
+      );
+
+      // Pick 2 images
+      await tester.tap(find.byIcon(Icons.add_photo_alternate_outlined));
+      await tester.pumpAndSettle();
+
+      expect(lastResult!.length, 2);
+
+      // Remove the first image (first close icon)
+      await tester.tap(find.byIcon(Icons.close).first);
+      await tester.pumpAndSettle();
+
+      expect(lastResult!.length, 1);
+      expect(lastResult!.first.path, '/tmp/b.jpg');
+    });
+
+    testWidgets('has correct semantics labels', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      await tester.pumpWidget(buildTestWidget());
+
+      final addButtonSemantics = tester.getSemantics(
+        find.byIcon(Icons.add_photo_alternate_outlined),
+      );
+      expect(addButtonSemantics.label, l10n.bugReportAttachImages);
+    });
+
+    testWidgets('disabled state prevents interaction', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      await tester.pumpWidget(buildTestWidget(enabled: false));
+
+      expect(
+        find.byIcon(Icons.add_photo_alternate_outlined),
+        findsOneWidget,
+      );
+      // Icon should be grey when disabled
+      final icon = tester.widget<Icon>(
+        find.byIcon(Icons.add_photo_alternate_outlined),
+      );
+      expect(icon.color, Colors.grey);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run from `mobile/`:
+
+```bash
+flutter test test/widgets/image_attachment_picker_test.dart
+```
+
+Expected: all tests pass. If `Image.file` causes issues in test (no real file), you may need to mock the file or adjust — the `Image.file` widget renders a placeholder in test without crashing. If tests fail due to missing file, wrap `Image.file` with an `errorBuilder` in the widget.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/widgets/image_attachment_picker_test.dart
+git commit -m "test: add ImageAttachmentPicker widget tests"
+```
+
+---
+
+## Task 4: Wire Picker Into BugReportDialog
+
+**Files:**
+- Modify: `mobile/lib/widgets/bug_report_dialog.dart`
+
+- [ ] **Step 1: Add imports**
+
+At the top of `mobile/lib/widgets/bug_report_dialog.dart`, add after the existing imports:
+
+```dart
+import 'package:image_picker/image_picker.dart';
+import 'package:openvine/widgets/image_attachment_picker.dart';
+```
+
+- [ ] **Step 2: Add state field**
+
+In `_BugReportDialogState`, after line 91 (`bool _isDisposed = false;`), add:
+
+```dart
+  List<XFile> _attachments = [];
+```
+
+- [ ] **Step 3: Add picker widget to the form**
+
+In the `build` method, between the "Expected Behavior" `TextField` (ending around line 257) and the `SizedBox(height: 8)` before the info text (line 259), insert:
+
+```dart
+              const SizedBox(height: 16),
+
+              // Image attachments (mobile only)
+              ImageAttachmentPicker(
+                enabled: !_isSubmitting,
+                onChanged: (files) => setState(() => _attachments = files),
+              ),
+```
+
+- [ ] **Step 4: Pass attachment paths to createStructuredBugReport**
+
+In `_submitReport()`, modify the call to `ZendeskSupportService.createStructuredBugReport()` (around line 129) to include the new parameter:
+
+```dart
+      final success = await ZendeskSupportService.createStructuredBugReport(
+        subject: subject,
+        description: description,
+        stepsToReproduce: _stepsController.text.trim(),
+        expectedBehavior: _expectedController.text.trim(),
+        reportId: reportData.reportId,
+        appVersion: reportData.appVersion,
+        deviceInfo: reportData.deviceInfo,
+        currentScreen: widget.currentScreen,
+        userPubkey: widget.userPubkey,
+        errorCounts: reportData.errorCounts,
+        logsSummary: _buildLogsSummary(reportData.recentLogs),
+        attachmentPaths: _attachments.map((f) => f.path).toList(),
+      );
+```
+
+Note: This will show an analysis error until Task 5 adds the parameter to the service. That's expected.
+
+- [ ] **Step 5: Verify the dialog compiles (will fail until Task 5)**
+
+Run from `mobile/`:
+
+```bash
+flutter analyze lib/widgets/bug_report_dialog.dart
+```
+
+Expected: error about `attachmentPaths` not being a valid parameter. This is resolved in Task 5.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/widgets/bug_report_dialog.dart
+git commit -m "feat: wire ImageAttachmentPicker into BugReportDialog"
+```
+
+---
+
+## Task 5: Add attachmentPaths to ZendeskSupportService
+
+**Files:**
+- Modify: `mobile/lib/services/zendesk_support_service.dart`
+
+- [ ] **Step 1: Add attachmentPaths to createStructuredBugReport**
+
+In `mobile/lib/services/zendesk_support_service.dart`, find the `createStructuredBugReport` method signature (line 837). Add `List<String>? attachmentPaths` as the last named parameter:
+
+```dart
+  static Future<bool> createStructuredBugReport({
+    required String subject,
+    required String description,
+    required String reportId,
+    required String appVersion,
+    required Map<String, dynamic> deviceInfo,
+    String? stepsToReproduce,
+    String? expectedBehavior,
+    String? currentScreen,
+    String? userPubkey,
+    Map<String, int>? errorCounts,
+    String? logsSummary,
+    List<String>? attachmentPaths,
+  }) async {
+```
+
+- [ ] **Step 2: Pass attachmentPaths through to createTicket**
+
+Find the `createTicket` call inside `createStructuredBugReport` (around line 949). Add the new parameter:
+
+```dart
+      return createTicket(
+        subject: effectiveSubject,
+        description: buffer.toString(),
+        tags: tags,
+        ticketFormId: 14772963437071,
+        customFields: customFields,
+        attachmentPaths: attachmentPaths,
+      );
+```
+
+- [ ] **Step 3: Add attachmentPaths to createTicket signature**
+
+Find the `createTicket` method signature (line 562). Add `List<String>? attachmentPaths` as the last named parameter:
+
+```dart
+  static Future<bool> createTicket({
+    required String subject,
+    required String description,
+    List<String>? tags,
+    int? ticketFormId,
+    List<Map<String, dynamic>>? customFields,
+    List<String>? attachmentPaths,
+  }) async {
+```
+
+- [ ] **Step 4: Include attachmentPaths in the platform channel call**
+
+In `createTicket`, find the first `_channel.invokeMethod('createTicket', {` block (around line 583). Add `attachmentPaths` to the args map:
+
+```dart
+      final result = await _channel.invokeMethod('createTicket', {
+        'subject': subject,
+        'description': description,
+        'tags': tags ?? [],
+        'ticketFormId': ?ticketFormId,
+        if (customFields != null && customFields.isNotEmpty)
+          'customFields': customFields,
+        if (attachmentPaths != null && attachmentPaths.isNotEmpty)
+          'attachmentPaths': attachmentPaths,
+      });
+```
+
+- [ ] **Step 5: Also add to the JWT retry path**
+
+Find the second `_channel.invokeMethod('createTicket', {` block inside the PlatformException handler (around line 647). Add the same parameter:
+
+```dart
+            final retryResult = await _channel.invokeMethod('createTicket', {
+              'subject': subject,
+              'description': description,
+              'tags': tags ?? [],
+              'ticketFormId': ?ticketFormId,
+              if (customFields != null && customFields.isNotEmpty)
+                'customFields': customFields,
+              if (attachmentPaths != null && attachmentPaths.isNotEmpty)
+                'attachmentPaths': attachmentPaths,
+            });
+```
+
+- [ ] **Step 6: Verify compilation**
+
+Run from `mobile/`:
+
+```bash
+flutter analyze lib/services/zendesk_support_service.dart lib/widgets/bug_report_dialog.dart
+```
+
+Expected: no issues.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/services/zendesk_support_service.dart
+git commit -m "feat: add attachmentPaths parameter to createTicket and createStructuredBugReport"
+```
+
+---
+
+## Task 6: Test ZendeskSupportService attachmentPaths
+
+**Files:**
+- Modify: `mobile/test/services/zendesk_support_service_test.dart`
+
+- [ ] **Step 1: Add test for attachmentPaths included in platform channel call**
+
+Add to the existing `createTicket` test group in `mobile/test/services/zendesk_support_service_test.dart`:
+
+```dart
+  group('ZendeskSupportService.createTicket attachmentPaths', () {
+    setUp(() async {
+      // Initialize Zendesk for tests
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+            if (call.method == 'initialize') return true;
+            return null;
+          });
+      await ZendeskSupportService.initialize(
+        appId: 'test',
+        clientId: 'test',
+        zendeskUrl: 'https://test.zendesk.com',
+      );
+    });
+
+    test('includes attachmentPaths when provided', () async {
+      Map<String, dynamic>? capturedArgs;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+            if (call.method == 'createTicket') {
+              capturedArgs = Map<String, dynamic>.from(
+                call.arguments as Map,
+              );
+              return true;
+            }
+            return null;
+          });
+
+      await ZendeskSupportService.createTicket(
+        subject: 'Test',
+        description: 'Test desc',
+        attachmentPaths: ['/tmp/img1.jpg', '/tmp/img2.jpg'],
+      );
+
+      expect(capturedArgs, isNotNull);
+      expect(capturedArgs!['attachmentPaths'], ['/tmp/img1.jpg', '/tmp/img2.jpg']);
+    });
+
+    test('omits attachmentPaths when null', () async {
+      Map<String, dynamic>? capturedArgs;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+            if (call.method == 'createTicket') {
+              capturedArgs = Map<String, dynamic>.from(
+                call.arguments as Map,
+              );
+              return true;
+            }
+            return null;
+          });
+
+      await ZendeskSupportService.createTicket(
+        subject: 'Test',
+        description: 'Test desc',
+      );
+
+      expect(capturedArgs, isNotNull);
+      expect(capturedArgs!.containsKey('attachmentPaths'), false);
+    });
+
+    test('omits attachmentPaths when empty list', () async {
+      Map<String, dynamic>? capturedArgs;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+            if (call.method == 'createTicket') {
+              capturedArgs = Map<String, dynamic>.from(
+                call.arguments as Map,
+              );
+              return true;
+            }
+            return null;
+          });
+
+      await ZendeskSupportService.createTicket(
+        subject: 'Test',
+        description: 'Test desc',
+        attachmentPaths: [],
+      );
+
+      expect(capturedArgs, isNotNull);
+      expect(capturedArgs!.containsKey('attachmentPaths'), false);
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run from `mobile/`:
+
+```bash
+flutter test test/services/zendesk_support_service_test.dart
+```
+
+Expected: all tests pass, including the new ones.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/services/zendesk_support_service_test.dart
+git commit -m "test: verify attachmentPaths in platform channel invocations"
+```
+
+---
+
+## Task 7: Test BugReportDialog Attachment Passthrough
+
+**Files:**
+- Modify: `mobile/test/widgets/bug_report_dialog_test.dart`
+
+- [ ] **Step 1: Add test for zero-attachment regression**
+
+Add to the existing test group in `mobile/test/widgets/bug_report_dialog_test.dart`. The existing tests already verify submission works — add a test that explicitly confirms no `attachmentPaths` parameter causes issues:
+
+```dart
+    testWidgets('submits successfully with zero attachments', (tester) async {
+      // This is a regression test — the new attachmentPaths parameter
+      // must not break submission when no images are attached.
+      when(() => mockBugReportService.collectDiagnostics(
+            userDescription: any(named: 'userDescription'),
+            currentScreen: any(named: 'currentScreen'),
+            userPubkey: any(named: 'userPubkey'),
+          )).thenAnswer((_) async => _FakeBugReportData());
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => InheritedGoRouter(
+                goRouter: GoRouter(routes: [
+                  GoRoute(path: '/', builder: (_, __) => const SizedBox()),
+                ]),
+                child: BugReportDialog(
+                  bugReportService: mockBugReportService,
+                  testMode: true,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Fill required fields
+      await tester.enterText(find.byType(TextField).at(0), 'Test subject');
+      await tester.enterText(find.byType(TextField).at(1), 'Test description');
+      await tester.pumpAndSettle();
+
+      // Verify Send button is enabled (canSubmit = true)
+      final sendButton = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, 'Send Report'),
+      );
+      expect(sendButton.onPressed, isNotNull);
+    });
+```
+
+Note: The exact test setup may need adjustment based on how `_FakeBugReportData` is configured in the existing test file. Check the existing `_FakeBugReportData` class and ensure it provides the required fields. If `collectDiagnostics` requires specific return values, match the existing test patterns.
+
+- [ ] **Step 2: Run the tests**
+
+Run from `mobile/`:
+
+```bash
+flutter test test/widgets/bug_report_dialog_test.dart
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/widgets/bug_report_dialog_test.dart
+git commit -m "test: add zero-attachment regression test for BugReportDialog"
+```
+
+---
+
+## Task 8: iOS Native — Upload Attachments via ZDKUploadProvider
+
+**Files:**
+- Modify: `mobile/ios/Runner/AppDelegate.swift`
+
+- [ ] **Step 1: Add upload logic to the createTicket handler**
+
+In `mobile/ios/Runner/AppDelegate.swift`, find the `createTicket` case (line 293). After extracting `customFieldsData` (line 309) and before building the `ZDKCreateRequest` (line 312), add attachment path extraction:
+
+```swift
+        let attachmentPaths = args["attachmentPaths"] as? [String] ?? []
+```
+
+- [ ] **Step 2: Add upload helper method**
+
+After the `setupZendeskChannel` method's closing brace (but still inside the `AppDelegate` class), add a helper to upload files sequentially and collect tokens:
+
+```swift
+  private func uploadAttachments(
+    _ paths: [String],
+    completion: @escaping (Result<[ZDKUploadResponse], FlutterError>) -> Void
+  ) {
+    var responses: [ZDKUploadResponse] = []
+    let uploadProvider = ZDKUploadProvider()
+
+    func uploadNext(index: Int) {
+      guard index < paths.count else {
+        completion(.success(responses))
+        return
+      }
+
+      let path = paths[index]
+      guard let data = FileManager.default.contents(atPath: path) else {
+        completion(.failure(FlutterError(
+          code: "UPLOAD_FAILED",
+          message: "Could not read file at \(path)",
+          details: nil
+        )))
+        return
+      }
+
+      let filename = (path as NSString).lastPathComponent
+      let contentType = filename.hasSuffix(".png") ? "image/png" : "image/jpeg"
+
+      uploadProvider.uploadAttachment(data, withFilename: filename, andContentType: contentType) {
+        uploadResponse, error in
+        if let error = error {
+          NSLog("❌ Zendesk: Upload failed for \(filename) - \(error.localizedDescription)")
+          completion(.failure(FlutterError(
+            code: "UPLOAD_FAILED",
+            message: "Failed to upload \(filename): \(error.localizedDescription)",
+            details: nil
+          )))
+          return
+        }
+
+        guard let response = uploadResponse else {
+          completion(.failure(FlutterError(
+            code: "UPLOAD_FAILED",
+            message: "No upload response for \(filename)",
+            details: nil
+          )))
+          return
+        }
+
+        NSLog("✅ Zendesk: Uploaded \(filename) - token: \(response.uploadToken ?? "nil")")
+        responses.append(response)
+        uploadNext(index: index + 1)
+      }
+    }
+
+    uploadNext(index: 0)
+  }
+```
+
+- [ ] **Step 3: Modify createTicket to upload before submitting**
+
+Replace the section from `ZDKCreateRequest()` creation through `ZDKRequestProvider().createRequest()` (lines 312-359). The new logic uploads attachments first if present, then creates the request:
+
+```swift
+        // Build create request object using ZDK API
+        let createRequest = ZDKCreateRequest()
+        createRequest.subject = subject
+        createRequest.requestDescription = description
+        createRequest.tags = tags
+
+        // Set ticket form ID if provided
+        if let formId = ticketFormId {
+          createRequest.ticketFormId = formId
+          NSLog("🎫 Zendesk: Using ticket form ID: \(formId)")
+        }
+
+        // Set custom fields if provided
+        if !customFieldsData.isEmpty {
+          var customFields: [CustomField] = []
+          for fieldData in customFieldsData {
+            if let fieldId = fieldData["id"] as? NSNumber,
+               let fieldValue = fieldData["value"] {
+              let customField = CustomField(dictionary: ["id": fieldId, "value": fieldValue])
+              customFields.append(customField)
+              NSLog("🎫 Zendesk: Custom field \(fieldId) = \(fieldValue)")
+            }
+          }
+          createRequest.customFields = customFields
+        }
+
+        NSLog("🎫 Zendesk: Submitting ticket - subject: '\(subject)', tags: \(tags), attachments: \(attachmentPaths.count)")
+
+        // Upload attachments first, then create ticket
+        if attachmentPaths.isEmpty {
+          // No attachments — submit directly (existing path)
+          ZDKRequestProvider().createRequest(createRequest) { (request, error) in
+            DispatchQueue.main.async {
+              if let error = error {
+                NSLog("❌ Zendesk: Failed to create ticket - \(error.localizedDescription)")
+                result(FlutterError(code: "CREATE_FAILED",
+                                  message: error.localizedDescription,
+                                  details: nil))
+              } else if let request = request as? ZDKRequest {
+                NSLog("✅ Zendesk: Ticket created successfully - ID: \(request.requestId)")
+                result(true)
+              } else {
+                NSLog("✅ Zendesk: Ticket created (no error, response type: \(type(of: request)))")
+                result(true)
+              }
+            }
+          }
+        } else {
+          // Upload attachments, then attach tokens to request
+          self.uploadAttachments(attachmentPaths) { uploadResult in
+            switch uploadResult {
+            case .success(let uploadResponses):
+              createRequest.attachments = uploadResponses
+              NSLog("🎫 Zendesk: All \(uploadResponses.count) attachments uploaded, creating ticket")
+
+              ZDKRequestProvider().createRequest(createRequest) { (request, error) in
+                DispatchQueue.main.async {
+                  if let error = error {
+                    NSLog("❌ Zendesk: Failed to create ticket - \(error.localizedDescription)")
+                    result(FlutterError(code: "CREATE_FAILED",
+                                      message: error.localizedDescription,
+                                      details: nil))
+                  } else if let request = request as? ZDKRequest {
+                    NSLog("✅ Zendesk: Ticket created with attachments - ID: \(request.requestId)")
+                    result(true)
+                  } else {
+                    NSLog("✅ Zendesk: Ticket created with attachments (no error)")
+                    result(true)
+                  }
+                }
+              }
+
+            case .failure(let error):
+              DispatchQueue.main.async {
+                result(error)
+              }
+            }
+          }
+        }
+```
+
+- [ ] **Step 4: Build iOS to verify compilation**
+
+Run from `mobile/`:
+
+```bash
+flutter build ios --no-codesign --debug 2>&1 | tail -20
+```
+
+Expected: build succeeds. If there are Swift type issues, adjust the `uploadAttachments` helper signatures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ios/Runner/AppDelegate.swift
+git commit -m "feat(ios): upload image attachments via ZDKUploadProvider before ticket creation"
+```
+
+---
+
+## Task 9: Android Native — Upload Attachments via UploadProvider
+
+**Files:**
+- Modify: `mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt`
+
+- [ ] **Step 1: Add UploadProvider import**
+
+At the top of `MainActivity.kt`, add after the existing Zendesk imports (around line 27):
+
+```kotlin
+import zendesk.support.UploadProvider
+import zendesk.support.UploadResponse
+import com.zendesk.service.ErrorResponse
+```
+
+- [ ] **Step 2: Extract attachmentPaths in createTicket handler**
+
+In the `createTicket` handler (line 442), after extracting `customFieldsData` (line 448), add:
+
+```kotlin
+                    val attachmentPaths = (args?.get("attachmentPaths") as? List<*>)?.filterIsInstance<String>() ?: emptyList()
+```
+
+- [ ] **Step 3: Add upload helper method**
+
+Add a private method to the `MainActivity` class (before or after `configureFlutterEngine`):
+
+```kotlin
+    private fun uploadAttachments(
+        uploadProvider: UploadProvider,
+        paths: List<String>,
+        mainHandler: Handler,
+        onComplete: (Result<List<UploadResponse>>) -> Unit
+    ) {
+        val responses = mutableListOf<UploadResponse>()
+
+        fun uploadNext(index: Int) {
+            if (index >= paths.size) {
+                onComplete(Result.success(responses))
+                return
+            }
+
+            val path = paths[index]
+            val file = File(path)
+            if (!file.exists()) {
+                onComplete(Result.failure(Exception("File not found: $path")))
+                return
+            }
+
+            val filename = file.name
+            val contentType = if (filename.endsWith(".png")) "image/png" else "image/jpeg"
+
+            uploadProvider.uploadAttachment(
+                filename,
+                file,
+                contentType,
+                object : ZendeskCallback<UploadResponse>() {
+                    override fun onSuccess(response: UploadResponse?) {
+                        if (response != null) {
+                            Log.d(ZENDESK_TAG, "Uploaded $filename - token: ${response.token}")
+                            responses.add(response)
+                            uploadNext(index + 1)
+                        } else {
+                            mainHandler.post {
+                                onComplete(Result.failure(Exception("No upload response for $filename")))
+                            }
+                        }
+                    }
+
+                    override fun onError(error: ErrorResponse?) {
+                        Log.e(ZENDESK_TAG, "Upload failed for $filename: ${error?.reason}")
+                        mainHandler.post {
+                            onComplete(Result.failure(Exception("Upload failed for $filename: ${error?.reason}")))
+                        }
+                    }
+                }
+            )
+        }
+
+        uploadNext(0)
+    }
+```
+
+- [ ] **Step 4: Modify createTicket to upload before submitting**
+
+Replace the ticket submission section in the `createTicket` handler (from `val mainHandler` around line 492 through the end of the `ZendeskCallback` at line 515). The new logic uploads first if attachments are present:
+
+```kotlin
+                        val mainHandler = Handler(Looper.getMainLooper())
+
+                        if (attachmentPaths.isEmpty()) {
+                            // No attachments — submit directly (existing path)
+                            provider.createRequest(createRequest, object : ZendeskCallback<Request>() {
+                                override fun onSuccess(request: Request?) {
+                                    mainHandler.post {
+                                        if (isActivityDestroyed || isFinishing) {
+                                            Log.w(ZENDESK_TAG, "Dropped ticket result: activity destroyed")
+                                            return@post
+                                        }
+                                        Log.d(ZENDESK_TAG, "Ticket created successfully - ID: ${request?.id}")
+                                        result.success(true)
+                                    }
+                                }
+
+                                override fun onError(error: ErrorResponse?) {
+                                    mainHandler.post {
+                                        if (isActivityDestroyed || isFinishing) {
+                                            Log.w(ZENDESK_TAG, "Dropped ticket error: activity destroyed")
+                                            return@post
+                                        }
+                                        Log.e(ZENDESK_TAG, "Failed to create ticket: ${error?.reason}")
+                                        result.success(false)
+                                    }
+                                }
+                            })
+                        } else {
+                            // Upload attachments first
+                            Log.d(ZENDESK_TAG, "Uploading ${attachmentPaths.size} attachments before ticket creation")
+                            val uploadProvider: UploadProvider = providerStore.uploadProvider()
+
+                            uploadAttachments(uploadProvider, attachmentPaths, mainHandler) { uploadResult ->
+                                uploadResult.fold(
+                                    onSuccess = { uploadResponses ->
+                                        createRequest.attachments = uploadResponses.map { it.token }
+                                        Log.d(ZENDESK_TAG, "All ${uploadResponses.size} attachments uploaded, creating ticket")
+
+                                        provider.createRequest(createRequest, object : ZendeskCallback<Request>() {
+                                            override fun onSuccess(request: Request?) {
+                                                mainHandler.post {
+                                                    if (isActivityDestroyed || isFinishing) {
+                                                        Log.w(ZENDESK_TAG, "Dropped ticket result: activity destroyed")
+                                                        return@post
+                                                    }
+                                                    Log.d(ZENDESK_TAG, "Ticket created with attachments - ID: ${request?.id}")
+                                                    result.success(true)
+                                                }
+                                            }
+
+                                            override fun onError(error: ErrorResponse?) {
+                                                mainHandler.post {
+                                                    if (isActivityDestroyed || isFinishing) {
+                                                        Log.w(ZENDESK_TAG, "Dropped ticket error: activity destroyed")
+                                                        return@post
+                                                    }
+                                                    Log.e(ZENDESK_TAG, "Failed to create ticket: ${error?.reason}")
+                                                    result.success(false)
+                                                }
+                                            }
+                                        })
+                                    },
+                                    onFailure = { error ->
+                                        mainHandler.post {
+                                            if (isActivityDestroyed || isFinishing) {
+                                                Log.w(ZENDESK_TAG, "Dropped upload error: activity destroyed")
+                                                return@post
+                                            }
+                                            Log.e(ZENDESK_TAG, "Attachment upload failed: ${error.message}")
+                                            result.error("UPLOAD_FAILED", error.message, null)
+                                        }
+                                    }
+                                )
+                            }
+                        }
+```
+
+- [ ] **Step 5: Build Android to verify compilation**
+
+Run from `mobile/`:
+
+```bash
+flutter build apk --debug 2>&1 | tail -20
+```
+
+Expected: build succeeds. Note: the Android SDK `CreateRequest.setAttachments()` takes a `List<String>` of upload tokens. The code uses `uploadResponses.map { it.token }` to extract tokens. If `UploadResponse.token` is named differently in `com.zendesk:support:5.1.2`, check the class with `javap` or IDE autocomplete and adjust the property name.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
+git commit -m "feat(android): upload image attachments via UploadProvider before ticket creation"
+```
+
+---
+
+## Task 10: Final Verification
+
+- [ ] **Step 1: Run full analysis**
+
+Run from `mobile/`:
+
+```bash
+flutter analyze lib/widgets/image_attachment_picker.dart lib/widgets/bug_report_dialog.dart lib/services/zendesk_support_service.dart
+```
+
+Expected: no issues.
+
+- [ ] **Step 2: Run all related tests**
+
+```bash
+flutter test test/widgets/image_attachment_picker_test.dart test/widgets/bug_report_dialog_test.dart test/services/zendesk_support_service_test.dart
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+flutter test
+```
+
+Expected: no regressions.
+
+- [ ] **Step 4: Format changed files**
+
+```bash
+dart format lib/widgets/image_attachment_picker.dart lib/widgets/bug_report_dialog.dart lib/services/zendesk_support_service.dart test/widgets/image_attachment_picker_test.dart test/widgets/bug_report_dialog_test.dart test/services/zendesk_support_service_test.dart
+```
+
+- [ ] **Step 5: Build iOS to verify native changes**
+
+```bash
+flutter build ios --no-codesign --debug 2>&1 | tail -20
+```
+
+- [ ] **Step 6: Build Android to verify native changes**
+
+```bash
+flutter build apk --debug 2>&1 | tail -20
+```
+
+- [ ] **Step 7: Commit any format fixes**
+
+If `dart format` changed anything:
+
+```bash
+git add -u
+git commit -m "style: format changed files"
+```
+
+---
+
+## Manual Testing Checklist (Post-Implementation)
+
+These must be verified on device before the PR is merge-ready:
+
+1. **iOS device/simulator:** Open bug report dialog → attach 1 image → submit → verify ticket in Zendesk has attachment
+2. **Android device/emulator:** Same as above
+3. **3 images max:** Attach 3 images → add button disappears → try long-press or other paths → no way to exceed limit
+4. **Remove image:** Attach 2 → remove 1 → submit → ticket has 1 attachment
+5. **Zero attachments (regression):** Submit bug report with no images → works exactly as before
+6. **Upload failure:** Attach 1 image → airplane mode → submit → error shown, no ticket created, user can retry
+7. **Desktop/macOS:** Open bug report → picker not shown → submit works as before
+8. **Disabled during submission:** Tap submit → while spinner showing, picker add/remove buttons are non-interactive

--- a/docs/superpowers/specs/2026-04-23-bug-report-image-attachments-design.md
+++ b/docs/superpowers/specs/2026-04-23-bug-report-image-attachments-design.md
@@ -1,0 +1,179 @@
+# Bug Report Image Attachments
+
+**Issue:** divinevideo/divine-mobile#3094
+**Date:** 2026-04-23
+**Status:** Design approved, pending implementation
+
+## Problem
+
+Users filing in-app bug reports cannot attach screenshots. Triage of vague reports ("error pop up", "video won't play") dead-ends because there is no visual context and no follow-up channel.
+
+## Scope
+
+Add image attachment support (up to 3 images) to the in-app bug report dialog on iOS and Android. Images are selected from the device gallery, resized for upload efficiency, and attached to the Zendesk ticket via the native SDK's upload API.
+
+### Not in scope
+
+- Desktop (macOS/Windows/Linux) attachment support. Desktop REST API path is internal-only and does not have `ZENDESK_API_TOKEN` in production builds.
+- Camera capture as image source. Gallery only, matching the existing profile avatar picker pattern.
+- Immediate-on-select uploads. Images upload at submission time.
+- Partial submission on upload failure. All-or-nothing: if any image fails to upload, the submission fails and the user retries.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Platform scope | Mobile only (iOS/Android) | Desktop bug reports go through Slack/GitHub; REST API fallback lacks `ZENDESK_API_TOKEN` in prod |
+| Image source | Gallery only | Matches existing `image_picker` usage for profile avatars; users screenshot first, then attach |
+| Max images | 3 | Covers the common case without overloading Zendesk tickets |
+| Compression | Resize to 1920px max width, JPEG 80% quality | Keeps uploads under ~500KB each; `image_picker` has built-in `maxWidth`/`imageQuality` params |
+| Upload timing | At submission | Simpler state management; spinner already shown during submission |
+| Upload failure | Fail entire submission | No partial state; user can retry. Avoids confusing triage with missing attachments |
+| Architecture | Extract `ImageAttachmentPicker` widget | Keeps `BugReportDialog` focused on form logic; picker is independently testable and reusable |
+| Desktop UI | Hide picker entirely | No false affordance; widget checks platform and renders `SizedBox.shrink()` on non-mobile |
+
+## Architecture
+
+### Component Flow
+
+```
+BugReportDialog
+  |-- ImageAttachmentPicker (new widget, mobile only)
+  |     |-- thumbnail previews (64x64, X to remove)
+  |     |-- add button (hidden at max count)
+  |     |-- onChanged callback -> List<XFile>
+  |
+  |-- _submitReport()
+        |-- BugReportService.collectDiagnostics() (unchanged)
+        |-- ZendeskSupportService.createStructuredBugReport(
+        |     ...,
+        |     attachmentPaths: [file paths from picker]
+        |   )
+              |-- createTicket(
+              |     ...,
+              |     attachmentPaths: [file paths]
+              |   )
+                    |-- MethodChannel('com.openvine/zendesk_support')
+                          |-- Native: upload each file via UploadProvider
+                          |-- Native: attach tokens to CreateRequest
+                          |-- Native: createRequest()
+```
+
+### New File
+
+**`mobile/lib/widgets/image_attachment_picker.dart`**
+
+Stateful widget with parameters:
+- `maxImages: int` (default 3)
+- `onChanged: ValueChanged<List<XFile>>`
+- `enabled: bool` (disabled during submission)
+
+Behavior:
+- Renders a horizontal row of thumbnail previews + an add button.
+- Thumbnails are ~64x64 with a small circular X overlay to remove.
+- Add button calls `ImagePicker().pickMultiImage(maxWidth: 1920, imageQuality: 80)`.
+- If the user selects more images than remaining slots, the selection is truncated to the limit.
+- On non-mobile platforms (`defaultTargetPlatform` is not iOS or Android), renders `SizedBox.shrink()`.
+- Styled with `VineTheme` colors: grey border on add button, `vineGreen` icon, dark card background on thumbnails.
+- All interactive elements wrapped with `Semantics(button: true, label: ...)` per `accessibility.md`. Minimum 48x48 touch targets on add and remove buttons.
+- `SemanticsService.announce()` after image add/remove to communicate count change to screen readers.
+- Thumbnail images get `semanticLabel`; decorative overlays (gradient behind X) wrapped in `ExcludeSemantics`.
+
+### Localization
+
+All user-facing strings use `context.l10n` per `localization.md`. ARB keys to add in `mobile/lib/l10n/app_en.arb` (feature-prefixed `bugReport*`):
+
+```json
+{
+  "bugReportAttachImages": "Attach images",
+  "bugReportRemoveImage": "Remove image",
+  "bugReportImagesCount": "{count} of {max} images",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": { "type": "int" },
+      "max": { "type": "int" }
+    }
+  },
+  "bugReportUploadFailed": "Image upload failed. Please try again."
+}
+```
+
+Run `flutter gen-l10n` from `mobile/` and commit generated files.
+
+### Modified Files
+
+**`mobile/lib/widgets/bug_report_dialog.dart`**
+- Add `List<XFile> _attachments` state field.
+- Host `ImageAttachmentPicker` between "Expected Behavior" field and info text.
+- Pass `_attachments.map((f) => f.path).toList()` to `createStructuredBugReport()`.
+
+**`mobile/lib/services/zendesk_support_service.dart`**
+- `createStructuredBugReport()`: new optional `List<String>? attachmentPaths` parameter, passed through to `createTicket()`.
+- `createTicket()`: new optional `List<String>? attachmentPaths` parameter. Added to platform channel `invokeMethod` args when non-null and non-empty. REST API fallback path ignores attachments (no crash, just text-only ticket).
+
+**`mobile/ios/Runner/AppDelegate.swift`** -- `createTicket` handler:
+- Extract optional `attachmentPaths: [String]` from args.
+- If present, upload each file sequentially via `ZDKUploadProvider().uploadAttachment()`.
+- Collect upload responses and set on `createRequest.attachments`.
+- If any upload fails, return `FlutterError(code: "UPLOAD_FAILED", message: ..., details: nil)` without creating the ticket.
+- No change to existing flow when no attachments provided.
+
+**`mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt`** -- `createTicket` handler:
+- Same pattern as iOS: extract `attachmentPaths`, upload via `UploadProvider`, collect tokens, set on `CreateRequest`.
+- Fail-fast on any upload error.
+- No change to existing flow when no attachments provided.
+
+### Platform Channel Contract
+
+The `createTicket` method gains one new optional field:
+
+```
+createTicket({
+  subject: String,            // existing
+  description: String,        // existing
+  tags: [String],             // existing
+  ticketFormId: int?,         // existing
+  customFields: [Map]?,       // existing
+  attachmentPaths: [String]?  // NEW - absolute file paths to upload
+})
+```
+
+Native implementations treat `attachmentPaths` as optional. When absent or empty, behavior is identical to today.
+
+## Testing
+
+### Dart Unit Tests
+
+**`mobile/test/widgets/image_attachment_picker_test.dart`** (new):
+- Renders add button when under max count.
+- Hides add button when at max count.
+- Displays thumbnails for selected images.
+- Remove button removes the correct image.
+- Calls `onChanged` with updated file list on add and remove.
+- Renders nothing (`SizedBox.shrink()`) on non-mobile platforms.
+- Test `MaterialApp` includes `AppLocalizations.localizationsDelegates` and `supportedLocales`.
+- String assertions use `lookupAppLocalizations` instead of hardcoded English.
+
+**`bug_report_dialog_test.dart`** (extend existing):
+- Attachment file paths are passed through to `createStructuredBugReport()`.
+- Submission works with zero attachments (regression).
+
+**`zendesk_support_service_test.dart`** (extend existing):
+- `attachmentPaths` included in platform channel invocation when provided.
+- `attachmentPaths` omitted from platform channel invocation when null/empty.
+- REST API fallback creates ticket without attachments (no error).
+
+### Native Verification (Manual)
+
+No native unit tests for iOS/Android upload flow. Verified manually on device:
+
+1. Submit with 0 images -- works as before (regression check).
+2. Submit with 1 image -- ticket created with attachment visible in Zendesk.
+3. Submit with 3 images, try to add a 4th -- add button not shown at max.
+4. Attach 2, remove 1, submit -- ticket has 1 attachment.
+5. Attach 1, airplane mode, submit -- error shown, no ticket created.
+6. Desktop/macOS -- picker not shown, submit works as before.
+
+## SDK API Notes
+
+The exact method signatures for `ZDKUploadProvider` (iOS) and `UploadProvider` (Android) need to be verified against the SDK versions linked in the Podfile and build.gradle during implementation. The design assumes a standard upload-file-get-token pattern which is consistent across Zendesk SDK versions, but parameter names may vary.

--- a/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
@@ -572,7 +572,8 @@ class MainActivity : FlutterActivity() {
                 override fun onSuccess(response: UploadResponse?) {
                     val token = response?.token
                     if (token != null) {
-                        Log.d(ZENDESK_TAG, "Uploaded $filename - token: $token")
+                        // Do not log uploadToken: short-lived Zendesk secure-download credential.
+                        Log.d(ZENDESK_TAG, "Uploaded $filename successfully")
                         tokens.add(token)
                         uploadNext(index + 1)
                     } else {

--- a/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
@@ -24,6 +24,8 @@ import zendesk.support.Support
 import zendesk.support.requestlist.RequestListActivity
 import zendesk.support.request.RequestActivity
 import zendesk.support.RequestProvider
+import zendesk.support.UploadProvider
+import zendesk.support.UploadResponse
 import zendesk.support.CreateRequest
 import zendesk.support.Request
 import zendesk.support.CustomField
@@ -430,6 +432,7 @@ class MainActivity : FlutterActivity() {
                     val tags = (args?.get("tags") as? List<*>)?.filterIsInstance<String>() ?: emptyList()
                     val ticketFormId = (args?.get("ticketFormId") as? Number)?.toLong()
                     val customFieldsData = (args?.get("customFields") as? List<*>)?.filterIsInstance<Map<*, *>>() ?: emptyList()
+                    val attachmentPaths = (args?.get("attachmentPaths") as? List<*>)?.filterIsInstance<String>() ?: emptyList()
 
                     if (subject == null || description == null) {
                         result.error("INVALID_ARGUMENT", "subject and description are required", null)
@@ -474,29 +477,58 @@ class MainActivity : FlutterActivity() {
                         // but Flutter platform channels require the main thread.
                         // Without this dispatch the app crashes (issue #1679).
                         val mainHandler = Handler(Looper.getMainLooper())
-                        provider.createRequest(createRequest, object : ZendeskCallback<Request>() {
-                            override fun onSuccess(request: Request?) {
-                                mainHandler.post {
-                                    if (isActivityDestroyed || isFinishing) {
-                                        Log.w(ZENDESK_TAG, "Dropped ticket result: activity destroyed")
-                                        return@post
-                                    }
-                                    Log.d(ZENDESK_TAG, "Ticket created successfully - ID: ${request?.id}")
-                                    result.success(true)
-                                }
-                            }
 
-                            override fun onError(error: ErrorResponse?) {
-                                mainHandler.post {
-                                    if (isActivityDestroyed || isFinishing) {
-                                        Log.w(ZENDESK_TAG, "Dropped ticket error: activity destroyed")
-                                        return@post
+                        val submitRequest = {
+                            provider.createRequest(createRequest, object : ZendeskCallback<Request>() {
+                                override fun onSuccess(request: Request?) {
+                                    mainHandler.post {
+                                        if (isActivityDestroyed || isFinishing) {
+                                            Log.w(ZENDESK_TAG, "Dropped ticket result: activity destroyed")
+                                            return@post
+                                        }
+                                        Log.d(ZENDESK_TAG, "Ticket created successfully - ID: ${request?.id}")
+                                        result.success(true)
                                     }
-                                    Log.e(ZENDESK_TAG, "Failed to create ticket: ${error?.reason}")
-                                    result.success(false)
                                 }
+
+                                override fun onError(error: ErrorResponse?) {
+                                    mainHandler.post {
+                                        if (isActivityDestroyed || isFinishing) {
+                                            Log.w(ZENDESK_TAG, "Dropped ticket error: activity destroyed")
+                                            return@post
+                                        }
+                                        Log.e(ZENDESK_TAG, "Failed to create ticket: ${error?.reason}")
+                                        result.success(false)
+                                    }
+                                }
+                            })
+                        }
+
+                        if (attachmentPaths.isEmpty()) {
+                            submitRequest()
+                        } else {
+                            Log.d(ZENDESK_TAG, "Uploading ${attachmentPaths.size} attachments before ticket creation")
+                            val uploadProvider: UploadProvider = providerStore.uploadProvider()
+                            uploadAttachments(uploadProvider, attachmentPaths, mainHandler) { uploadResult ->
+                                uploadResult.fold(
+                                    onSuccess = { tokens ->
+                                        createRequest.attachments = tokens
+                                        Log.d(ZENDESK_TAG, "All ${tokens.size} attachments uploaded, creating ticket")
+                                        submitRequest()
+                                    },
+                                    onFailure = { error ->
+                                        mainHandler.post {
+                                            if (isActivityDestroyed || isFinishing) {
+                                                Log.w(ZENDESK_TAG, "Dropped upload error: activity destroyed")
+                                                return@post
+                                            }
+                                            Log.e(ZENDESK_TAG, "Attachment upload failed: ${error.message}")
+                                            result.error("UPLOAD_FAILED", error.message, null)
+                                        }
+                                    }
+                                )
                             }
-                        })
+                        }
                     } catch (e: Exception) {
                         Log.e(ZENDESK_TAG, "Failed to create ticket", e)
                         result.error("CREATE_TICKET_FAILED", e.message, null)
@@ -510,6 +542,56 @@ class MainActivity : FlutterActivity() {
         }
 
         Log.d(ZENDESK_TAG, "Zendesk platform channel registered")
+    }
+
+    private fun uploadAttachments(
+        uploadProvider: UploadProvider,
+        paths: List<String>,
+        mainHandler: Handler,
+        onComplete: (Result<List<String>>) -> Unit
+    ) {
+        val tokens = mutableListOf<String>()
+
+        fun uploadNext(index: Int) {
+            if (index >= paths.size) {
+                onComplete(Result.success(tokens))
+                return
+            }
+
+            val path = paths[index]
+            val file = File(path)
+            if (!file.exists()) {
+                onComplete(Result.failure(Exception("File not found: $path")))
+                return
+            }
+
+            val filename = file.name
+            val contentType = if (filename.endsWith(".png")) "image/png" else "image/jpeg"
+
+            uploadProvider.uploadAttachment(filename, file, contentType, object : ZendeskCallback<UploadResponse>() {
+                override fun onSuccess(response: UploadResponse?) {
+                    val token = response?.token
+                    if (token != null) {
+                        Log.d(ZENDESK_TAG, "Uploaded $filename - token: $token")
+                        tokens.add(token)
+                        uploadNext(index + 1)
+                    } else {
+                        mainHandler.post {
+                            onComplete(Result.failure(Exception("No upload token for $filename")))
+                        }
+                    }
+                }
+
+                override fun onError(error: ErrorResponse?) {
+                    Log.e(ZENDESK_TAG, "Upload failed for $filename: ${error?.reason}")
+                    mainHandler.post {
+                        onComplete(Result.failure(Exception("Upload failed for $filename: ${error?.reason}")))
+                    }
+                }
+            })
+        }
+
+        uploadNext(0)
     }
 }
 

--- a/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
@@ -561,7 +561,7 @@ class MainActivity : FlutterActivity() {
             val path = paths[index]
             val file = File(path)
             if (!file.exists()) {
-                onComplete(Result.failure(Exception("File not found: $path")))
+                onComplete(Result.failure(Exception("Could not read the selected image")))
                 return
             }
 
@@ -578,7 +578,7 @@ class MainActivity : FlutterActivity() {
                         uploadNext(index + 1)
                     } else {
                         mainHandler.post {
-                            onComplete(Result.failure(Exception("No upload token for $filename")))
+                            onComplete(Result.failure(Exception("Attachment upload did not return a token")))
                         }
                     }
                 }
@@ -586,7 +586,7 @@ class MainActivity : FlutterActivity() {
                 override fun onError(error: ErrorResponse?) {
                     Log.e(ZENDESK_TAG, "Upload failed for $filename: ${error?.reason}")
                     mainHandler.post {
-                        onComplete(Result.failure(Exception("Upload failed for $filename: ${error?.reason}")))
+                        onComplete(Result.failure(Exception("Failed to upload selected image")))
                     }
                 }
             })

--- a/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
@@ -570,7 +570,7 @@ class MainActivity : FlutterActivity() {
             }
 
             val filename = file.name
-            val contentType = if (filename.endsWith(".png")) "image/png" else "image/jpeg"
+            val contentType = attachmentContentType(filename)
 
             uploadProvider.uploadAttachment(filename, file, contentType, object : ZendeskCallback<UploadResponse>() {
                 override fun onSuccess(response: UploadResponse?) {
@@ -597,6 +597,18 @@ class MainActivity : FlutterActivity() {
         }
 
         uploadNext(0)
+    }
+
+    private fun attachmentContentType(filename: String): String {
+        return when (filename.substringAfterLast('.', "").lowercase()) {
+            "png" -> "image/png"
+            "jpg", "jpeg" -> "image/jpeg"
+            "heic" -> "image/heic"
+            "heif" -> "image/heif"
+            "webp" -> "image/webp"
+            "gif" -> "image/gif"
+            else -> "image/jpeg"
+        }
     }
 }
 

--- a/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
@@ -554,14 +554,18 @@ class MainActivity : FlutterActivity() {
 
         fun uploadNext(index: Int) {
             if (index >= paths.size) {
-                onComplete(Result.success(tokens))
+                mainHandler.post {
+                    onComplete(Result.success(tokens))
+                }
                 return
             }
 
             val path = paths[index]
             val file = File(path)
             if (!file.exists()) {
-                onComplete(Result.failure(Exception("Could not read the selected image")))
+                mainHandler.post {
+                    onComplete(Result.failure(Exception("Could not read the selected image")))
+                }
                 return
             }
 

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -408,7 +408,7 @@ extension FlutterError: @retroactive Error {}
       guard let data = FileManager.default.contents(atPath: path) else {
         completion(.failure(FlutterError(
           code: "UPLOAD_FAILED",
-          message: "Could not read file at \(path)",
+          message: "Could not read the selected image",
           details: nil
         )))
         return
@@ -423,7 +423,7 @@ extension FlutterError: @retroactive Error {}
           NSLog("❌ Zendesk: Upload failed for \(filename) - \(error.localizedDescription)")
           completion(.failure(FlutterError(
             code: "UPLOAD_FAILED",
-            message: "Failed to upload \(filename): \(error.localizedDescription)",
+            message: "Failed to upload selected image",
             details: nil
           )))
           return
@@ -432,7 +432,7 @@ extension FlutterError: @retroactive Error {}
         guard let response = uploadResponse else {
           completion(.failure(FlutterError(
             code: "UPLOAD_FAILED",
-            message: "No upload response for \(filename)",
+            message: "Attachment upload did not return a token",
             details: nil
           )))
           return

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -6,6 +6,8 @@ import ZendeskCoreSDK
 import SupportSDK
 import SupportProvidersSDK
 
+extension FlutterError: @retroactive Error {}
+
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -315,6 +315,7 @@ import SupportProvidersSDK
         let tags = args["tags"] as? [String] ?? []
         let ticketFormId = args["ticketFormId"] as? NSNumber
         let customFieldsData = args["customFields"] as? [[String: Any]] ?? []
+        let attachmentPaths = args["attachmentPaths"] as? [String] ?? []
 
         // Build create request object using ZDK API
         let createRequest = ZDKCreateRequest()
@@ -334,7 +335,6 @@ import SupportProvidersSDK
           for fieldData in customFieldsData {
             if let fieldId = fieldData["id"] as? NSNumber,
                let fieldValue = fieldData["value"] {
-              // CustomField uses dictionary-based initializer in modern SDK
               let customField = CustomField(dictionary: ["id": fieldId, "value": fieldValue])
               customFields.append(customField)
               NSLog("🎫 Zendesk: Custom field \(fieldId) = \(fieldValue)")
@@ -343,25 +343,40 @@ import SupportProvidersSDK
           createRequest.customFields = customFields
         }
 
-        NSLog("🎫 Zendesk: Submitting ticket - subject: '\(subject)', tags: \(tags)")
+        NSLog("🎫 Zendesk: Submitting ticket - subject: '\(subject)', tags: \(tags), attachments: \(attachmentPaths.count)")
 
-        // Submit ticket asynchronously using ZDKRequestProvider
-        ZDKRequestProvider().createRequest(createRequest) { (request, error) in
-          DispatchQueue.main.async {
-            if let error = error {
-              NSLog("❌ Zendesk: Failed to create ticket - \(error.localizedDescription)")
-              result(FlutterError(code: "CREATE_FAILED",
-                                message: error.localizedDescription,
-                                details: nil))
-            } else if let request = request as? ZDKRequest {
-              NSLog("✅ Zendesk: Ticket created successfully - ID: \(request.requestId)")
-              result(true)
-            } else {
-              // No error means the ticket was created — the response type may differ
-              // under JWT auth vs anonymous auth. Treat as success to avoid duplicate
-              // ticket creation via REST API fallback.
-              NSLog("✅ Zendesk: Ticket created (no error, response type: \(type(of: request)))")
-              result(true)
+        let submitRequest = {
+          ZDKRequestProvider().createRequest(createRequest) { (request, error) in
+            DispatchQueue.main.async {
+              if let error = error {
+                NSLog("❌ Zendesk: Failed to create ticket - \(error.localizedDescription)")
+                result(FlutterError(code: "CREATE_FAILED",
+                                  message: error.localizedDescription,
+                                  details: nil))
+              } else if let request = request as? ZDKRequest {
+                NSLog("✅ Zendesk: Ticket created successfully - ID: \(request.requestId)")
+                result(true)
+              } else {
+                NSLog("✅ Zendesk: Ticket created (no error, response type: \(type(of: request)))")
+                result(true)
+              }
+            }
+          }
+        }
+
+        if attachmentPaths.isEmpty {
+          submitRequest()
+        } else {
+          self.uploadAttachments(attachmentPaths) { uploadResult in
+            switch uploadResult {
+            case .success(let uploadResponses):
+              createRequest.attachments = uploadResponses
+              NSLog("🎫 Zendesk: All \(uploadResponses.count) attachments uploaded, creating ticket")
+              submitRequest()
+            case .failure(let error):
+              DispatchQueue.main.async {
+                result(error)
+              }
             }
           }
         }
@@ -372,5 +387,61 @@ import SupportProvidersSDK
     }
 
     NSLog("✅ Zendesk: Platform channel registered")
+  }
+
+  private func uploadAttachments(
+    _ paths: [String],
+    completion: @escaping (Result<[ZDKUploadResponse], FlutterError>) -> Void
+  ) {
+    var responses: [ZDKUploadResponse] = []
+    let uploadProvider = ZDKUploadProvider()
+
+    func uploadNext(index: Int) {
+      guard index < paths.count else {
+        completion(.success(responses))
+        return
+      }
+
+      let path = paths[index]
+      guard let data = FileManager.default.contents(atPath: path) else {
+        completion(.failure(FlutterError(
+          code: "UPLOAD_FAILED",
+          message: "Could not read file at \(path)",
+          details: nil
+        )))
+        return
+      }
+
+      let filename = (path as NSString).lastPathComponent
+      let contentType = filename.hasSuffix(".png") ? "image/png" : "image/jpeg"
+
+      uploadProvider.uploadAttachment(data, withFilename: filename, andContentType: contentType) {
+        uploadResponse, error in
+        if let error = error {
+          NSLog("❌ Zendesk: Upload failed for \(filename) - \(error.localizedDescription)")
+          completion(.failure(FlutterError(
+            code: "UPLOAD_FAILED",
+            message: "Failed to upload \(filename): \(error.localizedDescription)",
+            details: nil
+          )))
+          return
+        }
+
+        guard let response = uploadResponse else {
+          completion(.failure(FlutterError(
+            code: "UPLOAD_FAILED",
+            message: "No upload response for \(filename)",
+            details: nil
+          )))
+          return
+        }
+
+        NSLog("✅ Zendesk: Uploaded \(filename) - token: \(response.uploadToken ?? "nil")")
+        responses.append(response)
+        uploadNext(index: index + 1)
+      }
+    }
+
+    uploadNext(index: 0)
   }
 }

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -372,9 +372,11 @@ extension FlutterError: @retroactive Error {}
           self.uploadAttachments(attachmentPaths) { uploadResult in
             switch uploadResult {
             case .success(let uploadResponses):
-              createRequest.attachments = uploadResponses
-              NSLog("🎫 Zendesk: All \(uploadResponses.count) attachments uploaded, creating ticket")
-              submitRequest()
+              DispatchQueue.main.async {
+                createRequest.attachments = uploadResponses
+                NSLog("🎫 Zendesk: All \(uploadResponses.count) attachments uploaded, creating ticket")
+                submitRequest()
+              }
             case .failure(let error):
               DispatchQueue.main.async {
                 result(error)

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -438,7 +438,8 @@ extension FlutterError: @retroactive Error {}
           return
         }
 
-        NSLog("✅ Zendesk: Uploaded \(filename) - token: \(response.uploadToken ?? "nil")")
+        // Do not log uploadToken: short-lived Zendesk secure-download credential.
+        NSLog("✅ Zendesk: Uploaded \(filename) successfully")
         responses.append(response)
         uploadNext(index: index + 1)
       }

--- a/mobile/ios/Runner/AppDelegate.swift
+++ b/mobile/ios/Runner/AppDelegate.swift
@@ -417,7 +417,7 @@ extension FlutterError: @retroactive Error {}
       }
 
       let filename = (path as NSString).lastPathComponent
-      let contentType = filename.hasSuffix(".png") ? "image/png" : "image/jpeg"
+      let contentType = attachmentContentType(for: filename)
 
       uploadProvider.uploadAttachment(data, withFilename: filename, andContentType: contentType) {
         uploadResponse, error in
@@ -448,5 +448,24 @@ extension FlutterError: @retroactive Error {}
     }
 
     uploadNext(index: 0)
+  }
+
+  private func attachmentContentType(for filename: String) -> String {
+    switch (filename as NSString).pathExtension.lowercased() {
+    case "png":
+      return "image/png"
+    case "jpg", "jpeg":
+      return "image/jpeg"
+    case "heic":
+      return "image/heic"
+    case "heif":
+      return "image/heif"
+    case "webp":
+      return "image/webp"
+    case "gif":
+      return "image/gif"
+    default:
+      return "image/jpeg"
+    }
   }
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2856,7 +2856,21 @@
     "bugReportExpectedBehaviorHint": "በምትኩ ምን መሆን ነበረበት?",
     "bugReportDiagnosticsNotice": "የመሳሪያ መረጃ እና ሎጎች በራስ-ሰር ይካተታሉ።",
     "bugReportSuccessMessage": "እናመሰግናለን! ሪፖርትዎን ተቀብለናል፣ Divineን ለማሻሻል እንጠቀምበታለን።",
-    "bugReportSendFailed": "የሳንካ ሪፖርት መላክ አልተሳካም። እባክዎ ቆይተው ይሞክሩ።",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "የሳንካ ሪፖርት መላክ አልተሳካም። እባክዎ ቆይተው ይሞክሩ።",
     "bugReportFailedWithError": "የሳንካ ሪፖርት መላክ አልተሳካም፦ {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3359,7 +3359,21 @@
     "bugReportExpectedBehaviorHint": "ماذا كان يجب أن يحدث بدلًا من ذلك؟",
     "bugReportDiagnosticsNotice": "ستُرفَق معلومات الجهاز والسجلات تلقائيًا.",
     "bugReportSuccessMessage": "شكرًا لك! استلمنا تقريرك وسنستخدمه لجعل Divine أفضل.",
-    "bugReportSendFailed": "فشل إرسال تقرير الخطأ. حاول مرّة أخرى لاحقًا.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "فشل إرسال تقرير الخطأ. حاول مرّة أخرى لاحقًا.",
     "bugReportFailedWithError": "فشل إرسال تقرير الخطأ: {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3494,7 +3494,21 @@
     "bugReportExpectedBehaviorHint": "Какво трябваше да стане вместо това?",
     "bugReportDiagnosticsNotice": "Информацията за устройството и логовете ще се прикачат автоматично.",
     "bugReportSuccessMessage": "Благодарим ти! Получихме доклада ти и ще го използваме, за да направим Divine по-добро.",
-    "bugReportSendFailed": "Изпращането на доклада не успя. Опитай пак по-късно.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "Изпращането на доклада не успя. Опитай пак по-късно.",
     "bugReportFailedWithError": "Докладът за бъг не успя да се изпрати: {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3359,7 +3359,21 @@
     "bugReportExpectedBehaviorHint": "Was hätte stattdessen passieren sollen?",
     "bugReportDiagnosticsNotice": "Geräteinfos und Logs werden automatisch beigelegt.",
     "bugReportSuccessMessage": "Danke! Wir haben deinen Bericht erhalten und nutzen ihn, um Divine besser zu machen.",
-    "bugReportSendFailed": "Bug-Bericht konnte nicht gesendet werden. Versuch es später nochmal.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "Bug-Bericht konnte nicht gesendet werden. Versuch es später nochmal.",
     "bugReportFailedWithError": "Bug-Bericht konnte nicht gesendet werden: {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3077,6 +3077,20 @@
   "bugReportExpectedBehaviorHint": "What should have happened instead?",
   "bugReportDiagnosticsNotice": "Device info and logs will be included automatically.",
   "bugReportSuccessMessage": "Thank you! We've received your report and will use it to make Divine better.",
+  "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
   "bugReportSendFailed": "Failed to send bug report. Please try again later.",
   "bugReportFailedWithError": "Bug report failed to send: {error}",
   "@bugReportFailedWithError": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3363,7 +3363,21 @@
     "bugReportExpectedBehaviorHint": "¿Qué tendría que haber pasado en su lugar?",
     "bugReportDiagnosticsNotice": "La info del dispositivo y los logs se incluyen automáticamente.",
     "bugReportSuccessMessage": "¡Gracias! Recibimos tu reporte y lo vamos a usar para hacer Divine mejor.",
-    "bugReportSendFailed": "No se pudo enviar el reporte de bug. Probá de nuevo más tarde.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "No se pudo enviar el reporte de bug. Probá de nuevo más tarde.",
     "bugReportFailedWithError": "No se pudo enviar el reporte de bug: {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1796,7 +1796,21 @@
     "bugReportExpectedBehaviorHint": "Ano sana dapat ang nangyari?",
     "bugReportExpectedBehaviorLabel": "Inaasahang Behavior",
     "bugReportFailedWithError": "Hindi naipadala ang bug report: {error}",
-    "bugReportSendFailed": "Hindi naipadala ang bug report. Subukan ulit mamaya.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "Hindi naipadala ang bug report. Subukan ulit mamaya.",
     "bugReportSendReport": "Ipadala ang Report",
     "bugReportStepsHint": "1. Pumunta sa...\n2. I-tap ang...\n3. Lalabas ang error",
     "bugReportStepsLabel": "Mga Hakbang Para Maulit",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3359,7 +3359,21 @@
     "bugReportExpectedBehaviorHint": "Que devait-il se passer à la place ?",
     "bugReportDiagnosticsNotice": "Les infos de l'appareil et les logs seront inclus automatiquement.",
     "bugReportSuccessMessage": "Merci ! On a bien reçu ton rapport et on s'en servira pour améliorer Divine.",
-    "bugReportSendFailed": "Échec de l'envoi du rapport de bug. Réessaie plus tard.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "Échec de l'envoi du rapport de bug. Réessaie plus tard.",
     "bugReportFailedWithError": "Échec de l'envoi du rapport de bug : {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3359,7 +3359,21 @@
     "bugReportExpectedBehaviorHint": "Apa yang seharusnya terjadi?",
     "bugReportDiagnosticsNotice": "Info perangkat dan log akan disertakan otomatis.",
     "bugReportSuccessMessage": "Terima kasih! Laporanmu sudah kami terima dan akan kami pakai untuk membuat Divine lebih baik.",
-    "bugReportSendFailed": "Gagal mengirim laporan bug. Coba lagi nanti.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "Gagal mengirim laporan bug. Coba lagi nanti.",
     "bugReportFailedWithError": "Laporan bug gagal terkirim: {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3359,7 +3359,21 @@
     "bugReportExpectedBehaviorHint": "Cosa sarebbe dovuto succedere?",
     "bugReportDiagnosticsNotice": "Le info sul dispositivo e i log saranno inclusi automaticamente.",
     "bugReportSuccessMessage": "Grazie! Abbiamo ricevuto la tua segnalazione e la useremo per migliorare Divine.",
-    "bugReportSendFailed": "Impossibile inviare la segnalazione. Riprova più tardi.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "Impossibile inviare la segnalazione. Riprova più tardi.",
     "bugReportFailedWithError": "Invio della segnalazione non riuscito: {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3359,7 +3359,21 @@
     "bugReportExpectedBehaviorHint": "本来どうなるはずだった?",
     "bugReportDiagnosticsNotice": "デバイス情報とログは自動で添付されるよ。",
     "bugReportSuccessMessage": "ありがとう！レポートを受け取ったよ。Divine をよくするのに使うね。",
-    "bugReportSendFailed": "バグレポートの送信に失敗。あとでもう一回試してみて。",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "バグレポートの送信に失敗。あとでもう一回試してみて。",
     "bugReportFailedWithError": "バグレポートの送信に失敗: {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2655,7 +2655,21 @@
     "bugReportExpectedBehaviorHint": "원래 어떻게 됐어야 했나요?",
     "bugReportDiagnosticsNotice": "기기 정보와 로그가 자동으로 함께 보내져요.",
     "bugReportSuccessMessage": "고마워요! 신고를 받았어요. Divine을 더 좋게 만드는 데 쓸게요.",
-    "bugReportSendFailed": "버그 신고를 보내지 못했어요. 잠시 후 다시 시도해주세요.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "버그 신고를 보내지 못했어요. 잠시 후 다시 시도해주세요.",
     "bugReportFailedWithError": "버그 신고를 보내지 못했어요: {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3359,7 +3359,21 @@
     "bugReportExpectedBehaviorHint": "Wat had er moeten gebeuren?",
     "bugReportDiagnosticsNotice": "Apparaatinfo en logs worden automatisch meegestuurd.",
     "bugReportSuccessMessage": "Dank je! We hebben je rapport ontvangen en gebruiken het om Divine beter te maken.",
-    "bugReportSendFailed": "Bugrapport verzenden mislukt. Probeer het later opnieuw.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "Bugrapport verzenden mislukt. Probeer het later opnieuw.",
     "bugReportFailedWithError": "Bugrapport verzenden mislukt: {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3359,7 +3359,21 @@
     "bugReportExpectedBehaviorHint": "Co powinno się stać zamiast tego?",
     "bugReportDiagnosticsNotice": "Informacje o urządzeniu i logi zostaną dołączone automatycznie.",
     "bugReportSuccessMessage": "Dzięki! Dostaliśmy twoje zgłoszenie i wykorzystamy je, żeby ulepszyć Divine.",
-    "bugReportSendFailed": "Nie udało się wysłać zgłoszenia błędu. Spróbuj ponownie później.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "Nie udało się wysłać zgłoszenia błędu. Spróbuj ponownie później.",
     "bugReportFailedWithError": "Nie udało się wysłać zgłoszenia błędu: {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3359,7 +3359,21 @@
     "bugReportExpectedBehaviorHint": "O que deveria ter acontecido?",
     "bugReportDiagnosticsNotice": "Informações do dispositivo e logs serão incluídos automaticamente.",
     "bugReportSuccessMessage": "Valeu! Recebemos seu relatório e vamos usar pra deixar o Divine melhor.",
-    "bugReportSendFailed": "Falha ao enviar relatório de bug. Tente novamente mais tarde.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "Falha ao enviar relatório de bug. Tente novamente mais tarde.",
     "bugReportFailedWithError": "Falha ao enviar relatório de bug: {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3359,7 +3359,21 @@
     "bugReportExpectedBehaviorHint": "Ce ar fi trebuit să se întâmple în schimb?",
     "bugReportDiagnosticsNotice": "Informațiile despre dispozitiv și jurnalele vor fi incluse automat.",
     "bugReportSuccessMessage": "Mulțumim! Am primit raportul tău și îl vom folosi ca să facem Divine mai bun.",
-    "bugReportSendFailed": "Trimiterea raportului de bug a eșuat. Încearcă din nou mai târziu.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "Trimiterea raportului de bug a eșuat. Încearcă din nou mai târziu.",
     "bugReportFailedWithError": "Trimiterea raportului de bug a eșuat: {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3359,7 +3359,21 @@
     "bugReportExpectedBehaviorHint": "Vad borde ha hänt istället?",
     "bugReportDiagnosticsNotice": "Enhetsinfo och loggar inkluderas automatiskt.",
     "bugReportSuccessMessage": "Tack! Vi har fått din rapport och använder den för att göra Divine bättre.",
-    "bugReportSendFailed": "Kunde inte skicka buggrapporten. Försök igen senare.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "Kunde inte skicka buggrapporten. Försök igen senare.",
     "bugReportFailedWithError": "Buggrapport kunde inte skickas: {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3359,7 +3359,21 @@
     "bugReportExpectedBehaviorHint": "Bunun yerine ne olmalıydı?",
     "bugReportDiagnosticsNotice": "Cihaz bilgileri ve günlükler otomatik olarak eklenecek.",
     "bugReportSuccessMessage": "Teşekkürler! Raporunu aldık ve Divine'i daha iyi yapmak için kullanacağız.",
-    "bugReportSendFailed": "Hata raporu gönderilemedi. Lütfen daha sonra tekrar dene.",
+    "bugReportAttachImages": "Attach images",
+  "bugReportImagesCount": "{count} of {max} images selected",
+  "@bugReportImagesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "max": {
+        "type": "int"
+      }
+    }
+  },
+  "bugReportRemoveImage": "Remove image",
+  "bugReportUploadFailed": "We couldn't upload the selected image. Try again or send the report without it.",
+  "bugReportSendFailed": "Hata raporu gönderilemedi. Lütfen daha sonra tekrar dene.",
     "bugReportFailedWithError": "Hata raporu gönderilemedi: {error}",
     "@bugReportFailedWithError": {
         "placeholders": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10058,6 +10058,30 @@ abstract class AppLocalizations {
   /// **'Thank you! We\'ve received your report and will use it to make Divine better.'**
   String get bugReportSuccessMessage;
 
+  /// No description provided for @bugReportAttachImages.
+  ///
+  /// In en, this message translates to:
+  /// **'Attach images'**
+  String get bugReportAttachImages;
+
+  /// No description provided for @bugReportImagesCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} of {max} images selected'**
+  String bugReportImagesCount(int count, int max);
+
+  /// No description provided for @bugReportRemoveImage.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove image'**
+  String get bugReportRemoveImage;
+
+  /// No description provided for @bugReportUploadFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'We couldn\'t upload the selected image. Try again or send the report without it.'**
+  String get bugReportUploadFailed;
+
   /// No description provided for @bugReportSendFailed.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5572,6 +5572,21 @@ class AppLocalizationsAm extends AppLocalizations {
       'እናመሰግናለን! ሪፖርትዎን ተቀብለናል፣ Divineን ለማሻሻል እንጠቀምበታለን።';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed => 'የሳንካ ሪፖርት መላክ አልተሳካም። እባክዎ ቆይተው ይሞክሩ።';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5639,6 +5639,21 @@ class AppLocalizationsAr extends AppLocalizations {
       'شكرًا لك! استلمنا تقريرك وسنستخدمه لجعل Divine أفضل.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'فشل إرسال تقرير الخطأ. حاول مرّة أخرى لاحقًا.';
 

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5753,6 +5753,21 @@ class AppLocalizationsBg extends AppLocalizations {
       'Благодарим ти! Получихме доклада ти и ще го използваме, за да направим Divine по-добро.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'Изпращането на доклада не успя. Опитай пак по-късно.';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5763,6 +5763,21 @@ class AppLocalizationsDe extends AppLocalizations {
       'Danke! Wir haben deinen Bericht erhalten und nutzen ihn, um Divine besser zu machen.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'Bug-Bericht konnte nicht gesendet werden. Versuch es später nochmal.';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5689,6 +5689,21 @@ class AppLocalizationsEn extends AppLocalizations {
       'Thank you! We\'ve received your report and will use it to make Divine better.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'Failed to send bug report. Please try again later.';
 

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5745,6 +5745,21 @@ class AppLocalizationsEs extends AppLocalizations {
       '¡Gracias! Recibimos tu reporte y lo vamos a usar para hacer Divine mejor.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'No se pudo enviar el reporte de bug. Probá de nuevo más tarde.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5763,6 +5763,21 @@ class AppLocalizationsFil extends AppLocalizations {
       'Salamat! Natanggap namin ang report mo at gagamitin namin ito para mas gumanda ang Divine.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'Hindi naipadala ang bug report. Subukan ulit mamaya.';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5768,6 +5768,21 @@ class AppLocalizationsFr extends AppLocalizations {
       'Merci ! On a bien reçu ton rapport et on s\'en servira pour améliorer Divine.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'Échec de l\'envoi du rapport de bug. Réessaie plus tard.';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5662,6 +5662,21 @@ class AppLocalizationsId extends AppLocalizations {
       'Terima kasih! Laporanmu sudah kami terima dan akan kami pakai untuk membuat Divine lebih baik.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'Gagal mengirim laporan bug. Coba lagi nanti.';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5739,6 +5739,21 @@ class AppLocalizationsIt extends AppLocalizations {
       'Grazie! Abbiamo ricevuto la tua segnalazione e la useremo per migliorare Divine.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'Impossibile inviare la segnalazione. Riprova più tardi.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5447,6 +5447,21 @@ class AppLocalizationsJa extends AppLocalizations {
   String get bugReportSuccessMessage => 'ありがとう！レポートを受け取ったよ。Divine をよくするのに使うね。';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed => 'バグレポートの送信に失敗。あとでもう一回試してみて。';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5472,6 +5472,21 @@ class AppLocalizationsKo extends AppLocalizations {
       '고마워요! 신고를 받았어요. Divine을 더 좋게 만드는 데 쓸게요.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed => '버그 신고를 보내지 못했어요. 잠시 후 다시 시도해주세요.';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5715,6 +5715,21 @@ class AppLocalizationsNl extends AppLocalizations {
       'Dank je! We hebben je rapport ontvangen en gebruiken het om Divine beter te maken.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'Bugrapport verzenden mislukt. Probeer het later opnieuw.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5832,6 +5832,21 @@ class AppLocalizationsPl extends AppLocalizations {
       'Dzięki! Dostaliśmy twoje zgłoszenie i wykorzystamy je, żeby ulepszyć Divine.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'Nie udało się wysłać zgłoszenia błędu. Spróbuj ponownie później.';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5725,6 +5725,21 @@ class AppLocalizationsPt extends AppLocalizations {
       'Valeu! Recebemos seu relatório e vamos usar pra deixar o Divine melhor.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'Falha ao enviar relatório de bug. Tente novamente mais tarde.';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5841,6 +5841,21 @@ class AppLocalizationsRo extends AppLocalizations {
       'Mulțumim! Am primit raportul tău și îl vom folosi ca să facem Divine mai bun.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'Trimiterea raportului de bug a eșuat. Încearcă din nou mai târziu.';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5688,6 +5688,21 @@ class AppLocalizationsSv extends AppLocalizations {
       'Tack! Vi har fått din rapport och använder den för att göra Divine bättre.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'Kunde inte skicka buggrapporten. Försök igen senare.';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5667,6 +5667,21 @@ class AppLocalizationsTr extends AppLocalizations {
       'Teşekkürler! Raporunu aldık ve Divine\'i daha iyi yapmak için kullanacağız.';
 
   @override
+  String get bugReportAttachImages => 'Attach images';
+
+  @override
+  String bugReportImagesCount(int count, int max) {
+    return '$count of $max images selected';
+  }
+
+  @override
+  String get bugReportRemoveImage => 'Remove image';
+
+  @override
+  String get bugReportUploadFailed =>
+      'We couldn\'t upload the selected image. Try again or send the report without it.';
+
+  @override
   String get bugReportSendFailed =>
       'Hata raporu gönderilemedi. Lütfen daha sonra tekrar dene.';
 

--- a/mobile/lib/services/zendesk_support_service.dart
+++ b/mobile/lib/services/zendesk_support_service.dart
@@ -562,6 +562,7 @@ class ZendeskSupportService {
     List<String>? tags,
     int? ticketFormId,
     List<Map<String, dynamic>>? customFields,
+    List<String>? attachmentPaths,
   }) async {
     if (!_initialized) {
       Log.warning(
@@ -584,6 +585,8 @@ class ZendeskSupportService {
         'ticketFormId': ?ticketFormId,
         if (customFields != null && customFields.isNotEmpty)
           'customFields': customFields,
+        if (attachmentPaths != null && attachmentPaths.isNotEmpty)
+          'attachmentPaths': attachmentPaths,
       });
 
       if (result == true) {
@@ -648,6 +651,8 @@ class ZendeskSupportService {
               'ticketFormId': ?ticketFormId,
               if (customFields != null && customFields.isNotEmpty)
                 'customFields': customFields,
+              if (attachmentPaths != null && attachmentPaths.isNotEmpty)
+                'attachmentPaths': attachmentPaths,
             });
             if (retryResult == true) {
               Log.info(
@@ -843,6 +848,7 @@ class ZendeskSupportService {
     String? userPubkey,
     Map<String, int>? errorCounts,
     String? logsSummary,
+    List<String>? attachmentPaths,
   }) async {
     Log.info(
       'Creating structured Zendesk bug report: $reportId',
@@ -949,6 +955,7 @@ class ZendeskSupportService {
         tags: tags,
         ticketFormId: 14772963437071,
         customFields: customFields,
+        attachmentPaths: attachmentPaths,
       );
     }
 

--- a/mobile/lib/services/zendesk_support_service.dart
+++ b/mobile/lib/services/zendesk_support_service.dart
@@ -17,6 +17,10 @@ typedef JwtIdentityRefresh =
       required String relayManagerUrl,
     });
 
+class ZendeskAttachmentUploadException implements Exception {
+  const ZendeskAttachmentUploadException();
+}
+
 /// Service for interacting with Zendesk Support SDK
 class ZendeskSupportService {
   static const MethodChannel _channel = MethodChannel(
@@ -625,6 +629,14 @@ class ZendeskSupportService {
         tags: tags,
       );
     } on PlatformException catch (e) {
+      if (e.code == 'UPLOAD_FAILED') {
+        Log.error(
+          'Zendesk attachment upload failed: ${e.message}',
+          category: LogCategory.system,
+        );
+        throw const ZendeskAttachmentUploadException();
+      }
+
       Log.error(
         '❌ Zendesk SDK error: ${e.code} - ${e.message}',
         category: LogCategory.system,

--- a/mobile/lib/widgets/bug_report_dialog.dart
+++ b/mobile/lib/widgets/bug_report_dialog.dart
@@ -7,10 +7,12 @@ import 'dart:async';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:openvine/config/bug_report_config.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/services/bug_report_service.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
+import 'package:openvine/widgets/image_attachment_picker.dart';
 import 'package:openvine/widgets/support_dialog_utils.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -90,6 +92,7 @@ class _BugReportDialogState extends State<BugReportDialog> {
   bool? _isSuccess;
   bool _isDisposed = false;
   Timer? _closeTimer;
+  List<XFile> _attachments = [];
 
   @override
   void dispose() {
@@ -139,6 +142,7 @@ class _BugReportDialogState extends State<BugReportDialog> {
         userPubkey: widget.userPubkey,
         errorCounts: reportData.errorCounts,
         logsSummary: _buildLogsSummary(reportData.recentLogs),
+        attachmentPaths: _attachments.map((f) => f.path).toList(),
       );
 
       if (!_isDisposed && mounted) {
@@ -253,6 +257,14 @@ class _BugReportDialogState extends State<BugReportDialog> {
                   hint: context.l10n.bugReportExpectedBehaviorHint,
                 ),
                 onChanged: (_) => setState(() {}),
+              ),
+
+              const SizedBox(height: 16),
+
+              // Image attachments (mobile only)
+              ImageAttachmentPicker(
+                enabled: !_isSubmitting,
+                onChanged: (files) => setState(() => _attachments = files),
               ),
 
               const SizedBox(height: 8),

--- a/mobile/lib/widgets/bug_report_dialog.dart
+++ b/mobile/lib/widgets/bug_report_dialog.dart
@@ -177,7 +177,9 @@ class _BugReportDialogState extends State<BugReportDialog> {
         setState(() {
           _isSubmitting = false;
           _isSuccess = false;
-          _resultMessage = context.l10n.bugReportFailedWithError('$e');
+          _resultMessage = e is ZendeskAttachmentUploadException
+              ? context.l10n.bugReportUploadFailed
+              : context.l10n.bugReportSendFailed;
         });
       }
     }
@@ -272,7 +274,7 @@ class _BugReportDialogState extends State<BugReportDialog> {
               // Info text
               Text(
                 context.l10n.bugReportDiagnosticsNotice,
-                style: TextStyle(color: Colors.grey.shade500, fontSize: 12),
+                style: VineTheme.bodySmallFont(color: VineTheme.lightText),
               ),
 
               const SizedBox(height: 16),

--- a/mobile/lib/widgets/image_attachment_picker.dart
+++ b/mobile/lib/widgets/image_attachment_picker.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 // ABOUTME: Mobile-only image attachment picker for bug reports.
 // ABOUTME: Limits the selection count, announces changes for accessibility,
@@ -43,10 +44,28 @@ class _ImageAttachmentPickerState extends State<ImageAttachmentPicker> {
     final remaining = widget.maxImages - _images.length;
     if (remaining <= 0) return;
 
-    final picked = await ImageAttachmentPicker.imagePicker.pickMultiImage(
-      maxWidth: 1920,
-      imageQuality: 80,
-    );
+    List<XFile> picked;
+    try {
+      picked = await ImageAttachmentPicker.imagePicker.pickMultiImage(
+        maxWidth: 1920,
+        imageQuality: 80,
+      );
+    } catch (error, stackTrace) {
+      Log.error(
+        'Failed to pick bug report attachments: $error',
+        category: LogCategory.ui,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(context.l10n.bugReportUploadFailed),
+          backgroundColor: VineTheme.error,
+        ),
+      );
+      return;
+    }
 
     if (!mounted) return;
     if (picked.isEmpty) return;

--- a/mobile/lib/widgets/image_attachment_picker.dart
+++ b/mobile/lib/widgets/image_attachment_picker.dart
@@ -19,15 +19,15 @@ class ImageAttachmentPicker extends StatefulWidget {
   final ValueChanged<List<XFile>> onChanged;
   final bool enabled;
 
+  @visibleForTesting
+  static ImagePicker imagePicker = ImagePicker();
+
   @override
   State<ImageAttachmentPicker> createState() => _ImageAttachmentPickerState();
 }
 
 class _ImageAttachmentPickerState extends State<ImageAttachmentPicker> {
   final List<XFile> _images = [];
-
-  @visibleForTesting
-  static ImagePicker imagePicker = ImagePicker();
 
   bool get _isMobile =>
       defaultTargetPlatform == TargetPlatform.iOS ||
@@ -39,7 +39,7 @@ class _ImageAttachmentPickerState extends State<ImageAttachmentPicker> {
     final remaining = widget.maxImages - _images.length;
     if (remaining <= 0) return;
 
-    final picked = await imagePicker.pickMultiImage(
+    final picked = await ImageAttachmentPicker.imagePicker.pickMultiImage(
       maxWidth: 1920,
       imageQuality: 80,
     );

--- a/mobile/lib/widgets/image_attachment_picker.dart
+++ b/mobile/lib/widgets/image_attachment_picker.dart
@@ -1,0 +1,218 @@
+import 'dart:io';
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+class ImageAttachmentPicker extends StatefulWidget {
+  const ImageAttachmentPicker({
+    required this.onChanged,
+    super.key,
+    this.maxImages = 3,
+    this.enabled = true,
+  });
+
+  final int maxImages;
+  final ValueChanged<List<XFile>> onChanged;
+  final bool enabled;
+
+  @override
+  State<ImageAttachmentPicker> createState() => _ImageAttachmentPickerState();
+}
+
+class _ImageAttachmentPickerState extends State<ImageAttachmentPicker> {
+  final List<XFile> _images = [];
+
+  @visibleForTesting
+  static ImagePicker imagePicker = ImagePicker();
+
+  bool get _isMobile =>
+      defaultTargetPlatform == TargetPlatform.iOS ||
+      defaultTargetPlatform == TargetPlatform.android;
+
+  Future<void> _pickImages() async {
+    if (!widget.enabled) return;
+
+    final remaining = widget.maxImages - _images.length;
+    if (remaining <= 0) return;
+
+    final picked = await imagePicker.pickMultiImage(
+      maxWidth: 1920,
+      imageQuality: 80,
+    );
+
+    if (picked.isEmpty) return;
+
+    setState(() {
+      final toAdd = picked.take(remaining).toList();
+      _images.addAll(toAdd);
+    });
+    widget.onChanged(List.unmodifiable(_images));
+
+    if (mounted) {
+      SemanticsService.sendAnnouncement(
+        View.of(context),
+        context.l10n.bugReportImagesCount(_images.length, widget.maxImages),
+        TextDirection.ltr,
+      );
+    }
+  }
+
+  void _removeImage(int index) {
+    if (!widget.enabled) return;
+
+    setState(() {
+      _images.removeAt(index);
+    });
+    widget.onChanged(List.unmodifiable(_images));
+
+    if (mounted) {
+      SemanticsService.sendAnnouncement(
+        View.of(context),
+        context.l10n.bugReportImagesCount(_images.length, widget.maxImages),
+        TextDirection.ltr,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isMobile) return const SizedBox.shrink();
+
+    final l10n = context.l10n;
+    final showAddButton = _images.length < widget.maxImages;
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        for (var i = 0; i < _images.length; i++)
+          _Thumbnail(
+            file: _images[i],
+            enabled: widget.enabled,
+            semanticsLabel: l10n.bugReportRemoveImage,
+            onRemove: () => _removeImage(i),
+          ),
+        if (showAddButton)
+          _AddButton(
+            enabled: widget.enabled,
+            semanticsLabel: l10n.bugReportAttachImages,
+            onTap: _pickImages,
+          ),
+      ],
+    );
+  }
+}
+
+class _Thumbnail extends StatelessWidget {
+  const _Thumbnail({
+    required this.file,
+    required this.enabled,
+    required this.semanticsLabel,
+    required this.onRemove,
+  });
+
+  final XFile file;
+  final bool enabled;
+  final String semanticsLabel;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 64,
+      height: 64,
+      child: Stack(
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: Image.file(
+              File(file.path),
+              width: 64,
+              height: 64,
+              fit: BoxFit.cover,
+              semanticLabel: file.name,
+              errorBuilder: (_, _, _) => Container(
+                width: 64,
+                height: 64,
+                color: VineTheme.cardBackground,
+                child: const Icon(
+                  Icons.broken_image_outlined,
+                  color: VineTheme.lightText,
+                  size: 24,
+                ),
+              ),
+            ),
+          ),
+          if (enabled)
+            Positioned(
+              top: 0,
+              right: 0,
+              child: Semantics(
+                button: true,
+                label: semanticsLabel,
+                child: GestureDetector(
+                  onTap: onRemove,
+                  child: ExcludeSemantics(
+                    child: Container(
+                      width: 20,
+                      height: 20,
+                      decoration: const BoxDecoration(
+                        color: VineTheme.cardBackground,
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        Icons.close,
+                        size: 14,
+                        color: VineTheme.whiteText,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AddButton extends StatelessWidget {
+  const _AddButton({
+    required this.enabled,
+    required this.semanticsLabel,
+    required this.onTap,
+  });
+
+  final bool enabled;
+  final String semanticsLabel;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: semanticsLabel,
+      child: GestureDetector(
+        onTap: enabled ? onTap : null,
+        child: ExcludeSemantics(
+          child: Container(
+            width: 64,
+            height: 64,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: Colors.grey),
+            ),
+            child: Icon(
+              Icons.add_photo_alternate_outlined,
+              color: enabled ? VineTheme.vineGreen : Colors.grey,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/image_attachment_picker.dart
+++ b/mobile/lib/widgets/image_attachment_picker.dart
@@ -7,6 +7,10 @@ import 'package:flutter/rendering.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:openvine/l10n/l10n.dart';
 
+// ABOUTME: Mobile-only image attachment picker for bug reports.
+// ABOUTME: Limits the selection count, announces changes for accessibility,
+// ABOUTME: and keeps interactions aligned with the Divine design system.
+
 class ImageAttachmentPicker extends StatefulWidget {
   const ImageAttachmentPicker({
     required this.onChanged,
@@ -44,6 +48,7 @@ class _ImageAttachmentPickerState extends State<ImageAttachmentPicker> {
       imageQuality: 80,
     );
 
+    if (!mounted) return;
     if (picked.isEmpty) return;
 
     setState(() {
@@ -56,7 +61,7 @@ class _ImageAttachmentPickerState extends State<ImageAttachmentPicker> {
       SemanticsService.sendAnnouncement(
         View.of(context),
         context.l10n.bugReportImagesCount(_images.length, widget.maxImages),
-        TextDirection.ltr,
+        Directionality.of(context),
       );
     }
   }
@@ -73,7 +78,7 @@ class _ImageAttachmentPickerState extends State<ImageAttachmentPicker> {
       SemanticsService.sendAnnouncement(
         View.of(context),
         context.l10n.bugReportImagesCount(_images.length, widget.maxImages),
-        TextDirection.ltr,
+        Directionality.of(context),
       );
     }
   }
@@ -139,10 +144,9 @@ class _Thumbnail extends StatelessWidget {
                 width: 64,
                 height: 64,
                 color: VineTheme.cardBackground,
-                child: const Icon(
-                  Icons.broken_image_outlined,
+                child: const DivineIcon(
+                  icon: DivineIconName.image,
                   color: VineTheme.lightText,
-                  size: 24,
                 ),
               ),
             ),
@@ -155,19 +159,27 @@ class _Thumbnail extends StatelessWidget {
                 button: true,
                 label: semanticsLabel,
                 child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
                   onTap: onRemove,
-                  child: ExcludeSemantics(
-                    child: Container(
-                      width: 20,
-                      height: 20,
-                      decoration: const BoxDecoration(
-                        color: VineTheme.cardBackground,
-                        shape: BoxShape.circle,
-                      ),
-                      child: const Icon(
-                        Icons.close,
-                        size: 14,
-                        color: VineTheme.whiteText,
+                  child: SizedBox(
+                    width: 48,
+                    height: 48,
+                    child: Align(
+                      alignment: Alignment.topRight,
+                      child: ExcludeSemantics(
+                        child: Container(
+                          width: 20,
+                          height: 20,
+                          decoration: const BoxDecoration(
+                            color: VineTheme.cardBackground,
+                            shape: BoxShape.circle,
+                          ),
+                          child: const DivineIcon(
+                            icon: DivineIconName.x,
+                            size: 14,
+                            color: VineTheme.whiteText,
+                          ),
+                        ),
                       ),
                     ),
                   ),
@@ -204,11 +216,17 @@ class _AddButton extends StatelessWidget {
             height: 64,
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(8),
-              border: Border.all(color: Colors.grey),
+              border: Border.all(
+                color: enabled
+                    ? VineTheme.vineGreen.withValues(alpha: 0.7)
+                    : VineTheme.lightText.withValues(alpha: 0.7),
+              ),
             ),
-            child: Icon(
-              Icons.add_photo_alternate_outlined,
-              color: enabled ? VineTheme.vineGreen : Colors.grey,
+            child: Center(
+              child: DivineIcon(
+                icon: DivineIconName.imagesSquare,
+                color: enabled ? VineTheme.vineGreen : VineTheme.lightText,
+              ),
             ),
           ),
         ),

--- a/mobile/test/services/zendesk_support_service_test.dart
+++ b/mobile/test/services/zendesk_support_service_test.dart
@@ -454,9 +454,7 @@ void main() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall call) async {
             if (call.method == 'createTicket') {
-              capturedArgs = Map<String, dynamic>.from(
-                call.arguments as Map,
-              );
+              capturedArgs = Map<String, dynamic>.from(call.arguments as Map);
               return true;
             }
             return null;
@@ -469,10 +467,10 @@ void main() {
       );
 
       expect(capturedArgs, isNotNull);
-      expect(
-        capturedArgs!['attachmentPaths'],
-        ['/tmp/img1.jpg', '/tmp/img2.jpg'],
-      );
+      expect(capturedArgs!['attachmentPaths'], [
+        '/tmp/img1.jpg',
+        '/tmp/img2.jpg',
+      ]);
     });
 
     test('omits attachmentPaths when null', () async {
@@ -480,9 +478,7 @@ void main() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall call) async {
             if (call.method == 'createTicket') {
-              capturedArgs = Map<String, dynamic>.from(
-                call.arguments as Map,
-              );
+              capturedArgs = Map<String, dynamic>.from(call.arguments as Map);
               return true;
             }
             return null;
@@ -502,9 +498,7 @@ void main() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, (MethodCall call) async {
             if (call.method == 'createTicket') {
-              capturedArgs = Map<String, dynamic>.from(
-                call.arguments as Map,
-              );
+              capturedArgs = Map<String, dynamic>.from(call.arguments as Map);
               return true;
             }
             return null;
@@ -519,6 +513,32 @@ void main() {
       expect(capturedArgs, isNotNull);
       expect(capturedArgs!.containsKey('attachmentPaths'), false);
     });
+
+    test(
+      'throws a sanitized attachment upload exception on upload failure',
+      () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (MethodCall call) async {
+              if (call.method == 'createTicket') {
+                throw PlatformException(
+                  code: 'UPLOAD_FAILED',
+                  message:
+                      'File not found: /private/var/mobile/Containers/Data/Application/foo.jpg',
+                );
+              }
+              return null;
+            });
+
+        await expectLater(
+          () => ZendeskSupportService.createTicket(
+            subject: 'Test',
+            description: 'Test desc',
+            attachmentPaths: ['/tmp/img1.jpg'],
+          ),
+          throwsA(isA<ZendeskAttachmentUploadException>()),
+        );
+      },
+    );
   });
 
   group('ZendeskSupportService.createTicket JWT expiry retry', () {

--- a/mobile/test/services/zendesk_support_service_test.dart
+++ b/mobile/test/services/zendesk_support_service_test.dart
@@ -435,6 +435,92 @@ void main() {
     });
   });
 
+  group('ZendeskSupportService.createTicket attachmentPaths', () {
+    setUp(() async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+            if (call.method == 'initialize') return true;
+            return null;
+          });
+      await ZendeskSupportService.initialize(
+        appId: 'test',
+        clientId: 'test',
+        zendeskUrl: 'https://test.zendesk.com',
+      );
+    });
+
+    test('includes attachmentPaths when provided', () async {
+      Map<String, dynamic>? capturedArgs;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+            if (call.method == 'createTicket') {
+              capturedArgs = Map<String, dynamic>.from(
+                call.arguments as Map,
+              );
+              return true;
+            }
+            return null;
+          });
+
+      await ZendeskSupportService.createTicket(
+        subject: 'Test',
+        description: 'Test desc',
+        attachmentPaths: ['/tmp/img1.jpg', '/tmp/img2.jpg'],
+      );
+
+      expect(capturedArgs, isNotNull);
+      expect(
+        capturedArgs!['attachmentPaths'],
+        ['/tmp/img1.jpg', '/tmp/img2.jpg'],
+      );
+    });
+
+    test('omits attachmentPaths when null', () async {
+      Map<String, dynamic>? capturedArgs;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+            if (call.method == 'createTicket') {
+              capturedArgs = Map<String, dynamic>.from(
+                call.arguments as Map,
+              );
+              return true;
+            }
+            return null;
+          });
+
+      await ZendeskSupportService.createTicket(
+        subject: 'Test',
+        description: 'Test desc',
+      );
+
+      expect(capturedArgs, isNotNull);
+      expect(capturedArgs!.containsKey('attachmentPaths'), false);
+    });
+
+    test('omits attachmentPaths when empty list', () async {
+      Map<String, dynamic>? capturedArgs;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+            if (call.method == 'createTicket') {
+              capturedArgs = Map<String, dynamic>.from(
+                call.arguments as Map,
+              );
+              return true;
+            }
+            return null;
+          });
+
+      await ZendeskSupportService.createTicket(
+        subject: 'Test',
+        description: 'Test desc',
+        attachmentPaths: [],
+      );
+
+      expect(capturedArgs, isNotNull);
+      expect(capturedArgs!.containsKey('attachmentPaths'), false);
+    });
+  });
+
   group('ZendeskSupportService.createTicket JWT expiry retry', () {
     test(
       'retries with anonymous identity when JWT returns unauthorized',

--- a/mobile/test/widgets/bug_report_dialog_test.dart
+++ b/mobile/test/widgets/bug_report_dialog_test.dart
@@ -274,5 +274,34 @@ void main() {
 
       expect(dialogClosed, isTrue);
     });
+
+    testWidgets('submits successfully with zero attachments', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: BugReportDialog(bugReportService: mockBugReportService),
+          ),
+        ),
+      );
+
+      // Fill required fields
+      await tester.enterText(find.byType(TextField).at(0), 'Test subject');
+      await tester.enterText(
+        find.byType(TextField).at(1),
+        'Test description',
+      );
+      await tester.pump();
+
+      // Verify Send button is enabled with zero attachments
+      final sendButton = find.text('Send Report');
+      final button = tester.widget<ElevatedButton>(
+        find.ancestor(of: sendButton, matching: find.byType(ElevatedButton)),
+      );
+      expect(button.onPressed, isNotNull);
+    });
   });
 }

--- a/mobile/test/widgets/bug_report_dialog_test.dart
+++ b/mobile/test/widgets/bug_report_dialog_test.dart
@@ -15,6 +15,8 @@ class _MockBugReportService extends Mock implements BugReportService {}
 class _FakeBugReportData extends Fake implements BugReportData {}
 
 void main() {
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
   setUpAll(() {
     registerFallbackValue(_FakeBugReportData());
   });
@@ -38,16 +40,16 @@ void main() {
       );
 
       // Verify title
-      expect(find.text('Report a Bug'), findsOneWidget);
+      expect(find.text(l10n.supportReportBug), findsOneWidget);
 
       // Verify all 4 text fields exist
       expect(find.byType(TextField), findsNWidgets(4));
 
       // Verify labels
-      expect(find.text('Subject *'), findsOneWidget);
-      expect(find.text('What happened? *'), findsOneWidget);
-      expect(find.text('Steps to Reproduce'), findsOneWidget);
-      expect(find.text('Expected Behavior'), findsOneWidget);
+      expect(find.text(l10n.supportSubjectRequiredLabel), findsOneWidget);
+      expect(find.text(l10n.bugReportDescriptionRequiredLabel), findsOneWidget);
+      expect(find.text(l10n.bugReportStepsLabel), findsOneWidget);
+      expect(find.text(l10n.bugReportExpectedBehaviorLabel), findsOneWidget);
     });
 
     testWidgets('should have Send and Cancel buttons', (tester) async {
@@ -61,8 +63,8 @@ void main() {
         ),
       );
 
-      expect(find.text('Send Report'), findsOneWidget);
-      expect(find.text('Cancel'), findsOneWidget);
+      expect(find.text(l10n.bugReportSendReport), findsOneWidget);
+      expect(find.text(l10n.commonCancel), findsOneWidget);
     });
 
     testWidgets('should disable Send button when required fields are empty', (
@@ -78,7 +80,7 @@ void main() {
         ),
       );
 
-      final sendButton = find.text('Send Report');
+      final sendButton = find.text(l10n.bugReportSendReport);
       expect(sendButton, findsOneWidget);
 
       // Button should be disabled when required fields are empty
@@ -112,7 +114,7 @@ void main() {
       );
       await tester.pump();
 
-      final sendButton = find.text('Send Report');
+      final sendButton = find.text(l10n.bugReportSendReport);
       final button = tester.widget<ElevatedButton>(
         find.ancestor(of: sendButton, matching: find.byType(ElevatedButton)),
       );
@@ -158,7 +160,7 @@ void main() {
       );
       await tester.pump();
 
-      await tester.tap(find.text('Send Report'));
+      await tester.tap(find.text(l10n.bugReportSendReport));
       await tester.pump();
 
       verify(
@@ -215,7 +217,7 @@ void main() {
       );
       await tester.pump();
 
-      await tester.tap(find.text('Send Report'));
+      await tester.tap(find.text(l10n.bugReportSendReport));
       await tester.pump();
 
       // Should show loading indicator
@@ -267,17 +269,15 @@ void main() {
       await tester.tap(find.text('Open'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Report a Bug'), findsOneWidget);
+      expect(find.text(l10n.supportReportBug), findsOneWidget);
 
-      await tester.tap(find.text('Cancel'));
+      await tester.tap(find.text(l10n.commonCancel));
       await tester.pumpAndSettle();
 
       expect(dialogClosed, isTrue);
     });
 
-    testWidgets('submits successfully with zero attachments', (
-      tester,
-    ) async {
+    testWidgets('submits successfully with zero attachments', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -290,14 +290,11 @@ void main() {
 
       // Fill required fields
       await tester.enterText(find.byType(TextField).at(0), 'Test subject');
-      await tester.enterText(
-        find.byType(TextField).at(1),
-        'Test description',
-      );
+      await tester.enterText(find.byType(TextField).at(1), 'Test description');
       await tester.pump();
 
       // Verify Send button is enabled with zero attachments
-      final sendButton = find.text('Send Report');
+      final sendButton = find.text(l10n.bugReportSendReport);
       final button = tester.widget<ElevatedButton>(
         find.ancestor(of: sendButton, matching: find.byType(ElevatedButton)),
       );

--- a/mobile/test/widgets/image_attachment_picker_test.dart
+++ b/mobile/test/widgets/image_attachment_picker_test.dart
@@ -1,3 +1,4 @@
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -46,7 +47,7 @@ void main() {
       try {
         await tester.pumpWidget(buildTestWidget());
         expect(
-          find.byIcon(Icons.add_photo_alternate_outlined),
+          find.bySemanticsLabel(l10n.bugReportAttachImages),
           findsOneWidget,
         );
       } finally {
@@ -58,7 +59,7 @@ void main() {
       debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
       try {
         await tester.pumpWidget(buildTestWidget());
-        expect(find.byIcon(Icons.add_photo_alternate_outlined), findsNothing);
+        expect(find.bySemanticsLabel(l10n.bugReportAttachImages), findsNothing);
       } finally {
         debugDefaultTargetPlatformOverride = null;
       }
@@ -80,7 +81,7 @@ void main() {
           buildTestWidget(onChanged: (files) => result = files),
         );
 
-        await tester.tap(find.byIcon(Icons.add_photo_alternate_outlined));
+        await tester.tap(find.bySemanticsLabel(l10n.bugReportAttachImages));
         await tester.pumpAndSettle();
 
         expect(result, isNotNull);
@@ -109,12 +110,10 @@ void main() {
 
         List<XFile>? result;
         await tester.pumpWidget(
-          buildTestWidget(
-            onChanged: (files) => result = files,
-          ),
+          buildTestWidget(onChanged: (files) => result = files),
         );
 
-        await tester.tap(find.byIcon(Icons.add_photo_alternate_outlined));
+        await tester.tap(find.bySemanticsLabel(l10n.bugReportAttachImages));
         await tester.pumpAndSettle();
 
         expect(result!.length, 3);
@@ -140,10 +139,10 @@ void main() {
 
         await tester.pumpWidget(buildTestWidget());
 
-        await tester.tap(find.byIcon(Icons.add_photo_alternate_outlined));
+        await tester.tap(find.bySemanticsLabel(l10n.bugReportAttachImages));
         await tester.pumpAndSettle();
 
-        expect(find.byIcon(Icons.add_photo_alternate_outlined), findsNothing);
+        expect(find.bySemanticsLabel(l10n.bugReportAttachImages), findsNothing);
       } finally {
         debugDefaultTargetPlatformOverride = null;
       }
@@ -165,12 +164,14 @@ void main() {
           buildTestWidget(onChanged: (files) => lastResult = files),
         );
 
-        await tester.tap(find.byIcon(Icons.add_photo_alternate_outlined));
+        await tester.tap(find.bySemanticsLabel(l10n.bugReportAttachImages));
         await tester.pumpAndSettle();
 
         expect(lastResult!.length, 2);
 
-        await tester.tap(find.byIcon(Icons.close).first);
+        await tester.tap(
+          find.bySemanticsLabel(l10n.bugReportRemoveImage).first,
+        );
         await tester.pumpAndSettle();
 
         expect(lastResult!.length, 1);
@@ -186,7 +187,7 @@ void main() {
         await tester.pumpWidget(buildTestWidget());
 
         final semantics = tester.getSemantics(
-          find.byIcon(Icons.add_photo_alternate_outlined),
+          find.bySemanticsLabel(l10n.bugReportAttachImages),
         );
         expect(semantics.label, l10n.bugReportAttachImages);
       } finally {
@@ -194,15 +195,50 @@ void main() {
       }
     });
 
-    testWidgets('disabled state shows grey icon', (tester) async {
+    testWidgets('disabled state uses themed disabled icon color', (
+      tester,
+    ) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
       try {
         await tester.pumpWidget(buildTestWidget(enabled: false));
 
-        final icon = tester.widget<Icon>(
-          find.byIcon(Icons.add_photo_alternate_outlined),
+        final icon = tester.widget<DivineIcon>(
+          find.descendant(
+            of: find.bySemanticsLabel(l10n.bugReportAttachImages),
+            matching: find.byType(DivineIcon),
+          ),
         );
-        expect(icon.color, Colors.grey);
+        expect(icon.color, VineTheme.lightText);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('remove button keeps a 48dp hit target', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      try {
+        final pickedFiles = [XFile('/tmp/img1.jpg')];
+        when(
+          () => mockPicker.pickMultiImage(
+            maxWidth: any(named: 'maxWidth'),
+            imageQuality: any(named: 'imageQuality'),
+          ),
+        ).thenAnswer((_) async => pickedFiles);
+
+        await tester.pumpWidget(buildTestWidget());
+
+        await tester.tap(find.bySemanticsLabel(l10n.bugReportAttachImages));
+        await tester.pumpAndSettle();
+
+        final hitTarget = find.descendant(
+          of: find.bySemanticsLabel(l10n.bugReportRemoveImage),
+          matching: find.byWidgetPredicate(
+            (widget) =>
+                widget is SizedBox && widget.width == 48 && widget.height == 48,
+          ),
+        );
+
+        expect(hitTarget, findsOneWidget);
       } finally {
         debugDefaultTargetPlatformOverride = null;
       }

--- a/mobile/test/widgets/image_attachment_picker_test.dart
+++ b/mobile/test/widgets/image_attachment_picker_test.dart
@@ -110,7 +110,6 @@ void main() {
         List<XFile>? result;
         await tester.pumpWidget(
           buildTestWidget(
-            maxImages: 3,
             onChanged: (files) => result = files,
           ),
         );
@@ -139,7 +138,7 @@ void main() {
           ),
         ).thenAnswer((_) async => threeFiles);
 
-        await tester.pumpWidget(buildTestWidget(maxImages: 3));
+        await tester.pumpWidget(buildTestWidget());
 
         await tester.tap(find.byIcon(Icons.add_photo_alternate_outlined));
         await tester.pumpAndSettle();

--- a/mobile/test/widgets/image_attachment_picker_test.dart
+++ b/mobile/test/widgets/image_attachment_picker_test.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/image_attachment_picker.dart';
+
+class _MockImagePicker extends Mock implements ImagePicker {}
+
+void main() {
+  late _MockImagePicker mockPicker;
+  late AppLocalizations l10n;
+
+  setUp(() {
+    mockPicker = _MockImagePicker();
+    ImageAttachmentPicker.imagePicker = mockPicker;
+    l10n = lookupAppLocalizations(const Locale('en'));
+  });
+
+  tearDown(() {
+    ImageAttachmentPicker.imagePicker = ImagePicker();
+  });
+
+  Widget buildTestWidget({
+    int maxImages = 3,
+    bool enabled = true,
+    ValueChanged<List<XFile>>? onChanged,
+  }) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: ImageAttachmentPicker(
+          maxImages: maxImages,
+          enabled: enabled,
+          onChanged: onChanged ?? (_) {},
+        ),
+      ),
+    );
+  }
+
+  group('ImageAttachmentPicker', () {
+    testWidgets('renders add button on mobile', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      try {
+        await tester.pumpWidget(buildTestWidget());
+        expect(
+          find.byIcon(Icons.add_photo_alternate_outlined),
+          findsOneWidget,
+        );
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('renders SizedBox.shrink on non-mobile', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      try {
+        await tester.pumpWidget(buildTestWidget());
+        expect(find.byIcon(Icons.add_photo_alternate_outlined), findsNothing);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('calls onChanged when images are picked', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      try {
+        final pickedFiles = [XFile('/tmp/img1.jpg')];
+        when(
+          () => mockPicker.pickMultiImage(
+            maxWidth: any(named: 'maxWidth'),
+            imageQuality: any(named: 'imageQuality'),
+          ),
+        ).thenAnswer((_) async => pickedFiles);
+
+        List<XFile>? result;
+        await tester.pumpWidget(
+          buildTestWidget(onChanged: (files) => result = files),
+        );
+
+        await tester.tap(find.byIcon(Icons.add_photo_alternate_outlined));
+        await tester.pumpAndSettle();
+
+        expect(result, isNotNull);
+        expect(result!.length, 1);
+        expect(result!.first.path, '/tmp/img1.jpg');
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('truncates selection to remaining slots', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      try {
+        final fourFiles = [
+          XFile('/tmp/a.jpg'),
+          XFile('/tmp/b.jpg'),
+          XFile('/tmp/c.jpg'),
+          XFile('/tmp/d.jpg'),
+        ];
+        when(
+          () => mockPicker.pickMultiImage(
+            maxWidth: any(named: 'maxWidth'),
+            imageQuality: any(named: 'imageQuality'),
+          ),
+        ).thenAnswer((_) async => fourFiles);
+
+        List<XFile>? result;
+        await tester.pumpWidget(
+          buildTestWidget(
+            maxImages: 3,
+            onChanged: (files) => result = files,
+          ),
+        );
+
+        await tester.tap(find.byIcon(Icons.add_photo_alternate_outlined));
+        await tester.pumpAndSettle();
+
+        expect(result!.length, 3);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('hides add button at max count', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      try {
+        final threeFiles = [
+          XFile('/tmp/a.jpg'),
+          XFile('/tmp/b.jpg'),
+          XFile('/tmp/c.jpg'),
+        ];
+        when(
+          () => mockPicker.pickMultiImage(
+            maxWidth: any(named: 'maxWidth'),
+            imageQuality: any(named: 'imageQuality'),
+          ),
+        ).thenAnswer((_) async => threeFiles);
+
+        await tester.pumpWidget(buildTestWidget(maxImages: 3));
+
+        await tester.tap(find.byIcon(Icons.add_photo_alternate_outlined));
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.add_photo_alternate_outlined), findsNothing);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('remove button removes correct image', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      try {
+        final twoFiles = [XFile('/tmp/a.jpg'), XFile('/tmp/b.jpg')];
+        when(
+          () => mockPicker.pickMultiImage(
+            maxWidth: any(named: 'maxWidth'),
+            imageQuality: any(named: 'imageQuality'),
+          ),
+        ).thenAnswer((_) async => twoFiles);
+
+        List<XFile>? lastResult;
+        await tester.pumpWidget(
+          buildTestWidget(onChanged: (files) => lastResult = files),
+        );
+
+        await tester.tap(find.byIcon(Icons.add_photo_alternate_outlined));
+        await tester.pumpAndSettle();
+
+        expect(lastResult!.length, 2);
+
+        await tester.tap(find.byIcon(Icons.close).first);
+        await tester.pumpAndSettle();
+
+        expect(lastResult!.length, 1);
+        expect(lastResult!.first.path, '/tmp/b.jpg');
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('has correct semantics label on add button', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      try {
+        await tester.pumpWidget(buildTestWidget());
+
+        final semantics = tester.getSemantics(
+          find.byIcon(Icons.add_photo_alternate_outlined),
+        );
+        expect(semantics.label, l10n.bugReportAttachImages);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
+    testWidgets('disabled state shows grey icon', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      try {
+        await tester.pumpWidget(buildTestWidget(enabled: false));
+
+        final icon = tester.widget<Icon>(
+          find.byIcon(Icons.add_photo_alternate_outlined),
+        );
+        expect(icon.color, Colors.grey);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+  });
+}

--- a/mobile/test/widgets/image_attachment_picker_test.dart
+++ b/mobile/test/widgets/image_attachment_picker_test.dart
@@ -92,6 +92,29 @@ void main() {
       }
     });
 
+    testWidgets('shows an error snackbar when image picker throws', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      try {
+        when(
+          () => mockPicker.pickMultiImage(
+            maxWidth: any(named: 'maxWidth'),
+            imageQuality: any(named: 'imageQuality'),
+          ),
+        ).thenThrow(Exception('picker failed'));
+
+        await tester.pumpWidget(buildTestWidget());
+
+        await tester.tap(find.bySemanticsLabel(l10n.bugReportAttachImages));
+        await tester.pump();
+
+        expect(find.text(l10n.bugReportUploadFailed), findsOneWidget);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+    });
+
     testWidgets('truncates selection to remaining slots', (tester) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
       try {


### PR DESCRIPTION
## Summary

- Add `ImageAttachmentPicker` widget for selecting up to 3 gallery images in the bug report dialog
- Thread `attachmentPaths` through `ZendeskSupportService.createStructuredBugReport()` → `createTicket()` → native platform channel
- iOS: upload via `ZDKUploadProvider`, attach tokens to `ZDKCreateRequest`
- Android: upload via `UploadProvider`, attach tokens to `CreateRequest`
- Desktop: picker hidden entirely (`SizedBox.shrink()`) — no false affordance
- All user-facing strings localized via ARB keys; accessibility semantics on all interactive elements

## Test plan

- [x] iOS device/simulator: attach 1 image → submit → verify attachment visible in Zendesk
- [x] Android device/emulator: same as above
- [x] Attach 3 images → add button disappears → cannot exceed limit
- [x] Attach 2 → remove 1 → submit → ticket has 1 attachment
- [x] Submit with 0 images → works as before (regression)
- [x] Attach 1 → airplane mode → submit → error shown, no ticket created
- [x] Desktop/macOS → picker not shown, submit works as before
- [x] Disabled during submission: spinner showing → picker non-interactive

Closes #3094