### PR TITLE
fix(video-editor): show unsaved changes warning only when there are no changes

### DIFF
--- a/mobile/lib/models/divine_video_draft.dart
+++ b/mobile/lib/models/divine_video_draft.dart
@@ -4,7 +4,6 @@
 import 'dart:convert';
 
 import 'package:db_client/db_client.dart';
-import 'package:flutter/foundation.dart';
 import 'package:models/models.dart'
     show AspectRatio, AudioEvent, InspiredByInfo, NativeProofData;
 import 'package:openvine/models/content_label.dart';
@@ -399,6 +398,12 @@ class DivineVideoDraft {
   bool get canRetry => publishStatus == PublishStatus.failed;
   bool get isPublishing => publishStatus == PublishStatus.publishing;
 
+  bool get hasEditorStateEdits {
+    if (editorStateHistory.isEmpty) return false;
+
+    return ImportStateHistory.fromMap(editorStateHistory).editorPosition != -1;
+  }
+
   /// Whether the draft has been edited beyond its initial recording.
   ///
   /// Checks metadata and editor state but ignores clips.
@@ -410,11 +415,7 @@ class DivineVideoDraft {
       (hasTitle ||
           hasDescription ||
           hasHashtags ||
-          (editorStateHistory.isNotEmpty &&
-              !mapEquals(
-                editorStateHistory,
-                CompleteParameters.fromMap({}).toMap(),
-              )) ||
+          hasEditorStateEdits ||
           finalRenderedClip != null ||
           selectedSound != null ||
           contentWarning != null ||

--- a/mobile/test/models/divine_video_draft_has_been_edited_test.dart
+++ b/mobile/test/models/divine_video_draft_has_been_edited_test.dart
@@ -104,6 +104,24 @@ void main() {
         expect(draft.hasBeenEdited, isTrue);
       });
 
+      test('returns false when editorStateHistory position is -1', () {
+        final draft = _minimalDraft().copyWith(
+          editorStateHistory: const {'position': -1},
+          skipUpdateLastModified: true,
+        );
+
+        expect(draft.hasBeenEdited, isFalse);
+      });
+
+      test('returns true when editorStateHistory position is not -1', () {
+        final draft = _minimalDraft().copyWith(
+          editorStateHistory: const {'position': 0},
+          skipUpdateLastModified: true,
+        );
+
+        expect(draft.hasBeenEdited, isTrue);
+      });
+
       test('returns false when draft has editorEditingParameters only', () {
         final draft = _minimalDraft().copyWith(
           editorEditingParameters: const {'param': 'value'},


### PR DESCRIPTION
Closes #3327

## Description

Until now, when the user tried to close the editor, they were always asked to discard changes, even if nothing had been modified. This PR fixes that and only prompts the user when there are actual changes.


**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore