### PR TITLE
fix(video-editor): update overlay visibility logic based on total duration

### DIFF
--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
@@ -101,6 +101,8 @@ class VideoEditorTimelineBody extends StatelessWidget {
     final trimExpand = clipTrimExpand > overlayTrimExpand
         ? clipTrimExpand
         : overlayTrimExpand;
+    final showMaxDurationOverlays =
+        !isReordering && totalDuration > VideoEditorConstants.maxDuration;
 
     return HitExpandedBox(
       expandLeft: trimExpand,
@@ -112,7 +114,7 @@ class VideoEditorTimelineBody extends StatelessWidget {
           // Keep stack slots stable during drag-reorder to avoid gesture drops.
           _TimelineMaxDurationStripeOverlay(
             pixelsPerSecond: pixelsPerSecond,
-            visible: !isReordering,
+            visible: showMaxDurationOverlays,
           ),
 
           Column(
@@ -187,7 +189,7 @@ class VideoEditorTimelineBody extends StatelessWidget {
           ),
           _TimelineMaxDurationDimOverlay(
             pixelsPerSecond: pixelsPerSecond,
-            visible: !isReordering,
+            visible: showMaxDurationOverlays,
           ),
         ],
       ),
@@ -201,13 +203,13 @@ class _TimelineMaxDurationStripeOverlay extends StatelessWidget {
     required this.visible,
   });
 
-  static const _outsideExtendWidth = 200.0;
-
   final double pixelsPerSecond;
   final bool visible;
 
   @override
   Widget build(BuildContext context) {
+    final outsideExtendWidth = MediaQuery.sizeOf(context).width / 2;
+
     return Positioned(
       left:
           VideoEditorConstants.maxDuration.inMilliseconds /
@@ -215,7 +217,7 @@ class _TimelineMaxDurationStripeOverlay extends StatelessWidget {
           pixelsPerSecond,
       top: 0,
       bottom: 0,
-      right: -_outsideExtendWidth,
+      right: -outsideExtendWidth,
       child: IgnorePointer(
         child: Visibility(
           visible: visible,
@@ -238,13 +240,13 @@ class _TimelineMaxDurationDimOverlay extends StatelessWidget {
     required this.visible,
   });
 
-  static const _outsideExtendWidth = 200.0;
-
   final double pixelsPerSecond;
   final bool visible;
 
   @override
   Widget build(BuildContext context) {
+    final outsideExtendWidth = MediaQuery.sizeOf(context).width / 2;
+
     return Positioned(
       left:
           VideoEditorConstants.maxDuration.inMilliseconds /
@@ -252,7 +254,7 @@ class _TimelineMaxDurationDimOverlay extends StatelessWidget {
           pixelsPerSecond,
       top: 0,
       bottom: 0,
-      right: -_outsideExtendWidth,
+      right: -outsideExtendWidth,
       child: IgnorePointer(
         child: Visibility(
           visible: visible,

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_body_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_body_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart';
@@ -42,6 +43,7 @@ void main() {
     Future<void> pumpBody(
       WidgetTester tester, {
       bool isReordering = false,
+      Duration totalDuration = const Duration(seconds: 12),
     }) async {
       when(
         () => mainBloc.state,
@@ -64,7 +66,7 @@ void main() {
             child: SizedBox(
               height: 120000,
               child: VideoEditorTimelineBody(
-                totalDuration: const Duration(seconds: 12),
+                totalDuration: totalDuration,
                 pixelsPerSecond: 80,
                 scrollController: scrollController,
                 scrollPadding: 16,
@@ -156,6 +158,61 @@ void main() {
                   VineTheme.surfaceContainerHigh.withValues(alpha: 0.3),
         ),
         findsNothing,
+      );
+    });
+
+    testWidgets(
+      'hides outside-area overlays when duration does not exceed max',
+      (tester) async {
+        await pumpBody(
+          tester,
+          totalDuration: VideoEditorConstants.maxDuration,
+        );
+
+        expect(
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is CustomPaint &&
+                widget.painter.runtimeType.toString() ==
+                    '_TimelineOutsideAreaPainter',
+          ),
+          findsNothing,
+        );
+
+        expect(
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is ColoredBox &&
+                widget.color ==
+                    VineTheme.surfaceContainerHigh.withValues(alpha: 0.3),
+          ),
+          findsNothing,
+        );
+      },
+    );
+
+    testWidgets('extends overlay by half screen width', (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1000, 1200);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await pumpBody(tester);
+
+      final expectedLeft =
+          VideoEditorConstants.maxDuration.inMilliseconds / 1000 * 80;
+      const expectedRight = -500.0;
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Positioned &&
+              widget.top == 0 &&
+              widget.bottom == 0 &&
+              widget.left == expectedLeft &&
+              widget.right == expectedRight,
+        ),
+        findsNWidgets(2),
       );
     });
 


### PR DESCRIPTION
Closes #3323


## Description

This fix updates the video editor timeline outside-area overlays so they only appear when the timeline duration actually exceeds the configured max duration.
It also replaces the previous fixed outside extension with a responsive half-screen-width extension, so the overlay behaves correctly on larger devices (for example tablets).
Widget tests were added to cover both the max-duration visibility rule and the half-screen-width layout behavior.

**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore