### PR TITLE
fix(video-player): guard invalid AVComposition render size

### DIFF
--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
@@ -132,24 +132,16 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     from: clipsRaw)
                 self.clipOffsets = offsets
                 self.clipDurations = durations
-                self.clipCount = clipsRaw.count
+                self.clipCount = offsets.count
                 self.totalDuration = offsets.last.map { $0 + (durations.last ?? 0) } ?? 0
                 self.firstFrameRendered = false
 
                 let playerItem = AVPlayerItem(asset: composition)
-                // `AVVideoComposition(propertiesOf:)` derives `renderSize`
-                // from the composition's video tracks. If the composition
-                // has no video segments (e.g. caller passed an empty
-                // clip list during teardown), `renderSize` is `.zero` and
-                // the setter throws `NSInvalidArgumentException`
-                // ("video composition must have a positive renderSize"),
-                // which terminates the app from a Swift Task.
                 let avComposition = AVVideoComposition(propertiesOf: composition)
-                if avComposition.renderSize.width > 0,
-                    avComposition.renderSize.height > 0
-                {
-                    playerItem.videoComposition = avComposition
+                guard avComposition.renderSize.isPositive else {
+                    throw CompositionError.invalidRenderSize
                 }
+                playerItem.videoComposition = avComposition
                 self.textureOutput?.attach(to: playerItem)
 
                 let startPositionMs = (args["startPositionMs"] as? NSNumber)?.int64Value ?? 0
@@ -235,6 +227,11 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             let assetAudioTracks = try await asset.loadTracks(withMediaType: .audio)
 
             guard let sourceVideoTrack = assetVideoTracks.first else { continue }
+            let (naturalSize, transform) = try await sourceVideoTrack.load(
+                .naturalSize, .preferredTransform
+            )
+            let displaySize = naturalSize.applying(transform).absoluteSize
+            guard displaySize.isPositive else { continue }
 
             let startTime = CMTime(value: startMs, timescale: 1000)
             let endTime: CMTime
@@ -244,6 +241,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 endTime = assetDuration
             }
             let timeRange = CMTimeRange(start: startTime, end: endTime)
+            let clipDuration = CMTimeSubtract(endTime, startTime)
+            guard CMTimeCompare(clipDuration, .zero) > 0 else { continue }
+
+            if offsets.isEmpty {
+                composition.naturalSize = displaySize
+                videoTrack.preferredTransform = transform
+            }
 
             try videoTrack.insertTimeRange(timeRange, of: sourceVideoTrack, at: insertTime)
 
@@ -251,25 +255,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 try audioTrack?.insertTimeRange(timeRange, of: sourceAudioTrack, at: insertTime)
             }
 
-            let clipDuration = CMTimeSubtract(endTime, startTime)
             offsets.append(CMTimeGetSeconds(insertTime))
             durations.append(CMTimeGetSeconds(clipDuration))
             insertTime = CMTimeAdd(insertTime, clipDuration)
         }
 
