### PR TITLE
feat(observability): deletion-lifecycle telemetry + divergence probe

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -171,6 +171,26 @@ class FullscreenFeedBloc
           category: LogCategory.video,
         );
 
+        // Divergence probe: the source-stream contract forbids pushing
+        // an id we have already swept via [removedVideoIds]. If this
+        // happens we have a regression in the upstream filter (or in
+        // a future caller bypassing the bus entirely). Log loudly so
+        // the local-observability log line surfaces in QA / CI.
+        if (state.removedVideoIds.isNotEmpty) {
+          final stale = videos
+              .where((v) => state.removedVideoIds.contains(v.id))
+              .map((v) => v.id)
+              .toList(growable: false);
+          if (stale.isNotEmpty) {
+            Log.warning(
+              'FullscreenFeedBloc: source pushed ${stale.length} '
+              'already-removed id(s) — upstream filter regression: $stale',
+              name: 'FullscreenFeedBloc',
+              category: LogCategory.video,
+            );
+          }
+        }
+
         // Clamp current index to valid range
         final clampedIndex = videos.isEmpty
             ? 0

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -2094,10 +2094,12 @@ Future<ContentDeletionService> contentDeletionService(Ref ref) async {
   final nostrService = ref.watch(nostrServiceProvider);
   final authService = ref.watch(authServiceProvider);
   final prefs = ref.watch(sharedPreferencesProvider);
+  final analyticsService = ref.watch(analyticsServiceProvider);
   final service = ContentDeletionService(
     nostrService: nostrService,
     authService: authService,
     prefs: prefs,
+    analyticsService: analyticsService,
   );
 
   // Initialize the service to enable content deletion

--- a/mobile/lib/services/analytics_service.dart
+++ b/mobile/lib/services/analytics_service.dart
@@ -10,6 +10,28 @@ import 'package:openvine/services/view_event_publisher.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Phase of a per-video deletion the user has initiated.
+///
+/// Mirrors the [ContentDeletionService] flow:
+/// `requested` → `relayConfirmed` → `localApplied`. On any error path
+/// the lifecycle ends with `failed` instead.
+enum DeletionLifecyclePhase {
+  /// User invoked deletion; the kind 5 has not been published yet.
+  requested,
+
+  /// Relay accepted the kind 5 event.
+  relayConfirmed,
+
+  /// Local caches scrubbed and the bus emit fired. The user-visible
+  /// outcome is "video gone."
+  localApplied,
+
+  /// The lifecycle terminated with an error before reaching
+  /// [localApplied]. The video is NOT in the local tombstone set; the
+  /// caller can retry.
+  failed,
+}
+
 /// Service for tracking video analytics with privacy controls.
 ///
 /// Publishes Kind 22236 ephemeral Nostr view events via [ViewEventPublisher].
@@ -283,6 +305,48 @@ class AnalyticsService implements BackgroundAwareService {
   /// Clear tracked views cache.
   void clearTrackedViews() {
     _recentlyTrackedViews.clear();
+  }
+
+  /// Phase of a per-video deletion the user has initiated.
+  ///
+  /// The lifecycle of [trackDeletion] mirrors the [ContentDeletionService]
+  /// flow:
+  ///
+  ///   `requested` → `relayConfirmed` → `localApplied`
+  ///
+  /// or, on any error path:
+  ///
+  ///   `requested` → `failed`
+  ///
+  /// Used purely for local observability — no Nostr publishing, no
+  /// remote dashboard. Greppable structured log lines are the
+  /// observable surface today.
+  // (kept here so callers can `import analytics_service.dart` and get
+  // both the service and the enum.)
+
+  /// Emit a structured local log line for one phase of a content
+  /// deletion. Respects the user's analytics opt-out preference — when
+  /// analytics are disabled, the call is a no-op.
+  ///
+  /// [phase] — which lifecycle transition just happened.
+  /// [videoId] — the original video event id being deleted.
+  /// [reason] — optional. For `failed`, the [DeleteFailureKind.name].
+  ///
+  /// Does NOT publish a Nostr event. The product / privacy surface for
+  /// publish-on-delete is tracked separately and intentionally out of
+  /// scope here — see #3380's brainstorm doc.
+  void trackDeletion({
+    required DeletionLifecyclePhase phase,
+    required String videoId,
+    String? reason,
+  }) {
+    if (_isDisposed || !_analyticsEnabled) return;
+    final reasonSuffix = reason == null ? '' : ' reason=$reason';
+    Log.info(
+      'AnalyticsDeletion: phase=${phase.name} videoId=$videoId$reasonSuffix',
+      name: 'AnalyticsService',
+      category: LogCategory.system,
+    );
   }
 
   // BackgroundAwareService implementation

--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -7,6 +7,7 @@ import 'package:models/models.dart' hide LogCategory, NIP71VideoKinds;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/constants/nip71_migration.dart';
+import 'package:openvine/services/analytics_service.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -107,14 +108,21 @@ class ContentDeletionService {
     required NostrClient nostrService,
     required AuthService authService,
     required SharedPreferences prefs,
+    AnalyticsService? analyticsService,
   }) : _nostrService = nostrService,
        _authService = authService,
-       _prefs = prefs {
+       _prefs = prefs,
+       _analyticsService = analyticsService {
     _loadDeletionHistory();
   }
   final NostrClient _nostrService;
   final AuthService _authService;
   final SharedPreferences _prefs;
+
+  /// Optional. When wired, every deletion-lifecycle transition is
+  /// reported via [AnalyticsService.trackDeletion] for local-only
+  /// observability — see the deletion-telemetry brainstorm.
+  final AnalyticsService? _analyticsService;
 
   static const String deletionsStorageKey = 'content_deletions_history';
 
@@ -165,9 +173,22 @@ class ContentDeletionService {
     required String reason,
     String? additionalContext,
   }) async {
+    _analyticsService?.trackDeletion(
+      phase: DeletionLifecyclePhase.requested,
+      videoId: video.id,
+    );
+    DeleteResult emitFailure(String message, DeleteFailureKind kind) {
+      _analyticsService?.trackDeletion(
+        phase: DeletionLifecyclePhase.failed,
+        videoId: video.id,
+        reason: kind.name,
+      );
+      return DeleteResult.failure(message, kind);
+    }
+
     try {
       if (!_isInitialized) {
-        return DeleteResult.failure(
+        return emitFailure(
           'Deletion service not initialized',
           DeleteFailureKind.notInitialized,
         );
@@ -175,7 +196,7 @@ class ContentDeletionService {
 
       // Verify this is the user's own content
       if (!_isUserOwnContent(video)) {
-        return DeleteResult.failure(
+        return emitFailure(
           'Can only delete your own content',
           DeleteFailureKind.notOwner,
         );
@@ -193,7 +214,7 @@ class ContentDeletionService {
       final deleteEvent = deleteOutcome.event;
       if (deleteEvent == null) {
         final kind = deleteOutcome.failureKind!;
-        return DeleteResult.failure(_failureMessageForKind(kind), kind);
+        return emitFailure(_failureMessageForKind(kind), kind);
       }
 
       final publishOutcome = await _nostrService.publishEventAwaitOk(
@@ -207,7 +228,7 @@ class ContentDeletionService {
           name: 'ContentDeletionService',
           category: LogCategory.system,
         );
-        return DeleteResult.failure(
+        return emitFailure(
           'Relay did not confirm deletion: ${publishOutcome.summary}',
           DeleteFailureKind.relayRejected,
         );
@@ -217,6 +238,10 @@ class ContentDeletionService {
         'Delete request confirmed by relay(s): ${publishOutcome.acceptedBy}',
         name: 'ContentDeletionService',
         category: LogCategory.system,
+      );
+      _analyticsService?.trackDeletion(
+        phase: DeletionLifecyclePhase.relayConfirmed,
+        videoId: video.id,
       );
 
       // Relay accepted — now it is safe to persist the deletion locally.
@@ -236,6 +261,10 @@ class ContentDeletionService {
         name: 'ContentDeletionService',
         category: LogCategory.system,
       );
+      _analyticsService?.trackDeletion(
+        phase: DeletionLifecyclePhase.localApplied,
+        videoId: video.id,
+      );
       return DeleteResult.createSuccess(deleteEvent.id);
     } catch (e) {
       Log.error(
@@ -243,7 +272,7 @@ class ContentDeletionService {
         name: 'ContentDeletionService',
         category: LogCategory.system,
       );
-      return DeleteResult.failure(
+      return emitFailure(
         'Failed to delete content: $e',
         DeleteFailureKind.unknown,
       );

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -318,6 +318,45 @@ void main() {
           ),
         ],
       );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'divergence probe: source push containing already-removed ids '
+        'still produces a state but flags the regression',
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(Duration.zero);
+          videosController.add([
+            createTestVideo('a'),
+            createTestVideo('b'),
+          ]);
+          await Future<void>.delayed(Duration.zero);
+          // Mark 'a' as removed.
+          bloc.add(const FullscreenFeedVideoRemoved('a'));
+          await Future<void>.delayed(Duration.zero);
+          // Now simulate the upstream regressing — pushing 'a' again.
+          // The probe must still allow the new state to land (we don't
+          // fight the source), but should warn in logs.
+          videosController.add([
+            createTestVideo('a'),
+            createTestVideo('b'),
+            createTestVideo('c'),
+          ]);
+          await Future<void>.delayed(Duration.zero);
+        },
+        verify: (bloc) {
+          // The new source push wins — the bloc trusts the source. The
+          // warn log line is the developer-facing signal; the state
+          // emission is unchanged.
+          expect(
+            bloc.state.videos.map((v) => v.id),
+            equals(['a', 'b', 'c']),
+          );
+          // 'a' stays in removedVideoIds since the bloc never removes
+          // tombstones on its own.
+          expect(bloc.state.removedVideoIds, contains('a'));
+        },
+      );
     });
 
     group('FullscreenFeedLoadMoreRequested', () {

--- a/mobile/test/services/analytics_service_test.dart
+++ b/mobile/test/services/analytics_service_test.dart
@@ -143,5 +143,41 @@ void main() {
 
       await expectLater(analyticsService.trackVideoViews(videos), completes);
     });
+
+    group('trackDeletion', () {
+      test('does not throw for any phase', () async {
+        await analyticsService.initialize();
+        for (final phase in DeletionLifecyclePhase.values) {
+          analyticsService.trackDeletion(
+            phase: phase,
+            videoId: 'video-id',
+            reason: phase == DeletionLifecyclePhase.failed
+                ? 'relayRejected'
+                : null,
+          );
+        }
+      });
+
+      test('is a no-op when analytics is disabled', () async {
+        await analyticsService.initialize();
+        await analyticsService.setAnalyticsEnabled(false);
+        // Just verify no throw / no exception path. The method is a
+        // logging-only side-effect today; the contract is "respect the
+        // user opt-out" which is verified at the if-guard.
+        analyticsService.trackDeletion(
+          phase: DeletionLifecyclePhase.requested,
+          videoId: 'video-id',
+        );
+      });
+
+      test('is a no-op after dispose', () async {
+        await analyticsService.initialize();
+        analyticsService.dispose();
+        // Avoid the default tearDown re-disposing.
+        analyticsService = AnalyticsService(disableNostrPublishing: true);
+        // No assertion beyond "does not throw" — the dispose-guard
+        // returns early before any logging or state mutation.
+      });
+    });
   });
 }

--- a/mobile/test/services/content_deletion_service_test.dart
+++ b/mobile/test/services/content_deletion_service_test.dart
@@ -9,6 +9,7 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/relay/publish_outcome.dart';
+import 'package:openvine/services/analytics_service.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/content_deletion_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -18,6 +19,22 @@ class _MockNostrClient extends Mock implements NostrClient {}
 class _MockAuthService extends Mock implements AuthService {}
 
 class _FakeEvent extends Fake implements Event {}
+
+/// Captures every [AnalyticsService.trackDeletion] call so the deletion
+/// service tests can assert the lifecycle phase sequence.
+class _RecordingAnalyticsService extends Fake implements AnalyticsService {
+  final List<({DeletionLifecyclePhase phase, String videoId, String? reason})>
+  calls = [];
+
+  @override
+  void trackDeletion({
+    required DeletionLifecyclePhase phase,
+    required String videoId,
+    String? reason,
+  }) {
+    calls.add((phase: phase, videoId: videoId, reason: reason));
+  }
+}
 
 void main() {
   setUpAll(() {
@@ -404,6 +421,174 @@ void main() {
       test('returns null for an id that was never deleted', () {
         expect(service.getDeletionForEvent('non_existent_event_id'), isNull);
       });
+    });
+
+    group('analytics lifecycle tracking', () {
+      late _RecordingAnalyticsService recorder;
+      late ContentDeletionService instrumentedService;
+
+      setUp(() async {
+        recorder = _RecordingAnalyticsService();
+        instrumentedService = ContentDeletionService(
+          nostrService: mockNostrService,
+          authService: mockAuthService,
+          prefs: prefs,
+          analyticsService: recorder,
+        );
+        await instrumentedService.initialize();
+      });
+
+      test(
+        'happy path emits requested → relayConfirmed → localApplied',
+        () async {
+          final video = createTestVideoEvent(testPublicKey);
+          final deleteEvent = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 5,
+            tags: [
+              ['e', video.id],
+            ],
+            content: '',
+          );
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => deleteEvent);
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => accepted(deleteEvent.id));
+
+          final result = await instrumentedService.deleteContent(
+            video: video,
+            reason: 'test',
+          );
+
+          expect(result.success, isTrue);
+          expect(
+            recorder.calls.map((c) => c.phase),
+            equals([
+              DeletionLifecyclePhase.requested,
+              DeletionLifecyclePhase.relayConfirmed,
+              DeletionLifecyclePhase.localApplied,
+            ]),
+          );
+          expect(
+            recorder.calls.every((c) => c.videoId == video.id),
+            isTrue,
+          );
+        },
+      );
+
+      test(
+        'relay rejection emits requested → failed with reason=relayRejected',
+        () async {
+          final video = createTestVideoEvent(testPublicKey);
+          final deleteEvent = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 5,
+            tags: [
+              ['e', video.id],
+            ],
+            content: '',
+          );
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => deleteEvent);
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => rejected(deleteEvent.id));
+
+          final result = await instrumentedService.deleteContent(
+            video: video,
+            reason: 'test',
+          );
+
+          expect(result.success, isFalse);
+          expect(
+            recorder.calls.map((c) => c.phase),
+            equals([
+              DeletionLifecyclePhase.requested,
+              DeletionLifecyclePhase.failed,
+            ]),
+          );
+          expect(recorder.calls.last.reason, equals('relayRejected'));
+        },
+      );
+
+      test(
+        'not-owner emits requested → failed with reason=notOwner',
+        () async {
+          // Sign in with a different pubkey so the video is NOT ours.
+          when(
+            () => mockAuthService.currentPublicKeyHex,
+          ).thenReturn('someone_else');
+          final video = createTestVideoEvent(testPublicKey);
+
+          final result = await instrumentedService.deleteContent(
+            video: video,
+            reason: 'test',
+          );
+
+          expect(result.success, isFalse);
+          expect(
+            recorder.calls.map((c) => c.phase),
+            equals([
+              DeletionLifecyclePhase.requested,
+              DeletionLifecyclePhase.failed,
+            ]),
+          );
+          expect(recorder.calls.last.reason, equals('notOwner'));
+        },
+      );
+
+      test(
+        'analyticsService is optional — null is safe',
+        () async {
+          // Use the original `service` without an analyticsService injected.
+          final video = createTestVideoEvent(testPublicKey);
+          final deleteEvent = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 5,
+            tags: [
+              ['e', video.id],
+            ],
+            content: '',
+          );
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => deleteEvent);
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => accepted(deleteEvent.id));
+
+          // No throw — the null-coalescing in the service swallows.
+          final result = await service.deleteContent(
+            video: video,
+            reason: 'test',
+          );
+          expect(result.success, isTrue);
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
## Description

Approach C from the post-#3380 brainstorm — local-only observability for the deletion bus. Stacked on #3382 (block/mute) which is stacked on #3380 (delete).

Local-only means: structured \`Log.info\` calls at every deletion lifecycle transition, plus a divergence probe in \`FullscreenFeedBloc\` that warns when an upstream filter regresses. **No Nostr publish, no new analytics SDK, no custom dashboard.** That's deliberate — the brainstorm flagged two open product questions (privacy surface for publish-on-delete, dashboard owner) that need team input. This PR delivers the "catch regressions before user reports" value without those decisions, and leaves the door open for an extension PR that layers a Nostr or third-party sink on top of the same \`trackDeletion\` call.

**Related Issue:** Closes #3385

**Stacked on:** #3382 (block/mute parity) which is stacked on #3380 (deletion propagation).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## What ships

### 1. \`AnalyticsService.trackDeletion(phase, videoId, reason?)\`

\`\`\`dart
enum DeletionLifecyclePhase { requested, relayConfirmed, localApplied, failed }

void trackDeletion({
  required DeletionLifecyclePhase phase,
  required String videoId,
  String? reason, // populated for `failed` with the DeleteFailureKind.name
});
\`\`\`

Respects the user's analytics opt-out (\`_analyticsEnabled\`). Safe after \`dispose\`. Pure logging — no side effects beyond a structured \`Log.info\` line per call.

### 2. \`ContentDeletionService.deleteContent\` lifecycle wiring

Optional \`AnalyticsService? analyticsService\` injected via constructor; the provider passes it. Every lifecycle transition emits via \`trackDeletion\`:

- top of \`deleteContent\` → \`requested\`
- after relay OK → \`relayConfirmed\`
- after local persistence + bus emit → \`localApplied\`
- every failure return → \`failed\` with \`DeleteFailureKind.name\` as the reason

The \`?\` makes the wiring optional — tests that don't care about analytics keep working.

### 3. \`FullscreenFeedBloc\` divergence probe

In \`_onStarted\`'s \`onData\` callback, before computing the new state, scan the incoming \`videos\` for any id already in \`state.removedVideoIds\`. If non-empty, \`Log.warning\` with the offending id list. **Does not block the state emission** — the upstream still wins; the warning is a developer-facing signal that someone has bypassed the bus or pushed pre-removed content.

## What's explicitly NOT in scope

- **Nostr-publish surface** for deletion analytics (kind 1085 / similar). Needs product / privacy input.
- **Custom analytics dashboard / metric ingestion**. Needs ownership decision.
- **Time-based divergence probe** ("warn after N seconds of divergence"). The current probe is invariant-based — fires synchronously on every emit. Time-based requires a Timer + state, which is more complex than the value justifies right now.
- **Block/mute lifecycle telemetry**. Same shape; can extend \`AnalyticsService\` with \`trackBlocklistChange\` later.

## Test plan

- [x] \`flutter analyze lib test integration_test\` clean
- [x] Scoped test runs green: 93 tests in analytics + deletion + bloc files; broader sweep over services + bloc/fullscreen_feed: 1807 tests pass
- [ ] Manual log-line check on a real device: tap delete on own video, observe four matching \`AnalyticsDeletion: phase=…\` lines
- [ ] Manual divergence-probe check: temporarily push a stale id from a test caller, confirm a \`source pushed N already-removed id(s) — upstream filter regression\` warning appears

## Tests added

- \`AnalyticsService\`: \`trackDeletion\` handles every phase, respects opt-out, safe after dispose.
- \`ContentDeletionService\`: happy path emits \`requested → relayConfirmed → localApplied\`; relay rejection emits \`requested → failed (relayRejected)\`; not-owner emits \`requested → failed (notOwner)\`; null \`analyticsService\` is safe.
- \`FullscreenFeedBloc\`: divergence probe path emits the new state correctly while flagging the regression in logs.