### PR TITLE
feat(video_editor): enhance trimming functionality with live seek preview

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -359,7 +359,21 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       trimEnd: clampedEnd,
     );
 
-    emit(state.copyWith(clips: List.unmodifiable(newClips)));
+    // Position of the dragged handle within the clip's *untrimmed*
+    // timeline (0..clip.duration). The preview player is switched to
+    // a single-clip view of [event.clipId] for the duration of the
+    // gesture, so seeking to this position lands on the correct frame.
+    final trimPosition = event.isStart
+        ? clampedStart
+        : clip.duration - clampedEnd;
+
+    emit(
+      state.copyWith(
+        clips: List.unmodifiable(newClips),
+        trimPosition: trimPosition,
+        trimmingClipId: event.clipId,
+      ),
+    );
   }
 
   void _onTrimDragStarted(
@@ -373,6 +387,12 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     ClipEditorTrimDragEnded event,
     Emitter<ClipEditorState> emit,
   ) {
-    emit(state.copyWith(isTrimDragging: false));
+    emit(
+      state.copyWith(
+        isTrimDragging: false,
+        clearTrimPosition: true,
+        clearTrimmingClipId: true,
+      ),
+    );
   }
 }

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
@@ -133,12 +133,18 @@ class ClipEditorSplitRequested extends ClipEditorEvent {
 class ClipEditorTrimUpdated extends ClipEditorEvent {
   const ClipEditorTrimUpdated({
     required this.clipId,
+    required this.isStart,
     required this.trimStart,
     required this.trimEnd,
   });
 
   /// ID of the clip being trimmed.
   final String clipId;
+
+  /// Whether the start handle (left) is being dragged.
+  ///
+  /// `true` → left handle; `false` → right handle.
+  final bool isStart;
 
   /// Offset from the beginning of the original clip.
   final Duration trimStart;
@@ -147,7 +153,7 @@ class ClipEditorTrimUpdated extends ClipEditorEvent {
   final Duration trimEnd;
 
   @override
-  List<Object?> get props => [clipId, trimStart, trimEnd];
+  List<Object?> get props => [clipId, isStart, trimStart, trimEnd];
 }
 
 /// Signals that a trim handle drag gesture has started.

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
@@ -15,6 +15,8 @@ class ClipEditorState extends Equatable {
     this.isEditing = false,
     this.isTrimDragging = false,
     this.lastSplit,
+    this.trimPosition,
+    this.trimmingClipId,
   });
 
   /// Local copy of clips managed by this editor session.
@@ -41,6 +43,19 @@ class ClipEditorState extends Equatable {
   /// fresh signal even when fields happen to repeat.
   final ClipSplitEvent? lastSplit;
 
+  /// The live absolute timeline position of the trim handle being dragged.
+  ///
+  /// Set while a trim gesture is active; `null` when no trim is in progress.
+  final Duration? trimPosition;
+
+  /// The ID of the clip currently being trimmed.
+  ///
+  /// Non-`null` while a trim gesture is active. Allows the preview
+  /// player to switch to a single-clip view of the trimmed clip so
+  /// [trimPosition] (which is relative to that clip's untrimmed
+  /// timeline) seeks to the correct frame.
+  final String? trimmingClipId;
+
   /// Total duration of all clips (respecting trim).
   Duration get totalDuration =>
       clips.fold(Duration.zero, (sum, clip) => sum + clip.trimmedDuration);
@@ -53,6 +68,10 @@ class ClipEditorState extends Equatable {
     bool? isEditing,
     bool? isTrimDragging,
     ClipSplitEvent? lastSplit,
+    Duration? trimPosition,
+    bool clearTrimPosition = false,
+    String? trimmingClipId,
+    bool clearTrimmingClipId = false,
   }) {
     return ClipEditorState(
       clips: clips ?? this.clips,
@@ -61,6 +80,12 @@ class ClipEditorState extends Equatable {
       isEditing: isEditing ?? this.isEditing,
       isTrimDragging: isTrimDragging ?? this.isTrimDragging,
       lastSplit: lastSplit ?? this.lastSplit,
+      trimPosition: clearTrimPosition
+          ? null
+          : (trimPosition ?? this.trimPosition),
+      trimmingClipId: clearTrimmingClipId
+          ? null
+          : (trimmingClipId ?? this.trimmingClipId),
     );
   }
 
@@ -73,6 +98,8 @@ class ClipEditorState extends Equatable {
     isTrimDragging,
     // Identity-only: each ClipSplitEvent is a fresh instance per split.
     identityHashCode(lastSplit),
+    trimPosition,
+    trimmingClipId,
   ];
 }
 

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -35,6 +35,7 @@ class TimelineOverlayBloc
     on<TimelineOverlayItemTrimmed>(_onItemTrimmed, transformer: restartable());
     on<TimelineOverlayItemSelected>(_onItemSelected);
     on<TimelineOverlayDragStarted>(_onDragStarted);
+    on<TimelineOverlayDragMoved>(_onDragMoved);
     on<TimelineOverlayDragEnded>(_onDragEnded);
     on<TimelineOverlayTrimStarted>(_onTrimStarted);
     on<TimelineOverlayTrimEnded>(_onTrimEnded);
@@ -318,10 +319,10 @@ class TimelineOverlayBloc
 
     final item = items[idx];
 
-    items[idx] = item.copyWith(
-      startTime: event.startTime,
-      endTime: event.endTime,
-    );
+    final newStart = event.startTime ?? item.startTime;
+    final newEnd = event.endTime ?? item.endTime;
+
+    items[idx] = item.copyWith(startTime: newStart, endTime: newEnd);
 
     // Only re-assign rows for the changed type; other types are unaffected.
     final changedType = item.type;
@@ -330,7 +331,12 @@ class TimelineOverlayBloc
       items.where((el) => el.type == changedType).toList(),
     );
 
