### PR TITLE
fix(blocklist): drop blocked / muted author videos from open feeds

### DIFF
--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -215,6 +215,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
   // Optional services for enhanced functionality
   ContentBlocklistRepository? _blocklistRepository;
+  StreamSubscription<BlocklistChange>? _blocklistChangesSubscription;
   AgeVerificationService? _ageVerificationService;
   LikesRepository? _likesRepository;
   ContentFilterService? _contentFilterService;
@@ -301,11 +302,97 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// Set the blocklist service for content filtering
   void setBlocklistRepository(ContentBlocklistRepository blocklistRepository) {
     _blocklistRepository = blocklistRepository;
+
+    // Subscribe to per-pubkey blocklist changes so a block / mute
+    // immediately propagates as `removedVideoIds` emissions for every
+    // video by the affected author. Mirrors the deletion bus contract:
+    // subscribers (FullscreenFeedBloc) drop the ids from their visible
+    // state without waiting for a route change or app restart.
+    //
+    // Cancel any prior subscription if `setBlocklistRepository` is
+    // called again — keeps the active subscription bound to the
+    // currently-attached repository.
+    unawaited(_blocklistChangesSubscription?.cancel());
+    _blocklistChangesSubscription = blocklistRepository.changes.listen(
+      (change) {
+        if (!change.isAddition) return;
+        _sweepAuthor(change.pubkey);
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        Log.error(
+          'VideoEventService: blocklist changes stream error - $error',
+          name: 'VideoEventService',
+          category: LogCategory.video,
+          error: error,
+          stackTrace: stackTrace,
+        );
+      },
+    );
+
     Log.debug(
       'Blocklist service attached to VideoEventService',
       name: 'VideoEventService',
       category: LogCategory.video,
     );
+  }
+
+  /// Emit `removedVideoIds` for every cached video authored by [pubkey].
+  ///
+  /// Used in response to block / mute events. Unlike
+  /// [removeVideoCompletely], this does NOT add ids to
+  /// [_locallyDeletedVideoIds] — block / mute are reversible and the
+  /// existing pagination filters (via [shouldHideVideo] /
+  /// [filterVideoList]) already guarantee that an unblocked author's
+  /// videos can come back on the next refresh. We only need the
+  /// fullscreen surface to drop them right now.
+  void _sweepAuthor(String pubkey) {
+    if (_removedVideoIdsController.isClosed) return;
+
+    // Collect ids across every cache that may hold this author's videos.
+    // Fullscreen blocs may be displaying videos sourced from any of
+    // these — discovery, profile, hashtag, etc. Dedupe by id since a
+    // video can appear in multiple buckets simultaneously.
+    final ids = <String>{};
+
+    final authorBucket = _authorBuckets[pubkey];
+    if (authorBucket != null) {
+      for (final video in authorBucket) {
+        ids.add(video.id);
+      }
+    }
+
+    for (final list in _eventLists.values) {
+      for (final video in list) {
+        if (video.pubkey == pubkey) ids.add(video.id);
+      }
+    }
+
+    for (final list in _hashtagBuckets.values) {
+      for (final video in list) {
+        if (video.pubkey == pubkey) ids.add(video.id);
+      }
+    }
+
+    if (ids.isEmpty) return;
+
+    Log.info(
+      'sweepAuthor: emitting ${ids.length} removal(s) for pubkey=$pubkey',
+      name: 'VideoEventService',
+      category: LogCategory.video,
+    );
+
+    for (final id in ids) {
+      _removedVideoIdsController.add(id);
+    }
+  }
+
+  /// Test-only seam: pre-populate the author bucket so [_sweepAuthor]
+  /// can be exercised without driving a real relay subscription.
+  /// Production code must never call this — use the public subscription
+  /// APIs instead.
+  @visibleForTesting
+  void debugSeedAuthorBucket(String pubkey, List<VideoEvent> videos) {
+    _authorBuckets[pubkey] = List.of(videos);
   }
 
   /// Set the age verification service for adult content filtering
