### PR TITLE
fix(invites): surface awarded invites in profile and notifications

### DIFF
--- a/mobile/lib/blocs/invite_status/invite_status_cubit.dart
+++ b/mobile/lib/blocs/invite_status/invite_status_cubit.dart
@@ -31,4 +31,23 @@ class InviteStatusCubit extends Cubit<InviteStatusState> {
       emit(state.copyWith(status: InviteStatusLoadingStatus.error));
     }
   }
+
+  Future<void> generateInvite() async {
+    if (state.status == InviteStatusLoadingStatus.loading) return;
+
+    emit(state.copyWith(status: InviteStatusLoadingStatus.loading));
+    try {
+      await _inviteApiClient.generateInvite();
+      final inviteStatus = await _inviteApiClient.getInviteStatus();
+      emit(
+        state.copyWith(
+          status: InviteStatusLoadingStatus.loaded,
+          inviteStatus: inviteStatus,
+        ),
+      );
+    } catch (e, stackTrace) {
+      addError(e, stackTrace);
+      emit(state.copyWith(status: InviteStatusLoadingStatus.error));
+    }
+  }
 }

--- a/mobile/lib/blocs/invite_status/invite_status_state.dart
+++ b/mobile/lib/blocs/invite_status/invite_status_state.dart
@@ -22,6 +22,16 @@ class InviteStatusState extends Equatable {
   /// The number of unclaimed invite codes.
   int get unclaimedCount => inviteStatus?.unclaimedCodes.length ?? 0;
 
+  /// Whether there are generated or still-generatable invites.
+  bool get hasAvailableInvites => availableInviteCount > 0;
+
+  /// Count of invites the user can share now or generate from allocation.
+  int get availableInviteCount {
+    final status = inviteStatus;
+    if (status == null) return 0;
+    return status.remaining + status.unclaimedCodes.length;
+  }
+
   /// Returns a copy with the given fields replaced.
   InviteStatusState copyWith({
     InviteStatusLoadingStatus? status,

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2926,5 +2926,8 @@
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "حدّد مقطع الصوت لفيديوك",
   "videoEditorClipGalleryInstruction": "اضغط للتعديل. اضغط مطولاً واسحب لإعادة الترتيب.",
-  "fullscreenFeedRemovedMessage": "تمت إزالة الفيديو"
+  "fullscreenFeedRemovedMessage": "تمت إزالة الفيديو",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "invitesGenerateButtonLabel": "Generate invite"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2926,5 +2926,8 @@
   "videoEditorClipGalleryInstruction": "Tippen zum Bearbeiten. Halten und ziehen zum Neuordnen.",
   "navSearch": "Suche",
   "navSearchTooltip": "Suchen",
-  "fullscreenFeedRemovedMessage": "Video entfernt"
+  "fullscreenFeedRemovedMessage": "Video entfernt",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "invitesGenerateButtonLabel": "Generate invite"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2472,6 +2472,21 @@
   "blueskyFailedToUpdateCrosspost": "Failed to update crosspost setting",
 
   "invitesTitle": "Invite Friends",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "@invitesGenerateCardTitle": {
+    "description": "Title of the generate-invite card on the invites screen, shown when the user has invite capacity that has not been generated as codes yet.",
+    "placeholders": {
+      "count": { "type": "int" }
+    }
+  },
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "@invitesGenerateCardSubtitle": {
+    "description": "Body text on the generate-invite card explaining what tapping the button does."
+  },
+  "invitesGenerateButtonLabel": "Generate invite",
+  "@invitesGenerateButtonLabel": {
+    "description": "Label of the button on the generate-invite card that creates a new invite code from remaining capacity."
+  },
 
   "searchSomethingWentWrong": "Something went wrong",
   "searchTryAgain": "Try again",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2926,5 +2926,8 @@
   "videoEditorClipGalleryInstruction": "Toca para editar. Mantén presionado y arrastra para reordenar.",
   "navSearch": "Buscar",
   "navSearchTooltip": "Buscar",
-  "fullscreenFeedRemovedMessage": "Video eliminado"
+  "fullscreenFeedRemovedMessage": "Video eliminado",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "invitesGenerateButtonLabel": "Generate invite"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2926,5 +2926,8 @@
   "videoEditorClipGalleryInstruction": "Appuie pour modifier. Maintiens appuyé et fais glisser pour réorganiser.",
   "navSearch": "Recherche",
   "navSearchTooltip": "Rechercher",
-  "fullscreenFeedRemovedMessage": "Vidéo supprimée"
+  "fullscreenFeedRemovedMessage": "Vidéo supprimée",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "invitesGenerateButtonLabel": "Generate invite"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2926,5 +2926,8 @@
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Pilih segmen audio untuk videomu",
   "videoEditorClipGalleryInstruction": "Ketuk untuk mengedit. Tekan lama dan seret untuk mengurutkan ulang.",
-  "fullscreenFeedRemovedMessage": "Video dihapus"
+  "fullscreenFeedRemovedMessage": "Video dihapus",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "invitesGenerateButtonLabel": "Generate invite"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2926,5 +2926,8 @@
   "videoEditorClipGalleryInstruction": "Tocca per modificare. Tieni premuto e trascina per riordinare.",
   "navSearch": "Cerca",
   "navSearchTooltip": "Cerca",
-  "fullscreenFeedRemovedMessage": "Video rimosso"
+  "fullscreenFeedRemovedMessage": "Video rimosso",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "invitesGenerateButtonLabel": "Generate invite"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2926,5 +2926,8 @@
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "動画に使うオーディオ範囲を選択",
   "videoEditorClipGalleryInstruction": "タップして編集。長押ししてドラッグで並べ替え。",
-  "fullscreenFeedRemovedMessage": "動画を削除しました"
+  "fullscreenFeedRemovedMessage": "動画を削除しました",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "invitesGenerateButtonLabel": "Generate invite"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2215,5 +2215,8 @@
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "동영상에 사용할 오디오 구간을 선택하세요",
   "videoEditorClipGalleryInstruction": "탭해서 편집하세요. 길게 누르고 드래그해 순서를 바꾸세요.",
-  "fullscreenFeedRemovedMessage": "동영상이 삭제됐어요"
+  "fullscreenFeedRemovedMessage": "동영상이 삭제됐어요",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "invitesGenerateButtonLabel": "Generate invite"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2926,5 +2926,8 @@
   "videoEditorClipGalleryInstruction": "Tik om te bewerken. Houd vast en sleep om te herordenen.",
   "navSearch": "Zoeken",
   "navSearchTooltip": "Zoeken",
-  "fullscreenFeedRemovedMessage": "Video verwijderd"
+  "fullscreenFeedRemovedMessage": "Video verwijderd",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "invitesGenerateButtonLabel": "Generate invite"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2926,5 +2926,8 @@
   "videoEditorClipGalleryInstruction": "Dotknij, aby edytować. Przytrzymaj i przeciągnij, aby zmienić kolejność.",
   "navSearch": "Szukaj",
   "navSearchTooltip": "Szukaj",
-  "fullscreenFeedRemovedMessage": "Film usunięty"
+  "fullscreenFeedRemovedMessage": "Film usunięty",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "invitesGenerateButtonLabel": "Generate invite"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2926,5 +2926,8 @@
   "videoEditorClipGalleryInstruction": "Toque para editar. Pressione e arraste para reordenar.",
   "navSearch": "Pesquisar",
   "navSearchTooltip": "Pesquisar",
-  "fullscreenFeedRemovedMessage": "Vídeo removido"
+  "fullscreenFeedRemovedMessage": "Vídeo removido",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "invitesGenerateButtonLabel": "Generate invite"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2926,5 +2926,8 @@
   "videoEditorClipGalleryInstruction": "Atinge pentru editare. Ține apăsat și trage pentru reordonare.",
   "navSearch": "Caută",
   "navSearchTooltip": "Caută",
-  "fullscreenFeedRemovedMessage": "Videoclip eliminat"
+  "fullscreenFeedRemovedMessage": "Videoclip eliminat",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "invitesGenerateButtonLabel": "Generate invite"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2926,5 +2926,8 @@
   "videoEditorClipGalleryInstruction": "Tryck för att redigera. Håll ned och dra för att ändra ordning.",
   "navSearch": "Sök",
   "navSearchTooltip": "Sök",
-  "fullscreenFeedRemovedMessage": "Video borttagen"
+  "fullscreenFeedRemovedMessage": "Video borttagen",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "invitesGenerateButtonLabel": "Generate invite"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2926,5 +2926,8 @@
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Videon için ses bölümünü seç",
   "videoEditorClipGalleryInstruction": "Düzenlemek için dokun. Yeniden sıralamak için basılı tutup sürükle.",
-  "fullscreenFeedRemovedMessage": "Video kaldırıldı"
+  "fullscreenFeedRemovedMessage": "Video kaldırıldı",
+  "invitesGenerateCardTitle": "{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}",
+  "invitesGenerateCardSubtitle": "Generate a code when you are ready to share one.",
+  "invitesGenerateButtonLabel": "Generate invite"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -8486,6 +8486,24 @@ abstract class AppLocalizations {
   /// **'Invite Friends'**
   String get invitesTitle;
 
+  /// Title of the generate-invite card on the invites screen, shown when the user has invite capacity that has not been generated as codes yet.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 invite ready to generate} other{{count} invites ready to generate}}'**
+  String invitesGenerateCardTitle(int count);
+
+  /// Body text on the generate-invite card explaining what tapping the button does.
+  ///
+  /// In en, this message translates to:
+  /// **'Generate a code when you are ready to share one.'**
+  String get invitesGenerateCardSubtitle;
+
+  /// Label of the button on the generate-invite card that creates a new invite code from remaining capacity.
+  ///
+  /// In en, this message translates to:
+  /// **'Generate invite'**
+  String get invitesGenerateButtonLabel;
+
   /// No description provided for @searchSomethingWentWrong.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4739,6 +4739,24 @@ class AppLocalizationsAr extends AppLocalizations {
   String get invitesTitle => 'دعوة الأصدقاء';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => 'حدث خطأ ما';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4844,6 +4844,24 @@ class AppLocalizationsDe extends AppLocalizations {
   String get invitesTitle => 'Freunde einladen';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => 'Etwas ist schiefgelaufen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4791,6 +4791,24 @@ class AppLocalizationsEn extends AppLocalizations {
   String get invitesTitle => 'Invite Friends';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => 'Something went wrong';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4837,6 +4837,24 @@ class AppLocalizationsEs extends AppLocalizations {
   String get invitesTitle => 'Invitar amigos';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => 'Algo salió mal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4851,6 +4851,24 @@ class AppLocalizationsFr extends AppLocalizations {
   String get invitesTitle => 'Inviter des amis';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => 'Quelque chose s\'est mal passé';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4759,6 +4759,24 @@ class AppLocalizationsId extends AppLocalizations {
   String get invitesTitle => 'Undang Teman';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => 'Terjadi kesalahan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4832,6 +4832,24 @@ class AppLocalizationsIt extends AppLocalizations {
   String get invitesTitle => 'Invita amici';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => 'Qualcosa è andato storto';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4580,6 +4580,24 @@ class AppLocalizationsJa extends AppLocalizations {
   String get invitesTitle => '友達を招待しよう';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => 'なんかうまくいかなかった';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4602,6 +4602,24 @@ class AppLocalizationsKo extends AppLocalizations {
   String get invitesTitle => '친구 초대';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => '문제가 발생했어요';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4806,6 +4806,24 @@ class AppLocalizationsNl extends AppLocalizations {
   String get invitesTitle => 'Vrienden uitnodigen';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => 'Er ging iets mis';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4921,6 +4921,24 @@ class AppLocalizationsPl extends AppLocalizations {
   String get invitesTitle => 'Zaproś znajomych';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => 'Coś poszło nie tak';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4817,6 +4817,24 @@ class AppLocalizationsPt extends AppLocalizations {
   String get invitesTitle => 'Convidar amigos';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => 'Algo deu errado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4918,6 +4918,24 @@ class AppLocalizationsRo extends AppLocalizations {
   String get invitesTitle => 'Invită prieteni';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => 'Ceva nu a mers bine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4778,6 +4778,24 @@ class AppLocalizationsSv extends AppLocalizations {
   String get invitesTitle => 'Bjud in vänner';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => 'Något gick fel';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4768,6 +4768,24 @@ class AppLocalizationsTr extends AppLocalizations {
   String get invitesTitle => 'Arkadaşları Davet Et';
 
   @override
+  String invitesGenerateCardTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count invites ready to generate',
+      one: '1 invite ready to generate',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get invitesGenerateCardSubtitle =>
+      'Generate a code when you are ready to share one.';
+
+  @override
+  String get invitesGenerateButtonLabel => 'Generate invite';
+
+  @override
   String get searchSomethingWentWrong => 'Bir şeyler ters gitti';
 
   @override

--- a/mobile/lib/screens/notifications_screen.dart
+++ b/mobile/lib/screens/notifications_screen.dart
@@ -300,50 +300,73 @@ class _NotificationTabContentState
               onRefresh: () async {
                 await ref.read(relayNotificationsProvider.notifier).refresh();
               },
-              child: LayoutBuilder(
-                builder: (context, constraints) => SingleChildScrollView(
-                  physics: const AlwaysScrollableScrollPhysics(),
-                  child: SizedBox(
-                    height: constraints.maxHeight,
-                    child: Center(
-                      child: isSearchingForFilteredContent
-                          ? _FilteredTabLoadingState(
-                              filterName: _getFilterName(widget.filter!),
-                            )
-                          : Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                const Icon(
-                                  Icons.notifications_none,
-                                  size: 64,
-                                  color: VineTheme.lightText,
+              child: BlocBuilder<InviteStatusCubit, InviteStatusState>(
+                builder: (context, inviteState) {
+                  final showInviteCard =
+                      widget.filter == null && inviteState.hasUnclaimedCodes;
+                  if (showInviteCard) {
+                    return ListView(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      controller: _scrollController,
+                      children: [
+                        _InviteNotificationCard(
+                          count: inviteState.unclaimedCount,
+                        ),
+                      ],
+                    );
+                  }
+
+                  return LayoutBuilder(
+                    builder: (context, constraints) => SingleChildScrollView(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      child: SizedBox(
+                        height: constraints.maxHeight,
+                        child: Center(
+                          child: isSearchingForFilteredContent
+                              ? _FilteredTabLoadingState(
+                                  filterName: _getFilterName(widget.filter!),
+                                )
+                              : Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    const Icon(
+                                      Icons.notifications_none,
+                                      size: 64,
+                                      color: VineTheme.lightText,
+                                    ),
+                                    const SizedBox(height: 16),
+                                    Text(
+                                      widget.filter == null
+                                          ? context.l10n.notificationsNoneYet
+                                          : context.l10n
+                                                .notificationsNoneForType(
+                                                  _getFilterName(
+                                                    widget.filter!,
+                                                  ),
+                                                ),
+                                      style: const TextStyle(
+                                        fontSize: 18,
+                                        color: VineTheme.secondaryText,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 8),
+                                    Text(
+                                      context
+                                          .l10n
+                                          .notificationsEmptyDescription,
+                                      textAlign: TextAlign.center,
+                                      style: const TextStyle(
+                                        fontSize: 14,
+                                        color: VineTheme.lightText,
+                                      ),
+                                    ),
+                                  ],
                                 ),
-                                const SizedBox(height: 16),
-                                Text(
-                                  widget.filter == null
-                                      ? context.l10n.notificationsNoneYet
-                                      : context.l10n.notificationsNoneForType(
-                                          _getFilterName(widget.filter!),
-                                        ),
-                                  style: const TextStyle(
-                                    fontSize: 18,
-                                    color: VineTheme.secondaryText,
-                                  ),
-                                ),
-                                const SizedBox(height: 8),
-                                Text(
-                                  context.l10n.notificationsEmptyDescription,
-                                  textAlign: TextAlign.center,
-                                  style: const TextStyle(
-                                    fontSize: 14,
-                                    color: VineTheme.lightText,
-                                  ),
-                                ),
-                              ],
-                            ),
+                        ),
+                      ),
                     ),
-                  ),
-                ),
+                  );
+                },
               ),
             ),
           );

--- a/mobile/lib/screens/notifications_screen.dart
+++ b/mobile/lib/screens/notifications_screen.dart
@@ -298,19 +298,22 @@ class _NotificationTabContentState
               color: VineTheme.onPrimary,
               backgroundColor: VineTheme.vineGreen,
               onRefresh: () async {
-                await ref.read(relayNotificationsProvider.notifier).refresh();
+                await Future.wait([
+                  ref.read(relayNotificationsProvider.notifier).refresh(),
+                  context.read<InviteStatusCubit>().load(),
+                ]);
               },
               child: BlocBuilder<InviteStatusCubit, InviteStatusState>(
                 builder: (context, inviteState) {
                   final showInviteCard =
-                      widget.filter == null && inviteState.hasUnclaimedCodes;
+                      widget.filter == null && inviteState.hasAvailableInvites;
                   if (showInviteCard) {
                     return ListView(
                       physics: const AlwaysScrollableScrollPhysics(),
                       controller: _scrollController,
                       children: [
                         _InviteNotificationCard(
-                          count: inviteState.unclaimedCount,
+                          count: inviteState.availableInviteCount,
                         ),
                       ],
                     );
@@ -379,12 +382,15 @@ class _NotificationTabContentState
             color: VineTheme.onPrimary,
             backgroundColor: VineTheme.vineGreen,
             onRefresh: () async {
-              await ref.read(relayNotificationsProvider.notifier).refresh();
+              await Future.wait([
+                ref.read(relayNotificationsProvider.notifier).refresh(),
+                context.read<InviteStatusCubit>().load(),
+              ]);
             },
             child: BlocBuilder<InviteStatusCubit, InviteStatusState>(
               builder: (context, inviteState) {
                 final showInviteCard =
-                    widget.filter == null && inviteState.hasUnclaimedCodes;
+                    widget.filter == null && inviteState.hasAvailableInvites;
                 final inviteCardOffset = showInviteCard ? 1 : 0;
                 final hasLoadingIndicator =
                     feedState.hasMoreContent &&
@@ -402,7 +408,7 @@ class _NotificationTabContentState
                     // Invite card at top of All tab
                     if (showInviteCard && index == 0) {
                       return _InviteNotificationCard(
-                        count: inviteState.unclaimedCount,
+                        count: inviteState.availableInviteCount,
                       );
                     }
                     final adjustedIndex = index - inviteCardOffset;

--- a/mobile/lib/screens/settings/invites_screen.dart
+++ b/mobile/lib/screens/settings/invites_screen.dart
@@ -80,8 +80,9 @@ class _LoadedView extends StatelessWidget {
   Widget build(BuildContext context) {
     final unclaimed = inviteStatus.unclaimedCodes;
     final claimed = inviteStatus.claimedCodes;
+    final hasRemainingCapacity = inviteStatus.remaining > 0;
 
-    if (unclaimed.isEmpty && claimed.isEmpty) {
+    if (unclaimed.isEmpty && claimed.isEmpty && !hasRemainingCapacity) {
       return const Center(
         child: Padding(
           padding: EdgeInsets.all(32),
@@ -108,6 +109,10 @@ class _LoadedView extends StatelessWidget {
           ...unclaimed.map((code) => _InviteCodeCard(code: code)),
           const SizedBox(height: 24),
         ],
+        if (hasRemainingCapacity) ...[
+          _GenerateInviteCard(remaining: inviteStatus.remaining),
+          const SizedBox(height: 24),
+        ],
         if (claimed.isNotEmpty) ...[
           Padding(
             padding: const EdgeInsets.only(bottom: 8),
@@ -119,6 +124,44 @@ class _LoadedView extends StatelessWidget {
           ...claimed.map((code) => _ClaimedCodeRow(code: code)),
         ],
       ],
+    );
+  }
+}
+
+class _GenerateInviteCard extends StatelessWidget {
+  const _GenerateInviteCard({required this.remaining});
+
+  final int remaining;
+
+  @override
+  Widget build(BuildContext context) {
+    final inviteLabel = remaining == 1 ? 'invite' : 'invites';
+
+    return Card(
+      color: VineTheme.surfaceContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          spacing: 12,
+          children: [
+            Text(
+              '$remaining $inviteLabel ready to generate',
+              style: VineTheme.titleMediumFont(),
+            ),
+            Text(
+              'Generate a code when you are ready to share one.',
+              style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
+            ),
+            DivineButton(
+              label: 'Generate invite',
+              expanded: true,
+              onPressed: () =>
+                  context.read<InviteStatusCubit>().generateInvite(),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/screens/settings/invites_screen.dart
+++ b/mobile/lib/screens/settings/invites_screen.dart
@@ -6,6 +6,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/invite_models.dart';
 import 'package:openvine/utils/clipboard_utils.dart';
 import 'package:share_plus/share_plus.dart';
@@ -135,8 +136,7 @@ class _GenerateInviteCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final inviteLabel = remaining == 1 ? 'invite' : 'invites';
-
+    final l10n = context.l10n;
     return Card(
       color: VineTheme.surfaceContainer,
       child: Padding(
@@ -146,15 +146,15 @@ class _GenerateInviteCard extends StatelessWidget {
           spacing: 12,
           children: [
             Text(
-              '$remaining $inviteLabel ready to generate',
+              l10n.invitesGenerateCardTitle(remaining),
               style: VineTheme.titleMediumFont(),
             ),
             Text(
-              'Generate a code when you are ready to share one.',
+              l10n.invitesGenerateCardSubtitle,
               style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
             ),
             DivineButton(
-              label: 'Generate invite',
+              label: l10n.invitesGenerateButtonLabel,
               expanded: true,
               onPressed: () =>
                   context.read<InviteStatusCubit>().generateInvite(),

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -60,7 +60,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   void initState() {
     super.initState();
     unawaited(_loadAppVersion());
-    unawaited(context.read<InviteStatusCubit>().load());
+    unawaited(context.read<InviteStatusCubit?>()?.load());
     _accountCubit = SettingsAccountCubit(
       authService: ref.read(authServiceProvider),
       draftStorageService: ref.read(draftStorageServiceProvider),

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -315,7 +315,7 @@ class _AccountHeader extends StatelessWidget {
               _AccountHeaderProfile(pubkey: pubkey),
               BlocBuilder<InviteStatusCubit, InviteStatusState>(
                 builder: (context, inviteState) {
-                  if (!inviteState.hasUnclaimedCodes) {
+                  if (!inviteState.hasAvailableInvites) {
                     return const SizedBox.shrink();
                   }
                   return Semantics(
@@ -361,7 +361,7 @@ class _AccountHeader extends StatelessWidget {
                                 borderRadius: BorderRadius.circular(12),
                               ),
                               child: Text(
-                                '${inviteState.unclaimedCount}',
+                                '${inviteState.availableInviteCount}',
                                 style: VineTheme.labelSmallFont(
                                   color: VineTheme.backgroundColor,
                                 ),

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -60,6 +60,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   void initState() {
     super.initState();
     unawaited(_loadAppVersion());
+    unawaited(context.read<InviteStatusCubit>().load());
     _accountCubit = SettingsAccountCubit(
       authService: ref.read(authServiceProvider),
       draftStorageService: ref.read(draftStorageServiceProvider),

--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -4,7 +4,9 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -105,6 +107,7 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
         // dropped by iOS/Android when app is backgrounded. Without this,
         // subscriptions sent to stale sockets will timeout (30s) with no response.
         _reconnectRelays();
+        unawaited(context.read<InviteStatusCubit?>()?.load());
 
         // Don't force resume playback - let visibility detectors naturally trigger
         // This prevents playing videos that are covered by modals/camera screen

--- a/mobile/test/blocs/invite_status/invite_status_cubit_test.dart
+++ b/mobile/test/blocs/invite_status/invite_status_cubit_test.dart
@@ -40,6 +40,8 @@ void main() {
       expect(cubit.state.inviteStatus, isNull);
       expect(cubit.state.hasUnclaimedCodes, isFalse);
       expect(cubit.state.unclaimedCount, equals(0));
+      expect(cubit.state.hasAvailableInvites, isFalse);
+      expect(cubit.state.availableInviteCount, equals(0));
     });
 
     blocTest<InviteStatusCubit, InviteStatusState>(
@@ -113,6 +115,36 @@ void main() {
       ],
     );
 
+    blocTest<InviteStatusCubit, InviteStatusState>(
+      'generateInvite creates one code then reloads invite status',
+      setUp: () {
+        when(
+          () => mockInviteApiClient.generateInvite(),
+        ).thenAnswer(
+          (_) async => const GenerateInviteResult(
+            code: 'WX56-3MKT',
+            remaining: 4,
+          ),
+        );
+        when(
+          () => mockInviteApiClient.getInviteStatus(),
+        ).thenAnswer((_) async => testStatus);
+      },
+      build: buildCubit,
+      act: (cubit) => cubit.generateInvite(),
+      expect: () => [
+        const InviteStatusState(status: InviteStatusLoadingStatus.loading),
+        const InviteStatusState(
+          status: InviteStatusLoadingStatus.loaded,
+          inviteStatus: testStatus,
+        ),
+      ],
+      verify: (_) {
+        verify(() => mockInviteApiClient.generateInvite()).called(1);
+        verify(() => mockInviteApiClient.getInviteStatus()).called(1);
+      },
+    );
+
     group('state computed properties', () {
       test('hasUnclaimedCodes returns true when unclaimed exist', () {
         const state = InviteStatusState(
@@ -126,6 +158,8 @@ void main() {
         );
         expect(state.hasUnclaimedCodes, isTrue);
         expect(state.unclaimedCount, equals(1));
+        expect(state.hasAvailableInvites, isTrue);
+        expect(state.availableInviteCount, equals(2));
       });
 
       test('hasUnclaimedCodes returns false when all claimed', () {
@@ -140,6 +174,24 @@ void main() {
         );
         expect(state.hasUnclaimedCodes, isFalse);
         expect(state.unclaimedCount, equals(0));
+        expect(state.hasAvailableInvites, isFalse);
+        expect(state.availableInviteCount, equals(0));
+      });
+
+      test('hasAvailableInvites includes remaining invite capacity', () {
+        const state = InviteStatusState(
+          status: InviteStatusLoadingStatus.loaded,
+          inviteStatus: InviteStatus(
+            canInvite: true,
+            remaining: 5,
+            total: 5,
+            codes: [],
+          ),
+        );
+        expect(state.hasUnclaimedCodes, isFalse);
+        expect(state.unclaimedCount, equals(0));
+        expect(state.hasAvailableInvites, isTrue);
+        expect(state.availableInviteCount, equals(5));
       });
     });
   });

--- a/mobile/test/screens/notifications_screen_test.dart
+++ b/mobile/test/screens/notifications_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/invite_models.dart';
 import 'package:openvine/providers/relay_notifications_provider.dart';
 import 'package:openvine/screens/notifications_screen.dart';
 import 'package:openvine/widgets/notification_list_item.dart';
@@ -110,9 +111,12 @@ void main() {
       'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 
   /// Build the NotificationsScreen directly in a ProviderScope
-  Widget buildScreenWidget(RelayNotifications Function() notifierFactory) {
+  Widget buildScreenWidget(
+    RelayNotifications Function() notifierFactory, {
+    InviteStatusState inviteStatusState = const InviteStatusState(),
+  }) {
     final mockInviteCubit = _MockInviteStatusCubit();
-    when(() => mockInviteCubit.state).thenReturn(const InviteStatusState());
+    when(() => mockInviteCubit.state).thenReturn(inviteStatusState);
     when(mockInviteCubit.load).thenAnswer((_) async {});
     return ProviderScope(
       overrides: [relayNotificationsProvider.overrideWith(notifierFactory)],
@@ -360,6 +364,37 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('No notifications yet'), findsOneWidget);
+        expect(find.byType(NotificationListItem), findsNothing);
+      });
+
+      testWidgets('shows invite card when only invites are available', (
+        WidgetTester tester,
+      ) async {
+        final mockNotifier = _MockEmptyRelayNotifications();
+        await tester.pumpWidget(
+          buildScreenWidget(
+            () => mockNotifier,
+            inviteStatusState: const InviteStatusState(
+              status: InviteStatusLoadingStatus.loaded,
+              inviteStatus: InviteStatus(
+                canInvite: true,
+                remaining: 2,
+                total: 2,
+                codes: [
+                  InviteCode(code: 'AB23-EF7K', claimed: false),
+                  InviteCode(code: 'HN4P-QR56', claimed: false),
+                ],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('You have 2 invites to share with friends!'),
+          findsOneWidget,
+        );
+        expect(find.text('No notifications yet'), findsNothing);
         expect(find.byType(NotificationListItem), findsNothing);
       });
 

--- a/mobile/test/screens/notifications_screen_test.dart
+++ b/mobile/test/screens/notifications_screen_test.dart
@@ -114,8 +114,9 @@ void main() {
   Widget buildScreenWidget(
     RelayNotifications Function() notifierFactory, {
     InviteStatusState inviteStatusState = const InviteStatusState(),
+    _MockInviteStatusCubit? inviteCubit,
   }) {
-    final mockInviteCubit = _MockInviteStatusCubit();
+    final mockInviteCubit = inviteCubit ?? _MockInviteStatusCubit();
     when(() => mockInviteCubit.state).thenReturn(inviteStatusState);
     when(mockInviteCubit.load).thenAnswer((_) async {});
     return ProviderScope(
@@ -378,7 +379,7 @@ void main() {
               status: InviteStatusLoadingStatus.loaded,
               inviteStatus: InviteStatus(
                 canInvite: true,
-                remaining: 2,
+                remaining: 0,
                 total: 2,
                 codes: [
                   InviteCode(code: 'AB23-EF7K', claimed: false),
@@ -392,6 +393,34 @@ void main() {
 
         expect(
           find.text('You have 2 invites to share with friends!'),
+          findsOneWidget,
+        );
+        expect(find.text('No notifications yet'), findsNothing);
+        expect(find.byType(NotificationListItem), findsNothing);
+      });
+
+      testWidgets('shows invite card when invite capacity is available', (
+        WidgetTester tester,
+      ) async {
+        final mockNotifier = _MockEmptyRelayNotifications();
+        await tester.pumpWidget(
+          buildScreenWidget(
+            () => mockNotifier,
+            inviteStatusState: const InviteStatusState(
+              status: InviteStatusLoadingStatus.loaded,
+              inviteStatus: InviteStatus(
+                canInvite: true,
+                remaining: 5,
+                total: 5,
+                codes: [],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('You have 5 invites to share with friends!'),
           findsOneWidget,
         );
         expect(find.text('No notifications yet'), findsNothing);
@@ -491,6 +520,42 @@ void main() {
         expect(find.text('Comments'), findsOneWidget);
         expect(find.text('Follows'), findsOneWidget);
         expect(find.text('Reposts'), findsOneWidget);
+      });
+    });
+
+    group('refresh', () {
+      testWidgets('pull to refresh also reloads invite status', (
+        WidgetTester tester,
+      ) async {
+        final mockNotifier = _MockEmptyRelayNotifications();
+        final mockInviteCubit = _MockInviteStatusCubit();
+        when(() => mockInviteCubit.state).thenReturn(
+          const InviteStatusState(),
+        );
+        when(mockInviteCubit.load).thenAnswer((_) async {});
+
+        await tester.pumpWidget(
+          buildScreenWidget(
+            () => mockNotifier,
+            inviteCubit: mockInviteCubit,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.drag(
+          find
+              .descendant(
+                of: find.byType(RefreshIndicator),
+                matching: find.byType(Scrollable),
+              )
+              .first,
+          const Offset(0, 500),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(seconds: 1));
+        await tester.pumpAndSettle();
+
+        verify(mockInviteCubit.load).called(1);
       });
     });
   });

--- a/mobile/test/screens/settings/invites_screen_test.dart
+++ b/mobile/test/screens/settings/invites_screen_test.dart
@@ -102,6 +102,25 @@ void main() {
         expect(listViewWidth, moreOrLessEquals(600));
       });
 
+      testWidgets('generate invite action when capacity is available', (
+        tester,
+      ) async {
+        when(() => mockCubit.state).thenReturn(
+          const InviteStatusState(
+            status: InviteStatusLoadingStatus.loaded,
+            inviteStatus: InviteStatus(
+              canInvite: true,
+              remaining: 5,
+              total: 5,
+              codes: [],
+            ),
+          ),
+        );
+        await tester.pumpWidget(buildSubject());
+        expect(find.text('Generate invite'), findsOneWidget);
+        expect(find.text('No invites available right now'), findsNothing);
+      });
+
       testWidgets('claimed codes section', (tester) async {
         when(() => mockCubit.state).thenReturn(
           const InviteStatusState(
@@ -145,6 +164,26 @@ void main() {
         await tester.pumpWidget(buildSubject());
         await tester.tap(find.text('Retry'));
         verify(() => mockCubit.load()).called(1);
+      });
+
+      testWidgets('tapping generate invite creates a code', (tester) async {
+        when(() => mockCubit.state).thenReturn(
+          const InviteStatusState(
+            status: InviteStatusLoadingStatus.loaded,
+            inviteStatus: InviteStatus(
+              canInvite: true,
+              remaining: 5,
+              total: 5,
+              codes: [],
+            ),
+          ),
+        );
+        when(() => mockCubit.generateInvite()).thenAnswer((_) async {});
+
+        await tester.pumpWidget(buildSubject());
+        await tester.tap(find.text('Generate invite'));
+
+        verify(() => mockCubit.generateInvite()).called(1);
       });
     });
   });

--- a/mobile/test/screens/settings/invites_screen_test.dart
+++ b/mobile/test/screens/settings/invites_screen_test.dart
@@ -117,7 +117,8 @@ void main() {
           ),
         );
         await tester.pumpWidget(buildSubject());
-        expect(find.text('Generate invite'), findsOneWidget);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.invitesGenerateButtonLabel), findsOneWidget);
         expect(find.text('No invites available right now'), findsNothing);
       });
 
@@ -181,7 +182,8 @@ void main() {
         when(() => mockCubit.generateInvite()).thenAnswer((_) async {});
 
         await tester.pumpWidget(buildSubject());
-        await tester.tap(find.text('Generate invite'));
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.invitesGenerateButtonLabel));
 
         verify(() => mockCubit.generateInvite()).called(1);
       });

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -196,7 +196,7 @@ void main() {
           status: InviteStatusLoadingStatus.loaded,
           inviteStatus: InviteStatus(
             canInvite: true,
-            remaining: 1,
+            remaining: 0,
             total: 1,
             codes: [InviteCode(code: 'AB23-EF7K', claimed: false)],
           ),
@@ -208,6 +208,33 @@ void main() {
 
       expect(find.text('Invites'), findsOneWidget);
       expect(find.text('1'), findsOneWidget);
+
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
+    });
+
+    testWidgets('renders invite shortcut when invite capacity exists', (
+      tester,
+    ) async {
+      final mockInviteCubit = _MockInviteStatusCubit();
+      when(mockInviteCubit.load).thenAnswer((_) async {});
+      when(() => mockInviteCubit.state).thenReturn(
+        const InviteStatusState(
+          status: InviteStatusLoadingStatus.loaded,
+          inviteStatus: InviteStatus(
+            canInvite: true,
+            remaining: 5,
+            total: 5,
+            codes: [],
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(buildSubject(inviteCubit: mockInviteCubit));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Invites'), findsOneWidget);
+      expect(find.text('5'), findsOneWidget);
 
       await tester.pumpWidget(const SizedBox());
       await tester.pump();

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:openvine/blocs/locale/locale_cubit.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/invite_models.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
@@ -40,6 +41,7 @@ class _MockLocaleCubit extends MockCubit<LocaleState> implements LocaleCubit {}
 _MockInviteStatusCubit _createMockInviteCubit() {
   final cubit = _MockInviteStatusCubit();
   when(() => cubit.state).thenReturn(const InviteStatusState());
+  when(cubit.load).thenAnswer((_) async {});
   return cubit;
 }
 
@@ -96,12 +98,13 @@ void main() {
       AuthState authState = AuthState.authenticated,
       MockGoRouter? goRouter,
       List<KnownAccount> knownAccounts = const [],
+      _MockInviteStatusCubit? inviteCubit,
     }) {
       when(
         () => mockAuthService.getKnownAccounts(),
       ).thenAnswer((_) async => knownAccounts);
 
-      final mockInviteCubit = _createMockInviteCubit();
+      final mockInviteCubit = inviteCubit ?? _createMockInviteCubit();
 
       final app = ProviderScope(
         overrides: [
@@ -164,6 +167,47 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(UserAvatar), findsOneWidget);
+
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
+    });
+
+    testWidgets('loads invite status so profile can show invite access', (
+      tester,
+    ) async {
+      final mockInviteCubit = _createMockInviteCubit();
+
+      await tester.pumpWidget(buildSubject(inviteCubit: mockInviteCubit));
+      await tester.pumpAndSettle();
+
+      verify(mockInviteCubit.load).called(1);
+
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
+    });
+
+    testWidgets('renders invite shortcut when unclaimed invites exist', (
+      tester,
+    ) async {
+      final mockInviteCubit = _MockInviteStatusCubit();
+      when(mockInviteCubit.load).thenAnswer((_) async {});
+      when(() => mockInviteCubit.state).thenReturn(
+        const InviteStatusState(
+          status: InviteStatusLoadingStatus.loaded,
+          inviteStatus: InviteStatus(
+            canInvite: true,
+            remaining: 1,
+            total: 1,
+            codes: [InviteCode(code: 'AB23-EF7K', claimed: false)],
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(buildSubject(inviteCubit: mockInviteCubit));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Invites'), findsOneWidget);
+      expect(find.text('1'), findsOneWidget);
 
       await tester.pumpWidget(const SizedBox());
       await tester.pump();


### PR DESCRIPTION
Closes #3376

## Summary
- Show awarded invite cards in Notifications even when the user has no social notifications yet.
- Refresh invite status when Settings opens so the profile invite shortcut can appear.
- Add widget coverage for invite-only notifications and Settings invite status loading.

## Test Plan
- [x] flutter analyze lib/screens/notifications_screen.dart lib/screens/settings/settings_screen.dart test/screens/notifications_screen_test.dart test/widgets/settings_screen_test.dart
- [x] flutter test test/screens/notifications_screen_test.dart test/widgets/settings_screen_test.dart
- [x] pre-commit analyzer hook
- [x] pre-push changed-file tests