### PR TITLE
fix(video_editor): improve layer interaction handling and enhance hit-testing for canvas

### DIFF
--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1216,7 +1216,7 @@ class _CanvasFitter extends ConsumerWidget {
         // mapping (cover-fit [renderSize] into [targetSize], centered
         // in [bodySize]).
         //
-        // [_HitTestExpander] wraps it so that taps in the scrim /
+        // [HitTestExpander] wraps it so that taps in the scrim /
         // letterbox zone (outside [targetSize]) are clamped to the
         // nearest point inside [targetSize] and re-dispatched into the
         // chain. Without this, `Center.hitTestChildren` drops every
@@ -1224,7 +1224,7 @@ class _CanvasFitter extends ConsumerWidget {
         // editor's top-level GestureDetector never opens an arena and
         // [onScaleStart] / [onScaleUpdate] never fire.
         return _OverlayCutArea(
-          child: _HitTestExpander(
+          child: HitTestExpander(
             visibleSize: targetSize,
             child: Center(
               child: SizedBox.fromSize(
@@ -1371,10 +1371,14 @@ class _OverlayCutArea extends ConsumerWidget {
 /// Subsequent move events flow through the gesture arena that the
 /// initial down opens, so [GestureDetector.onScaleUpdate] still
 /// receives real-pointer deltas.
-class _HitTestExpander extends SingleChildRenderObjectWidget {
-  const _HitTestExpander({
+@visibleForTesting
+class HitTestExpander extends SingleChildRenderObjectWidget {
+  /// Creates a [HitTestExpander].
+  @visibleForTesting
+  const HitTestExpander({
     required this.visibleSize,
     required Widget super.child,
+    super.key,
   });
 
   /// The size of the painted, hit-testable region inside the parent
@@ -1382,7 +1386,10 @@ class _HitTestExpander extends SingleChildRenderObjectWidget {
   /// onto its nearest edge before being forwarded.
   final Size visibleSize;
 
+  // The render object is a true implementation detail; the widget is
+  // only public for `@visibleForTesting`.
   @override
+  // ignore: library_private_types_in_public_api
   _RenderHitTestExpander createRenderObject(BuildContext context) {
     return _RenderHitTestExpander(visibleSize: visibleSize);
   }
@@ -1390,6 +1397,7 @@ class _HitTestExpander extends SingleChildRenderObjectWidget {
   @override
   void updateRenderObject(
     BuildContext context,
+    // ignore: library_private_types_in_public_api
     _RenderHitTestExpander renderObject,
   ) {
     renderObject.visibleSize = visibleSize;

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1255,11 +1255,6 @@ class _OverlayCutArea extends ConsumerWidget {
 
   final Widget child;
 
-  /// Opacity applied to the letterbox scrim while a layer is being
-  /// dragged or transformed — dimmed but not hidden, so the canvas
-  /// boundary stays visible.
-  static const double _scrimDimmedOpacity = 0.4;
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final targetAspectRatio = ref.watch(
@@ -1267,91 +1262,79 @@ class _OverlayCutArea extends ConsumerWidget {
     );
     if (targetAspectRatio == null) return const SizedBox.shrink();
 
-    return BlocBuilder<VideoEditorMainBloc, VideoEditorMainState>(
-      buildWhen: (previous, current) =>
-          previous.isLayerInteractionActive != current.isLayerInteractionActive,
-      builder: (context, state) {
-        final hideOverlay = state.isLayerInteractionActive;
+    final overlayColor = VineTheme.backgroundCamera.withAlpha(166);
+    final safeArea = MediaQuery.paddingOf(context);
 
-        return LayoutBuilder(
-          builder: (context, constraints) {
-            final boxSize = constraints.biggest;
-            // Compute the visible child size: largest rect with
-            // targetAspectRatio that fits inside boxSize (BoxFit.contain).
-            final double childWidth;
-            final double childHeight;
-            if (boxSize.width / boxSize.height > targetAspectRatio.value) {
-              childHeight = boxSize.height;
-              childWidth = boxSize.height * targetAspectRatio.value;
-            } else {
-              childWidth = boxSize.width;
-              childHeight = boxSize.width / targetAspectRatio.value;
-            }
-            final verticalGap = (boxSize.height - childHeight) / 2;
-            final horizontalGap = (boxSize.width - childWidth) / 2;
-            final safeArea = MediaQuery.paddingOf(context);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final boxSize = constraints.biggest;
+        // Compute the visible child size: largest rect with
+        // targetAspectRatio that fits inside boxSize (BoxFit.contain).
+        final double childWidth;
+        final double childHeight;
+        if (boxSize.width / boxSize.height > targetAspectRatio.value) {
+          childHeight = boxSize.height;
+          childWidth = boxSize.height * targetAspectRatio.value;
+        } else {
+          childWidth = boxSize.width;
+          childHeight = boxSize.width / targetAspectRatio.value;
+        }
+        final verticalGap = (boxSize.height - childHeight) / 2;
+        final horizontalGap = (boxSize.width - childWidth) / 2;
 
-            return Stack(
-              fit: StackFit.expand,
-              clipBehavior: .none,
-              children: [
-                child,
-                IgnorePointer(
-                  child: AnimatedOpacity(
-                    // Dim (don't fully hide) the scrim during layer
-                    // interactions so the user still sees the canvas
-                    // boundary while dragging a layer.
-                    opacity: hideOverlay ? _scrimDimmedOpacity : 1,
-                    duration: const Duration(milliseconds: 200),
-                    child: Stack(
-                      fit: StackFit.expand,
-                      clipBehavior: .none,
-                      children: [
-                        // Top bar — extends up into the safe area so there
-                        // is no uncovered strip above the scrim when the
-                        // canvas is padded below the status bar.
-                        if (verticalGap > 0 || safeArea.top > 0)
-                          Positioned(
-                            top: -safeArea.top,
-                            left: 0,
-                            right: 0,
-                            height: verticalGap + safeArea.top,
-                            child: const ColoredBox(color: VineTheme.scrim65),
-                          ),
-                        // Bottom bar
-                        if (verticalGap > 0)
-                          Positioned(
-                            bottom: 0,
-                            left: 0,
-                            right: 0,
-                            height: verticalGap,
-                            child: const ColoredBox(color: VineTheme.scrim65),
-                          ),
-                        // Left bar
-                        if (horizontalGap > 0)
-                          Positioned(
-                            top: 0,
-                            bottom: 0,
-                            left: 0,
-                            width: horizontalGap,
-                            child: const ColoredBox(color: VineTheme.scrim65),
-                          ),
-                        // Right bar
-                        if (horizontalGap > 0)
-                          Positioned(
-                            top: 0,
-                            bottom: 0,
-                            right: 0,
-                            width: horizontalGap,
-                            child: const ColoredBox(color: VineTheme.scrim65),
-                          ),
-                      ],
+        return Stack(
+          fit: StackFit.expand,
+          clipBehavior: .none,
+          children: [
+            child,
+
+            IgnorePointer(
+              child: Stack(
+                fit: StackFit.expand,
+                clipBehavior: .none,
+                children: [
+                  // Top bar — extends up into the safe area so there
+                  // is no uncovered strip above the scrim when the
+                  // canvas is padded below the status bar.
+                  if (verticalGap > 0 || safeArea.top > 0)
+                    Positioned(
+                      top: -safeArea.top,
+                      left: 0,
+                      right: 0,
+                      height: verticalGap + safeArea.top,
+                      child: ColoredBox(color: overlayColor),
                     ),
-                  ),
-                ),
-              ],
-            );
-          },
+                  // Bottom bar
+                  if (verticalGap > 0)
+                    Positioned(
+                      bottom: 0,
+                      left: 0,
+                      right: 0,
+                      height: verticalGap,
+                      child: ColoredBox(color: overlayColor),
+                    ),
+                  // Left bar
+                  if (horizontalGap > 0)
+                    Positioned(
+                      top: 0,
+                      bottom: 0,
+                      left: 0,
+                      width: horizontalGap,
+                      child: ColoredBox(color: overlayColor),
+                    ),
+                  // Right bar
+                  if (horizontalGap > 0)
+                    Positioned(
+                      top: 0,
+                      bottom: 0,
+                      right: 0,
+                      width: horizontalGap,
+                      child: ColoredBox(color: overlayColor),
+                    ),
+                ],
+              ),
+            ),
+          ],
         );
       },
     );

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -8,6 +8,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:divine_video_player/divine_video_player.dart';
 import 'package:flutter/foundation.dart' show kReleaseMode, listEquals;
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' hide Layer;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -279,33 +280,38 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
 
   /// Creates the [ProVideoController] (only once, not tied to a file).
   void _initializeController() {
-    _proVideoController = ProVideoController(
-      videoPlayer: ValueListenableBuilder(
-        valueListenable: _isPlayerReadyNotifier,
-        builder: (_, isPlayerReady, _) {
-          return Consumer(
-            builder: (context, ref, _) {
-              final clip = ref.watch(
-                clipManagerProvider.select((s) => s.firstClipOrNull),
-              );
-              if (clip == null) return const SizedBox.shrink();
+    _proVideoController =
+        ProVideoController(
+          videoPlayer: ValueListenableBuilder(
+            valueListenable: _isPlayerReadyNotifier,
+            builder: (_, isPlayerReady, _) {
+              return Consumer(
+                builder: (context, ref, _) {
+                  final clip = ref.watch(
+                    clipManagerProvider.select((s) => s.firstClipOrNull),
+                  );
+                  if (clip == null) return const SizedBox.shrink();
 
-              return VideoEditorPlayer(
-                controller: _videoPlayer,
-                targetAspectRatio: clip.targetAspectRatio,
-                originalAspectRatio: clip.originalAspectRatio,
-                bodySize: widget.bodySize,
-                renderSize: widget.renderSize,
+                  return VideoEditorPlayer(
+                    controller: _videoPlayer,
+                    targetAspectRatio: clip.targetAspectRatio,
+                    originalAspectRatio: clip.originalAspectRatio,
+                    bodySize: widget.bodySize,
+                    renderSize: widget.renderSize,
+                  );
+                },
               );
             },
-          );
-        },
-      ),
-      initialResolution: widget.renderSize,
-      // These values are not used since we provide a custom-UI.
-      fileSize: 0,
-      videoDuration: .zero,
-    );
+          ),
+          initialResolution: widget.renderSize,
+          // These values are not used since we provide a custom-UI.
+          fileSize: 0,
+          videoDuration: .zero,
+        )..initialize(
+          callbacksAudioFunction: () => const AudioEditorCallbacks(),
+          callbacksFunction: VideoEditorCallbacks.new,
+          configsFunction: () => const VideoEditorConfigs(),
+        );
   }
 
   /// Initializes (or reinitializes) the native video player with [clipPaths].
@@ -700,440 +706,428 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
     );
 
     // Listen for playback control requests from BLoC
-    return _OverlayCutArea(
-      child: MultiBlocListener(
-        listeners: [
-          // Re-export state history when an overlay item drag or trim
-          // ends so the updated positions are persisted for ProofMode.
-          BlocListener<TimelineOverlayBloc, TimelineOverlayState>(
-            listenWhen: (previous, current) =>
-                (previous.draggingItemId != null &&
-                    current.draggingItemId == null) ||
-                (previous.trimmingItemId != null &&
-                    current.trimmingItemId == null),
-            listener: (context, state) {
-              _onStateHistoryChange(scope, bloc);
-            },
-          ),
-          // Sync native audio tracks when audio sources change
-          // (sound added/removed) or a sound item is dragged/trimmed.
-          BlocListener<TimelineOverlayBloc, TimelineOverlayState>(
-            listenWhen: (previous, current) {
-              // Audio sources changed (add / remove / replace).
-              if (previous.audioTracks != current.audioTracks) return true;
+    return MultiBlocListener(
+      listeners: [
+        // Re-export state history when an overlay item drag or trim
+        // ends so the updated positions are persisted for ProofMode.
+        BlocListener<TimelineOverlayBloc, TimelineOverlayState>(
+          listenWhen: (previous, current) =>
+              (previous.draggingItemId != null &&
+                  current.draggingItemId == null) ||
+              (previous.trimmingItemId != null &&
+                  current.trimmingItemId == null),
+          listener: (context, state) {
+            _onStateHistoryChange(scope, bloc);
+          },
+        ),
+        // Sync native audio tracks when audio sources change
+        // (sound added/removed) or a sound item is dragged/trimmed.
+        BlocListener<TimelineOverlayBloc, TimelineOverlayState>(
+          listenWhen: (previous, current) {
+            // Audio sources changed (add / remove / replace).
+            if (previous.audioTracks != current.audioTracks) return true;
 
-              // Sound item drag/trim ended.
-              final dragEnded =
-                  previous.draggingItemId != null &&
-                  current.draggingItemId == null;
-              final trimEnded =
-                  previous.trimmingItemId != null &&
-                  current.trimmingItemId == null;
-              if (!dragEnded && !trimEnded) return false;
+            // Sound item drag/trim ended.
+            final dragEnded =
+                previous.draggingItemId != null &&
+                current.draggingItemId == null;
+            final trimEnded =
+                previous.trimmingItemId != null &&
+                current.trimmingItemId == null;
+            if (!dragEnded && !trimEnded) return false;
 
-              final changedId =
-                  previous.draggingItemId ?? previous.trimmingItemId;
-              final item = current.items
-                  .where((i) => i.id == changedId)
-                  .firstOrNull;
-              return item?.type == TimelineOverlayType.sound;
-            },
-            listener: (context, state) {
-              _syncAudioTracks();
-            },
-          ),
-          // Update native player clip boundaries when trim handle is
-          // released or for non-trim clip changes (reorder, add, remove).
-          BlocListener<ClipEditorBloc, ClipEditorState>(
-            listenWhen: (previous, current) {
-              // Trim handle released.
-              if (previous.isTrimDragging && !current.isTrimDragging) {
-                return true;
-              }
-              // Non-trim clip changes (reorder, add, remove).
-              if (!current.isTrimDragging &&
-                  !previous.isTrimDragging &&
-                  previous.clips != current.clips) {
-                return true;
-              }
-              return false;
-            },
-            listener: (context, state) {
-              // See note on the trim-times listener above: skip empty
-              // clip lists to avoid crashing the iOS native player.
-              if (state.clips.isEmpty) return;
-              final currentPosition = context
-                  .read<VideoEditorMainBloc>()
-                  .state
-                  .currentPosition;
-              _videoPlayer?.setClips([
-                for (final clip in state.clips)
-                  if (clip.video.file?.path case final path?)
-                    VideoClip(
-                      uri: path,
-                      start: clip.trimStart,
-                      end: clip.duration - clip.trimEnd,
-                    ),
-              ], startPosition: currentPosition);
-            },
-          ),
-          BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
-            listenWhen: (previous, current) =>
-                previous.isExternalPauseRequested !=
-                current.isExternalPauseRequested,
-            listener: (context, state) {
-              _onExternalPauseChanged(isPaused: state.isExternalPauseRequested);
-            },
-          ),
-          BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
-            listenWhen: (previous, current) =>
-                previous.playbackRestartCounter !=
-                current.playbackRestartCounter,
-            listener: (context, state) {
-              _onPlaybackRestartRequested();
-            },
-          ),
-          BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
-            listenWhen: (previous, current) =>
-                previous.playbackToggleCounter != current.playbackToggleCounter,
-            listener: (context, state) {
-              _onPlaybackToggleRequested();
-            },
-          ),
-          BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
-            listenWhen: (previous, current) =>
-                previous.seekCounter != current.seekCounter,
-            listener: (context, state) {
-              _onSeekRequested(state.seekPosition);
-            },
-          ),
-          BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
-            listenWhen: (previous, current) =>
-                previous.isMuted != current.isMuted,
-            listener: (context, state) {
-              _videoPlayer?.setVolume(state.isMuted ? 0 : 1);
-              ref
-                  .read(videoEditorProvider.notifier)
-                  .setOriginalAudioVolume(state.isMuted ? 0 : 1);
-            },
-          ),
-        ],
-        child: ProImageEditor.video(
-          _proVideoController,
-          key: scope.editorKey,
-          configs: ProImageEditorConfigs(
-            stateHistory: StateHistoryConfigs(
-              initStateHistory: editorStateHistory.isNotEmpty
-                  ? .fromMap(editorStateHistory)
-                  : null,
-            ),
-            imageGeneration: ImageGenerationConfigs(
-              captureImageByteFormat: .rawStraightRgba,
-              outputFormat: .png,
-              enableBackgroundGeneration: false,
-              enableUseOriginalBytes: false,
-              // Disabled in debug mode: combined RAM usage from the editor
-              // and MediaKit (background) causes crashes on hot-reload.
-              // Release builds are unaffected.
-              enableIsolateGeneration: kReleaseMode,
-              processorConfigs: const ProcessorConfigs(
-                numberOfBackgroundProcessors: 3,
-                processorMode: .limit,
-                initializationDelay:
-                    VideoEditorConstants.isolatesInitialisationDelay,
-              ),
-              customPixelRatio: max(
-                1,
-                max(
-                  VideoEditorConstants.quality.resolution.height /
-                      widget.renderSize.height,
-                  VideoEditorConstants.quality.resolution.width /
-                      widget.renderSize.width,
-                ),
-              ),
-            ),
-            mainEditor: MainEditorConfigs(
-              safeArea: const EditorSafeArea.none(),
-              style: const MainEditorStyle(
-                uiOverlayStyle: VideoEditorConstants.uiOverlayStyle,
-                background: VineTheme.backgroundCamera,
-              ),
-              captureLayersOnDone: true,
-              captureImageOnDone: false,
-              widgets: MainEditorWidgets(
-                appBar: (_, _) => null,
-                bottomBar: (_, _, key) => null,
-                removeLayerArea: (key, _, _, _) => SizedBox.shrink(key: key),
-                bodyItems: (editor, rebuildStream) {
-                  return [
-                    ReactiveWidget(
-                      builder: (context) =>
-                          BlocSelector<
-                            VideoEditorMainBloc,
-                            VideoEditorMainState,
-                            ({
-                              bool isOver,
-                              bool isReordering,
-                              bool isSubEditorOpen,
-                            })
-                          >(
-                            selector: (state) => (
-                              isOver:
-                                  state.currentPosition.inMilliseconds >
-                                  VideoEditorConstants
-                                      .maxDuration
-                                      .inMilliseconds,
-                              isReordering: state.isReordering,
-                              isSubEditorOpen: state.isSubEditorOpen,
-                            ),
-                            builder: (context, record) {
-                              if (!record.isOver ||
-                                  record.isReordering ||
-                                  record.isSubEditorOpen) {
-                                return const SizedBox.shrink();
-                              }
-                              return IgnorePointer(
-                                child: ColoredBox(
-                                  color: VineTheme.backgroundColor.withAlpha(
-                                    128,
-                                  ),
-                                  child: const SizedBox.expand(),
-                                ),
-                              );
-                            },
-                          ),
-                      stream: rebuildStream,
-                    ),
-                    ReactiveWidget(
-                      builder: (context) => VideoEditorFeedPreviewOverlay(
-                        targetAspectRatio: targetAspectRatio.value,
-                        isFeedPreviewVisible: editor.isLayerBeingTransformed,
-                      ),
-                      stream: rebuildStream,
-                    ),
-                  ];
-                },
-              ),
-            ),
-            paintEditor: PaintEditorConfigs(
-              eraserSize:
-                  DrawToolType.eraser.config.strokeWidth /
-                  scope.fittedBoxScale /
-                  2,
-              safeArea: const EditorSafeArea.none(),
-              enableEdit: false,
-              style: const PaintEditorStyle(
-                background: VineTheme.backgroundCamera,
-              ),
-              widgets: PaintEditorWidgets(
-                appBar: (_, _) => null,
-                bottomBar: (_, _) => null,
-                colorPicker: (_, _, _, _) => null,
-              ),
-            ),
-            filterEditor: FilterEditorConfigs(
-              safeArea: const EditorSafeArea.none(),
-              enableMultiSelection: false,
-              style: const FilterEditorStyle(
-                background: VineTheme.backgroundCamera,
-              ),
-              widgets: FilterEditorWidgets(
-                appBar: (_, _) => null,
-                bottomBar: (_, _) => null,
-              ),
-            ),
-            helperLines: HelperLineConfigs(
-              style: HelperLineStyle(
-                // 1.25 is the pro_image_editor default; we divide by fittedBoxScale
-                // to compensate for the FittedBox transformation.
-                strokeWidth: 1.25 / scope.fittedBoxScale,
-                horizontalColor: VideoEditorConstants.primaryColor,
-                verticalColor: VideoEditorConstants.primaryColor,
-                rotateColor: VideoEditorConstants.primaryColor,
-                layerAlignColor: VideoEditorConstants.primaryColor,
-              ),
-            ),
-            dialogConfigs: DialogConfigs(
-              widgets: DialogWidgets(
-                loadingDialog: (message, configs) => const SizedBox.shrink(),
-              ),
-            ),
-            videoEditor: VideoEditorConfigs(
-              showControls: false,
-              widgets: VideoEditorWidgets(
-                videoSetupLoadingIndicator: _VideoSetupLoadingIndicator(
-                  renderSize: widget.renderSize,
-                  bodySize: widget.bodySize,
-                  targetAspectRatio: targetAspectRatio,
-                ),
-              ),
-            ),
-          ),
-          callbacks: ProImageEditorCallbacks(
-            onCompleteWithParameters: _handleEditorComplete,
-            mainEditorCallbacks: MainEditorCallbacks(
-              onAfterViewInit: () {
-                _isInitialized = true;
-
-                if (editorStateHistory.isEmpty) {
-                  final clips = ref.read(clipManagerProvider).clips;
-
-                  scope.requireEditor.stateManager.replaceHistory(
-                    scope.requireEditor.stateHistory.first.copyWith(
-                      meta: {
-                        ...scope.requireEditor.stateManager.activeMeta,
-                        VideoEditorConstants.clipsStateHistoryKey: clips
-                            .map((e) => e.toJson())
-                            .toList(),
-                      },
-                    ),
-                    index: 0,
-                  );
-                }
-
-                _syncMainCapabilities(scope, bloc);
-              },
-              onDone: _handleDone,
-              onImportHistoryStart: (state, import) {
-                Log.debug(
-                  '🎬 Importing history started',
-                  name: 'VideoEditorCanvas',
-                  category: LogCategory.video,
-                );
-                _isImportingHistory = true;
-              },
-              onImportHistoryEnd: (state, import) {
-                Log.debug(
-                  '🎬 Importing history completed',
-                  name: 'VideoEditorCanvas',
-                  category: LogCategory.video,
-                );
-                _isImportingHistory = false;
-                _syncMainCapabilities(scope, bloc);
-              },
-              onStateHistoryChange: (_, _) =>
-                  _onStateHistoryChange(scope, bloc),
-              onOpenSubEditor: (editorMode) {
-                Log.debug(
-                  '🎬 Opening sub-editor: $editorMode',
-                  name: 'VideoEditorCanvas',
-                  category: LogCategory.video,
-                );
-                final SubEditorType? subEditorType = switch (editorMode) {
-                  .paint => .draw,
-                  .text => .text,
-                  .filter => .filter,
-                  .sticker => .stickers,
-                  _ => null,
-                };
-                if (subEditorType != null) {
-                  bloc.add(VideoEditorMainOpenSubEditor(subEditorType));
-                }
-              },
-              onStartCloseSubEditor: (_) {
-                Log.debug(
-                  '🎬 Closing sub-editor',
-                  name: 'VideoEditorCanvas',
-                  category: LogCategory.video,
-                );
-                bloc.add(const VideoEditorMainSubEditorClosed());
-              },
-              onScaleStart: (_) {
-                Log.debug(
-                  '🎬 Layer interaction started',
-                  name: 'VideoEditorCanvas',
-                  category: LogCategory.video,
-                );
-                bloc.add(const VideoEditorLayerInteractionStarted());
-                _selectedLayer = scope.editor?.selectedLayer;
-              },
-              onScaleUpdate: (details) {
-                if (!_isLayerBeingTransformed) return;
-                final isOverRemoveArea = scope.isOverRemoveArea(
-                  details.focalPoint,
-                );
-
-                // Trigger haptic feedback when entering the remove area
-                if (isOverRemoveArea && !_wasOverRemoveArea) {
-                  unawaited(HapticService.destructiveZoneFeedback());
-                }
-                _wasOverRemoveArea = isOverRemoveArea;
-
-                bloc.add(
-                  VideoEditorLayerOverRemoveAreaChanged(
-                    isOver: isOverRemoveArea,
+            final changedId =
+                previous.draggingItemId ?? previous.trimmingItemId;
+            final item = current.items
+                .where((i) => i.id == changedId)
+                .firstOrNull;
+            return item?.type == TimelineOverlayType.sound;
+          },
+          listener: (context, state) {
+            _syncAudioTracks();
+          },
+        ),
+        // Update native player clip boundaries when trim handle is
+        // released or for non-trim clip changes (reorder, add, remove).
+        BlocListener<ClipEditorBloc, ClipEditorState>(
+          listenWhen: (previous, current) {
+            // Trim handle released.
+            if (previous.isTrimDragging && !current.isTrimDragging) {
+              return true;
+            }
+            // Non-trim clip changes (reorder, add, remove).
+            if (!current.isTrimDragging &&
+                !previous.isTrimDragging &&
+                previous.clips != current.clips) {
+              return true;
+            }
+            return false;
+          },
+          listener: (context, state) {
+            // See note on the trim-times listener above: skip empty
+            // clip lists to avoid crashing the iOS native player.
+            if (state.clips.isEmpty) return;
+            final currentPosition = context
+                .read<VideoEditorMainBloc>()
+                .state
+                .currentPosition;
+            _videoPlayer?.setClips([
+              for (final clip in state.clips)
+                if (clip.video.file?.path case final path?)
+                  VideoClip(
+                    uri: path,
+                    start: clip.trimStart,
+                    end: clip.duration - clip.trimEnd,
                   ),
-                );
-              },
-              onScaleEnd: (_) {
-                if (_isLayerBeingTransformed) {
-                  if (bloc.state.isLayerOverRemoveArea) {
-                    Log.debug(
-                      '🎬 Layer removed via drag',
-                      name: 'VideoEditorCanvas',
-                      category: LogCategory.video,
-                    );
-                    scope.editor?.activeLayers.remove(_selectedLayer);
-                  }
-
-                  _onStateHistoryChange(scope, bloc);
-                  _selectedLayer = null;
-                }
-
-                _wasOverRemoveArea = false;
-                bloc.add(const VideoEditorLayerInteractionEnded());
-              },
-              onAddLayer: (layer) {
-                Log.debug(
-                  '🎬 Layer added: ${layer.runtimeType}',
-                  name: 'VideoEditorCanvas',
-                  category: LogCategory.video,
-                );
-                _syncMainCapabilities(scope, bloc);
-              },
-              onRemoveLayer: (layer) {
-                Log.debug(
-                  '🎬 Layer removed: ${layer.runtimeType}',
-                  name: 'VideoEditorCanvas',
-                  category: LogCategory.video,
-                );
-                _syncMainCapabilities(scope, bloc);
-              },
-              onRedo: () => _syncMainCapabilities(scope, bloc),
-              onUndo: () => _syncMainCapabilities(scope, bloc),
-              onCreateTextLayer: scope.onAddEditTextLayer,
-              onEditTextLayer: scope.onAddEditTextLayer,
-              helperLines: HelperLinesCallbacks(
-                onLineHit: () => unawaited(HapticService.snapFeedback()),
+            ], startPosition: currentPosition);
+          },
+        ),
+        BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
+          listenWhen: (previous, current) =>
+              previous.isExternalPauseRequested !=
+              current.isExternalPauseRequested,
+          listener: (context, state) {
+            _onExternalPauseChanged(isPaused: state.isExternalPauseRequested);
+          },
+        ),
+        BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
+          listenWhen: (previous, current) =>
+              previous.playbackRestartCounter != current.playbackRestartCounter,
+          listener: (context, state) {
+            _onPlaybackRestartRequested();
+          },
+        ),
+        BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
+          listenWhen: (previous, current) =>
+              previous.playbackToggleCounter != current.playbackToggleCounter,
+          listener: (context, state) {
+            _onPlaybackToggleRequested();
+          },
+        ),
+        BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
+          listenWhen: (previous, current) =>
+              previous.seekCounter != current.seekCounter,
+          listener: (context, state) {
+            _onSeekRequested(state.seekPosition);
+          },
+        ),
+        BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
+          listenWhen: (previous, current) =>
+              previous.isMuted != current.isMuted,
+          listener: (context, state) {
+            _videoPlayer?.setVolume(state.isMuted ? 0 : 1);
+            ref
+                .read(videoEditorProvider.notifier)
+                .setOriginalAudioVolume(state.isMuted ? 0 : 1);
+          },
+        ),
+      ],
+      child: ProImageEditor.video(
+        _proVideoController,
+        key: scope.editorKey,
+        configs: ProImageEditorConfigs(
+          stateHistory: StateHistoryConfigs(
+            initStateHistory: editorStateHistory.isNotEmpty
+                ? .fromMap(editorStateHistory)
+                : null,
+          ),
+          imageGeneration: ImageGenerationConfigs(
+            captureImageByteFormat: .rawStraightRgba,
+            outputFormat: .png,
+            enableBackgroundGeneration: false,
+            enableUseOriginalBytes: false,
+            // Disabled in debug mode: combined RAM usage from the editor
+            // and MediaKit (background) causes crashes on hot-reload.
+            // Release builds are unaffected.
+            enableIsolateGeneration: kReleaseMode,
+            processorConfigs: const ProcessorConfigs(
+              numberOfBackgroundProcessors: 3,
+              processorMode: .limit,
+              initializationDelay:
+                  VideoEditorConstants.isolatesInitialisationDelay,
+            ),
+            customPixelRatio: max(
+              1,
+              max(
+                VideoEditorConstants.quality.resolution.height /
+                    widget.renderSize.height,
+                VideoEditorConstants.quality.resolution.width /
+                    widget.renderSize.width,
               ),
             ),
-            paintEditorCallbacks: PaintEditorCallbacks(
-              onInit: () {
-                drawBloc.add(const VideoEditorDrawReset());
+          ),
+          mainEditor: MainEditorConfigs(
+            safeArea: const EditorSafeArea.none(),
+            style: const MainEditorStyle(
+              uiOverlayStyle: VideoEditorConstants.uiOverlayStyle,
+              background: VineTheme.backgroundCamera,
+            ),
+            captureLayersOnDone: true,
+            captureImageOnDone: false,
+            widgets: MainEditorWidgets(
+              appBar: (_, _) => null,
+              bottomBar: (_, _, key) => null,
+              removeLayerArea: (key, _, _, _) => SizedBox.shrink(key: key),
+              bodyItems: (editor, rebuildStream) {
+                return [
+                  ReactiveWidget(
+                    builder: (context) =>
+                        BlocSelector<
+                          VideoEditorMainBloc,
+                          VideoEditorMainState,
+                          ({
+                            bool isOver,
+                            bool isReordering,
+                            bool isSubEditorOpen,
+                          })
+                        >(
+                          selector: (state) => (
+                            isOver:
+                                state.currentPosition.inMilliseconds >
+                                VideoEditorConstants.maxDuration.inMilliseconds,
+                            isReordering: state.isReordering,
+                            isSubEditorOpen: state.isSubEditorOpen,
+                          ),
+                          builder: (context, record) {
+                            if (!record.isOver ||
+                                record.isReordering ||
+                                record.isSubEditorOpen) {
+                              return const SizedBox.shrink();
+                            }
+                            return IgnorePointer(
+                              child: ColoredBox(
+                                color: VineTheme.backgroundColor.withAlpha(128),
+                                child: const SizedBox.expand(),
+                              ),
+                            );
+                          },
+                        ),
+                    stream: rebuildStream,
+                  ),
+                  ReactiveWidget(
+                    builder: (context) => VideoEditorFeedPreviewOverlay(
+                      targetAspectRatio: targetAspectRatio.value,
+                      isFeedPreviewVisible: editor.isLayerBeingTransformed,
+                    ),
+                    stream: rebuildStream,
+                  ),
+                ];
+              },
+            ),
+          ),
+          paintEditor: PaintEditorConfigs(
+            eraserSize:
+                DrawToolType.eraser.config.strokeWidth /
+                scope.fittedBoxScale /
+                2,
+            safeArea: const EditorSafeArea.none(),
+            enableEdit: false,
+            style: const PaintEditorStyle(
+              background: VineTheme.backgroundCamera,
+            ),
+            widgets: PaintEditorWidgets(
+              appBar: (_, _) => null,
+              bottomBar: (_, _) => null,
+              colorPicker: (_, _, _, _) => null,
+            ),
+          ),
+          filterEditor: FilterEditorConfigs(
+            safeArea: const EditorSafeArea.none(),
+            enableMultiSelection: false,
+            style: const FilterEditorStyle(
+              background: VineTheme.backgroundCamera,
+            ),
+            widgets: FilterEditorWidgets(
+              appBar: (_, _) => null,
+              bottomBar: (_, _) => null,
+            ),
+          ),
+          helperLines: HelperLineConfigs(
+            style: HelperLineStyle(
+              // 1.25 is the pro_image_editor default; we divide by fittedBoxScale
+              // to compensate for the FittedBox transformation.
+              strokeWidth: 1.25 / scope.fittedBoxScale,
+              horizontalColor: VideoEditorConstants.primaryColor,
+              verticalColor: VideoEditorConstants.primaryColor,
+              rotateColor: VideoEditorConstants.primaryColor,
+              layerAlignColor: VideoEditorConstants.primaryColor,
+            ),
+          ),
+          dialogConfigs: DialogConfigs(
+            widgets: DialogWidgets(
+              loadingDialog: (message, configs) => const SizedBox.shrink(),
+            ),
+          ),
+          videoEditor: VideoEditorConfigs(
+            showControls: false,
+            widgets: VideoEditorWidgets(
+              videoSetupLoadingIndicator: _VideoSetupLoadingIndicator(
+                renderSize: widget.renderSize,
+                bodySize: widget.bodySize,
+                targetAspectRatio: targetAspectRatio,
+              ),
+            ),
+          ),
+        ),
+        callbacks: ProImageEditorCallbacks(
+          onCompleteWithParameters: _handleEditorComplete,
+          mainEditorCallbacks: MainEditorCallbacks(
+            onAfterViewInit: () {
+              _isInitialized = true;
 
-                final paintEditor = scope.paintEditor;
-                final drawState = context.read<VideoEditorDrawBloc>().state;
-                final toolConfig = drawState.selectedTool.config;
-                // Sync editor with current BLoC state - use tool config for
-                // strokeWidth/opacity/mode to ensure consistency with tool switch
-                paintEditor
-                  ?..setColor(drawState.selectedColor)
-                  ..setStrokeWidth(
-                    toolConfig.strokeWidth / scope.fittedBoxScale,
-                  )
-                  ..setOpacity(toolConfig.opacity)
-                  ..setMode(toolConfig.mode);
-              },
-              onDrawingDone: () => _syncDrawCapabilities(scope, drawBloc),
-              onRedo: () => _syncDrawCapabilities(scope, drawBloc),
-              onUndo: () => _syncDrawCapabilities(scope, drawBloc),
+              if (editorStateHistory.isEmpty) {
+                final clips = ref.read(clipManagerProvider).clips;
+
+                scope.requireEditor.stateManager.replaceHistory(
+                  scope.requireEditor.stateHistory.first.copyWith(
+                    meta: {
+                      ...scope.requireEditor.stateManager.activeMeta,
+                      VideoEditorConstants.clipsStateHistoryKey: clips
+                          .map((e) => e.toJson())
+                          .toList(),
+                    },
+                  ),
+                  index: 0,
+                );
+              }
+
+              _syncMainCapabilities(scope, bloc);
+            },
+            onDone: _handleDone,
+            onImportHistoryStart: (state, import) {
+              Log.debug(
+                '🎬 Importing history started',
+                name: 'VideoEditorCanvas',
+                category: LogCategory.video,
+              );
+              _isImportingHistory = true;
+            },
+            onImportHistoryEnd: (state, import) {
+              Log.debug(
+                '🎬 Importing history completed',
+                name: 'VideoEditorCanvas',
+                category: LogCategory.video,
+              );
+              _isImportingHistory = false;
+              _syncMainCapabilities(scope, bloc);
+            },
+            onStateHistoryChange: (_, _) => _onStateHistoryChange(scope, bloc),
+            onOpenSubEditor: (editorMode) {
+              Log.debug(
+                '🎬 Opening sub-editor: $editorMode',
+                name: 'VideoEditorCanvas',
+                category: LogCategory.video,
+              );
+              final SubEditorType? subEditorType = switch (editorMode) {
+                .paint => .draw,
+                .text => .text,
+                .filter => .filter,
+                .sticker => .stickers,
+                _ => null,
+              };
+              if (subEditorType != null) {
+                bloc.add(VideoEditorMainOpenSubEditor(subEditorType));
+              }
+            },
+            onStartCloseSubEditor: (_) {
+              Log.debug(
+                '🎬 Closing sub-editor',
+                name: 'VideoEditorCanvas',
+                category: LogCategory.video,
+              );
+              bloc.add(const VideoEditorMainSubEditorClosed());
+            },
+            onScaleStart: (_) {
+              Log.debug(
+                '🎬 Layer interaction started',
+                name: 'VideoEditorCanvas',
+                category: LogCategory.video,
+              );
+              bloc.add(const VideoEditorLayerInteractionStarted());
+              _selectedLayer = scope.editor?.selectedLayer;
+            },
+            onScaleUpdate: (details) {
+              if (!_isLayerBeingTransformed) return;
+              final isOverRemoveArea = scope.isOverRemoveArea(
+                details.focalPoint,
+              );
+
+              // Trigger haptic feedback when entering the remove area
+              if (isOverRemoveArea && !_wasOverRemoveArea) {
+                unawaited(HapticService.destructiveZoneFeedback());
+              }
+              _wasOverRemoveArea = isOverRemoveArea;
+
+              bloc.add(
+                VideoEditorLayerOverRemoveAreaChanged(isOver: isOverRemoveArea),
+              );
+            },
+            onScaleEnd: (_) {
+              if (_isLayerBeingTransformed) {
+                if (bloc.state.isLayerOverRemoveArea) {
+                  Log.debug(
+                    '🎬 Layer removed via drag',
+                    name: 'VideoEditorCanvas',
+                    category: LogCategory.video,
+                  );
+                  scope.editor?.activeLayers.remove(_selectedLayer);
+                }
+
+                _onStateHistoryChange(scope, bloc);
+                _selectedLayer = null;
+              }
+
+              _wasOverRemoveArea = false;
+              bloc.add(const VideoEditorLayerInteractionEnded());
+            },
+            onAddLayer: (layer) {
+              Log.debug(
+                '🎬 Layer added: ${layer.runtimeType}',
+                name: 'VideoEditorCanvas',
+                category: LogCategory.video,
+              );
+              _syncMainCapabilities(scope, bloc);
+            },
+            onRemoveLayer: (layer) {
+              Log.debug(
+                '🎬 Layer removed: ${layer.runtimeType}',
+                name: 'VideoEditorCanvas',
+                category: LogCategory.video,
+              );
+              _syncMainCapabilities(scope, bloc);
+            },
+            onRedo: () => _syncMainCapabilities(scope, bloc),
+            onUndo: () => _syncMainCapabilities(scope, bloc),
+            onCreateTextLayer: scope.onAddEditTextLayer,
+            onEditTextLayer: scope.onAddEditTextLayer,
+            helperLines: HelperLinesCallbacks(
+              onLineHit: () => unawaited(HapticService.snapFeedback()),
             ),
-            filterEditorCallbacks: FilterEditorCallbacks(
-              onInit: () {
-                final filterBloc = context.read<VideoEditorFilterBloc>();
-                filterBloc.add(const VideoEditorFilterEditorInitialized());
-              },
-            ),
+          ),
+          paintEditorCallbacks: PaintEditorCallbacks(
+            onInit: () {
+              drawBloc.add(const VideoEditorDrawReset());
+
+              final paintEditor = scope.paintEditor;
+              final drawState = context.read<VideoEditorDrawBloc>().state;
+              final toolConfig = drawState.selectedTool.config;
+              // Sync editor with current BLoC state - use tool config for
+              // strokeWidth/opacity/mode to ensure consistency with tool switch
+              paintEditor
+                ?..setColor(drawState.selectedColor)
+                ..setStrokeWidth(toolConfig.strokeWidth / scope.fittedBoxScale)
+                ..setOpacity(toolConfig.opacity)
+                ..setMode(toolConfig.mode);
+            },
+            onDrawingDone: () => _syncDrawCapabilities(scope, drawBloc),
+            onRedo: () => _syncDrawCapabilities(scope, drawBloc),
+            onUndo: () => _syncDrawCapabilities(scope, drawBloc),
+          ),
+          filterEditorCallbacks: FilterEditorCallbacks(
+            onInit: () {
+              final filterBloc = context.read<VideoEditorFilterBloc>();
+              filterBloc.add(const VideoEditorFilterEditorInitialized());
+            },
           ),
         ),
       ),
@@ -1200,20 +1194,6 @@ class _CanvasFitter extends ConsumerWidget {
         // Notify parent about body size
         scope.bodySizeNotifier.value = bodySize;
 
-        // The child content (ProImageEditor with originalAspectRatio)
-        final child = SizedBox.fromSize(
-          size: renderSize,
-          // Wraps sub-editors in a nested Navigator so they open within
-          // the fitted aspect-ratio area instead of full-screen, since
-          // cropping hasn't been applied yet.
-          child: Navigator(
-            clipBehavior: Clip.none,
-            onGenerateRoute: (_) => PageRouteBuilder(
-              pageBuilder: (_, _, _) => builder(bodySize, renderSize),
-            ),
-          ),
-        );
-
         // Contain mode: fit targetAspectRatio within bodySize,
         // then cover that area with the original aspect ratio
         final Size targetSize;
@@ -1231,10 +1211,38 @@ class _CanvasFitter extends ConsumerWidget {
           );
         }
 
-        return Center(
-          child: SizedBox.fromSize(
-            size: targetSize,
-            child: FittedBox(fit: BoxFit.cover, child: child),
+        // The visual chain below (Center > SizedBox > FittedBox >
+        // SizedBox > Navigator) is unchanged — it owns the aspect-ratio
+        // mapping (cover-fit [renderSize] into [targetSize], centered
+        // in [bodySize]).
+        //
+        // [_HitTestExpander] wraps it so that taps in the scrim /
+        // letterbox zone (outside [targetSize]) are clamped to the
+        // nearest point inside [targetSize] and re-dispatched into the
+        // chain. Without this, `Center.hitTestChildren` drops every
+        // pointer event that falls outside its child rect, so the
+        // editor's top-level GestureDetector never opens an arena and
+        // [onScaleStart] / [onScaleUpdate] never fire.
+        return _OverlayCutArea(
+          child: _HitTestExpander(
+            visibleSize: targetSize,
+            child: Center(
+              child: SizedBox.fromSize(
+                size: targetSize,
+                child: FittedBox(
+                  fit: BoxFit.cover,
+                  child: SizedBox.fromSize(
+                    size: renderSize,
+                    child: Navigator(
+                      clipBehavior: Clip.none,
+                      onGenerateRoute: (_) => PageRouteBuilder(
+                        pageBuilder: (_, _, _) => builder(bodySize, renderSize),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
           ),
         );
       },
@@ -1247,14 +1255,17 @@ class _OverlayCutArea extends ConsumerWidget {
 
   final Widget child;
 
+  /// Opacity applied to the letterbox scrim while a layer is being
+  /// dragged or transformed — dimmed but not hidden, so the canvas
+  /// boundary stays visible.
+  static const double _scrimDimmedOpacity = 0.4;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final targetAspectRatio = ref.read(
+    final targetAspectRatio = ref.watch(
       clipManagerProvider.select((s) => s.firstClipOrNull?.targetAspectRatio),
     );
     if (targetAspectRatio == null) return const SizedBox.shrink();
-
-    if (targetAspectRatio == .vertical) return child;
 
     return BlocBuilder<VideoEditorMainBloc, VideoEditorMainState>(
       buildWhen: (previous, current) =>
@@ -1265,59 +1276,77 @@ class _OverlayCutArea extends ConsumerWidget {
         return LayoutBuilder(
           builder: (context, constraints) {
             final boxSize = constraints.biggest;
-            // Child is always 1:1 and BoxFit.contain, so it fills the
-            // shorter dimension fully.
-            final childSide = boxSize.shortestSide;
-            final verticalGap = (boxSize.height - childSide) / 2;
-            final horizontalGap = (boxSize.width - childSide) / 2;
+            // Compute the visible child size: largest rect with
+            // targetAspectRatio that fits inside boxSize (BoxFit.contain).
+            final double childWidth;
+            final double childHeight;
+            if (boxSize.width / boxSize.height > targetAspectRatio.value) {
+              childHeight = boxSize.height;
+              childWidth = boxSize.height * targetAspectRatio.value;
+            } else {
+              childWidth = boxSize.width;
+              childHeight = boxSize.width / targetAspectRatio.value;
+            }
+            final verticalGap = (boxSize.height - childHeight) / 2;
+            final horizontalGap = (boxSize.width - childWidth) / 2;
+            final safeArea = MediaQuery.paddingOf(context);
 
             return Stack(
               fit: StackFit.expand,
+              clipBehavior: .none,
               children: [
                 child,
-                AnimatedOpacity(
-                  opacity: hideOverlay ? 0 : 1,
-                  duration: const Duration(milliseconds: 200),
-                  child: Stack(
-                    fit: StackFit.expand,
-                    children: [
-                      // Top bar
-                      if (verticalGap > 0)
-                        Positioned(
-                          top: 0,
-                          left: 0,
-                          right: 0,
-                          height: verticalGap,
-                          child: const ColoredBox(color: VineTheme.scrim65),
-                        ),
-                      // Bottom bar
-                      if (verticalGap > 0)
-                        Positioned(
-                          bottom: 0,
-                          left: 0,
-                          right: 0,
-                          height: verticalGap,
-                          child: const ColoredBox(color: VineTheme.scrim65),
-                        ),
-                      // Left bar
-                      if (horizontalGap > 0)
-                        Positioned(
-                          top: 0,
-                          bottom: 0,
-                          left: 0,
-                          width: horizontalGap,
-                          child: const ColoredBox(color: VineTheme.scrim65),
-                        ),
-                      // Right bar
-                      if (horizontalGap > 0)
-                        Positioned(
-                          top: 0,
-                          bottom: 0,
-                          right: 0,
-                          width: horizontalGap,
-                          child: const ColoredBox(color: VineTheme.scrim65),
-                        ),
-                    ],
+                IgnorePointer(
+                  child: AnimatedOpacity(
+                    // Dim (don't fully hide) the scrim during layer
+                    // interactions so the user still sees the canvas
+                    // boundary while dragging a layer.
+                    opacity: hideOverlay ? _scrimDimmedOpacity : 1,
+                    duration: const Duration(milliseconds: 200),
+                    child: Stack(
+                      fit: StackFit.expand,
+                      clipBehavior: .none,
+                      children: [
+                        // Top bar — extends up into the safe area so there
+                        // is no uncovered strip above the scrim when the
+                        // canvas is padded below the status bar.
+                        if (verticalGap > 0 || safeArea.top > 0)
+                          Positioned(
+                            top: -safeArea.top,
+                            left: 0,
+                            right: 0,
+                            height: verticalGap + safeArea.top,
+                            child: const ColoredBox(color: VineTheme.scrim65),
+                          ),
+                        // Bottom bar
+                        if (verticalGap > 0)
+                          Positioned(
+                            bottom: 0,
+                            left: 0,
+                            right: 0,
+                            height: verticalGap,
+                            child: const ColoredBox(color: VineTheme.scrim65),
+                          ),
+                        // Left bar
+                        if (horizontalGap > 0)
+                          Positioned(
+                            top: 0,
+                            bottom: 0,
+                            left: 0,
+                            width: horizontalGap,
+                            child: const ColoredBox(color: VineTheme.scrim65),
+                          ),
+                        // Right bar
+                        if (horizontalGap > 0)
+                          Positioned(
+                            top: 0,
+                            bottom: 0,
+                            right: 0,
+                            width: horizontalGap,
+                            child: const ColoredBox(color: VineTheme.scrim65),
+                          ),
+                      ],
+                    ),
                   ),
                 ),
               ],
@@ -1326,5 +1355,82 @@ class _OverlayCutArea extends ConsumerWidget {
         );
       },
     );
+  }
+}
+
+/// Forwards hit-tests from the entire parent box into [child], even
+/// when the pointer falls outside [child]'s painted area.
+///
+/// Layout / paint are unchanged — [child] is laid out with the parent
+/// constraints and painted at offset zero, exactly like a passthrough
+/// wrapper. Only [hitTest] is customised: positions outside the
+/// centered [visibleSize] rect are clamped to its nearest edge so the
+/// downstream hit-test chain (which clips to `Center > SizedBox`) sees
+/// a position it accepts and forwards the down event normally.
+///
+/// Subsequent move events flow through the gesture arena that the
+/// initial down opens, so [GestureDetector.onScaleUpdate] still
+/// receives real-pointer deltas.
+class _HitTestExpander extends SingleChildRenderObjectWidget {
+  const _HitTestExpander({
+    required this.visibleSize,
+    required Widget super.child,
+  });
+
+  /// The size of the painted, hit-testable region inside the parent
+  /// box, centered on both axes. Hits outside this rect are clamped
+  /// onto its nearest edge before being forwarded.
+  final Size visibleSize;
+
+  @override
+  _RenderHitTestExpander createRenderObject(BuildContext context) {
+    return _RenderHitTestExpander(visibleSize: visibleSize);
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    _RenderHitTestExpander renderObject,
+  ) {
+    renderObject.visibleSize = visibleSize;
+  }
+}
+
+class _RenderHitTestExpander extends RenderProxyBox {
+  _RenderHitTestExpander({required Size visibleSize})
+    : _visibleSize = visibleSize;
+
+  /// Symmetric 1 px inset applied when clamping a hit position onto
+  /// the visible rect. Required because downstream transforms
+  /// (FittedBox cover-fit) can map an exact `left`/`top` value to a
+  /// slightly negative local coordinate after float multiplication,
+  /// which then fails `Rect.contains` and drops the hit. The trailing
+  /// inset is needed because `Rect.contains` excludes the right /
+  /// bottom edge.
+  static const double _hitTestEpsilon = 1.0;
+
+  Size _visibleSize;
+  set visibleSize(Size value) {
+    if (value == _visibleSize) return;
+    _visibleSize = value;
+    // No markNeedsLayout/Paint: layout and paint don't depend on
+    // [visibleSize] — only [hitTest] does, and that runs per-event.
+  }
+
+  @override
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    final c = child;
+    if (c == null) return false;
+    final left = (size.width - _visibleSize.width) / 2;
+    final top = (size.height - _visibleSize.height) / 2;
+    final clampedDx = position.dx.clamp(
+      left + _hitTestEpsilon,
+      left + _visibleSize.width - _hitTestEpsilon,
+    );
+    final clampedDy = position.dy.clamp(
+      top + _hitTestEpsilon,
+      top + _visibleSize.height - _hitTestEpsilon,
+    );
+    return c.hitTest(result, position: Offset(clampedDx, clampedDy));
   }
 }

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1181,6 +1181,9 @@ class _CanvasFitter extends ConsumerWidget {
     );
     if (clip == null) return const SizedBox.shrink();
     final scope = VideoEditorScope.of(context);
+    final isSubEditorOpen = context.select(
+      (VideoEditorMainBloc bloc) => bloc.state.isSubEditorOpen,
+    );
 
     return LayoutBuilder(
       builder: (_, constraints) {
@@ -1226,6 +1229,7 @@ class _CanvasFitter extends ConsumerWidget {
         return _OverlayCutArea(
           child: HitTestExpander(
             visibleSize: targetSize,
+            enabled: !isSubEditorOpen,
             child: Center(
               child: SizedBox.fromSize(
                 size: targetSize,
@@ -1288,51 +1292,60 @@ class _OverlayCutArea extends ConsumerWidget {
           children: [
             child,
 
-            IgnorePointer(
-              child: Stack(
-                fit: StackFit.expand,
-                clipBehavior: .none,
-                children: [
-                  // Top bar — extends up into the safe area so there
-                  // is no uncovered strip above the scrim when the
-                  // canvas is padded below the status bar.
-                  if (verticalGap > 0 || safeArea.top > 0)
-                    Positioned(
-                      top: -safeArea.top,
-                      left: 0,
-                      right: 0,
-                      height: verticalGap + safeArea.top,
-                      child: ColoredBox(color: overlayColor),
+            BlocSelector<VideoEditorMainBloc, VideoEditorMainState, bool>(
+              selector: (state) => state.isLayerInteractionActive,
+              builder: (context, isLayerInteractionActive) {
+                return IgnorePointer(
+                  child: AnimatedOpacity(
+                    opacity: isLayerInteractionActive ? 0 : 1,
+                    duration: const Duration(milliseconds: 200),
+                    child: Stack(
+                      fit: StackFit.expand,
+                      clipBehavior: .none,
+                      children: [
+                        // Top bar — extends up into the safe area so there
+                        // is no uncovered strip above the scrim when the
+                        // canvas is padded below the status bar.
+                        if (verticalGap > 0 || safeArea.top > 0)
+                          Positioned(
+                            top: -safeArea.top,
+                            left: 0,
+                            right: 0,
+                            height: verticalGap + safeArea.top,
+                            child: ColoredBox(color: overlayColor),
+                          ),
+                        // Bottom bar
+                        if (verticalGap > 0)
+                          Positioned(
+                            bottom: 0,
+                            left: 0,
+                            right: 0,
+                            height: verticalGap,
+                            child: ColoredBox(color: overlayColor),
+                          ),
+                        // Left bar
+                        if (horizontalGap > 0)
+                          Positioned(
+                            top: 0,
+                            bottom: 0,
+                            left: 0,
+                            width: horizontalGap,
+                            child: ColoredBox(color: overlayColor),
+                          ),
+                        // Right bar
+                        if (horizontalGap > 0)
+                          Positioned(
+                            top: 0,
+                            bottom: 0,
+                            right: 0,
+                            width: horizontalGap,
+                            child: ColoredBox(color: overlayColor),
+                          ),
+                      ],
                     ),
-                  // Bottom bar
-                  if (verticalGap > 0)
-                    Positioned(
-                      bottom: 0,
-                      left: 0,
-                      right: 0,
-                      height: verticalGap,
-                      child: ColoredBox(color: overlayColor),
-                    ),
-                  // Left bar
-                  if (horizontalGap > 0)
-                    Positioned(
-                      top: 0,
-                      bottom: 0,
-                      left: 0,
-                      width: horizontalGap,
-                      child: ColoredBox(color: overlayColor),
-                    ),
-                  // Right bar
-                  if (horizontalGap > 0)
-                    Positioned(
-                      top: 0,
-                      bottom: 0,
-                      right: 0,
-                      width: horizontalGap,
-                      child: ColoredBox(color: overlayColor),
-                    ),
-                ],
-              ),
+                  ),
+                );
+              },
             ),
           ],
         );
@@ -1361,6 +1374,7 @@ class HitTestExpander extends SingleChildRenderObjectWidget {
   const HitTestExpander({
     required this.visibleSize,
     required Widget super.child,
+    this.enabled = true,
     super.key,
   });
 
@@ -1369,12 +1383,15 @@ class HitTestExpander extends SingleChildRenderObjectWidget {
   /// onto its nearest edge before being forwarded.
   final Size visibleSize;
 
+  /// Whether hits outside [visibleSize] should be clamped into the child.
+  final bool enabled;
+
   // The render object is a true implementation detail; the widget is
   // only public for `@visibleForTesting`.
   @override
   // ignore: library_private_types_in_public_api
   _RenderHitTestExpander createRenderObject(BuildContext context) {
-    return _RenderHitTestExpander(visibleSize: visibleSize);
+    return _RenderHitTestExpander(visibleSize: visibleSize, enabled: enabled);
   }
 
   @override
@@ -1383,13 +1400,16 @@ class HitTestExpander extends SingleChildRenderObjectWidget {
     // ignore: library_private_types_in_public_api
     _RenderHitTestExpander renderObject,
   ) {
-    renderObject.visibleSize = visibleSize;
+    renderObject
+      ..visibleSize = visibleSize
+      ..enabled = enabled;
   }
 }
 
 class _RenderHitTestExpander extends RenderProxyBox {
-  _RenderHitTestExpander({required Size visibleSize})
-    : _visibleSize = visibleSize;
+  _RenderHitTestExpander({required Size visibleSize, required bool enabled})
+    : _visibleSize = visibleSize,
+      _enabled = enabled;
 
   /// Symmetric 1 px inset applied when clamping a hit position onto
   /// the visible rect. Required because downstream transforms
@@ -1408,8 +1428,15 @@ class _RenderHitTestExpander extends RenderProxyBox {
     // [visibleSize] — only [hitTest] does, and that runs per-event.
   }
 
+  bool _enabled;
+  set enabled(bool value) {
+    if (value == _enabled) return;
+    _enabled = value;
+  }
+
   @override
   bool hitTest(BoxHitTestResult result, {required Offset position}) {
+    if (!_enabled) return super.hitTest(result, position: position);
     final c = child;
     if (c == null) return false;
     final left = (size.width - _visibleSize.width) / 2;

--- a/mobile/test/widgets/video_editor/main_editor/hit_test_expander_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/hit_test_expander_test.dart
@@ -145,5 +145,40 @@ void main() {
       await tester.tapAt(expanderRect.topLeft + const Offset(10, 10));
       expect(hits, 2);
     });
+
+    testWidgets('does not clamp scrim taps when disabled', (tester) async {
+      var hits = 0;
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox.fromSize(
+              size: const Size(200, 200),
+              child: HitTestExpander(
+                visibleSize: const Size(100, 100),
+                enabled: false,
+                child: Center(
+                  child: SizedBox.fromSize(
+                    size: const Size(100, 100),
+                    child: Listener(
+                      behavior: HitTestBehavior.opaque,
+                      onPointerDown: (_) => hits++,
+                      child: const SizedBox.expand(),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final expanderRect = tester.getRect(find.byType(HitTestExpander));
+      await tester.tapAt(expanderRect.topLeft + const Offset(10, 10));
+      expect(hits, 0);
+
+      await tester.tapAt(tester.getCenter(find.byType(Listener)));
+      expect(hits, 1);
+    });
   });
 }

--- a/mobile/test/widgets/video_editor/main_editor/hit_test_expander_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/hit_test_expander_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/video_editor/main_editor/video_editor_canvas.dart';
+
+void main() {
+  group(HitTestExpander, () {
+    /// Pumps a [HitTestExpander] of [outerSize] containing a centered
+    /// [visibleSize] [Listener] and returns a getter for the number of
+    /// pointer-down events the listener has received.
+    Future<int Function()> pumpExpander(
+      WidgetTester tester, {
+      required Size outerSize,
+      required Size visibleSize,
+    }) async {
+      var hits = 0;
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox.fromSize(
+              size: outerSize,
+              child: HitTestExpander(
+                visibleSize: visibleSize,
+                child: Center(
+                  child: SizedBox.fromSize(
+                    size: visibleSize,
+                    child: Listener(
+                      behavior: HitTestBehavior.opaque,
+                      onPointerDown: (_) => hits++,
+                      child: const SizedBox.expand(),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      return () => hits;
+    }
+
+    testWidgets('routes taps inside visible rect to the child', (tester) async {
+      final hitCount = await pumpExpander(
+        tester,
+        outerSize: const Size(200, 200),
+        visibleSize: const Size(100, 100),
+      );
+
+      await tester.tapAt(tester.getCenter(find.byType(Listener)));
+
+      expect(hitCount(), 1);
+    });
+
+    testWidgets('clamps taps in the top-left scrim into the child', (
+      tester,
+    ) async {
+      final hitCount = await pumpExpander(
+        tester,
+        outerSize: const Size(200, 200),
+        visibleSize: const Size(100, 100),
+      );
+
+      // Tap deep into the top-left scrim — well outside the centered
+      // 100x100 visible rect (which lives at (50,50)..(150,150)).
+      // Without HitTestExpander, the standard `Center` hit-test would
+      // drop this position and the listener would never see it.
+      final expanderRect = tester.getRect(find.byType(HitTestExpander));
+      await tester.tapAt(expanderRect.topLeft + const Offset(10, 10));
+
+      expect(hitCount(), 1);
+    });
+
+    testWidgets('clamps taps in the bottom-right scrim into the child', (
+      tester,
+    ) async {
+      final hitCount = await pumpExpander(
+        tester,
+        outerSize: const Size(200, 200),
+        visibleSize: const Size(100, 100),
+      );
+
+      final expanderRect = tester.getRect(find.byType(HitTestExpander));
+      await tester.tapAt(expanderRect.bottomRight - const Offset(10, 10));
+
+      expect(hitCount(), 1);
+    });
+
+    testWidgets('routes taps in every scrim quadrant to the child', (
+      tester,
+    ) async {
+      final hitCount = await pumpExpander(
+        tester,
+        outerSize: const Size(200, 200),
+        visibleSize: const Size(100, 100),
+      );
+
+      final expanderRect = tester.getRect(find.byType(HitTestExpander));
+      // Each of these falls in a different scrim quadrant; without the
+      // expander the listener would receive zero of them.
+      await tester.tapAt(expanderRect.topLeft + const Offset(5, 100));
+      await tester.tapAt(expanderRect.topRight + const Offset(-5, 100));
+      await tester.tapAt(expanderRect.bottomLeft + const Offset(100, -5));
+      await tester.tapAt(expanderRect.topLeft + const Offset(100, 5));
+
+      expect(hitCount(), 4);
+    });
+
+    testWidgets('updates clamp region when visibleSize changes', (
+      tester,
+    ) async {
+      var hits = 0;
+
+      Widget buildWith(Size visibleSize) {
+        return Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox.fromSize(
+              size: const Size(200, 200),
+              child: HitTestExpander(
+                visibleSize: visibleSize,
+                child: Center(
+                  child: SizedBox.fromSize(
+                    size: visibleSize,
+                    child: Listener(
+                      behavior: HitTestBehavior.opaque,
+                      onPointerDown: (_) => hits++,
+                      child: const SizedBox.expand(),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildWith(const Size(100, 100)));
+      final expanderRect = tester.getRect(find.byType(HitTestExpander));
+      await tester.tapAt(expanderRect.topLeft + const Offset(10, 10));
+      expect(hits, 1);
+
+      // Shrink the visible rect — the clamp region must follow so that
+      // the same scrim tap still resolves into the smaller listener.
+      await tester.pumpWidget(buildWith(const Size(50, 50)));
+      await tester.tapAt(expanderRect.topLeft + const Offset(10, 10));
+      expect(hits, 2);
+    });
+  });
+}


### PR DESCRIPTION
Closes #3405

## Description

Resolve an issue where text layers outside the video could no longer be moved. The updated logic now allows layers to be repositioned and correctly applies a dark overlay outside the video over the layers.


**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore