### PR TITLE
docs(claude): codify remaining lessons from #3224 not covered by #3231

### DIFF
--- a/.claude/rules/code_style.md
+++ b/.claude/rules/code_style.md
@@ -21,6 +21,32 @@ Write straightforward code. Clever or obscure code is difficult to maintain.
 ### Reuse Before Writing
 Before writing a new helper, utility, or formatter, search `mobile/packages/` for an existing package that already provides the functionality. The monorepo contains shared packages (e.g., `count_formatter`, `divine_ui`) specifically to avoid duplication across features.
 
+### Document Design-System Divergence
+
+If a bespoke widget deliberately diverges from a `divine_ui` component (different size, different structure, bypassed variant), the class's docstring **must** say why — specifically, which design-system component it's close to and what forced the divergence. Without that note, the next reviewer (or the next you, six months later) will re-raise the "why not just use `DivineIconButton`?" question, and you'll have to re-litigate the decision.
+
+**Good — explains the divergence inline:**
+```dart
+/// Shared Figma-matched center control used for transient play/pause states.
+///
+/// Visually equivalent to a [DivineIconButton] in ghost style (scrim65
+/// background + white glyph) but sized 64×64 with a 32 icon instead of
+/// DivineIconButton's 40×40 (small) / 56×56 (base) presets, because the
+/// Figma spec for the paused-video affordance (node 15314:53971) calls
+/// for a larger tap target than any standard DivineIconButton size. Kept
+/// as a bespoke widget rather than extending DivineIconButton with a
+/// third size enum that only this surface would use.
+class CenterPlaybackControl extends StatelessWidget { ... }
+```
+
+**Bad — no hint that the bespoke widget is intentional:**
+```dart
+/// Center play/pause control.
+class CenterPlaybackControl extends StatelessWidget { ... }
+```
+
+The rule is satisfied by a 2–4 sentence note in the docstring. No separate ADR required — but a link to the Figma node that forced the divergence (when applicable) saves a round-trip.
+
 ---
 
 ## Naming Conventions
