### PR TITLE
fix(profile): use unified views for profile loop count

### DIFF
--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -230,15 +230,20 @@ class ProfileRepository {
 
     if (social == null && stats == null && engagement == null) return;
 
+    int? publicViewCount;
+    if (engagement != null) {
+      publicViewCount = engagement.totalViews > 0
+          ? engagement.totalViews
+          : engagement.totalLoops.round();
+    }
+
     await dao.upsertStats(
       pubkey: pubkey,
       followerCount: social?.followerCount,
       followingCount: social?.followingCount,
       videoCount: stats?.videoCount,
       totalLikes: engagement?.totalReactions,
-      // total_loops can be fractional due to a backend aggregation issue;
-      // round to the nearest integer.
-      totalViews: engagement?.totalLoops.round(),
+      totalViews: publicViewCount,
     );
   }
 

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -628,6 +628,7 @@ void main() {
               engagement: ProfileEngagementData.fromJson(const {
                 'total_reactions': 42,
                 'total_loops': 12.6,
+                'total_views': 99,
               }),
             ),
           );
@@ -654,7 +655,7 @@ void main() {
               followingCount: 7,
               videoCount: 3,
               totalLikes: 42,
-              totalViews: 13,
+              totalViews: 99,
             ),
           ).called(1);
         });

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -660,6 +660,38 @@ void main() {
           ).called(1);
         });
 
+        test('uses rounded loops when unified views are unavailable', () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getUserProfile(testPubkey),
+          ).thenAnswer(
+            (_) async => UserProfileNotPublished(
+              pubkey: testPubkey,
+              engagement: ProfileEngagementData.fromJson(const {
+                'total_loops': 12.6,
+                'total_views': 0,
+              }),
+            ),
+          );
+
+          final result = await repoWithFunnelcake.fetchFreshProfile(
+            pubkey: testPubkey,
+          );
+
+          expect(result, isNull);
+          expect(repoWithFunnelcake.isConfirmedMissing(testPubkey), isTrue);
+          verify(
+            () => mockProfileStatsDao.upsertStats(
+              pubkey: testPubkey,
+              followerCount: any(named: 'followerCount'),
+              followingCount: any(named: 'followingCount'),
+              videoCount: any(named: 'videoCount'),
+              totalLikes: any(named: 'totalLikes'),
+              totalViews: 13,
+            ),
+          ).called(1);
+        });
+
         test('skips Funnelcake when not available', () async {
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);
 


### PR DESCRIPTION
Closes #3378

## Summary
- Cache profile public view totals from engagement.total_views instead of engagement.total_loops
- Keep total_loops as a fallback when unified views are unavailable
- Update profile repository coverage for the mapping

## Test Plan
- [x] flutter test test/src/profile_repository_test.dart
- [x] pre-commit format and analyzer hook