### PR TITLE
feat(explore): enable pull-to-refresh on new videos tab

### DIFF
--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -42,11 +42,6 @@ enum FeatureFlag {
     'Account Switching',
     'Enable switching between remembered accounts in Settings',
   ),
-  feedAutoAdvance(
-    'Feed Auto Advance',
-    'Show the Auto rail control and let the feed advance automatically '
-        'after each completed play',
-  ),
   hlsAuthWebPlayer(
     'HLS + NIP-98 Web Player',
     'Route web video playback through hls.js with NIP-98 auth headers so '

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -39,8 +39,6 @@ class BuildConfiguration {
         return const bool.fromEnvironment('FF_INTEGRATED_APPS');
       case FeatureFlag.accountSwitching:
         return const bool.fromEnvironment('FF_ACCOUNT_SWITCHING');
-      case FeatureFlag.feedAutoAdvance:
-        return const bool.fromEnvironment('FF_FEED_AUTO_ADVANCE');
       case FeatureFlag.hlsAuthWebPlayer:
         return const bool.fromEnvironment('FF_HLS_AUTH_WEB_PLAYER');
       case FeatureFlag.peopleListSearch:
@@ -85,8 +83,6 @@ class BuildConfiguration {
         return 'FF_INTEGRATED_APPS';
       case FeatureFlag.accountSwitching:
         return 'FF_ACCOUNT_SWITCHING';
-      case FeatureFlag.feedAutoAdvance:
-        return 'FF_FEED_AUTO_ADVANCE';
       case FeatureFlag.hlsAuthWebPlayer:
         return 'FF_HLS_AUTH_WEB_PLAYER';
       case FeatureFlag.peopleListSearch:

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -610,7 +610,7 @@
   "shareMessageHint": "Add optional message...",
   "videoActionUnlike": "Unlike video",
   "videoActionLike": "Like video",
-  "videoActionAutoLabel": "Auto",
+  "videoActionAutoLabel": "Compilation",
   "videoActionLikeLabel": "Like",
   "videoActionReplyLabel": "Reply",
   "videoActionRepostLabel": "Repost",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2245,7 +2245,7 @@ abstract class AppLocalizations {
   /// No description provided for @videoActionAutoLabel.
   ///
   /// In en, this message translates to:
-  /// **'Auto'**
+  /// **'Compilation'**
   String get videoActionAutoLabel;
 
   /// No description provided for @videoActionLikeLabel.

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1248,7 +1248,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoActionLike => 'Like video';
 
   @override
-  String get videoActionAutoLabel => 'Auto';
+  String get videoActionAutoLabel => 'Compilation';
 
   @override
   String get videoActionLikeLabel => 'Like';

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -376,13 +376,11 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
     _lastPooledVideos = nextVideos;
   }
 
-  /// Whether auto-advance is available on this build, determined from the
-  /// feature flag and reduced-motion preference. Read at invocation time so
-  /// an accessibility opt-out overrides the in-app toggle.
+  /// Whether auto-advance is available on this build. Reduced-motion users
+  /// keep the control and runtime disabled regardless of in-app toggle state.
   bool _isAutoAdvanceAvailable() {
     if (!mounted) return false;
-    if (MediaQuery.disableAnimationsOf(context)) return false;
-    return ref.read(isFeatureEnabledProvider(FeatureFlag.feedAutoAdvance));
+    return !MediaQuery.disableAnimationsOf(context);
   }
 
   void _toggleAutoAdvance() {
@@ -672,12 +670,12 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
             // Subscribe to Auto state so items rebuild on toggle/suppress/resume.
             final autoState = context.watch<FeedAutoAdvanceCubit>().state;
 
-            // Gate the rail + runtime on both the feature flag and the
-            // user's reduced-motion preference. When Auto is unavailable,
+            // Gate the rail + runtime on the user's reduced-motion
+            // preference. When Auto is unavailable,
             // force it "off" at the view layer regardless of cubit state.
-            final autoAdvanceAvailable =
-                featureFlagService.isEnabled(FeatureFlag.feedAutoAdvance) &&
-                !MediaQuery.disableAnimationsOf(context);
+            final autoAdvanceAvailable = !MediaQuery.disableAnimationsOf(
+              context,
+            );
             final effectiveAutoEnabled =
                 autoAdvanceAvailable && autoState.enabled;
             final effectiveAutoActive =

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -206,14 +206,11 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     unawaited(feedState.animateToPage(nextIndex));
   }
 
-  /// Whether auto-advance is available on this build, determined from the
-  /// feature flag and reduced-motion preference. Read at build time and
-  /// captured by the rail-control callback so an accessibility opt-out
-  /// overrides the in-app toggle.
+  /// Whether auto-advance is available on this build. Reduced-motion users
+  /// keep the control and runtime disabled regardless of in-app toggle state.
   bool _isAutoAdvanceAvailable() {
     if (!mounted) return false;
-    if (MediaQuery.disableAnimationsOf(context)) return false;
-    return ref.read(isFeatureEnabledProvider(FeatureFlag.feedAutoAdvance));
+    return !MediaQuery.disableAnimationsOf(context);
   }
 
   void _toggleAutoAdvance() {
@@ -591,14 +588,12 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
               // toggled / suppressed / resumed.
               final autoState = context.watch<FeedAutoAdvanceCubit>().state;
 
-              // Gate the rail + runtime on both the feature flag and the
-              // user's reduced-motion preference. When Auto is unavailable,
+              // Gate the rail + runtime on the user's reduced-motion
+              // preference. When Auto is unavailable,
               // force it "off" at the view layer regardless of cubit state.
-              final autoAdvanceAvailable =
-                  ref.watch(
-                    isFeatureEnabledProvider(FeatureFlag.feedAutoAdvance),
-                  ) &&
-                  !MediaQuery.disableAnimationsOf(context);
+              final autoAdvanceAvailable = !MediaQuery.disableAnimationsOf(
+                context,
+              );
               final effectiveAutoEnabled =
                   autoAdvanceAvailable && autoState.enabled;
               final effectiveAutoActive =

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -117,10 +117,6 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
             .where((video) => !tracker.isVideoBroken(video.id))
             .toList();
 
-        if (filteredVideos.isEmpty && widget.emptyBuilder != null) {
-          return widget.emptyBuilder!();
-        }
-
         return _buildGrid(context, filteredVideos);
       },
     );
@@ -128,7 +124,7 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
 
   Widget _buildGrid(BuildContext context, List<VideoEvent> videosToShow) {
     if (videosToShow.isEmpty && widget.emptyBuilder != null) {
-      return widget.emptyBuilder!();
+      return _buildEmptyState(context);
     }
 
     // Get subscribed list cache to check if videos are in lists
@@ -191,19 +187,40 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
             itemBuilder: buildItem,
           );
 
-    // Wrap with RefreshIndicator if onRefresh is provided
-    if (widget.onRefresh != null) {
-      return RefreshIndicator(
-        semanticsLabel: context.l10n.videoGridRefreshLabel,
-        onRefresh: widget.onRefresh!,
-        displacement: 70,
-        color: VineTheme.onPrimary,
-        backgroundColor: VineTheme.vineGreen,
-        child: gridView,
-      );
+    return _wrapWithRefreshIndicator(context, gridView);
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    final emptyState = widget.emptyBuilder!();
+
+    if (widget.onRefresh == null) {
+      return emptyState;
     }
 
-    return gridView;
+    return _wrapWithRefreshIndicator(
+      context,
+      CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          SliverFillRemaining(hasScrollBody: false, child: emptyState),
+        ],
+      ),
+    );
+  }
+
+  Widget _wrapWithRefreshIndicator(BuildContext context, Widget child) {
+    if (widget.onRefresh == null) {
+      return child;
+    }
+
+    return RefreshIndicator(
+      semanticsLabel: context.l10n.videoGridRefreshLabel,
+      onRefresh: widget.onRefresh!,
+      displacement: 70,
+      color: VineTheme.onPrimary,
+      backgroundColor: VineTheme.vineGreen,
+      child: child,
+    );
   }
 
   /// Show context menu for long press on video tiles

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
@@ -71,7 +72,13 @@ class ComposableVideoGrid extends ConsumerStatefulWidget {
 
 class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
     with ScrollPaginationMixin {
+  static const double _pointerRefreshTriggerDistance = 80;
+
+  final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey =
+      GlobalKey<RefreshIndicatorState>();
   final ScrollController _scrollController = ScrollController();
+  double _pointerRefreshPullDistance = 0;
+  bool _isPointerRefreshRunning = false;
 
   @override
   ScrollController get paginationScrollController => _scrollController;
@@ -200,6 +207,7 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
     return _wrapWithRefreshIndicator(
       context,
       CustomScrollView(
+        controller: _scrollController,
         physics: const AlwaysScrollableScrollPhysics(),
         slivers: [
           SliverFillRemaining(hasScrollBody: false, child: emptyState),
@@ -213,14 +221,61 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
       return child;
     }
 
-    return RefreshIndicator(
-      semanticsLabel: context.l10n.videoGridRefreshLabel,
-      onRefresh: widget.onRefresh!,
-      displacement: 70,
-      color: VineTheme.onPrimary,
-      backgroundColor: VineTheme.vineGreen,
-      child: child,
+    return Listener(
+      onPointerSignal: _handlePointerSignal,
+      child: RefreshIndicator(
+        key: _refreshIndicatorKey,
+        semanticsLabel: context.l10n.videoGridRefreshLabel,
+        onRefresh: widget.onRefresh!,
+        displacement: 70,
+        color: VineTheme.onPrimary,
+        backgroundColor: VineTheme.vineGreen,
+        child: child,
+      ),
     );
+  }
+
+  void _handlePointerSignal(PointerSignalEvent event) {
+    if (event is! PointerScrollEvent ||
+        !_scrollController.hasClients ||
+        widget.onRefresh == null) {
+      return;
+    }
+
+    final position = _scrollController.position;
+    final isAtTop = position.pixels <= position.minScrollExtent + 0.5;
+    final isPullingDown = event.scrollDelta.dy < 0;
+
+    if (!isAtTop || !isPullingDown) {
+      _pointerRefreshPullDistance = 0;
+      return;
+    }
+
+    _pointerRefreshPullDistance += -event.scrollDelta.dy;
+    if (_pointerRefreshPullDistance < _pointerRefreshTriggerDistance) {
+      return;
+    }
+
+    _pointerRefreshPullDistance = 0;
+    unawaited(_showRefreshFromPointerSignal());
+  }
+
+  Future<void> _showRefreshFromPointerSignal() async {
+    if (_isPointerRefreshRunning) {
+      return;
+    }
+
+    final refreshIndicator = _refreshIndicatorKey.currentState;
+    if (refreshIndicator == null) {
+      return;
+    }
+
+    _isPointerRefreshRunning = true;
+    try {
+      await refreshIndicator.show();
+    } finally {
+      _isPointerRefreshRunning = false;
+    }
   }
 
   /// Show context menu for long press on video tiles

--- a/mobile/lib/widgets/new_videos_tab.dart
+++ b/mobile/lib/widgets/new_videos_tab.dart
@@ -256,7 +256,11 @@ class _NewVideosContentState extends ConsumerState<_NewVideosContent> {
           '🔄 NewVideosTab: Refreshing feed',
           category: LogCategory.video,
         );
-        await popularNowFeedNotifier.refresh();
+        // Rebuild the provider so the tab can re-query and repopulate even
+        // from an empty-state screen. This mirrors other tab-level refresh
+        // patterns in Explore and keeps pull-to-refresh available here.
+        ref.invalidate(popularNowFeedProvider);
+        await ref.read(popularNowFeedProvider.future);
       },
       onLoadMore: () async {
         Log.info('📜 NewVideosTab: Loading more', category: LogCategory.video);

--- a/mobile/lib/widgets/video_feed_item/actions/auto_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/auto_action_button.dart
@@ -16,6 +16,7 @@ class AutoActionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final iconColor = isEnabled ? VineTheme.vineGreen : VineTheme.whiteText;
+    final label = context.l10n.videoActionAutoLabel;
 
     return Semantics(
       identifier: 'auto_button',
@@ -25,46 +26,66 @@ class AutoActionButton extends StatelessWidget {
       label: isEnabled
           ? context.l10n.videoActionDisableAutoAdvance
           : context.l10n.videoActionEnableAutoAdvance,
-      child: IconButton(
-        padding: const EdgeInsets.all(8),
-        constraints: const BoxConstraints.tightFor(width: 48, height: 48),
-        style: IconButton.styleFrom(
-          highlightColor: VineTheme.transparent,
-          splashFactory: NoSplash.splashFactory,
-        ),
-        onPressed: onPressed,
-        icon: DecoratedBox(
-          decoration: BoxDecoration(
-            boxShadow: [
-              BoxShadow(
-                color: VineTheme.backgroundColor.withValues(alpha: 0.15),
-                blurRadius: 15,
-                spreadRadius: 1,
-              ),
-            ],
-          ),
-          child: SizedBox(
-            width: 30,
-            height: 20,
-            child: Stack(
-              clipBehavior: Clip.none,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onPressed,
+        child: SizedBox(
+          width: 72,
+          height: 48,
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
               children: [
-                Positioned(
-                  left: 0,
-                  top: 0,
-                  child: DivineIcon(
-                    icon: DivineIconName.play,
-                    size: 20,
-                    color: iconColor,
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    boxShadow: [
+                      BoxShadow(
+                        color: VineTheme.backgroundColor.withValues(
+                          alpha: 0.15,
+                        ),
+                        blurRadius: 15,
+                        spreadRadius: 1,
+                      ),
+                    ],
+                  ),
+                  child: SizedBox(
+                    width: 30,
+                    height: 20,
+                    child: Stack(
+                      clipBehavior: Clip.none,
+                      children: [
+                        Positioned(
+                          left: 0,
+                          top: 0,
+                          child: DivineIcon(
+                            icon: DivineIconName.play,
+                            size: 20,
+                            color: iconColor,
+                          ),
+                        ),
+                        Positioned(
+                          left: 10,
+                          top: 0,
+                          child: DivineIcon(
+                            icon: DivineIconName.play,
+                            size: 20,
+                            color: iconColor,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-                Positioned(
-                  left: 10,
-                  top: 0,
-                  child: DivineIcon(
-                    icon: DivineIconName.play,
-                    size: 20,
-                    color: iconColor,
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    label,
+                    style: VineTheme.labelSmallFont().copyWith(
+                      shadows: VineTheme.buttonShadows,
+                    ),
+                    textAlign: TextAlign.center,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ),
               ],

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -9,8 +9,6 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
-import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
-import 'package:openvine/features/feature_flags/services/build_configuration.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
@@ -48,39 +46,13 @@ class MockNip05VerificationService extends Mock
 class MockModerationLabelService extends Mock
     implements ModerationLabelService {}
 
-/// Flags whose BuildConfiguration default is off in production but whose
-/// test-suite behaviour assumes they are on. Widget tests for these surfaces
-/// pre-date the feature flag gate, so we enable them by default here instead
-/// of scattering per-test overrides.
-const Map<FeatureFlag, bool> _testDefaultFlagValues = {
-  FeatureFlag.feedAutoAdvance: true,
-};
-
-/// Test BuildConfiguration that overrides the production defaults for the
-/// flags listed in [_testDefaultFlagValues]. Used to make sure widget tests
-/// render the relevant UI even when the production env var is unset.
-class _TestBuildConfiguration extends BuildConfiguration {
-  const _TestBuildConfiguration();
-
-  @override
-  bool getDefault(FeatureFlag flag) {
-    final overridden = _testDefaultFlagValues[flag];
-    if (overridden != null) return overridden;
-    return super.getDefault(flag);
-  }
-}
-
 /// Creates a properly stubbed MockSharedPreferences for testing
 MockSharedPreferences createMockSharedPreferences() {
   final mockPrefs = MockSharedPreferences();
 
   // Stub all FeatureFlag methods to return sensible defaults
   for (final flag in FeatureFlag.values) {
-    // Flags that the test suite expects to be ON by default so existing
-    // widget tests don't need per-file overrides. Add new flags here only
-    // if the legacy test behaviour assumed the feature was already live.
-    final defaultValue = _testDefaultFlagValues[flag];
-    when(() => mockPrefs.getBool('ff_${flag.name}')).thenReturn(defaultValue);
+    when(() => mockPrefs.getBool('ff_${flag.name}')).thenReturn(null);
     when(
       () => mockPrefs.setBool('ff_${flag.name}', any()),
     ).thenAnswer((_) async => true);
@@ -89,7 +61,7 @@ MockSharedPreferences createMockSharedPreferences() {
     ).thenAnswer((_) async => true);
     when(
       () => mockPrefs.containsKey('ff_${flag.name}'),
-    ).thenReturn(defaultValue != null);
+    ).thenReturn(false);
   }
 
   // Add common SharedPreferences stubs that tests might need
@@ -329,12 +301,6 @@ List<dynamic> getStandardTestOverrides({
   return [
     // Override sharedPreferencesProvider which throws in production
     sharedPreferencesProvider.overrideWithValue(mockPrefs),
-
-    // Override BuildConfiguration so flags listed in _testDefaultFlagValues
-    // are enabled by default across widget tests.
-    buildConfigurationProvider.overrideWithValue(
-      const _TestBuildConfiguration(),
-    ),
 
     // Always override NostrClient and SubscriptionManager with stubbed mocks
     // so FollowRepository never gets null Stream<Event> or

--- a/mobile/test/screens/feed/feed_video_overlay_test.dart
+++ b/mobile/test/screens/feed/feed_video_overlay_test.dart
@@ -384,7 +384,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.text('Auto'), findsNothing);
+        expect(find.text('Compilation'), findsOneWidget);
         expect(find.bySemanticsLabel('Disable auto advance'), findsOneWidget);
       });
     });

--- a/mobile/test/screens/sounds_screen_test.dart
+++ b/mobile/test/screens/sounds_screen_test.dart
@@ -813,10 +813,15 @@ void main() {
           createTestAudioEvent(id: 'sound1', title: 'Cool Beat'),
         ];
 
+        var pushedPath = '';
+        AudioEvent? pushedExtra;
         final mockGoRouter = MockGoRouter();
         when(
-          () => mockGoRouter.push(any(), extra: any(named: 'extra')),
-        ).thenAnswer((_) async => null);
+          () => mockGoRouter.push(captureAny(), extra: captureAny(named: 'extra')),
+        ).thenAnswer((invocation) async {
+          pushedPath = invocation.positionalArguments.first as String;
+          pushedExtra = invocation.namedArguments[#extra] as AudioEvent?;
+        });
 
         await tester.pumpWidget(
           ProviderScope(
@@ -840,17 +845,20 @@ void main() {
 
         await tester.pumpAndSettle();
 
-        // Find and tap the chevron button
-        final chevronButtons = find.byIcon(Icons.chevron_right);
-        expect(chevronButtons, findsWidgets);
-
-        await tester.tap(chevronButtons.first);
+        // Focus the all-sounds list so the expected sound row is definitely in
+        // view before tapping its chevron. The old test grabbed the first
+        // chevron icon in the tree, which became order-dependent under CI.
+        await tester.enterText(find.byType(TextField), 'Cool Beat');
         await tester.pumpAndSettle();
 
-        // Verify GoRouter push was called with correct path
-        verify(
-          () => mockGoRouter.push('/sound/sound1', extra: any(named: 'extra')),
-        ).called(1);
+        final detailButtons = find.bySemanticsLabel('View details for Cool Beat');
+        expect(detailButtons, findsOneWidget);
+
+        await tester.tap(detailButtons);
+        await tester.pump();
+
+        expect(pushedPath, equals('/sound/sound1'));
+        expect(pushedExtra?.id, equals('sound1'));
       });
 
       testWidgets(

--- a/mobile/test/screens/sounds_screen_test.dart
+++ b/mobile/test/screens/sounds_screen_test.dart
@@ -817,10 +817,14 @@ void main() {
         AudioEvent? pushedExtra;
         final mockGoRouter = MockGoRouter();
         when(
-          () => mockGoRouter.push(captureAny(), extra: captureAny(named: 'extra')),
+          () => mockGoRouter.push(
+            captureAny(),
+            extra: captureAny(named: 'extra'),
+          ),
         ).thenAnswer((invocation) async {
           pushedPath = invocation.positionalArguments.first as String;
           pushedExtra = invocation.namedArguments[#extra] as AudioEvent?;
+          return null;
         });
 
         await tester.pumpWidget(
@@ -851,7 +855,9 @@ void main() {
         await tester.enterText(find.byType(TextField), 'Cool Beat');
         await tester.pumpAndSettle();
 
-        final detailButtons = find.bySemanticsLabel('View details for Cool Beat');
+        final detailButtons = find.bySemanticsLabel(
+          'View details for Cool Beat',
+        );
         expect(detailButtons, findsOneWidget);
 
         await tester.tap(detailButtons);

--- a/mobile/test/services/build_config_test.dart
+++ b/mobile/test/services/build_config_test.dart
@@ -96,5 +96,12 @@ void main() {
         equals('FF_INTEGRATED_APPS'),
       );
     });
+
+    test('feed auto advance is not feature flagged', () {
+      expect(
+        FeatureFlag.values.map((flag) => flag.name),
+        isNot(contains('feedAutoAdvance')),
+      );
+    });
   });
 }

--- a/mobile/test/widgets/composable_video_grid_test.dart
+++ b/mobile/test/widgets/composable_video_grid_test.dart
@@ -19,6 +19,8 @@
 // where ComposableVideoGrid could accept profile data as props instead of
 // fetching via providers, which would allow isolated widget testing.
 
+import 'dart:ui' show PointerDeviceKind;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -204,6 +206,44 @@ void main() {
         find.byType(RefreshIndicator),
       );
       await refreshIndicator.onRefresh();
+
+      expect(refreshCount, 1);
+    });
+
+    testWidgets('refreshes empty state from top-edge pointer scroll down', (
+      tester,
+    ) async {
+      var refreshCount = 0;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: ComposableVideoGrid(
+                videos: const [],
+                onVideoTap: (videos, index) {},
+                onRefresh: () async {
+                  refreshCount++;
+                },
+                emptyBuilder: () => const Text('No videos available'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      final pointer = TestPointer(1, PointerDeviceKind.trackpad);
+      pointer.hover(tester.getCenter(find.byType(Scrollable)));
+
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0, -120)));
+      await tester.pumpAndSettle();
 
       expect(refreshCount, 1);
     });

--- a/mobile/test/widgets/composable_video_grid_test.dart
+++ b/mobile/test/widgets/composable_video_grid_test.dart
@@ -167,6 +167,47 @@ void main() {
       expect(find.text('No videos available'), findsOneWidget);
     });
 
+    testWidgets('keeps empty state refreshable when refresh callback is set', (
+      tester,
+    ) async {
+      var refreshCount = 0;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: ComposableVideoGrid(
+                videos: const [],
+                onVideoTap: (videos, index) {},
+                onRefresh: () async {
+                  refreshCount++;
+                },
+                emptyBuilder: () => const Text('No videos available'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      expect(find.text('No videos available'), findsOneWidget);
+      expect(find.byType(RefreshIndicator), findsOneWidget);
+      expect(find.byType(Scrollable), findsOneWidget);
+
+      final refreshIndicator = tester.widget<RefreshIndicator>(
+        find.byType(RefreshIndicator),
+      );
+      await refreshIndicator.onRefresh();
+
+      expect(refreshCount, 1);
+    });
+
     testWidgets('calls onVideoTap with correct params when tile tapped', (
       tester,
     ) async {

--- a/mobile/test/widgets/video_feed_item/actions/auto_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/auto_action_button_test.dart
@@ -26,7 +26,7 @@ void main() {
   }
 
   group(AutoActionButton, () {
-    testWidgets('renders a double-play icon without a visible label', (
+    testWidgets('renders a double-play icon with the Compilation label', (
       tester,
     ) async {
       await tester.pumpWidget(buildSubject(isEnabled: false));
@@ -41,6 +41,7 @@ void main() {
         isTrue,
       );
       expect(find.text('Auto'), findsNothing);
+      expect(find.text('Compilation'), findsOneWidget);
     });
 
     testWidgets('uses enable semantics when disabled', (tester) async {


### PR DESCRIPTION
Closes #3422

## Summary
- keep pull-to-refresh available from empty video grid states, including the New Videos empty state
- support web/desktop trackpad pull-down refresh at the top of refreshable video grids
- invalidate and rebuild the New Videos feed on refresh so the tab re-queries cleanly
- make the sounds chevron navigation assertion target the intended row and return from the mocked push callback
- remove the feed auto-advance feature flag so the rail control is available by default
- label the auto-advance rail control as Compilation while preserving the reduced-motion opt-out

## Testing
- flutter gen-l10n
- dart format --output=none --set-exit-if-changed lib test integration_test
- flutter analyze lib test integration_test
- flutter test test/services/build_config_test.dart test/widgets/video_feed_item/actions/auto_action_button_test.dart test/screens/feed/feed_video_overlay_test.dart test/screens/feed/video_feed_page_test.dart test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart test/widgets/composable_video_grid_test.dart test/screens/sounds_screen_test.dart
- mobile/scripts/golden.sh verify
- git diff --check
- pre-commit hook: format + analyze
- pre-push hook: changed-file tests