-    emit(state.copyWith(items: [...unchanged, ...reassigned]));
+    emit(
+      state.copyWith(
+        items: [...unchanged, ...reassigned],
+        trimPosition: event.isStart ? newStart : newEnd,
+      ),
+    );
   }
 
   void _onItemSelected(
@@ -351,6 +357,14 @@ class TimelineOverlayBloc
     emit(state.copyWith(draggingItemId: event.itemId));
   }
 
+  void _onDragMoved(
+    TimelineOverlayDragMoved event,
+    Emitter<TimelineOverlayState> emit,
+  ) {
+    if (state.draggingItemId == null) return;
+    emit(state.copyWith(dragPosition: event.position));
+  }
+
   void _onDragEnded(
     TimelineOverlayDragEnded event,
     Emitter<TimelineOverlayState> emit,
@@ -360,6 +374,7 @@ class TimelineOverlayBloc
       state.copyWith(
         items: _recalculateRows(state.items),
         clearDraggingItemId: true,
+        clearDragPosition: true,
       ),
     );
   }
@@ -379,6 +394,7 @@ class TimelineOverlayBloc
       state.copyWith(
         items: _recalculateRows(state.items),
         clearTrimmingItemId: true,
+        clearTrimPosition: true,
       ),
     );
   }

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_event.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_event.dart
@@ -91,6 +91,19 @@ class TimelineOverlayDragStarted extends TimelineOverlayEvent {
   List<Object?> get props => [itemId];
 }
 
+/// Live position update during a drag gesture.
+///
+/// Emitted on every frame while the user moves an item along the
+/// timeline so the canvas can mirror the seek preview.
+class TimelineOverlayDragMoved extends TimelineOverlayEvent {
+  const TimelineOverlayDragMoved(this.position);
+
+  final Duration position;
+
+  @override
+  List<Object?> get props => [position];
+}
+
 /// Signal that the current drag gesture ended.
 class TimelineOverlayDragEnded extends TimelineOverlayEvent {
   const TimelineOverlayDragEnded();

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_state.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_state.dart
@@ -7,7 +7,9 @@ class TimelineOverlayState extends Equatable {
     this.audioTracks = const [],
     this.selectedItemId,
     this.draggingItemId,
+    this.dragPosition,
     this.trimmingItemId,
+    this.trimPosition,
     this.collapsedTypes = const {},
   });
 