@@ -4988,6 +5075,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     _retryTimer?.cancel();
     _likeCountBatchTimer?.cancel();
     _authStateSubscription?.cancel();
+    unawaited(_blocklistChangesSubscription?.cancel());
     _connectionService.dispose();
     unsubscribeFromVideoFeed();
     unawaited(_removedVideoIdsController.close());

--- a/mobile/packages/content_blocklist_repository/lib/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/content_blocklist_repository.dart
@@ -3,4 +3,5 @@
 library;
 
 export 'src/block_list_signer.dart' show BlockListSigner;
+export 'src/blocklist_change.dart' show BlocklistChange, BlocklistOp;
 export 'src/content_blocklist_repository.dart' show ContentBlocklistRepository;

--- a/mobile/packages/content_blocklist_repository/lib/src/blocklist_change.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/blocklist_change.dart
@@ -1,0 +1,63 @@
+// ABOUTME: Granular blocklist change events emitted on the changes stream
+// ABOUTME: Subscribers (e.g. VideoEventService) react per-pubkey on additions
+
+/// Type of blocklist mutation. Used by [BlocklistChange.op] so subscribers
+/// can decide whether the change should hide content
+/// (any "added" op) or restore it (any "removed" op).
+enum BlocklistOp {
+  /// We blocked someone — added to our runtime blocklist.
+  blocked,
+
+  /// We unblocked someone — removed from our runtime blocklist.
+  unblocked,
+
+  /// Someone muted us — added to the mutual-mute set.
+  muted,
+
+  /// Someone unmuted us — removed from the mutual-mute set.
+  unmuted,
+
+  /// Someone blocked us — added to the blocked-by-others set.
+  blockedUs,
+
+  /// Someone unblocked us — removed from the blocked-by-others set.
+  unblockedUs,
+}
+
+/// A granular change to the blocklist composition.
+///
+/// Emitted on `ContentBlocklistRepository.changes` whenever the user (or
+/// remote sync) modifies which pubkeys are blocked / muted / blocking-us.
+/// Subscribers can react per-pubkey rather than reading whole-state
+/// snapshots and diffing them.
+class BlocklistChange {
+  const BlocklistChange({required this.pubkey, required this.op});
+
+  /// The pubkey (hex) the change applies to.
+  final String pubkey;
+
+  /// What kind of change occurred.
+  final BlocklistOp op;
+
+  /// `true` when the change adds the pubkey to a hide-bucket — the
+  /// signal that downstream caches should drop content from this author.
+  /// `false` when the change removes the pubkey, restoring visibility on
+  /// the next pagination.
+  bool get isAddition => switch (op) {
+    BlocklistOp.blocked || BlocklistOp.muted || BlocklistOp.blockedUs => true,
+    BlocklistOp.unblocked ||
+    BlocklistOp.unmuted ||
+    BlocklistOp.unblockedUs => false,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BlocklistChange && other.pubkey == pubkey && other.op == op;
+
+  @override
+  int get hashCode => Object.hash(pubkey, op);
+
+  @override
+  String toString() => 'BlocklistChange(pubkey: $pubkey, op: $op)';
+}

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:content_blocklist_repository/src/block_list_signer.dart';
+import 'package:content_blocklist_repository/src/blocklist_change.dart';
 import 'package:content_policy/content_policy.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
@@ -76,6 +77,11 @@ class ContentBlocklistRepository {
 
   final _stateController = StreamController<ContentPolicyState>.broadcast();
 
+  // Granular per-pubkey change events. Subscribers (e.g. VideoEventService)
+  // react per-author rather than diffing snapshots from [stateStream].
+  // See [changes] for the public getter.
+  final _changesController = StreamController<BlocklistChange>.broadcast();
+
   // Subscription tracking for mutual mutes
   String? _mutualMuteSubscriptionId;
   bool _mutualMuteSyncStarted = false;
@@ -94,6 +100,20 @@ class ContentBlocklistRepository {
   /// Emits a new [ContentPolicyState] snapshot whenever the policy changes.
   Stream<ContentPolicyState> get stateStream => _stateController.stream;
 
+  /// Emits per-pubkey [BlocklistChange] events the moment the
+  /// composition mutates (block, unblock, mute, unmute, externally-applied
+  /// changes).
+  ///
+  /// Subscribers should use this stream when they need to react to a
+  /// specific pubkey transitioning into or out of a hide-bucket — e.g.
+  /// dropping that author's videos from open feed surfaces. Diffing the
+  /// snapshots from [stateStream] would also work but is brittle and
+  /// allocation-heavy.
+  ///
+  /// Broadcast semantics: late subscribers do not receive past emissions;
+  /// the canonical truth is [currentState] / the contains-checks.
+  Stream<BlocklistChange> get changes => _changesController.stream;
+
   ContentPolicyState _buildCurrentState() => ContentPolicyState(
     currentUserPubkey: _ourPubkey,
     // TODO(rabble): populate from our own kind 10000 once personal-mute
@@ -111,6 +131,15 @@ class ContentBlocklistRepository {
     _onChanged?.call();
     if (!_stateController.isClosed) {
       _stateController.add(_buildCurrentState());
+    }
+  }
+
+  /// Emit a granular change on [changes]. Call sites pair this with
+  /// [_notifyChanged] so the broad-state listeners and the per-pubkey
+  /// listeners stay in sync.
+  void _emitChange(BlocklistChange change) {
+    if (!_changesController.isClosed) {
+      _changesController.add(change);
     }
   }
 
@@ -352,6 +381,9 @@ class ContentBlocklistRepository {
     if (!_runtimeBlocklist.contains(pubkey)) {
       _runtimeBlocklist.add(pubkey);
       await _saveBlockedUsers();
+      _emitChange(
+        BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked),
+      );
       _notifyChanged();
       await _publishBlockListToNostr();
 
@@ -379,6 +411,9 @@ class ContentBlocklistRepository {
     if (_runtimeBlocklist.contains(pubkey)) {
       _runtimeBlocklist.remove(pubkey);
       await _saveBlockedUsers();
+      _emitChange(
+        BlocklistChange(pubkey: pubkey, op: BlocklistOp.unblocked),
+      );
       _notifyChanged();
       await _publishBlockListToNostr();
 
@@ -625,6 +660,9 @@ class ContentBlocklistRepository {
       // They muted us - add to blocklist
       if (!_mutualMuteBlocklist.contains(muterPubkey)) {
         _mutualMuteBlocklist.add(muterPubkey);
+        _emitChange(
+          BlocklistChange(pubkey: muterPubkey, op: BlocklistOp.muted),
+        );
         _notifyChanged();
         Log.info(
           'Added mutual mute: $muterPubkey',
@@ -636,6 +674,9 @@ class ContentBlocklistRepository {
       // They removed us from mute list - remove from blocklist
       if (_mutualMuteBlocklist.contains(muterPubkey)) {
         _mutualMuteBlocklist.remove(muterPubkey);
+        _emitChange(
+          BlocklistChange(pubkey: muterPubkey, op: BlocklistOp.unmuted),
+        );
         _notifyChanged();
         Log.info(
           'Removed mutual mute (unmuted): $muterPubkey',
@@ -691,6 +732,11 @@ class ContentBlocklistRepository {
 
     _runtimeBlocklist.addAll(added);
     unawaited(_saveBlockedUsers());
+    for (final pubkey in added) {
+      _emitChange(
+        BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked),
+      );
+    }
     _notifyChanged();
 
     Log.info(
@@ -720,6 +766,9 @@ class ContentBlocklistRepository {
     if (stillBlocked) {
       if (!_blockedByOthers.contains(blockerPubkey)) {
         _blockedByOthers.add(blockerPubkey);
+        _emitChange(
+          BlocklistChange(pubkey: blockerPubkey, op: BlocklistOp.blockedUs),
+        );
         _notifyChanged();
         Log.info(
           'Detected block from user: $blockerPubkey',
@@ -730,6 +779,9 @@ class ContentBlocklistRepository {
     } else {
       if (_blockedByOthers.contains(blockerPubkey)) {
         _blockedByOthers.remove(blockerPubkey);
+        _emitChange(
+          BlocklistChange(pubkey: blockerPubkey, op: BlocklistOp.unblockedUs),
+        );
         _notifyChanged();
         Log.info(
           'Detected unblock from user: $blockerPubkey',
@@ -747,5 +799,6 @@ class ContentBlocklistRepository {
     _mutualMuteSubscriptionId = null;
     _blockListSyncStarted = false;
     unawaited(_stateController.close());
+    unawaited(_changesController.close());
   }
 }

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -209,6 +209,115 @@ void main() {
       expect(changeCount, equals(2));
     });
 
+    group('changes stream', () {
+      test('blockUser emits BlocklistOp.blocked', () async {
+        const target = 'pubkey-target';
+        final emitted = <BlocklistChange>[];
+        final sub = service.changes.listen(emitted.add);
+        addTearDown(sub.cancel);
+
+        await service.blockUser(target);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          emitted,
+          equals([
+            const BlocklistChange(
+              pubkey: target,
+              op: BlocklistOp.blocked,
+            ),
+          ]),
+        );
+      });
+
+      test('unblockUser emits BlocklistOp.unblocked', () async {
+        const target = 'pubkey-target';
+        await service.blockUser(target);
+
+        final emitted = <BlocklistChange>[];
+        final sub = service.changes.listen(emitted.add);
+        addTearDown(sub.cancel);
+
+        await service.unblockUser(target);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          emitted,
+          equals([
+            const BlocklistChange(
+              pubkey: target,
+              op: BlocklistOp.unblocked,
+            ),
+          ]),
+        );
+      });
+
+      test('block + unblock round-trip emits both ops in order', () async {
+        const target = 'pubkey-target';
+        final emitted = <BlocklistChange>[];
+        final sub = service.changes.listen(emitted.add);
+        addTearDown(sub.cancel);
+
+        await service.blockUser(target);
+        await service.unblockUser(target);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          emitted.map((c) => c.op),
+          equals([
+            BlocklistOp.blocked,
+            BlocklistOp.unblocked,
+          ]),
+        );
+        expect(emitted.every((c) => c.pubkey == target), isTrue);
+      });
+
+      test(
+        're-blocking the same pubkey is a no-op (no duplicate emit)',
+        () async {
+          const target = 'pubkey-target';
+          await service.blockUser(target);
+
+          final emitted = <BlocklistChange>[];
+          final sub = service.changes.listen(emitted.add);
+          addTearDown(sub.cancel);
+
+          await service.blockUser(target);
+          await Future<void>.delayed(Duration.zero);
+
+          expect(emitted, isEmpty);
+        },
+      );
+
+      test('isAddition is correct for every op', () {
+        const additions = [
+          BlocklistOp.blocked,
+          BlocklistOp.muted,
+          BlocklistOp.blockedUs,
+        ];
+        const removals = [
+          BlocklistOp.unblocked,
+          BlocklistOp.unmuted,
+          BlocklistOp.unblockedUs,
+        ];
+
+        for (final op in additions) {
+          expect(
+            BlocklistChange(pubkey: 'p', op: op).isAddition,
+            isTrue,
+            reason: 'op $op should be an addition',
+          );
+        }
+        for (final op in removals) {
+          expect(
+            BlocklistChange(pubkey: 'p', op: op).isAddition,
+            isFalse,
+            reason: 'op $op should NOT be an addition',
+          );
+        }
+      });
+    });
+
     group('self-block prevention', () {
       test(
         'blockUser() ignores when pubkey matches ourPubkey parameter',

--- a/mobile/test/services/video_event_service_blocklist_sweep_test.dart
+++ b/mobile/test/services/video_event_service_blocklist_sweep_test.dart
@@ -1,0 +1,204 @@
+// ABOUTME: Tests the block/mute bus bridge — VideoEventService subscribes to
+// ContentBlocklistRepository.changes and emits removedVideoIds for every
+// cached video by the affected author when an "addition" event fires.
+
+@Tags(['skip_very_good_optimization'])
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+VideoEvent _video({required String id, required String pubkey}) {
+  final now = DateTime.now();
+  return VideoEvent(
+    id: id,
+    pubkey: pubkey,
+    createdAt: now.millisecondsSinceEpoch ~/ 1000,
+    content: '',
+    timestamp: now,
+    title: id,
+    videoUrl: 'https://example.com/$id.mp4',
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<Filter>[]);
+  });
+
+  group('VideoEventService blocklist sweep', () {
+    late VideoEventService service;
+    late ContentBlocklistRepository blocklistRepo;
+    late _MockNostrClient nostrClient;
+    late _MockSubscriptionManager subscriptionManager;
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      subscriptionManager = _MockSubscriptionManager();
+      when(() => nostrClient.isInitialized).thenReturn(true);
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(
+        () => nostrClient.subscribe(any()),
+      ).thenAnswer((_) => const Stream<Event>.empty());
+
+      service = VideoEventService(
+        nostrClient,
+        subscriptionManager: subscriptionManager,
+      );
+      // No prefs — in-memory blocklist for the test.
+      blocklistRepo = ContentBlocklistRepository();
+      service.setBlocklistRepository(blocklistRepo);
+    });
+
+    tearDown(() {
+      service.dispose();
+      blocklistRepo.dispose();
+    });
+
+    test(
+      'blockUser triggers a sweep — removedVideoIds emits every cached id '
+      'for the blocked author',
+      () async {
+        const author = 'author-pubkey';
+        service.debugSeedAuthorBucket(author, [
+          _video(id: 'v1', pubkey: author),
+          _video(id: 'v2', pubkey: author),
+          _video(id: 'v3', pubkey: author),
+        ]);
+
+        final emitted = <String>[];
+        final sub = service.removedVideoIds.listen(emitted.add);
+        addTearDown(sub.cancel);
+
+        await blocklistRepo.blockUser(author);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emitted, containsAll(['v1', 'v2', 'v3']));
+        expect(emitted.length, 3);
+      },
+    );
+
+    test('unblockUser does NOT trigger a sweep (no-op for removals)', () async {
+      const author = 'author-pubkey';
+      await blocklistRepo.blockUser(author); // pre-block so unblock fires
+      service.debugSeedAuthorBucket(author, [
+        _video(id: 'v1', pubkey: author),
+      ]);
+
+      // Listener after pre-block so the initial blocked emit isn't counted.
+      final emitted = <String>[];
+      final sub = service.removedVideoIds.listen(emitted.add);
+      addTearDown(sub.cancel);
+
+      await blocklistRepo.unblockUser(author);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, isEmpty);
+    });
+
+    test(
+      'sweep does NOT add ids to _locallyDeletedVideoIds (block is reversible)',
+      () async {
+        const author = 'author-pubkey';
+        service.debugSeedAuthorBucket(author, [
+          _video(id: 'v1', pubkey: author),
+        ]);
+
+        await blocklistRepo.blockUser(author);
+        await Future<void>.delayed(Duration.zero);
+
+        // The session-tombstone set is reserved for irrevocable
+        // user-initiated deletions. Unblocking should restore visibility,
+        // which would be impossible if we polluted the tombstone set.
+        expect(service.isVideoLocallyDeleted('v1'), isFalse);
+      },
+    );
+
+    test('block on author with no cached videos is a silent no-op', () async {
+      final emitted = <String>[];
+      final sub = service.removedVideoIds.listen(emitted.add);
+      addTearDown(sub.cancel);
+
+      await blocklistRepo.blockUser('unknown-author');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, isEmpty);
+    });
+
+    test(
+      're-blocking the same author is dedupe at the repository level — no '
+      'duplicate sweep',
+      () async {
+        const author = 'author-pubkey';
+        service.debugSeedAuthorBucket(author, [
+          _video(id: 'v1', pubkey: author),
+        ]);
+
+        await blocklistRepo.blockUser(author);
+        await Future<void>.delayed(Duration.zero);
+
+        final emitted = <String>[];
+        final sub = service.removedVideoIds.listen(emitted.add);
+        addTearDown(sub.cancel);
+
+        await blocklistRepo.blockUser(author); // already blocked → no-op
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emitted, isEmpty);
+      },
+    );
+
+    test(
+      'dispose cancels the blocklist subscription (further repo emits are '
+      'ignored without errors)',
+      () async {
+        // Build a separate service so the global tearDown does not double-
+        // dispose. Pre-existing helpers (`service`, `blocklistRepo`) stay
+        // owned by the outer setUp/tearDown.
+        final localNostr = _MockNostrClient();
+        when(() => localNostr.isInitialized).thenReturn(true);
+        when(() => localNostr.connectedRelayCount).thenReturn(1);
+        when(
+          () => localNostr.subscribe(any()),
+        ).thenAnswer((_) => const Stream<Event>.empty());
+        final localService = VideoEventService(
+          localNostr,
+          subscriptionManager: subscriptionManager,
+        );
+        final localRepo = ContentBlocklistRepository();
+        addTearDown(localRepo.dispose);
+
+        localService.setBlocklistRepository(localRepo);
+        const author = 'author-pubkey';
+        localService.debugSeedAuthorBucket(author, [
+          _video(id: 'v1', pubkey: author),
+        ]);
+
+        final emitted = <String>[];
+        final sub = localService.removedVideoIds.listen(
+          emitted.add,
+          onError: (Object _) {},
+        );
+        addTearDown(sub.cancel);
+
+        localService.dispose();
+
+        // Repo is still live; emit a Blocked. The cancelled subscription
+        // means the bus does not see this event.
+        await localRepo.blockUser(author);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emitted, isEmpty);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description

Stacked on #3380. Plugs the blocklist into the generic \`removedVideoIds\` bus that #3380 introduced, so blocking or muting an author drops their videos from any open feed surface in real time — instead of waiting for an app restart, which is the broken state on \`main\`.

**Related Issue:** Closes #3381

**Stacked on:** #3380 (delete propagation). Merge #3380 first; this PR's diff is then a clean addition.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Root cause

Same shape as #3379 / #3380, different surface. \`ContentBlocklistRepository._notifyChanged()\` was a \`void Function()?\` that bumped a Riverpod version counter; it carried no payload and nothing told per-pubkey caches to drop the affected author's videos. With the deletion bus from #3380 in place, the fix is small — extend the repository's signalling and bridge it into the existing bus.

## What ships

- **\`BlocklistChange\`** value object: \`{pubkey, op}\` where \`op\` is \`blocked\` / \`unblocked\` / \`muted\` / \`unmuted\` / \`blockedUs\` / \`unblockedUs\`. \`isAddition\` collapses the six into the binary "should we hide this pubkey's content now" signal. Exported from the \`content_blocklist_repository\` barrel.
- **\`ContentBlocklistRepository.changes\`**: \`Stream<BlocklistChange>\` (broadcast) emitted alongside the existing \`stateStream\`. Every existing \`_notifyChanged()\` call site now emits a granular change first; the legacy \`onChanged\` callback stays untouched for backward compat. Closed in \`dispose\`.
- **\`VideoEventService.setBlocklistRepository\`** subscribes to \`changes\`. On any \`isAddition\` op, calls \`_sweepAuthor(pubkey)\` which iterates the author bucket plus \`_eventLists\` and \`_hashtagBuckets\` for videos by that pubkey and emits each id on the existing \`removedVideoIds\` bus. \`FullscreenFeedBloc\` + the 21 fullscreen entry points need zero changes — the bus contract from #3380 already wires them.
- **Reversibility preserved**: \`_sweepAuthor\` deliberately does NOT add ids to \`_locallyDeletedVideoIds\`. Block / mute can be undone; the existing \`shouldHideVideo\` / \`filterVideoList\` filters restore visibility on the next pagination once the pubkey is no longer blocked.

## How to reproduce on \`main\` + #3380 (without this PR)

**Preconditions:** signed-in account; at least one block target with cached videos visible in your feeds; #3380 either merged or applied locally.

1. Open a fullscreen feed that contains content from author X (For You, hashtag, profile, etc.).
2. Open author X's profile.
3. Tap **Block** (or wait for them to add you to their kind 10000 mute list — same path).
4. Back-navigate to the original fullscreen feed.

**Observed:** author X's videos still appear and play. Profile grids that contained their content still show the thumbnails. Force-quit and relaunch clears it.

**Expected:** author X's videos disappear within ~1 s of the block. The route advances to the next non-X video, or auto-pops if X was the only author.

## How to verify the fix on this branch

### 1. Block sweep
1. Open a fullscreen feed with ≥ 3 videos including ≥ 1 from author X.
2. Tap into author X's profile from the kebab / mention.
3. Tap **Block** → confirm.
4. ✅ Within ~1 s, all of X's videos drop from the open feed; the route advances to the next video.
5. ✅ Back to the source feed → no thumbnails from X.
6. ✅ Force-quit and reopen → identical state (no regression).

### 2. Unblock restores
1. After the sweep above, navigate to the block list and **Unblock** X.
2. ✅ Pull-to-refresh on the For You / hashtag feed → X's videos reappear (no app restart).
3. ✅ X's profile shows their videos again.

### 3. Mute path (NIP-51 kind 10000)
1. Have a peer add you to their mute list (kind 10000 'p' tag).
2. ✅ Their videos disappear from your open feeds within seconds of the relay event arriving.
3. Have them remove the mute.
4. ✅ Their videos reappear on next pagination.

### 4. Log assertion

\`\`\`
ContentBlocklistRepository: Added user to blocklist: <author-pubkey>
VideoEventService: sweepAuthor: emitting N removal(s) for pubkey=<author-pubkey>
FullscreenFeedBloc: ... (state.videos count drops by N)
\`\`\`

No \`PooledPlayer: load_start ... reused=true\` for any of the swept ids after the sweep line.

## Test plan

- [x] \`flutter analyze lib test integration_test\` clean
- [x] \`flutter test\` against package + service + bloc + provider + widget + screen scopes — 2553 tests pass, including 11 new ones (5 in the package, 6 on the service)
- [ ] Manual repro on \`main\` + #3380 to confirm the bug
- [ ] Manual verification on this branch — block sweep
- [ ] Manual verification on this branch — unblock restores
- [ ] Manual verification on this branch — mute path
- [ ] Log-line acceptance check

## Out of scope (file separately if needed)

- Bucket-level cleanup on block (we only emit removals on the bus; \`_authorBuckets[pubkey]\` and \`_eventLists\` retain stale entries that are filtered at retrieval via \`filterVideoList\`). Acceptable today; if memory pressure becomes a concern, a separate cache-eviction pass can be added.
- The deletion telemetry workstream (Approach C from the post-3380 brainstorm) — separate small PR.
- The structural \`ViewSource\` refactor (Approach B) — multi-week, tracked separately.