### PR TITLE
fix(video-editor): resolve incorrect layer output quality

### DIFF
--- a/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_preview_screen.dart
@@ -117,9 +117,9 @@ class _VideoMetadataPreviewScreenState
                   _VideoPreviewContent(
                     clip: widget.clip,
                     controller: _controller,
-                    isPreviewReady: _isPreviewReady,
-                    previewOnly: widget.previewOnly,
                   ),
+                  if (!widget.previewOnly)
+                    _PreviewOverlay(isPreviewReady: _isPreviewReady),
                   const _CloseButton(),
                 ],
               ),
@@ -137,21 +137,16 @@ class _VideoMetadataPreviewScreenState
   }
 }
 
-/// Container widget that wraps the video player and overlay in a hero
-/// transition.
+/// Container widget that wraps the video player in a hero transition.
 class _VideoPreviewContent extends ConsumerWidget {
   /// Creates the video preview content wrapper.
   const _VideoPreviewContent({
     required this.clip,
     required this.controller,
-    required this.isPreviewReady,
-    this.previewOnly = false,
   });
 
   final DivineVideoClip clip;
   final DivineVideoPlayerController? controller;
-  final ValueNotifier<bool> isPreviewReady;
-  final bool previewOnly;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -167,18 +162,9 @@ class _VideoPreviewContent extends ConsumerWidget {
           aspectRatio: aspectRatio,
           child: ClipRRect(
             borderRadius: BorderRadius.circular(16),
-            child: Stack(
-              fit: StackFit.expand,
-              children: [
-                // Video playback layer
-                DivineVideoPlayer(
-                  controller: controller,
-                  placeholder: VideoMetadataCapturePreviewThumbnail(clip: clip),
-                ),
-                // Metadata overlay layer
-                if (!previewOnly)
-                  _PreviewOverlay(isPreviewReady: isPreviewReady),
-              ],
+            child: DivineVideoPlayer(
+              controller: controller,
+              placeholder: VideoMetadataCapturePreviewThumbnail(clip: clip),
             ),
           ),
         ),
@@ -208,43 +194,40 @@ class _PreviewOverlay extends ConsumerWidget {
       nostrServiceProvider.select((s) => s.publicKey),
     );
 
-    // Non-interactive overlay with reduced opacity
-    return MediaQuery.removeViewPadding(
-      context: context,
-      removeBottom: true,
-      child: IgnorePointer(
-        child: Opacity(
-          opacity: 0.5,
-          child: Material(
-            type: .transparency,
-            child: ValueListenableBuilder(
-              valueListenable: isPreviewReady,
-              builder: (_, isActive, _) {
-                // Show overlay actions in preview mode
-                return Stack(
-                  fit: StackFit.expand,
-                  children: [
-                    const FeedModeSwitch(isPreviewMode: true),
-                    VideoOverlayActions(
-                      video: VideoEvent(
-                        id: 'id',
-                        pubkey: publicKey,
-                        timestamp: DateTime.now(),
-                        createdAt: DateTime.now().millisecondsSinceEpoch,
-                        content: metadata.title,
-                        hashtags: metadata.tags.toList(),
-                        originalLikes: 1,
-                        originalComments: 1,
-                        originalReposts: 1,
-                      ),
-                      isVisible: true,
-                      isActive: isActive,
-                      isPreviewMode: true,
+    // Non-interactive overlay with reduced opacity.
+    // Lives in the outer full-screen Stack so it always renders at
+    // phone-screen proportions, independent of the video's aspect ratio.
+    return IgnorePointer(
+      child: Opacity(
+        opacity: 0.5,
+        child: Material(
+          type: .transparency,
+          child: ValueListenableBuilder(
+            valueListenable: isPreviewReady,
+            builder: (_, isActive, _) {
+              return Stack(
+                fit: StackFit.expand,
+                children: [
+                  const FeedModeSwitch(isPreviewMode: true),
+                  VideoOverlayActions(
+                    video: VideoEvent(
+                      id: 'id',
+                      pubkey: publicKey,
+                      timestamp: DateTime.now(),
+                      createdAt: DateTime.now().millisecondsSinceEpoch,
+                      content: metadata.title,
+                      hashtags: metadata.tags.toList(),
+                      originalLikes: 1,
+                      originalComments: 1,
+                      originalReposts: 1,
                     ),
-                  ],
-                );
-              },
-            ),
+                    isVisible: true,
+                    isActive: isActive,
+                    isPreviewMode: true,
+                  ),
+                ],
+              );
+            },
           ),
         ),
       ),

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -844,6 +844,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
             ),
             imageGeneration: ImageGenerationConfigs(
               captureImageByteFormat: .rawStraightRgba,
+              outputFormat: .png,
               enableBackgroundGeneration: false,
               enableUseOriginalBytes: false,
               // Disabled in debug mode: combined RAM usage from the editor
@@ -920,7 +921,6 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
                     ),
                     ReactiveWidget(
                       builder: (context) => VideoEditorFeedPreviewOverlay(
-                        renderSize: widget.renderSize,
                         targetAspectRatio: targetAspectRatio.value,
                         isFeedPreviewVisible: editor.isLayerBeingTransformed,
                       ),

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_feed_preview_overlay.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_feed_preview_overlay.dart
@@ -22,16 +22,12 @@ import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 class VideoEditorFeedPreviewOverlay extends ConsumerWidget {
   /// Creates a [VideoEditorFeedPreviewOverlay].
   const VideoEditorFeedPreviewOverlay({
-    required this.renderSize,
     required this.targetAspectRatio,
     required this.isFeedPreviewVisible,
     super.key,
   });
 
   static const _animationDuration = Duration(milliseconds: 200);
-
-  /// The render size of the editor content (bodyItems coordinate space).
-  final Size renderSize;
 
   /// The target aspect ratio of the video being edited.
   final double targetAspectRatio;

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_player.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_player.dart
@@ -28,9 +28,7 @@ class VideoEditorPlayer extends StatelessWidget {
       clipper: _RoundedRectClipper(
         bodySize: bodySize,
         targetAspectRatio: targetAspectRatio.value,
-        borderRadius: targetAspectRatio == .square
-            ? 0
-            : VideoEditorConstants.canvasRadius,
+        borderRadius: VideoEditorConstants.canvasRadius,
       ),
       child: AspectRatio(
         aspectRatio: aspectRatio,

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_player.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_player.dart
@@ -28,7 +28,7 @@ class VideoEditorPlayer extends StatelessWidget {
       clipper: _RoundedRectClipper(
         bodySize: bodySize,
         targetAspectRatio: targetAspectRatio.value,
-        borderRadius: VideoEditorConstants.canvasRadius,
+        borderRadius: canvasBorderRadiusForAspectRatio(targetAspectRatio),
       ),
       child: AspectRatio(
         aspectRatio: aspectRatio,
@@ -39,6 +39,13 @@ class VideoEditorPlayer extends StatelessWidget {
       ),
     );
   }
+}
+
+@visibleForTesting
+double canvasBorderRadiusForAspectRatio(model.AspectRatio targetAspectRatio) {
+  return targetAspectRatio == model.AspectRatio.square
+      ? 0
+      : VideoEditorConstants.canvasRadius;
 }
 
 class _RoundedRectClipper extends CustomClipper<Path> {

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1800,10 +1800,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: b12229ecf7371f930f4acc3bdba2a69fd69330cf53b08bb28768db7f21b569c7
+      sha256: b9ef2e934b74c7e12e7803697433d00c12187fc83e210313ac20ec93370a61b4
       url: "https://pub.dev"
     source: hosted
-    version: "12.4.3"
+    version: "12.4.4"
   pro_video_editor:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -260,7 +260,7 @@ dependencies:
   convert: ^3.1.2
   audio_session: ^0.2.2
   pro_video_editor: ^1.15.0
-  pro_image_editor: ^12.4.3
+  pro_image_editor: ^12.4.4
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7
   sensors_plus: ^7.0.0

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_feed_preview_overlay_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_feed_preview_overlay_test.dart
@@ -1,7 +1,6 @@
 // ABOUTME: Unit tests for VideoEditorFeedPreviewOverlay.
 // ABOUTME: Verifies constructor wiring and widget type.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_feed_preview_overlay.dart';
@@ -10,19 +9,16 @@ void main() {
   group(VideoEditorFeedPreviewOverlay, () {
     test('stores constructor parameters', () {
       const overlay = VideoEditorFeedPreviewOverlay(
-        renderSize: Size(1080, 1920),
         targetAspectRatio: 9 / 16,
         isFeedPreviewVisible: true,
       );
 
-      expect(overlay.renderSize, equals(const Size(1080, 1920)));
       expect(overlay.targetAspectRatio, equals(9 / 16));
       expect(overlay.isFeedPreviewVisible, isTrue);
     });
 
     test('is a ConsumerWidget', () {
       const overlay = VideoEditorFeedPreviewOverlay(
-        renderSize: Size(300, 500),
         targetAspectRatio: 1,
         isFeedPreviewVisible: false,
       );

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_player_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_player_test.dart
@@ -1,9 +1,27 @@
 import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_player.dart';
 
 void main() {
+  group(canvasBorderRadiusForAspectRatio, () {
+    test('keeps square previews unrounded', () {
+      expect(
+        canvasBorderRadiusForAspectRatio(model.AspectRatio.square),
+        equals(0),
+      );
+    });
+
+    test('rounds non-square previews', () {
+      expect(
+        canvasBorderRadiusForAspectRatio(model.AspectRatio.vertical),
+        equals(VideoEditorConstants.canvasRadius),
+      );
+    });
+  });
+
   group(computeClipSize, () {
     group('square (1:1) target', () {
       test('clips tall widget to square using width as shortest side', () {


### PR DESCRIPTION


## Description

Some videos had text layers with very low resolution. The main fix was done in the package, so this PR only includes minimal adjustments. In addition, it also fixes an issue in the metadata video preview screen where the demo feed action overlay was incorrectly positioned for 1:1 videos.



**Related Issue:** Closes #3329

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore