### PR TITLE
feat(onboarding): support reusable creator invites

### DIFF
--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -28,6 +28,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
     required PendingVerificationService pendingVerificationService,
     InviteApiClient? inviteApiClient,
     String? inviteCode,
+    String? inviteSourceSlug,
   }) : _oauthClient = oauthClient,
        _authService = authService,
        _pendingVerificationService = pendingVerificationService,
@@ -35,6 +36,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
        _inviteCode = inviteCode == null
            ? null
            : InviteApiClient.normalizeCode(inviteCode),
+       _inviteSourceSlug = inviteSourceSlug,
        super(const DivineAuthInitial());
 
   final KeycastOAuth _oauthClient;
@@ -42,6 +44,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
   final PendingVerificationService _pendingVerificationService;
   final InviteApiClient? _inviteApiClient;
   final String? _inviteCode;
+  final String? _inviteSourceSlug;
 
   /// Initialize form with default state (sign up mode)
   void initialize({bool isSignIn = false, String? initialEmail}) {
@@ -282,6 +285,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
             generalError: InviteErrorUtils.activationFailureMessage(e),
             showInviteGateRecovery: true,
             inviteRecoveryCode: _inviteCode,
+            inviteRecoverySourceSlug: _inviteSourceSlug,
           ),
         );
       }
@@ -400,6 +404,7 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
             generalError: InviteErrorUtils.activationFailureMessage(e),
             showInviteGateRecovery: true,
             inviteRecoveryCode: _inviteCode,
+            inviteRecoverySourceSlug: _inviteSourceSlug,
           ),
         );
       }