@@ -148,6 +174,60 @@ if (useOldSearch) {
 
 ---
 
+## No Speculative Parameters on Reusable Widgets
+
+Before adding a parameter to a reusable widget or utility (anything in
+`divine_ui` or `lib/utils/`), trace the caller flow end-to-end and
+confirm the branch it unlocks is actually reachable. "Future-proof" or
+anticipatory parameters tend to sit unused, inflate the API surface,
+and confuse the next reader — the parameter's only documentation is
+the dead branch.
+
+**Smell: parameter name includes "Builder" / "Callback" / "Resolver"
+and there is exactly one caller, which always supplies it.** That's a
+named-parameter closure being used as a late-binding for behavior
+that could live in the caller's code. Ask whether the caller can
+compute the value directly and pass the resolved value in.
+
+**Example (from review on #3224):**
+
+```dart
+// Bad — caller computes an initial size based on keyboard state,
+// but the sheet is only ever opened from a surface that has no text
+// input (feed), so the keyboard is never open at show time. The
+// parameter's entire body is dead.
+static Future<T?> show<T>({
+  double initialChildSize = 0.6,
+  double Function(BuildContext)? initialChildSizeBuilder,
+  // ...
+}) {
+  final size = initialChildSizeBuilder?.call(context) ?? initialChildSize;
+  // ...
+}
+
+// Good — the speculative branch is deleted; callers pass a plain
+// number, and there's nothing to miss-configure.
+static Future<T?> show<T>({
+  double initialChildSize = 0.6,
+  // ...
+}) { /* ... */ }
+```
+
+Bias toward **removing** a parameter that has one caller and one
+code path — adding it back later is cheap; living with a
+never-exercised branch is not. If a parameter genuinely must exist
+for one forced scenario, assert that scenario at the top of the
+function so the invariant is explicit:
+
+```dart
+assert(
+  initialChildSizeBuilder == null || someScenarioHolds,
+  'initialChildSizeBuilder is only valid when ...',
+);
+```
+
+---
+
 ## Dart Best Practices
 
 ### Null Safety
@@ -261,6 +341,85 @@ class MyWidget extends StatelessWidget {
 2. Enables efficient rendering and DevTools inspection
 3. Widgets can be tested in isolation
 4. Widget classes can be `const` and benefit from Flutter's diffing algorithm
+
+### Don't Hide Ancestors Inside a One-Off `Widget Function` Closure
+
+When a call site needs to inject an **ancestor** (a `BlocProvider`,
+`InheritedWidget`, `Theme`, etc.) above a widget's whole subtree, do
+**not** reach for a one-off `Widget Function(BuildContext, Widget)`
+closure at the call site — that's a `_buildFoo` in disguise, just
+lifted into an argument. Instead, add a `contentWrapper` (or similarly
+named) parameter to the target widget/utility and let each call site
+supply the wrapper declaratively.
+
+**Smell: the call site invents a named closure that takes `(context,
+child)` and wraps `child` in a provider / inherited widget.** That
+call site is asking for a `contentWrapper` parameter.
+
+**Bad — the wrapping is a builder closure baked into a single call
+site. It's easy to miss that the provider must wrap the *entire*
+sheet, and if the target widget ever gains a new slot, the closure
+silently won't apply there:**
+
+```dart
+// In a utility that shows a sheet:
+Future<void> showMySheet(BuildContext context, {
+  required Widget Function(BuildContext, Widget) builder,
+  required Widget body,
+}) {
+  return showModalBottomSheet(
+    context: context,
+    builder: (ctx) => builder(ctx, MySheet(body: body)),
+  );
+}
+
+// At the call site:
+showMySheet(
+  context,
+  builder: (ctx, child) => BlocProvider<MyBloc>(
+    create: (_) => MyBloc(),
+    child: child,
+  ),
+  body: ...,
+);
+```
+
+**Good — the target exposes a `contentWrapper` parameter that
+participates in its own API. The wrapping is declarative and the
+target can guarantee it applies across every slot:**
+
+```dart
+Future<void> showMySheet(BuildContext context, {
+  Widget Function(BuildContext, Widget)? contentWrapper,
+  required Widget body,
+}) {
+  return showModalBottomSheet(
+    context: context,
+    builder: (ctx) {
+      final Widget sheet = MySheet(body: body);
+      return contentWrapper?.call(ctx, sheet) ?? sheet;
+    },
+  );
+}
+
+showMySheet(
+  context,
+  contentWrapper: (ctx, child) => BlocProvider<MyBloc>(
+    create: (_) => MyBloc(),
+    child: child,
+  ),
+  body: ...,
+);
+```
+
+The cue is almost always a `BlocProvider` / `InheritedWidget` that
+needs to sit **above** every slot of the target — not beside one of
+them. The `contentWrapper` parameter turns that intent into part of
+the widget's contract instead of a call-site pattern.
+
+See the companion rule in
+[`state_management.md`](state_management.md#scoping-blocprovider-to-a-modal-route)
+for why this matters specifically for `BlocProvider` lifecycle.
 
 ---
 

--- a/.claude/rules/code_style.md
+++ b/.claude/rules/code_style.md
@@ -576,6 +576,46 @@ if (user == null) return; // return if user is null
 if (user == null) return;
 ```
 
+**Don't write long design-rationale comments just for Claude.** AI
+tools happily cite inline comments as if they were specs — and when
+the code changes and the comment doesn't, the stale citation carries
+forward as bad authority. A reviewer on #3202 described seeing Claude
+refer to "a comment of nonsense" as its source when asked for
+references. Two corollaries:
+
+1. **Document design decisions in the code, not around it.** A
+   well-named widget, a named constant, a typed enum, or a focused
+   doc under `.claude/rules/` or `docs/` survives rename refactors
+   and grep; an inline paragraph doesn't.
+2. **Use inline comments as pointers, not homes.** If you need more
+   than a sentence to explain a design decision, write the full
+   explanation in the PR description (or a rule file) and leave a
+   brief `// See PR #N / rules/foo.md` pointer inline — not a
+   paragraph the next change will quietly outdate.
+
+```dart
+// Bad — design rationale as a paragraph above the code. Will drift
+// the first time the 30 or 32 changes.
+// ┌────────────────────────────────────────────────────────────────┐
+// │ The outer shell uses 30 px bottom corners and the inner tabs  │
+// │ container uses 32 px top corners so that the inner surface    │
+// │ visibly nests inside the outer shell. We picked these values  │
+// │ from Figma node 12345:67 and they should stay in sync …       │
+// └────────────────────────────────────────────────────────────────┘
+ClipRRect(borderRadius: .vertical(bottom: .circular(30)), ...);
+
+// Good — the rationale is carried by the named constants.
+// (If you still need a pointer, one line is enough.)
+// Inner radius is 2 px larger so the tabs container visibly nests
+// inside the nav-rounded shell.
+ClipRRect(
+  borderRadius: .vertical(
+    bottom: .circular(VineTheme.shellCornerRadius),
+  ),
+  ...
+);
+```
+
 ---
 
 ## Logging

--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -61,18 +61,38 @@ Design system (check `divine_ui` first — most review nits map here):
 - [ ] Interactive tap targets (`GestureDetector`, `InkWell`, custom) are
   wrapped in `Semantics(button: true, label: ...)`. Decorative images
   use `ExcludeSemantics`. See [`accessibility.md`](accessibility.md).
+- [ ] Any bespoke widget that deliberately diverges from a `divine_ui`
+  component has a docstring explaining **why** (size delta, missing
+  variant, Figma node that forced it). See
+  [`code_style.md`](code_style.md#document-design-system-divergence).
 
 Composition and style:
 
 - [ ] No methods returning `Widget`. Extract to a widget class (private
   `_Xxx` inside the same file is fine). See
   [`code_style.md`](code_style.md).
-- [ ] No `Future.delayed()` for UI timing. Use `AnimatedSwitcher`,
-  animation controllers, stream listeners.
+- [ ] No `Future.delayed()` **or `Timer`** for UI timing. Use
+  `AnimationController` + `FadeTransition` / `AnimatedSwitcher` /
+  stream listeners — they pause with the route, respect reduced-motion,
+  and align with vsync. See
+  [`ui_theming.md`](ui_theming.md#animationcontroller-over-timer-for-ui-timing).
+- [ ] No `ValueKey` on `AnimatedSwitcher` branches that are already
+  different runtime types. See
+  [`ui_theming.md`](ui_theming.md#animatedswitcher-differentiates-children-by-runtime-type).
 - [ ] Build methods stay small — a high-level composition of widget
   classes.
 - [ ] Check `context.mounted` after every `await` before using
   `BuildContext`.
+- [ ] No speculative parameters on a reusable widget/utility. If the
+  branch a parameter unlocks is unreachable from any caller, delete
+  the parameter. See
+  [`code_style.md`](code_style.md#no-speculative-parameters-on-reusable-widgets).
+- [ ] To inject an ancestor (`BlocProvider`, `InheritedWidget`) above
+  every slot of a modal/sheet/route, use a `contentWrapper` parameter
+  on the target — not a builder closure at the call site. See
+  [`code_style.md`](code_style.md#dont-hide-ancestors-inside-a-one-off-widget-function-closure)
+  and
+  [`state_management.md`](state_management.md#scoping-blocprovider-to-a-modal-route).
 
 Scroll and navigation:
 
@@ -92,6 +112,9 @@ State management:
   enums + `addError`. See [`state_management.md`](state_management.md).
 - [ ] No mutable instance variables on a BLoC class. All state lives in
   the state object.
+- [ ] Modal-scoped blocs are owned by a `BlocProvider` **inside** the
+  modal's subtree (via `contentWrapper` or equivalent) — never
+  instantiated at the call site and `close()`-d in a `try/finally`.
 
 Testing:
 
@@ -102,6 +125,19 @@ Testing:
 - [ ] New public method on a strict-coverage package (currently
   `mobile/packages/divine_ui`) has a matching test **in the same PR**.
   See [`testing.md`](testing.md#strict-coverage-packages).
+- [ ] No absolute wall-clock bounds on benchmark assertions (`<100 ns`,
+  `<100 ms`); use relative comparisons, `fakeAsync`, or skip with a
+  `TODO(any):`. See
+  [`testing.md`](testing.md#absolute-timing-bounds-flake-on-shared-ci-runners).
+- [ ] No incidental `expect(tester.takeException(), isNotNull)` that
+  depends on a partially-set-up provider throwing. Assert the test's
+  actual contract; drain incidental errors with
+  `tester.takeException()` without assertion. See
+  [`testing.md`](testing.md#testertakeexception-isnotnull-is-fragile-under-test-suite-optimization).
+- [ ] Code that compares wall-clock timestamps (`DateTime.now()`) reads
+  through `package:clock`'s `clock.now()`; the test wraps its body in
+  `withClock(...)` so the comparison is deterministic. See
+  [`testing.md`](testing.md#inject-packageclock-for-time-sensitive-logic).
 
 ---
 

--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -93,6 +93,11 @@ Composition and style:
   [`code_style.md`](code_style.md#dont-hide-ancestors-inside-a-one-off-widget-function-closure)
   and
   [`state_management.md`](state_management.md#scoping-blocprovider-to-a-modal-route).
+- [ ] No multi-line design-rationale inline comments. If the
+  explanation is longer than a sentence, move it to the PR
+  description or a rule file and leave at most a one-line pointer in
+  the code. Paragraph-length comments drift and get cited by LLMs as
+  bad authority. See [`code_style.md`](code_style.md#comments).
 
 Scroll and navigation:
 

--- a/.claude/rules/state_management.md
+++ b/.claude/rules/state_management.md
@@ -248,6 +248,98 @@ bloc needs its own consumer; one consumer does not wake the others.
 
 ---
 
+## Scoping `BlocProvider` to a modal route
+
+When a modal (bottom sheet, dialog, pushed route) needs a bloc that
+should live only for the duration of that modal, put the
+`BlocProvider` **inside** the modal's widget subtree. Do **not**:
+
+1. Instantiate the bloc at the call site, push the modal, and
+   `await`-then-`close()` the bloc in a `try/finally`.
+2. Wrap the modal's returned widget in a builder closure at the call
+   site.
+
+Option (1) duplicates lifecycle management that `BlocProvider` already
+does, and goes wrong any time the modal's build throws mid-flight or
+the route is popped by a different path than `await` returning.
+Option (2) hides an ancestor inside a single-use closure (see
+[`code_style.md` → "Don't Hide Ancestors Inside a One-Off `Widget
+Function` Closure"](code_style.md#dont-hide-ancestors-inside-a-one-off-widget-function-closure)).
+
+**The right shape:** expose a `contentWrapper` (or similarly named)
+parameter on the modal utility, and pass a `BlocProvider` through it.
+`BlocProvider(create:)` owns the close automatically when its subtree
+unmounts on route pop.
+
+**Bad — lifecycle managed at the call site:**
+
+```dart
+Future<void> show(BuildContext context, ...) async {
+  final bloc = CommentsBloc(...)..add(const CommentsLoadRequested());
+  try {
+    await context.showVideoPausingVineBottomSheet<void>(
+      // Manual wiring of a builder closure that injects the bloc into
+      // only one slot — easy to miss the others.
+      title: BlocProvider<CommentsBloc>.value(
+        value: bloc,
+        child: _CommentsTitle(...),
+      ),
+      bottomInput: BlocProvider<CommentsBloc>.value(
+        value: bloc,
+        child: const _MainCommentInput(),
+      ),
+      buildScrollBody: (controller) => BlocProvider<CommentsBloc>.value(
+        value: bloc,
+        child: _CommentsScreenBody(...),
+      ),
+    );
+  } finally {
+    await bloc.close(); // Duplicates what BlocProvider would do.
+  }
+}
+```
+
+**Good — `contentWrapper` scopes the provider to the whole sheet,
+and `BlocProvider` owns the close:**
+
+```dart
+Future<void> show(BuildContext context, ...) {
+  // Reads are synchronous; the bloc is created inside the modal
+  // subtree when the sheet builds.
+  final container = ProviderScope.containerOf(context, listen: false);
+  final repo = container.read(commentsRepositoryProvider);
+  // ... other captured deps ...
+
+  return context.showVideoPausingVineBottomSheet<void>(
+    contentWrapper: (context, child) => BlocProvider<CommentsBloc>(
+      create: (_) => CommentsBloc(repo: repo, ...)
+        ..add(const CommentsLoadRequested()),
+      child: child,
+    ),
+    title: _CommentsTitle(...),
+    bottomInput: const _MainCommentInput(),
+    buildScrollBody: (controller) => _CommentsScreenBody(...),
+  );
+}
+```
+
+Benefits:
+
+- **One provider, every slot.** The wrapper sits above `title`,
+  `trailing`, `bottomInput`, `body`, `buildScrollBody` — you can't
+  accidentally drop it from one of them.
+- **No manual `close()`.** `BlocProvider` disposes the bloc on unmount.
+- **No `try/finally` around a `Future` that may never complete via the
+  `await` path.** The sheet gets popped, the subtree unmounts, the
+  bloc is disposed — regardless of which code path popped it.
+
+If the reusable widget/utility doesn't yet accept a `contentWrapper`,
+**add one** instead of working around it at the call site. (See
+[`code_style.md`](code_style.md#dont-hide-ancestors-inside-a-one-off-widget-function-closure)
+for the corresponding widget-API rule.)
+
+---
+
 ## Persisting state across shell-route transitions
 
 Screens inside a `ShellRoute` whose content is gated on the current URL

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -403,3 +403,173 @@ A common symptom of the missing setup is an assertion that passes when
 the string is hardcoded but fails after an l10n migration with
 `Found 0 widgets with text "…"`. The widget tree built correctly; only
 the text child failed to resolve.
+
+---
+
+## Absolute timing bounds flake on shared CI runners
+
+Tests that assert a benchmark runs in under N nanoseconds /
+microseconds / milliseconds fail intermittently in CI because
+GitHub-hosted runners are shared, noisy, and substantially slower
+than a dev laptop. Two failures seen on this repo:
+
+- `NativeProofData isComplete` expected `<100 ns/op` but ran at
+  `443 ns/op` on CI.
+- `StartupCoordinator FastService` used `Future.delayed(50 ms)` and
+  asserted `<100 ms` — flaked at `114 ms` on CI.
+
+There are three valid responses:
+
+1. **Relative comparison**, when the benchmark's real contract is
+   ordering between two measured things:
+   ```dart
+   final fastMs = metrics.serviceTimings['FastService']!.inMilliseconds;
+   final slowMs = metrics.serviceTimings['SlowService']!.inMilliseconds;
+   expect(fastMs, lessThan(slowMs));
+   expect(slowMs, greaterThanOrEqualTo(200));
+   ```
+2. **Skip with `skip: true`** and a `TODO(any):` referencing the
+   flakiness, for benchmarks that exist as regression alarms rather
+   than correctness checks. Follow the precedent of the already-
+   skipped sibling in the same file:
+   ```dart
+   test('X should be fast', () {
+     // ...
+     expect(avgNanoseconds, lessThan(100), reason: '...');
+     // TODO(any): Fix and enable — 100 ns target is unreachable on
+     // shared GitHub-runner hardware (seen 443 ns on CI, <100 ns
+     // locally).
+   }, skip: true);
+   ```
+3. **Wrap in `fakeAsync`** if the goal was to verify logical
+   durations (e.g. "feedback fades after 500 ms") rather than wall-
+   clock performance. See the `fakeAsync` pattern already used in
+   `follow_repository` tests.
+
+Never bump the threshold "a little" to make the flake go away — that
+just delays the next flake. Pick one of the three above.
+
+---
+
+## `tester.takeException(), isNotNull` is fragile under test-suite optimization
+
+`very_good test --optimization` merges many test files into one
+generated `main()` for CI. Leaked provider state (Riverpod
+`keepAlive`, registered fallbacks, singletons) from a previously-run
+test can make a partial dependency resolve "successfully" in a later
+test, silencing the exception that the test was relying on as a
+side-effect signal.
+
+If a test's description is "does X, and also throws because the test
+harness lacks dependency Y," that **incidental** throw is not a
+durable assertion. Drop it and assert only what the description
+names:
+
+```dart
+// Bad — depends on provider ordering luck
+await tester.tap(find.byType(ShareButton));
+await tester.pump();
+expect(shareCalled, isTrue);
+expect(tester.takeException(), isNotNull); // flakes under CI merging
+
+// Good — asserts the contract and drains any incidental error
+await tester.tap(find.byType(ShareButton));
+await tester.pump();
+expect(shareCalled, isTrue);
+tester.takeException(); // drain any incidental error, no assertion
+```
+
+If the test legitimately needs to verify an error path, **set up the
+conditions that cause the error explicitly** (e.g. override the
+provider to return a failure, or pre-throw in a test double) so the
+exception is deterministic.
+
+---
+
+## Coordinate-based `tapAt` is sensitive to modal layout
+
+`tester.tapAt(Offset(200, 20))` depends on what actually occupies that
+pixel — a `DraggableScrollableSheet(expand: false)` has **transparent
+empty space above** its content that delegates to the widget tree
+under it (the modal barrier), whereas `expand: true` fills the same
+rectangle with the sheet's own hit-testing. That's enough of a
+layout detail to flip the test between "dismissal via barrier" and
+"dismissal via our custom gesture detector" — and CI may see a
+different layout than your laptop if the test viewport differs.
+
+**Prefer:**
+- `find.text(...)`, `find.byType(...)`, `find.bySemanticsIdentifier(...)`
+  — stable across layout changes.
+- `tester.tap(find.byKey(...))` when you need a specific sub-region.
+
+When you must use `tapAt`, document the layout assumption inline and
+keep the offset well inside the intended region (don't tap on the
+boundary of a sheet/barrier split):
+
+```dart
+// Sheet covers the bottom 50% of an 800-high test viewport. Tapping
+// at y=20 lands squarely in the barrier area, not on any sheet
+// content.
+await tester.tapAt(const Offset(200, 20));
+```
+
+Also note: modal controls often have two "dismiss on outside tap"
+mechanisms (the Flutter `ModalBarrier` via `isDismissible`, and any
+custom tap-catcher in the sheet's own widget tree). If your wrapper
+exposes a `tapOutsideToDismiss` parameter, make sure it links to the
+underlying `isDismissible` so the two mechanisms can't disagree —
+otherwise tests that pass `tapOutsideToDismiss: false` still see the
+barrier dismiss the sheet.
+
+---
+
+## Inject `package:clock` for time-sensitive logic
+
+`tester.pump(Duration)` advances the Flutter test clock — which drives
+`SchedulerBinding`, `Timer`, animation controllers, etc. It does
+**not** advance `DateTime.now()` / `Stopwatch.elapsed` / anything else
+that reads the host machine's wall clock. If your code compares
+wall-clock timestamps (e.g. "did the pause last longer than 150 ms?"),
+`pump` gives you no way to make that comparison deterministic.
+
+**Fix:** read time through `package:clock`'s `clock.now()` in the code
+under test, and wrap the test body in `withClock(...)` with a
+manually-advanced time source.
+
+```dart
+// Code under test (e.g. paused_video_play_overlay.dart):
+import 'package:clock/clock.dart';
+
+if (!isPlaying && wasPlaying) {
+  _pausedAt = clock.now();
+} else if (isPlaying && !wasPlaying && _pausedAt != null) {
+  final pauseDuration = clock.now().difference(_pausedAt!);
+  if (pauseDuration >= _minPauseForFeedback) {
+    _triggerUnpauseFeedback();
+  }
+}
+
+// Test:
+testWidgets('triggers feedback for pauses > 150 ms', (tester) async {
+  var now = DateTime(2026);
+  await withClock(Clock(() => now), () async {
+    await tester.pumpWidget(buildSubject());
+    // ... set up "playing" state ...
+
+    playingController.add(false);
+    await tester.pump();
+
+    // Advance BOTH clocks so timers and wall-clock agree.
+    now = now.add(const Duration(milliseconds: 220));
+    await tester.pump(const Duration(milliseconds: 220));
+
+    playingController.add(true);
+    await tester.pump();
+
+    expect(find.byType(UnpauseFeedback), findsOneWidget);
+  });
+});
+```
+
+`clock` is already a transitive dependency in this repo, so no
+`pubspec.yaml` change is needed to start using it.

--- a/.claude/rules/ui_theming.md
+++ b/.claude/rules/ui_theming.md
@@ -471,6 +471,117 @@ so they live in the always-visible sliver region.
 
 ---
 
+## `AnimatedSwitcher` differentiates children by runtime type
+
+`AnimatedSwitcher` decides "is this a new child?" with
+`Widget.canUpdate(oldChild, newChild)` — which is true when
+`oldChild.runtimeType == newChild.runtimeType && oldChild.key ==
+newChild.key`. If your switcher's branches already return **different
+widget types** (`Center`, `IgnorePointer`, `SizedBox`, etc.), they are
+already distinguishable. Adding a `ValueKey` on top is redundant.
+
+Worse: hardcoded `ValueKey`s in a widget that is reused elsewhere in
+the same subtree (or inside another `AnimatedSwitcher`) can trigger
+"duplicate GlobalKey in the widget tree" assertions. Only add a
+`ValueKey` when:
+
+1. The branches are the **same** runtime type (e.g. two `Text`
+   widgets with different strings — `AnimatedSwitcher` won't see a
+   transition without a key), **or**
+2. A test anchors on the key via `find.byKey(...)`. In that case,
+   leave a one-line comment on the key explaining the test dependency,
+   so the key can't be silently renamed.
+
+**Bad — redundant keys on already-different runtime types:**
+```dart
+AnimatedSwitcher(
+  duration: _kFadeDuration,
+  child: shouldShowPlay
+      ? Center(
+          key: const ValueKey('play'),     // Center is already unique
+          child: const PlayIcon(),
+        )
+      : shouldShowFeedback
+          ? IgnorePointer(
+              key: const ValueKey('feedback'),  // IgnorePointer is unique
+              child: const FeedbackIcon(),
+            )
+          : const SizedBox.shrink(
+              key: ValueKey('hidden'),     // SizedBox is unique
+            ),
+);
+```
+
+**Good — rely on runtime type; keep the one key a test anchors on:**
+```dart
+AnimatedSwitcher(
+  duration: _kFadeDuration,
+  child: shouldShowPlay
+      ? Center(
+          // Tested via find.byKey(ValueKey('play')); see
+          // paused_video_play_overlay_test.dart.
+          key: const ValueKey('play'),
+          child: const PlayIcon(),
+        )
+      : shouldShowFeedback
+          ? IgnorePointer(child: const FeedbackIcon())
+          : const SizedBox.shrink(),
+);
+```
+
+---
+
+## `AnimationController` over `Timer` for UI timing
+
+The [`self_review_checklist.md`](self_review_checklist.md) already
+says "No `Future.delayed()` for UI timing." `Timer` from `dart:async`
+falls in the same bucket and for the same reasons — plus a few
+specific to Flutter:
+
+- A ticker-backed `AnimationController` **pauses with the route**
+  (offscreen sheets stop firing frames); a `Timer` keeps running and
+  fires `setState` after the widget is disposed unless you cancel it
+  by hand.
+- `AnimationController` respects `MediaQuery.disableAnimations`
+  (reduced-motion); a `Timer`-driven fade doesn't.
+- `AnimationController` uses the frame scheduler, so opacity /
+  position updates align with the next vsync. `Timer`-driven
+  `setState` can land mid-frame.
+
+Prefer this shape for transient flashes (unpause feedback, badge
+pulses, snackbar-like overlays):
+
+```dart
+// Good — AnimationController + FadeTransition/AnimatedBuilder.
+late final AnimationController _feedbackController = AnimationController(
+  vsync: this,
+  duration: const Duration(milliseconds: 550),
+);
+
+@override
+void dispose() {
+  _feedbackController.dispose();
+  super.dispose();
+}
+
+void _triggerFeedback() {
+  _feedbackController.forward(from: 0);
+}
+
+// In build:
+FadeTransition(
+  opacity: Tween(begin: 1.0, end: 0.0).animate(_feedbackController),
+  child: const FeedbackIcon(),
+)
+```
+
+Reach for `Timer` (or its partner-in-crime `Future.delayed`) only when
+the effect is genuinely outside the rendering pipeline — e.g. a
+debounce before hitting the network, or a cancellable delay before
+logging analytics. If you're animating pixels, use an animation API.
+
+---
+
 ## Accessibility
 
 See `accessibility.md` for the full accessibility guide (semantic labels, announcements, traversal order, contrast, font responsiveness, motion, and testing).


### PR DESCRIPTION
Follow-up to closed PR #3308.

## Context: why this PR exists

PR #3308 was closed on the basis that "the same issues were addressed in #3231." That framing conflated the scope: **#3231 only covered a small slice of what was in #3308.**

### What #3231 actually added

`.claude/rules/code_style.md` only (+27 lines) — a revamp of the existing **Comments** section:

- "Keep comments short" preamble, multi-line restrictions
- Comment rules (`///` vs `//`, why-not-what, no section headers)
- "Comments go stale" block
- "LLM-specific: don't restate the code" example

### What was in #3308 but **is NOT on main today**

After #3231 merged, zero grep matches on current main for any of the following ten rules. They were all derived from the #3224 (home-screen) review cycle and the CI fix-loop on that same branch — separate workstream, separate lessons, non-overlapping scope with #3231:

| File | Rule | Source |
|---|---|---|
| `code_style.md` | **Document Design-System Divergence** (why diverging from `DivineIconButton` needs a docstring note) | [#3224 T1](https://github.com/divinevideo/divine-mobile/pull/3224#discussion_r3121966356) |
| `code_style.md` | **No Speculative Parameters on Reusable Widgets** (`initialChildSizeBuilder`-style YAGNI) | [#3224 T5](https://github.com/divinevideo/divine-mobile/pull/3224#discussion_r3122073231), [T6](https://github.com/divinevideo/divine-mobile/pull/3224#discussion_r3122092691) |
| `code_style.md` | **Don't Hide Ancestors in a One-Off `Widget Function` Closure** (use `contentWrapper` instead) | [#3224 T4](https://github.com/divinevideo/divine-mobile/pull/3224#discussion_r3122044898) |
| `code_style.md` | **Don't write long design-rationale comments just for Claude** (small follow-up bullet in the existing LLM-specific subsection) | [#3202 T1](https://github.com/divinevideo/divine-mobile/pull/3202#discussion_r3115605709) |
| `state_management.md` | **Scoping `BlocProvider` to a modal route** (no `try/finally bloc.close()` around modals) | [#3224 T4](https://github.com/divinevideo/divine-mobile/pull/3224#discussion_r3122044898) |
| `ui_theming.md` | **`AnimatedSwitcher` differentiates children by runtime type** (don't add redundant `ValueKey`s) | [#3224 T2](https://github.com/divinevideo/divine-mobile/pull/3224#discussion_r3121984957) |
| `ui_theming.md` | **`AnimationController` over `Timer` for UI timing** | [#3224 T3](https://github.com/divinevideo/divine-mobile/pull/3224#discussion_r3122016780) |
| `testing.md` | **Absolute timing bounds flake on shared CI runners** (`<100 ns` / `<100 ms` CI-only flakes) | CI fix-loop on #3224 |
| `testing.md` | **`tester.takeException(), isNotNull` is fragile under `very_good test --optimization`** | CI fix-loop on #3224 |
| `testing.md` | **Coordinate-based `tapAt` is sensitive to modal layout** | CI fix-loop on #3224 |
| `testing.md` | **Inject `package:clock` for time-sensitive logic** (so `tester.pump(Duration)` + `DateTime.now()` agree) | CI fix-loop on #3224 |

### State of the related issues

- **#3307** (tracker for the original #3308) is still **OPEN**. Only a small slice of what it tracks shipped via #3231. This PR finishes the job and should close it.
- **#3309** (golden tests for `NavRoundedShell`) is still **OPEN**. Unrelated to #3308's closure; still a valid standalone request.

## What this PR does

Re-applies the ten rules above (as two cherry-picked commits from the closed #3308's branch) on top of today's main — which already has #3231 in place. Cherry-picks resolved cleanly; no content from #3231 is touched. `self_review_checklist.md` picks up matching bullets, each cross-linked to the new sub-section.

No `lib/` or `test/` changes — docs only, same shape as #3200 and #3231.

Closes #3307.

## Test plan

- [x] Every internal `.md` link and `#anchor` resolves (validated with a small script before pushing; 20+ new cross-links all point to real headings).
- [x] No overlap with #3231's Comments-section revamp — cherry-pick landed cleanly on top of it.
- [x] No code changes, so no CI impact beyond `Analyze` / `Format` passing cleanly.

## Related

- Original PR (closed): #3308
- Source review where the lessons came from: #3224
- `.claude/rules/` precedent PRs: #3200 (first lessons pass), #3231 (Comments section revamp)
- Follow-up issue for the Timer → AnimationController refactor (thread #3 on #3224): #3303