@@ -26,8 +28,20 @@ class TimelineOverlayState extends Equatable {
   /// The item being dragged, or `null`.
   final String? draggingItemId;
 
+  /// The live startTime of the item currently being dragged.
+  ///
+  /// Set to the dragged item's `startTime` while a move gesture is
+  /// active; `null` when no drag is in progress.
+  final Duration? dragPosition;
+
   /// The item being trimmed, or `null`.
   final String? trimmingItemId;
+
+  /// The live position of the trim handle currently being dragged.
+  ///
+  /// Set to the dragged [startTime] or [endTime] while a trim gesture is
+  /// active; `null` when no trim is in progress.
+  final Duration? trimPosition;
 
   /// Strip types that are in collapsed view.
   final Set<TimelineOverlayType> collapsedTypes;
@@ -39,8 +53,12 @@ class TimelineOverlayState extends Equatable {
     bool clearSelectedItemId = false,
     String? draggingItemId,
     bool clearDraggingItemId = false,
+    Duration? dragPosition,
+    bool clearDragPosition = false,
     String? trimmingItemId,
     bool clearTrimmingItemId = false,
+    Duration? trimPosition,
+    bool clearTrimPosition = false,
     Set<TimelineOverlayType>? collapsedTypes,
   }) {
     return TimelineOverlayState(
@@ -52,9 +70,15 @@ class TimelineOverlayState extends Equatable {
       draggingItemId: clearDraggingItemId
           ? null
           : (draggingItemId ?? this.draggingItemId),
+      dragPosition: clearDragPosition
+          ? null
+          : (dragPosition ?? this.dragPosition),
       trimmingItemId: clearTrimmingItemId
           ? null
           : (trimmingItemId ?? this.trimmingItemId),
+      trimPosition: clearTrimPosition
+          ? null
+          : (trimPosition ?? this.trimPosition),
       collapsedTypes: collapsedTypes ?? this.collapsedTypes,
     );
   }
@@ -65,7 +89,9 @@ class TimelineOverlayState extends Equatable {
     audioTracks,
     selectedItemId,
     draggingItemId,
+    dragPosition,
     trimmingItemId,
+    trimPosition,
     collapsedTypes,
   ];
 }

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -118,8 +118,35 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
   /// Processed as a trailing seek once the current seek completes.
   Duration? _pendingSeekPosition;
 
+  /// Monotonically increasing seek generation. Bumped on every composition
+  /// swap so in-flight seeks from the previous composition are discarded.
+  int _seekEpoch = 0;
+
   /// Cached documents directory path — resolved once in [initState].
   late final Future<String> _documentsPath;
