### PR TITLE
fix(router): rewrite divine.video universal links before GoRouter match

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1189,6 +1189,10 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                   category: LogCategory.ui,
                 );
                 try {
+                  // GoRouter's universal-link redirect may have already
+                  // navigated here; skip the duplicate go() to avoid a
+                  // second navigation frame on the same target.
+                  if (currentLocation == targetPath) break;
                   router.go(targetPath);
                   Log.info(
                     '✅ Navigation completed to: $targetPath',
@@ -1220,6 +1224,10 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                   category: LogCategory.ui,
                 );
                 try {
+                  // GoRouter's universal-link redirect may have already
+                  // navigated here; skip the duplicate go() to avoid a
+                  // second navigation frame on the same target.
+                  if (currentLocation == targetPath) break;
                   router.go(targetPath);
                   Log.info(
                     '✅ Navigation completed to: $targetPath',
@@ -1240,8 +1248,6 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                   category: LogCategory.ui,
                 );
               }
-            // TODO(#3032): Currently unreachable — GoRouter intercepts
-            // deep links before DeepLinkService can parse them.
             case DeepLinkType.search:
               if (deepLink.searchTerm != null) {
                 final targetPath = SearchResultsPage.pathForQuery(
@@ -1253,6 +1259,10 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                   category: LogCategory.ui,
                 );
                 try {
+                  // GoRouter's universal-link redirect may have already
+                  // navigated here; skip the duplicate go() to avoid a
+                  // second navigation frame on the same target.
+                  if (currentLocation == targetPath) break;
                   router.go(targetPath);
                   Log.info(
                     '✅ Navigation completed to: $targetPath',

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1180,9 +1180,16 @@ class _DivineAppState extends ConsumerState<DivineApp> {
               }
             case DeepLinkType.profile:
               if (deepLink.npub != null) {
-                final index = deepLink.index ?? 0;
-                final targetPath =
-                    '${ProfileScreenRouter.pathForNpub(deepLink.npub!)}/$index';
+                // Mirror universalLinkToRouterPath: no index → grid mode
+                // (/profile/<npub>), explicit index → feed mode
+                // (/profile/<npub>/<index>). The old `index ?? 0` form always
+                // produced a feed-mode path, which disagreed with the
+                // resolver's grid-mode redirect for index-less universal links
+                // and caused a spurious second navigation.
+                final index = deepLink.index;
+                final targetPath = index != null
+                    ? ProfileScreenRouter.pathForIndex(deepLink.npub!, index)
+                    : ProfileScreenRouter.pathForNpub(deepLink.npub!);
                 Log.info(
                   '📱 Navigating to profile: $targetPath',
                   name: 'DeepLinkHandler',

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -15,6 +15,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/router.dart';
+import 'package:openvine/router/universal_link_resolver.dart';
 import 'package:openvine/screens/apps/app_detail_screen.dart';
 import 'package:openvine/screens/apps/apps_directory_screen.dart';
 import 'package:openvine/screens/apps/apps_permissions_screen.dart';
@@ -110,6 +111,22 @@ final goRouterProvider = Provider<GoRouter>((ref) {
     // Refresh router when auth state changes
     refreshListenable: authListenable,
     redirect: (context, state) {
+      // Rewrite divine.video universal-link URLs to internal paths before the
+      // auth/match logic runs. Android delivers the full intent URL (scheme +
+      // host + path) to GoRouter, which only matches on path. Without this
+      // step, paths that differ between the public URL contract and the
+      // internal route table (notably `/search/*` → `/search-results/:query`)
+      // would fall through to GoRouter's "Page Not Found" page.
+      final universalRedirect = universalLinkToRouterPath(state.uri);
+      if (universalRedirect != null) {
+        Log.info(
+          'Router redirect: universal link ${state.uri} → $universalRedirect',
+          name: 'AppRouter',
+          category: LogCategory.ui,
+        );
+        return universalRedirect;
+      }
+
       final location = state.matchedLocation;
       final authService = ref.read(authServiceProvider);
       final authState = authService.authState;

--- a/mobile/lib/router/universal_link_resolver.dart
+++ b/mobile/lib/router/universal_link_resolver.dart
@@ -1,0 +1,54 @@
+// ABOUTME: Pure resolver from universal-link URIs to internal GoRouter paths
+// ABOUTME: Shared source of truth used by the router redirect and tests
+
+import 'package:openvine/screens/hashtag_screen_router.dart';
+import 'package:openvine/screens/profile_screen_router.dart';
+import 'package:openvine/screens/search_results/view/search_results_page.dart';
+import 'package:openvine/services/deep_link_service.dart';
+
+/// Converts a universal-link [uri] into an internal GoRouter path.
+///
+/// Returns the internal path (e.g. `/search-results/music`) when the URI is a
+/// divine.video universal link that maps to an in-app destination and the
+/// mapping should be applied at the router layer. Returns `null` otherwise —
+/// either because the URI is not a universal link, or because its handling is
+/// deferred to the [DeepLinkService] stream listener.
+///
+/// Video deep links (`/video/:id`) intentionally return `null`: the listener
+/// uses `router.push` to keep the home feed underneath the detail page so
+/// back-navigation returns to the main screen. Rewriting in the router
+/// redirect would replace the stack instead of stacking on top.
+///
+/// Only `divine.video` is accepted here, mirroring
+/// [DeepLinkService.parseDeepLink]. Paths on `login.divine.video`
+/// (OAuth callbacks) already match internal GoRoutes by coincidence of path
+/// (e.g. `/reset-password`, `/verify-email`) so no rewrite is needed for them.
+String? universalLinkToRouterPath(Uri uri) {
+  if (!uri.scheme.startsWith('http')) return null;
+  if (uri.host != 'divine.video') return null;
+
+  final deepLink = DeepLinkService.parseDeepLink(uri.toString());
+  switch (deepLink.type) {
+    case DeepLinkType.profile:
+      final npub = deepLink.npub;
+      if (npub == null || npub.isEmpty) return null;
+      final index = deepLink.index;
+      if (index != null) {
+        return ProfileScreenRouter.pathForIndex(npub, index);
+      }
+      return ProfileScreenRouter.pathForNpub(npub);
+    case DeepLinkType.hashtag:
+      final tag = deepLink.hashtag;
+      if (tag == null || tag.isEmpty) return null;
+      return HashtagScreenRouter.pathForTag(tag);
+    case DeepLinkType.search:
+      final term = deepLink.searchTerm;
+      if (term == null || term.isEmpty) return null;
+      return SearchResultsPage.pathForQuery(term);
+    case DeepLinkType.video:
+    case DeepLinkType.invite:
+    case DeepLinkType.signerCallback:
+    case DeepLinkType.unknown:
+      return null;
+  }
+}

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -81,7 +81,7 @@ class DeepLinkService {
           name: 'DeepLinkService',
           category: LogCategory.ui,
         );
-        final deepLink = parseDeepLink(initialUri.toString());
+        final deepLink = DeepLinkService.parseDeepLink(initialUri.toString());
         _controller.add(deepLink);
       }
 
@@ -92,7 +92,7 @@ class DeepLinkService {
           name: 'DeepLinkService',
           category: LogCategory.ui,
         );
-        final deepLink = parseDeepLink(uri.toString());
+        final deepLink = DeepLinkService.parseDeepLink(uri.toString());
         _controller.add(deepLink);
       });
     } catch (e) {
@@ -104,8 +104,10 @@ class DeepLinkService {
     }
   }
 
-  /// Parse a divine.video URL into a DeepLink
-  DeepLink parseDeepLink(String url) {
+  /// Parse a divine.video URL into a [DeepLink].
+  ///
+  /// Pure: no instance state is touched, safe to call from route redirects.
+  static DeepLink parseDeepLink(String url) {
     try {
       final uri = Uri.parse(url);
 

--- a/mobile/test/router/universal_link_resolver_test.dart
+++ b/mobile/test/router/universal_link_resolver_test.dart
@@ -1,0 +1,163 @@
+// ABOUTME: Unit tests for universal_link_resolver — pure Uri -> path mapping
+// ABOUTME: Covers divine.video host gating and every DeepLinkType branch
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/router/universal_link_resolver.dart';
+
+void main() {
+  group('universalLinkToRouterPath', () {
+    group('host gating', () {
+      test('returns null for non-http schemes', () {
+        expect(
+          universalLinkToRouterPath(Uri.parse('divine://signer-callback')),
+          isNull,
+        );
+      });
+
+      test('returns null for unrelated hosts', () {
+        expect(
+          universalLinkToRouterPath(
+            Uri.parse('https://example.com/search/music'),
+          ),
+          isNull,
+        );
+      });
+
+      test('returns null for path-only URIs (in-app navigation)', () {
+        expect(
+          universalLinkToRouterPath(Uri.parse('/home/0')),
+          isNull,
+        );
+      });
+
+      test('accepts divine.video host', () {
+        expect(
+          universalLinkToRouterPath(
+            Uri.parse('https://divine.video/search/music'),
+          ),
+          equals('/search-results/music'),
+        );
+      });
+
+      test(
+        'returns null for login.divine.video — OAuth callback paths '
+        'already match internal GoRoutes by coincidence',
+        () {
+          expect(
+            universalLinkToRouterPath(
+              Uri.parse('https://login.divine.video/search/music'),
+            ),
+            isNull,
+          );
+        },
+      );
+    });
+
+    group('search', () {
+      test('maps /search/:term to /search-results/:term', () {
+        expect(
+          universalLinkToRouterPath(
+            Uri.parse('https://divine.video/search/flutter'),
+          ),
+          equals('/search-results/flutter'),
+        );
+      });
+
+      test('maps /search/:term/:index by dropping the index', () {
+        // The internal SearchResultsPage route does not accept a trailing
+        // index, so it is intentionally dropped.
+        expect(
+          universalLinkToRouterPath(
+            Uri.parse('https://divine.video/search/flutter/3'),
+          ),
+          equals('/search-results/flutter'),
+        );
+      });
+
+      test('returns null for /search without a term', () {
+        expect(
+          universalLinkToRouterPath(Uri.parse('https://divine.video/search')),
+          isNull,
+        );
+      });
+    });
+
+    group('profile', () {
+      test('maps /profile/:npub to /profile/:npub', () {
+        const npub =
+            'npub1xyz000000000000000000000000000000000000000000000000000000000';
+        expect(
+          universalLinkToRouterPath(
+            Uri.parse('https://divine.video/profile/$npub'),
+          ),
+          equals('/profile/$npub'),
+        );
+      });
+
+      test('maps /profile/:npub/:index to /profile/:npub/:index', () {
+        const npub =
+            'npub1abc000000000000000000000000000000000000000000000000000000000';
+        expect(
+          universalLinkToRouterPath(
+            Uri.parse('https://divine.video/profile/$npub/7'),
+          ),
+          equals('/profile/$npub/7'),
+        );
+      });
+    });
+
+    group('hashtag', () {
+      test('maps /hashtag/:tag to /hashtag/:tag', () {
+        expect(
+          universalLinkToRouterPath(
+            Uri.parse('https://divine.video/hashtag/flutter'),
+          ),
+          equals('/hashtag/flutter'),
+        );
+      });
+
+      test('preserves URL-encoded non-ASCII tags', () {
+        // `Uri` round-trips the encoded form back through `parseDeepLink`,
+        // which in turn passes it to `HashtagScreenRouter.pathForTag`. The
+        // caller (route matcher) decodes it before rendering.
+        final encoded = Uri.encodeComponent('🔥');
+        final result = universalLinkToRouterPath(
+          Uri.parse('https://divine.video/hashtag/$encoded'),
+        );
+        expect(result, startsWith('/hashtag/'));
+        expect(result!.length, greaterThan('/hashtag/'.length));
+      });
+    });
+
+    group('paths deferred to the DeepLinkService listener', () {
+      test('/video/:id returns null (listener uses push for back-nav)', () {
+        expect(
+          universalLinkToRouterPath(
+            Uri.parse('https://divine.video/video/abc123'),
+          ),
+          isNull,
+        );
+      });
+
+      test('/invite/:code returns null', () {
+        // Invite is not part of the Android intent filter; it reaches the
+        // app via other channels and is handled by the listener.
+        expect(
+          universalLinkToRouterPath(
+            Uri.parse('https://divine.video/invite/ABCD-EFGH'),
+          ),
+          isNull,
+        );
+      });
+
+      test('unknown divine.video path returns null', () {
+        expect(
+          universalLinkToRouterPath(
+            Uri.parse('https://divine.video/nope'),
+          ),
+          isNull,
+        );
+      });
+    });
+  });
+}

--- a/mobile/test/router/universal_link_resolver_test.dart
+++ b/mobile/test/router/universal_link_resolver_test.dart
@@ -117,15 +117,14 @@ void main() {
       });
 
       test('preserves URL-encoded non-ASCII tags', () {
-        // `Uri` round-trips the encoded form back through `parseDeepLink`,
-        // which in turn passes it to `HashtagScreenRouter.pathForTag`. The
-        // caller (route matcher) decodes it before rendering.
+        // Uri.parse decodes the percent-encoded emoji into pathSegments;
+        // HashtagScreenRouter.pathForTag then re-encodes it via
+        // Uri.encodeComponent, so the round-trip is deterministic.
         final encoded = Uri.encodeComponent('🔥');
         final result = universalLinkToRouterPath(
           Uri.parse('https://divine.video/hashtag/$encoded'),
         );
-        expect(result, startsWith('/hashtag/'));
-        expect(result!.length, greaterThan('/hashtag/'.length));
+        expect(result, equals('/hashtag/$encoded'));
       });
     });
 

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -6,22 +6,12 @@ import 'package:openvine/services/deep_link_service.dart';
 
 void main() {
   group('DeepLinkService URL Parsing', () {
-    late DeepLinkService service;
-
-    setUp(() {
-      service = DeepLinkService();
-    });
-
-    tearDown(() {
-      service.dispose();
-    });
-
     group('Video URL Parsing', () {
       test('parses valid video URL correctly', () {
         const videoId = 'abc123def456';
         const url = 'https://divine.video/video/$videoId';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.video));
         expect(result.videoId, equals(videoId));
@@ -33,7 +23,7 @@ void main() {
             'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2';
         const url = 'https://divine.video/video/$videoId';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.video));
         expect(result.videoId, equals(videoId));
@@ -43,7 +33,7 @@ void main() {
         const videoId = 'abc123';
         const url = 'https://divine.video/video/$videoId/';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         // Should still parse - trailing slash creates empty segment
         expect(result.type, equals(DeepLinkType.unknown));
@@ -52,7 +42,7 @@ void main() {
       test('rejects video URL without ID', () {
         const url = 'https://divine.video/video';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.unknown));
         expect(result.videoId, isNull);
@@ -61,7 +51,7 @@ void main() {
       test('rejects video URL with extra path segments', () {
         const url = 'https://divine.video/video/abc123/extra';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.unknown));
       });
@@ -72,7 +62,7 @@ void main() {
         const npub = 'npub1abc123def456';
         const url = 'https://divine.video/profile/$npub';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.profile));
         expect(result.npub, equals(npub));
@@ -84,7 +74,7 @@ void main() {
             'npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9';
         const url = 'https://divine.video/profile/$npub';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.profile));
         expect(result.npub, equals(npub));
@@ -93,7 +83,7 @@ void main() {
       test('rejects profile URL without npub', () {
         const url = 'https://divine.video/profile';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.unknown));
         expect(result.npub, isNull);
@@ -103,7 +93,7 @@ void main() {
         const npub = 'npub1abc123def456';
         const url = 'https://divine.video/profile/$npub/3';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.profile));
         expect(result.npub, equals(npub));
@@ -114,7 +104,7 @@ void main() {
         const npub = 'npub1abc123def456';
         const url = 'https://divine.video/profile/$npub/extra';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.profile));
         expect(result.npub, equals(npub));
@@ -124,7 +114,7 @@ void main() {
 
     group('Hashtag URL Parsing', () {
       test('parses /hashtag/{tag} correctly', () {
-        final result = service.parseDeepLink(
+        final result = DeepLinkService.parseDeepLink(
           'https://divine.video/hashtag/vibes',
         );
 
@@ -134,7 +124,7 @@ void main() {
       });
 
       test('parses /hashtag/{tag}/{index} with index', () {
-        final result = service.parseDeepLink(
+        final result = DeepLinkService.parseDeepLink(
           'https://divine.video/hashtag/music/5',
         );
 
@@ -144,7 +134,9 @@ void main() {
       });
 
       test('rejects hashtag URL without tag', () {
-        final result = service.parseDeepLink('https://divine.video/hashtag');
+        final result = DeepLinkService.parseDeepLink(
+          'https://divine.video/hashtag',
+        );
 
         expect(result.type, equals(DeepLinkType.unknown));
       });
@@ -152,7 +144,7 @@ void main() {
 
     group('Search URL Parsing', () {
       test('parses /search/{term} correctly', () {
-        final result = service.parseDeepLink(
+        final result = DeepLinkService.parseDeepLink(
           'https://divine.video/search/flutter',
         );
 
@@ -162,7 +154,7 @@ void main() {
       });
 
       test('parses /search/{term}/{index} with index', () {
-        final result = service.parseDeepLink(
+        final result = DeepLinkService.parseDeepLink(
           'https://divine.video/search/dart/2',
         );
 
@@ -172,7 +164,9 @@ void main() {
       });
 
       test('rejects search URL without term', () {
-        final result = service.parseDeepLink('https://divine.video/search');
+        final result = DeepLinkService.parseDeepLink(
+          'https://divine.video/search',
+        );
 
         expect(result.type, equals(DeepLinkType.unknown));
       });
@@ -180,7 +174,7 @@ void main() {
 
     group('Invite URL Parsing', () {
       test('parses /invite/{code} correctly', () {
-        final result = service.parseDeepLink(
+        final result = DeepLinkService.parseDeepLink(
           'https://divine.video/invite/ABCD-EFGH',
         );
 
@@ -189,7 +183,7 @@ void main() {
       });
 
       test('parses /invite?code={code} correctly', () {
-        final result = service.parseDeepLink(
+        final result = DeepLinkService.parseDeepLink(
           'https://divine.video/invite?code=WXYZ-1234',
         );
 
@@ -198,7 +192,9 @@ void main() {
       });
 
       test('rejects invite URL without code', () {
-        final result = service.parseDeepLink('https://divine.video/invite');
+        final result = DeepLinkService.parseDeepLink(
+          'https://divine.video/invite',
+        );
 
         expect(result.type, equals(DeepLinkType.unknown));
       });
@@ -208,7 +204,7 @@ void main() {
       test('rejects non-divine.video domain', () {
         const url = 'https://example.com/video/abc123';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.unknown));
       });
@@ -216,7 +212,7 @@ void main() {
       test('rejects invalid path structure', () {
         const url = 'https://divine.video/unknown/path';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.unknown));
       });
@@ -224,7 +220,7 @@ void main() {
       test('rejects root URL', () {
         const url = 'https://divine.video/';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.unknown));
       });
@@ -232,7 +228,7 @@ void main() {
       test('handles malformed URL gracefully', () {
         const url = 'not-a-valid-url';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.unknown));
       });
@@ -240,7 +236,7 @@ void main() {
       test('handles empty string gracefully', () {
         const url = '';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.unknown));
       });
@@ -251,7 +247,7 @@ void main() {
         const videoId = 'abc123';
         const url = 'http://divine.video/video/$videoId';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.video));
         expect(result.videoId, equals(videoId));
@@ -261,7 +257,7 @@ void main() {
         const videoId = 'abc123';
         const url = 'https://divine.video/video/$videoId';
 
-        final result = service.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.video));
         expect(result.videoId, equals(videoId));


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Android delivers the full intent URL (scheme + host + path) toMaterialApp.router, and GoRouter only matches on path. Paths that differ between the public URL contract and the internal route table — notably /search/:term vs /search-results/:query —fell through to GoRouter's Page Not Found error page.

Add a pure universalLinkToRouterPath(Uri) resolver in router/universal_link_resolver.dart, share it with the existing DeepLinkService parser (now static), and call it at the top of the GoRouter.redirect callback. Video is intentionally deferred to the stream listener so router.push keeps the home feed under the detail page for back-navigation. Idempotency guards added to profile/hashtag/ search listener arms to absorb double-emit from app_links. Stale

<!--- Describe your changes in detail -->

**Related Issue:** Closes #3032 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore