### PR TITLE
fix(video-editor): enhance clip splitting logic and thumbnail management

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -270,6 +270,8 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
                 endClipId: endClip.id,
                 absoluteSplitPosition: selectedClip.trimStart + splitPosition,
                 sourceDuration: selectedClip.duration,
+                sourceTrimStart: selectedClip.trimStart,
+                sourceTrimEnd: selectedClip.trimEnd,
               ),
             ),
           );

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -255,6 +255,11 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         sourceClip: selectedClip,
         splitPosition: splitPosition,
         onClipsCreated: (startClip, endClip) {
+          // splitClip's render phase awaits Future.wait on parallel
+          // video renders. If the bloc is closed mid-render (user
+          // navigates away from the editor), the late callbacks fire
+          // on a done emitter — guard each one.
+          if (emit.isDone) return;
           final clips = state.clips;
           final index = clips.indexWhere((c) => c.id == selectedClip.id);
           if (index == -1) return;
@@ -283,6 +288,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
           );
         },
         onThumbnailExtracted: (clip, thumbnailPath) {
+          if (emit.isDone) return;
           final clips = state.clips;
           final index = clips.indexWhere((c) => c.id == clip.id);
           if (index == -1) return;
@@ -293,6 +299,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
           emit(state.copyWith(clips: List.unmodifiable(newClips)));
         },
         onClipRendered: (clip, video) {
+          if (emit.isDone) return;
           final clips = state.clips;
           final index = clips.indexWhere((c) => c.id == clip.id);
           if (index == -1) return;

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -22,7 +22,7 @@ part 'clip_editor_state.dart';
 /// architecture replaces the Riverpod provider with a [VideoEditorRepository]
 /// injected directly into this BLoC.
 class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
-  ClipEditorBloc({required void Function() this.onFinalClipInvalidated})
+  ClipEditorBloc({required this.onFinalClipInvalidated})
     : super(const ClipEditorState()) {
     // Clip data
     on<ClipEditorInitialized>(_onInitialized);
@@ -49,7 +49,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     on<ClipEditorTrimDragEnded>(_onTrimDragEnded);
   }
 
-  final void Function()? onFinalClipInvalidated;
+  final void Function() onFinalClipInvalidated;
 
   // === CLIP DATA ===
 
@@ -245,38 +245,58 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     emit(state.copyWith(isEditing: false));
 
     try {
+      // Emit directly from callbacks instead of dispatching events.
+      // Cross-event-type handlers run concurrently in BLoC, which
+      // caused a race where ClipEditorClipUpdated (rendered video
+      // file) was processed before ClipEditorOriginalClipReplaced
+      // had inserted the new clip ids — the index lookup failed and
+      // the clips kept pointing at the original source video.
       await VideoEditorSplitService.splitClip(
         sourceClip: selectedClip,
         splitPosition: splitPosition,
         onClipsCreated: (startClip, endClip) {
-          add(
-            ClipEditorOriginalClipReplaced(
-              sourceClipId: selectedClip.id,
-              startClip: startClip,
-              endClip: endClip,
+          final clips = state.clips;
+          final index = clips.indexWhere((c) => c.id == selectedClip.id);
+          if (index == -1) return;
+          final newClips = List<DivineVideoClip>.of(clips)
+            ..[index] = startClip
+            ..insert(index + 1, endClip);
+          emit(
+            state.copyWith(
+              clips: List.unmodifiable(newClips),
+              lastSplit: ClipSplitEvent(
+                sourceClipId: selectedClip.id,
+                startClipId: startClip.id,
+                endClipId: endClip.id,
+                absoluteSplitPosition: selectedClip.trimStart + splitPosition,
+                sourceDuration: selectedClip.duration,
+              ),
             ),
+          );
+          Log.debug(
+            '✂️ Replaced ${selectedClip.id} with '
+            '${startClip.id} + ${endClip.id}',
+            name: 'ClipEditorBloc',
+            category: LogCategory.video,
           );
         },
         onThumbnailExtracted: (clip, thumbnailPath) {
-          add(
-            ClipEditorClipUpdated(
-              clipId: clip.id,
-              clip: clip.copyWith(thumbnailPath: thumbnailPath),
-            ),
+          final clips = state.clips;
+          final index = clips.indexWhere((c) => c.id == clip.id);
+          if (index == -1) return;
+          final newClips = List<DivineVideoClip>.of(clips);
+          newClips[index] = newClips[index].copyWith(
+            thumbnailPath: thumbnailPath,
           );
+          emit(state.copyWith(clips: List.unmodifiable(newClips)));
         },
         onClipRendered: (clip, video) {
-          // Read the current clip from BLoC state to avoid
-          // overwriting fields updated by earlier callbacks
-          // (e.g. thumbnailPath from onThumbnailExtracted).
-          final current = state.clips.where((c) => c.id == clip.id);
-          final base = current.isNotEmpty ? current.first : clip;
-          add(
-            ClipEditorClipUpdated(
-              clipId: clip.id,
-              clip: base.copyWith(video: video),
-            ),
-          );
+          final clips = state.clips;
+          final index = clips.indexWhere((c) => c.id == clip.id);
+          if (index == -1) return;
+          final newClips = List<DivineVideoClip>.of(clips);
+          newClips[index] = newClips[index].copyWith(video: video);
+          emit(state.copyWith(clips: List.unmodifiable(newClips)));
           Log.debug(
             '\u2705 Clip rendered: ${clip.id}',
             name: 'ClipEditorBloc',
@@ -285,7 +305,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         },
       );
 
-      onFinalClipInvalidated?.call();
+      onFinalClipInvalidated.call();
 
       Log.info(
         '✅ Successfully split clip into 2 segments',

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
@@ -88,6 +88,8 @@ class ClipSplitEvent {
     required this.endClipId,
     required this.absoluteSplitPosition,
     required this.sourceDuration,
+    this.sourceTrimStart = Duration.zero,
+    this.sourceTrimEnd = Duration.zero,
   });
 
   final String sourceClipId;
@@ -95,4 +97,6 @@ class ClipSplitEvent {
   final String endClipId;
   final Duration absoluteSplitPosition;
   final Duration sourceDuration;
+  final Duration sourceTrimStart;
+  final Duration sourceTrimEnd;
 }

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
@@ -14,6 +14,7 @@ class ClipEditorState extends Equatable {
     this.splitPosition = Duration.zero,
     this.isEditing = false,
     this.isTrimDragging = false,
+    this.lastSplit,
   });
 
   /// Local copy of clips managed by this editor session.
@@ -31,6 +32,15 @@ class ClipEditorState extends Equatable {
   /// Whether a trim handle is currently being dragged.
   final bool isTrimDragging;
 
+  /// Last completed split operation. Consumed by the timeline strip
+  /// to seed the new clips' thumbnail notifiers from the source clip
+  /// — avoiding a flash of placeholder/wrong-range thumbnails while
+  /// the trimmed segment files are still being rendered.
+  ///
+  /// Identity-compared (not value-compared) so each split delivers a
+  /// fresh signal even when fields happen to repeat.
+  final ClipSplitEvent? lastSplit;
+
   /// Total duration of all clips (respecting trim).
   Duration get totalDuration =>
       clips.fold(Duration.zero, (sum, clip) => sum + clip.trimmedDuration);
@@ -42,6 +52,7 @@ class ClipEditorState extends Equatable {
     Duration? splitPosition,
     bool? isEditing,
     bool? isTrimDragging,
+    ClipSplitEvent? lastSplit,
   }) {
     return ClipEditorState(
       clips: clips ?? this.clips,
@@ -49,6 +60,7 @@ class ClipEditorState extends Equatable {
       splitPosition: splitPosition ?? this.splitPosition,
       isEditing: isEditing ?? this.isEditing,
       isTrimDragging: isTrimDragging ?? this.isTrimDragging,
+      lastSplit: lastSplit ?? this.lastSplit,
     );
   }
 
@@ -59,5 +71,28 @@ class ClipEditorState extends Equatable {
     splitPosition,
     isEditing,
     isTrimDragging,
+    // Identity-only: each ClipSplitEvent is a fresh instance per split.
+    identityHashCode(lastSplit),
   ];
+}
+
+/// One-shot signal describing a split operation that just occurred.
+///
+/// The timeline strip uses this to seed the newly-created clips'
+/// thumbnail notifiers from the source clip's already-loaded
+/// thumbnails.
+class ClipSplitEvent {
+  ClipSplitEvent({
+    required this.sourceClipId,
+    required this.startClipId,
+    required this.endClipId,
+    required this.absoluteSplitPosition,
+    required this.sourceDuration,
+  });
+
+  final String sourceClipId;
+  final String startClipId;
+  final String endClipId;
+  final Duration absoluteSplitPosition;
+  final Duration sourceDuration;
 }

--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -14,6 +14,17 @@ class ClipThumbnailManager {
   final Map<String, ValueNotifier<List<StripThumbnail>>> _notifiers = {};
   final Map<String, StreamSubscription<List<StripThumbnail>>> _subscriptions =
       {};
+  // Tracks the video path each subscription was started with so we can
+  // detect when a clip's underlying source file changes (e.g. after a
+  // split renders the trimmed segment to a new file) and restart
+  // thumbnail generation against the new file.
+  final Map<String, String> _videoPaths = {};
+  // IDs whose notifier has been pre-populated from another clip's
+  // thumbnails (e.g. split). For these we suppress auto-loading until
+  // the rendered file path arrives — otherwise the seeded frames would
+  // be immediately overwritten by a fresh subscription against the
+  // (still un-trimmed) source video.
+  final Set<String> _seeded = {};
 
   /// Returns the thumbnail notifier for the given [clipId].
   ValueNotifier<List<StripThumbnail>> operator [](String clipId) =>
@@ -39,6 +50,8 @@ class ClipThumbnailManager {
         .toList();
     for (final id in staleIds) {
       _subscriptions.remove(id)?.cancel();
+      _videoPaths.remove(id);
+      _seeded.remove(id);
       final notifier = _notifiers.remove(id);
       if (notifier != null) {
         _deleteFiles(notifier.value);
@@ -46,17 +59,86 @@ class ClipThumbnailManager {
       }
     }
 
-    // Ensure notifiers exist and start loading for new clips.
+    // Ensure notifiers exist and start (or restart) loading.
     for (final clip in clips) {
       _notifiers.putIfAbsent(clip.id, () => ValueNotifier(const []));
-      if (!_subscriptions.containsKey(clip.id)) {
+      final newPath = clip.video.file?.path;
+      final currentPath = _videoPaths[clip.id];
+      final hasSubscription = _subscriptions.containsKey(clip.id);
+      final isSeeded = _seeded.contains(clip.id);
+
+      if (!hasSubscription) {
+        // Skip auto-loading for seeded clips — their notifier already
+        // shows the right frames borrowed from the source clip. The
+        // real subscription kicks in once the rendered (trimmed) file
+        // path arrives via the path-change branch below.
+        if (isSeeded && newPath == currentPath) continue;
         _loadThumbnails(
           clip,
           devicePixelRatio,
           priorityTimestamps: priorityTimestamps[clip.id],
         );
+      } else if (newPath != null && newPath != currentPath) {
+        // Source file changed (e.g. clip was rendered to a trimmed
+        // file after a split). Restart against the new file so the
+        // thumbnails reflect the actual segment content.
+        _subscriptions.remove(clip.id)?.cancel();
+        _seeded.remove(clip.id);
+        final notifier = _notifiers[clip.id];
+        if (notifier != null) {
+          _deleteFiles(notifier.value);
+          notifier.value = const [];
+        }
+        _loadThumbnails(
+          clip,
+          devicePixelRatio,
+          priorityTimestamps: priorityTimestamps[clip.id],
+        );
+      } else if (isSeeded && newPath != null && newPath == currentPath) {
+        // Seeded clip is still pointing at the source video (render
+        // hasn't finished yet) — keep the seeded frames visible.
+        continue;
       }
     }
+  }
+
+  /// Pre-populates the notifier for [targetClipId] by borrowing
+  /// thumbnails from another clip ([sourceClipId]) whose timestamps
+  /// fall within [sourceRange]. Timestamps are shifted by
+  /// `-sourceRange.start` so they map to the new clip's local
+  /// timeline (which starts at zero after rendering).
+  ///
+  /// The clip is marked as "seeded" so [sync] will not auto-load a
+  /// fresh subscription against the still-un-trimmed source video
+  /// — that would overwrite these correct frames with the wrong
+  /// range. The real subscription starts once the rendered file
+  /// path arrives via the path-change branch in [sync].
+  ///
+  /// [currentSourcePath] is the video path the target clip currently
+  /// points at (typically the source video). Recording it lets
+  /// [sync] detect when the rendered file path arrives and swap the
+  /// subscription.
+  void seedFromSource({
+    required String sourceClipId,
+    required String targetClipId,
+    required DurationRange sourceRange,
+    required String currentSourcePath,
+  }) {
+    final source = _notifiers[sourceClipId];
+    if (source == null) return;
+    final shift = sourceRange.start;
+    final seeded = <StripThumbnail>[
+      for (final t in source.value)
+        if (t.timestamp >= sourceRange.start && t.timestamp < sourceRange.end)
+          StripThumbnail(path: t.path, timestamp: t.timestamp - shift),
+    ];
+    final notifier = _notifiers.putIfAbsent(
+      targetClipId,
+      () => ValueNotifier(const []),
+    );
+    notifier.value = seeded;
+    _videoPaths[targetClipId] = currentSourcePath;
+    _seeded.add(targetClipId);
   }
 
   void _loadThumbnails(
@@ -66,6 +148,8 @@ class ClipThumbnailManager {
   }) {
     final videoPath = clip.video.file?.path;
     if (videoPath == null) return;
+
+    _videoPaths[clip.id] = videoPath;
 
     final outputSize = Size(
       TimelineConstants.thumbnailWidth * devicePixelRatio,
@@ -109,5 +193,17 @@ class ClipThumbnailManager {
       _deleteFiles(notifier.value);
       notifier.dispose();
     }
+    _subscriptions.clear();
+    _notifiers.clear();
+    _videoPaths.clear();
+    _seeded.clear();
   }
+}
+
+/// Inclusive-exclusive duration range `[start, end)`.
+class DurationRange {
+  const DurationRange({required this.start, required this.end});
+
+  final Duration start;
+  final Duration end;
 }

--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
+import 'package:path/path.dart' as p;
 
 /// Manages thumbnail loading and cleanup for a set of clips.
 ///
@@ -104,9 +105,9 @@ class ClipThumbnailManager {
 
   /// Pre-populates the notifier for [targetClipId] by borrowing
   /// thumbnails from another clip ([sourceClipId]) whose timestamps
-  /// fall within [sourceRange]. Timestamps are shifted by
-  /// `-sourceRange.start` so they map to the new clip's local
-  /// timeline (which starts at zero after rendering).
+  /// fall within [sourceRange]. By default timestamps are shifted by
+  /// `-sourceRange.start` so they map to the new clip's local timeline.
+  /// Pass [timestampOffset] to use a different source-to-target mapping.
   ///
   /// The clip is marked as "seeded" so [sync] will not auto-load a
   /// fresh subscription against the still-un-trimmed source video
@@ -123,15 +124,25 @@ class ClipThumbnailManager {
     required String targetClipId,
     required DurationRange sourceRange,
     required String currentSourcePath,
+    Duration? timestampOffset,
   }) {
     final source = _notifiers[sourceClipId];
     if (source == null) return;
-    final shift = sourceRange.start;
-    final seeded = <StripThumbnail>[
-      for (final t in source.value)
-        if (t.timestamp >= sourceRange.start && t.timestamp < sourceRange.end)
-          StripThumbnail(path: t.path, timestamp: t.timestamp - shift),
-    ];
+    final shift = timestampOffset ?? sourceRange.start;
+    final seeded = <StripThumbnail>[];
+    for (var i = 0; i < source.value.length; i++) {
+      final thumbnail = source.value[i];
+      if (thumbnail.timestamp < sourceRange.start ||
+          thumbnail.timestamp >= sourceRange.end) {
+        continue;
+      }
+      seeded.add(
+        StripThumbnail(
+          path: _copySeededThumbnailFile(thumbnail.path, targetClipId, i),
+          timestamp: thumbnail.timestamp - shift,
+        ),
+      );
+    }
     final notifier = _notifiers.putIfAbsent(
       targetClipId,
       () => ValueNotifier(const []),
@@ -139,6 +150,28 @@ class ClipThumbnailManager {
     notifier.value = seeded;
     _videoPaths[targetClipId] = currentSourcePath;
     _seeded.add(targetClipId);
+  }
+
+  static String _copySeededThumbnailFile(
+    String sourcePath,
+    String targetClipId,
+    int index,
+  ) {
+    final sourceFile = File(sourcePath);
+    if (!sourceFile.existsSync()) return sourcePath;
+
+    final extension = p.extension(sourcePath);
+    final destinationPath = p.join(
+      p.dirname(sourcePath),
+      'seed_${targetClipId}_${DateTime.now().microsecondsSinceEpoch}_'
+      '$index$extension',
+    );
+
+    try {
+      return sourceFile.copySync(destinationPath).path;
+    } catch (_) {
+      return sourcePath;
+    }
   }
 
   void _loadThumbnails(

--- a/mobile/lib/services/video_editor/video_editor_split_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_split_service.dart
@@ -10,21 +10,6 @@ import 'package:path/path.dart' as p;
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-/// Result of a clip split operation containing both resulting clips
-class SplitClipResult {
-  const SplitClipResult({
-    required this.startClip,
-    required this.endClip,
-    required this.startClipPath,
-    required this.endClipPath,
-  });
-
-  final DivineVideoClip startClip;
-  final DivineVideoClip endClip;
-  final String startClipPath;
-  final String endClipPath;
-}
-
 /// Service for splitting video clips into two separate segments
 class VideoEditorSplitService {
   static const minClipDuration = Duration(milliseconds: 30);
@@ -41,7 +26,7 @@ class VideoEditorSplitService {
         clip.trimmedDuration - splitPosition >= minClipDuration;
   }
 
-  /// Splits a clip at the specified position and returns both resulting clips
+  /// Splits a clip at the specified position.
   ///
   /// This method:
   /// 1. Creates two new clip objects with completers for tracking processing
@@ -51,7 +36,7 @@ class VideoEditorSplitService {
   /// 5. Renders both clips in parallel
   ///
   /// Throws if rendering fails or split position is invalid
-  static Future<SplitClipResult> splitClip({
+  static Future<void> splitClip({
     required DivineVideoClip sourceClip,
     required Duration splitPosition,
     required void Function(DivineVideoClip startClip, DivineVideoClip endClip)?
@@ -137,7 +122,10 @@ class VideoEditorSplitService {
       name: 'VideoEditorSplitService',
       category: .video,
     );
-    // Render both clips in parallel using absolute positions
+    // Render both clips in parallel using absolute positions.
+    // Trim must be set on the VideoSegment, not on VideoRenderData —
+    // VideoRenderData.startTime/endTime only apply to the deprecated
+    // single-video field and are ignored when videoSegments is used.
     await Future.wait([
       _renderSplitClip(
         clip: startClip,
@@ -145,8 +133,9 @@ class VideoEditorSplitService {
         sourceVideo: sourceClip.video,
         renderData: VideoRenderData(
           id: startClip.id,
-          videoSegments: [VideoSegment(video: sourceClip.video)],
-          endTime: absoluteSplitPos,
+          videoSegments: [
+            VideoSegment(video: sourceClip.video, endTime: absoluteSplitPos),
+          ],
         ),
         onClipRendered: onClipRendered,
       ),
@@ -156,8 +145,9 @@ class VideoEditorSplitService {
         sourceVideo: sourceClip.video,
         renderData: VideoRenderData(
           id: endClip.id,
-          videoSegments: [VideoSegment(video: sourceClip.video)],
-          startTime: absoluteSplitPos,
+          videoSegments: [
+            VideoSegment(video: sourceClip.video, startTime: absoluteSplitPos),
+          ],
         ),
         onClipRendered: onClipRendered,
       ),
@@ -167,13 +157,6 @@ class VideoEditorSplitService {
       '✅ Split complete - created 2 clips from ${sourceClip.id}',
       name: 'VideoEditorSplitService',
       category: .video,
-    );
-
-    return SplitClipResult(
-      startClip: startClip,
-      endClip: endClip,
-      startClipPath: startClipPath,
-      endClipPath: endClipPath,
     );
   }
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -6,6 +6,8 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -108,6 +110,10 @@ class _VideoEditorTimelineClipStripState
   /// clip tile rebuilds, not the entire strip.
   final _thumbnails = ClipThumbnailManager();
 
+  /// Identity of the last split event we already seeded thumbnails
+  /// for. Used to ensure each split is processed exactly once.
+  ClipSplitEvent? _lastSeededSplit;
+
   static const double _reorderSize = TimelineConstants.thumbnailStripHeight;
 
   // Auto-scroll state.
@@ -129,6 +135,7 @@ class _VideoEditorTimelineClipStripState
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    _maybeSeedSplit();
     _syncThumbnails();
   }
 
@@ -138,6 +145,7 @@ class _VideoEditorTimelineClipStripState
     if (!_isReordering) {
       _orderedClips = List.of(widget.clips);
     }
+    _maybeSeedSplit();
     _syncThumbnails();
   }
 
@@ -154,6 +162,50 @@ class _VideoEditorTimelineClipStripState
       clips: widget.clips,
       devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
       priorityTimestamps: _computeSlotTimestamps(),
+    );
+  }
+
+  /// Seeds the new clips' thumbnail notifiers from the source clip's
+  /// already-loaded thumbnails when a split has just occurred. This
+  /// avoids a flash of placeholder/wrong-range frames while the
+  /// trimmed segment files are being rendered — the real
+  /// subscriptions kick in once the rendered file paths arrive.
+  void _maybeSeedSplit() {
+    final bloc = context.read<ClipEditorBloc?>();
+    if (bloc == null) return;
+    final split = bloc.state.lastSplit;
+    if (split == null || identical(split, _lastSeededSplit)) return;
+    _lastSeededSplit = split;
+
+    final startClipIdx = widget.clips.indexWhere(
+      (c) => c.id == split.startClipId,
+    );
+    final endClipIdx = widget.clips.indexWhere(
+      (c) => c.id == split.endClipId,
+    );
+    if (startClipIdx == -1 || endClipIdx == -1) return;
+    final startClip = widget.clips[startClipIdx];
+    final endClip = widget.clips[endClipIdx];
+    final sourcePath = startClip.video.file?.path;
+    if (sourcePath == null) return;
+
+    _thumbnails.seedFromSource(
+      sourceClipId: split.sourceClipId,
+      targetClipId: split.startClipId,
+      sourceRange: DurationRange(
+        start: Duration.zero,
+        end: split.absoluteSplitPosition,
+      ),
+      currentSourcePath: sourcePath,
+    );
+    _thumbnails.seedFromSource(
+      sourceClipId: split.sourceClipId,
+      targetClipId: split.endClipId,
+      sourceRange: DurationRange(
+        start: split.absoluteSplitPosition,
+        end: split.sourceDuration,
+      ),
+      currentSourcePath: endClip.video.file?.path ?? sourcePath,
     );
   }
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -193,9 +193,10 @@ class _VideoEditorTimelineClipStripState
       sourceClipId: split.sourceClipId,
       targetClipId: split.startClipId,
       sourceRange: DurationRange(
-        start: Duration.zero,
+        start: split.sourceTrimStart,
         end: split.absoluteSplitPosition,
       ),
+      timestampOffset: Duration.zero,
       currentSourcePath: sourcePath,
     );
     _thumbnails.seedFromSource(
@@ -203,7 +204,7 @@ class _VideoEditorTimelineClipStripState
       targetClipId: split.endClipId,
       sourceRange: DurationRange(
         start: split.absoluteSplitPosition,
-        end: split.sourceDuration,
+        end: split.sourceDuration - split.sourceTrimEnd,
       ),
       currentSourcePath: endClip.video.file?.path ?? sourcePath,
     );

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -518,6 +518,77 @@ void main() {
           isFalse,
         );
       });
+
+      test(
+        'sets lastSplit with correct ids and position after split',
+        () async {
+          final clip = _createClip(
+            id: 'source-clip',
+            duration: const Duration(seconds: 2),
+          );
+          final bloc = buildBloc()
+            ..emit(
+              ClipEditorState(
+                clips: [clip],
+                isEditing: true,
+                splitPosition: const Duration(seconds: 1),
+              ),
+            );
+
+          bloc.add(const ClipEditorSplitRequested());
+          // First emit: isEditing=false. Second: onClipsCreated with lastSplit.
+          final states = await bloc.stream.take(2).toList();
+          final splitState = states.last;
+
+          expect(splitState.lastSplit, isNotNull);
+          expect(
+            splitState.lastSplit!.sourceClipId,
+            equals('source-clip'),
+          );
+          expect(
+            splitState.lastSplit!.startClipId,
+            equals(splitState.clips.first.id),
+          );
+          expect(
+            splitState.lastSplit!.endClipId,
+            equals(splitState.clips.last.id),
+          );
+
+          await bloc.close();
+        },
+      );
+
+      test(
+        'absoluteSplitPosition equals trimStart + splitPosition',
+        () async {
+          final clip = _createClip(
+            id: 'c',
+            duration: const Duration(seconds: 4),
+          ).copyWith(trimStart: const Duration(milliseconds: 500));
+
+          final bloc = buildBloc()
+            ..emit(
+              ClipEditorState(
+                clips: [clip],
+                isEditing: true,
+                // 1 s into the trimmed view
+                splitPosition: const Duration(seconds: 1),
+              ),
+            );
+
+          bloc.add(const ClipEditorSplitRequested());
+          final states = await bloc.stream.take(2).toList();
+          final split = states.last.lastSplit!;
+
+          expect(
+            split.absoluteSplitPosition,
+            // trimStart(500ms) + splitPosition(1000ms)
+            equals(const Duration(milliseconds: 1500)),
+          );
+
+          await bloc.close();
+        },
+      );
     });
 
     // =========================================================
@@ -560,6 +631,52 @@ void main() {
         // Other fields unchanged
         expect(updated.currentClipIndex, equals(0));
       });
+
+      test('lastSplit defaults to null', () {
+        const state = ClipEditorState();
+        expect(state.lastSplit, isNull);
+      });
+
+      test('copyWith sets lastSplit', () {
+        const state = ClipEditorState();
+        final split = ClipSplitEvent(
+          sourceClipId: 'src',
+          startClipId: 'start',
+          endClipId: 'end',
+          absoluteSplitPosition: const Duration(seconds: 1),
+          sourceDuration: const Duration(seconds: 2),
+        );
+
+        final updated = state.copyWith(lastSplit: split);
+
+        expect(updated.lastSplit, same(split));
+      });
+
+      test(
+        'two ClipSplitEvents with identical fields are treated as distinct',
+        () {
+          final split1 = ClipSplitEvent(
+            sourceClipId: 'src',
+            startClipId: 'start',
+            endClipId: 'end',
+            absoluteSplitPosition: const Duration(seconds: 1),
+            sourceDuration: const Duration(seconds: 2),
+          );
+          final split2 = ClipSplitEvent(
+            sourceClipId: 'src',
+            startClipId: 'start',
+            endClipId: 'end',
+            absoluteSplitPosition: const Duration(seconds: 1),
+            sourceDuration: const Duration(seconds: 2),
+          );
+
+          final state1 = ClipEditorState(lastSplit: split1);
+          final state2 = ClipEditorState(lastSplit: split2);
+
+          // Identity hash differs between instances → props differ → not equal
+          expect(state1, isNot(equals(state2)));
+        },
+      );
     });
 
     // =========================================================

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -589,6 +589,35 @@ void main() {
           await bloc.close();
         },
       );
+
+      test('lastSplit captures source trim bounds', () async {
+        final clip =
+            _createClip(
+              id: 'c',
+              duration: const Duration(seconds: 10),
+            ).copyWith(
+              trimStart: const Duration(seconds: 3),
+              trimEnd: const Duration(seconds: 2),
+            );
+
+        final bloc = buildBloc()
+          ..emit(
+            ClipEditorState(
+              clips: [clip],
+              isEditing: true,
+              splitPosition: const Duration(seconds: 2),
+            ),
+          );
+
+        bloc.add(const ClipEditorSplitRequested());
+        final states = await bloc.stream.take(2).toList();
+        final split = states.last.lastSplit!;
+
+        expect(split.sourceTrimStart, equals(const Duration(seconds: 3)));
+        expect(split.sourceTrimEnd, equals(const Duration(seconds: 2)));
+
+        await bloc.close();
+      });
     });
 
     // =========================================================

--- a/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
@@ -82,6 +82,193 @@ void main() {
       });
     });
 
+    // ---------------------------------------------------------
+    // seedFromSource
+    // ---------------------------------------------------------
+
+    group('seedFromSource', () {
+      test('populates target notifier with time-shifted thumbnails', () {
+        final sourceClip = _createTestClip(id: 'src', seconds: 4);
+        manager.sync(clips: [sourceClip], devicePixelRatio: 1);
+
+        manager['src'].value = [
+          const StripThumbnail(path: '/t/0.jpg', timestamp: Duration.zero),
+          const StripThumbnail(
+            path: '/t/1.jpg',
+            timestamp: Duration(seconds: 1),
+          ),
+          const StripThumbnail(
+            path: '/t/2.jpg',
+            timestamp: Duration(seconds: 2),
+          ),
+          const StripThumbnail(
+            path: '/t/3.jpg',
+            timestamp: Duration(seconds: 3),
+          ),
+        ];
+
+        manager.seedFromSource(
+          sourceClipId: 'src',
+          targetClipId: 'tgt',
+          sourceRange: const DurationRange(
+            start: Duration(seconds: 1),
+            end: Duration(seconds: 3),
+          ),
+          currentSourcePath: '/video/src.mp4',
+        );
+
+        final thumbnails = manager['tgt'].value;
+        expect(thumbnails, hasLength(2));
+        // 1 s thumbnail shifted by −1 s → 0 s
+        expect(thumbnails[0].path, equals('/t/1.jpg'));
+        expect(thumbnails[0].timestamp, equals(Duration.zero));
+        // 2 s thumbnail shifted by −1 s → 1 s
+        expect(thumbnails[1].path, equals('/t/2.jpg'));
+        expect(
+          thumbnails[1].timestamp,
+          equals(const Duration(seconds: 1)),
+        );
+      });
+
+      test('excludes thumbnails outside the requested range', () {
+        final sourceClip = _createTestClip(id: 'src', seconds: 10);
+        manager.sync(clips: [sourceClip], devicePixelRatio: 1);
+
+        manager['src'].value = [
+          const StripThumbnail(path: '/t/0.jpg', timestamp: Duration.zero),
+          const StripThumbnail(
+            path: '/t/5.jpg',
+            timestamp: Duration(seconds: 5),
+          ),
+          const StripThumbnail(
+            path: '/t/9.jpg',
+            timestamp: Duration(seconds: 9),
+          ),
+        ];
+
+        manager.seedFromSource(
+          sourceClipId: 'src',
+          targetClipId: 'tgt',
+          sourceRange: const DurationRange(
+            start: Duration(seconds: 4),
+            end: Duration(seconds: 6),
+          ),
+          currentSourcePath: '/video/src.mp4',
+        );
+
+        final thumbnails = manager['tgt'].value;
+        expect(thumbnails, hasLength(1));
+        expect(thumbnails.first.path, equals('/t/5.jpg'));
+        expect(
+          thumbnails.first.timestamp,
+          equals(const Duration(seconds: 1)),
+        );
+      });
+
+      test('is a no-op when source notifier does not exist', () {
+        expect(
+          () => manager.seedFromSource(
+            sourceClipId: 'nonexistent',
+            targetClipId: 'tgt',
+            sourceRange: const DurationRange(
+              start: Duration.zero,
+              end: Duration(seconds: 1),
+            ),
+            currentSourcePath: '/video/src.mp4',
+          ),
+          returnsNormally,
+        );
+      });
+
+      test('creates target notifier even when target is not yet in sync', () {
+        final sourceClip = _createTestClip(id: 'src', seconds: 2);
+        manager.sync(clips: [sourceClip], devicePixelRatio: 1);
+
+        manager['src'].value = [
+          const StripThumbnail(path: '/t/0.jpg', timestamp: Duration.zero),
+        ];
+
+        manager.seedFromSource(
+          sourceClipId: 'src',
+          targetClipId: 'tgt',
+          sourceRange: const DurationRange(
+            start: Duration.zero,
+            end: Duration(seconds: 2),
+          ),
+          currentSourcePath: '/video/src.mp4',
+        );
+
+        expect(
+          manager['tgt'],
+          isA<ValueNotifier<List<StripThumbnail>>>(),
+        );
+        expect(manager['tgt'].value, hasLength(1));
+      });
+
+      test('seeded notifier value is preserved after re-sync', () {
+        // Simulates the window between split (seed) and render complete
+        // (path swap). While the target clip still points at the source
+        // video (no file path / null), re-syncing must not reset the
+        // already-correct seeded thumbnails.
+        final sourceClip = _createTestClip(id: 'src', seconds: 4);
+        final targetClip = _createTestClip(id: 'tgt', seconds: 2);
+        manager.sync(clips: [sourceClip], devicePixelRatio: 1);
+
+        manager['src'].value = [
+          const StripThumbnail(path: '/t/0.jpg', timestamp: Duration.zero),
+          const StripThumbnail(
+            path: '/t/1.jpg',
+            timestamp: Duration(seconds: 1),
+          ),
+        ];
+
+        manager.seedFromSource(
+          sourceClipId: 'src',
+          targetClipId: 'tgt',
+          sourceRange: const DurationRange(
+            start: Duration.zero,
+            end: Duration(seconds: 2),
+          ),
+          currentSourcePath: '/video/src.mp4',
+        );
+
+        final seededValue = manager['tgt'].value;
+        expect(seededValue, hasLength(2));
+
+        // Re-sync with target added. targetClip uses a network URL so
+        // _loadThumbnails exits early and never overwrites the notifier.
+        manager.sync(
+          clips: [sourceClip, targetClip],
+          devicePixelRatio: 1,
+        );
+
+        expect(manager['tgt'].value, equals(seededValue));
+      });
+
+      test('seeded target is removed from sync when absent from clip list', () {
+        final sourceClip = _createTestClip(id: 'src', seconds: 2);
+        manager.sync(clips: [sourceClip], devicePixelRatio: 1);
+        manager['src'].value = [
+          const StripThumbnail(path: '/t/0.jpg', timestamp: Duration.zero),
+        ];
+
+        manager.seedFromSource(
+          sourceClipId: 'src',
+          targetClipId: 'tgt',
+          sourceRange: const DurationRange(
+            start: Duration.zero,
+            end: Duration(seconds: 2),
+          ),
+          currentSourcePath: '/video/src.mp4',
+        );
+
+        // Sync without the target clip — it should be cleaned up.
+        manager.sync(clips: [sourceClip], devicePixelRatio: 1);
+
+        expect(() => manager['tgt'], throwsA(isA<TypeError>()));
+      });
+    });
+
     group('dispose', () {
       test('can be called on empty manager', () {
         final localManager = ClipThumbnailManager();
@@ -100,6 +287,31 @@ void main() {
         // Should not throw.
         localManager.dispose();
       });
+    });
+  });
+
+  // =========================================================
+  // DurationRange
+  // =========================================================
+
+  group(DurationRange, () {
+    test('stores start and end', () {
+      const range = DurationRange(
+        start: Duration(seconds: 1),
+        end: Duration(seconds: 5),
+      );
+
+      expect(range.start, equals(const Duration(seconds: 1)));
+      expect(range.end, equals(const Duration(seconds: 5)));
+    });
+
+    test('allows zero-length range', () {
+      const range = DurationRange(
+        start: Duration(seconds: 2),
+        end: Duration(seconds: 2),
+      );
+
+      expect(range.start, equals(range.end));
     });
   });
 }

--- a/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Unit tests for ClipThumbnailManager.
 // ABOUTME: Validates notifier lifecycle, sync logic, and disposal.
 
+import 'dart:io';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -267,6 +269,101 @@ void main() {
 
         expect(() => manager['tgt'], throwsA(isA<TypeError>()));
       });
+
+      test(
+        'copies seeded files before source cleanup deletes originals',
+        () async {
+          final tempDir = Directory.systemTemp.createTempSync(
+            'clip_thumbnail_seed_test_',
+          );
+          addTearDown(() {
+            if (tempDir.existsSync()) {
+              tempDir.deleteSync(recursive: true);
+            }
+          });
+
+          final sourceThumbnail = File('${tempDir.path}/source.jpg')
+            ..writeAsStringSync('source-thumbnail');
+          final sourceVideoPath = '${tempDir.path}/source.mp4';
+
+          final sourceClip = _createTestClip(id: 'src', seconds: 2);
+          final targetClip = _createFileClip(
+            id: 'tgt',
+            videoPath: sourceVideoPath,
+            seconds: 2,
+          );
+          manager.sync(clips: [sourceClip], devicePixelRatio: 1);
+          manager['src'].value = [
+            StripThumbnail(
+              path: sourceThumbnail.path,
+              timestamp: const Duration(seconds: 1),
+            ),
+          ];
+
+          manager.seedFromSource(
+            sourceClipId: 'src',
+            targetClipId: 'tgt',
+            sourceRange: const DurationRange(
+              start: Duration.zero,
+              end: Duration(seconds: 2),
+            ),
+            currentSourcePath: sourceVideoPath,
+          );
+
+          final seededPath = manager['tgt'].value.single.path;
+          expect(seededPath, isNot(equals(sourceThumbnail.path)));
+
+          // Simulate the split lifecycle: the source clip is removed, but
+          // the seeded target still points at the source video until render
+          // completes. Target thumbnails must survive stale source cleanup.
+          manager.sync(clips: [targetClip], devicePixelRatio: 1);
+          await Future<void>.delayed(Duration.zero);
+
+          expect(sourceThumbnail.existsSync(), isFalse);
+          expect(File(seededPath).existsSync(), isTrue);
+        },
+      );
+
+      test('can preserve source timestamps while filtering a range', () {
+        final sourceClip = _createTestClip(id: 'src', seconds: 6);
+        manager.sync(clips: [sourceClip], devicePixelRatio: 1);
+        manager['src'].value = [
+          const StripThumbnail(
+            path: '/t/2.jpg',
+            timestamp: Duration(seconds: 2),
+          ),
+          const StripThumbnail(
+            path: '/t/3.jpg',
+            timestamp: Duration(seconds: 3),
+          ),
+          const StripThumbnail(
+            path: '/t/4.jpg',
+            timestamp: Duration(seconds: 4),
+          ),
+          const StripThumbnail(
+            path: '/t/5.jpg',
+            timestamp: Duration(seconds: 5),
+          ),
+        ];
+
+        manager.seedFromSource(
+          sourceClipId: 'src',
+          targetClipId: 'tgt',
+          sourceRange: const DurationRange(
+            start: Duration(seconds: 3),
+            end: Duration(seconds: 5),
+          ),
+          timestampOffset: Duration.zero,
+          currentSourcePath: '/video/src.mp4',
+        );
+
+        final thumbnails = manager['tgt'].value;
+        expect(thumbnails, hasLength(2));
+        expect(thumbnails[0].path, equals('/t/3.jpg'));
+        expect(thumbnails[0].timestamp, equals(const Duration(seconds: 3)));
+        expect(thumbnails[1].path, equals('/t/4.jpg'));
+        expect(thumbnails[1].timestamp, equals(const Duration(seconds: 4)));
+      });
     });
 
     group('dispose', () {
@@ -323,6 +420,21 @@ DivineVideoClip _createTestClip({required String id, int seconds = 3}) {
   return DivineVideoClip(
     id: id,
     video: EditorVideo.network('https://example.com/$id.mp4'),
+    duration: Duration(seconds: seconds),
+    recordedAt: DateTime(2025),
+    originalAspectRatio: 9 / 16,
+    targetAspectRatio: .vertical,
+  );
+}
+
+DivineVideoClip _createFileClip({
+  required String id,
+  required String videoPath,
+  int seconds = 3,
+}) {
+  return DivineVideoClip(
+    id: id,
+    video: EditorVideo.file(videoPath),
     duration: Duration(seconds: seconds),
     recordedAt: DateTime(2025),
     originalAspectRatio: 9 / 16,

--- a/mobile/test/services/video_editor/video_editor_split_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_split_service_test.dart
@@ -208,7 +208,7 @@ void main() {
         DivineVideoClip? capturedStartClip;
         DivineVideoClip? capturedEndClip;
 
-        final result = await VideoEditorSplitService.splitClip(
+        await VideoEditorSplitService.splitClip(
           sourceClip: clip,
           splitPosition: const Duration(seconds: 2),
           onClipsCreated: (start, end) {
@@ -219,8 +219,6 @@ void main() {
           onClipRendered: null,
         );
 
-        expect(result.startClip.duration, const Duration(seconds: 2));
-        expect(result.endClip.duration, const Duration(seconds: 3));
         expect(capturedStartClip, isNotNull);
         expect(capturedEndClip, isNotNull);
         expect(capturedStartClip!.duration, const Duration(seconds: 2));
@@ -325,19 +323,26 @@ void main() {
           originalAspectRatio: 9 / 16,
         );
 
-        final result = await VideoEditorSplitService.splitClip(
+        DivineVideoClip? capturedStartClip;
+        DivineVideoClip? capturedEndClip;
+
+        await VideoEditorSplitService.splitClip(
           sourceClip: clip,
           splitPosition: const Duration(seconds: 2),
-          onClipsCreated: null,
+          onClipsCreated: (start, end) {
+            capturedStartClip = start;
+            capturedEndClip = end;
+          },
           onThumbnailExtracted: null,
           onClipRendered: null,
         );
 
-        expect(result.startClip.processingCompleter?.isCompleted, isTrue);
-        expect(result.endClip.processingCompleter?.isCompleted, isTrue);
+        expect(capturedStartClip!.processingCompleter?.isCompleted, isTrue);
+        expect(capturedEndClip!.processingCompleter?.isCompleted, isTrue);
 
-        final startSuccess = await result.startClip.processingCompleter!.future;
-        final endSuccess = await result.endClip.processingCompleter!.future;
+        final startSuccess =
+            await capturedStartClip!.processingCompleter!.future;
+        final endSuccess = await capturedEndClip!.processingCompleter!.future;
 
         expect(startSuccess, isTrue);
         expect(endSuccess, isTrue);
@@ -379,10 +384,13 @@ void main() {
           originalAspectRatio: 9 / 16,
         );
 
-        final result1 = await VideoEditorSplitService.splitClip(
+        DivineVideoClip? endClip1;
+        DivineVideoClip? endClip2;
+
+        await VideoEditorSplitService.splitClip(
           sourceClip: clip,
           splitPosition: const Duration(seconds: 2),
-          onClipsCreated: null,
+          onClipsCreated: (_, end) => endClip1 = end,
           onThumbnailExtracted: null,
           onClipRendered: null,
         );
@@ -390,15 +398,15 @@ void main() {
         // Wait a bit to ensure different timestamp
         await Future<void>.delayed(const Duration(milliseconds: 2));
 
-        final result2 = await VideoEditorSplitService.splitClip(
+        await VideoEditorSplitService.splitClip(
           sourceClip: clip,
           splitPosition: const Duration(seconds: 2),
-          onClipsCreated: null,
+          onClipsCreated: (_, end) => endClip2 = end,
           onThumbnailExtracted: null,
           onClipRendered: null,
         );
 
-        expect(result1.endClip.id, isNot(equals(result2.endClip.id)));
+        expect(endClip1!.id, isNot(equals(endClip2!.id)));
       });
 
       test('splits trimmed clip at correct absolute position', () async {
@@ -417,7 +425,7 @@ void main() {
         DivineVideoClip? capturedStartClip;
         DivineVideoClip? capturedEndClip;
 
-        final result = await VideoEditorSplitService.splitClip(
+        await VideoEditorSplitService.splitClip(
           sourceClip: clip,
           // Split at 2s into the trimmed clip (absolute 5s)
           splitPosition: const Duration(seconds: 2),
@@ -429,29 +437,28 @@ void main() {
           onClipRendered: null,
         );
 
+        expect(capturedStartClip, isNotNull);
+        expect(capturedEndClip, isNotNull);
+
         // Start clip: 0–5s (absolute), trimStart=3s, trimEnd=0
         // trimmedDuration = 5 - 3 = 2s ✓
-        expect(result.startClip.duration, const Duration(seconds: 5));
-        expect(result.startClip.trimStart, const Duration(seconds: 3));
-        expect(result.startClip.trimEnd, Duration.zero);
-        expect(result.startClip.trimmedDuration, const Duration(seconds: 2));
+        expect(capturedStartClip!.duration, const Duration(seconds: 5));
+        expect(capturedStartClip!.trimStart, const Duration(seconds: 3));
+        expect(capturedStartClip!.trimEnd, Duration.zero);
+        expect(capturedStartClip!.trimmedDuration, const Duration(seconds: 2));
 
         // End clip: 5s–10s (absolute), trimStart=0, trimEnd=2s
         // trimmedDuration = 5 - 2 = 3s ✓
-        expect(result.endClip.duration, const Duration(seconds: 5));
-        expect(result.endClip.trimStart, Duration.zero);
-        expect(result.endClip.trimEnd, const Duration(seconds: 2));
-        expect(result.endClip.trimmedDuration, const Duration(seconds: 3));
+        expect(capturedEndClip!.duration, const Duration(seconds: 5));
+        expect(capturedEndClip!.trimStart, Duration.zero);
+        expect(capturedEndClip!.trimEnd, const Duration(seconds: 2));
+        expect(capturedEndClip!.trimmedDuration, const Duration(seconds: 3));
 
         // Total trimmedDuration preserved: 2 + 3 = 5s
         expect(
-          result.startClip.trimmedDuration + result.endClip.trimmedDuration,
+          capturedStartClip!.trimmedDuration + capturedEndClip!.trimmedDuration,
           clip.trimmedDuration,
         );
-
-        // onClipsCreated should receive matching clips
-        expect(capturedStartClip!.duration, const Duration(seconds: 5));
-        expect(capturedEndClip!.duration, const Duration(seconds: 5));
       });
     });
   });


### PR DESCRIPTION
Closes #3393

## Description

Resolve the issue where split clips incorrectly show the pre-split content for both the segment before and after the split position


**Related Issue:** 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore