### PR TITLE
fix(l10n): prefer English for unsupported locale fallback

### DIFF
--- a/mobile/l10n.yaml
+++ b/mobile/l10n.yaml
@@ -4,3 +4,5 @@ output-localization-file: app_localizations.dart
 output-class: AppLocalizations
 output-dir: lib/l10n/generated
 nullable-getter: false
+preferred-supported-locales:
+  - en

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -107,9 +107,9 @@ abstract class AppLocalizations {
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
+    Locale('en'),
     Locale('ar'),
     Locale('de'),
-    Locale('en'),
     Locale('es'),
     Locale('fr'),
     Locale('id'),

--- a/mobile/test/helpers/test_provider_overrides.dart
+++ b/mobile/test/helpers/test_provider_overrides.dart
@@ -323,6 +323,8 @@ List<dynamic> getStandardTestOverrides({
   final mockBlossom = mockBlossomAuthService ?? createMockBlossomAuthService();
   final mockCache = mockMediaCacheManager ?? createMockMediaCacheManager();
   final mockProfile = mockProfileRepository ?? createMockProfileRepository();
+  final mockNip05 =
+      mockNip05VerificationService ?? createMockNip05VerificationService();
   final mockModeration =
       mockModerationLabelService ?? createMockModerationLabelService();
 
@@ -354,10 +356,7 @@ List<dynamic> getStandardTestOverrides({
 
     // Override NIP-05 verification service to avoid opening Drift/SQLite in
     // widget tests that only care about badge presence, not verification.
-    if (mockNip05VerificationService != null)
-      nip05VerificationServiceProvider.overrideWithValue(
-        mockNip05VerificationService,
-      ),
+    nip05VerificationServiceProvider.overrideWithValue(mockNip05),
 
     // ONLY override other service providers if explicitly requested
     if (mockAuthService != null)

--- a/mobile/test/helpers/test_provider_overrides_test.dart
+++ b/mobile/test/helpers/test_provider_overrides_test.dart
@@ -1,0 +1,22 @@
+// ABOUTME: Tests for shared widget-test provider overrides.
+// ABOUTME: Guards against real services leaking into unrelated widget tests.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/providers/nip05_verification_provider.dart';
+
+import 'test_provider_overrides.dart';
+
+void main() {
+  test('standard overrides mock NIP-05 verification by default', () {
+    final container = ProviderContainer(
+      overrides: getStandardTestOverrides().cast(),
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      container.read(nip05VerificationServiceProvider),
+      isA<MockNip05VerificationService>(),
+    );
+  });
+}

--- a/mobile/test/l10n/resolve_app_ui_locale_test.dart
+++ b/mobile/test/l10n/resolve_app_ui_locale_test.dart
@@ -9,6 +9,10 @@ void main() {
   const supported = AppLocalizations.supportedLocales;
 
   group('resolveAppUiLocale', () {
+    test('keeps English first for Flutter framework fallback', () {
+      expect(supported.first.languageCode, 'en');
+    });
+
     test('uses English when device language is not supported (Russian)', () {
       final locale = resolveAppUiLocale(
         const [Locale('ru')],


### PR DESCRIPTION
Closes #3400

## Summary
- Configure Flutter gen-l10n to keep English first in generated supported locales.
- Regenerate `AppLocalizations.supportedLocales` so Flutter framework fallback paths land on English instead of Arabic.
- Add regression coverage for generated locale ordering and for standard widget-test overrides mocking NIP-05 by default.
- Mock NIP-05 verification in shared widget-test overrides to prevent real Drift/SQLite cleanup from leaking into unrelated widget tests under concurrent CI.

## Research
Flutter's `basicLocaleListResolution` falls back to `supportedLocales.first` when no preferred locale matches: https://api.flutter.dev/flutter/widgets/basicLocaleListResolution.html

The failing CI share-menu test was caused by a real `Nip05VerificationService` being created through standard widget-test overrides. That provider schedules `deleteExpired`, which can touch SQLite during unrelated widget tests and collide with concurrent test workers.

## Test Plan
- [x] RED: `flutter test test/l10n/resolve_app_ui_locale_test.dart` failed before the locale fix with `Expected: 'en'` / `Actual: 'ar'`.
- [x] RED: `flutter test test/helpers/test_provider_overrides_test.dart` failed before the provider override fix because it returned a real `Nip05VerificationService`.
- [x] `flutter test test/helpers/test_provider_overrides_test.dart test/widgets/share_video_menu_comprehensive_test.dart test/l10n/resolve_app_ui_locale_test.dart test/l10n/l10n_test.dart --test-randomize-ordering-seed=332026833`
- [x] `flutter analyze lib test integration_test`
- [x] `git diff --check`
- [x] Pre-commit format/analyze hook
- [x] Pre-push changed-file tests
- [x] GitHub Mobile CI: Analyze, Format, Generated Files, Tests, VGV Tag Gate