--- a/mobile/lib/blocs/divine_auth/divine_auth_state.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_state.dart
@@ -27,6 +27,7 @@ class DivineAuthFormState extends DivineAuthState {
     this.generalError,
     this.showInviteGateRecovery = false,
     this.inviteRecoveryCode,
+    this.inviteRecoverySourceSlug,
     this.obscurePassword = true,
     this.isSubmitting = false,
     this.isSkipping = false,
@@ -56,6 +57,9 @@ class DivineAuthFormState extends DivineAuthState {
   /// Invite code to prefill if recovery should return to the invite gate.
   final String? inviteRecoveryCode;
 
+  /// Creator source slug to preserve when recovery falls back to waitlist.
+  final String? inviteRecoverySourceSlug;
+
   /// Whether password is obscured in the UI
   final bool obscurePassword;
 
@@ -83,6 +87,7 @@ class DivineAuthFormState extends DivineAuthState {
     String? generalError,
     bool? showInviteGateRecovery,
     String? inviteRecoveryCode,
+    String? inviteRecoverySourceSlug,
     bool? obscurePassword,
     bool? isSubmitting,
     bool? isSkipping,
@@ -108,6 +113,9 @@ class DivineAuthFormState extends DivineAuthState {
       inviteRecoveryCode: clearInviteGateRecovery
           ? null
           : (inviteRecoveryCode ?? this.inviteRecoveryCode),
+      inviteRecoverySourceSlug: clearInviteGateRecovery
+          ? null
+          : (inviteRecoverySourceSlug ?? this.inviteRecoverySourceSlug),
       obscurePassword: obscurePassword ?? this.obscurePassword,
       isSubmitting: isSubmitting ?? this.isSubmitting,
       isSkipping: isSkipping ?? this.isSkipping,
@@ -124,6 +132,7 @@ class DivineAuthFormState extends DivineAuthState {
     generalError,
     showInviteGateRecovery,
     inviteRecoveryCode,
+    inviteRecoverySourceSlug,
     obscurePassword,
     isSubmitting,
     isSkipping,

--- a/mobile/lib/blocs/invite_gate/invite_gate_bloc.dart
+++ b/mobile/lib/blocs/invite_gate/invite_gate_bloc.dart
@@ -118,6 +118,9 @@ class InviteGateBloc extends Bloc<InviteGateEvent, InviteGateState> {
             accessGrant: InviteAccessGrant(
               code: result.code ?? normalizedCode,
               validatedAt: DateTime.now(),
+              creatorSlug: result.creatorSlug,
+              creatorDisplayName: result.creatorDisplayName,
+              remaining: result.remaining,
             ),
             clearInviteCodeError: true,
             clearGeneralError: true,
@@ -126,13 +129,15 @@ class InviteGateBloc extends Bloc<InviteGateEvent, InviteGateState> {
         return;
       }
 
+      final inviteCodeError = _inviteCodeErrorForResult(result);
+      final generalError = _generalErrorForResult(result);
       emit(
         state.copyWith(
           isValidatingCode: false,
-          inviteCodeError: result.used
-              ? 'That invite code has already been used or revoked.'
-              : 'That invite code does not look valid.',
-          clearGeneralError: true,
+          inviteCodeError: inviteCodeError,
+          generalError: generalError,
+          clearInviteCodeError: inviteCodeError == null,
+          clearGeneralError: generalError == null,
         ),
       );
     } on InviteApiException catch (error) {
@@ -201,5 +206,35 @@ class InviteGateBloc extends Bloc<InviteGateEvent, InviteGateState> {
     }
 
     emit(state.copyWith(clearAccessGrant: true));
+  }
+
+  String? _inviteCodeErrorForResult(InviteValidationResult result) {
+    switch (result.errorCode) {
+      case 'creator_page_full':
+      case 'invite_revoked':
+      case 'invite_code_rotated':
+      case 'creator_page_disabled':
+        return null;
+      case 'invite_not_found':
+      case 'invite_invalid_format':
+        return 'That invite code does not look valid.';
+    }
+
+    return result.used
+        ? 'That invite code has already been used or revoked.'
+        : 'That invite code does not look valid.';
+  }
+
+  String? _generalErrorForResult(InviteValidationResult result) {
+    switch (result.errorCode) {
+      case 'creator_page_full':
+        return "This creator's invites are full";
+      case 'invite_revoked':
+      case 'invite_code_rotated':
+      case 'creator_page_disabled':
+        return 'That invite code is unavailable. Join the waitlist and '
+            "we'll send an invite when there's room.";
+    }
+    return null;
   }
 }

--- a/mobile/lib/models/invite_models.dart
+++ b/mobile/lib/models/invite_models.dart
@@ -7,6 +7,7 @@ export 'package:invite_api_client/invite_api_client.dart'
         InviteClientConfig,
         InviteCode,
         InviteConsumeResult,
+        InviteConsumeStatus,
         InviteStatus,
         InviteValidationResult,
         OnboardingMode,

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -511,6 +511,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             builder: (_, state) => InviteGateScreen(
               initialCode: state.uri.queryParameters['code'],
               initialError: state.uri.queryParameters['error'],
+              initialSourceSlug: state.uri.queryParameters['sourceSlug'],
             ),
           ),
           GoRoute(

--- a/mobile/lib/screens/auth/create_account_screen.dart
+++ b/mobile/lib/screens/auth/create_account_screen.dart
@@ -48,15 +48,18 @@ class CreateAccountScreen extends ConsumerWidget {
         pendingVerificationService: pendingVerificationService,
         inviteApiClient: inviteApiClient,
         inviteCode: inviteAccessGrant?.code,
+        inviteSourceSlug: inviteAccessGrant?.creatorSlug,
       )..initialize(),
-      child: const _CreateAccountView(),
+      child: _CreateAccountView(inviteAccessGrant: inviteAccessGrant),
     );
   }
 }
 
 /// Create account screen — View that consumes [DivineAuthCubit] state.
 class _CreateAccountView extends StatelessWidget {
-  const _CreateAccountView();
+  const _CreateAccountView({this.inviteAccessGrant});
+
+  final InviteAccessGrant? inviteAccessGrant;
 
   @override
   Widget build(BuildContext context) {
@@ -78,7 +81,10 @@ class _CreateAccountView extends StatelessWidget {
       child: BlocBuilder<DivineAuthCubit, DivineAuthState>(
         builder: (context, state) {
           if (state is DivineAuthFormState) {
-            return _CreateAccountBody(state: state);
+            return _CreateAccountBody(
+              state: state,
+              inviteAccessGrant: inviteAccessGrant,
+            );
           }
           return const Scaffold(
             backgroundColor: VineTheme.backgroundColor,
@@ -94,9 +100,10 @@ class _CreateAccountView extends StatelessWidget {
 
 /// Body of the create account form with email and password.
 class _CreateAccountBody extends StatefulWidget {
-  const _CreateAccountBody({required this.state});
+  const _CreateAccountBody({required this.state, this.inviteAccessGrant});
 
   final DivineAuthFormState state;
+  final InviteAccessGrant? inviteAccessGrant;
 
   @override
   State<_CreateAccountBody> createState() => _CreateAccountBodyState();
@@ -162,6 +169,7 @@ class _CreateAccountBodyState extends State<_CreateAccountBody> {
       WelcomeScreen.inviteGatePathWithCode(
         inviteCode,
         error: widget.state.generalError,
+        sourceSlug: widget.state.inviteRecoverySourceSlug,
       ),
     );
   }
@@ -171,9 +179,16 @@ class _CreateAccountBodyState extends State<_CreateAccountBody> {
     final isSubmitting = widget.state.isSubmitting;
     final isSkipping = widget.state.isSkipping;
     final isDisabled = isSubmitting || isSkipping;
+    final inviteGrant = widget.inviteAccessGrant;
+    final hasCreatorContext =
+        (inviteGrant?.creatorDisplayName?.isNotEmpty ?? false) ||
+        inviteGrant?.remaining != null;
 
     return AuthFormScaffold(
       title: context.l10n.authCreateAccountTitle,
+      headerWidget: hasCreatorContext
+          ? _CreatorInviteContext(grant: inviteGrant)
+          : null,
       onBack: isDisabled ? null : () => context.pop(),
       emailController: _emailController,
       passwordController: _passwordController,
@@ -213,6 +228,37 @@ class _CreateAccountBodyState extends State<_CreateAccountBody> {
         isSkipping: isSkipping,
         isDisabled: isDisabled,
         onPressed: _skip,
+      ),
+    );
+  }
+}
+
+class _CreatorInviteContext extends StatelessWidget {
+  const _CreatorInviteContext({this.grant});
+
+  final InviteAccessGrant? grant;
+
+  @override
+  Widget build(BuildContext context) {
+    final displayName = grant?.creatorDisplayName;
+    final remaining = grant?.remaining;
+    if ((displayName == null || displayName.isEmpty) && remaining == null) {
+      return const SizedBox.shrink();
+    }
+
+    final lines = <String>[
+      if (displayName != null && displayName.isNotEmpty)
+        '$displayName invited you',
+      if (remaining != null) '$remaining invites left',
+    ];
+
+    return Text(
+      lines.join('\n'),
+      style: const TextStyle(
+        fontFamily: 'Inter',
+        fontSize: 15,
+        height: 1.4,
+        color: VineTheme.lightText,
       ),
     );
   }

--- a/mobile/lib/screens/auth/invite_gate_screen.dart
+++ b/mobile/lib/screens/auth/invite_gate_screen.dart
@@ -20,13 +20,19 @@ import 'package:openvine/widgets/rounded_icon_button.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class InviteGateScreen extends StatefulWidget {
-  const InviteGateScreen({super.key, this.initialCode, this.initialError});
+  const InviteGateScreen({
+    super.key,
+    this.initialCode,
+    this.initialError,
+    this.initialSourceSlug,
+  });
 
   static const String routeName = 'invite-gate';
   static const String path = '/invite';
 
   final String? initialCode;
   final String? initialError;
+  final String? initialSourceSlug;
 
   @override
   State<InviteGateScreen> createState() => _InviteGateScreenState();
@@ -70,6 +76,9 @@ class _InviteGateScreenState extends State<InviteGateScreen> {
   }
 
   Future<void> _showWaitlistSheet(InviteClientConfig config) async {
+    final sourceSlug =
+        context.read<InviteGateBloc>().state.accessGrant?.creatorSlug ??
+        widget.initialSourceSlug;
     final joinedEmail = await showModalBottomSheet<String>(
       context: context,
       isScrollControlled: true,
@@ -77,6 +86,7 @@ class _InviteGateScreenState extends State<InviteGateScreen> {
       builder: (_) => _WaitlistEntrySheet(
         inviteApiClient: context.read<InviteApiClient>(),
         supportEmail: config.supportEmail,
+        sourceSlug: sourceSlug,
       ),
     );
 
@@ -589,10 +599,12 @@ class _WaitlistEntrySheet extends StatefulWidget {
   const _WaitlistEntrySheet({
     required this.inviteApiClient,
     required this.supportEmail,
+    this.sourceSlug,
   });
 
   final InviteApiClient inviteApiClient;
   final String supportEmail;
+  final String? sourceSlug;
 
   @override
   State<_WaitlistEntrySheet> createState() => _WaitlistEntrySheetState();
@@ -629,7 +641,10 @@ class _WaitlistEntrySheetState extends State<_WaitlistEntrySheet> {
     });
 
     try {
-      await widget.inviteApiClient.joinWaitlist(contact: email);
+      await widget.inviteApiClient.joinWaitlist(
+        contact: email,
+        sourceSlug: widget.sourceSlug,
+      );
       if (!mounted) return;
       Navigator.of(context).pop(email);
     } on InviteApiException catch (error) {

--- a/mobile/lib/screens/auth/welcome_screen.dart
+++ b/mobile/lib/screens/auth/welcome_screen.dart
@@ -51,13 +51,20 @@ class WelcomeScreen extends ConsumerWidget {
   ).toString();
 
   /// Build invite gate path with optional recovery context prefilled.
-  static String inviteGatePathWithCode(String code, {String? error}) {
+  static String inviteGatePathWithCode(
+    String code, {
+    String? error,
+    String? sourceSlug,
+  }) {
     final queryParameters = <String, String>{
       'code': code,
     };
 
     if (error != null && error.isNotEmpty) {
       queryParameters['error'] = error;
+    }
+    if (sourceSlug != null && sourceSlug.isNotEmpty) {
+      queryParameters['sourceSlug'] = sourceSlug;
     }
 
     return Uri(

--- a/mobile/lib/utils/invite_error_utils.dart
+++ b/mobile/lib/utils/invite_error_utils.dart
@@ -15,6 +15,9 @@ enum InviteActivationFailureReason {
   /// Invite code is invalid, revoked, expired, or not eligible.
   invalid,
 
+  /// Creator invite cap has been reached.
+  creatorFull,
+
   /// Temporary server or network problem (retryable).
   temporary,
 
@@ -32,6 +35,11 @@ class InviteErrorUtils {
   ) {
     final statusCode = error.statusCode;
     final normalizedMessage = error.message.toLowerCase();
+    final code = error.code;
+
+    if (code == 'creator_page_full') {
+      return InviteActivationFailureReason.creatorFull;
+    }
 
     final isUsedError =
         statusCode == 409 ||
@@ -81,6 +89,7 @@ class InviteErrorUtils {
       case InviteActivationFailureReason.alreadyUsed:
         return EmailVerificationError.inviteAlreadyUsed;
       case InviteActivationFailureReason.invalid:
+      case InviteActivationFailureReason.creatorFull:
         return EmailVerificationError.inviteInvalid;
       case InviteActivationFailureReason.temporary:
         return EmailVerificationError.inviteTemporary;
@@ -106,6 +115,9 @@ class InviteErrorUtils {
         return 'That invite code cannot be used right now. '
             'Go back to your invite code, join the waitlist, '
             'or contact support.';
+      case InviteActivationFailureReason.creatorFull:
+        return "This creator's invites are full. Join the waitlist and "
+            "we'll send an invite when there's room.";
       case InviteActivationFailureReason.temporary:
         return "We couldn't confirm your invite right now. "
             'Go back to your invite code and try again, or contact support.';

--- a/mobile/lib/widgets/auth/auth_form_scaffold.dart
+++ b/mobile/lib/widgets/auth/auth_form_scaffold.dart
@@ -38,6 +38,7 @@ class AuthFormScaffold extends StatelessWidget {
     this.onEmailChanged,
     this.onPasswordChanged,
     this.errorWidget,
+    this.headerWidget,
     this.secondaryButton,
     this.onBack,
   });
@@ -68,6 +69,9 @@ class AuthFormScaffold extends StatelessWidget {
 
   /// Optional error widget displayed below the dog sticker.
   final Widget? errorWidget;
+
+  /// Optional content displayed between the title and form fields.
+  final Widget? headerWidget;
 
   /// The primary action button (e.g. "Create account").
   final Widget primaryButton;
@@ -112,7 +116,12 @@ class AuthFormScaffold extends StatelessWidget {
                       ),
                     ),
 
-                    const SizedBox(height: 32),
+                    if (headerWidget != null) ...[
+                      const SizedBox(height: 12),
+                      headerWidget!,
+                      const SizedBox(height: 24),
+                    ] else
+                      const SizedBox(height: 32),
 
                     // AutofillGroup + Form enables password manager
                     // autofill for the email and password fields.

--- a/mobile/packages/invite_api_client/lib/src/invite_api_client.dart
+++ b/mobile/packages/invite_api_client/lib/src/invite_api_client.dart
@@ -140,11 +140,15 @@ class InviteApiClient {
   Future<WaitlistJoinResult> joinWaitlist({
     required String contact,
     String? pubkey,
+    String? sourceSlug,
   }) async {
     final uri = Uri.parse('$_baseUrl/v1/waitlist');
     final payload = <String, dynamic>{'contact': contact};
     if (pubkey != null && pubkey.isNotEmpty) {
       payload['pubkey'] = pubkey;
+    }
+    if (sourceSlug != null && sourceSlug.isNotEmpty) {
+      payload['source_slug'] = sourceSlug;
     }
 
     try {
@@ -233,6 +237,15 @@ class InviteApiClient {
           .timeout(_defaultTimeout);
 
       if (response.statusCode != 200) {
+        final alreadyJoined =
+            _parseErrorCode(response.body) == 'user_already_joined';
+        if (alreadyJoined) {
+          return InviteConsumeResult.fromJson({
+            'result': 'user_already_joined',
+            'code': normalizedCode,
+          });
+        }
+
         throw _requestFailed(
           message: 'Failed to activate invite code',
           response: response,
@@ -394,10 +407,23 @@ class InviteApiClient {
     required String message,
     required http.Response response,
   }) {
+    final errorCode = _parseErrorCode(response.body);
+    final creatorSlug = _extractString(response.body, [
+      'creatorSlug',
+      'creator_slug',
+    ]);
+    final creatorDisplayName = _extractString(response.body, [
+      'creatorDisplayName',
+      'creator_display_name',
+    ]);
+
     return InviteApiException(
       _extractErrorMessage(response.body) ?? message,
       statusCode: response.statusCode,
       responseBody: response.body,
+      code: errorCode,
+      creatorSlug: creatorSlug,
+      creatorDisplayName: creatorDisplayName,
     );
   }
 
@@ -418,7 +444,13 @@ class InviteApiClient {
         return InviteValidationResult.fromJson({
           'valid': decoded['valid'] ?? false,
           'used': decoded['used'] ?? false,
+          'available': decoded['available'],
           'code': decoded['code'] ?? fallbackCode,
+          'errorCode': decoded['errorCode'] ?? decoded['code'],
+          'creatorSlug': decoded['creatorSlug'] ?? decoded['creator_slug'],
+          'creatorDisplayName':
+              decoded['creatorDisplayName'] ?? decoded['creator_display_name'],
+          'remaining': decoded['remaining'],
         });
       }
     } on Object catch (_) {
@@ -440,6 +472,27 @@ class InviteApiClient {
       }
     } on Object catch (_) {
       // Ignore malformed bodies and fall back to the caller's default message.
+    }
+    return null;
+  }
+
+  String? _parseErrorCode(String body) {
+    return _extractString(body, ['code', 'errorCode', 'error_code']);
+  }
+
+  String? _extractString(String body, List<String> keys) {
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map<String, dynamic>) {
+        for (final key in keys) {
+          final value = decoded[key];
+          if (value is String && value.isNotEmpty) {
+            return value;
+          }
+        }
+      }
+    } on Object catch (_) {
+      // Ignore malformed bodies and fall back to null.
     }
     return null;
   }

--- a/mobile/packages/invite_api_client/lib/src/invite_api_exception.dart
+++ b/mobile/packages/invite_api_client/lib/src/invite_api_exception.dart
@@ -1,11 +1,22 @@
 class InviteApiException implements Exception {
-  const InviteApiException(this.message, {this.statusCode, this.responseBody});
+  const InviteApiException(
+    this.message, {
+    this.statusCode,
+    this.responseBody,
+    this.code,
+    this.creatorSlug,
+    this.creatorDisplayName,
+  });
 
   final String message;
   final int? statusCode;
   final String? responseBody;
+  final String? code;
+  final String? creatorSlug;
+  final String? creatorDisplayName;
 
   @override
   String toString() =>
-      'InviteApiException(message: $message, statusCode: $statusCode)';
+      'InviteApiException(message: $message, statusCode: $statusCode, '
+      'code: $code)';
 }

--- a/mobile/packages/invite_api_client/lib/src/invite_models.dart
+++ b/mobile/packages/invite_api_client/lib/src/invite_models.dart
@@ -43,22 +43,43 @@ class InviteValidationResult {
   const InviteValidationResult({
     required this.valid,
     required this.used,
+    this.available,
     this.code,
+    this.errorCode,
+    this.creatorSlug,
+    this.creatorDisplayName,
+    this.remaining,
   });
 
   factory InviteValidationResult.fromJson(Map<String, dynamic> json) {
     return InviteValidationResult(
       valid: json['valid'] == true,
       used: json['used'] == true,
+      available: json['available'] as bool?,
       code: json['code'] as String?,
+      errorCode:
+          json['errorCode'] as String? ??
+          json['error_code'] as String? ??
+          json['code_name'] as String?,
+      creatorSlug:
+          json['creatorSlug'] as String? ?? json['creator_slug'] as String?,
+      creatorDisplayName:
+          json['creatorDisplayName'] as String? ??
+          json['creator_display_name'] as String?,
+      remaining: json['remaining'] as int?,
     );
   }
 
   final bool valid;
   final bool used;
+  final bool? available;
   final String? code;
+  final String? errorCode;
+  final String? creatorSlug;
+  final String? creatorDisplayName;
+  final int? remaining;
 
-  bool get canContinue => valid && !used;
+  bool get canContinue => valid && (available ?? !used);
 }
 
 class WaitlistJoinResult {
@@ -75,10 +96,34 @@ class WaitlistJoinResult {
   final String message;
 }
 
+enum InviteConsumeStatus {
+  consumed,
+  alreadyConsumed,
+  userAlreadyJoined,
+  unknown,
+}
+
+InviteConsumeStatus parseInviteConsumeStatus(String? rawValue) {
+  switch (rawValue?.trim().toLowerCase()) {
+    case 'consumed':
+      return InviteConsumeStatus.consumed;
+    case 'already_consumed':
+      return InviteConsumeStatus.alreadyConsumed;
+    case 'user_already_joined':
+      return InviteConsumeStatus.userAlreadyJoined;
+    default:
+      return InviteConsumeStatus.unknown;
+  }
+}
+
 class InviteConsumeResult {
   const InviteConsumeResult({
     required this.message,
     required this.codesAllocated,
+    this.result = InviteConsumeStatus.consumed,
+    this.code,
+    this.creatorSlug,
+    this.creatorDisplayName,
   });
 
   factory InviteConsumeResult.fromJson(Map<String, dynamic> json) {
@@ -86,18 +131,43 @@ class InviteConsumeResult {
       message: json['message'] as String? ?? '',
       codesAllocated:
           (json['codesAllocated'] ?? json['codes_allocated'] ?? 0) as int,
+      result: parseInviteConsumeStatus(json['result'] as String?),
+      code: json['code'] as String?,
+      creatorSlug:
+          json['creatorSlug'] as String? ?? json['creator_slug'] as String?,
+      creatorDisplayName:
+          json['creatorDisplayName'] as String? ??
+          json['creator_display_name'] as String?,
     );
   }
 
   final String message;
   final int codesAllocated;
+  final InviteConsumeStatus result;
+  final String? code;
+  final String? creatorSlug;
+  final String? creatorDisplayName;
+
+  bool get isSuccess =>
+      result == InviteConsumeStatus.consumed ||
+      result == InviteConsumeStatus.alreadyConsumed ||
+      result == InviteConsumeStatus.userAlreadyJoined;
 }
 
 class InviteAccessGrant {
-  const InviteAccessGrant({required this.code, required this.validatedAt});
+  const InviteAccessGrant({
+    required this.code,
+    required this.validatedAt,
+    this.creatorSlug,
+    this.creatorDisplayName,
+    this.remaining,
+  });
 
   final String code;
   final DateTime validatedAt;
+  final String? creatorSlug;
+  final String? creatorDisplayName;
+  final int? remaining;
 }
 
 class InviteCode extends Equatable {

--- a/mobile/packages/invite_api_client/test/src/invite_api_client_test.dart
+++ b/mobile/packages/invite_api_client/test/src/invite_api_client_test.dart
@@ -45,6 +45,7 @@ void main() {
     test('recognizes full invite code format', () {
       expect(InviteApiClient.looksLikeInviteCode('AB12-EF34'), isTrue);
       expect(InviteApiClient.looksLikeInviteCode('abcd1234'), isTrue);
+      expect(InviteApiClient.looksLikeInviteCode('LELE-PONS'), isTrue);
       expect(InviteApiClient.looksLikeInviteCode('AB12'), isFalse);
       expect(InviteApiClient.looksLikeInviteCode(''), isFalse);
     });
@@ -111,6 +112,40 @@ void main() {
       expect(result.canContinue, isTrue);
       expect(result.code, 'AB12-EF34');
     });
+
+    test(
+      'validates reusable creator invite codes with creator metadata',
+      () async {
+        final response = _MockResponse();
+        when(() => response.statusCode).thenReturn(200);
+        when(() => response.body).thenReturn(
+          jsonEncode({
+            'valid': true,
+            'available': true,
+            'used': true,
+            'code': 'LELE-PONS',
+            'creatorSlug': 'lele-pons',
+            'creatorDisplayName': 'Lele Pons',
+            'remaining': 842,
+          }),
+        );
+        when(
+          () => mockClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) async => response);
+
+        final result = await client.validateCode('lele-pons');
+
+        expect(result.canContinue, isTrue);
+        expect(result.code, 'LELE-PONS');
+        expect(result.creatorSlug, 'lele-pons');
+        expect(result.creatorDisplayName, 'Lele Pons');
+        expect(result.remaining, 842);
+      },
+    );
 
     test('maps validation rejection responses to an invalid result', () async {
       final rejectionStatuses = [400, 403, 404, 409];
@@ -225,6 +260,37 @@ void main() {
       expect(result.message, 'You are on the waitlist');
     });
 
+    test('joins waitlist with creator source slug when provided', () async {
+      final waitlistClient = InviteApiClient(
+        baseUrl: 'https://invites.divine.video',
+        client: MockClient((request) async {
+          expect(request.method, 'POST');
+          expect(request.url.path, contains('/v1/waitlist'));
+          expect(
+            jsonDecode(request.body),
+            {
+              'contact': 'test@example.com',
+              'source_slug': 'lele-pons',
+            },
+          );
+          return http.Response(
+            jsonEncode({
+              'id': 'waitlist-entry-1',
+              'message': 'You are on the waitlist',
+            }),
+            201,
+          );
+        }),
+      );
+
+      final result = await waitlistClient.joinWaitlist(
+        contact: 'test@example.com',
+        sourceSlug: 'lele-pons',
+      );
+
+      expect(result.id, 'waitlist-entry-1');
+    });
+
     test('returns invite status on 200', () async {
       final statusClient = InviteApiClient(
         baseUrl: 'https://invites.divine.video',
@@ -306,6 +372,92 @@ void main() {
       ).called(1);
 
       keyContainer.dispose();
+    });
+
+    test(
+      'parses already consumed invite responses as successful consumption',
+      () async {
+        final response = _MockResponse();
+        when(() => response.statusCode).thenReturn(200);
+        when(() => response.body).thenReturn(
+          jsonEncode({
+            'result': 'already_consumed',
+            'code': 'LELE-PONS',
+            'codesAllocated': 0,
+            'creatorSlug': 'lele-pons',
+            'creatorDisplayName': 'Lele Pons',
+          }),
+        );
+        when(
+          () => mockClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer((_) async => response);
+
+        final result = await client.consumeInvite('lele-pons');
+
+        expect(result.isSuccess, isTrue);
+        expect(result.result, InviteConsumeStatus.alreadyConsumed);
+        expect(result.code, 'LELE-PONS');
+        expect(result.creatorSlug, 'lele-pons');
+        expect(result.creatorDisplayName, 'Lele Pons');
+      },
+    );
+
+    test('surfaces creator page full as structured invite API error', () async {
+      final response = _MockResponse();
+      when(() => response.statusCode).thenReturn(409);
+      when(() => response.body).thenReturn(
+        jsonEncode({
+          'code': 'creator_page_full',
+          'error': "This creator's invites are full",
+          'creatorSlug': 'lele-pons',
+          'creatorDisplayName': 'Lele Pons',
+        }),
+      );
+      when(
+        () => mockClient.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer((_) async => response);
+
+      await expectLater(
+        client.consumeInvite('lele-pons'),
+        throwsA(
+          isA<InviteApiException>()
+              .having((e) => e.statusCode, 'statusCode', 409)
+              .having((e) => e.code, 'code', 'creator_page_full')
+              .having((e) => e.creatorSlug, 'creatorSlug', 'lele-pons'),
+        ),
+      );
+    });
+
+    test('treats user already joined consume errors as success', () async {
+      final response = _MockResponse();
+      when(() => response.statusCode).thenReturn(409);
+      when(() => response.body).thenReturn(
+        jsonEncode({
+          'code': 'user_already_joined',
+          'error': 'User has already joined',
+        }),
+      );
+      when(
+        () => mockClient.post(
+          any(),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+        ),
+      ).thenAnswer((_) async => response);
+
+      final result = await client.consumeInvite('lele-pons');
+
+      expect(result.isSuccess, isTrue);
+      expect(result.result, InviteConsumeStatus.userAlreadyJoined);
+      expect(result.code, 'LELE-PONS');
     });
 
     test('surfaces server errors as InviteApiException', () async {

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -1558,6 +1558,7 @@ void main() {
         expect(cleared.generalError, isNull);
         expect(cleared.showInviteGateRecovery, isFalse);
         expect(cleared.inviteRecoveryCode, isNull);
+        expect(cleared.inviteRecoverySourceSlug, isNull);
       });
 
       test('props contains all fields', () {
@@ -1570,10 +1571,11 @@ void main() {
           generalError: 'g',
           showInviteGateRecovery: true,
           inviteRecoveryCode: 'AB12-EF34',
+          inviteRecoverySourceSlug: 'lele-pons',
           obscurePassword: false,
           isSubmitting: true,
         );
-        expect(state.props, hasLength(11));
+        expect(state.props, hasLength(12));
       });
     });
 

--- a/mobile/test/blocs/invite_gate/invite_gate_bloc_test.dart
+++ b/mobile/test/blocs/invite_gate/invite_gate_bloc_test.dart
@@ -92,6 +92,52 @@ void main() {
     );
 
     blocTest<InviteGateBloc, InviteGateState>(
+      'stores creator metadata when reusable creator invite validates',
+      setUp: () {
+        when(
+          () => mockInviteApiClient.validateCode('LELE-PONS'),
+        ).thenAnswer(
+          (_) async => const InviteValidationResult(
+            valid: true,
+            used: true,
+            available: true,
+            code: 'LELE-PONS',
+            creatorSlug: 'lele-pons',
+            creatorDisplayName: 'Lele Pons',
+            remaining: 842,
+          ),
+        );
+      },
+      build: buildBloc,
+      act: (bloc) => bloc.add(const InviteGateCodeSubmitted('lele-pons')),
+      expect: () => [
+        const InviteGateState(isValidatingCode: true),
+        isA<InviteGateState>()
+            .having((state) => state.hasAccessGrant, 'hasAccessGrant', true)
+            .having(
+              (state) => state.accessGrant?.code,
+              'accessGrant.code',
+              'LELE-PONS',
+            )
+            .having(
+              (state) => state.accessGrant?.creatorSlug,
+              'accessGrant.creatorSlug',
+              'lele-pons',
+            )
+            .having(
+              (state) => state.accessGrant?.creatorDisplayName,
+              'accessGrant.creatorDisplayName',
+              'Lele Pons',
+            )
+            .having(
+              (state) => state.accessGrant?.remaining,
+              'accessGrant.remaining',
+              842,
+            ),
+      ],
+    );
+
+    blocTest<InviteGateBloc, InviteGateState>(
       'maps used invite validations to invite code error state',
       setUp: () {
         when(
@@ -110,6 +156,56 @@ void main() {
         const InviteGateState(isValidatingCode: true),
         const InviteGateState(
           inviteCodeError: 'That invite code has already been used or revoked.',
+        ),
+      ],
+    );
+
+    blocTest<InviteGateBloc, InviteGateState>(
+      'maps unavailable creator codes to waitlist-friendly general error',
+      setUp: () {
+        when(
+          () => mockInviteApiClient.validateCode('LELE-PONS'),
+        ).thenAnswer(
+          (_) async => const InviteValidationResult(
+            valid: false,
+            used: false,
+            available: false,
+            code: 'LELE-PONS',
+            errorCode: 'creator_page_full',
+            creatorSlug: 'lele-pons',
+            creatorDisplayName: 'Lele Pons',
+          ),
+        );
+      },
+      build: buildBloc,
+      act: (bloc) => bloc.add(const InviteGateCodeSubmitted('lele-pons')),
+      expect: () => [
+        const InviteGateState(isValidatingCode: true),
+        const InviteGateState(generalError: "This creator's invites are full"),
+      ],
+    );
+
+    blocTest<InviteGateBloc, InviteGateState>(
+      'keeps invalid invite codes editable',
+      setUp: () {
+        when(
+          () => mockInviteApiClient.validateCode('NOPE-CODE'),
+        ).thenAnswer(
+          (_) async => const InviteValidationResult(
+            valid: false,
+            used: false,
+            available: false,
+            code: 'NOPE-CODE',
+            errorCode: 'invite_invalid_format',
+          ),
+        );
+      },
+      build: buildBloc,
+      act: (bloc) => bloc.add(const InviteGateCodeSubmitted('nope-code')),
+      expect: () => [
+        const InviteGateState(isValidatingCode: true),
+        const InviteGateState(
+          inviteCodeError: 'That invite code does not look valid.',
         ),
       ],
     );

--- a/mobile/test/screens/auth/create_account_screen_test.dart
+++ b/mobile/test/screens/auth/create_account_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:openvine/blocs/divine_auth/divine_auth_cubit.dart';
 import 'package:openvine/blocs/invite_gate/invite_gate_bloc.dart';
+import 'package:openvine/blocs/invite_gate/invite_gate_state.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/auth/create_account_screen.dart';
@@ -35,6 +36,18 @@ class _MockPendingVerificationService extends Mock
 class _MockInviteApiClient extends Mock implements InviteApiClient {}
 
 class _FakeSecureKeyContainer extends Fake implements SecureKeyContainer {}
+
+class _SeededInviteGateBloc extends InviteGateBloc {
+  _SeededInviteGateBloc({
+    required super.inviteApiClient,
+    required InviteGateState initialState,
+  }) : _state = initialState;
+
+  final InviteGateState _state;
+
+  @override
+  InviteGateState get state => _state;
+}
 
 void main() {
   late _MockKeycastOAuth mockOAuth;
@@ -57,7 +70,7 @@ void main() {
     ).thenAnswer((_) async {});
   });
 
-  Widget createTestWidget() {
+  Widget createTestWidget({InviteAccessGrant? inviteAccessGrant}) {
     return ProviderScope(
       overrides: [
         ...getStandardTestOverrides(mockAuthService: mockAuthService),
@@ -68,8 +81,15 @@ void main() {
       ],
       child: RepositoryProvider<InviteApiClient>.value(
         value: mockInviteApiClient,
-        child: BlocProvider(
-          create: (_) => InviteGateBloc(inviteApiClient: mockInviteApiClient),
+        child: BlocProvider<InviteGateBloc>(
+          create: (_) => inviteAccessGrant == null
+              ? InviteGateBloc(inviteApiClient: mockInviteApiClient)
+              : _SeededInviteGateBloc(
+                  inviteApiClient: mockInviteApiClient,
+                  initialState: InviteGateState(
+                    accessGrant: inviteAccessGrant,
+                  ),
+                ),
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -133,6 +153,24 @@ void main() {
           find.widgetWithText(DivineButton, 'Create account'),
           findsOneWidget,
         );
+      });
+
+      testWidgets('shows creator invite context when present', (tester) async {
+        await tester.pumpWidget(
+          createTestWidget(
+            inviteAccessGrant: InviteAccessGrant(
+              code: 'LELE-PONS',
+              validatedAt: DateTime(2026, 4, 24),
+              creatorSlug: 'lele-pons',
+              creatorDisplayName: 'Lele Pons',
+              remaining: 842,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('Lele Pons invited you'), findsOneWidget);
+        expect(find.textContaining('842 invites left'), findsOneWidget);
       });
 
       testWidgets('displays skip button', (tester) async {

--- a/mobile/test/screens/auth/invite_gate_screen_test.dart
+++ b/mobile/test/screens/auth/invite_gate_screen_test.dart
@@ -55,6 +55,8 @@ void main() {
                     builder: (context, state) => InviteGateScreen(
                       initialCode: state.uri.queryParameters['code'],
                       initialError: state.uri.queryParameters['error'],
+                      initialSourceSlug:
+                          state.uri.queryParameters['sourceSlug'],
                     ),
                   ),
                   GoRoute(
@@ -192,6 +194,8 @@ void main() {
                         builder: (context, state) => InviteGateScreen(
                           initialCode: state.uri.queryParameters['code'],
                           initialError: state.uri.queryParameters['error'],
+                          initialSourceSlug:
+                              state.uri.queryParameters['sourceSlug'],
                         ),
                       ),
                     ],
@@ -207,6 +211,82 @@ void main() {
       expect(find.text('Invite problem'), findsOneWidget);
       expect(find.text('Add your invite code'), findsOneWidget);
       expect(find.byType(TextField), findsOneWidget);
+    });
+
+    testWidgets('preserves creator source slug when joining waitlist', (
+      tester,
+    ) async {
+      when(
+        () => mockInviteApiClient.getClientConfig(),
+      ).thenAnswer(
+        (_) async => const InviteClientConfig(
+          mode: OnboardingMode.inviteCodeRequired,
+          supportEmail: 'support@divine.video',
+        ),
+      );
+      when(
+        () => mockInviteApiClient.joinWaitlist(
+          contact: any(named: 'contact'),
+          sourceSlug: any(named: 'sourceSlug'),
+        ),
+      ).thenAnswer(
+        (_) async => const WaitlistJoinResult(
+          id: 'waitlist-entry-1',
+          message: 'Joined',
+        ),
+      );
+
+      await tester.pumpWidget(
+        RepositoryProvider<InviteApiClient>.value(
+          value: mockInviteApiClient,
+          child: BlocProvider(
+            create: (_) => InviteGateBloc(inviteApiClient: mockInviteApiClient),
+            child: MaterialApp.router(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              theme: VineTheme.theme,
+              routerConfig: GoRouter(
+                initialLocation:
+                    '${WelcomeScreen.inviteGatePath}?code=LELE-PONS'
+                    '&error=This%20creator%27s%20invites%20are%20full'
+                    '&sourceSlug=lele-pons',
+                routes: [
+                  GoRoute(
+                    path: WelcomeScreen.path,
+                    builder: (context, state) =>
+                        const Scaffold(body: Text('Welcome')),
+                    routes: [
+                      GoRoute(
+                        path: 'invite',
+                        builder: (context, state) => InviteGateScreen(
+                          initialCode: state.uri.queryParameters['code'],
+                          initialError: state.uri.queryParameters['error'],
+                          initialSourceSlug:
+                              state.uri.queryParameters['sourceSlug'],
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(DivineButton, 'Join waitlist'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField).last, 'fan@example.com');
+      await tester.tap(find.widgetWithText(DivineButton, 'Join waitlist').last);
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockInviteApiClient.joinWaitlist(
+          contact: 'fan@example.com',
+          sourceSlug: 'lele-pons',
+        ),
+      ).called(1);
     });
   });
 }


### PR DESCRIPTION
Closes #3333

## Summary
- support reusable creator invite validation metadata and consume result states
- preserve creator attribution through creator-full recovery into waitlist signup
- show creator invite context during account creation

## Verification
- flutter test test/src/invite_api_client_test.dart (from mobile/packages/invite_api_client)
- flutter test test/blocs/invite_gate/invite_gate_bloc_test.dart test/screens/auth/invite_gate_screen_test.dart test/screens/auth/create_account_screen_test.dart (from mobile)
- flutter test test/blocs/divine_auth/divine_auth_cubit_test.dart (from mobile)
- flutter analyze (from mobile)
- pre-push selected tests passed