### PR TITLE
fix(video-editor): prevent crash on iOS when video composition has no clips

### DIFF
--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -684,6 +684,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
         if (listEquals(previous, current)) return;
 
         final clips = ref.read(clipManagerProvider).clips;
+        // Skip when there are no clips left (e.g. clearAll during
+        // teardown). Sending `setClips([])` to the native player
+        // builds a composition with `renderSize == .zero` on iOS,
+        // which crashes `AVPlayerItem.setVideoComposition:`.
+        if (clips.isEmpty) return;
         final currentPosition = context
             .read<VideoEditorMainBloc>()
             .state
@@ -764,6 +769,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
               return false;
             },
             listener: (context, state) {
+              // See note on the trim-times listener above: skip empty
+              // clip lists to avoid crashing the iOS native player.
+              if (state.clips.isEmpty) return;
               final currentPosition = context
                   .read<VideoEditorMainBloc>()
                   .state

--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
@@ -137,9 +137,19 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 self.firstFrameRendered = false
 
                 let playerItem = AVPlayerItem(asset: composition)
-                playerItem.videoComposition = AVVideoComposition(
-                    propertiesOf: composition
-                )
+                // `AVVideoComposition(propertiesOf:)` derives `renderSize`
+                // from the composition's video tracks. If the composition
+                // has no video segments (e.g. caller passed an empty
+                // clip list during teardown), `renderSize` is `.zero` and
+                // the setter throws `NSInvalidArgumentException`
+                // ("video composition must have a positive renderSize"),
+                // which terminates the app from a Swift Task.
+                let avComposition = AVVideoComposition(propertiesOf: composition)
+                if avComposition.renderSize.width > 0,
+                    avComposition.renderSize.height > 0
+                {
+                    playerItem.videoComposition = avComposition
+                }
                 self.textureOutput?.attach(to: playerItem)
 
                 let startPositionMs = (args["startPositionMs"] as? NSNumber)?.int64Value ?? 0

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
@@ -134,9 +134,19 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 self.firstFrameRendered = false
 
                 let playerItem = AVPlayerItem(asset: composition)
-                playerItem.videoComposition = AVVideoComposition(
-                    propertiesOf: composition
-                )
+                // `AVVideoComposition(propertiesOf:)` derives `renderSize`
+                // from the composition's video tracks. If the composition
+                // has no video segments (e.g. caller passed an empty
+                // clip list during teardown), `renderSize` is `.zero` and
+                // the setter throws `NSInvalidArgumentException`
+                // ("video composition must have a positive renderSize"),
+                // which terminates the app from a Swift Task.
+                let avComposition = AVVideoComposition(propertiesOf: composition)
+                if avComposition.renderSize.width > 0,
+                    avComposition.renderSize.height > 0
+                {
+                    playerItem.videoComposition = avComposition
+                }
                 self.textureOutput?.attach(to: playerItem)
 
                 if let existing = self.player {


### PR DESCRIPTION
Closes #3317



## Description

Prevent an issue that sometimes happens on iOS where the app crashes when the user taps “Discard changes” to leave the video editor.

**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore