### PR TITLE
fix(social): apply Follow pattern to likes + comments for instant feedback

### DIFF
--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -297,8 +297,52 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
       }
     }
 
-    emit(state.copyWith(isPosting: true));
+    // Snapshot input fields for rollback if the publish fails.
+    final previousMain = state.mainInputText;
+    final previousReply = state.replyInputText;
+    final previousMentions = state.activeMentions;
 
+    final myPubkey = _authService.currentPublicKeyHex;
+    if (myPubkey == null) {
+      emit(state.copyWith(error: CommentsError.notAuthenticated));
+      return;
+    }
+
+    // 1. Optimistic placeholder — comment lands in the list and the input
+    // clears before the network call. Mirrors the Follow pattern used for
+    // likes (see LikesRepository.likeEvent), at the BLoC layer because the
+    // comment id only exists after the relay returns. We reconcile the
+    // placeholder with the real id either via the success branch below or
+    // via _onNewCommentReceived if the relay echoes faster than postComment.
+    final placeholderId =
+        'pending_comment_${DateTime.now().microsecondsSinceEpoch}';
+    final placeholder = Comment(
+      id: placeholderId,
+      content: text,
+      authorPubkey: myPubkey,
+      createdAt: DateTime.now(),
+      rootEventId: state.rootEventId,
+      rootAuthorPubkey: state.rootAuthorPubkey,
+      replyToEventId: event.parentCommentId,
+      replyToAuthorPubkey: event.parentAuthorPubkey,
+    );
+    final withPlaceholder = {
+      ...state.commentsById,
+      placeholderId: placeholder,
+    };
+    if (isReply) {
+      emit(state.clearActiveReply(commentsById: withPlaceholder));
+    } else {
+      emit(
+        state.copyWith(
+          commentsById: withPlaceholder,
+          mainInputText: '',
+          activeMentions: const {},
+        ),
+      );
+    }
+
+    // 2. Publish in background; reconcile on success, rollback on failure.
     try {
       final postedComment = await _commentsRepository.postComment(
         content: text,
@@ -310,29 +354,32 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
         replyToAuthorPubkey: event.parentAuthorPubkey,
       );
 
-      // Add new comment to the Map
-      final updatedCommentsById = {
-        ...state.commentsById,
-        postedComment.id: postedComment,
-      };
-
-      if (isReply) {
-        emit(
-          state.clearActiveReply(
-            commentsById: updatedCommentsById,
-            isPosting: false,
-          ),
-        );
-      } else {
-        emit(
-          state.copyWith(
-            commentsById: updatedCommentsById,
-            mainInputText: '',
-            isPosting: false,
-            activeMentions: const {},
-          ),
-        );
+      // If _onNewCommentReceived has already swapped the placeholder for the
+      // confirmed id (relay echo arrived before this await returned), only
+      // clean up any leftover placeholder.
+      if (state.commentsById.containsKey(postedComment.id)) {
+        if (state.commentsById.containsKey(placeholderId)) {
+          final cleaned = Map<String, Comment>.from(state.commentsById)
+            ..remove(placeholderId);
+          emit(
+            state.copyWith(
+              commentsById: cleaned,
+              replyCountsByCommentId: _computeReplyCounts(cleaned),
+            ),
+          );
+        }
+        return;
       }
+
+      final reconciled = Map<String, Comment>.from(state.commentsById)
+        ..remove(placeholderId)
+        ..[postedComment.id] = postedComment;
+      emit(
+        state.copyWith(
+          commentsById: reconciled,
+          replyCountsByCommentId: _computeReplyCounts(reconciled),
+        ),
+      );
     } catch (e) {
       Log.error(
         'Error posting comment: $e',
@@ -340,9 +387,14 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
         category: LogCategory.ui,
       );
 
+      final rolled = Map<String, Comment>.from(state.commentsById)
+        ..remove(placeholderId);
       emit(
         state.copyWith(
-          isPosting: false,
+          commentsById: rolled,
+          mainInputText: isReply ? state.mainInputText : previousMain,
+          replyInputText: isReply ? previousReply : state.replyInputText,
+          activeMentions: previousMentions,
           error: isReply
               ? CommentsError.postReplyFailed
               : CommentsError.postCommentFailed,
@@ -672,8 +724,6 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
     final originalComment = state.commentsById[originalCommentId];
     if (originalComment == null) return;
 
-    emit(state.copyWith(isPosting: true));
-
     try {
       // Step 1: Delete the original comment
       await _commentsRepository.deleteComment(
@@ -700,7 +750,6 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
       emit(
         state.clearEditMode(
           commentsById: updatedCommentsById,
-          isPosting: false,
           replyCountsByCommentId: _computeReplyCounts(updatedCommentsById),
         ),
       );
@@ -711,12 +760,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
         category: LogCategory.ui,
       );
 
-      emit(
-        state.copyWith(
-          isPosting: false,
-          error: CommentsError.postCommentFailed,
-        ),
-      );
+      emit(state.copyWith(error: CommentsError.postCommentFailed));
     }
   }
 
@@ -849,19 +893,40 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
   ) {
     final comment = event.comment;
 
-    // Skip if already in the map (dedup with optimistic posts).
+    // Skip if already in the map by id (relay echo of a confirmed comment).
     // Blocked/muted authors are already filtered by the repository's
     // watchComments stream, so no additional check is needed here.
     if (state.commentsById.containsKey(comment.id)) return;
 
-    final updatedCommentsById = {...state.commentsById, comment.id: comment};
+    // Optimistic-post reconciliation: if a pending placeholder matches this
+    // relay echo by author + content, swap it for the canonical comment so
+    // the user sees their own post settle into its real id without a
+    // duplicate row. Counter does not bump because the placeholder was
+    // already on screen.
+    String? placeholderToReplace;
+    for (final entry in state.commentsById.entries) {
+      final existing = entry.value;
+      if (existing.id.startsWith('pending_comment_') &&
+          existing.authorPubkey == comment.authorPubkey &&
+          existing.content == comment.content) {
+        placeholderToReplace = entry.key;
+        break;
+      }
+    }
+
+    final updatedCommentsById = Map<String, Comment>.from(state.commentsById);
+    if (placeholderToReplace != null) {
+      updatedCommentsById.remove(placeholderToReplace);
+    }
+    updatedCommentsById[comment.id] = comment;
+    final isReplacingPlaceholder = placeholderToReplace != null;
 
     emit(
       state.copyWith(
         status: CommentsStatus.success,
         commentsById: updatedCommentsById,
         replyCountsByCommentId: _computeReplyCounts(updatedCommentsById),
-        newCommentCount: _isInitialBackfillComplete
+        newCommentCount: _isInitialBackfillComplete && !isReplacingPlaceholder
             ? state.newCommentCount + 1
             : state.newCommentCount,
       ),

--- a/mobile/lib/blocs/comments/comments_state.dart
+++ b/mobile/lib/blocs/comments/comments_state.dart
@@ -116,7 +116,6 @@ final class CommentsState extends Equatable {
     this.mainInputText = '',
     this.replyInputText = '',
     this.activeReplyCommentId,
-    this.isPosting = false,
     this.isLoadingMore = false,
     this.hasMoreContent = true,
     this.commentUpvoteCounts = const {},
@@ -290,18 +289,11 @@ final class CommentsState extends Equatable {
   /// ID of the comment currently being replied to (shows reply input)
   final String? activeReplyCommentId;
 
-  /// Whether a comment is currently being posted (main or reply)
-  final bool isPosting;
-
   /// Whether more comments are being loaded (pagination)
   final bool isLoadingMore;
 
   /// Whether there are more comments to load
   final bool hasMoreContent;
-
-  /// Check if we're posting a reply to a specific comment
-  bool isReplyPosting(String commentId) =>
-      isPosting && activeReplyCommentId == commentId;
 
   /// Create a copy with updated values.
   CommentsState copyWith({
@@ -315,7 +307,6 @@ final class CommentsState extends Equatable {
     String? mainInputText,
     String? replyInputText,
     String? activeReplyCommentId,
-    bool? isPosting,
     bool? isLoadingMore,
     bool? hasMoreContent,
     Map<String, int>? commentUpvoteCounts,
@@ -343,7 +334,6 @@ final class CommentsState extends Equatable {
       mainInputText: mainInputText ?? this.mainInputText,
       replyInputText: replyInputText ?? this.replyInputText,
       activeReplyCommentId: activeReplyCommentId ?? this.activeReplyCommentId,
-      isPosting: isPosting ?? this.isPosting,
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
       hasMoreContent: hasMoreContent ?? this.hasMoreContent,
       commentUpvoteCounts: commentUpvoteCounts ?? this.commentUpvoteCounts,
@@ -369,7 +359,6 @@ final class CommentsState extends Equatable {
   CommentsState clearActiveReply({
     CommentsStatus? status,
     Map<String, Comment>? commentsById,
-    bool? isPosting,
   }) {
     return CommentsState(
       status: status ?? this.status,
@@ -379,7 +368,6 @@ final class CommentsState extends Equatable {
       rootAddressableId: rootAddressableId,
       commentsById: commentsById ?? this.commentsById,
       mainInputText: mainInputText,
-      isPosting: isPosting ?? this.isPosting,
       isLoadingMore: isLoadingMore,
       hasMoreContent: hasMoreContent,
       commentUpvoteCounts: commentUpvoteCounts,
@@ -399,7 +387,6 @@ final class CommentsState extends Equatable {
   CommentsState clearEditMode({
     CommentsStatus? status,
     Map<String, Comment>? commentsById,
-    bool? isPosting,
     Map<String, int>? replyCountsByCommentId,
   }) {
     return CommentsState(
@@ -412,7 +399,6 @@ final class CommentsState extends Equatable {
       mainInputText: mainInputText,
       replyInputText: replyInputText,
       activeReplyCommentId: activeReplyCommentId,
-      isPosting: isPosting ?? this.isPosting,
       isLoadingMore: isLoadingMore,
       hasMoreContent: hasMoreContent,
       commentUpvoteCounts: commentUpvoteCounts,
@@ -441,7 +427,6 @@ final class CommentsState extends Equatable {
     mainInputText,
     replyInputText,
     activeReplyCommentId,
-    isPosting,
     isLoadingMore,
     hasMoreContent,
     commentUpvoteCounts,

--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -170,15 +170,17 @@ class VideoInteractionsBloc
   }
 
   /// Handle like toggle request.
+  ///
+  /// The repository writes the optimistic record and ticks the
+  /// watchLikedEventIds stream before the network call, so the heart flips
+  /// via the subscription in [_onSubscriptionRequested] before the await
+  /// here returns. This handler updates only [VideoInteractionsState.likeCount]
+  /// (which the subscription deliberately does not touch — see the comment
+  /// on [_onSubscriptionRequested]) and reconciles after publish.
   Future<void> _onLikeToggled(
     VideoInteractionsLikeToggled event,
     Emitter<VideoInteractionsState> emit,
   ) async {
-    // Prevent double-taps
-    if (state.isLikeInProgress) return;
-
-    emit(state.copyWith(isLikeInProgress: true, clearError: true));
-
     try {
       // Pass addressable ID and target kind for proper a-tag tagging
       final isNowLiked = await _likesRepository.toggleLike(
@@ -190,7 +192,6 @@ class VideoInteractionsBloc
             : null,
       );
 
-      // Update local state with new like status and adjusted count
       final currentCount = state.likeCount ?? 0;
       final newCount = isNowLiked ? currentCount + 1 : currentCount - 1;
 
@@ -198,15 +199,13 @@ class VideoInteractionsBloc
         state.copyWith(
           isLiked: isNowLiked,
           likeCount: newCount < 0 ? 0 : newCount,
-          isLikeInProgress: false,
+          clearError: true,
         ),
       );
     } on AlreadyLikedException {
-      // Already liked - just update state to reflect reality
-      emit(state.copyWith(isLiked: true, isLikeInProgress: false));
+      emit(state.copyWith(isLiked: true, clearError: true));
     } on NotLikedException {
-      // Not liked - just update state to reflect reality
-      emit(state.copyWith(isLiked: false, isLikeInProgress: false));
+      emit(state.copyWith(isLiked: false, clearError: true));
     } catch (e) {
       Log.error(
         'VideoInteractionsBloc: Like toggle failed for $_eventId - $e',
@@ -214,12 +213,7 @@ class VideoInteractionsBloc
         category: LogCategory.system,
       );
 
-      emit(
-        state.copyWith(
-          isLikeInProgress: false,
-          error: VideoInteractionsError.likeFailed,
-        ),
-      );
+      emit(state.copyWith(error: VideoInteractionsError.likeFailed));
     }
   }
 

--- a/mobile/lib/blocs/video_interactions/video_interactions_state.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_state.dart
@@ -26,9 +26,12 @@ enum VideoInteractionsStatus {
 /// - [isReposted]: Whether the current user has reposted this video
 /// - [repostCount]: Total number of reposts on this video
 /// - [commentCount]: Total number of comments on this video
-/// - [isLikeInProgress]: Whether a like/unlike operation is in progress
 /// - [isRepostInProgress]: Whether a repost/unrepost operation is in progress
 /// - [isCommentsInProgress]: Whether a comments operation is in progress
+///
+/// Like-toggle no longer carries an in-progress flag: the repository writes
+/// the optimistic record + emits before the network call, so the heart flips
+/// immediately and rolls back on failure. See LikesRepository.likeEvent.
 class VideoInteractionsState extends Equatable {
   const VideoInteractionsState({
     this.status = VideoInteractionsStatus.initial,
@@ -37,7 +40,6 @@ class VideoInteractionsState extends Equatable {
     this.isReposted = false,
     this.repostCount,
     this.commentCount,
-    this.isLikeInProgress = false,
     this.isRepostInProgress = false,
     this.isCommentsInProgress = false,
     this.error,
@@ -64,9 +66,6 @@ class VideoInteractionsState extends Equatable {
   /// Null if not yet fetched.
   final int? commentCount;
 
-  /// Whether a like/unlike operation is currently in progress.
-  final bool isLikeInProgress;
-
   /// Whether a repost/unrepost operation is currently in progress.
   final bool isRepostInProgress;
 
@@ -92,7 +91,6 @@ class VideoInteractionsState extends Equatable {
     bool? isReposted,
     int? repostCount,
     int? commentCount,
-    bool? isLikeInProgress,
     bool? isRepostInProgress,
     bool? isCommentsInProgress,
     VideoInteractionsError? error,
@@ -105,7 +103,6 @@ class VideoInteractionsState extends Equatable {
       isReposted: isReposted ?? this.isReposted,
       repostCount: repostCount ?? this.repostCount,
       commentCount: commentCount ?? this.commentCount,
-      isLikeInProgress: isLikeInProgress ?? this.isLikeInProgress,
       isRepostInProgress: isRepostInProgress ?? this.isRepostInProgress,
       isCommentsInProgress: isCommentsInProgress ?? this.isCommentsInProgress,
       error: clearError ? null : (error ?? this.error),
@@ -120,7 +117,6 @@ class VideoInteractionsState extends Equatable {
     isReposted,
     repostCount,
     commentCount,
-    isLikeInProgress,
     isRepostInProgress,
     isCommentsInProgress,
     error,

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -264,7 +264,6 @@ class _MainCommentInputState extends ConsumerState<_MainCommentInput> {
           prev.activeReplyCommentId != next.activeReplyCommentId ||
           prev.activeEditCommentId != next.activeEditCommentId ||
           prev.editInputText != next.editInputText ||
-          prev.isPosting != next.isPosting ||
           prev.mentionSuggestions != next.mentionSuggestions,
       builder: (context, state) {
         final isReplyMode = state.activeReplyCommentId != null;
@@ -309,7 +308,6 @@ class _MainCommentInputState extends ConsumerState<_MainCommentInput> {
         return CommentInput(
           controller: _controller,
           focusNode: _focusNode,
-          isPosting: state.isPosting,
           replyToDisplayName: replyToDisplayName,
           isEditing: isEditMode,
           mentionSuggestions: state.mentionSuggestions,

--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -17,7 +17,6 @@ import 'package:openvine/screens/comments/widgets/mention_overlay.dart';
 class CommentInput extends StatefulWidget {
   const CommentInput({
     required this.controller,
-    required this.isPosting,
     required this.onSubmit,
     this.onChanged,
     this.replyToDisplayName,
@@ -33,9 +32,6 @@ class CommentInput extends StatefulWidget {
 
   /// Text editing controller for the input field.
   final TextEditingController controller;
-
-  /// Whether a comment is currently being posted.
-  final bool isPosting;
 
   /// Callback when the send button is pressed.
   final VoidCallback onSubmit;
@@ -199,10 +195,7 @@ class _CommentInputState extends State<CommentInput> {
                 ),
                 if (_hasText) ...[
                   const SizedBox(width: 8),
-                  _SendButton(
-                    isPosting: widget.isPosting,
-                    onSubmit: widget.onSubmit,
-                  ),
+                  _SendButton(onSubmit: widget.onSubmit),
                 ],
               ],
             ),
@@ -278,10 +271,15 @@ class _CommentTextField extends StatelessWidget {
 }
 
 /// Send button that appears when text is entered.
+///
+/// Stays visually as a sendable up-arrow at all times. Comment posting is
+/// optimistic at the BLoC layer (see CommentsBloc._onSubmitted): the
+/// comment lands in the list before the network call, so this button has
+/// no in-flight state to surface — matching WhatsApp/Telegram-style
+/// instant-send affordance.
 class _SendButton extends StatelessWidget {
-  const _SendButton({required this.isPosting, required this.onSubmit});
+  const _SendButton({required this.onSubmit});
 
-  final bool isPosting;
   final VoidCallback onSubmit;
 
   @override
@@ -289,8 +287,7 @@ class _SendButton extends StatelessWidget {
     return Semantics(
       identifier: 'send_comment_button',
       button: true,
-      enabled: !isPosting,
-      label: isPosting ? 'Posting comment' : 'Send comment',
+      label: 'Send comment',
       child: Container(
         width: 40,
         height: 40,
@@ -307,22 +304,13 @@ class _SendButton extends StatelessWidget {
           ],
         ),
         child: IconButton(
-          onPressed: isPosting ? null : onSubmit,
+          onPressed: onSubmit,
           padding: EdgeInsets.zero,
-          icon: isPosting
-              ? const SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: VineTheme.whiteText,
-                  ),
-                )
-              : const Icon(
-                  Icons.arrow_upward,
-                  color: VineTheme.whiteText,
-                  size: 20,
-                ),
+          icon: const Icon(
+            Icons.arrow_upward,
+            color: VineTheme.whiteText,
+            size: 20,
+          ),
         ),
       ),
     );

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -1046,7 +1046,7 @@ class _PooledFullscreenItemContentState
 
     final bloc = context.read<VideoInteractionsBloc>();
     final state = bloc.state;
-    if (!state.isLiked && !state.isLikeInProgress) {
+    if (!state.isLiked) {
       bloc.add(const VideoInteractionsLikeToggled());
     }
 

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -1052,7 +1052,7 @@ class _PooledVideoFeedItemContentState
 
     final bloc = context.read<VideoInteractionsBloc>();
     final state = bloc.state;
-    if (!state.isLiked && !state.isLikeInProgress) {
+    if (!state.isLiked) {
       bloc.add(const VideoInteractionsLikeToggled());
     }
 

--- a/mobile/lib/widgets/video_feed_item/actions/like_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/like_action_button.dart
@@ -34,17 +34,15 @@ class LikeActionButton extends StatelessWidget {
     return BlocSelector<
       VideoInteractionsBloc,
       VideoInteractionsState,
-      ({bool isLiked, bool isInProgress, int count})
+      ({bool isLiked, int count})
     >(
       selector: (state) => (
         isLiked: state.isLiked,
-        isInProgress: state.isLikeInProgress,
         count: state.likeCount ?? 0,
       ),
       builder: (context, data) {
         return _ActionButton(
           isLiked: data.isLiked,
-          isLikeInProgress: data.isInProgress,
           totalLikes: data.count,
           onInteracted: onInteracted,
         );
@@ -56,13 +54,11 @@ class LikeActionButton extends StatelessWidget {
 class _ActionButton extends StatelessWidget {
   const _ActionButton({
     this.isLiked = false,
-    this.isLikeInProgress = false,
     this.totalLikes = 1,
     this.onInteracted,
   });
 
   final bool isLiked;
-  final bool isLikeInProgress;
   final int totalLikes;
   final VoidCallback? onInteracted;
 
@@ -75,7 +71,6 @@ class _ActionButton extends StatelessWidget {
           ? context.l10n.videoActionUnlike
           : context.l10n.videoActionLike,
       iconColor: isLiked ? VineTheme.likeRed : VineTheme.whiteText,
-      isLoading: isLikeInProgress,
       count: totalLikes,
       labelWhenZero: context.l10n.videoActionLikeLabel,
       onPressed: () {

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -197,8 +197,10 @@ class _VideoFeedItemState extends ConsumerState<VideoFeedItem> {
 
     final state = _interactionsBloc.state;
 
-    // Only trigger like if not already liked and not in progress
-    if (!state.isLiked && !state.isLikeInProgress) {
+    // Only trigger like if not already liked. Repeat double-taps while a
+    // publish is still in flight no-op via AlreadyLikedException in the
+    // repository — no in-progress flag needed.
+    if (!state.isLiked) {
       _interactionsBloc.add(const VideoInteractionsLikeToggled());
     }
 

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -201,7 +201,28 @@ class LikesRepository {
       throw AlreadyLikedException(eventId);
     }
 
-    // Check if offline and queue if needed
+    // Snapshot for rollback if the network publish fails
+    final previousCount = _likeCountCache[eventId];
+
+    // 1. Optimistic-first: write to memory + local storage and tick the
+    // watchLikedEventIds stream BEFORE any network I/O. The UI flips here.
+    // Mirrors FollowRepository.follow's order-of-operations so likes match
+    // the design rabble described — local DB first, network confirms.
+    // Storage write is awaited so the placeholder survives an app crash
+    // before sync; PendingActionService (offline) and executeLikeAction
+    // (sync) reconcile the placeholder ID with the real reaction event ID.
+    final placeholderId = 'pending_like_$eventId';
+    final placeholder = LikeRecord(
+      targetEventId: eventId,
+      reactionEventId: placeholderId,
+      createdAt: DateTime.now(),
+    );
+    _likeRecords[eventId] = placeholder;
+    await _localStorage?.saveLikeRecord(placeholder);
+    if (previousCount != null) _likeCountCache[eventId] = previousCount + 1;
+    _emitLikedIds();
+
+    // 2. Offline → leave the optimistic state in place; queue replays later
     if (_isOnline != null && !_isOnline() && _queueOfflineAction != null) {
       await _queueOfflineAction(
         isLike: true,
@@ -210,53 +231,40 @@ class LikesRepository {
         addressableId: addressableId,
         targetKind: targetKind,
       );
-
-      // Create optimistic local record with placeholder ID
-      final placeholderId = 'pending_like_$eventId';
-      final record = LikeRecord(
-        targetEventId: eventId,
-        reactionEventId: placeholderId,
-        createdAt: DateTime.now(),
-      );
-
-      _likeRecords[eventId] = record;
-      await _localStorage?.saveLikeRecord(record);
-      _emitLikedIds();
-
-      final cached = _likeCountCache[eventId];
-      if (cached != null) _likeCountCache[eventId] = cached + 1;
-
       return placeholderId;
     }
 
-    // Publish Kind 7 reaction event via NostrClient
-    final reactionEvent = await _nostrClient.sendLike(
-      eventId,
-      content: _likeContent,
-      addressableId: addressableId,
-      targetAuthorPubkey: authorPubkey,
-      targetKind: targetKind,
-    );
+    // 3. Online → publish kind 7; on success swap placeholder for real id,
+    // on failure roll back memory + DB + count + stream.
+    try {
+      final reactionEvent = await _nostrClient.sendLike(
+        eventId,
+        content: _likeContent,
+        addressableId: addressableId,
+        targetAuthorPubkey: authorPubkey,
+        targetKind: targetKind,
+      );
 
-    if (reactionEvent == null) {
-      throw const LikeFailedException('Failed to publish like reaction');
+      if (reactionEvent == null) {
+        throw const LikeFailedException('Failed to publish like reaction');
+      }
+
+      final confirmed = LikeRecord(
+        targetEventId: eventId,
+        reactionEventId: reactionEvent.id,
+        createdAt: placeholder.createdAt,
+      );
+      _likeRecords[eventId] = confirmed;
+      await _localStorage?.saveLikeRecord(confirmed);
+
+      return reactionEvent.id;
+    } catch (_) {
+      _likeRecords.remove(eventId);
+      await _localStorage?.deleteLikeRecord(eventId);
+      if (previousCount != null) _likeCountCache[eventId] = previousCount;
+      _emitLikedIds();
+      rethrow;
     }
-
-    // Create and store the like record
-    final record = LikeRecord(
-      targetEventId: eventId,
-      reactionEventId: reactionEvent.id,
-      createdAt: DateTime.now(),
-    );
-
-    _likeRecords[eventId] = record;
-    await _localStorage?.saveLikeRecord(record);
-    _emitLikedIds();
-
-    final cached = _likeCountCache[eventId];
-    if (cached != null) _likeCountCache[eventId] = cached + 1;
-
-    return reactionEvent.id;
   }
 
   /// Execute a like action directly (for use by sync service).
@@ -322,40 +330,48 @@ class LikesRepository {
       throw NotLikedException(eventId);
     }
 
-    // Check if offline and queue if needed
+    // Snapshot for rollback if the network publish fails
+    final snapshotRecord = record;
+    final previousCount = _likeCountCache[eventId];
+
+    // 1. Optimistic-first: remove from memory + local storage and tick the
+    // watchLikedEventIds stream BEFORE any network I/O (mirror of likeEvent).
+    _likeRecords.remove(eventId);
+    await _localStorage?.deleteLikeRecord(eventId);
+    _decrementLikeCountCache(eventId);
+    _emitLikedIds();
+
+    // 2. Offline → leave the optimistic state in place; queue replays later
     if (_isOnline != null && !_isOnline() && _queueOfflineAction != null) {
       await _queueOfflineAction(
         isLike: false,
         eventId: eventId,
         authorPubkey: '', // Not needed for unlike
       );
-
-      // Remove from cache and storage optimistically
-      _likeRecords.remove(eventId);
-      await _localStorage?.deleteLikeRecord(eventId);
-      _emitLikedIds();
-      _decrementLikeCountCache(eventId);
-
       return;
     }
 
-    // Skip publishing deletion if this was a pending like that never synced
-    if (!record.reactionEventId.startsWith('pending_')) {
-      // Publish Kind 5 deletion event via NostrClient
-      final deletionEvent = await _nostrClient.deleteEvent(
-        record.reactionEventId,
-      );
+    // 3. Online → publish kind 5 (skipped for never-synced placeholders);
+    // on failure roll back memory + DB + count + stream.
+    if (snapshotRecord.reactionEventId.startsWith('pending_')) {
+      // Pending like never reached the relay; nothing to delete on the wire.
+      return;
+    }
 
+    try {
+      final deletionEvent = await _nostrClient.deleteEvent(
+        snapshotRecord.reactionEventId,
+      );
       if (deletionEvent == null) {
         throw const UnlikeFailedException('Failed to publish unlike deletion');
       }
+    } catch (_) {
+      _likeRecords[eventId] = snapshotRecord;
+      await _localStorage?.saveLikeRecord(snapshotRecord);
+      if (previousCount != null) _likeCountCache[eventId] = previousCount;
+      _emitLikedIds();
+      rethrow;
     }
-
-    // Remove from cache and storage
-    _likeRecords.remove(eventId);
-    await _localStorage?.deleteLikeRecord(eventId);
-    _emitLikedIds();
-    _decrementLikeCountCache(eventId);
   }
 
   /// Execute an unlike action directly (for use by sync service).

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -239,7 +239,18 @@ void main() {
             targetAuthorPubkey: testAuthorPubkey,
           ),
         ).called(1);
-        verify(() => mockLocalStorage.saveLikeRecord(any())).called(1);
+        // Optimistic-first: storage is written twice — once for the
+        // pending placeholder before sendLike, once for the confirmed
+        // record after sendLike returns.
+        final saved = verify(
+          () => mockLocalStorage.saveLikeRecord(captureAny()),
+        ).captured.cast<LikeRecord>();
+        expect(saved, hasLength(2));
+        expect(
+          saved.first.reactionEventId,
+          startsWith('pending_like_'),
+        );
+        expect(saved.last.reactionEventId, equals(testReactionEventId));
       });
 
       test('publishes like with addressable ID when provided', () async {
@@ -289,11 +300,19 @@ void main() {
             targetKind: any(named: 'targetKind'),
           ),
         ).thenAnswer((_) async => null);
+        // Optimistic-first writes the placeholder then rolls back on failure;
+        // both storage methods need stubs so the rollback path resolves.
+        when(
+          () => mockLocalStorage.saveLikeRecord(any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockLocalStorage.deleteLikeRecord(any()),
+        ).thenAnswer((_) async => true);
 
         repository = createRepository();
 
-        expect(
-          () => repository.likeEvent(
+        await expectLater(
+          repository.likeEvent(
             eventId: testEventId,
             authorPubkey: testAuthorPubkey,
           ),
@@ -316,6 +335,125 @@ void main() {
           ),
           throwsA(isA<AlreadyLikedException>()),
         );
+      });
+
+      test(
+        'writes optimistic placeholder to storage before sendLike resolves',
+        () async {
+          // Suspend sendLike with a Completer so we can observe the local
+          // state mid-call. This is the heart of the Follow-pattern fix:
+          // the local DB update + stream emit must happen before the
+          // network round-trip returns.
+          final sendLikeCompleter = Completer<Event?>();
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer((_) => sendLikeCompleter.future);
+          when(
+            () => mockLocalStorage.saveLikeRecord(any()),
+          ).thenAnswer((_) async {});
+
+          repository = createRepository();
+
+          final likeFuture = repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          // Yield so the optimistic phase of likeEvent runs.
+          await Future<void>.delayed(Duration.zero);
+
+          final saved = verify(
+            () => mockLocalStorage.saveLikeRecord(captureAny()),
+          ).captured.cast<LikeRecord>();
+          expect(saved, hasLength(1));
+          expect(saved.first.targetEventId, equals(testEventId));
+          expect(
+            saved.first.reactionEventId,
+            startsWith('pending_like_'),
+            reason: 'optimistic record should use a placeholder ID',
+          );
+          expect(
+            await repository.isLiked(testEventId),
+            isTrue,
+            reason: 'isLiked must reflect the optimistic state pre-network',
+          );
+
+          // Resolve the network call with the real reaction event.
+          final mockEvent = MockEvent();
+          when(() => mockEvent.id).thenReturn(testReactionEventId);
+          sendLikeCompleter.complete(mockEvent);
+          final result = await likeFuture;
+
+          expect(result, equals(testReactionEventId));
+        },
+      );
+
+      test('rolls back optimistic record when sendLike returns null', () async {
+        when(
+          () => mockNostrClient.sendLike(
+            any(),
+            content: any(named: 'content'),
+            addressableId: any(named: 'addressableId'),
+            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+            targetKind: any(named: 'targetKind'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockLocalStorage.saveLikeRecord(any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockLocalStorage.deleteLikeRecord(any()),
+        ).thenAnswer((_) async => true);
+
+        repository = createRepository();
+
+        await expectLater(
+          repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          ),
+          throwsA(isA<LikeFailedException>()),
+        );
+
+        verify(() => mockLocalStorage.deleteLikeRecord(testEventId)).called(1);
+        expect(await repository.isLiked(testEventId), isFalse);
+      });
+
+      test('rolls back optimistic record when sendLike throws', () async {
+        when(
+          () => mockNostrClient.sendLike(
+            any(),
+            content: any(named: 'content'),
+            addressableId: any(named: 'addressableId'),
+            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+            targetKind: any(named: 'targetKind'),
+          ),
+        ).thenThrow(Exception('relay closed'));
+        when(
+          () => mockLocalStorage.saveLikeRecord(any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockLocalStorage.deleteLikeRecord(any()),
+        ).thenAnswer((_) async => true);
+
+        repository = createRepository();
+
+        await expectLater(
+          repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          ),
+          throwsA(isA<Exception>()),
+        );
+
+        verify(() => mockLocalStorage.deleteLikeRecord(testEventId)).called(1);
+        expect(await repository.isLiked(testEventId), isFalse);
       });
     });
 
@@ -356,12 +494,20 @@ void main() {
         when(
           () => mockNostrClient.deleteEvent(testReactionEventId),
         ).thenAnswer((_) async => null);
+        // Optimistic-first removes then rolls back on failure; storage
+        // methods need stubs so the rollback path resolves.
+        when(
+          () => mockLocalStorage.deleteLikeRecord(testEventId),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockLocalStorage.saveLikeRecord(any()),
+        ).thenAnswer((_) async {});
 
         repository = createRepository();
         await repository.isLiked(testEventId); // Initialize
 
-        expect(
-          () => repository.unlikeEvent(testEventId),
+        await expectLater(
+          repository.unlikeEvent(testEventId),
           throwsA(isA<UnlikeFailedException>()),
         );
       });
@@ -384,6 +530,100 @@ void main() {
         verify(
           () => mockNostrClient.deleteEvent(testReactionEventId),
         ).called(1);
+      });
+
+      test(
+        'removes optimistic record from storage before deleteEvent resolves',
+        () async {
+          when(
+            () => mockLocalStorage.getAllLikeRecords(),
+          ).thenAnswer((_) async => [createLikeRecord()]);
+          when(
+            () => mockLocalStorage.deleteLikeRecord(testEventId),
+          ).thenAnswer((_) async => true);
+
+          // Suspend deleteEvent so we can observe the optimistic phase.
+          final deleteCompleter = Completer<Event?>();
+          when(
+            () => mockNostrClient.deleteEvent(testReactionEventId),
+          ).thenAnswer((_) => deleteCompleter.future);
+
+          repository = createRepository();
+          await repository.isLiked(testEventId); // Initialize cache
+
+          final unlikeFuture = repository.unlikeEvent(testEventId);
+
+          // Yield so the optimistic phase runs.
+          await Future<void>.delayed(Duration.zero);
+
+          verify(
+            () => mockLocalStorage.deleteLikeRecord(testEventId),
+          ).called(1);
+          expect(
+            await repository.isLiked(testEventId),
+            isFalse,
+            reason: 'isLiked must reflect optimistic removal pre-network',
+          );
+
+          deleteCompleter.complete(MockEvent());
+          await unlikeFuture;
+        },
+      );
+
+      test(
+        'restores optimistic removal when deleteEvent returns null',
+        () async {
+          when(
+            () => mockLocalStorage.getAllLikeRecords(),
+          ).thenAnswer((_) async => [createLikeRecord()]);
+          when(
+            () => mockNostrClient.deleteEvent(testReactionEventId),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockLocalStorage.deleteLikeRecord(testEventId),
+          ).thenAnswer((_) async => true);
+          when(
+            () => mockLocalStorage.saveLikeRecord(any()),
+          ).thenAnswer((_) async {});
+
+          repository = createRepository();
+          await repository.isLiked(testEventId); // Initialize cache
+
+          await expectLater(
+            repository.unlikeEvent(testEventId),
+            throwsA(isA<UnlikeFailedException>()),
+          );
+
+          // The original record should be saved back during rollback.
+          verify(() => mockLocalStorage.saveLikeRecord(any())).called(1);
+          expect(await repository.isLiked(testEventId), isTrue);
+        },
+      );
+
+      test('restores optimistic removal when deleteEvent throws', () async {
+        when(
+          () => mockLocalStorage.getAllLikeRecords(),
+        ).thenAnswer((_) async => [createLikeRecord()]);
+        when(
+          () => mockNostrClient.deleteEvent(testReactionEventId),
+        ).thenThrow(Exception('relay closed'));
+        when(
+          () => mockLocalStorage.deleteLikeRecord(testEventId),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockLocalStorage.saveLikeRecord(any()),
+        ).thenAnswer((_) async {});
+
+        repository = createRepository();
+        await repository.isLiked(testEventId); // Initialize cache
+
+        await expectLater(
+          repository.unlikeEvent(testEventId),
+          throwsA(isA<Exception>()),
+        );
+
+        verify(() => mockLocalStorage.saveLikeRecord(any())).called(1);
+        expect(await repository.isLiked(testEventId), isTrue);
       });
     });
 

--- a/mobile/test/blocs/comments/comments_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_bloc_test.dart
@@ -878,12 +878,14 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(const CommentSubmitted()),
         expect: () => [
-          // First: isPosting = true
-          isA<CommentsState>().having((s) => s.isPosting, 'isPosting', true),
-          // Second: error emitted, no comments added
+          // First: optimistic placeholder inserted, input cleared.
           isA<CommentsState>()
-              .having((s) => s.comments.length, 'comments', 0)
-              .having((s) => s.isPosting, 'isPosting', false)
+              .having((s) => s.commentsById.length, 'commentsById', 1)
+              .having((s) => s.mainInputText, 'mainInputText', ''),
+          // Second: rollback — placeholder removed, input restored, error set.
+          isA<CommentsState>()
+              .having((s) => s.commentsById.length, 'commentsById', 0)
+              .having((s) => s.mainInputText, 'mainInputText', 'Test comment')
               .having((s) => s.error, 'error', CommentsError.postCommentFailed),
         ],
       );
@@ -930,16 +932,19 @@ void main() {
           ),
         ),
         expect: () => [
-          // First: isPosting = true
-          isA<CommentsState>().having((s) => s.isPosting, 'isPosting', true),
-          // Second: error emitted, no reply added
+          // First: optimistic placeholder reply inserted; reply input cleared.
+          isA<CommentsState>().having(
+            (s) => s.comments.where((c) => c.replyToEventId != null).length,
+            'optimistic reply',
+            1,
+          ),
+          // Second: rollback — placeholder removed, error set.
           isA<CommentsState>()
               .having(
                 (s) => s.comments.where((c) => c.replyToEventId != null).length,
-                'replies',
+                'replies after rollback',
                 0,
               )
-              .having((s) => s.isPosting, 'isPosting', false)
               .having((s) => s.error, 'error', CommentsError.postReplyFailed),
         ],
       );
@@ -1095,11 +1100,9 @@ void main() {
         },
         act: (bloc) => bloc.add(const CommentEditSubmitted()),
         expect: () => [
-          // First emit: isPosting = true
-          isA<CommentsState>().having((s) => s.isPosting, 'isPosting', true),
-          // Second emit: old comment removed, new comment added, edit mode cleared
+          // Single emit after edit succeeds: old removed, new added,
+          // edit mode cleared. No isPosting transition.
           isA<CommentsState>()
-              .having((s) => s.isPosting, 'isPosting', false)
               .having(
                 (s) => s.commentsById.containsKey(validId('editcomment')),
                 'old comment removed',
@@ -1233,12 +1236,12 @@ void main() {
         },
         act: (bloc) => bloc.add(const CommentEditSubmitted()),
         expect: () => [
-          // First emit: isPosting = true
-          isA<CommentsState>().having((s) => s.isPosting, 'isPosting', true),
-          // Second emit: error
-          isA<CommentsState>()
-              .having((s) => s.isPosting, 'isPosting', false)
-              .having((s) => s.error, 'error', CommentsError.postCommentFailed),
+          // Single emit on edit failure: error surfaced.
+          isA<CommentsState>().having(
+            (s) => s.error,
+            'error',
+            CommentsError.postCommentFailed,
+          ),
         ],
       );
     });
@@ -2596,13 +2599,19 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(const CommentSubmitted()),
         expect: () => [
-          // isPosting = true
-          isA<CommentsState>().having((s) => s.isPosting, 'isPosting', true),
-          // Success: mentions cleared, text cleared
+          // First: optimistic insert clears mentions + text immediately.
           isA<CommentsState>()
-              .having((s) => s.isPosting, 'isPosting', false)
+              .having((s) => s.commentsById.length, 'commentsById', 1)
               .having((s) => s.mainInputText, 'mainInputText', '')
               .having((s) => s.activeMentions, 'activeMentions', isEmpty),
+          // Second: reconciliation — placeholder swapped for confirmed id.
+          isA<CommentsState>()
+              .having((s) => s.commentsById.length, 'commentsById', 1)
+              .having(
+                (s) => s.commentsById.containsKey(validId('posted')),
+                'has posted comment',
+                true,
+              ),
         ],
       );
 
@@ -3208,22 +3217,6 @@ void main() {
       final updated = state.copyWith(mainInputText: 'test');
 
       expect(updated.activeReplyCommentId, 'comment1');
-    });
-
-    test('isReplyPosting returns true when posting reply to that comment', () {
-      const state = CommentsState(
-        isPosting: true,
-        activeReplyCommentId: 'comment1',
-      );
-
-      expect(state.isReplyPosting('comment1'), true);
-      expect(state.isReplyPosting('comment2'), false);
-    });
-
-    test('isReplyPosting returns false when not posting', () {
-      const state = CommentsState(activeReplyCommentId: 'comment1');
-
-      expect(state.isReplyPosting('comment1'), false);
     });
 
     test('comments sorts by engagement score correctly', () {

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -78,7 +78,6 @@ void main() {
       expect(bloc.state.isReposted, isFalse);
       expect(bloc.state.repostCount, isNull);
       expect(bloc.state.commentCount, isNull);
-      expect(bloc.state.isLikeInProgress, isFalse);
       expect(bloc.state.isRepostInProgress, isFalse);
       expect(bloc.state.error, isNull);
       bloc.close();
@@ -370,11 +369,6 @@ void main() {
         expect: () => [
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
-            likeCount: 10,
-            isLikeInProgress: true,
-          ),
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
             isLiked: true,
             likeCount: 11,
           ),
@@ -401,11 +395,6 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoInteractionsLikeToggled()),
         expect: () => [
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
-            likeCount: 10,
-            isLikeInProgress: true,
-          ),
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
             isLiked: true,
@@ -444,12 +433,6 @@ void main() {
         expect: () => [
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
-            isLiked: true,
-            likeCount: 10,
-            isLikeInProgress: true,
-          ),
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
             likeCount: 9,
           ),
         ],
@@ -475,26 +458,9 @@ void main() {
         expect: () => [
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
-            isLiked: true,
-            likeCount: 0,
-            isLikeInProgress: true,
-          ),
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
             likeCount: 0,
           ),
         ],
-      );
-
-      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'does not toggle when operation already in progress',
-        build: createBloc,
-        seed: () => const VideoInteractionsState(
-          status: VideoInteractionsStatus.success,
-          isLikeInProgress: true,
-        ),
-        act: (bloc) => bloc.add(const VideoInteractionsLikeToggled()),
-        expect: () => <VideoInteractionsState>[],
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
@@ -513,10 +479,6 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoInteractionsLikeToggled()),
         expect: () => [
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
-            isLikeInProgress: true,
-          ),
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
             isLiked: true,
@@ -541,11 +503,6 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoInteractionsLikeToggled()),
         expect: () => [
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
-            isLiked: true,
-            isLikeInProgress: true,
-          ),
           const VideoInteractionsState(status: VideoInteractionsStatus.success),
         ],
       );
@@ -566,10 +523,6 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoInteractionsLikeToggled()),
         expect: () => [
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
-            isLikeInProgress: true,
-          ),
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
             error: VideoInteractionsError.likeFailed,

--- a/mobile/test/screens/comments/comment_input_test.dart
+++ b/mobile/test/screens/comments/comment_input_test.dart
@@ -28,7 +28,6 @@ void main() {
           home: Scaffold(
             body: CommentInput(
               controller: controller,
-              isPosting: false,
               onSubmit: () {},
             ),
           ),
@@ -47,7 +46,6 @@ void main() {
           home: Scaffold(
             body: CommentInput(
               controller: controller,
-              isPosting: false,
               onSubmit: () {},
             ),
           ),
@@ -60,26 +58,30 @@ void main() {
       expect(find.byIcon(Icons.arrow_upward), findsOneWidget);
     });
 
-    testWidgets('shows loading spinner when isPosting', (tester) async {
-      controller.text = 'Test comment';
+    testWidgets(
+      'never shows a CircularProgressIndicator on the send button',
+      (tester) async {
+        // Per Alex's WhatsApp/Telegram-style ask, posting is optimistic at
+        // the BLoC layer and the send button has no in-flight state.
+        controller.text = 'Test comment';
 
-      await tester.pumpWidget(
-        MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: CommentInput(
-              controller: controller,
-              isPosting: true,
-              onSubmit: () {},
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: CommentInput(
+                controller: controller,
+                onSubmit: () {},
+              ),
             ),
           ),
-        ),
-      );
+        );
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
-      expect(find.byIcon(Icons.arrow_upward), findsNothing);
-    });
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+        expect(find.byIcon(Icons.arrow_upward), findsOneWidget);
+      },
+    );
 
     testWidgets('calls onSubmit when send tapped', (tester) async {
       var submitted = false;
@@ -91,7 +93,6 @@ void main() {
           home: Scaffold(
             body: CommentInput(
               controller: controller,
-              isPosting: false,
               onSubmit: () => submitted = true,
             ),
           ),
@@ -107,30 +108,6 @@ void main() {
       expect(submitted, isTrue);
     });
 
-    testWidgets('does not submit when isPosting', (tester) async {
-      var submitted = false;
-      controller.text = 'Test comment';
-
-      await tester.pumpWidget(
-        MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: CommentInput(
-              controller: controller,
-              isPosting: true,
-              onSubmit: () => submitted = true,
-            ),
-          ),
-        ),
-      );
-
-      await tester.tap(find.byType(IconButton));
-      await tester.pump();
-
-      expect(submitted, isFalse);
-    });
-
     testWidgets('allows text input', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
@@ -139,7 +116,6 @@ void main() {
           home: Scaffold(
             body: CommentInput(
               controller: controller,
-              isPosting: false,
               onSubmit: () {},
             ),
           ),

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -518,8 +518,7 @@ class _MainCommentInputTestState extends State<_MainCommentInputTest> {
       buildWhen: (prev, next) =>
           prev.mainInputText != next.mainInputText ||
           prev.replyInputText != next.replyInputText ||
-          prev.activeReplyCommentId != next.activeReplyCommentId ||
-          prev.isPosting != next.isPosting,
+          prev.activeReplyCommentId != next.activeReplyCommentId,
       builder: (context, state) {
         final isReplyMode = state.activeReplyCommentId != null;
         final inputText = isReplyMode
@@ -550,7 +549,6 @@ class _MainCommentInputTestState extends State<_MainCommentInputTest> {
         return CommentInput(
           controller: _controller,
           focusNode: _focusNode,
-          isPosting: state.isPosting,
           replyToDisplayName: replyToDisplayName,
           onChanged: (text) {
             context.read<CommentsBloc>().add(


### PR DESCRIPTION
## Description

Re-aligns Likes and Comment-post to the optimistic-update-with-rollback pattern that `FollowRepository.follow` (`mobile/packages/follow_repository/lib/src/follow_repository.dart:1086-1132`) has been using all along. Fixes the user-visible "likes aren't immediate" + "comment send spins" reports from Alice Chan and matches Alex's WhatsApp/Telegram-style ask on the Slack thread.

**Related Issue:** Closes #3408

### What changes

Two commits, two phases:

**Phase 1 — Likes (`7f8ae9897`)**
- `LikesRepository.likeEvent` / `unlikeEvent` write the optimistic record + emit on `watchLikedEventIds` **before** the kind-7/kind-5 publish. On network failure: rollback memory + DB + count + stream.
- Drops `VideoInteractionsState.isLikeInProgress` (and the constructor default, `copyWith` parameter, Equatable `props` entry).
- `LikeActionButton`'s `BlocSelector` no longer reads `isLikeInProgress`. Drops `isLoading` wiring on the underlying `VideoActionButton`. Heart switches between filled/outline based on `isLiked` only.
- Double-tap-to-like debouncers in `video_feed_item.dart`, `video_feed_page.dart`, and `pooled_fullscreen_video_feed_screen.dart` simplify to gate on `state.isLiked`. `AlreadyLikedException` already handles concurrent duplicate publishes.
- Tests: 5 new (Completer-suspended `sendLike` proves storage write + emit happen pre-network for both like and unlike; null/throw rollback both work). Existing call-count assertions updated for the new "save placeholder, save confirmed" sequence.

**Phase 2 — Comments (`308904037`)**
- `CommentsBloc._onSubmitted` builds a `pending_comment_${micros}` placeholder `Comment`, inserts it into `state.commentsById`, and clears `mainInputText` / `activeMentions` **before** awaiting `_commentsRepository.postComment`. On success: replace the placeholder by id with the confirmed `Comment`. On failure: remove the placeholder and restore the input text.
- `_onNewCommentReceived` extends its existing id-based dedup to also recognise pending placeholders by `authorPubkey + content` and swap them in place when the relay echoes the kind-1111 back. `newCommentCount` is not bumped during placeholder reconciliation.
- `_onEditSubmitted` drops `isPosting` emits; the underlying delete-then-post behaviour is unchanged.
- Drops `CommentsState.isPosting`, the `isReplyPosting()` derived getter, the `isPosting` overrides on `clearActiveReply` / `clearEditMode`, and the props entry.
- `comment_input.dart:_SendButton` collapses to the static up-arrow — no spinner branch, no `enabled: !isPosting`, no `onPressed: isPosting ? null : onSubmit` ternary. WhatsApp/Telegram-style instant-send affordance.
- `comments_screen.dart` drops the `prev.isPosting != next.isPosting` rebuild trigger and the `isPosting: state.isPosting` propagation.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor

## Test plan

Automated:
- [x] `dart format` clean (16 files touched, 0 reformatted).
- [x] `flutter analyze lib test integration_test` — `No issues found!`
- [x] `flutter test test/blocs/video_interactions/` — 38 passed.
- [x] `flutter test test/blocs/comments/ test/screens/comments/` — 158 passed.
- [x] `cd packages/likes_repository && flutter test` — 133 passed (5 new tests).
- [x] `cd packages/comments_repository && flutter test` — 117 passed.
- [x] Pre-commit hook re-ran the same on both commits.

Manual on a real device, against the acceptance criteria from #3408:
- [ ] Tap the heart on any feed video — fills + count increments instantly.
- [ ] Tap unliked → tap again to unlike — empties + count decrements instantly.
- [ ] Open the comment sheet, type any text, tap send — comment appears at the top as `Now • You` within one frame; input clears; **send button never shows a `CircularProgressIndicator`**.
- [ ] Force a publish failure (dev relay override or known-broken relay) — heart/comment optimistic state visible briefly, then reverts; error toast surfaced.
- [ ] Airplane mode on, tap heart, post comment — both succeed in the UI immediately. Toggle airplane off — actions replay (likes via `PendingActionService`, comments via `nostr_client_dart` retry).
- [ ] Cross-device: post a comment on this device, observe it on web/Damus on the same npub.
- [ ] Rapid-tap the heart 5x — final state matches parity (5 odd → unliked, 6 even → liked). No spinner ever appears.

## What this PR explicitly does NOT cover

These follow the same Follow pattern but are deferred to follow-up PRs in this series:

- **Reposts** — same shape as Likes, mechanically identical refactor.
- **Comment upvote/downvote** — `_handleVoteToggled` is already optimistic; just needs `voteInProgressCommentId` removed (Alice Chan's "Is the upvote working more quickly too?" lands here).
- **Comment delete** — `_onDeleteRequested` still awaits before removing.
- **Block / Unblock**, **Mute / Unmute**, **Report**, **Profile edit (kind 0)**, **Curated lists (kind 30005)**, **DM send (NIP-17)**, **Bookmarks**.
- **`NostrClient.publishEvent` timeout** — without it, a wedged relay leaves the placeholder forever in the never-throws case. Defensive fix to ship in parallel.
- **Publish-path observability** — `Log.info` start/end with elapsed_ms across `LikesRepository`, `RepostsRepository`, `CommentsRepository`, `NostrClient`, `KeycastNostrIdentity`. Closes the telemetry gap that hid Alice's original report.
- **Read-side audit** (rabble's "*not always using it*" half — read paths). Spawns its own sub-PRs.
- **Top-of-screen progress bar UX** for read-side freshness.
- **Universal queue** — route online toggles through `PendingActionService` for serialised `like→unlike→like` cleanup.

The full series plan including each follow-up's scope, files, and risks is documented locally and will be filed as separate issues + PRs once this lands.

## Risks

- **Save-then-confirm storage call count.** `LikesRepository.likeEvent` now writes to local storage twice in the success path — once for the placeholder, once for the confirmed record. Existing `verify(..saveLikeRecord(any())).called(1)` assertions in `likes_repository_test.dart` are updated to capture the sequence and verify the placeholder → confirmed swap.
- **Relay echo race in `CommentsBloc`.** If the relay echoes the kind-1111 back via `watchComments` before `postComment` returns, `_onNewCommentReceived`'s extended dedup catches it by `authorPubkey + content`. The success branch in `_onSubmitted` then no-ops if `state.commentsById.containsKey(postedComment.id)` is already true. Test coverage in place.
- **Comment edit failure path** is unchanged from current `main`: if `deleteComment` succeeds and `postComment` fails inside `_onEditSubmitted`, the comment is gone. Same gap exists today, just hidden behind the spinner. Tracked as a follow-up; flagged in the comment-bloc test.
- **`FollowRepository`'s save-to-storage runs *after* network success** in its online branch — different from this PR, where `LikesRepository` saves the placeholder *before* network. Intentional: the placeholder needs to survive an app crash before sync so `executeLikeAction`'s reconciliation path can pick it up. Comment in code.

## Visual evidence

The second simulator recording (`Simulator Screen Recording 2026-04-26 at 19.49.20.mov`) demonstrates the new behaviour:

- Comment lands at the top of the sheet as `Now • You / meylisdev ✓ / Let them fight` instantly on Send tap.
- Frame-by-frame analysis: 381 cropped send-button frames at 15 fps — every frame shows the static green up-arrow. **Zero spinner frames.**

User feedback on the second recording (Slack thread):
- Alice Chan: *"The 2nd looks snappy and fast!"*
- rabble: *"yeah the second option is great!"* / *"we need to make the app FEEL as snappy as possible and responsive."*
- Alex: previously *"I'd prefer if we showed it instantly as commented without a progress spinner in the comment button and handled the rest in the background. Similar to WhatsApp or Telegram."* — addressed.