+
+  bool _isTrimmingLayer = false;
+  bool _isTrimmingClip = false;
+  bool _isDraggingLayer = false;
+
+  /// Most recent live-preview seek target captured while a layer trim
+  /// handle is being dragged. Used at gesture end to sync the
+  /// VideoEditorMainBloc's currentPosition (and thus the UI timeline
+  /// scrubber) to the release point in a single dispatch — doing it
+  /// inside the seek loop would let the scrubber jump mid-drag.
+  Duration? _lastLayerTrimPosition;
+
+  /// Same as [_lastLayerTrimPosition] but for layer item drag
+  /// (move-along-timeline) gestures. Captures the dragged item's
+  /// startTime during the drag and is dispatched once on release.
+  Duration? _lastLayerDragPosition;
+
+  /// Most recent in-progress clip trim. Captured while the gesture is
+  /// active so that, once it ends and the multi-clip composite is
+  /// restored, we can seek to the composite-timeline position that
+  /// matches where the user released the trim handle.
+  String? _lastTrimClipId;
+  Duration? _lastTrimPositionInClip;
 
   @override
   void initState() {
@@ -201,6 +228,35 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
   ///
   /// This relies on both Android and iOS returning from seekTo only
   /// after the frame is actually decoded and rendered.
+  ///
+  /// Returns the composite-timeline position of the most recent
+  /// in-progress clip trim (and clears the captured values), so that
+  /// after a trim drag ends and the multi-clip composite is restored,
+  /// playback stays on the frame the user released. Returns `null`
+  /// when no trim was in progress, the trimmed clip is no longer in
+  /// the list, or the captured position falls outside the clip's
+  /// trimmed range.
+  Duration? _consumeTrimEndStartPosition(List<DivineVideoClip> clips) {
+    final clipId = _lastTrimClipId;
+    final positionInClip = _lastTrimPositionInClip;
+    _lastTrimClipId = null;
+    _lastTrimPositionInClip = null;
+    if (clipId == null || positionInClip == null) return null;
+
+    var precedingDuration = Duration.zero;
+    for (final clip in clips) {
+      if (clip.id == clipId) {
+        final relative = positionInClip - clip.trimStart;
+        if (relative < Duration.zero || relative > clip.trimmedDuration) {
+          return null;
+        }
+        return precedingDuration + relative;
+      }
+      precedingDuration += clip.trimmedDuration;
+    }
+    return null;
+  }
+
   Future<void> _onSeekRequested(Duration position) async {
     if (!_isPlayerReadyNotifier.value) return;
 
@@ -212,16 +268,30 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
     }
 
     _isSeeking = true;
-    await _videoPlayer?.seekTo(position);
+    final epoch = _seekEpoch;
+    try {
+      await _videoPlayer?.seekTo(position);
+      if (_seekEpoch != epoch) {
+        _pendingSeekPosition = null;
+        return;
+      }
 
-    // Process trailing seek if one arrived while we were busy.
-    while (_pendingSeekPosition != null && mounted) {
-      final pending = _pendingSeekPosition!;
-      _pendingSeekPosition = null;
-      await _videoPlayer?.seekTo(pending);
+      // Process trailing seek if one arrived while we were busy.
+      while (_pendingSeekPosition != null && mounted) {
+        final pending = _pendingSeekPosition!;
+        _pendingSeekPosition = null;
+        await _videoPlayer?.seekTo(pending);
+        if (_seekEpoch != epoch) {
+          _pendingSeekPosition = null;
+          break;
+        }
+      }
+    } finally {
+      // Only reset under the current epoch; a composition swap takes over ownership.
+      if (_seekEpoch == epoch) {
+        _isSeeking = false;
+      }
     }
-
-    _isSeeking = false;
   }
 
   /// Dispatches playback state changes to the BLoC.
@@ -238,7 +308,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
       bloc.add(VideoEditorPlaybackChanged(isPlaying: isPlaying));
     }
 
-    if (playerState.position != _lastReportedPosition) {
+    if (!_isTrimmingLayer &&
+        !_isTrimmingClip &&
+        !_isDraggingLayer &&
+        _pendingSeekPosition == null &&
+        playerState.position != _lastReportedPosition) {
       _lastReportedPosition = playerState.position;
       bloc.add(VideoEditorPositionChanged(playerState.position));
       _proVideoController.setPlayTime(playerState.position);
@@ -708,6 +782,98 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
     // Listen for playback control requests from BLoC
     return MultiBlocListener(
       listeners: [
+        BlocListener<TimelineOverlayBloc, TimelineOverlayState>(
+          listenWhen: (previous, current) {
+            _isTrimmingLayer = previous.trimmingItemId != null;
+            return previous.trimPosition != current.trimPosition &&
+                _isTrimmingLayer;
+          },
+          listener: (context, state) {
+            // trimPosition is null on the release emit — skip to preserve
+            // _lastLayerTrimPosition for the end-listener below.
+            final position = state.trimPosition;
+            if (position == null) return;
+            _lastLayerTrimPosition = position;
+            _onSeekRequested(position);
+          },
+        ),
+        // Sync scrubber once at gesture end (not mid-drag) to avoid
+        // premature scrubber jumps while the seek is still in flight.
+        BlocListener<TimelineOverlayBloc, TimelineOverlayState>(
+          listenWhen: (previous, current) =>
+              previous.trimmingItemId != null && current.trimmingItemId == null,
+          listener: (context, _) {
+            final position = _lastLayerTrimPosition;
+            _lastLayerTrimPosition = null;
+            if (position == null) return;
+            _lastReportedPosition = position;
+            context.read<VideoEditorMainBloc>().add(
+              VideoEditorPositionChanged(position),
+            );
+          },
+        ),
+        // Live seek while a layer item is dragged: follow its startTime.
+        BlocListener<TimelineOverlayBloc, TimelineOverlayState>(
+          listenWhen: (previous, current) {
+            _isDraggingLayer = current.draggingItemId != null;
+            return previous.dragPosition != current.dragPosition &&
+                current.dragPosition != null;
+          },
+          listener: (context, state) {
+            final position = state.dragPosition;
+            if (position == null) return;
+            _lastLayerDragPosition = position;
+            _onSeekRequested(position);
+          },
+        ),
+        // Sync scrubber once at drag end (not mid-drag).
+        BlocListener<TimelineOverlayBloc, TimelineOverlayState>(
+          listenWhen: (previous, current) =>
+              previous.draggingItemId != null && current.draggingItemId == null,
+          listener: (context, _) {
+            final position = _lastLayerDragPosition;
+            _lastLayerDragPosition = null;
+            if (position == null) return;
+            _lastReportedPosition = position;
+            context.read<VideoEditorMainBloc>().add(
+              VideoEditorPositionChanged(position),
+            );
+          },
+        ),
+        BlocListener<ClipEditorBloc, ClipEditorState>(
+          // Swap to single-clip (untrimmed) view on trim start so
+          // trimPosition seeks the correct frame.
+          listenWhen: (previous, current) =>
+              previous.trimmingClipId != current.trimmingClipId,
+          listener: (context, state) {
+            _isTrimmingClip = state.trimmingClipId != null;
+            if (state.trimmingClipId == null) return;
+            final clip = state.clips.firstWhere(
+              (c) => c.id == state.trimmingClipId,
+            );
+            final path = clip.video.file?.path;
+            if (path == null) return;
+            // Composition swap: invalidate in-flight seeks and release _isSeeking.
+            _seekEpoch++;
+            _pendingSeekPosition = null;
+            _isSeeking = false;
+            _videoPlayer?.setClips([
+              VideoClip(uri: path, end: clip.duration),
+            ]);
+          },
+        ),
+        BlocListener<ClipEditorBloc, ClipEditorState>(
+          // Live preview seek while a clip trim handle is dragged.
+          listenWhen: (previous, current) =>
+              current.trimmingClipId != null &&
+              previous.trimPosition != current.trimPosition &&
+              current.trimPosition != null,
+          listener: (context, state) {
+            _lastTrimClipId = state.trimmingClipId;
+            _lastTrimPositionInClip = state.trimPosition;
+            _onSeekRequested(state.trimPosition!);
+          },
+        ),
         // Re-export state history when an overlay item drag or trim
         // ends so the updated positions are persisted for ProofMode.
         BlocListener<TimelineOverlayBloc, TimelineOverlayState>(
@@ -767,19 +933,49 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
             // See note on the trim-times listener above: skip empty
             // clip lists to avoid crashing the iOS native player.
             if (state.clips.isEmpty) return;
-            final currentPosition = context
-                .read<VideoEditorMainBloc>()
-                .state
-                .currentPosition;
-            _videoPlayer?.setClips([
-              for (final clip in state.clips)
-                if (clip.video.file?.path case final path?)
-                  VideoClip(
-                    uri: path,
-                    start: clip.trimStart,
-                    end: clip.duration - clip.trimEnd,
-                  ),
-            ], startPosition: currentPosition);
+
+            // Seek to the trim handle's release point when restoring the composite.
+            final trimEndPosition = _consumeTrimEndStartPosition(state.clips);
+            final mainBloc = context.read<VideoEditorMainBloc>();
+            final startPosition =
+                trimEndPosition ?? mainBloc.state.currentPosition;
+            // Sync so subsequent re-emits read the post-seek position.
+            if (trimEndPosition != null) {
+              mainBloc.add(VideoEditorPositionChanged(trimEndPosition));
+            }
+            // Composition swap back — invalidate in-flight single-clip seeks.
+            _seekEpoch++;
+            _pendingSeekPosition = null;
+            // Claim _isSeeking under the new epoch; try/finally ensures
+            // release even if setClips throws.
+            _isSeeking = true;
+            final ownerEpoch = _seekEpoch;
+            unawaited(() async {
+              try {
+                await _videoPlayer?.setClips([
+                  for (final clip in state.clips)
+                    if (clip.video.file?.path case final path?)
+                      VideoClip(
+                        uri: path,
+                        start: clip.trimStart,
+                        end: clip.duration - clip.trimEnd,
+                      ),
+                ], startPosition: startPosition);
+              } catch (e, s) {
+                Log.error(
+                  'setClips failed on trim release: $e',
+                  name: 'VideoEditorCanvas',
+                  category: LogCategory.video,
+                  error: e,
+                  stackTrace: s,
+                );
+              } finally {
+                _lastReportedPosition = startPosition;
+                if (_seekEpoch == ownerEpoch) {
+                  _isSeeking = false;
+                }
+              }
+            }());
           },
         ),
         BlocListener<VideoEditorMainBloc, VideoEditorMainState>(

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -21,6 +21,7 @@ part 'video_editor_timeline_clip_strip_tiles.dart';
 typedef ClipTrimCallback =
     void Function({
       required String clipId,
+      required bool isStart,
       required Duration trimStart,
       required Duration trimEnd,
     });

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -71,6 +71,7 @@ class _TrimmableClipTileState extends State<_TrimmableClipTile> {
 
     widget.onTrimChanged?.call(
       clipId: clip.id,
+      isStart: true,
       trimStart: newTrimStart,
       trimEnd: clip.trimEnd,
     );
@@ -102,6 +103,7 @@ class _TrimmableClipTileState extends State<_TrimmableClipTile> {
 
     widget.onTrimChanged?.call(
       clipId: clip.id,
+      isStart: false,
       trimStart: clip.trimStart,
       trimEnd: newTrimEnd,
     );

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -289,12 +289,14 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
 
   void _onClipTrimChange({
     required String clipId,
+    required bool isStart,
     required Duration trimStart,
     required Duration trimEnd,
   }) {
     context.read<ClipEditorBloc>().add(
       ClipEditorTrimUpdated(
         clipId: clipId,
+        isStart: isStart,
         trimStart: trimStart,
         trimEnd: trimEnd,
       ),
@@ -313,12 +315,9 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
         const VideoEditorExternalPauseRequested(isPaused: true),
       );
     } else {
-      final clips = context
-          .read<ClipEditorBloc>()
-          .state
-          .clips
-          .map((e) => e.toJson())
-          .toList();
+      clipEditorBloc.add(const ClipEditorTrimDragEnded());
+
+      final clips = clipEditorBloc.state.clips.map((e) => e.toJson()).toList();
 
       editor.addHistory(
         meta: {
@@ -590,6 +589,13 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
     // Mirror the position live during drag so the canvas updates every frame,
     // just like trim does via setLayerTimeline/setFilterTimeline.
     final editor = VideoEditorScope.of(context).requireEditor;
+
+    // Publish the live drag position to the BLoC so the canvas can
+    // seek the player preview to the new startTime on every frame
+    // (parallel to trimPosition for trim gestures).
+    context.read<TimelineOverlayBloc>().add(
+      TimelineOverlayDragMoved(startTime),
+    );
 
     switch (item.type) {
       case .layer:

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -720,6 +720,7 @@ void main() {
         act: (bloc) => bloc.add(
           const ClipEditorTrimUpdated(
             clipId: 'a',
+            isStart: true,
             trimStart: Duration(milliseconds: 500),
             trimEnd: Duration(milliseconds: 300),
           ),
@@ -746,6 +747,7 @@ void main() {
         act: (bloc) => bloc.add(
           const ClipEditorTrimUpdated(
             clipId: 'unknown',
+            isStart: true,
             trimStart: Duration(seconds: 1),
             trimEnd: Duration.zero,
           ),
@@ -760,6 +762,7 @@ void main() {
         act: (bloc) => bloc.add(
           const ClipEditorTrimUpdated(
             clipId: 'a',
+            isStart: true,
             trimStart: Duration(milliseconds: 500),
             trimEnd: Duration.zero,
           ),
@@ -782,6 +785,7 @@ void main() {
         act: (bloc) => bloc.add(
           const ClipEditorTrimUpdated(
             clipId: 'a',
+            isStart: true,
             trimStart: Duration(seconds: 1),
             trimEnd: Duration.zero,
           ),
@@ -790,6 +794,53 @@ void main() {
           expect(bloc.state.clips.last.trimStart, equals(Duration.zero));
           expect(bloc.state.clips.last.trimEnd, equals(Duration.zero));
         },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'sets trimmingClipId and trimPosition to clampedStart when isStart',
+        build: buildBloc,
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) => bloc.add(
+          const ClipEditorTrimUpdated(
+            clipId: 'a',
+            isStart: true,
+            trimStart: Duration(milliseconds: 500),
+            trimEnd: Duration.zero,
+          ),
+        ),
+        expect: () => [
+          isA<ClipEditorState>()
+              .having((s) => s.trimmingClipId, 'trimmingClipId', 'a')
+              .having(
+                (s) => s.trimPosition,
+                'trimPosition',
+                const Duration(milliseconds: 500),
+              ),
+        ],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'sets trimPosition to clip.duration - clampedEnd when !isStart',
+        build: buildBloc,
+        seed: () => ClipEditorState(clips: twoClips),
+        act: (bloc) => bloc.add(
+          // Clip 'a' has duration 2s; trimEnd 500ms → trimPosition 1.5s
+          const ClipEditorTrimUpdated(
+            clipId: 'a',
+            isStart: false,
+            trimStart: Duration.zero,
+            trimEnd: Duration(milliseconds: 500),
+          ),
+        ),
+        expect: () => [
+          isA<ClipEditorState>()
+              .having((s) => s.trimmingClipId, 'trimmingClipId', 'a')
+              .having(
+                (s) => s.trimPosition,
+                'trimPosition',
+                const Duration(milliseconds: 1500),
+              ),
+        ],
       );
     });
 
@@ -820,6 +871,22 @@ void main() {
             'isTrimDragging',
             isFalse,
           ),
+        ],
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'clears trimPosition and trimmingClipId',
+        build: buildBloc,
+        seed: () => const ClipEditorState(
+          isTrimDragging: true,
+          trimmingClipId: 'a',
+          trimPosition: Duration(milliseconds: 500),
+        ),
+        act: (bloc) => bloc.add(const ClipEditorTrimDragEnded()),
+        expect: () => [
+          isA<ClipEditorState>()
+              .having((s) => s.trimmingClipId, 'trimmingClipId', isNull)
+              .having((s) => s.trimPosition, 'trimPosition', isNull),
         ],
       );
     });
@@ -905,12 +972,14 @@ void main() {
         expect(
           const ClipEditorTrimUpdated(
             clipId: 'a',
+            isStart: true,
             trimStart: Duration(seconds: 1),
             trimEnd: Duration.zero,
           ),
           equals(
             const ClipEditorTrimUpdated(
               clipId: 'a',
+              isStart: true,
               trimStart: Duration(seconds: 1),
               trimEnd: Duration.zero,
             ),

--- a/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
@@ -233,6 +233,7 @@ void main() {
                 row: 1,
               ),
             ],
+            trimPosition: const Duration(seconds: 4),
           ),
         ],
       );
@@ -330,6 +331,93 @@ void main() {
           const TimelineOverlayState(),
         ],
       );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'TimelineOverlayDragMoved sets dragPosition while dragging',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) {
+          bloc
+            ..add(const TimelineOverlayDragStarted('x'))
+            ..add(
+              const TimelineOverlayDragMoved(Duration(milliseconds: 750)),
+            );
+        },
+        expect: () => [
+          const TimelineOverlayState(draggingItemId: 'x'),
+          const TimelineOverlayState(
+            draggingItemId: 'x',
+            dragPosition: Duration(milliseconds: 750),
+          ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'TimelineOverlayDragMoved is ignored when no drag is active',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) => bloc.add(
+          const TimelineOverlayDragMoved(Duration(milliseconds: 500)),
+        ),
+        expect: () => <TimelineOverlayState>[],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'TimelineOverlayDragEnded clears dragPosition',
+        build: TimelineOverlayBloc.new,
+        seed: () => const TimelineOverlayState(
+          draggingItemId: 'x',
+          dragPosition: Duration(milliseconds: 500),
+        ),
+        act: (bloc) => bloc.add(const TimelineOverlayDragEnded()),
+        expect: () => [
+          isA<TimelineOverlayState>()
+              .having((s) => s.draggingItemId, 'draggingItemId', isNull)
+              .having((s) => s.dragPosition, 'dragPosition', isNull),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'TimelineOverlayItemTrimmed exposes trimPosition for the dragged handle',
+        build: TimelineOverlayBloc.new,
+        seed: () => TimelineOverlayState(
+          items: [
+            _item(
+              id: 'a',
+              type: TimelineOverlayType.layer,
+              start: Duration.zero,
+              end: const Duration(seconds: 2),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const TimelineOverlayItemTrimmed(
+            itemId: 'a',
+            isStart: false,
+            endTime: Duration(seconds: 4),
+          ),
+        ),
+        expect: () => [
+          isA<TimelineOverlayState>().having(
+            (s) => s.trimPosition,
+            'trimPosition',
+            const Duration(seconds: 4),
+          ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'TimelineOverlayTrimEnded clears trimPosition',
+        build: TimelineOverlayBloc.new,
+        seed: () => const TimelineOverlayState(
+          trimmingItemId: 'x',
+          trimPosition: Duration(seconds: 1),
+        ),
+        act: (bloc) => bloc.add(const TimelineOverlayTrimEnded()),
+        expect: () => [
+          isA<TimelineOverlayState>()
+              .having((s) => s.trimmingItemId, 'trimmingItemId', isNull)
+              .having((s) => s.trimPosition, 'trimPosition', isNull),
+        ],
+      );
     });
 
     group(TimelineOverlayCollapseToggled, () {
@@ -404,6 +492,21 @@ void main() {
       expect(cleared.selectedItemId, isNull);
       expect(cleared.draggingItemId, isNull);
       expect(cleared.trimmingItemId, isNull);
+    });
+
+    test('copyWith clear flags reset dragPosition and trimPosition', () {
+      const state = TimelineOverlayState(
+        dragPosition: Duration(milliseconds: 500),
+        trimPosition: Duration(seconds: 2),
+      );
+
+      final cleared = state.copyWith(
+        clearDragPosition: true,
+        clearTrimPosition: true,
+      );
+
+      expect(cleared.dragPosition, isNull);
+      expect(cleared.trimPosition, isNull);
     });
   });
 


### PR DESCRIPTION

## Description

When a user trims a clip or layer, or drags a layer, the video instantly shows a live preview from the current trim position so the user can clearly see where the new start or end point will be.


Closes #3144
Closes #3260 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore