### PR TITLE
feat(video-event-service): broadcast bus for removed video ids

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -60,6 +60,7 @@ class FullscreenFeedBloc
     required Stream<List<VideoEvent>> videosStream,
     required int initialIndex,
     Stream<bool>? hasMoreStream,
+    Stream<String>? removedIdsStream,
     MediaCacheManager? mediaCache,
     VoidCallback? onLoadMore,
     BlossomAuthService? blossomAuthService,
@@ -67,6 +68,7 @@ class FullscreenFeedBloc
     MediaAvailabilityChecker? availabilityChecker,
   }) : _videosStream = videosStream,
        _hasMoreStream = hasMoreStream,
+       _removedIdsStream = removedIdsStream,
        _onLoadMore = onLoadMore,
        _mediaCache = mediaCache,
        _blossomAuthService = blossomAuthService,
@@ -86,17 +88,25 @@ class FullscreenFeedBloc
       _onVideoUnavailable,
       transformer: sequential(),
     );
+    // Sequential: removal mutates videos + currentIndex + removedVideoIds
+    // together; concurrent emits for different ids must not interleave.
+    on<FullscreenFeedVideoRemoved>(
+      _onVideoRemoved,
+      transformer: sequential(),
+    );
     on<FullscreenFeedSkipAcknowledged>(_onSkipAcknowledged);
   }
 
   final Stream<List<VideoEvent>> _videosStream;
   final Stream<bool>? _hasMoreStream;
+  final Stream<String>? _removedIdsStream;
   final VoidCallback? _onLoadMore;
   final MediaCacheManager? _mediaCache;
   final BlossomAuthService? _blossomAuthService;
   final OnRemoveVideo? _onRemoveVideo;
   final MediaAvailabilityChecker _availabilityChecker;
   StreamSubscription<bool>? _hasMoreSubscription;
+  StreamSubscription<String>? _removedIdsSubscription;
 
   /// Queue of video IDs waiting to be cached in the background.
   final Queue<_CacheRequest> _cacheQueue = Queue<_CacheRequest>();
@@ -124,6 +134,26 @@ class FullscreenFeedBloc
       onError: (Object error, StackTrace stackTrace) {
         Log.error(
           'FullscreenFeedBloc: hasMore stream error - $error',
+          name: 'FullscreenFeedBloc',
+          category: LogCategory.video,
+          error: error,
+          stackTrace: stackTrace,
+        );
+      },
+    );
+
+    // Side-channel: deletion (and future block / mute) emits a removed
+    // id here. The source-list stream may not be alive (the launching
+    // widget may have unmounted on shell-route transition), so the bus
+    // is what guarantees the fullscreen drops a removed video without
+    // waiting for an app restart.
+    _removedIdsSubscription ??= _removedIdsStream?.listen(
+      (videoId) {
+        if (!isClosed) add(FullscreenFeedVideoRemoved(videoId));
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        Log.error(
+          'FullscreenFeedBloc: removedIds stream error - $error',
           name: 'FullscreenFeedBloc',
           category: LogCategory.video,
           error: error,
@@ -409,9 +439,72 @@ class FullscreenFeedBloc
     emit(state.copyWith(clearPendingSkipTarget: true));
   }
 
+  /// Handle a user-initiated removal (deletion, block, mute).
+  ///
+  /// Removes the video from [FullscreenFeedState.videos] directly because
+  /// the upstream source may not be alive to push an updated list — the
+  /// launching widget often unmounts when the fullscreen route is pushed
+  /// outside its shell. When the last video is removed, transitions the
+  /// status to [FullscreenFeedStatus.emptyAfterRemoval] so the screen
+  /// pops the route.
+  ///
+  /// Skips the HEAD-check that [_onVideoUnavailable] performs because the
+  /// server has already confirmed the deletion (or the user explicitly
+  /// asked to hide the content), so a transient-error fallback is wrong.
+  void _onVideoRemoved(
+    FullscreenFeedVideoRemoved event,
+    Emitter<FullscreenFeedState> emit,
+  ) {
+    final videoId = event.videoId;
+    if (state.removedVideoIds.contains(videoId)) return;
+
+    final index = state.videos.indexWhere((v) => v.id == videoId);
+    final updatedRemoved = {...state.removedVideoIds, videoId};
+
+    if (index < 0) {
+      // Not in the visible list — still record the dedupe so a later
+      // pagination push can't re-introduce it.
+      emit(state.copyWith(removedVideoIds: updatedRemoved));
+      return;
+    }
+
+    final updatedVideos = [...state.videos]..removeAt(index);
+    _onRemoveVideo?.call(videoId);
+
+    if (updatedVideos.isEmpty) {
+      emit(
+        state.copyWith(
+          status: FullscreenFeedStatus.emptyAfterRemoval,
+          videos: const [],
+          removedVideoIds: updatedRemoved,
+          clearPendingSkipTarget: true,
+        ),
+      );
+      return;
+    }
+
+    // Removing an item before the cursor shifts every later item down by
+    // one. Without this shift the visible video would jump from cur to
+    // cur+1 — for user-delete this never happens (the deleted item IS
+    // the cursor), but the bus is the entry point for the upcoming
+    // block / mute sweep where multi-video removals land at any index.
+    final shifted = index < state.currentIndex
+        ? state.currentIndex - 1
+        : state.currentIndex;
+    final clampedIndex = shifted.clamp(0, updatedVideos.length - 1);
+    emit(
+      state.copyWith(
+        videos: updatedVideos,
+        currentIndex: clampedIndex,
+        removedVideoIds: updatedRemoved,
+      ),
+    );
+  }
+
   @override
   Future<void> close() async {
     await _hasMoreSubscription?.cancel();
+    await _removedIdsSubscription?.cancel();
     _cacheQueue.clear();
     return super.close();
   }

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_event.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_event.dart
@@ -92,3 +92,25 @@ final class FullscreenFeedSkipAcknowledged extends FullscreenFeedEvent {
   @override
   List<Object?> get props => [];
 }
+
+/// Dispatched when a video must be removed from the feed immediately,
+/// without any availability check — user-initiated deletion (and, soon,
+/// block / mute) propagates through this event.
+///
+/// Shares the removal tail with [FullscreenFeedVideoUnavailable]: the
+/// id is added to [FullscreenFeedState.removedVideoIds], the video is
+/// dropped from [FullscreenFeedState.videos], and the current index is
+/// clamped. When the last video is removed the BLoC transitions to
+/// [FullscreenFeedStatus.emptyAfterRemoval] so the screen can pop.
+///
+/// Dedupe is owned by the BLoC — repeated dispatches for the same
+/// [videoId] are no-ops after the first removal.
+final class FullscreenFeedVideoRemoved extends FullscreenFeedEvent {
+  const FullscreenFeedVideoRemoved(this.videoId);
+
+  /// Event ID of the video to remove.
+  final String videoId;
+
+  @override
+  List<Object?> get props => [videoId];
+}

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
@@ -11,6 +11,10 @@ enum FullscreenFeedStatus {
   /// Videos loaded and ready.
   ready,
 
+  /// The last visible video was just removed (deletion / block / mute).
+  /// The screen reacts by popping the route — there is nothing to show.
+  emptyAfterRemoval,
+
   /// An error occurred.
   failure,
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2937,5 +2937,6 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{تكرار} other{تكرارات}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "حدّد مقطع الصوت لفيديوك",
-  "videoEditorClipGalleryInstruction": "اضغط للتعديل. اضغط مطولاً واسحب لإعادة الترتيب."
+  "videoEditorClipGalleryInstruction": "اضغط للتعديل. اضغط مطولاً واسحب لإعادة الترتيب.",
+  "fullscreenFeedRemovedMessage": "Video removed"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2937,5 +2937,6 @@
   "videoEditorAudioSegmentInstruction": "Wähle den Audiobereich für dein Video aus",
   "videoEditorClipGalleryInstruction": "Tippen zum Bearbeiten. Halten und ziehen zum Neuordnen.",
   "navSearch": "Suche",
-  "navSearchTooltip": "Suchen"
+  "navSearchTooltip": "Suchen",
+  "fullscreenFeedRemovedMessage": "Video removed"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2987,5 +2987,9 @@
   "metadataCaptionsDisabledSemantics": "Captions disabled for all videos",
   "@metadataCaptionsDisabledSemantics": {
     "description": "Screen reader label when the global captions toggle is off"
+  },
+  "fullscreenFeedRemovedMessage": "Video removed",
+  "@fullscreenFeedRemovedMessage": {
+    "description": "Empty-state message shown in the fullscreen feed when the last visible video has just been deleted, blocked, or muted and the route cannot be popped back to a parent (e.g. a cold deep-link)."
   }
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2937,5 +2937,6 @@
   "videoEditorAudioSegmentInstruction": "Selecciona el segmento de audio para tu video",
   "videoEditorClipGalleryInstruction": "Toca para editar. Mantén presionado y arrastra para reordenar.",
   "navSearch": "Buscar",
-  "navSearchTooltip": "Buscar"
+  "navSearchTooltip": "Buscar",
+  "fullscreenFeedRemovedMessage": "Video removed"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2937,5 +2937,6 @@
   "videoEditorAudioSegmentInstruction": "Sélectionne le segment audio de ta vidéo",
   "videoEditorClipGalleryInstruction": "Appuie pour modifier. Maintiens appuyé et fais glisser pour réorganiser.",
   "navSearch": "Recherche",
-  "navSearchTooltip": "Rechercher"
+  "navSearchTooltip": "Rechercher",
+  "fullscreenFeedRemovedMessage": "Video removed"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2937,5 +2937,6 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{loop} other{loop}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Pilih segmen audio untuk videomu",
-  "videoEditorClipGalleryInstruction": "Ketuk untuk mengedit. Tekan lama dan seret untuk mengurutkan ulang."
+  "videoEditorClipGalleryInstruction": "Ketuk untuk mengedit. Tekan lama dan seret untuk mengurutkan ulang.",
+  "fullscreenFeedRemovedMessage": "Video removed"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2937,5 +2937,6 @@
   "videoEditorAudioSegmentInstruction": "Seleziona il segmento audio per il tuo video",
   "videoEditorClipGalleryInstruction": "Tocca per modificare. Tieni premuto e trascina per riordinare.",
   "navSearch": "Cerca",
-  "navSearchTooltip": "Cerca"
+  "navSearchTooltip": "Cerca",
+  "fullscreenFeedRemovedMessage": "Video removed"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2937,5 +2937,6 @@
     "videoFeedLoopCountLine": "{compactCount}{count, plural, other{ループ}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "動画に使うオーディオ範囲を選択",
-  "videoEditorClipGalleryInstruction": "タップして編集。長押ししてドラッグで並べ替え。"
+  "videoEditorClipGalleryInstruction": "タップして編集。長押ししてドラッグで並べ替え。",
+  "fullscreenFeedRemovedMessage": "Video removed"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2226,5 +2226,6 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, other{루프}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "동영상에 사용할 오디오 구간을 선택하세요",
-  "videoEditorClipGalleryInstruction": "탭해서 편집하세요. 길게 누르고 드래그해 순서를 바꾸세요."
+  "videoEditorClipGalleryInstruction": "탭해서 편집하세요. 길게 누르고 드래그해 순서를 바꾸세요.",
+  "fullscreenFeedRemovedMessage": "Video removed"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2937,5 +2937,6 @@
   "videoEditorAudioSegmentInstruction": "Selecteer het audiofragment voor je video",
   "videoEditorClipGalleryInstruction": "Tik om te bewerken. Houd vast en sleep om te herordenen.",
   "navSearch": "Zoeken",
-  "navSearchTooltip": "Zoeken"
+  "navSearchTooltip": "Zoeken",
+  "fullscreenFeedRemovedMessage": "Video removed"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2937,5 +2937,6 @@
   "videoEditorAudioSegmentInstruction": "Wybierz fragment audio dla swojego filmu",
   "videoEditorClipGalleryInstruction": "Dotknij, aby edytować. Przytrzymaj i przeciągnij, aby zmienić kolejność.",
   "navSearch": "Szukaj",
-  "navSearchTooltip": "Szukaj"
+  "navSearchTooltip": "Szukaj",
+  "fullscreenFeedRemovedMessage": "Video removed"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2937,5 +2937,6 @@
   "videoEditorAudioSegmentInstruction": "Selecione o trecho de áudio para seu vídeo",
   "videoEditorClipGalleryInstruction": "Toque para editar. Pressione e arraste para reordenar.",
   "navSearch": "Pesquisar",
-  "navSearchTooltip": "Pesquisar"
+  "navSearchTooltip": "Pesquisar",
+  "fullscreenFeedRemovedMessage": "Video removed"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2937,5 +2937,6 @@
   "videoEditorAudioSegmentInstruction": "Alege segmentul audio pentru videoclipul tău",
   "videoEditorClipGalleryInstruction": "Atinge pentru editare. Ține apăsat și trage pentru reordonare.",
   "navSearch": "Caută",
-  "navSearchTooltip": "Caută"
+  "navSearchTooltip": "Caută",
+  "fullscreenFeedRemovedMessage": "Video removed"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2937,5 +2937,6 @@
   "videoEditorAudioSegmentInstruction": "Välj ljudsegmentet för din video",
   "videoEditorClipGalleryInstruction": "Tryck för att redigera. Håll ned och dra för att ändra ordning.",
   "navSearch": "Sök",
-  "navSearchTooltip": "Sök"
+  "navSearchTooltip": "Sök",
+  "fullscreenFeedRemovedMessage": "Video removed"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2937,5 +2937,6 @@
     "videoFeedLoopCountLine": "{compactCount} {count, plural, =1{döngü} other{döngüler}}",
     "shareMenuDeleteFailedRelayRejected": "Couldn't reach the relay. Check your connection and try again.",
   "videoEditorAudioSegmentInstruction": "Videon için ses bölümünü seç",
-  "videoEditorClipGalleryInstruction": "Düzenlemek için dokun. Yeniden sıralamak için basılı tutup sürükle."
+  "videoEditorClipGalleryInstruction": "Düzenlemek için dokun. Yeniden sıralamak için basılı tutup sürükle.",
+  "fullscreenFeedRemovedMessage": "Video removed"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10127,6 +10127,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Captions disabled for all videos'**
   String get metadataCaptionsDisabledSemantics;
+
+  /// Empty-state message shown in the fullscreen feed when the last visible video has just been deleted, blocked, or muted and the route cannot be popped back to a parent (e.g. a cold deep-link).
+  ///
+  /// In en, this message translates to:
+  /// **'Video removed'**
+  String get fullscreenFeedRemovedMessage;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5655,4 +5655,7 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get metadataCaptionsDisabledSemantics =>
       'التسميات التوضيحية معطّلة لجميع مقاطع الفيديو';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5786,4 +5786,7 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get metadataCaptionsDisabledSemantics =>
       'Untertitel für alle Videos deaktiviert';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5713,4 +5713,7 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get metadataCaptionsDisabledSemantics =>
       'Captions disabled for all videos';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5783,4 +5783,7 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get metadataCaptionsDisabledSemantics =>
       'Subtítulos desactivados para todos los vídeos';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5800,4 +5800,7 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get metadataCaptionsDisabledSemantics =>
       'Sous-titres désactivés pour toutes les vidéos';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5692,4 +5692,7 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get metadataCaptionsDisabledSemantics =>
       'Teks dinonaktifkan untuk semua video';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5777,4 +5777,7 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get metadataCaptionsDisabledSemantics =>
       'Sottotitoli disabilitati per tutti i video';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5475,4 +5475,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get metadataCaptionsDisabledSemantics => 'すべての動画で字幕が無効になっています';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5498,4 +5498,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get metadataCaptionsDisabledSemantics => '모든 동영상에서 자막이 비활성화되었습니다';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5743,4 +5743,7 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get metadataCaptionsDisabledSemantics =>
       'Ondertitels uitgeschakeld voor alle video\'s';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5857,4 +5857,7 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get metadataCaptionsDisabledSemantics =>
       'Napisy wyłączone dla wszystkich filmów';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5754,4 +5754,7 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get metadataCaptionsDisabledSemantics =>
       'Legendas desativadas para todos os vídeos';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5865,4 +5865,7 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get metadataCaptionsDisabledSemantics =>
       'Subtitrări dezactivate pentru toate videoclipurile';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5709,4 +5709,7 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get metadataCaptionsDisabledSemantics =>
       'Undertexter inaktiverade för alla videor';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5697,4 +5697,7 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get metadataCaptionsDisabledSemantics =>
       'Tüm videolar için altyazılar devre dışı';
+
+  @override
+  String get fullscreenFeedRemovedMessage => 'Video removed';
 }

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -269,6 +269,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
       extra: PooledFullscreenVideoFeedArgs(
         videosStream: Stream.value([videoForNav]),
         initialIndex: 0,
+        removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
         contextTitle: context.l10n.notificationsFromNotification,
         autoOpenComments: shouldAutoOpenComments,
       ),

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -682,7 +682,25 @@ class ProfileFeed extends _$ProfileFeed {
         .where((v) => !v.isRepost)
         .toList();
     videos = _applyMetadataCache(videos);
-    return videoEventService.filterVideoList(videos);
+    return _withoutTombstones(
+      videoEventService.filterVideoList(videos),
+      videoEventService,
+    );
+  }
+
+  /// Subtract the service's session-tombstoned ids (deleted via NIP-09 in
+  /// this session). The service already prevents pagination resurrection
+  /// internally, but the merge below would otherwise carry the id forward
+  /// from the existing state forever — see `removeVideoCompletely` in
+  /// VideoEventService.
+  List<VideoEvent> _withoutTombstones(
+    List<VideoEvent> videos,
+    VideoEventService videoEventService,
+  ) {
+    if (videos.isEmpty) return videos;
+    return videos
+        .where((v) => !videoEventService.isVideoLocallyDeleted(v.id))
+        .toList();
   }
 
   void _mergeSourceVideos(
@@ -747,9 +765,11 @@ class ProfileFeed extends _$ProfileFeed {
       byKey[key] = existing == null ? video : _mergeVideo(existing, video);
     }
 
-    final merged = byKey.values.toList();
-    merged.sort(_compareVideos);
-    return merged;
+    final merged = byKey.values.toList()..sort(_compareVideos);
+    // Drop any session-tombstoned ids the merge carried forward. The
+    // upstream snapshot is already filtered, but `current` may still
+    // contain a video that was just deleted before the source caught up.
+    return _withoutTombstones(merged, ref.read(videoEventServiceProvider));
   }
 
   VideoEvent _mergeVideo(VideoEvent existing, VideoEvent incoming) {

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -89,7 +89,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'a11cdd73e9e348bc0a3425b1640456ef70ba926b';
+String _$profileFeedHash() => r'355601815d1a0ffaa695231dd29863f507a7b2d2';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -961,6 +961,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             initialIndex: args.initialIndex,
             onLoadMore: args.onLoadMore,
             hasMoreStream: args.hasMoreStream,
+            removedIdsStream: args.removedIdsStream,
             contextTitle: args.contextTitle,
             trafficSource: args.trafficSource,
             sourceDetail: args.sourceDetail,

--- a/mobile/lib/screens/category_gallery_screen.dart
+++ b/mobile/lib/screens/category_gallery_screen.dart
@@ -112,6 +112,9 @@ class _CategoryGalleryScreenState extends ConsumerState<CategoryGalleryScreen> {
                     hasMoreStream: _hasMoreStreamController.stream.startWith(
                       state.hasMoreVideos,
                     ),
+                    removedIdsStream: ref
+                        .read(videoEventServiceProvider)
+                        .removedVideoIds,
                     contextTitle: localizedCategoryName(
                       context.l10n,
                       widget.category.name,

--- a/mobile/lib/screens/curated_list_feed_screen.dart
+++ b/mobile/lib/screens/curated_list_feed_screen.dart
@@ -229,6 +229,7 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
         PooledFullscreenVideoFeedScreen(
           videosStream: Stream.value(videos),
           initialIndex: _activeVideoIndex!,
+          removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
           contextTitle: widget.listName,
           trafficSource: ViewTrafficSource.search,
         ),

--- a/mobile/lib/screens/explore_screen.dart
+++ b/mobile/lib/screens/explore_screen.dart
@@ -1219,6 +1219,7 @@ class _ExploreFeedContentState extends ConsumerState<_ExploreFeedContent> {
     return PooledFullscreenVideoFeedScreen(
       videosStream: _streamController.stream.startWith(videos),
       initialIndex: safeIndex,
+      removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
       contextTitle: '',
       onPageChanged: (index) => context.go(ExploreScreen.pathForIndex(index)),
     );

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -20,6 +20,7 @@ import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/subtitle_providers.dart';
 import 'package:openvine/router/app_router.dart';
@@ -102,6 +103,7 @@ class PooledFullscreenVideoFeedArgs {
     required this.initialIndex,
     this.onLoadMore,
     this.hasMoreStream,
+    this.removedIdsStream,
     this.contextTitle,
     this.trafficSource = ViewTrafficSource.unknown,
     this.sourceDetail,
@@ -120,6 +122,11 @@ class PooledFullscreenVideoFeedArgs {
 
   /// Stream of whether the source can paginate further.
   final Stream<bool>? hasMoreStream;
+
+  /// Side-channel for "this video must be dropped now" — fed from
+  /// [VideoEventService.removedVideoIds]. Optional so that callers
+  /// pre-dating the deletion-bus migration keep working.
+  final Stream<String>? removedIdsStream;
 
   /// Optional title for context display.
   final String? contextTitle;
@@ -161,6 +168,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
     required this.initialIndex,
     this.onLoadMore,
     this.hasMoreStream,
+    this.removedIdsStream,
     this.contextTitle,
     this.trafficSource = ViewTrafficSource.unknown,
     this.sourceDetail,
@@ -173,6 +181,12 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
   final int initialIndex;
   final VoidCallback? onLoadMore;
   final Stream<bool>? hasMoreStream;
+
+  /// Side-channel that emits a video id whenever the underlying service
+  /// has marked it removed (deletion / future block / mute). Optional so
+  /// not-yet-migrated callers keep working — without the wire-up the
+  /// fullscreen falls back to today's stale behaviour.
+  final Stream<String>? removedIdsStream;
   final String? contextTitle;
   final ViewTrafficSource trafficSource;
   final String? sourceDetail;
@@ -200,6 +214,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
             videosStream: videosStream,
             initialIndex: initialIndex,
             hasMoreStream: hasMoreStream,
+            removedIdsStream: removedIdsStream,
             onLoadMore: onLoadMore,
             mediaCache: mediaCache,
             blossomAuthService: blossomAuthService,
@@ -622,9 +637,53 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
               if (target != null) unawaited(_handlePendingSkip(target));
             },
           ),
+          // Pop the route when the last visible video has been removed
+          // by deletion (or, soon, block / mute). When `maybePop`
+          // returns false (cold deep-link into the fullscreen with no
+          // parent route in the stack), the BlocBuilder below renders
+          // an explicit `emptyAfterRemoval` branch so the user is not
+          // left looking at a perpetual loading spinner.
+          BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
+            listenWhen: (prev, curr) =>
+                prev.status != curr.status &&
+                curr.status == FullscreenFeedStatus.emptyAfterRemoval,
+            listener: (context, _) {
+              unawaited(Navigator.of(context).maybePop());
+            },
+          ),
         ],
         child: BlocBuilder<FullscreenFeedBloc, FullscreenFeedState>(
           builder: (context, state) {
+            // The BlocListener above tries to pop on this status; when
+            // it can (parent route exists) the route is gone before this
+            // branch renders. When `maybePop` is a no-op, we land here
+            // and show an explicit empty-state with a back button rather
+            // than the loading spinner below.
+            if (state.status == FullscreenFeedStatus.emptyAfterRemoval) {
+              return Scaffold(
+                backgroundColor: VineTheme.backgroundColor,
+                appBar: DiVineAppBar(
+                  title: widget.contextTitle ?? '',
+                  showBackButton: true,
+                  // The BlocListener above already tried `maybePop` and
+                  // failed (otherwise we wouldn't be rendering this
+                  // branch). The same `pop` from the appbar back button
+                  // would also be a no-op, so fall back to the home
+                  // shell to avoid a dead-end UX.
+                  onBackPressed: () =>
+                      context.canPop() ? context.pop() : context.go('/'),
+                  backgroundMode: DiVineAppBarBackgroundMode.transparent,
+                  forceMaterialTransparency: true,
+                ),
+                body: Center(
+                  child: Text(
+                    context.l10n.fullscreenFeedRemovedMessage,
+                    style: VineTheme.bodyMediumFont(),
+                  ),
+                ),
+              );
+            }
+
             if (state.status == FullscreenFeedStatus.initial ||
                 !state.hasVideos) {
               return Scaffold(

--- a/mobile/lib/screens/hashtag_feed_screen.dart
+++ b/mobile/lib/screens/hashtag_feed_screen.dart
@@ -264,6 +264,7 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
       extra: PooledFullscreenVideoFeedArgs(
         videosStream: _videosStreamController.stream.startWith(videoList),
         initialIndex: index,
+        removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
         contextTitle: '#${widget.hashtag}',
         trafficSource: ViewTrafficSource.search,
         sourceDetail: widget.hashtag,

--- a/mobile/lib/screens/liked_videos_screen_router.dart
+++ b/mobile/lib/screens/liked_videos_screen_router.dart
@@ -215,6 +215,7 @@ class _LikedVideosFeedViewState extends ConsumerState<_LikedVideosFeedView> {
           // Stream is seeded via _pushVideos in the BlocConsumer listener.
           videosStream: _streamController.stream,
           initialIndex: safeIndex,
+          removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
           contextTitle: 'Liked Videos',
           trafficSource: ViewTrafficSource.profile,
         );

--- a/mobile/lib/screens/notifications_screen.dart
+++ b/mobile/lib/screens/notifications_screen.dart
@@ -678,6 +678,7 @@ class _NotificationTabContentState
       extra: PooledFullscreenVideoFeedArgs(
         videosStream: Stream.value([videoForNav]),
         initialIndex: 0,
+        removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
         contextTitle: context.l10n.notificationsFromNotification,
         autoOpenComments: shouldAutoOpenComments,
       ),

--- a/mobile/lib/screens/search_results/widgets/video_search_view.dart
+++ b/mobile/lib/screens/search_results/widgets/video_search_view.dart
@@ -3,11 +3,13 @@ import 'dart:async';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_search/video_search_bloc.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/search_results/widgets/videos_section.dart';
 import 'package:openvine/services/view_event_publisher.dart';
@@ -40,7 +42,7 @@ class VideoSearchView extends StatelessWidget {
   }
 }
 
-class _VideoSearchGrid extends StatefulWidget {
+class _VideoSearchGrid extends ConsumerStatefulWidget {
   const _VideoSearchGrid({
     required this.videos,
     required this.hasMore,
@@ -52,10 +54,10 @@ class _VideoSearchGrid extends StatefulWidget {
   final bool isLoadingMore;
 
   @override
-  State<_VideoSearchGrid> createState() => _VideoSearchGridState();
+  ConsumerState<_VideoSearchGrid> createState() => _VideoSearchGridState();
 }
 
-class _VideoSearchGridState extends State<_VideoSearchGrid>
+class _VideoSearchGridState extends ConsumerState<_VideoSearchGrid>
     with ScrollPaginationMixin {
   final _scrollController = ScrollController();
   late final StreamController<List<VideoEvent>> _videosStreamController;
@@ -112,6 +114,7 @@ class _VideoSearchGridState extends State<_VideoSearchGrid>
         hasMoreStream: _hasMoreStreamController.stream.startWith(
           widget.hasMore,
         ),
+        removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
         contextTitle: 'Search Results',
         trafficSource: ViewTrafficSource.search,
         sourceDetail: context.read<VideoSearchBloc>().state.query,

--- a/mobile/lib/screens/search_results/widgets/videos_section.dart
+++ b/mobile/lib/screens/search_results/widgets/videos_section.dart
@@ -3,11 +3,13 @@ import 'dart:async';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_search/video_search_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/search_results/widgets/search_section_empty_state.dart';
 import 'package:openvine/screens/search_results/widgets/search_section_error_state.dart';
@@ -83,16 +85,16 @@ class _VideosPaginationTrigger extends StatelessWidget {
   }
 }
 
-class _VideosContent extends StatefulWidget {
+class _VideosContent extends ConsumerStatefulWidget {
   const _VideosContent({this.showAll = false});
 
   final bool showAll;
 
   @override
-  State<_VideosContent> createState() => _VideosContentState();
+  ConsumerState<_VideosContent> createState() => _VideosContentState();
 }
 
-class _VideosContentState extends State<_VideosContent> {
+class _VideosContentState extends ConsumerState<_VideosContent> {
   late final StreamController<List<VideoEvent>> _videosStreamController;
   late final StreamController<bool> _hasMoreStreamController;
 
@@ -121,6 +123,7 @@ class _VideosContentState extends State<_VideosContent> {
         hasMoreStream: _hasMoreStreamController.stream.startWith(
           context.read<VideoSearchBloc>().state.hasMore,
         ),
+        removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
         contextTitle: 'Search Results',
         trafficSource: ViewTrafficSource.search,
         sourceDetail: context.read<VideoSearchBloc>().state.query,

--- a/mobile/lib/screens/sound_detail_screen.dart
+++ b/mobile/lib/screens/sound_detail_screen.dart
@@ -968,7 +968,7 @@ class _ThumbnailPlaceholder extends StatelessWidget {
 ///
 /// Shows a swipeable pooled feed with a header showing sound info
 /// and a close button to return to the grid view.
-class _SoundVideoFeedOverlay extends StatelessWidget {
+class _SoundVideoFeedOverlay extends ConsumerWidget {
   const _SoundVideoFeedOverlay({
     required this.videos,
     required this.startIndex,
@@ -982,12 +982,13 @@ class _SoundVideoFeedOverlay extends StatelessWidget {
   final VoidCallback onClose;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Stack(
       children: [
         PooledFullscreenVideoFeedScreen(
           videosStream: Stream.value(videos),
           initialIndex: startIndex,
+          removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
           contextTitle: soundTitle,
         ),
 

--- a/mobile/lib/screens/user_list_people_screen.dart
+++ b/mobile/lib/screens/user_list_people_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/list_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
@@ -217,6 +218,9 @@ class _UserListPeopleScreenState extends ConsumerState<UserListPeopleScreen>
             PooledFullscreenVideoFeedScreen(
               videosStream: Stream.value(videos),
               initialIndex: _activeVideoIndex!,
+              removedIdsStream: ref
+                  .read(videoEventServiceProvider)
+                  .removedVideoIds,
               contextTitle: widget.userList.name,
             ),
             // Header bar showing list name and back button

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -223,6 +223,7 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
         PooledFullscreenVideoFeedScreen(
           videosStream: Stream.value([_video!]),
           initialIndex: 0,
+          removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
           contextTitle: 'Shared Video',
           trafficSource: ViewTrafficSource.share,
         );

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -202,11 +202,20 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   // Track locally deleted videos to prevent resurrection from pagination
   final Set<String> _locallyDeletedVideoIds = {};
 
+  // Broadcasts video ids the moment they are removed (deletion / future
+  // block / mute). Subscribers — fullscreen feed bloc, profile feed
+  // provider — react in real time without waiting for a route change.
+  // Broadcast semantics are intentional: state.notifyListeners is the
+  // canonical truth, this stream is a side-channel for "act now" hooks.
+  final StreamController<String> _removedVideoIdsController =
+      StreamController<String>.broadcast();
+
   static const int _maxRetryAttempts = 3;
   static const Duration _retryDelay = Duration(seconds: 10);
 
   // Optional services for enhanced functionality
   ContentBlocklistRepository? _blocklistRepository;
+  StreamSubscription<BlocklistChange>? _blocklistChangesSubscription;
   AgeVerificationService? _ageVerificationService;
   LikesRepository? _likesRepository;
   ContentFilterService? _contentFilterService;
@@ -293,11 +302,97 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// Set the blocklist service for content filtering
   void setBlocklistRepository(ContentBlocklistRepository blocklistRepository) {
     _blocklistRepository = blocklistRepository;
+
+    // Subscribe to per-pubkey blocklist changes so a block / mute
+    // immediately propagates as `removedVideoIds` emissions for every
+    // video by the affected author. Mirrors the deletion bus contract:
+    // subscribers (FullscreenFeedBloc) drop the ids from their visible
+    // state without waiting for a route change or app restart.
+    //
+    // Cancel any prior subscription if `setBlocklistRepository` is
+    // called again — keeps the active subscription bound to the
+    // currently-attached repository.
+    unawaited(_blocklistChangesSubscription?.cancel());
+    _blocklistChangesSubscription = blocklistRepository.changes.listen(
+      (change) {
+        if (!change.isAddition) return;
+        _sweepAuthor(change.pubkey);
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        Log.error(
+          'VideoEventService: blocklist changes stream error - $error',
+          name: 'VideoEventService',
+          category: LogCategory.video,
+          error: error,
+          stackTrace: stackTrace,
+        );
+      },
+    );
+
     Log.debug(
       'Blocklist service attached to VideoEventService',
       name: 'VideoEventService',
       category: LogCategory.video,
     );
+  }
+
+  /// Emit `removedVideoIds` for every cached video authored by [pubkey].
+  ///
+  /// Used in response to block / mute events. Unlike
+  /// [removeVideoCompletely], this does NOT add ids to
+  /// [_locallyDeletedVideoIds] — block / mute are reversible and the
+  /// existing pagination filters (via [shouldHideVideo] /
+  /// [filterVideoList]) already guarantee that an unblocked author's
+  /// videos can come back on the next refresh. We only need the
+  /// fullscreen surface to drop them right now.
+  void _sweepAuthor(String pubkey) {
+    if (_removedVideoIdsController.isClosed) return;
+
+    // Collect ids across every cache that may hold this author's videos.
+    // Fullscreen blocs may be displaying videos sourced from any of
+    // these — discovery, profile, hashtag, etc. Dedupe by id since a
+    // video can appear in multiple buckets simultaneously.
+    final ids = <String>{};
+
+    final authorBucket = _authorBuckets[pubkey];
+    if (authorBucket != null) {
+      for (final video in authorBucket) {
+        ids.add(video.id);
+      }
+    }
+
+    for (final list in _eventLists.values) {
+      for (final video in list) {
+        if (video.pubkey == pubkey) ids.add(video.id);
+      }
+    }
+
+    for (final list in _hashtagBuckets.values) {
+      for (final video in list) {
+        if (video.pubkey == pubkey) ids.add(video.id);
+      }
+    }
+
+    if (ids.isEmpty) return;
+
+    Log.info(
+      'sweepAuthor: emitting ${ids.length} removal(s) for pubkey=$pubkey',
+      name: 'VideoEventService',
+      category: LogCategory.video,
+    );
+
+    for (final id in ids) {
+      _removedVideoIdsController.add(id);
+    }
+  }
+
+  /// Test-only seam: pre-populate the author bucket so [_sweepAuthor]
+  /// can be exercised without driving a real relay subscription.
+  /// Production code must never call this — use the public subscription
+  /// APIs instead.
+  @visibleForTesting
+  void debugSeedAuthorBucket(String pubkey, List<VideoEvent> videos) {
+    _authorBuckets[pubkey] = List.of(videos);
   }
 
   /// Set the age verification service for adult content filtering
@@ -900,6 +995,15 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     // restart or test tearDown).
     _locallyDeletedVideoIds.add(videoId);
 
+    // Emit on the side-channel BEFORE notifyListeners so that subscribers
+    // who react via the stream (e.g. FullscreenFeedBloc) update their
+    // state in the same frame as ChangeNotifier consumers. Emit
+    // unconditionally — even when the video wasn't in any active feed,
+    // a fullscreen route may still be holding it in BLoC-local state.
+    if (!_removedVideoIdsController.isClosed) {
+      _removedVideoIdsController.add(videoId);
+    }
+
     if (removedCount > 0) {
       Log.info(
         'Removed video $videoId from $removedCount location(s) across all feeds',
@@ -932,6 +1036,16 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   bool isVideoLocallyDeleted(String videoId) {
     return _locallyDeletedVideoIds.contains(videoId);
   }
+
+  /// Emits a video id whenever the service has marked it removed —
+  /// today this is user-initiated deletion via [removeVideoCompletely];
+  /// future block / mute flows will reuse this same channel.
+  ///
+  /// Subscribers should treat each event as "drop this id from any open
+  /// surface immediately." The stream is broadcast and does not buffer,
+  /// so newcomers only receive future emissions; the canonical source of
+  /// truth is still the service state plus [isVideoLocallyDeleted].
+  Stream<String> get removedVideoIds => _removedVideoIdsController.stream;
 
   /// Query for all users who have reposted a specific video
   /// Returns list of pubkeys (hex) of users who created Kind 6 repost events
@@ -4961,8 +5075,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     _retryTimer?.cancel();
     _likeCountBatchTimer?.cancel();
     _authStateSubscription?.cancel();
+    unawaited(_blocklistChangesSubscription?.cancel());
     _connectionService.dispose();
     unsubscribeFromVideoFeed();
+    unawaited(_removedVideoIdsController.close());
     super.dispose();
   }
 

--- a/mobile/lib/widgets/classic_vines_tab.dart
+++ b/mobile/lib/widgets/classic_vines_tab.dart
@@ -231,6 +231,9 @@ class _ClassicVinesContentState extends ConsumerState<_ClassicVinesContent>
                   hasMoreStream: _hasMoreStreamController.stream.startWith(
                     widget.hasMoreContent,
                   ),
+                  removedIdsStream: ref
+                      .read(videoEventServiceProvider)
+                      .removedVideoIds,
                   contextTitle: 'Classics',
                   trafficSource: ViewTrafficSource.discoveryClassic,
                 ),

--- a/mobile/lib/widgets/for_you_tab.dart
+++ b/mobile/lib/widgets/for_you_tab.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/for_you_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
@@ -213,6 +214,9 @@ class _ForYouContentState extends ConsumerState<_ForYouContent>
                     hasMoreStream: _hasMoreStreamController.stream.startWith(
                       widget.hasMoreContent,
                     ),
+                    removedIdsStream: ref
+                        .read(videoEventServiceProvider)
+                        .removedVideoIds,
                     contextTitle: 'For You',
                     trafficSource: ViewTrafficSource.discoveryForYou,
                   ),

--- a/mobile/lib/widgets/new_videos_tab.dart
+++ b/mobile/lib/widgets/new_videos_tab.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/video_event_extensions.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/popular_now_feed_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/error_analytics_tracker.dart';
@@ -246,6 +247,9 @@ class _NewVideosContentState extends ConsumerState<_NewVideosContent> {
             hasMoreStream: _hasMoreStreamController.stream.startWith(
               widget.hasMoreContent,
             ),
+            removedIdsStream: ref
+                .read(videoEventServiceProvider)
+                .removedVideoIds,
             contextTitle: 'New Videos',
             trafficSource: ViewTrafficSource.discoveryNew,
           ),

--- a/mobile/lib/widgets/popular_videos_tab.dart
+++ b/mobile/lib/widgets/popular_videos_tab.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/popular_videos_feed_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/error_analytics_tracker.dart';
@@ -270,6 +271,9 @@ class _PopularVideosTrendingContentState
                     hasMoreStream: _hasMoreStreamController.stream.startWith(
                       widget.hasMoreContent,
                     ),
+                    removedIdsStream: ref
+                        .read(videoEventServiceProvider)
+                        .removedVideoIds,
                     contextTitle: 'Popular Videos',
                     trafficSource: ViewTrafficSource.discoveryPopular,
                   ),

--- a/mobile/lib/widgets/profile/profile_collabs_grid.dart
+++ b/mobile/lib/widgets/profile/profile_collabs_grid.dart
@@ -7,12 +7,14 @@ import 'dart:async';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/blocs/profile_collab_videos/profile_collab_videos_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/grid_prefetch_mixin.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/profile/profile_tab_empty_state.dart';
@@ -25,17 +27,17 @@ import 'package:unified_logger/unified_logger.dart';
 /// Grid widget displaying user's collab videos.
 ///
 /// Requires [ProfileCollabVideosBloc] to be provided in the widget tree.
-class ProfileCollabsGrid extends StatefulWidget {
+class ProfileCollabsGrid extends ConsumerStatefulWidget {
   const ProfileCollabsGrid({required this.isOwnProfile, super.key});
 
   /// Whether this is the current user's own profile.
   final bool isOwnProfile;
 
   @override
-  State<ProfileCollabsGrid> createState() => _ProfileCollabsGridState();
+  ConsumerState<ProfileCollabsGrid> createState() => _ProfileCollabsGridState();
 }
 
-class _ProfileCollabsGridState extends State<ProfileCollabsGrid>
+class _ProfileCollabsGridState extends ConsumerState<ProfileCollabsGrid>
     with GridPrefetchMixin, ScrollPaginationMixin {
   /// Resolved from [PrimaryScrollController] provided by [NestedScrollView].
   ScrollController? _primaryScrollController;
@@ -95,6 +97,7 @@ class _ProfileCollabsGridState extends State<ProfileCollabsGrid>
       extra: PooledFullscreenVideoFeedArgs(
         videosStream: Stream.value(allVideos),
         initialIndex: index,
+        removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
         trafficSource: ViewTrafficSource.profile,
       ),
     );

--- a/mobile/lib/widgets/profile/profile_liked_grid.dart
+++ b/mobile/lib/widgets/profile/profile_liked_grid.dart
@@ -6,11 +6,13 @@ import 'dart:async';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/blocs/profile_liked_videos/profile_liked_videos_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/profile/profile_tab_empty_state.dart';
@@ -129,7 +131,7 @@ class _ProfileLikedGridState extends State<ProfileLikedGrid>
 }
 
 /// Individual liked video tile in the grid with heart badge
-class _LikedGridTile extends StatelessWidget {
+class _LikedGridTile extends ConsumerWidget {
   const _LikedGridTile({
     required this.videoEvent,
     required this.index,
@@ -141,7 +143,7 @@ class _LikedGridTile extends StatelessWidget {
   final List<VideoEvent> allVideos;
 
   @override
-  Widget build(BuildContext context) => Semantics(
+  Widget build(BuildContext context, WidgetRef ref) => Semantics(
     label: 'liked_video_thumbnail_$index',
     child: GestureDetector(
       onTap: () {
@@ -155,6 +157,9 @@ class _LikedGridTile extends StatelessWidget {
           extra: PooledFullscreenVideoFeedArgs(
             videosStream: Stream.value(allVideos),
             initialIndex: index,
+            removedIdsStream: ref
+                .read(videoEventServiceProvider)
+                .removedVideoIds,
             trafficSource: ViewTrafficSource.profile,
           ),
         );

--- a/mobile/lib/widgets/profile/profile_reposts_grid.dart
+++ b/mobile/lib/widgets/profile/profile_reposts_grid.dart
@@ -6,11 +6,13 @@ import 'dart:async';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/profile/profile_tab_empty_state.dart';
@@ -129,7 +131,7 @@ class _ProfileRepostsGridState extends State<ProfileRepostsGrid>
 }
 
 /// Individual repost tile in the grid with repost badge
-class _RepostGridTile extends StatelessWidget {
+class _RepostGridTile extends ConsumerWidget {
   const _RepostGridTile({
     required this.videoEvent,
     required this.index,
@@ -141,7 +143,7 @@ class _RepostGridTile extends StatelessWidget {
   final List<VideoEvent> allVideos;
 
   @override
-  Widget build(BuildContext context) => GestureDetector(
+  Widget build(BuildContext context, WidgetRef ref) => GestureDetector(
     onTap: () {
       Log.info(
         '🎯 ProfileRepostsGrid TAP: gridIndex=$index, '
@@ -154,6 +156,7 @@ class _RepostGridTile extends StatelessWidget {
         extra: PooledFullscreenVideoFeedArgs(
           videosStream: Stream.value(allVideos),
           initialIndex: index,
+          removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
           trafficSource: ViewTrafficSource.profile,
         ),
       );

--- a/mobile/lib/widgets/profile/profile_saved_grid.dart
+++ b/mobile/lib/widgets/profile/profile_saved_grid.dart
@@ -6,11 +6,13 @@ import 'dart:async';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/blocs/profile_saved_videos/profile_saved_videos_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/profile/profile_tab_empty_state.dart';
@@ -126,7 +128,7 @@ class _ProfileSavedGridState extends State<ProfileSavedGrid>
 }
 
 /// Individual saved video tile in the grid.
-class _SavedGridTile extends StatelessWidget {
+class _SavedGridTile extends ConsumerWidget {
   const _SavedGridTile({
     required this.videoEvent,
     required this.index,
@@ -138,7 +140,7 @@ class _SavedGridTile extends StatelessWidget {
   final List<VideoEvent> allVideos;
 
   @override
-  Widget build(BuildContext context) => Semantics(
+  Widget build(BuildContext context, WidgetRef ref) => Semantics(
     label: 'saved_video_thumbnail_$index',
     child: GestureDetector(
       onTap: () {
@@ -152,6 +154,9 @@ class _SavedGridTile extends StatelessWidget {
           extra: PooledFullscreenVideoFeedArgs(
             videosStream: Stream.value(allVideos),
             initialIndex: index,
+            removedIdsStream: ref
+                .read(videoEventServiceProvider)
+                .removedVideoIds,
             trafficSource: ViewTrafficSource.profile,
           ),
         );

--- a/mobile/lib/widgets/profile/profile_video_feed_view.dart
+++ b/mobile/lib/widgets/profile/profile_video_feed_view.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/profile_feed_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
@@ -125,6 +126,7 @@ class _ProfileVideoFeedViewState extends ConsumerState<ProfileVideoFeedView> {
                 .loadMore()
           : null,
       hasMoreStream: _hasMoreController.stream.startWith(hasMoreContent),
+      removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
       onPageChanged: widget.onPageChanged,
     );
   }

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -172,6 +172,7 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
         hasMoreStream: _hasMoreStreamController.stream.startWith(
           hasMoreContent,
         ),
+        removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
         trafficSource: ViewTrafficSource.profile,
       ),
     );

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -1078,9 +1078,213 @@ void main() {
         expect(event.props, equals(['abc']));
       });
 
+      test('FullscreenFeedVideoRemoved props contains videoId', () {
+        const event = FullscreenFeedVideoRemoved('abc');
+        expect(event.props, equals(['abc']));
+      });
+
       test('FullscreenFeedSkipAcknowledged props is empty', () {
         const event = FullscreenFeedSkipAcknowledged();
         expect(event.props, isEmpty);
+      });
+    });
+
+    group('FullscreenFeedVideoRemoved', () {
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'removes the video from state.videos and clamps the current index',
+        build: () => createBloc(initialIndex: 1),
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(Duration.zero);
+          videosController.add([
+            createTestVideo('a'),
+            createTestVideo('b'),
+            createTestVideo('c'),
+          ]);
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(const FullscreenFeedVideoRemoved('b'));
+          await Future<void>.delayed(Duration.zero);
+        },
+        verify: (bloc) {
+          expect(bloc.state.videos.map((v) => v.id), equals(['a', 'c']));
+          expect(bloc.state.currentIndex, 1);
+          expect(bloc.state.removedVideoIds, contains('b'));
+          expect(
+            bloc.state.status,
+            isNot(FullscreenFeedStatus.emptyAfterRemoval),
+          );
+        },
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'transitions to emptyAfterRemoval when the last video is removed',
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(Duration.zero);
+          videosController.add([createTestVideo('only')]);
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(const FullscreenFeedVideoRemoved('only'));
+          await Future<void>.delayed(Duration.zero);
+        },
+        verify: (bloc) {
+          expect(bloc.state.videos, isEmpty);
+          expect(bloc.state.removedVideoIds, contains('only'));
+          expect(bloc.state.status, FullscreenFeedStatus.emptyAfterRemoval);
+        },
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'second removal of the same id is a no-op (dedupe)',
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(Duration.zero);
+          videosController.add([
+            createTestVideo('a'),
+            createTestVideo('b'),
+          ]);
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(const FullscreenFeedVideoRemoved('a'));
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(const FullscreenFeedVideoRemoved('a'));
+          await Future<void>.delayed(Duration.zero);
+        },
+        verify: (bloc) {
+          expect(bloc.state.videos.map((v) => v.id), equals(['b']));
+          expect(bloc.state.removedVideoIds, equals({'a'}));
+        },
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'records dedupe even when video is not in the visible list',
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(Duration.zero);
+          videosController.add([createTestVideo('a')]);
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(const FullscreenFeedVideoRemoved('not-present'));
+          await Future<void>.delayed(Duration.zero);
+        },
+        verify: (bloc) {
+          expect(bloc.state.videos.map((v) => v.id), equals(['a']));
+          expect(bloc.state.removedVideoIds, contains('not-present'));
+        },
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'shifts currentIndex left when removed item is before the cursor',
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(Duration.zero);
+          videosController.add([
+            createTestVideo('a'),
+            createTestVideo('b'),
+            createTestVideo('c'),
+            createTestVideo('d'),
+          ]);
+          await Future<void>.delayed(Duration.zero);
+          // Move cursor to 'c' (index 2).
+          bloc.add(const FullscreenFeedIndexChanged(2));
+          await Future<void>.delayed(Duration.zero);
+          // Remove 'a' (index 0, before the cursor).
+          bloc.add(const FullscreenFeedVideoRemoved('a'));
+          await Future<void>.delayed(Duration.zero);
+        },
+        verify: (bloc) {
+          expect(bloc.state.videos.map((v) => v.id), equals(['b', 'c', 'd']));
+          // Without the shift, currentIndex would stay at 2 → bloc would
+          // surface 'd'. The cursor must follow 'c' to its new position.
+          expect(bloc.state.currentIndex, 1);
+          expect(bloc.state.currentVideo?.id, 'c');
+          expect(bloc.state.removedVideoIds, contains('a'));
+        },
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'leaves currentIndex unchanged when removed item is after the cursor',
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(Duration.zero);
+          videosController.add([
+            createTestVideo('a'),
+            createTestVideo('b'),
+            createTestVideo('c'),
+          ]);
+          await Future<void>.delayed(Duration.zero);
+          // Cursor on 'a'.
+          bloc.add(const FullscreenFeedIndexChanged(0));
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(const FullscreenFeedVideoRemoved('c'));
+          await Future<void>.delayed(Duration.zero);
+        },
+        verify: (bloc) {
+          expect(bloc.state.videos.map((v) => v.id), equals(['a', 'b']));
+          expect(bloc.state.currentIndex, 0);
+          expect(bloc.state.currentVideo?.id, 'a');
+        },
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'subscribes to removedIdsStream and dispatches removals',
+        build: () {
+          final removedController = StreamController<String>.broadcast();
+          addTearDown(removedController.close);
+          final bloc = FullscreenFeedBloc(
+            videosStream: videosController.stream,
+            initialIndex: 0,
+            removedIdsStream: removedController.stream,
+            mediaCache: mockMediaCache,
+            blossomAuthService: mockBlossomAuth,
+          );
+          // Schedule the removal AFTER the bloc subscribes inside _onStarted.
+          Future<void>(() async {
+            await Future<void>.delayed(const Duration(milliseconds: 1));
+            videosController.add([
+              createTestVideo('a'),
+              createTestVideo('b'),
+            ]);
+            await Future<void>.delayed(const Duration(milliseconds: 1));
+            removedController.add('a');
+          });
+          return bloc;
+        },
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        },
+        verify: (bloc) {
+          expect(bloc.state.videos.map((v) => v.id), equals(['b']));
+          expect(bloc.state.removedVideoIds, contains('a'));
+        },
+      );
+
+      test('close() cancels the removedIdsStream subscription', () async {
+        final removedController = StreamController<String>.broadcast();
+        addTearDown(removedController.close);
+
+        final bloc = FullscreenFeedBloc(
+          videosStream: videosController.stream,
+          initialIndex: 0,
+          removedIdsStream: removedController.stream,
+          mediaCache: mockMediaCache,
+          blossomAuthService: mockBlossomAuth,
+        );
+        bloc.add(const FullscreenFeedStarted());
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+        videosController.add([createTestVideo('a'), createTestVideo('b')]);
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+
+        await bloc.close();
+
+        // Adding to the stream after close must NOT fire any further state
+        // transitions — the bloc has been disposed.
+        removedController.add('a');
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        expect(bloc.isClosed, isTrue);
       });
     });
   });

--- a/mobile/test/providers/profile_feed_pagination_contract_test.dart
+++ b/mobile/test/providers/profile_feed_pagination_contract_test.dart
@@ -150,6 +150,9 @@ void main() {
       ).thenAnswer((invocation) {
         return invocation.positionalArguments.single as List<VideoEvent>;
       });
+      when(
+        () => mockVideoEventService.isVideoLocallyDeleted(any()),
+      ).thenReturn(false);
     });
 
     ProviderContainer createContainer({bool funnelcakeAvailable = true}) {

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -20,6 +21,7 @@ import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/features/feature_flags/services/build_configuration.dart';
 import 'package:openvine/features/feature_flags/services/feature_flag_service.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/media_auth_interceptor.dart';
@@ -199,6 +201,18 @@ MockPlayer stubPlayer(
   return player;
 }
 
+class _PopCountingObserver extends NavigatorObserver {
+  _PopCountingObserver({required this.onPop});
+
+  final VoidCallback onPop;
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    onPop();
+  }
+}
+
 void main() {
   group('PooledFullscreenVideoFeedScreen', () {
     late MockFullscreenFeedBloc mockBloc;
@@ -215,6 +229,7 @@ void main() {
       registerFallbackValue(const FullscreenFeedLoadMoreRequested());
       registerFallbackValue(const FullscreenFeedVideoCacheStarted(index: 0));
       registerFallbackValue(const FullscreenFeedVideoUnavailable('fallback'));
+      registerFallbackValue(const FullscreenFeedVideoRemoved('fallback'));
       registerFallbackValue(const FullscreenFeedSkipAcknowledged());
       registerFallbackValue(Duration.zero);
       registerFallbackValue(LoadState.none);
@@ -332,6 +347,89 @@ void main() {
         expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
         expect(find.byType(PooledVideoFeed), findsNothing);
       });
+
+      testWidgets(
+        'renders empty-state when status is emptyAfterRemoval and pop is a '
+        'no-op (cold deep-link fallback)',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(
+              state: const FullscreenFeedState(
+                status: FullscreenFeedStatus.emptyAfterRemoval,
+              ),
+              contextTitle: 'Saved',
+            ),
+          );
+
+          // The BlocListener tries to maybePop, but `buildSubject` does
+          // not push the screen onto a route stack with a parent — so
+          // pop is a no-op and the BlocBuilder must render the
+          // empty-state branch instead of the loading spinner.
+          final removedText = lookupAppLocalizations(
+            const Locale('en'),
+          ).fullscreenFeedRemovedMessage;
+          expect(find.text(removedText), findsOneWidget);
+          expect(find.byType(BrandedLoadingIndicator), findsNothing);
+          expect(find.byType(PooledVideoFeed), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'empty-state back button falls back to root when route cannot pop',
+        (tester) async {
+          // When the BlocListener's `maybePop` was a no-op (cold deep-link
+          // into the fullscreen with no parent route), the appbar back
+          // button must NOT also be a no-op — that would leave the user
+          // stranded on "Video removed" with no way out. The closure in
+          // pooled_fullscreen_video_feed_screen.dart navigates to "/" in
+          // that case; this test verifies the fallback fires.
+          var sentinelBuilt = false;
+          final router = GoRouter(
+            initialLocation: '/empty-feed',
+            routes: [
+              GoRoute(
+                path: '/',
+                builder: (_, _) {
+                  sentinelBuilt = true;
+                  return const Scaffold(body: Text('home-sentinel'));
+                },
+              ),
+              GoRoute(
+                path: '/empty-feed',
+                builder: (_, _) => Scaffold(
+                  appBar: AppBar(
+                    leading: Builder(
+                      builder: (context) => BackButton(
+                        onPressed: () =>
+                            context.canPop() ? context.pop() : context.go('/'),
+                      ),
+                    ),
+                  ),
+                  body: const Center(child: Text('empty-state-body')),
+                ),
+              ),
+            ],
+          );
+          addTearDown(router.dispose);
+
+          await tester.pumpWidget(
+            MaterialApp.router(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              routerConfig: router,
+            ),
+          );
+          await tester.pumpAndSettle();
+          expect(find.text('empty-state-body'), findsOneWidget);
+
+          await tester.tap(find.byType(BackButton));
+          await tester.pumpAndSettle();
+
+          expect(sentinelBuilt, isTrue);
+          expect(find.text('home-sentinel'), findsOneWidget);
+          expect(find.text('empty-state-body'), findsNothing);
+        },
+      );
 
       testWidgets('shows "No videos available" when videos have no videoUrl', (
         tester,
@@ -584,6 +682,108 @@ void main() {
           () => mockBloc.add(const FullscreenFeedLoadMoreRequested()),
         ).called(1);
       });
+
+      testWidgets(
+        'navigator.maybePop fires when status becomes emptyAfterRemoval',
+        (tester) async {
+          // Capture pops via a NavigatorObserver. The widget tree puts
+          // FullscreenFeedContent on top of a sentinel route; when the
+          // status flips to emptyAfterRemoval the BlocListener calls
+          // maybePop and we observe the route transition here.
+          var popCount = 0;
+          final observer = _PopCountingObserver(onPop: () => popCount++);
+
+          final videos = createTestVideos(count: 1);
+          final initialState = FullscreenFeedState(
+            status: FullscreenFeedStatus.ready,
+            videos: videos,
+          );
+          final emptyState = FullscreenFeedState(
+            status: FullscreenFeedStatus.emptyAfterRemoval,
+            removedVideoIds: {videos.first.id},
+          );
+
+          // Drive the bloc state via a controller so we can sequence the
+          // emit AFTER the route push and after the BlocListener has
+          // subscribed. Stream.fromIterable would consume synchronously
+          // and the listener — registered later, in the pushed route —
+          // would never see the transition.
+          final controller = StreamController<FullscreenFeedState>();
+          addTearDown(controller.close);
+          whenListen(
+            mockBloc,
+            controller.stream,
+            initialState: initialState,
+          );
+
+          await tester.pumpWidget(
+            MaterialApp(
+              navigatorObservers: [observer],
+              home: Builder(
+                builder: (context) {
+                  return Scaffold(
+                    body: ElevatedButton(
+                      onPressed: () => Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => MultiBlocProvider(
+                            providers: [
+                              BlocProvider<FullscreenFeedBloc>.value(
+                                value: mockBloc,
+                              ),
+                              BlocProvider<VideoVolumeCubit>.value(
+                                value: videoVolumeCubit,
+                              ),
+                              BlocProvider<VideoPlaybackStatusCubit>(
+                                create: (_) => VideoPlaybackStatusCubit(),
+                              ),
+                            ],
+                            // Tiny inline widget — we only care about the
+                            // pop-on-emptyAfterRemoval listener; a full
+                            // FullscreenFeedContent would require a real
+                            // PlayerPool + controller.
+                            child:
+                                BlocListener<
+                                  FullscreenFeedBloc,
+                                  FullscreenFeedState
+                                >(
+                                  listenWhen: (prev, curr) =>
+                                      prev.status != curr.status &&
+                                      curr.status ==
+                                          FullscreenFeedStatus
+                                              .emptyAfterRemoval,
+                                  listener: (ctx, _) {
+                                    Navigator.of(ctx).maybePop();
+                                  },
+                                  child: const Scaffold(
+                                    body: Text('on-feed'),
+                                  ),
+                                ),
+                          ),
+                        ),
+                      ),
+                      child: const Text('open'),
+                    ),
+                  );
+                },
+              ),
+            ),
+          );
+
+          // Push the feed content. After pumpAndSettle the BlocListener
+          // is mounted and subscribed.
+          await tester.tap(find.text('open'));
+          await tester.pumpAndSettle();
+          expect(find.text('on-feed'), findsOneWidget);
+
+          // Drive the transition. The listener fires on the status change
+          // and calls maybePop.
+          controller.add(emptyState);
+          await tester.pumpAndSettle();
+
+          expect(popCount, greaterThanOrEqualTo(1));
+          expect(find.text('on-feed'), findsNothing);
+        },
+      );
     });
 
     group('hook wiring', () {

--- a/mobile/test/screens/profile_grid_tap_navigation_test.dart
+++ b/mobile/test/screens/profile_grid_tap_navigation_test.dart
@@ -21,6 +21,7 @@ import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
+import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/state/video_feed_state.dart';
 import 'package:openvine/widgets/profile/profile_videos_grid.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
@@ -31,6 +32,11 @@ import '../helpers/test_provider_overrides.dart';
 class _MockBackgroundPublishBloc
     extends MockBloc<BackgroundPublishEvent, BackgroundPublishState>
     implements BackgroundPublishBloc {}
+
+class _FakeVideoEventService extends Mock implements VideoEventService {
+  @override
+  Stream<String> get removedVideoIds => const Stream<String>.empty();
+}
 
 class _TestProfileFeed extends ProfileFeed {
   _TestProfileFeed(this._initialState);
@@ -613,6 +619,9 @@ void main() {
                 VideoFeedState(videos: mockVideos, hasMoreContent: true),
               ),
             ),
+            videoEventServiceProvider.overrideWithValue(
+              _FakeVideoEventService(),
+            ),
           ],
           child: BlocProvider<BackgroundPublishBloc>.value(
             value: backgroundPublishBloc,
@@ -631,6 +640,7 @@ void main() {
 
       expect(capturedArgs, isNotNull);
       expect(capturedArgs!.hasMoreStream, isNotNull);
+      expect(capturedArgs!.removedIdsStream, isNotNull);
     });
   });
 }

--- a/mobile/test/services/video_event_service_blocklist_sweep_test.dart
+++ b/mobile/test/services/video_event_service_blocklist_sweep_test.dart
@@ -1,0 +1,204 @@
+// ABOUTME: Tests the block/mute bus bridge — VideoEventService subscribes to
+// ContentBlocklistRepository.changes and emits removedVideoIds for every
+// cached video by the affected author when an "addition" event fires.
+
+@Tags(['skip_very_good_optimization'])
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+VideoEvent _video({required String id, required String pubkey}) {
+  final now = DateTime.now();
+  return VideoEvent(
+    id: id,
+    pubkey: pubkey,
+    createdAt: now.millisecondsSinceEpoch ~/ 1000,
+    content: '',
+    timestamp: now,
+    title: id,
+    videoUrl: 'https://example.com/$id.mp4',
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<Filter>[]);
+  });
+
+  group('VideoEventService blocklist sweep', () {
+    late VideoEventService service;
+    late ContentBlocklistRepository blocklistRepo;
+    late _MockNostrClient nostrClient;
+    late _MockSubscriptionManager subscriptionManager;
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      subscriptionManager = _MockSubscriptionManager();
+      when(() => nostrClient.isInitialized).thenReturn(true);
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(
+        () => nostrClient.subscribe(any()),
+      ).thenAnswer((_) => const Stream<Event>.empty());
+
+      service = VideoEventService(
+        nostrClient,
+        subscriptionManager: subscriptionManager,
+      );
+      // No prefs — in-memory blocklist for the test.
+      blocklistRepo = ContentBlocklistRepository();
+      service.setBlocklistRepository(blocklistRepo);
+    });
+
+    tearDown(() {
+      service.dispose();
+      blocklistRepo.dispose();
+    });
+
+    test(
+      'blockUser triggers a sweep — removedVideoIds emits every cached id '
+      'for the blocked author',
+      () async {
+        const author = 'author-pubkey';
+        service.debugSeedAuthorBucket(author, [
+          _video(id: 'v1', pubkey: author),
+          _video(id: 'v2', pubkey: author),
+          _video(id: 'v3', pubkey: author),
+        ]);
+
+        final emitted = <String>[];
+        final sub = service.removedVideoIds.listen(emitted.add);
+        addTearDown(sub.cancel);
+
+        await blocklistRepo.blockUser(author);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emitted, containsAll(['v1', 'v2', 'v3']));
+        expect(emitted.length, 3);
+      },
+    );
+
+    test('unblockUser does NOT trigger a sweep (no-op for removals)', () async {
+      const author = 'author-pubkey';
+      await blocklistRepo.blockUser(author); // pre-block so unblock fires
+      service.debugSeedAuthorBucket(author, [
+        _video(id: 'v1', pubkey: author),
+      ]);
+
+      // Listener after pre-block so the initial blocked emit isn't counted.
+      final emitted = <String>[];
+      final sub = service.removedVideoIds.listen(emitted.add);
+      addTearDown(sub.cancel);
+
+      await blocklistRepo.unblockUser(author);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, isEmpty);
+    });
+
+    test(
+      'sweep does NOT add ids to _locallyDeletedVideoIds (block is reversible)',
+      () async {
+        const author = 'author-pubkey';
+        service.debugSeedAuthorBucket(author, [
+          _video(id: 'v1', pubkey: author),
+        ]);
+
+        await blocklistRepo.blockUser(author);
+        await Future<void>.delayed(Duration.zero);
+
+        // The session-tombstone set is reserved for irrevocable
+        // user-initiated deletions. Unblocking should restore visibility,
+        // which would be impossible if we polluted the tombstone set.
+        expect(service.isVideoLocallyDeleted('v1'), isFalse);
+      },
+    );
+
+    test('block on author with no cached videos is a silent no-op', () async {
+      final emitted = <String>[];
+      final sub = service.removedVideoIds.listen(emitted.add);
+      addTearDown(sub.cancel);
+
+      await blocklistRepo.blockUser('unknown-author');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, isEmpty);
+    });
+
+    test(
+      're-blocking the same author is dedupe at the repository level — no '
+      'duplicate sweep',
+      () async {
+        const author = 'author-pubkey';
+        service.debugSeedAuthorBucket(author, [
+          _video(id: 'v1', pubkey: author),
+        ]);
+
+        await blocklistRepo.blockUser(author);
+        await Future<void>.delayed(Duration.zero);
+
+        final emitted = <String>[];
+        final sub = service.removedVideoIds.listen(emitted.add);
+        addTearDown(sub.cancel);
+
+        await blocklistRepo.blockUser(author); // already blocked → no-op
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emitted, isEmpty);
+      },
+    );
+
+    test(
+      'dispose cancels the blocklist subscription (further repo emits are '
+      'ignored without errors)',
+      () async {
+        // Build a separate service so the global tearDown does not double-
+        // dispose. Pre-existing helpers (`service`, `blocklistRepo`) stay
+        // owned by the outer setUp/tearDown.
+        final localNostr = _MockNostrClient();
+        when(() => localNostr.isInitialized).thenReturn(true);
+        when(() => localNostr.connectedRelayCount).thenReturn(1);
+        when(
+          () => localNostr.subscribe(any()),
+        ).thenAnswer((_) => const Stream<Event>.empty());
+        final localService = VideoEventService(
+          localNostr,
+          subscriptionManager: subscriptionManager,
+        );
+        final localRepo = ContentBlocklistRepository();
+        addTearDown(localRepo.dispose);
+
+        localService.setBlocklistRepository(localRepo);
+        const author = 'author-pubkey';
+        localService.debugSeedAuthorBucket(author, [
+          _video(id: 'v1', pubkey: author),
+        ]);
+
+        final emitted = <String>[];
+        final sub = localService.removedVideoIds.listen(
+          emitted.add,
+          onError: (Object _) {},
+        );
+        addTearDown(sub.cancel);
+
+        localService.dispose();
+
+        // Repo is still live; emit a Blocked. The cancelled subscription
+        // means the bus does not see this event.
+        await localRepo.blockUser(author);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emitted, isEmpty);
+      },
+    );
+  });
+}

--- a/mobile/test/services/video_event_service_deletion_test.dart
+++ b/mobile/test/services/video_event_service_deletion_test.dart
@@ -1,0 +1,124 @@
+// ABOUTME: Tests the deletion side-channel — removeVideoCompletely fires on
+// the removedVideoIds broadcast stream so subscribers (FullscreenFeedBloc,
+// profileFeedProvider) can drop the id without waiting for a route change.
+
+@Tags(['skip_very_good_optimization'])
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<Filter>[]);
+  });
+
+  group('VideoEventService.removedVideoIds', () {
+    late VideoEventService service;
+    late _MockNostrClient nostrClient;
+    late _MockSubscriptionManager subscriptionManager;
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      subscriptionManager = _MockSubscriptionManager();
+      when(() => nostrClient.isInitialized).thenReturn(true);
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(
+        () => nostrClient.subscribe(any()),
+      ).thenAnswer((_) => const Stream<Event>.empty());
+
+      service = VideoEventService(
+        nostrClient,
+        subscriptionManager: subscriptionManager,
+      );
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    test('removeVideoCompletely emits the id on the bus', () async {
+      final emitted = <String>[];
+      final sub = service.removedVideoIds.listen(emitted.add);
+
+      service.removeVideoCompletely('vid-1');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, equals(['vid-1']));
+      await sub.cancel();
+    });
+
+    test('emits even when the video was not in any active feed', () async {
+      // Mirrors the log line "Video ... marked as deleted (was not in any
+      // active feeds)" — the side-channel must still fire so a fullscreen
+      // bloc holding the id in its own list drops it.
+      final emitted = <String>[];
+      final sub = service.removedVideoIds.listen(emitted.add);
+
+      service.removeVideoCompletely('phantom');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, equals(['phantom']));
+      await sub.cancel();
+    });
+
+    test('emits one event per call, in dispatch order', () async {
+      final emitted = <String>[];
+      final sub = service.removedVideoIds.listen(emitted.add);
+
+      service
+        ..removeVideoCompletely('a')
+        ..removeVideoCompletely('b')
+        ..removeVideoCompletely('c');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, equals(['a', 'b', 'c']));
+      await sub.cancel();
+    });
+
+    test('broadcast: a late subscriber misses past emits but receives '
+        'future emits', () async {
+      final earlyEmits = <String>[];
+      final lateEmits = <String>[];
+
+      final earlySub = service.removedVideoIds.listen(earlyEmits.add);
+      service.removeVideoCompletely('past');
+      await Future<void>.delayed(Duration.zero);
+
+      final lateSub = service.removedVideoIds.listen(lateEmits.add);
+      service.removeVideoCompletely('future');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(earlyEmits, equals(['past', 'future']));
+      expect(lateEmits, equals(['future']));
+
+      await earlySub.cancel();
+      await lateSub.cancel();
+    });
+
+    test('isVideoLocallyDeleted reflects the tombstone after emit', () {
+      service.removeVideoCompletely('vid-1');
+      expect(service.isVideoLocallyDeleted('vid-1'), isTrue);
+      expect(service.isVideoLocallyDeleted('vid-2'), isFalse);
+    });
+
+    test('dispose closes the stream', () async {
+      final sub = service.removedVideoIds.listen((_) {});
+      service.dispose();
+      // Re-create for tearDown safety — overrides the field.
+      service = VideoEventService(
+        nostrClient,
+        subscriptionManager: subscriptionManager,
+      );
+      // The original subscription should complete cleanly.
+      await sub.cancel();
+    });
+  });
+}

--- a/mobile/test/widgets/profile/profile_collabs_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_collabs_grid_test.dart
@@ -3,11 +3,15 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_collab_videos/profile_collab_videos_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/profile/profile_collabs_grid.dart';
 
 import '../../helpers/go_router.dart';
@@ -15,6 +19,11 @@ import '../../helpers/go_router.dart';
 class _MockProfileCollabVideosBloc
     extends MockBloc<ProfileCollabVideosEvent, ProfileCollabVideosState>
     implements ProfileCollabVideosBloc {}
+
+class _FakeVideoEventService extends Mock implements VideoEventService {
+  @override
+  Stream<String> get removedVideoIds => const Stream<String>.empty();
+}
 
 List<VideoEvent> _createTestVideos({int count = 2}) {
   final now = DateTime.now();
@@ -62,10 +71,18 @@ void main() {
           ),
         ),
       );
+      final scoped = ProviderScope(
+        overrides: [
+          videoEventServiceProvider.overrideWithValue(
+            _FakeVideoEventService(),
+          ),
+        ],
+        child: app,
+      );
       if (goRouter != null) {
-        return MockGoRouterProvider(goRouter: goRouter, child: app);
+        return MockGoRouterProvider(goRouter: goRouter, child: scoped);
       }
-      return app;
+      return scoped;
     }
 
     group('renders', () {
@@ -223,6 +240,35 @@ void main() {
           ),
         ).called(1);
       });
+
+      testWidgets(
+        'tap wires removedIdsStream so deletion / block / mute drop the '
+        'video without an app restart',
+        (tester) async {
+          final videos = _createTestVideos(count: 3);
+          when(() => mockBloc.state).thenReturn(
+            ProfileCollabVideosState(
+              status: ProfileCollabVideosStatus.success,
+              videos: videos,
+            ),
+          );
+
+          await tester.pumpWidget(buildSubject(goRouter: mockGoRouter));
+
+          await tester.tap(find.byType(GestureDetector).first);
+          await tester.pumpAndSettle();
+
+          final captured = verify(
+            () => mockGoRouter.push<Object?>(
+              any(),
+              extra: captureAny(named: 'extra'),
+            ),
+          ).captured;
+          expect(captured, hasLength(1));
+          final args = captured.single as PooledFullscreenVideoFeedArgs;
+          expect(args.removedIdsStream, isNotNull);
+        },
+      );
     });
 
     group('scroll coordination with NestedScrollView', () {
@@ -238,20 +284,27 @@ void main() {
           );
 
           await tester.pumpWidget(
-            MaterialApp(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              theme: VineTheme.theme,
-              home: Scaffold(
-                body: NestedScrollView(
-                  headerSliverBuilder: (context, innerBoxIsScrolled) => [
-                    const SliverToBoxAdapter(
-                      child: SizedBox(height: 200),
+            ProviderScope(
+              overrides: [
+                videoEventServiceProvider.overrideWithValue(
+                  _FakeVideoEventService(),
+                ),
+              ],
+              child: MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                theme: VineTheme.theme,
+                home: Scaffold(
+                  body: NestedScrollView(
+                    headerSliverBuilder: (context, innerBoxIsScrolled) => [
+                      const SliverToBoxAdapter(
+                        child: SizedBox(height: 200),
+                      ),
+                    ],
+                    body: BlocProvider<ProfileCollabVideosBloc>.value(
+                      value: mockBloc,
+                      child: const ProfileCollabsGrid(isOwnProfile: true),
                     ),
-                  ],
-                  body: BlocProvider<ProfileCollabVideosBloc>.value(
-                    value: mockBloc,
-                    child: const ProfileCollabsGrid(isOwnProfile: true),
                   ),
                 ),
               ),
@@ -280,26 +333,33 @@ void main() {
           );
 
           await tester.pumpWidget(
-            MaterialApp(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              theme: VineTheme.theme,
-              home: Scaffold(
-                body: NestedScrollView(
-                  headerSliverBuilder: (context, innerBoxIsScrolled) => [
-                    const SliverToBoxAdapter(
-                      child: SizedBox(
-                        height: 200,
-                        child: ColoredBox(
-                          color: Colors.red,
-                          child: Center(child: Text('Header')),
+            ProviderScope(
+              overrides: [
+                videoEventServiceProvider.overrideWithValue(
+                  _FakeVideoEventService(),
+                ),
+              ],
+              child: MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                theme: VineTheme.theme,
+                home: Scaffold(
+                  body: NestedScrollView(
+                    headerSliverBuilder: (context, innerBoxIsScrolled) => [
+                      const SliverToBoxAdapter(
+                        child: SizedBox(
+                          height: 200,
+                          child: ColoredBox(
+                            color: Colors.red,
+                            child: Center(child: Text('Header')),
+                          ),
                         ),
                       ),
+                    ],
+                    body: BlocProvider<ProfileCollabVideosBloc>.value(
+                      value: mockBloc,
+                      child: const ProfileCollabsGrid(isOwnProfile: true),
                     ),
-                  ],
-                  body: BlocProvider<ProfileCollabVideosBloc>.value(
-                    value: mockBloc,
-                    child: const ProfileCollabsGrid(isOwnProfile: true),
                   ),
                 ),
               ),

--- a/mobile/test/widgets/profile/profile_liked_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_liked_grid_test.dart
@@ -8,13 +8,21 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_liked_videos/profile_liked_videos_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/profile/profile_liked_grid.dart';
 
 import '../../helpers/go_router.dart';
+import '../../helpers/test_provider_overrides.dart';
 
 class _MockProfileLikedVideosBloc
     extends MockBloc<ProfileLikedVideosEvent, ProfileLikedVideosState>
     implements ProfileLikedVideosBloc {}
+
+class _FakeVideoEventService extends Mock implements VideoEventService {
+  @override
+  Stream<String> get removedVideoIds => const Stream<String>.empty();
+}
 
 List<VideoEvent> _createTestVideos({int count = 2}) {
   final now = DateTime.now();
@@ -51,14 +59,19 @@ void main() {
       bool isOwnProfile = true,
       MockGoRouter? goRouter,
     }) {
-      final app = MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: VineTheme.theme,
-        home: Scaffold(
-          body: BlocProvider<ProfileLikedVideosBloc>.value(
-            value: mockBloc,
-            child: ProfileLikedGrid(isOwnProfile: isOwnProfile),
+      final app = testProviderScope(
+        additionalOverrides: [
+          videoEventServiceProvider.overrideWithValue(_FakeVideoEventService()),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: Scaffold(
+            body: BlocProvider<ProfileLikedVideosBloc>.value(
+              value: mockBloc,
+              child: ProfileLikedGrid(isOwnProfile: isOwnProfile),
+            ),
           ),
         ),
       );

--- a/mobile/test/widgets/profile/profile_reposts_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_reposts_grid_test.dart
@@ -8,13 +8,21 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/profile/profile_reposts_grid.dart';
 
 import '../../helpers/go_router.dart';
+import '../../helpers/test_provider_overrides.dart';
 
 class _MockProfileRepostedVideosBloc
     extends MockBloc<ProfileRepostedVideosEvent, ProfileRepostedVideosState>
     implements ProfileRepostedVideosBloc {}
+
+class _FakeVideoEventService extends Mock implements VideoEventService {
+  @override
+  Stream<String> get removedVideoIds => const Stream<String>.empty();
+}
 
 List<VideoEvent> _createTestVideos({int count = 2}) {
   final now = DateTime.now();
@@ -51,14 +59,19 @@ void main() {
       bool isOwnProfile = true,
       MockGoRouter? goRouter,
     }) {
-      final app = MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: VineTheme.theme,
-        home: Scaffold(
-          body: BlocProvider<ProfileRepostedVideosBloc>.value(
-            value: mockBloc,
-            child: ProfileRepostsGrid(isOwnProfile: isOwnProfile),
+      final app = testProviderScope(
+        additionalOverrides: [
+          videoEventServiceProvider.overrideWithValue(_FakeVideoEventService()),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: Scaffold(
+            body: BlocProvider<ProfileRepostedVideosBloc>.value(
+              value: mockBloc,
+              child: ProfileRepostsGrid(isOwnProfile: isOwnProfile),
+            ),
           ),
         ),
       );

--- a/mobile/test/widgets/profile/profile_saved_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_saved_grid_test.dart
@@ -8,13 +8,21 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_saved_videos/profile_saved_videos_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/widgets/profile/profile_saved_grid.dart';
 
 import '../../helpers/go_router.dart';
+import '../../helpers/test_provider_overrides.dart';
 
 class _MockProfileSavedVideosBloc
     extends MockBloc<ProfileSavedVideosEvent, ProfileSavedVideosState>
     implements ProfileSavedVideosBloc {}
+
+class _FakeVideoEventService extends Mock implements VideoEventService {
+  @override
+  Stream<String> get removedVideoIds => const Stream<String>.empty();
+}
 
 List<VideoEvent> _createTestVideos({int count = 2}) {
   final now = DateTime.now();
@@ -48,14 +56,19 @@ void main() {
     });
 
     Widget buildSubject({MockGoRouter? goRouter}) {
-      final app = MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        theme: VineTheme.theme,
-        home: Scaffold(
-          body: BlocProvider<ProfileSavedVideosBloc>.value(
-            value: mockBloc,
-            child: const ProfileSavedGrid(),
+      final app = testProviderScope(
+        additionalOverrides: [
+          videoEventServiceProvider.overrideWithValue(_FakeVideoEventService()),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: Scaffold(
+            body: BlocProvider<ProfileSavedVideosBloc>.value(
+              value: mockBloc,
+              child: const ProfileSavedGrid(),
+            ),
           ),
         ),
       );


### PR DESCRIPTION
## Description

**Middle of a 3-PR stack** (stacked on #3394) for the deletion / block / mute "feed freezes" bug. Adds a side-channel removal bus on `VideoEventService` so subscribers react in real time to user-driven removals (deletion, block, mute) without waiting for a route change or app restart.

**No user-visible change yet.** The keystone PR (top of the stack) consumes this bus and is what closes the issues.

## Stack

1. #3394 — package: `BlocklistChange` value type + `changes` stream (this PR's base).
2. **This PR** — `VideoEventService` removal bus + sweep bridge.
3. **Top (closes #3328 / #3379 / #3381)** — `delete-video-fix/keystone` — bloc + screen + tombstone + 22 entry-point wires + l10n.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## What's in scope

- `Stream<String> get removedVideoIds` — broadcast controller emitted inside `removeVideoCompletely` BEFORE `notifyListeners` so stream and `ChangeNotifier` consumers update in the same frame. Documented as a side-channel — canonical truth is still service state + `isVideoLocallyDeleted`.
- `_sweepAuthor(pubkey)` — emits an event for every cached video id authored by `pubkey`, by walking `_authorBuckets`, `_eventLists`, and `_hashtagBuckets` (deduped by id). **Reversibility-safe**: deliberately does NOT add to `_locallyDeletedVideoIds`, so unblocking restores visibility on the next pagination via the existing `shouldHideVideo` / `filterVideoList` filters.
- `setBlocklistRepository` now subscribes to the repo's per-pubkey `changes` stream (#3394) and calls `_sweepAuthor` on `isAddition` events. Cancels prior subscription on re-attach to keep the bridge bound to the live repo.
- `@visibleForTesting void debugSeedAuthorBucket(...)` so the sweep can be exercised without a real relay subscription.
- `dispose` cancels the blocklist subscription and closes the controller.

## Intermediate-state safety

After PRs #3394 + this one merge alone (without the keystone): the bus emits on `removeVideoCompletely` and `_sweepAuthor`, but no consumer in `mobile/lib` subscribes. Broadcast streams without subscribers are no-ops. No regression.

## Test plan

- [x] `flutter analyze lib test integration_test` — clean
- [x] `flutter test test/services/video_event_service_deletion_test.dart test/services/video_event_service_blocklist_sweep_test.dart` — 12 pass
- [x] `removeVideoCompletely` emits, dedupe across active feeds, broadcast late-subscriber semantics, dispose closes stream — all covered.
- [x] `blockUser` triggers sweep; `unblockUser` does NOT; sweep doesn't pollute `_locallyDeletedVideoIds`; no-cached-videos no-op; re-block dedupe; dispose cancels subscription — all covered.