-        // Apply the preferred transform from the first video track.
-        if let firstClipUri = clipsRaw.first?["uri"] as? String {
-            let firstURL: URL
-            if firstClipUri.hasPrefix("/") {
-                firstURL = URL(fileURLWithPath: firstClipUri)
-            } else {
-                firstURL = URL(string: firstClipUri)!
-            }
-            let firstAsset = AVURLAsset(url: firstURL)
-            if let firstTrack = try? await firstAsset.loadTracks(withMediaType: .video).first {
-                let transform = try await firstTrack.load(.preferredTransform)
-                videoTrack.preferredTransform = transform
-            }
+        guard !offsets.isEmpty else {
+            throw CompositionError.noPlayableVideoTracks
         }
 
         return (composition, offsets, durations)
@@ -630,11 +622,27 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
 
 private enum CompositionError: Error, LocalizedError {
     case cannotCreateTrack
+    case noPlayableVideoTracks
+    case invalidRenderSize
 
     var errorDescription: String? {
         switch self {
         case .cannotCreateTrack:
             return "Failed to create composition track."
+        case .noPlayableVideoTracks:
+            return "No playable video tracks found."
+        case .invalidRenderSize:
+            return "Video composition has an invalid render size."
         }
+    }
+}
+
+private extension CGSize {
+    var absoluteSize: CGSize {
+        CGSize(width: abs(width), height: abs(height))
+    }
+
+    var isPositive: Bool {
+        width.isFinite && height.isFinite && width > 0 && height > 0
     }
 }

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -218,6 +218,9 @@ class DivineVideoPlayerController {
     Duration? startPosition,
   }) async {
     _ensureInitialized();
+    if (clips.isEmpty) {
+      throw ArgumentError.value(clips, 'clips', 'must not be empty');
+    }
     if (_firstFrameCompleter.isCompleted) {
       _firstFrameCompleter = Completer<bool>();
     }

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
@@ -129,24 +129,16 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 let (composition, offsets, durations) = try await self.buildComposition(from: clipsRaw)
                 self.clipOffsets = offsets
                 self.clipDurations = durations
-                self.clipCount = clipsRaw.count
+                self.clipCount = offsets.count
                 self.totalDuration = offsets.last.map { $0 + (durations.last ?? 0) } ?? 0
                 self.firstFrameRendered = false
 
                 let playerItem = AVPlayerItem(asset: composition)
-                // `AVVideoComposition(propertiesOf:)` derives `renderSize`
-                // from the composition's video tracks. If the composition
-                // has no video segments (e.g. caller passed an empty
-                // clip list during teardown), `renderSize` is `.zero` and
-                // the setter throws `NSInvalidArgumentException`
-                // ("video composition must have a positive renderSize"),
-                // which terminates the app from a Swift Task.
                 let avComposition = AVVideoComposition(propertiesOf: composition)
-                if avComposition.renderSize.width > 0,
-                    avComposition.renderSize.height > 0
-                {
-                    playerItem.videoComposition = avComposition
+                guard avComposition.renderSize.isPositive else {
+                    throw CompositionError.invalidRenderSize
                 }
+                playerItem.videoComposition = avComposition
                 self.textureOutput?.attach(to: playerItem)
 
                 if let existing = self.player {
@@ -218,6 +210,11 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             let assetAudioTracks = try await asset.loadTracks(withMediaType: .audio)
 
             guard let sourceVideoTrack = assetVideoTracks.first else { continue }
+            let (naturalSize, transform) = try await sourceVideoTrack.load(
+                .naturalSize, .preferredTransform
+            )
+            let displaySize = naturalSize.applying(transform).absoluteSize
+            guard displaySize.isPositive else { continue }
 
             let startTime = CMTime(value: startMs, timescale: 1000)
             let endTime: CMTime
@@ -227,6 +224,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 endTime = assetDuration
             }
             let timeRange = CMTimeRange(start: startTime, end: endTime)
+            let clipDuration = CMTimeSubtract(endTime, startTime)
+            guard CMTimeCompare(clipDuration, .zero) > 0 else { continue }
+
+            if offsets.isEmpty {
+                composition.naturalSize = displaySize
+                videoTrack.preferredTransform = transform
+            }
 
             try videoTrack.insertTimeRange(timeRange, of: sourceVideoTrack, at: insertTime)
 
@@ -234,24 +238,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 try audioTrack?.insertTimeRange(timeRange, of: sourceAudioTrack, at: insertTime)
             }
 
-            let clipDuration = CMTimeSubtract(endTime, startTime)
             offsets.append(CMTimeGetSeconds(insertTime))
             durations.append(CMTimeGetSeconds(clipDuration))
             insertTime = CMTimeAdd(insertTime, clipDuration)
         }
 
-        if let firstClipUri = clipsRaw.first?["uri"] as? String {
-            let firstURL: URL
-            if firstClipUri.hasPrefix("/") {
-                firstURL = URL(fileURLWithPath: firstClipUri)
-            } else {
-                firstURL = URL(string: firstClipUri)!
-            }
-            let firstAsset = AVURLAsset(url: firstURL)
-            if let firstTrack = try? await firstAsset.loadTracks(withMediaType: .video).first {
-                let transform = try await firstTrack.load(.preferredTransform)
-                videoTrack.preferredTransform = transform
-            }
+        guard !offsets.isEmpty else {
+            throw CompositionError.noPlayableVideoTracks
         }
 
         return (composition, offsets, durations)
@@ -594,13 +587,28 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
 
 private enum CompositionError: Error, LocalizedError {
     case cannotCreateTrack
+    case noPlayableVideoTracks
+    case invalidRenderSize
 
     var errorDescription: String? {
         switch self {
         case .cannotCreateTrack:
             return "Failed to create composition track."
+        case .noPlayableVideoTracks:
+            return "No playable video tracks found."
+        case .invalidRenderSize:
+            return "Video composition has an invalid render size."
         }
     }
 }
 
+private extension CGSize {
+    var absoluteSize: CGSize {
+        CGSize(width: abs(width), height: abs(height))
+    }
+
+    var isPositive: Bool {
+        width.isFinite && height.isFinite && width > 0 && height > 0
+    }
+}
 

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -349,6 +349,14 @@ void main() {
         expect(sent, hasLength(2));
       });
 
+      test('setClips rejects an empty clip list', () async {
+        expect(
+          () => controller.setClips(const []),
+          throwsArgumentError,
+        );
+        expect(playerCalls, isEmpty);
+      });
+
       test(
         'setClips includes startPositionMs when startPosition > zero',
         () async {


### PR DESCRIPTION
Closes #3403

## Summary
- reject empty clip lists before they reach the native video player channel
- validate AVFoundation compositions have playable video segments and positive render sizes before assigning `videoComposition`
- mirror the iOS composition guard in the macOS player implementation

## Test Plan
- [x] `flutter test` from `mobile/packages/divine_video_player`
- [x] `flutter analyze` from `mobile/packages/divine_video_player`
- [x] `flutter build ios --debug --no-codesign --simulator` from `mobile`
- [x] pre-push targeted `divine_video_player_controller_test.dart`