### PR TITLE
feat(nav): consolidate bottom nav on VineBottomNav + match Figma 5595:133692

### DIFF
--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -4,13 +4,10 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:openvine/app_update/app_update.dart';
-import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/providers/active_video_provider.dart';
@@ -18,19 +15,16 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/classic_vines_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/for_you_provider.dart';
-import 'package:openvine/providers/relay_notifications_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
-import 'package:openvine/screens/inbox/inbox_page.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
-import 'package:openvine/utils/camera_permission_check.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/npub_hex.dart';
 import 'package:openvine/widgets/environment_indicator.dart';
-import 'package:openvine/widgets/notification_badge.dart';
+import 'package:openvine/widgets/vine_bottom_nav.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -152,63 +146,6 @@ class _AppShellState extends ConsumerState<AppShell> {
     }
   }
 
-  /// Handles tab tap - navigates to last known position in that tab
-  void _handleTabTap(BuildContext context, WidgetRef ref, int tabIndex) {
-    final routeType = _routeTypeForTab(tabIndex);
-    final lastIndex = ref
-        .read(lastTabPositionProvider.notifier)
-        .getPosition(routeType);
-
-    // Log user interaction
-    Log.info(
-      '👆 User tapped bottom nav: tab=$tabIndex (${_tabName(context, tabIndex)})',
-      name: 'Navigation',
-      category: LogCategory.ui,
-    );
-
-    // Pop any pushed routes (like CuratedListFeedScreen, UserListPeopleScreen)
-    // that were pushed via Navigator.push() on top of the shell
-    // Only pop if there are actually pushed routes to avoid interfering with GoRouter
-    final navigator = Navigator.of(context);
-    if (navigator.canPop()) {
-      // There are pushed routes - pop them before navigating
-      // This ensures we return to the shell before GoRouter navigation
-      navigator.popUntil((route) => route.isFirst);
-    }
-
-    // Navigate to last position in that tab
-    // GoRouter handles navigation state, but we need to clear pushed routes first
-    switch (tabIndex) {
-      case 0:
-        return context.go(VideoFeedPage.pathForIndex(lastIndex ?? 0));
-      case 1:
-        // Always reset to grid mode (null) when tapping Explore tab
-        // This prevents the "No videos available" bug when returning from another tab
-        return context.go(ExploreScreen.path);
-      case 2:
-        return context.go(InboxPage.path);
-      case 3:
-        // Always navigate to current user's profile when tapping Profile tab
-        final authService = ref.read(authServiceProvider);
-        final currentUserHex = authService.currentPublicKeyHex;
-        if (currentUserHex != null) {
-          final npub = NostrKeyUtils.encodePubKey(currentUserHex);
-          return context.go(ProfileScreenRouter.pathForNpub(npub));
-        }
-    }
-  }
-
-  String _tabName(BuildContext context, int index) {
-    final l10n = context.l10n;
-    return switch (index) {
-      0 => l10n.navHome,
-      1 => l10n.navExplore,
-      2 => l10n.navInbox,
-      3 => l10n.navProfile,
-      _ => l10n.navUnknown,
-    };
-  }
-
   /// Builds the header title - tappable for Explore and Hashtag routes to navigate back
   Widget _buildTappableTitle(
     BuildContext context,
@@ -254,34 +191,6 @@ class _AppShellState extends ConsumerState<AppShell> {
         context.go(ExploreScreen.path);
       },
       child: titleWidget,
-    );
-  }
-
-  /// Builds a tab button for the bottom navigation bar
-  Widget _buildTabButton(
-    BuildContext context,
-    WidgetRef ref,
-    String iconPath,
-    int tabIndex,
-    int currentIndex,
-    String semanticIdentifier,
-  ) {
-    final isSelected = currentIndex == tabIndex;
-
-    return Semantics(
-      identifier: semanticIdentifier,
-      child: GestureDetector(
-        onTap: () => _handleTabTap(context, ref, tabIndex),
-        child: Opacity(
-          opacity: isSelected ? 1.0 : 0.5,
-          child: Container(
-            width: 48,
-            height: 48,
-            padding: const EdgeInsets.all(8),
-            child: SvgPicture.asset(iconPath, width: 32, height: 32),
-          ),
-        ),
-      ),
     );
   }
 
@@ -460,94 +369,16 @@ class _AppShellState extends ConsumerState<AppShell> {
               ],
             )
           : child,
-      // Bottom nav visible for all shell routes (search, tabs, etc.)
-      // For search (currentIndex=-1), no tab is highlighted
+      // Bottom nav visible for all shell routes (search, tabs, etc.).
+      // For search (currentIndex=-1), no tab is highlighted.
       // PointerInterceptor ensures the bottom nav receives taps on web
       // even when HTML platform views (video elements) overlap the area.
+      //
+      // The nav itself lives in [VineBottomNav] so home / explore /
+      // inbox / profile-router all render the same shared widget.
       bottomNavigationBar: PointerInterceptor(
         intercepting: kIsWeb,
-        child: Container(
-          color: VineTheme.navGreen,
-          padding: const EdgeInsets.symmetric(vertical: 12),
-          child: SafeArea(
-            top: false,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              children: [
-                _buildTabButton(
-                  context,
-                  ref,
-                  DivineIconName.house.assetPath,
-                  0,
-                  currentIndex,
-                  'home_tab',
-                ),
-                _buildTabButton(
-                  context,
-                  ref,
-                  DivineIconName.compass.assetPath,
-                  1,
-                  currentIndex,
-                  'explore_tab',
-                ),
-                // Camera button in center of bottom nav
-                Semantics(
-                  identifier: 'camera_button',
-                  button: true,
-                  label: context.l10n.navOpenCamera,
-                  child: GestureDetector(
-                    onTap: () {
-                      Log.info(
-                        '👆 User tapped camera button',
-                        name: 'Navigation',
-                        category: LogCategory.ui,
-                      );
-                      context.pushToCameraWithPermission();
-                    },
-                    child: Container(
-                      width: 72,
-                      height: 48,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 20,
-                        vertical: 8,
-                      ),
-                      decoration: BoxDecoration(
-                        color: VineTheme.cameraButtonGreen,
-                        borderRadius: BorderRadius.circular(20),
-                      ),
-                      child: SvgPicture.asset(
-                        DivineIconName.cameraRetro.assetPath,
-                        width: 32,
-                        height: 32,
-                      ),
-                    ),
-                  ),
-                ),
-                NotificationBadge(
-                  count:
-                      context.watch<DmUnreadCountCubit>().state +
-                      ref.watch(relayNotificationUnreadCountProvider),
-                  child: _buildTabButton(
-                    context,
-                    ref,
-                    DivineIconName.chat.assetPath,
-                    2,
-                    currentIndex,
-                    'inbox_tab',
-                  ),
-                ),
-                _buildTabButton(
-                  context,
-                  ref,
-                  DivineIconName.userCircle.assetPath,
-                  3,
-                  currentIndex,
-                  'profile_tab',
-                ),
-              ],
-            ),
-          ),
-        ),
+        child: VineBottomNav(currentIndex: currentIndex),
       ),
     );
   }

--- a/mobile/lib/widgets/vine_bottom_nav.dart
+++ b/mobile/lib/widgets/vine_bottom_nav.dart
@@ -1,15 +1,17 @@
 // ABOUTME: Shared bottom navigation bar widget for app shell and profile screens
 // ABOUTME: Provides consistent bottom nav across screens with/without shell
 
+import 'dart:ui' show ImageFilter;
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/relay_notifications_provider.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
@@ -18,6 +20,7 @@ import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/utils/camera_permission_check.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/notification_badge.dart';
+import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Shared bottom navigation bar used by AppShell and standalone profile screens.
@@ -95,60 +98,27 @@ class VineBottomNav extends ConsumerWidget {
     return dmCount + notifCount;
   }
 
-  Widget _buildTabButton(
-    BuildContext context,
-    WidgetRef ref,
-    String iconPath,
-    int tabIndex,
-    String semanticIdentifier,
-  ) {
-    final isSelected = currentIndex == tabIndex;
-    final iconColor = isSelected
-        ? VineTheme.whiteText
-        : VineTheme.tabIconInactive;
-
-    return Semantics(
-      identifier: semanticIdentifier,
-      child: GestureDetector(
-        onTap: () => _handleTabTap(context, ref, tabIndex),
-        child: Container(
-          width: 48,
-          height: 48,
-          padding: const EdgeInsets.all(8),
-          child: SvgPicture.asset(
-            iconPath,
-            width: 32,
-            height: 32,
-            colorFilter: ColorFilter.mode(iconColor, BlendMode.srcIn),
-          ),
-        ),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Container(
-      color: VineTheme.navGreen,
+      color: VineTheme.surfaceBackground,
       padding: const EdgeInsets.symmetric(vertical: 12),
       child: SafeArea(
         top: false,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           children: [
-            _buildTabButton(
-              context,
-              ref,
-              DivineIconName.house.assetPath,
-              0,
-              'home_tab',
+            _IconTabButton(
+              semanticIdentifier: 'home_tab',
+              icon: DivineIconName.houseSimple,
+              isSelected: currentIndex == 0,
+              onTap: () => _handleTabTap(context, ref, 0),
             ),
-            _buildTabButton(
-              context,
-              ref,
-              DivineIconName.compass.assetPath,
-              1,
-              'explore_tab',
+            _IconTabButton(
+              semanticIdentifier: 'explore_tab',
+              icon: DivineIconName.search,
+              isSelected: currentIndex == 1,
+              onTap: () => _handleTabTap(context, ref, 1),
             ),
             // Camera button in center of bottom nav
             _CameraButton(
@@ -163,23 +133,247 @@ class VineBottomNav extends ConsumerWidget {
             ),
             NotificationBadge(
               count: _inboxUnreadCount(context, ref),
-              child: _buildTabButton(
-                context,
-                ref,
-                DivineIconName.chat.assetPath,
-                2,
-                'inbox_tab',
+              child: _IconTabButton(
+                semanticIdentifier: 'inbox_tab',
+                icon: DivineIconName.chat,
+                isSelected: currentIndex == 2,
+                onTap: () => _handleTabTap(context, ref, 2),
               ),
             ),
-            _buildTabButton(
-              context,
-              ref,
-              DivineIconName.userCircle.assetPath,
-              3,
-              'profile_tab',
+            _ProfileTabButton(
+              isSelected: currentIndex == 3,
+              onTap: () => _handleTabTap(context, ref, 3),
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+// =============================================================================
+// Tab buttons
+// =============================================================================
+//
+// The Figma component (node 5595:133692) specifies two tab-button shapes:
+//   * **Icon tabs** (Home / Search / Inbox) — 48×48 tap target, 24×24 glyph,
+//     selected = full opacity + shadow-10 drop shadows on the glyph,
+//     unselected = 32 % opacity, no shadow.
+//   * **Profile tab** — 48×48 tap target, 24×24 rounded-8 box,
+//     lime fill + avatar rendered with `BlendMode.luminosity`,
+//     selected = 2 px white border + inset scrim-65 shadow,
+//     unselected = 1 px onSurfaceDisabled border.
+
+/// Tap target + Semantics wrapper shared by the three icon tabs.
+///
+/// The child gets the 32 %-opacity dim in the unselected state and the
+/// glyph-shaped shadow pair in the selected state. See [_ShadowedNavIcon].
+class _IconTabButton extends StatelessWidget {
+  const _IconTabButton({
+    required this.semanticIdentifier,
+    required this.icon,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final String semanticIdentifier;
+  final DivineIconName icon;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      identifier: semanticIdentifier,
+      child: GestureDetector(
+        onTap: onTap,
+        child: SizedBox(
+          width: 48,
+          height: 48,
+          child: Center(
+            child: Opacity(
+              // Figma: unselected tabs render at 32 % opacity; selected stays
+              // at 100 %. No color tint — just dim + shadow toggle.
+              opacity: isSelected ? 1.0 : 0.32,
+              child: _ShadowedNavIcon(icon: icon, showShadow: isSelected),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 24×24 [DivineIcon] that optionally paints the Figma `effects/shadow-10`
+/// drop-shadow pair underneath the glyph. The shadow copies are
+/// [DivineIcon]s tinted in [VineTheme.innerShadow] and blurred via
+/// [ImageFiltered] so the shadow silhouette tracks the glyph, not the
+/// bounding rect.
+///
+/// Same pattern as `_ShadowedIcon` in `video_action_button.dart` — when we
+/// consolidate those, move to a shared `divine_ui` widget.
+class _ShadowedNavIcon extends StatelessWidget {
+  const _ShadowedNavIcon({required this.icon, required this.showShadow});
+
+  final DivineIconName icon;
+  final bool showShadow;
+
+  @override
+  Widget build(BuildContext context) {
+    final glyph = DivineIcon(icon: icon, color: VineTheme.whiteText);
+    if (!showShadow) return glyph;
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        _NavIconShadow(icon: icon, offset: const Offset(1, 1), blurSigma: 1),
+        _NavIconShadow(
+          icon: icon,
+          offset: const Offset(0.4, 0.4),
+          blurSigma: 0.6,
+        ),
+        glyph,
+      ],
+    );
+  }
+}
+
+class _NavIconShadow extends StatelessWidget {
+  const _NavIconShadow({
+    required this.icon,
+    required this.offset,
+    required this.blurSigma,
+  });
+
+  final DivineIconName icon;
+  final Offset offset;
+  final double blurSigma;
+
+  @override
+  Widget build(BuildContext context) {
+    return Transform.translate(
+      offset: offset,
+      child: ImageFiltered(
+        imageFilter: ImageFilter.blur(sigmaX: blurSigma, sigmaY: blurSigma),
+        // Excluded from semantics — the foreground glyph carries the
+        // accessibility node; these are decorative shadow copies.
+        child: ExcludeSemantics(
+          child: DivineIcon(icon: icon, color: VineTheme.innerShadow),
+        ),
+      ),
+    );
+  }
+}
+
+/// Profile tab: 24×24 rounded-8 box with a lime background, the
+/// currently-signed-in user's avatar rendered with [BlendMode.luminosity],
+/// and a state-dependent border (1 px disabled / 2 px white).
+///
+/// Falls back to the standard icon-tab treatment with [DivineIconName.userCircle]
+/// when no user is signed in (e.g. during sign-out) or while the profile
+/// is still loading.
+class _ProfileTabButton extends ConsumerWidget {
+  const _ProfileTabButton({required this.isSelected, required this.onTap});
+
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authService = ref.watch(authServiceProvider);
+    final pubkey = authService.currentPublicKeyHex;
+    final profile = pubkey == null
+        ? null
+        : ref.watch(userProfileReactiveProvider(pubkey)).value;
+    final imageUrl = profile?.picture;
+    final hasAvatar = imageUrl != null && imageUrl.isNotEmpty;
+
+    return Semantics(
+      identifier: 'profile_tab',
+      child: GestureDetector(
+        onTap: onTap,
+        child: SizedBox(
+          width: 48,
+          height: 48,
+          child: Center(
+            child: hasAvatar
+                ? _ProfileAvatarBox(
+                    imageUrl: imageUrl,
+                    isSelected: isSelected,
+                  )
+                // No signed-in avatar: render the same icon-tab treatment
+                // (opacity dim / shadow) as Home / Search / Inbox so the
+                // nav bar still feels uniform until the profile loads.
+                : Opacity(
+                    opacity: isSelected ? 1.0 : 0.32,
+                    child: _ShadowedNavIcon(
+                      icon: DivineIconName.userCircle,
+                      showShadow: isSelected,
+                    ),
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The Figma profile-tab avatar box: 24×24 rounded-8 container with a
+/// lime fallback fill and the user's avatar image on top. The two
+/// variants differ only in the outer border — 1 px `onSurfaceDisabled`
+/// when unselected, 2 px white when selected.
+class _ProfileAvatarBox extends StatelessWidget {
+  const _ProfileAvatarBox({
+    required this.imageUrl,
+    required this.isSelected,
+  });
+
+  final String imageUrl;
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: 24,
+      child: Stack(
+        children: [
+          // Lime base — visible through transparent pixels of the
+          // avatar and while the image is still loading.
+          Positioned.fill(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: const ColoredBox(color: VineTheme.accentLime),
+            ),
+          ),
+          // Avatar image, clipped to the rounded 8-px square.
+          Positioned.fill(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: VineCachedImage(
+                imageUrl: imageUrl,
+                width: 24,
+                height: 24,
+              ),
+            ),
+          ),
+          // Border on top — 1 px `onSurfaceDisabled` when unselected,
+          // 2 px white when selected. (No inset shadow / opacity / blend
+          // — the avatar shows in full color in both states.)
+          Positioned.fill(
+            child: IgnorePointer(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(
+                    color: isSelected
+                        ? VineTheme.whiteText
+                        : VineTheme.onSurfaceDisabled,
+                    width: isSelected ? 2 : 1,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/lib/widgets/vine_bottom_nav.dart
+++ b/mobile/lib/widgets/vine_bottom_nav.dart
@@ -9,6 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/relay_notifications_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
@@ -110,12 +111,14 @@ class VineBottomNav extends ConsumerWidget {
           children: [
             _IconTabButton(
               semanticIdentifier: 'home_tab',
+              semanticLabel: context.l10n.navHome,
               icon: DivineIconName.houseSimple,
               isSelected: currentIndex == 0,
               onTap: () => _handleTabTap(context, ref, 0),
             ),
             _IconTabButton(
               semanticIdentifier: 'explore_tab',
+              semanticLabel: context.l10n.navExplore,
               icon: DivineIconName.search,
               isSelected: currentIndex == 1,
               onTap: () => _handleTabTap(context, ref, 1),
@@ -135,12 +138,14 @@ class VineBottomNav extends ConsumerWidget {
               count: _inboxUnreadCount(context, ref),
               child: _IconTabButton(
                 semanticIdentifier: 'inbox_tab',
+                semanticLabel: context.l10n.navInbox,
                 icon: DivineIconName.chat,
                 isSelected: currentIndex == 2,
                 onTap: () => _handleTabTap(context, ref, 2),
               ),
             ),
             _ProfileTabButton(
+              semanticLabel: context.l10n.navProfile,
               isSelected: currentIndex == 3,
               onTap: () => _handleTabTap(context, ref, 3),
             ),
@@ -160,9 +165,10 @@ class VineBottomNav extends ConsumerWidget {
 //     selected = full opacity + shadow-10 drop shadows on the glyph,
 //     unselected = 32 % opacity, no shadow.
 //   * **Profile tab** — 48×48 tap target, 24×24 rounded-8 box,
-//     lime fill + avatar rendered with `BlendMode.luminosity`,
-//     selected = 2 px white border + inset scrim-65 shadow,
-//     unselected = 1 px onSurfaceDisabled border.
+//     lime fallback fill with the user's avatar on top. Selected and
+//     unselected differ only in the outer border (2 px white vs 1 px
+//     `onSurfaceDisabled`); no filter / opacity / shadow on the avatar
+//     itself.
 
 /// Tap target + Semantics wrapper shared by the three icon tabs.
 ///
@@ -171,12 +177,14 @@ class VineBottomNav extends ConsumerWidget {
 class _IconTabButton extends StatelessWidget {
   const _IconTabButton({
     required this.semanticIdentifier,
+    required this.semanticLabel,
     required this.icon,
     required this.isSelected,
     required this.onTap,
   });
 
   final String semanticIdentifier;
+  final String semanticLabel;
   final DivineIconName icon;
   final bool isSelected;
   final VoidCallback onTap;
@@ -185,6 +193,8 @@ class _IconTabButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       identifier: semanticIdentifier,
+      button: true,
+      label: semanticLabel,
       child: GestureDetector(
         onTap: onTap,
         child: SizedBox(
@@ -264,16 +274,22 @@ class _NavIconShadow extends StatelessWidget {
   }
 }
 
-/// Profile tab: 24×24 rounded-8 box with a lime background, the
-/// currently-signed-in user's avatar rendered with [BlendMode.luminosity],
-/// and a state-dependent border (1 px disabled / 2 px white).
+/// Profile tab: 24×24 rounded-8 box with a lime fallback background and
+/// the currently-signed-in user's avatar on top. Selection state is
+/// communicated only by the outer border (1 px `onSurfaceDisabled` →
+/// 2 px white).
 ///
 /// Falls back to the standard icon-tab treatment with [DivineIconName.userCircle]
 /// when no user is signed in (e.g. during sign-out) or while the profile
 /// is still loading.
 class _ProfileTabButton extends ConsumerWidget {
-  const _ProfileTabButton({required this.isSelected, required this.onTap});
+  const _ProfileTabButton({
+    required this.semanticLabel,
+    required this.isSelected,
+    required this.onTap,
+  });
 
+  final String semanticLabel;
   final bool isSelected;
   final VoidCallback onTap;
 
@@ -289,6 +305,8 @@ class _ProfileTabButton extends ConsumerWidget {
 
     return Semantics(
       identifier: 'profile_tab',
+      button: true,
+      label: semanticLabel,
       child: GestureDetector(
         onTap: onTap,
         child: SizedBox(
@@ -390,7 +408,7 @@ class _CameraButton extends StatelessWidget {
     return Semantics(
       identifier: 'camera_button',
       button: true,
-      label: 'Open camera',
+      label: context.l10n.navOpenCamera,
       child: GestureDetector(
         onTap: onTap,
         child: Container(


### PR DESCRIPTION
## Description

Consolidates the bottom navigation onto a single shared `VineBottomNav` widget and updates it to match the Figma design at [node `5595:133692`](https://www.figma.com/design/rp1DsDEUuCaicW0lk6I2aZ/UI-Design?node-id=5595-133692&m=dev).

Before this PR there were two implementations: `VineBottomNav` (used only by the npub-addressed profile router) and an inlined ~85-line block in `AppShell` (used by every other shell route). They had drifted visually — Profile used color tinting, AppShell used opacity dim. Now both go through `VineBottomNav`. Editing the nav once propagates everywhere.

Visible changes:

- **Home icon**: `house` → `houseSimple`
- **Explore icon**: `compass` → `search`
- **Tab icon size**: 32 px → 24 px (tap target stays 48 × 48)
- **Selected / unselected treatment**: full opacity + Figma `effects/shadow-10` glyph drop-shadow when selected, 32 % opacity when unselected (was opacity-based-only before)
- **Profile tab**: now renders the signed-in user's avatar in a 24 × 24 rounded-8 box on a lime fallback background. Selection state changes only the outer border (1 px `onSurfaceDisabled` → 2 px white). Falls back to a `userCircle` icon when no user is signed in or while the profile is still loading.
- **Surface color**: `navGreen` → `surfaceBackground` (the Figma-specified token)

Internal cleanup:

- `AppShell` loses three private helpers (`_buildTabButton`, `_handleTabTap`, `_tabName`) and seven now-unused imports (`flutter_bloc`, `flutter_svg`, `dm_unread_count_cubit`, `relay_notifications_provider`, `inbox_page`, `camera_permission_check`, `notification_badge`). The file is 183 lines shorter.
- `VineBottomNav` extracts `_IconTabButton`, `_ShadowedNavIcon`, `_NavIconShadow`, `_ProfileTabButton`, and `_ProfileAvatarBox` as small private widgets — no methods returning `Widget`.

**Related Issue:** none

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] ♻️ Code refactor
- [ ] ⚙️ Build configuration change
- [ ] 📝 Documentation
- [ ] 🧹 Chore

## Follow-up

- **#3331** — extract the glyph drop-shadow stacking pattern (currently duplicated between `_ShadowedIcon` in `video_action_button.dart` and `_ShadowedNavIcon` in this PR) into a shared `divine_ui` widget. Flagged in an inline TODO comment in `vine_bottom_nav.dart`; deferred from this PR to keep the consolidation focused.

## Test plan

- [x] `flutter analyze lib test` clean
- [x] `flutter test test/router/app_shell_integration_test.dart test/router/app_shell_notification_badge_test.dart` — green (2 pass, 9 pre-existing skips, none related to the nav)
- [ ] Manual: home / explore / inbox / profile tabs all render the new design (verify on a logged-in account so the Profile tab shows your avatar)
- [ ] Manual: tap a tab → routes correctly; routes outside the shell (npub-profile pages) still show the same nav

