### PR TITLE
docs: plan iOS QA PR builds

### DIFF
--- a/docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md
+++ b/docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md
@@ -16,17 +16,24 @@
 - Existing iOS Codemagic workflow: `codemagic.yaml`
 - Existing web PR preview workflows: `.github/workflows/mobile_pr_preview_build.yml`, `.github/workflows/mobile_pr_preview_deploy.yml`
 - Existing web preview comment renderer: `.github/scripts/mobile_pr_preview_comment.py`
+- External docs checked on 2026-04-26:
+  - [Codemagic Builds API](https://docs.codemagic.io/rest-api/builds/): `POST /builds` accepts `appId`, `workflowId`, `branch`, `environment.variables`, and returns `buildId`.
+  - [Codemagic iOS signing](https://docs.codemagic.io/yaml-code-signing/signing-ios/): Firebase/App Distribution uses Ad Hoc signing; bundle-identifier based signing also fetches matching extension profiles.
+  - [Firebase App Distribution CLI](https://firebase.google.com/docs/app-distribution/ios/distribute-cli): use the stable `testing_uri` for testers; direct binary links expire quickly.
+  - [Codemagic Firebase distribution](https://docs.codemagic.io/yaml-distributing/firebase-app-distribution/): prefer Firebase service-account auth over deprecated Firebase token auth.
+  - [Codemagic post-publish scripts](https://docs.codemagic.io/yaml-distributing/post-publish/): post-publish scripts run even after build failure unless the build is canceled or times out; use them for GitHub status notification.
+  - [GitHub Security Lab pwn request guidance](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/): `pull_request_target` must not execute PR-controlled code in a privileged context.
 
 ## File Structure
 
 - Create: `.github/ios_qa_slots.json`
-  - Slot table for `qa01` through `qa15`: bundle IDs, extension bundle IDs, app groups, display names, and Firebase app IDs.
+  - Slot table for `qa01` through `qa15`: enabled flag, bundle IDs, extension bundle IDs, app groups, display names, and Firebase app IDs.
 - Create: `.github/scripts/ios_qa_slots.py`
-  - Pure Python logic for trust decisions, slot parsing, slot allocation, comment rendering, and directory rendering.
+  - Pure Python logic for trust decisions, slot parsing, slot allocation, sticky comment state markers, comment rendering, and directory rendering.
 - Create: `.github/scripts/tests/test_ios_qa_slots.py`
-  - Unit tests for slot selection, trust, labels, stale states, and rendered comments.
+  - Unit tests for slot selection, trust, labels, sticky state markers, stale states, queued ordering, and rendered comments.
 - Create: `.github/workflows/mobile_ios_qa_allocate.yml`
-  - Trusted metadata workflow. Uses `pull_request_target`, never checks out PR code, mirrors trusted PR heads to `ios-qa/pr-<number>`, assigns slots, triggers Codemagic, and cleans up on close.
+  - Trusted metadata workflow. Uses `pull_request_target`, checks out only base-repo scripts, never executes PR code, mirrors trusted PR heads to `ios-qa/pr-<number>`, assigns slots, triggers Codemagic, and cleans up on close.
 - Create: `mobile/lib/config/build_identity.dart`
   - Build-time identity values shared by Firebase options and push registration.
 - Modify: `mobile/lib/firebase_options.dart`
@@ -36,11 +43,11 @@
 - Create: `mobile/test/config/build_identity_test.dart`
   - Tests default production identity and QA identity under `--dart-define`.
 - Create: `mobile/scripts/ci/configure_ios_qa_slot.py`
-  - Patch iOS project build settings and entitlements for one QA slot.
+  - Patch iOS project build settings, entitlements, `GoogleService-Info.plist`, and `firebase_app_id_file.json` for one QA slot. Supports a no-write dry-run diff for the real project check.
 - Create: `mobile/scripts/ci/tests/test_configure_ios_qa_slot.py`
-  - Unit tests for project/entitlement patching using temporary fixtures.
+  - Unit tests for project, entitlement, and Firebase metadata patching using temporary fixtures.
 - Modify: `codemagic.yaml`
-  - Add an `ios-qa-pr-build` workflow using Ad Hoc signing, slot configuration, stale checks, Firebase distribution, and GitHub notification.
+  - Add an `ios-qa-pr-build` workflow using Ad Hoc signing, slot configuration before signing-profile application, stale checks, Firebase service-account distribution, and GitHub notification.
 
 ## Chunk 0: External Setup Checklist
 
@@ -94,12 +101,13 @@ ios_qa_signing
 Expected secrets:
 
 ```text
-GITHUB_TOKEN or GH_TOKEN with PR comment permissions
-FIREBASE_TOKEN or service-account auth usable by firebase-tools
+IOS_QA_GITHUB_TOKEN with PR comment/label permissions and pull request read permissions
+FIREBASE_SERVICE_ACCOUNT JSON with Firebase App Distribution Admin role
+GOOGLE_APPLICATION_CREDENTIALS=$CM_BUILD_DIR/firebase_credentials.json
 QA_FIREBASE_GROUP_ALIAS=ios-qa
 ```
 
-Codemagic must also have access to the Ad Hoc signing certificate and `qa01` provisioning profiles.
+Use Firebase token auth only as a temporary fallback; Codemagic's Firebase App Distribution docs mark token auth deprecated. Codemagic must also have access to the Ad Hoc signing certificate and `qa01` provisioning profiles.
 
 - [ ] **Step 5: Configure GitHub secrets**
 
@@ -113,6 +121,17 @@ DIVINEVIDEO_ORG_READ_TOKEN
 
 `DIVINEVIDEO_ORG_READ_TOKEN` must be able to check active org membership for private members.
 
+- [ ] **Step 6: Configure GitHub variables**
+
+Add:
+
+```text
+IOS_QA_DIRECTORY_ISSUE_NUMBER
+IOS_QA_DEFAULT_ENV=STAGING
+```
+
+If there is not yet a QA tracking issue, create one titled `iOS QA PR Builds` and store its issue number in `IOS_QA_DIRECTORY_ISSUE_NUMBER`.
+
 ## Chunk 1: Build-Time App Identity
 
 ### Task 1: Add Identity Defaults And Tests
@@ -122,7 +141,7 @@ DIVINEVIDEO_ORG_READ_TOKEN
 - Create: `mobile/lib/config/build_identity.dart`
 - Create: `mobile/test/config/build_identity_test.dart`
 
-- [ ] **Step 1: Write the default identity test**
+- [ ] **Step 1: Write the identity test**
 
 Create `mobile/test/config/build_identity_test.dart`:
 
@@ -131,10 +150,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/config/build_identity.dart';
 
 void main() {
-  test('uses production iOS identity by default', () {
-    expect(BuildIdentity.iosBundleId, 'co.openvine.app');
-    expect(BuildIdentity.pushAppIdentifier, 'co.openvine.app');
-    expect(BuildIdentity.firebaseIosAppId, '1:972941478875:ios:f61272b3cf485df244b5fe');
+  test('uses iOS identity from dart defines with production defaults', () {
+    const expectedBundleId = String.fromEnvironment(
+      'EXPECTED_IOS_BUNDLE_ID',
+      defaultValue: 'co.openvine.app',
+    );
+    const expectedPushAppIdentifier = String.fromEnvironment(
+      'EXPECTED_PUSH_APP_IDENTIFIER',
+      defaultValue: expectedBundleId,
+    );
+    const expectedFirebaseAppId = String.fromEnvironment(
+      'EXPECTED_FIREBASE_IOS_APP_ID',
+      defaultValue: '1:972941478875:ios:f61272b3cf485df244b5fe',
+    );
+
+    expect(BuildIdentity.iosBundleId, expectedBundleId);
+    expect(BuildIdentity.pushAppIdentifier, expectedPushAppIdentifier);
+    expect(BuildIdentity.firebaseIosAppId, expectedFirebaseAppId);
   });
 }
 ```
@@ -146,6 +178,13 @@ Run:
 ```bash
 cd mobile
 flutter test test/config/build_identity_test.dart
+flutter test test/config/build_identity_test.dart \
+  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
+  --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
 ```
 
 Expected: FAIL because `BuildIdentity` does not exist.
@@ -196,41 +235,9 @@ cd mobile
 flutter test test/config/build_identity_test.dart \
   --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
   --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
-  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
-```
-
-Expected: FAIL until the test is extended for override mode.
-
-- [ ] **Step 6: Extend the test for override mode**
-
-Append to `mobile/test/config/build_identity_test.dart`:
-
-```dart
-  test('can use QA identity from dart defines', () {
-    const expectedBundleId = String.fromEnvironment('EXPECTED_IOS_BUNDLE_ID');
-    const expectedFirebaseAppId = String.fromEnvironment(
-      'EXPECTED_FIREBASE_IOS_APP_ID',
-    );
-
-    if (expectedBundleId.isEmpty && expectedFirebaseAppId.isEmpty) {
-      return;
-    }
-
-    expect(BuildIdentity.iosBundleId, expectedBundleId);
-    expect(BuildIdentity.pushAppIdentifier, expectedBundleId);
-    expect(BuildIdentity.firebaseIosAppId, expectedFirebaseAppId);
-  });
-```
-
-Run:
-
-```bash
-cd mobile
-flutter test test/config/build_identity_test.dart \
-  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
-  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
   --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
   --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
   --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
 ```
 
@@ -291,6 +298,7 @@ flutter test test/config/build_identity_test.dart \
   --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
   --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
   --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
   --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
 ```
 
@@ -323,8 +331,12 @@ Create tests that copy minimal fixtures into a temp directory and verify:
 
 - `PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app;` changes to `co.openvine.app.qa01`.
 - `PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.NotificationServiceExtension;` changes to `co.openvine.app.qa01.NotificationServiceExtension`.
+- `PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.RunnerTests;` does not change.
 - `INFOPLIST_KEY_CFBundleDisplayName = divine;` changes to `"Divine QA 01";`.
 - `group.co.openvine.app` changes to `group.co.openvine.app.qa01` in both entitlements files.
+- `BUNDLE_ID` in `Runner/GoogleService-Info.plist` changes to `co.openvine.app.qa01`.
+- `GOOGLE_APP_ID` in `Runner/GoogleService-Info.plist` and `ios/firebase_app_id_file.json` changes to the slot Firebase app ID.
+- `--dry-run` prints a unified diff and leaves fixture files unchanged.
 - Missing required arguments fail with a non-zero exit.
 
 Run:
@@ -352,9 +364,10 @@ The script should accept:
 --extension-bundle-id co.openvine.app.qa01.NotificationServiceExtension
 --app-group group.co.openvine.app.qa01
 --display-name "Divine QA 01"
+--firebase-ios-app-id 1:972941478875:ios:qa01placeholder
 ```
 
-Use `plistlib` for entitlements. Patch `Runner.xcodeproj/project.pbxproj` as text, but keep replacements narrow and fail if an expected production identifier is not found.
+Use `plistlib` for entitlements and Firebase plist/JSON metadata. Patch `Runner.xcodeproj/project.pbxproj` as text, but keep replacements narrow, do not change RunnerTests bundle IDs, and fail if an expected production identifier is not found. The script must support `--dry-run` for the real-project check.
 
 - [ ] **Step 2: Run script tests**
 
@@ -376,28 +389,26 @@ python3 mobile/scripts/ci/configure_ios_qa_slot.py \
   --bundle-id co.openvine.app.qa01 \
   --extension-bundle-id co.openvine.app.qa01.NotificationServiceExtension \
   --app-group group.co.openvine.app.qa01 \
-  --display-name "Divine QA 01"
-
-git diff -- mobile/ios/Runner.xcodeproj/project.pbxproj \
-  mobile/ios/Runner/Runner.entitlements \
-  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements
+  --display-name "Divine QA 01" \
+  --firebase-ios-app-id 1:972941478875:ios:qa01placeholder \
+  --dry-run
 ```
 
-Expected: diff shows only bundle ID, display name, and app group changes.
-
-- [ ] **Step 4: Revert the dry-run project changes**
+Expected: stdout diff shows only bundle ID, display name, app group, Firebase bundle ID, and Firebase app ID changes. `git diff -- mobile/ios` is empty after the command.
 
 Run:
 
 ```bash
-git checkout -- mobile/ios/Runner.xcodeproj/project.pbxproj \
+git diff --exit-code -- mobile/ios/Runner.xcodeproj/project.pbxproj \
   mobile/ios/Runner/Runner.entitlements \
-  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements
+  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements \
+  mobile/ios/Runner/GoogleService-Info.plist \
+  mobile/ios/firebase_app_id_file.json
 ```
 
-This checkout is only for changes made by this dry-run step.
+Expected: exits 0.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 4: Commit**
 
 Run:
 
@@ -417,7 +428,7 @@ git commit -m "build(ios): add qa slot project patcher"
 
 - [ ] **Step 1: Add slot map**
 
-Create `.github/ios_qa_slots.json` with all 15 slots. Use the real Firebase app IDs as they are created. For slots not created yet, set `firebaseAppId` to an empty string and keep the allocator disabled for those slots.
+Create `.github/ios_qa_slots.json` with all 15 slots. Use the real Firebase app IDs as they are created. For slots not created yet, set `enabled` to `false` and `firebaseAppId` to an empty string. Stage 1 should enable only `qa01`.
 
 ```json
 {
@@ -425,10 +436,21 @@ Create `.github/ios_qa_slots.json` with all 15 slots. Use the real Firebase app 
     {
       "slot": "qa01",
       "label": "ios-qa-slot-01",
+      "enabled": true,
       "bundleId": "co.openvine.app.qa01",
       "extensionBundleId": "co.openvine.app.qa01.NotificationServiceExtension",
       "appGroup": "group.co.openvine.app.qa01",
       "displayName": "Divine QA 01",
+      "firebaseAppId": "1:972941478875:ios:qa01placeholder"
+    },
+    {
+      "slot": "qa02",
+      "label": "ios-qa-slot-02",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa02",
+      "extensionBundleId": "co.openvine.app.qa02.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa02",
+      "displayName": "Divine QA 02",
       "firebaseAppId": ""
     }
   ]
@@ -461,11 +483,15 @@ Cover:
 - Not trusted for outside fork and non-member.
 - Draft PR without `needs-ios-qa` is not eligible.
 - Draft PR with `needs-ios-qa` is eligible.
+- PRs with no changes under `mobile/**` or `codemagic.yaml` are skipped but still cleaned up if labels already exist.
 - Existing slot label is preserved.
-- First free slot is assigned.
-- Queued state when all configured slots are occupied.
+- First free enabled slot is assigned.
+- Disabled slots and slots with empty `firebaseAppId` are not assigned.
+- Queued state when all enabled slots are occupied.
+- Queued PRs are ordered by oldest `needs-ios-qa`/ready eligibility timestamp, then PR number for deterministic reconciliation.
 - Closed PR cleanup returns labels to remove and mirror branch to delete.
-- Comment renderer includes slot, PR, SHA, Firebase testing URI, and Codemagic URL.
+- Sticky state marker round-trips JSON for slot, PR number, full commit SHA, status, Codemagic build ID/URL, Firebase `testing_uri`, and failure reason.
+- Comment renderer includes slot, PR, full SHA, Firebase testing URI, and Codemagic URL. Do not truncate Nostr IDs; commit SHAs may be shortened only for display if the full SHA remains in the hidden state marker and table.
 
 Run:
 
@@ -488,10 +514,13 @@ Required functions:
 
 ```python
 def load_slots(path): ...
+def enabled_slots(slots): ...
 def is_trusted_pr(head_repo_owner, author_is_org_member): ...
 def is_eligible_pr(is_draft, labels): ...
 def current_slot(labels): ...
 def choose_slot(slots, open_prs): ...
+def render_state_marker(state): ...
+def parse_state_marker(comment_body): ...
 def render_status_comment(...): ...
 def render_directory(...): ...
 ```
@@ -505,9 +534,13 @@ allocate
 render-comment
 render-directory
 cleanup
+parse-comment-state
+render-codemagic-payload
+upsert-comment
+notify-github
 ```
 
-The workflow can pass event JSON paths and write outputs to `$GITHUB_OUTPUT`.
+The workflow can pass event JSON paths and write outputs to `$GITHUB_OUTPUT`. Use JSON files for PR metadata to avoid shell interpolation of untrusted PR titles, branch names, labels, or author names.
 
 - [ ] **Step 3: Run tests**
 
@@ -551,14 +584,13 @@ on:
   pull_request_target:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, closed, labeled, unlabeled]
-    paths:
-      - "mobile/**"
-      - "codemagic.yaml"
   workflow_dispatch:
     inputs:
       pr_number:
         required: true
 ```
+
+Do not use workflow `paths` filters here. The script should decide whether the PR touches mobile/Codemagic files so close events, manual dispatches, and scheduled reconciliation cannot be skipped by path filtering.
 
 Permissions:
 
@@ -587,40 +619,65 @@ Expected trusted condition:
 head repo owner is divinevideo OR author is active divinevideo org member/owner
 ```
 
+For `workflow_dispatch`, fetch the PR metadata with the GitHub API by `pr_number` and write it to a JSON file consumed by `.github/scripts/ios_qa_slots.py`.
+
 - [ ] **Step 3: Mirror trusted PR head to base repo**
 
 For trusted eligible PRs:
 
 ```bash
-git fetch origin "pull/${PR_NUMBER}/head"
-git push origin "FETCH_HEAD:refs/heads/ios-qa/pr-${PR_NUMBER}" --force
+git fetch --no-tags origin "pull/${PR_NUMBER}/head"
+git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+  "FETCH_HEAD:refs/heads/ios-qa/pr-${PR_NUMBER}" --force
 ```
 
 For closed PRs:
 
 ```bash
-git push origin ":refs/heads/ios-qa/pr-${PR_NUMBER}" || true
+git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+  ":refs/heads/ios-qa/pr-${PR_NUMBER}" || true
 ```
+
+The checkout step must use the base repository only, with `persist-credentials: false`. Fetching the PR head is allowed only after the trust check and only for mirroring; no step may run code from `FETCH_HEAD`.
 
 - [ ] **Step 4: Trigger Codemagic**
 
-Use the Codemagic Builds API with:
+Use the Codemagic Builds API with `appId`, `workflowId`, `branch`, labels, and `environment.variables`:
+
+```bash
+payload_file="${RUNNER_TEMP}/codemagic-ios-qa-build.json"
+python3 .github/scripts/ios_qa_slots.py render-codemagic-payload \
+  --app-id "$CODEMAGIC_APP_ID" \
+  --workflow-id ios-qa-pr-build \
+  --branch "ios-qa/pr-${PR_NUMBER}" \
+  --pr-json "$RUNNER_TEMP/pr.json" \
+  --slot-json "$RUNNER_TEMP/slot.json" \
+  --default-env "${IOS_QA_DEFAULT_ENV:-STAGING}" \
+  > "$payload_file"
+
+curl --fail-with-body \
+  -H "Content-Type: application/json" \
+  -H "x-auth-token: ${CODEMAGIC_API_TOKEN}" \
+  --data @"$payload_file" \
+  -X POST https://api.codemagic.io/builds \
+  > "$RUNNER_TEMP/codemagic-response.json"
+```
+
+The payload must include these `environment.variables`:
 
 ```text
-workflow_id=ios-qa-pr-build
-branch=ios-qa/pr-<number>
-environment variables:
-  PR_NUMBER
-  PR_HEAD_SHA
-  PR_HEAD_REPO
-  PR_HEAD_REF
-  QA_SLOT
-  QA_BUNDLE_ID
-  QA_EXTENSION_BUNDLE_ID
-  QA_APP_GROUP
-  QA_DISPLAY_NAME
-  QA_FIREBASE_APP_ID
-  DEFAULT_ENV
+PR_NUMBER
+PR_HEAD_SHA
+PR_HEAD_REPO
+PR_HEAD_REF
+QA_SLOT
+QA_BUNDLE_ID
+QA_EXTENSION_BUNDLE_ID
+QA_APP_GROUP
+QA_DISPLAY_NAME
+QA_FIREBASE_APP_ID
+DEFAULT_ENV
+CODEMAGIC_APP_ID
 ```
 
 Use `CODEMAGIC_APP_ID` and `CODEMAGIC_API_TOKEN` from GitHub secrets.
@@ -632,8 +689,9 @@ The workflow should:
 - Add or preserve `ios-qa-slot-NN`.
 - Add `ios-qa:building` when a build is triggered.
 - Add `ios-qa:queued` when no slot is available.
-- Add a sticky comment with a hidden marker `<!-- divine-ios-qa-build -->`.
+- Add or update a sticky comment with a hidden marker `<!-- divine-ios-qa-build:v1 ... -->` containing JSON state.
 - Avoid duplicate comments.
+- Store the Codemagic `buildId` returned by `POST /builds` in the hidden state marker.
 
 - [ ] **Step 6: Validate workflow YAML**
 
@@ -668,24 +726,64 @@ git commit -m "ci(ios): allocate qa slots for trusted prs"
 Add reusable scripts:
 
 ```yaml
+- &validate_ios_qa_env
+  name: Validate iOS QA environment
+  script: |
+    set -eu
+    for name in \
+      PR_NUMBER PR_HEAD_SHA PR_HEAD_REPO PR_HEAD_REF \
+      QA_SLOT QA_BUNDLE_ID QA_EXTENSION_BUNDLE_ID QA_APP_GROUP \
+      QA_DISPLAY_NAME QA_FIREBASE_APP_ID DEFAULT_ENV \
+      CODEMAGIC_APP_ID IOS_QA_GITHUB_TOKEN QA_FIREBASE_GROUP_ALIAS
+    do
+      eval "value=\${$name:-}"
+      if [ -z "$value" ]; then
+        echo "Missing required iOS QA variable: $name"
+        exit 1
+      fi
+    done
+    echo "GH_TOKEN=$IOS_QA_GITHUB_TOKEN" >> "$CM_ENV"
+
 - &configure_ios_qa_slot
   name: Configure iOS QA slot
   script: |
+    set -eu
     python3 scripts/ci/configure_ios_qa_slot.py \
       --project-root . \
       --bundle-id "$QA_BUNDLE_ID" \
       --extension-bundle-id "$QA_EXTENSION_BUNDLE_ID" \
       --app-group "$QA_APP_GROUP" \
-      --display-name "$QA_DISPLAY_NAME"
+      --display-name "$QA_DISPLAY_NAME" \
+      --firebase-ios-app-id "$QA_FIREBASE_APP_ID"
 
 - &verify_ios_qa_head
   name: Verify mirrored PR SHA
   script: |
+    set -eu
     ACTUAL_SHA="$(git rev-parse HEAD)"
     if [ "$ACTUAL_SHA" != "$PR_HEAD_SHA" ]; then
       echo "Stale mirror branch: expected $PR_HEAD_SHA, got $ACTUAL_SHA"
       exit 1
     fi
+
+- &write_firebase_credentials
+  name: Write Firebase service-account credentials
+  script: |
+    set -eu
+    if [ -n "${FIREBASE_SERVICE_ACCOUNT:-}" ]; then
+      : "${GOOGLE_APPLICATION_CREDENTIALS:=$CM_BUILD_DIR/firebase_credentials.json}"
+      printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$GOOGLE_APPLICATION_CREDENTIALS"
+      echo "GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS" >> "$CM_ENV"
+      exit 0
+    fi
+
+    if [ -n "${FIREBASE_TOKEN:-}" ]; then
+      echo "Using deprecated FIREBASE_TOKEN fallback. Prefer FIREBASE_SERVICE_ACCOUNT."
+      exit 0
+    fi
+
+    echo "Missing FIREBASE_SERVICE_ACCOUNT or FIREBASE_TOKEN"
+    exit 1
 ```
 
 - [ ] **Step 2: Add QA build script**
@@ -696,6 +794,7 @@ Build with slot dart defines:
 - &build_ios_qa
   name: Build iOS QA IPA
   script: |
+    set -eu
     flutter build ipa --release --build-number="$PROJECT_BUILD_NUMBER" \
       --dart-define=ZENDESK_APP_ID="$ZENDESK_APP_ID" \
       --dart-define=ZENDESK_CLIENT_ID="$ZENDESK_CLIENT_ID" \
@@ -717,18 +816,40 @@ Install Firebase CLI if needed, distribute the IPA, and capture JSON output:
 - &distribute_ios_qa_firebase
   name: Distribute iOS QA build to Firebase
   script: |
+    set -eu
+    if [ "${STALE_IOS_QA_BUILD:-}" = "true" ]; then
+      echo "Skipping Firebase distribution for stale iOS QA build"
+      exit 0
+    fi
+
     npm install -g firebase-tools
     IPA_PATH="$(ls build/ios/ipa/*.ipa | head -1)"
+    firebase_token_args=""
+    if [ -n "${FIREBASE_TOKEN:-}" ] && [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
+      firebase_token_args="--token $FIREBASE_TOKEN"
+    fi
     firebase appdistribution:distribute "$IPA_PATH" \
       --app "$QA_FIREBASE_APP_ID" \
       --groups "$QA_FIREBASE_GROUP_ALIAS" \
       --release-notes "PR #$PR_NUMBER $PR_HEAD_SHA ($QA_SLOT)" \
-      --json > "$CM_BUILD_DIR/firebase-distribution.json"
+      --json \
+      $firebase_token_args \
+      > firebase-distribution.json
+
+    python3 - <<'PY'
+    import json
+    from pathlib import Path
+
+    path = Path("firebase-distribution.json")
+    data = json.loads(path.read_text())
+    if not data.get("testing_uri"):
+        raise SystemExit("Firebase distribution JSON did not include testing_uri")
+    PY
 ```
 
 - [ ] **Step 4: Add stale PR check before distribution**
 
-Before Firebase distribution, call GitHub API using `GH_TOKEN` and verify:
+Before Firebase distribution, call GitHub API using `IOS_QA_GITHUB_TOKEN` and verify:
 
 ```text
 PR is open
@@ -737,9 +858,95 @@ PR head SHA equals PR_HEAD_SHA
 
 If stale, exit 0 after notifying GitHub with stale status. Do not upload the IPA.
 
+Add a reusable script:
+
+```yaml
+- &verify_ios_qa_pr_current
+  name: Verify PR is still current before distribution
+  script: |
+    set -eu
+    pr_json="pr-current.json"
+    curl --fail-with-body \
+      -H "Authorization: Bearer $IOS_QA_GITHUB_TOKEN" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/$CM_REPO_SLUG/pulls/$PR_NUMBER" \
+      > "$pr_json"
+
+    python3 - "$pr_json" <<'PY'
+    import json
+    import os
+    import sys
+
+    pr = json.load(open(sys.argv[1], encoding="utf-8"))
+    expected = os.environ["PR_HEAD_SHA"]
+    actual = pr["head"]["sha"]
+    if pr["state"] != "open" or actual != expected:
+        print(f"STALE_IOS_QA_BUILD=true", file=open(os.environ["CM_ENV"], "a", encoding="utf-8"))
+        print(f"Stale PR build: state={pr['state']} expected={expected} actual={actual}")
+        raise SystemExit(0)
+    PY
+```
+
+Make `*distribute_ios_qa_firebase` skip upload when `STALE_IOS_QA_BUILD=true`, then run the GitHub notification script with `status=stale`.
+
 - [ ] **Step 5: Add GitHub notification script**
 
-After Firebase distribution, parse `firebase-distribution.json`, extract the tester URI, and update the sticky PR comment. If Firebase CLI JSON shape differs, adapt the parser and document the observed output in the commit.
+Add this as a Codemagic post-publish script so it runs even when the main build fails. After Firebase distribution, parse `firebase-distribution.json`, extract `testing_uri`, and update the sticky PR comment. If `STALE_IOS_QA_BUILD=true`, update the same sticky comment with stale status and do not require a Firebase JSON file. If Firebase CLI JSON shape differs, adapt the parser and document the observed output in the commit.
+
+The notification script should:
+
+- Replace `ios-qa:building` with `ios-qa:ready` on successful distribution.
+- Replace `ios-qa:building` with `ios-qa:failed` on build/distribution failure.
+- Keep the slot label on ready, stale, and failed states.
+- Preserve a hidden JSON state marker with full commit SHA, Codemagic build URL, Firebase `testing_uri`, and updated timestamp.
+- Use `IOS_QA_GITHUB_TOKEN`/`GH_TOKEN` from Codemagic, not a GitHub Actions token.
+
+Add a reusable script:
+
+```yaml
+- &notify_ios_qa_github
+  name: Notify GitHub about iOS QA build
+  script: |
+    set -eu
+    status="ready"
+    firebase_json="firebase-distribution.json"
+    if [ "${STALE_IOS_QA_BUILD:-}" = "true" ]; then
+      status="stale"
+      firebase_json=""
+    elif [ ! -s "$firebase_json" ]; then
+      status="failed"
+      firebase_json=""
+    fi
+    codemagic_build_url="https://codemagic.io/app/$CODEMAGIC_APP_ID/build/$CM_BUILD_ID"
+
+    if [ -n "$firebase_json" ]; then
+      python3 ../.github/scripts/ios_qa_slots.py render-comment \
+        --status "$status" \
+        --pr-number "$PR_NUMBER" \
+        --slot "$QA_SLOT" \
+        --sha "$PR_HEAD_SHA" \
+        --codemagic-build-url "$codemagic_build_url" \
+        --firebase-json "$firebase_json" \
+        > ios-qa-comment.md
+    else
+      python3 ../.github/scripts/ios_qa_slots.py render-comment \
+        --status "$status" \
+        --pr-number "$PR_NUMBER" \
+        --slot "$QA_SLOT" \
+        --sha "$PR_HEAD_SHA" \
+        --codemagic-build-url "$codemagic_build_url" \
+        > ios-qa-comment.md
+    fi
+
+    python3 ../.github/scripts/ios_qa_slots.py notify-github \
+      --repo "$CM_REPO_SLUG" \
+      --issue-number "$PR_NUMBER" \
+      --token-env IOS_QA_GITHUB_TOKEN \
+      --status "$status" \
+      --body-file ios-qa-comment.md
+```
+
+Implement marker-based update-or-create in this task: list existing issue comments, find `<!-- divine-ios-qa-build:v1`, patch that comment when present, and create only when absent. The same mode should update labels for `ready`, `failed`, and `stale` statuses.
 
 - [ ] **Step 6: Add `ios-qa-pr-build` workflow**
 
@@ -763,27 +970,40 @@ ios-qa-pr-build:
       - github_credentials
       - firebase_app_distribution
       - ios_qa_signing
+    vars:
+      QA_FIREBASE_GROUP_ALIAS: ios-qa
     ios_signing:
       distribution_type: ad_hoc
       bundle_identifier: $QA_BUNDLE_ID
   triggering:
     events: []
   scripts:
+    - *validate_ios_qa_env
     - *verify_ios_qa_head
-    - *setup_code_signing_xcode
+    - *write_firebase_credentials
     - *install_flutterfire
     - *enable_spm
+    - *flutter_pub_get
     - *prepare_ios_spm_packages
     - *configure_ios_qa_slot
+    - *setup_code_signing_xcode
     - *pod_install
     - *build_ios_qa
+    - *verify_ios_qa_pr_current
     - *distribute_ios_qa_firebase
   artifacts:
     - build/ios/ipa/*.ipa
     - build/ios/archive/Runner.xcarchive/dSYMs/**
     - /tmp/xcodebuild_logs/*.log
     - firebase-distribution.json
+    - pr-current.json
+    - ios-qa-comment.md
+  publishing:
+    scripts:
+      - *notify_ios_qa_github
 ```
+
+The slot patch must run before `*setup_code_signing_xcode`; otherwise `xcode-project use-profiles` can bind production profiles to the unpatched project.
 
 If Codemagic does not accept `$QA_BUNDLE_ID` in `ios_signing.bundle_identifier`, replace this with 15 generated workflows or a script-level `app-store-connect fetch-signing-files` approach after proving the constraint in a dry run.
 
@@ -823,9 +1043,11 @@ Test that rendered directory includes:
 - Active slots.
 - Queued PRs.
 - Failed PRs.
+- Stale builds superseded by newer commits.
 - Firebase install links.
 - Codemagic build links.
 - Last updated timestamp.
+- Build metadata recovered from sticky comment state markers.
 
 - [ ] **Step 2: Add scheduled reconciliation**
 
@@ -842,7 +1064,8 @@ The scheduled job should:
 - List open PRs.
 - Remove stale slot labels from closed PRs if any remain.
 - Delete stale `ios-qa/pr-*` branches for closed PRs.
-- Assign queued PRs when slots are free.
+- Assign queued PRs when slots are free, using deterministic queued ordering from the slot library.
+- Refresh stale/building states whose Codemagic build has finished without a post-publish update.
 - Re-render the active build directory.
 
 - [ ] **Step 3: Decide directory home**
@@ -889,6 +1112,8 @@ git commit -m "ci(ios): reconcile qa slots and directory"
 
 - No source changes expected unless verification exposes issues.
 
+GitHub only runs `pull_request_target` and `workflow_dispatch` workflows that exist on `main`. Do not treat the bootstrap PR as fully end-to-end verified until this workflow has been merged or otherwise exists on `main`; use a throwaway trusted mobile PR for the live `qa01` proof.
+
 - [ ] **Step 1: Run local verification**
 
 Run:
@@ -898,15 +1123,35 @@ python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
 python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
 ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml')"
 ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
+python3 mobile/scripts/ci/configure_ios_qa_slot.py \
+  --project-root mobile \
+  --bundle-id co.openvine.app.qa01 \
+  --extension-bundle-id co.openvine.app.qa01.NotificationServiceExtension \
+  --app-group group.co.openvine.app.qa01 \
+  --display-name "Divine QA 01" \
+  --firebase-ios-app-id 1:972941478875:ios:qa01placeholder \
+  --dry-run >/tmp/ios-qa-slot-dry-run.diff
+git diff --exit-code -- mobile/ios/Runner.xcodeproj/project.pbxproj \
+  mobile/ios/Runner/Runner.entitlements \
+  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements \
+  mobile/ios/Runner/GoogleService-Info.plist \
+  mobile/ios/firebase_app_id_file.json
 cd mobile
 flutter test test/config/build_identity_test.dart
+flutter test test/config/build_identity_test.dart \
+  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
+  --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
 ```
 
 Expected: all pass.
 
-- [ ] **Step 2: Trigger one trusted PR manually**
+- [ ] **Step 2: Trigger one trusted throwaway PR manually**
 
-Use workflow dispatch on `Mobile iOS QA Allocate` with a trusted PR number.
+After the bootstrap workflow exists on `main`, use workflow dispatch on `Mobile iOS QA Allocate` with a trusted throwaway PR number.
 
 Expected:
 
@@ -914,13 +1159,15 @@ Expected:
 - PR receives `ios-qa:building`.
 - Branch `ios-qa/pr-<number>` exists and points to the PR head SHA.
 - Codemagic starts `ios-qa-pr-build`.
+- PR sticky comment contains `<!-- divine-ios-qa-build:v1` with the full PR head SHA and Codemagic build ID.
 
 - [ ] **Step 3: Verify Firebase install**
 
 Expected:
 
 - Firebase App Distribution shows a release for `co.openvine.app.qa01`.
-- PR sticky comment includes Firebase tester link.
+- PR sticky comment includes Firebase `testing_uri`.
+- PR label changes from `ios-qa:building` to `ios-qa:ready`.
 - QA can install `Divine QA 01` on a registered iOS device.
 - Production/TestFlight app remains installed side by side.
 
@@ -933,6 +1180,7 @@ Expected:
 - Slot labels are removed.
 - Mirror branch is deleted.
 - Directory updates.
+- A still-running Codemagic build skips distribution when it reaches the stale/closed check.
 
 ## Chunk 8: Expand To 15 Slots
 
@@ -947,9 +1195,9 @@ Expected:
 
 Repeat external setup for `qa02` through `qa15`.
 
-- [ ] **Step 2: Fill real Firebase app IDs**
+- [ ] **Step 2: Fill real Firebase app IDs and enable slots**
 
-Update `.github/ios_qa_slots.json`.
+Update `.github/ios_qa_slots.json` with each real Firebase app ID and set `enabled: true` only after the matching Apple identifiers, App Group, Ad Hoc profiles, Firebase app, and Codemagic signing assets exist.
 
 - [ ] **Step 3: Run slot tests**
 
@@ -999,4 +1247,3 @@ gh pr create \
   --title "ci(ios): add QA PR build slots" \
   --body "Adds the iOS QA PR build slot design and implementation for Ad Hoc Firebase distribution."
 ```
-

--- a/docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md
+++ b/docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md
@@ -132,6 +132,44 @@ IOS_QA_DEFAULT_ENV=STAGING
 
 If there is not yet a QA tracking issue, create one titled `iOS QA PR Builds` and store its issue number in `IOS_QA_DIRECTORY_ISSUE_NUMBER`.
 
+- [ ] **Step 7: Bootstrap GitHub labels**
+
+Create or update the labels the allocator uses before enabling the workflow. The repo does not currently have `ios-qa*` labels, so this must be idempotent and part of rollout.
+
+Run:
+
+```bash
+for n in $(seq -w 1 15); do
+  gh label create "ios-qa-slot-$n" \
+    --color "0E8A16" \
+    --description "iOS QA build slot $n" \
+    --force
+done
+
+gh label create "ios-qa:building" \
+  --color "FBCA04" \
+  --description "iOS QA build is running" \
+  --force
+gh label create "ios-qa:ready" \
+  --color "0E8A16" \
+  --description "iOS QA build is ready for testing" \
+  --force
+gh label create "ios-qa:queued" \
+  --color "D4C5F9" \
+  --description "iOS QA build is waiting for a slot" \
+  --force
+gh label create "ios-qa:failed" \
+  --color "D93F0B" \
+  --description "iOS QA build failed" \
+  --force
+gh label create "needs-ios-qa" \
+  --color "5319E7" \
+  --description "Build this draft PR for iOS QA" \
+  --force
+```
+
+Expected: command exits 0 and `gh label list --limit 300 | rg '^ios-qa|^needs-ios-qa'` shows all 20 labels.
+
 ## Chunk 1: Build-Time App Identity
 
 ### Task 1: Add Identity Defaults And Tests
@@ -491,6 +529,8 @@ Cover:
 - Queued PRs are ordered by oldest `needs-ios-qa`/ready eligibility timestamp, then PR number for deterministic reconciliation.
 - Closed PR cleanup returns labels to remove and mirror branch to delete.
 - Sticky state marker round-trips JSON for slot, PR number, full commit SHA, status, Codemagic build ID/URL, Firebase `testing_uri`, and failure reason.
+- Required-label renderer returns all 15 slot labels plus `ios-qa:building`, `ios-qa:ready`, `ios-qa:queued`, `ios-qa:failed`, and `needs-ios-qa`.
+- Firebase distribution parser extracts `testing_uri` from known Firebase CLI JSON shapes: top-level, `result`, and `result.release`. It rejects JSON that only has `binary_download_uri`.
 - Comment renderer includes slot, PR, full SHA, Firebase testing URI, and Codemagic URL. Do not truncate Nostr IDs; commit SHAs may be shortened only for display if the full SHA remains in the hidden state marker and table.
 
 Run:
@@ -521,6 +561,8 @@ def current_slot(labels): ...
 def choose_slot(slots, open_prs): ...
 def render_state_marker(state): ...
 def parse_state_marker(comment_body): ...
+def required_labels(slots): ...
+def extract_firebase_testing_uri(firebase_distribution_json): ...
 def render_status_comment(...): ...
 def render_directory(...): ...
 ```
@@ -538,6 +580,8 @@ parse-comment-state
 render-codemagic-payload
 upsert-comment
 notify-github
+render-label-bootstrap
+parse-firebase-distribution
 ```
 
 The workflow can pass event JSON paths and write outputs to `$GITHUB_OUTPUT`. Use JSON files for PR metadata to avoid shell interpolation of untrusted PR titles, branch names, labels, or author names.
@@ -609,7 +653,22 @@ concurrency:
   cancel-in-progress: false
 ```
 
-- [ ] **Step 2: Add trust check**
+- [ ] **Step 2: Add idempotent label bootstrap**
+
+The workflow should ensure labels exist before it tries to apply them. Add a step that renders the required labels from `.github/scripts/ios_qa_slots.py render-label-bootstrap`, then creates/updates them through the GitHub API or `gh label create --force`.
+
+Expected labels:
+
+```text
+ios-qa-slot-01 through ios-qa-slot-15
+ios-qa:building
+ios-qa:ready
+ios-qa:queued
+ios-qa:failed
+needs-ios-qa
+```
+
+- [ ] **Step 3: Add trust check**
 
 The workflow should call the GitHub org membership API using `DIVINEVIDEO_ORG_READ_TOKEN` when `head.repo.owner.login != "divinevideo"`.
 
@@ -621,7 +680,7 @@ head repo owner is divinevideo OR author is active divinevideo org member/owner
 
 For `workflow_dispatch`, fetch the PR metadata with the GitHub API by `pr_number` and write it to a JSON file consumed by `.github/scripts/ios_qa_slots.py`.
 
-- [ ] **Step 3: Mirror trusted PR head to base repo**
+- [ ] **Step 4: Mirror trusted PR head to base repo**
 
 For trusted eligible PRs:
 
@@ -640,7 +699,7 @@ git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
 
 The checkout step must use the base repository only, with `persist-credentials: false`. Fetching the PR head is allowed only after the trust check and only for mirroring; no step may run code from `FETCH_HEAD`.
 
-- [ ] **Step 4: Trigger Codemagic**
+- [ ] **Step 5: Trigger Codemagic**
 
 Use the Codemagic Builds API with `appId`, `workflowId`, `branch`, labels, and `environment.variables`:
 
@@ -682,7 +741,7 @@ CODEMAGIC_APP_ID
 
 Use `CODEMAGIC_APP_ID` and `CODEMAGIC_API_TOKEN` from GitHub secrets.
 
-- [ ] **Step 5: Update labels and comments**
+- [ ] **Step 6: Update labels and comments**
 
 The workflow should:
 
@@ -693,7 +752,7 @@ The workflow should:
 - Avoid duplicate comments.
 - Store the Codemagic `buildId` returned by `POST /builds` in the hidden state marker.
 
-- [ ] **Step 6: Validate workflow YAML**
+- [ ] **Step 7: Validate workflow YAML**
 
 Run:
 
@@ -704,7 +763,7 @@ python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
 
 Expected: both commands exit 0.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 8: Commit**
 
 Run:
 
@@ -836,16 +895,13 @@ Install Firebase CLI if needed, distribute the IPA, and capture JSON output:
       $firebase_token_args \
       > firebase-distribution.json
 
-    python3 - <<'PY'
-    import json
-    from pathlib import Path
-
-    path = Path("firebase-distribution.json")
-    data = json.loads(path.read_text())
-    if not data.get("testing_uri"):
-        raise SystemExit("Firebase distribution JSON did not include testing_uri")
-    PY
+    python3 ../.github/scripts/ios_qa_slots.py parse-firebase-distribution \
+      --json-file firebase-distribution.json \
+      --require-testing-uri \
+      > firebase-distribution-links.json
 ```
+
+`parse-firebase-distribution` must support the Firebase CLI JSON shapes observed in tests: top-level links, `result` links, and `result.release` links. It must fail when only `binary_download_uri` is present, because that link expires after one hour and is not acceptable for QA comments.
 
 - [ ] **Step 4: Add stale PR check before distribution**
 
@@ -900,6 +956,7 @@ The notification script should:
 - Keep the slot label on ready, stale, and failed states.
 - Preserve a hidden JSON state marker with full commit SHA, Codemagic build URL, Firebase `testing_uri`, and updated timestamp.
 - Use `IOS_QA_GITHUB_TOKEN`/`GH_TOKEN` from Codemagic, not a GitHub Actions token.
+- Tolerate early build failures before validation has run. If the minimum GitHub context (`IOS_QA_GITHUB_TOKEN`, `CM_REPO_SLUG`, `PR_NUMBER`) is missing, log the missing keys and exit 0 instead of masking the original build failure.
 
 Add a reusable script:
 
@@ -907,7 +964,19 @@ Add a reusable script:
 - &notify_ios_qa_github
   name: Notify GitHub about iOS QA build
   script: |
-    set -eu
+    set -u
+    missing_context=""
+    for name in IOS_QA_GITHUB_TOKEN CM_REPO_SLUG PR_NUMBER; do
+      eval "value=\${$name:-}"
+      if [ -z "$value" ]; then
+        missing_context="$missing_context $name"
+      fi
+    done
+    if [ -n "$missing_context" ]; then
+      echo "Cannot update GitHub for iOS QA build; missing:$missing_context"
+      exit 0
+    fi
+
     status="ready"
     firebase_json="firebase-distribution.json"
     if [ "${STALE_IOS_QA_BUILD:-}" = "true" ]; then
@@ -917,14 +986,20 @@ Add a reusable script:
       status="failed"
       firebase_json=""
     fi
-    codemagic_build_url="https://codemagic.io/app/$CODEMAGIC_APP_ID/build/$CM_BUILD_ID"
+    if [ -n "${CODEMAGIC_APP_ID:-}" ] && [ -n "${CM_BUILD_ID:-}" ]; then
+      codemagic_build_url="https://codemagic.io/app/$CODEMAGIC_APP_ID/build/$CM_BUILD_ID"
+    else
+      codemagic_build_url="Codemagic build URL unavailable"
+    fi
+    qa_slot="${QA_SLOT:-unknown}"
+    pr_head_sha="${PR_HEAD_SHA:-unknown}"
 
     if [ -n "$firebase_json" ]; then
       python3 ../.github/scripts/ios_qa_slots.py render-comment \
         --status "$status" \
         --pr-number "$PR_NUMBER" \
-        --slot "$QA_SLOT" \
-        --sha "$PR_HEAD_SHA" \
+        --slot "$qa_slot" \
+        --sha "$pr_head_sha" \
         --codemagic-build-url "$codemagic_build_url" \
         --firebase-json "$firebase_json" \
         > ios-qa-comment.md
@@ -932,8 +1007,8 @@ Add a reusable script:
       python3 ../.github/scripts/ios_qa_slots.py render-comment \
         --status "$status" \
         --pr-number "$PR_NUMBER" \
-        --slot "$QA_SLOT" \
-        --sha "$PR_HEAD_SHA" \
+        --slot "$qa_slot" \
+        --sha "$pr_head_sha" \
         --codemagic-build-url "$codemagic_build_url" \
         > ios-qa-comment.md
     fi
@@ -996,6 +1071,7 @@ ios-qa-pr-build:
     - build/ios/archive/Runner.xcarchive/dSYMs/**
     - /tmp/xcodebuild_logs/*.log
     - firebase-distribution.json
+    - firebase-distribution-links.json
     - pr-current.json
     - ios-qa-comment.md
   publishing:
@@ -1228,8 +1304,29 @@ python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
 python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
 ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml')"
 ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
+python3 mobile/scripts/ci/configure_ios_qa_slot.py \
+  --project-root mobile \
+  --bundle-id co.openvine.app.qa01 \
+  --extension-bundle-id co.openvine.app.qa01.NotificationServiceExtension \
+  --app-group group.co.openvine.app.qa01 \
+  --display-name "Divine QA 01" \
+  --firebase-ios-app-id 1:972941478875:ios:qa01placeholder \
+  --dry-run >/tmp/ios-qa-slot-dry-run.diff
+git diff --exit-code -- mobile/ios/Runner.xcodeproj/project.pbxproj \
+  mobile/ios/Runner/Runner.entitlements \
+  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements \
+  mobile/ios/Runner/GoogleService-Info.plist \
+  mobile/ios/firebase_app_id_file.json
 cd mobile
 flutter test test/config/build_identity_test.dart
+flutter test test/config/build_identity_test.dart \
+  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
+  --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
+cd ..
 ```
 
 - [ ] **Review diff**

--- a/docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md
+++ b/docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md
@@ -1,0 +1,1002 @@
+# iOS QA PR Builds Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an automated iOS QA distribution lane where trusted mobile PRs get reusable side-by-side Ad Hoc builds published through Firebase App Distribution.
+
+**Architecture:** GitHub Actions owns trust checks, slot allocation, labels, mirror branches, comments, and the active build directory. Codemagic owns the signed Ad Hoc IPA build for a specific QA slot. The Flutter app and iOS project read build identity from explicit build-time inputs so one codebase can produce production and `qa01` through `qa15` apps.
+
+**Tech Stack:** GitHub Actions, Python 3 standard library tests, Codemagic YAML, Flutter/Dart compile-time environment values, Xcode project/entitlements patching, Firebase App Distribution CLI, Apple Ad Hoc signing.
+
+---
+
+## Source Documents
+
+- Design spec: `docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md`
+- Existing iOS Codemagic workflow: `codemagic.yaml`
+- Existing web PR preview workflows: `.github/workflows/mobile_pr_preview_build.yml`, `.github/workflows/mobile_pr_preview_deploy.yml`
+- Existing web preview comment renderer: `.github/scripts/mobile_pr_preview_comment.py`
+
+## File Structure
+
+- Create: `.github/ios_qa_slots.json`
+  - Slot table for `qa01` through `qa15`: bundle IDs, extension bundle IDs, app groups, display names, and Firebase app IDs.
+- Create: `.github/scripts/ios_qa_slots.py`
+  - Pure Python logic for trust decisions, slot parsing, slot allocation, comment rendering, and directory rendering.
+- Create: `.github/scripts/tests/test_ios_qa_slots.py`
+  - Unit tests for slot selection, trust, labels, stale states, and rendered comments.
+- Create: `.github/workflows/mobile_ios_qa_allocate.yml`
+  - Trusted metadata workflow. Uses `pull_request_target`, never checks out PR code, mirrors trusted PR heads to `ios-qa/pr-<number>`, assigns slots, triggers Codemagic, and cleans up on close.
+- Create: `mobile/lib/config/build_identity.dart`
+  - Build-time identity values shared by Firebase options and push registration.
+- Modify: `mobile/lib/firebase_options.dart`
+  - Use build-time iOS Firebase app ID and bundle ID while preserving production defaults.
+- Modify: `mobile/lib/services/push_notification_service.dart`
+  - Use build-time push app identifier while preserving `co.openvine.app` by default.
+- Create: `mobile/test/config/build_identity_test.dart`
+  - Tests default production identity and QA identity under `--dart-define`.
+- Create: `mobile/scripts/ci/configure_ios_qa_slot.py`
+  - Patch iOS project build settings and entitlements for one QA slot.
+- Create: `mobile/scripts/ci/tests/test_configure_ios_qa_slot.py`
+  - Unit tests for project/entitlement patching using temporary fixtures.
+- Modify: `codemagic.yaml`
+  - Add an `ios-qa-pr-build` workflow using Ad Hoc signing, slot configuration, stale checks, Firebase distribution, and GitHub notification.
+
+## Chunk 0: External Setup Checklist
+
+This chunk is a prerequisite. Do not start build automation until `qa01` exists in Apple Developer, Firebase, Codemagic, and GitHub secrets.
+
+- [ ] **Step 1: Create Apple identifiers for `qa01`**
+
+Create:
+
+```text
+co.openvine.app.qa01
+co.openvine.app.qa01.NotificationServiceExtension
+group.co.openvine.app.qa01
+```
+
+Enable the capabilities needed by the main app and extension. At minimum include app groups. Add push notifications and associated domains only if QA must test those flows in stage 1.
+
+- [ ] **Step 2: Create Ad Hoc provisioning profiles for `qa01`**
+
+Create profiles for:
+
+```text
+co.openvine.app.qa01
+co.openvine.app.qa01.NotificationServiceExtension
+```
+
+Include the current QA device UDIDs. Remember Apple device limits: Ad Hoc devices are capped per product family per membership year.
+
+- [ ] **Step 3: Create Firebase iOS app for `qa01`**
+
+Create a Firebase iOS app with bundle ID:
+
+```text
+co.openvine.app.qa01
+```
+
+Record its Firebase app ID for `.github/ios_qa_slots.json`.
+
+- [ ] **Step 4: Configure Codemagic environment groups**
+
+Add or confirm groups:
+
+```text
+zendesk_credentials
+proofmode_credentials
+github_credentials
+firebase_app_distribution
+ios_qa_signing
+```
+
+Expected secrets:
+
+```text
+GITHUB_TOKEN or GH_TOKEN with PR comment permissions
+FIREBASE_TOKEN or service-account auth usable by firebase-tools
+QA_FIREBASE_GROUP_ALIAS=ios-qa
+```
+
+Codemagic must also have access to the Ad Hoc signing certificate and `qa01` provisioning profiles.
+
+- [ ] **Step 5: Configure GitHub secrets**
+
+Add:
+
+```text
+CODEMAGIC_APP_ID
+CODEMAGIC_API_TOKEN
+DIVINEVIDEO_ORG_READ_TOKEN
+```
+
+`DIVINEVIDEO_ORG_READ_TOKEN` must be able to check active org membership for private members.
+
+## Chunk 1: Build-Time App Identity
+
+### Task 1: Add Identity Defaults And Tests
+
+**Files:**
+
+- Create: `mobile/lib/config/build_identity.dart`
+- Create: `mobile/test/config/build_identity_test.dart`
+
+- [ ] **Step 1: Write the default identity test**
+
+Create `mobile/test/config/build_identity_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/config/build_identity.dart';
+
+void main() {
+  test('uses production iOS identity by default', () {
+    expect(BuildIdentity.iosBundleId, 'co.openvine.app');
+    expect(BuildIdentity.pushAppIdentifier, 'co.openvine.app');
+    expect(BuildIdentity.firebaseIosAppId, '1:972941478875:ios:f61272b3cf485df244b5fe');
+  });
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/config/build_identity_test.dart
+```
+
+Expected: FAIL because `BuildIdentity` does not exist.
+
+- [ ] **Step 3: Add the build identity implementation**
+
+Create `mobile/lib/config/build_identity.dart`:
+
+```dart
+// ABOUTME: Centralizes build-time app identity for production and QA slot builds.
+// ABOUTME: Values default to production and can be overridden by CI dart-defines.
+
+class BuildIdentity {
+  static const iosBundleId = String.fromEnvironment(
+    'IOS_BUNDLE_ID',
+    defaultValue: 'co.openvine.app',
+  );
+
+  static const pushAppIdentifier = String.fromEnvironment(
+    'PUSH_APP_IDENTIFIER',
+    defaultValue: iosBundleId,
+  );
+
+  static const firebaseIosAppId = String.fromEnvironment(
+    'FIREBASE_IOS_APP_ID',
+    defaultValue: '1:972941478875:ios:f61272b3cf485df244b5fe',
+  );
+}
+```
+
+- [ ] **Step 4: Run the default identity test**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/config/build_identity_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the QA override test command**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/config/build_identity_test.dart \
+  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
+```
+
+Expected: FAIL until the test is extended for override mode.
+
+- [ ] **Step 6: Extend the test for override mode**
+
+Append to `mobile/test/config/build_identity_test.dart`:
+
+```dart
+  test('can use QA identity from dart defines', () {
+    const expectedBundleId = String.fromEnvironment('EXPECTED_IOS_BUNDLE_ID');
+    const expectedFirebaseAppId = String.fromEnvironment(
+      'EXPECTED_FIREBASE_IOS_APP_ID',
+    );
+
+    if (expectedBundleId.isEmpty && expectedFirebaseAppId.isEmpty) {
+      return;
+    }
+
+    expect(BuildIdentity.iosBundleId, expectedBundleId);
+    expect(BuildIdentity.pushAppIdentifier, expectedBundleId);
+    expect(BuildIdentity.firebaseIosAppId, expectedFirebaseAppId);
+  });
+```
+
+Run:
+
+```bash
+cd mobile
+flutter test test/config/build_identity_test.dart \
+  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
+  --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
+```
+
+Expected: PASS.
+
+### Task 2: Wire Identity Into Firebase And Push
+
+**Files:**
+
+- Modify: `mobile/lib/firebase_options.dart`
+- Modify: `mobile/lib/services/push_notification_service.dart`
+- Test: `mobile/test/config/build_identity_test.dart`
+
+- [ ] **Step 1: Update Firebase iOS options**
+
+Modify `mobile/lib/firebase_options.dart`:
+
+```dart
+import 'package:openvine/config/build_identity.dart';
+```
+
+Then change the iOS options:
+
+```dart
+  static const FirebaseOptions ios = FirebaseOptions(
+    apiKey: 'AIzaSyChiPGndRdZwsMoLqnel2WSocROmoKLdB4',
+    appId: BuildIdentity.firebaseIosAppId,
+    messagingSenderId: '972941478875',
+    projectId: 'openvine-co',
+    storageBucket: 'openvine-co.firebasestorage.app',
+    iosBundleId: BuildIdentity.iosBundleId,
+  );
+```
+
+- [ ] **Step 2: Update push app identifier**
+
+Modify `mobile/lib/services/push_notification_service.dart`:
+
+```dart
+import 'package:openvine/config/build_identity.dart';
+```
+
+Then change:
+
+```dart
+static const pushAppIdentifier = BuildIdentity.pushAppIdentifier;
+```
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/config/build_identity_test.dart
+flutter test test/config/build_identity_test.dart \
+  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
+  --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add mobile/lib/config/build_identity.dart \
+  mobile/lib/firebase_options.dart \
+  mobile/lib/services/push_notification_service.dart \
+  mobile/test/config/build_identity_test.dart
+git commit -m "feat(ios): make app identity build configurable"
+```
+
+## Chunk 2: iOS Slot Project Patching
+
+### Task 3: Add Patch Script Tests
+
+**Files:**
+
+- Create: `mobile/scripts/ci/tests/test_configure_ios_qa_slot.py`
+- Create later: `mobile/scripts/ci/configure_ios_qa_slot.py`
+
+- [ ] **Step 1: Write failing Python tests**
+
+Create tests that copy minimal fixtures into a temp directory and verify:
+
+- `PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app;` changes to `co.openvine.app.qa01`.
+- `PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.NotificationServiceExtension;` changes to `co.openvine.app.qa01.NotificationServiceExtension`.
+- `INFOPLIST_KEY_CFBundleDisplayName = divine;` changes to `"Divine QA 01";`.
+- `group.co.openvine.app` changes to `group.co.openvine.app.qa01` in both entitlements files.
+- Missing required arguments fail with a non-zero exit.
+
+Run:
+
+```bash
+python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
+```
+
+Expected: FAIL because `configure_ios_qa_slot.py` does not exist.
+
+### Task 4: Implement Project Patching Script
+
+**Files:**
+
+- Create: `mobile/scripts/ci/configure_ios_qa_slot.py`
+- Test: `mobile/scripts/ci/tests/test_configure_ios_qa_slot.py`
+
+- [ ] **Step 1: Implement the script**
+
+The script should accept:
+
+```text
+--project-root mobile
+--bundle-id co.openvine.app.qa01
+--extension-bundle-id co.openvine.app.qa01.NotificationServiceExtension
+--app-group group.co.openvine.app.qa01
+--display-name "Divine QA 01"
+```
+
+Use `plistlib` for entitlements. Patch `Runner.xcodeproj/project.pbxproj` as text, but keep replacements narrow and fail if an expected production identifier is not found.
+
+- [ ] **Step 2: Run script tests**
+
+Run:
+
+```bash
+python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run a local dry check on the real project**
+
+Run from repo root:
+
+```bash
+python3 mobile/scripts/ci/configure_ios_qa_slot.py \
+  --project-root mobile \
+  --bundle-id co.openvine.app.qa01 \
+  --extension-bundle-id co.openvine.app.qa01.NotificationServiceExtension \
+  --app-group group.co.openvine.app.qa01 \
+  --display-name "Divine QA 01"
+
+git diff -- mobile/ios/Runner.xcodeproj/project.pbxproj \
+  mobile/ios/Runner/Runner.entitlements \
+  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements
+```
+
+Expected: diff shows only bundle ID, display name, and app group changes.
+
+- [ ] **Step 4: Revert the dry-run project changes**
+
+Run:
+
+```bash
+git checkout -- mobile/ios/Runner.xcodeproj/project.pbxproj \
+  mobile/ios/Runner/Runner.entitlements \
+  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements
+```
+
+This checkout is only for changes made by this dry-run step.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add mobile/scripts/ci/configure_ios_qa_slot.py \
+  mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
+git commit -m "build(ios): add qa slot project patcher"
+```
+
+## Chunk 3: Slot Allocation Library
+
+### Task 5: Add Slot Map
+
+**Files:**
+
+- Create: `.github/ios_qa_slots.json`
+
+- [ ] **Step 1: Add slot map**
+
+Create `.github/ios_qa_slots.json` with all 15 slots. Use the real Firebase app IDs as they are created. For slots not created yet, set `firebaseAppId` to an empty string and keep the allocator disabled for those slots.
+
+```json
+{
+  "slots": [
+    {
+      "slot": "qa01",
+      "label": "ios-qa-slot-01",
+      "bundleId": "co.openvine.app.qa01",
+      "extensionBundleId": "co.openvine.app.qa01.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa01",
+      "displayName": "Divine QA 01",
+      "firebaseAppId": ""
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Validate JSON**
+
+Run:
+
+```bash
+python3 -m json.tool .github/ios_qa_slots.json >/tmp/ios_qa_slots.json
+```
+
+Expected: command exits 0.
+
+### Task 6: Add Slot Library Tests
+
+**Files:**
+
+- Create: `.github/scripts/tests/test_ios_qa_slots.py`
+- Create later: `.github/scripts/ios_qa_slots.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Cover:
+
+- Trusted when `head_repo_owner == "divinevideo"`.
+- Trusted when membership API result is active member.
+- Not trusted for outside fork and non-member.
+- Draft PR without `needs-ios-qa` is not eligible.
+- Draft PR with `needs-ios-qa` is eligible.
+- Existing slot label is preserved.
+- First free slot is assigned.
+- Queued state when all configured slots are occupied.
+- Closed PR cleanup returns labels to remove and mirror branch to delete.
+- Comment renderer includes slot, PR, SHA, Firebase testing URI, and Codemagic URL.
+
+Run:
+
+```bash
+python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+```
+
+Expected: FAIL because `ios_qa_slots.py` does not exist.
+
+### Task 7: Implement Slot Library
+
+**Files:**
+
+- Create: `.github/scripts/ios_qa_slots.py`
+- Test: `.github/scripts/tests/test_ios_qa_slots.py`
+
+- [ ] **Step 1: Implement pure functions first**
+
+Required functions:
+
+```python
+def load_slots(path): ...
+def is_trusted_pr(head_repo_owner, author_is_org_member): ...
+def is_eligible_pr(is_draft, labels): ...
+def current_slot(labels): ...
+def choose_slot(slots, open_prs): ...
+def render_status_comment(...): ...
+def render_directory(...): ...
+```
+
+- [ ] **Step 2: Add CLI modes**
+
+CLI modes:
+
+```text
+allocate
+render-comment
+render-directory
+cleanup
+```
+
+The workflow can pass event JSON paths and write outputs to `$GITHUB_OUTPUT`.
+
+- [ ] **Step 3: Run tests**
+
+Run:
+
+```bash
+python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add .github/ios_qa_slots.json \
+  .github/scripts/ios_qa_slots.py \
+  .github/scripts/tests/test_ios_qa_slots.py
+git commit -m "ci(ios): add qa slot allocation logic"
+```
+
+## Chunk 4: GitHub Allocator Workflow
+
+### Task 8: Add Trusted Allocator Workflow
+
+**Files:**
+
+- Create: `.github/workflows/mobile_ios_qa_allocate.yml`
+- Modify: `.github/scripts/ios_qa_slots.py` if CLI gaps appear
+- Test: `.github/scripts/tests/test_ios_qa_slots.py`
+
+- [ ] **Step 1: Add workflow skeleton**
+
+Use `pull_request_target` so secrets are available, but never check out or execute PR code in this workflow.
+
+Triggers:
+
+```yaml
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, closed, labeled, unlabeled]
+    paths:
+      - "mobile/**"
+      - "codemagic.yaml"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        required: true
+```
+
+Permissions:
+
+```yaml
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+```
+
+Concurrency:
+
+```yaml
+concurrency:
+  group: ios-qa-slot-allocator
+  cancel-in-progress: false
+```
+
+- [ ] **Step 2: Add trust check**
+
+The workflow should call the GitHub org membership API using `DIVINEVIDEO_ORG_READ_TOKEN` when `head.repo.owner.login != "divinevideo"`.
+
+Expected trusted condition:
+
+```text
+head repo owner is divinevideo OR author is active divinevideo org member/owner
+```
+
+- [ ] **Step 3: Mirror trusted PR head to base repo**
+
+For trusted eligible PRs:
+
+```bash
+git fetch origin "pull/${PR_NUMBER}/head"
+git push origin "FETCH_HEAD:refs/heads/ios-qa/pr-${PR_NUMBER}" --force
+```
+
+For closed PRs:
+
+```bash
+git push origin ":refs/heads/ios-qa/pr-${PR_NUMBER}" || true
+```
+
+- [ ] **Step 4: Trigger Codemagic**
+
+Use the Codemagic Builds API with:
+
+```text
+workflow_id=ios-qa-pr-build
+branch=ios-qa/pr-<number>
+environment variables:
+  PR_NUMBER
+  PR_HEAD_SHA
+  PR_HEAD_REPO
+  PR_HEAD_REF
+  QA_SLOT
+  QA_BUNDLE_ID
+  QA_EXTENSION_BUNDLE_ID
+  QA_APP_GROUP
+  QA_DISPLAY_NAME
+  QA_FIREBASE_APP_ID
+  DEFAULT_ENV
+```
+
+Use `CODEMAGIC_APP_ID` and `CODEMAGIC_API_TOKEN` from GitHub secrets.
+
+- [ ] **Step 5: Update labels and comments**
+
+The workflow should:
+
+- Add or preserve `ios-qa-slot-NN`.
+- Add `ios-qa:building` when a build is triggered.
+- Add `ios-qa:queued` when no slot is available.
+- Add a sticky comment with a hidden marker `<!-- divine-ios-qa-build -->`.
+- Avoid duplicate comments.
+
+- [ ] **Step 6: Validate workflow YAML**
+
+Run:
+
+```bash
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
+python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add .github/workflows/mobile_ios_qa_allocate.yml .github/scripts/ios_qa_slots.py
+git commit -m "ci(ios): allocate qa slots for trusted prs"
+```
+
+## Chunk 5: Codemagic QA Build Workflow
+
+### Task 9: Add iOS QA Workflow
+
+**Files:**
+
+- Modify: `codemagic.yaml`
+
+- [ ] **Step 1: Add QA scripts**
+
+Add reusable scripts:
+
+```yaml
+- &configure_ios_qa_slot
+  name: Configure iOS QA slot
+  script: |
+    python3 scripts/ci/configure_ios_qa_slot.py \
+      --project-root . \
+      --bundle-id "$QA_BUNDLE_ID" \
+      --extension-bundle-id "$QA_EXTENSION_BUNDLE_ID" \
+      --app-group "$QA_APP_GROUP" \
+      --display-name "$QA_DISPLAY_NAME"
+
+- &verify_ios_qa_head
+  name: Verify mirrored PR SHA
+  script: |
+    ACTUAL_SHA="$(git rev-parse HEAD)"
+    if [ "$ACTUAL_SHA" != "$PR_HEAD_SHA" ]; then
+      echo "Stale mirror branch: expected $PR_HEAD_SHA, got $ACTUAL_SHA"
+      exit 1
+    fi
+```
+
+- [ ] **Step 2: Add QA build script**
+
+Build with slot dart defines:
+
+```yaml
+- &build_ios_qa
+  name: Build iOS QA IPA
+  script: |
+    flutter build ipa --release --build-number="$PROJECT_BUILD_NUMBER" \
+      --dart-define=ZENDESK_APP_ID="$ZENDESK_APP_ID" \
+      --dart-define=ZENDESK_CLIENT_ID="$ZENDESK_CLIENT_ID" \
+      --dart-define=ZENDESK_URL="$ZENDESK_URL" \
+      --dart-define=DEFAULT_ENV="$DEFAULT_ENV" \
+      --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT="$PROOFMODE_SIGNING_SERVER_ENDPOINT" \
+      --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN="$PROOFMODE_SIGNING_SERVER_TOKEN" \
+      --dart-define=IOS_BUNDLE_ID="$QA_BUNDLE_ID" \
+      --dart-define=PUSH_APP_IDENTIFIER="$QA_BUNDLE_ID" \
+      --dart-define=FIREBASE_IOS_APP_ID="$QA_FIREBASE_APP_ID" \
+      --export-options-plist=/Users/builder/export_options.plist
+```
+
+- [ ] **Step 3: Add Firebase distribution script**
+
+Install Firebase CLI if needed, distribute the IPA, and capture JSON output:
+
+```yaml
+- &distribute_ios_qa_firebase
+  name: Distribute iOS QA build to Firebase
+  script: |
+    npm install -g firebase-tools
+    IPA_PATH="$(ls build/ios/ipa/*.ipa | head -1)"
+    firebase appdistribution:distribute "$IPA_PATH" \
+      --app "$QA_FIREBASE_APP_ID" \
+      --groups "$QA_FIREBASE_GROUP_ALIAS" \
+      --release-notes "PR #$PR_NUMBER $PR_HEAD_SHA ($QA_SLOT)" \
+      --json > "$CM_BUILD_DIR/firebase-distribution.json"
+```
+
+- [ ] **Step 4: Add stale PR check before distribution**
+
+Before Firebase distribution, call GitHub API using `GH_TOKEN` and verify:
+
+```text
+PR is open
+PR head SHA equals PR_HEAD_SHA
+```
+
+If stale, exit 0 after notifying GitHub with stale status. Do not upload the IPA.
+
+- [ ] **Step 5: Add GitHub notification script**
+
+After Firebase distribution, parse `firebase-distribution.json`, extract the tester URI, and update the sticky PR comment. If Firebase CLI JSON shape differs, adapt the parser and document the observed output in the commit.
+
+- [ ] **Step 6: Add `ios-qa-pr-build` workflow**
+
+Add workflow:
+
+```yaml
+ios-qa-pr-build:
+  name: iOS QA PR Build
+  working_directory: mobile
+  max_build_duration: 60
+  instance_type: mac_mini_m2
+  integrations:
+    app_store_connect: API key for Codemagic
+  environment:
+    flutter: 3.41.1
+    xcode: latest
+    cocoapods: default
+    groups:
+      - zendesk_credentials
+      - proofmode_credentials
+      - github_credentials
+      - firebase_app_distribution
+      - ios_qa_signing
+    ios_signing:
+      distribution_type: ad_hoc
+      bundle_identifier: $QA_BUNDLE_ID
+  triggering:
+    events: []
+  scripts:
+    - *verify_ios_qa_head
+    - *setup_code_signing_xcode
+    - *install_flutterfire
+    - *enable_spm
+    - *prepare_ios_spm_packages
+    - *configure_ios_qa_slot
+    - *pod_install
+    - *build_ios_qa
+    - *distribute_ios_qa_firebase
+  artifacts:
+    - build/ios/ipa/*.ipa
+    - build/ios/archive/Runner.xcarchive/dSYMs/**
+    - /tmp/xcodebuild_logs/*.log
+    - firebase-distribution.json
+```
+
+If Codemagic does not accept `$QA_BUNDLE_ID` in `ios_signing.bundle_identifier`, replace this with 15 generated workflows or a script-level `app-store-connect fetch-signing-files` approach after proving the constraint in a dry run.
+
+- [ ] **Step 7: Validate YAML**
+
+Run:
+
+```bash
+ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml')"
+```
+
+Expected: exits 0.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add codemagic.yaml
+git commit -m "ci(ios): add qa pr codemagic workflow"
+```
+
+## Chunk 6: Directory And Reconciliation
+
+### Task 10: Add Active Directory And Cleanup
+
+**Files:**
+
+- Modify: `.github/scripts/ios_qa_slots.py`
+- Modify: `.github/workflows/mobile_ios_qa_allocate.yml`
+- Test: `.github/scripts/tests/test_ios_qa_slots.py`
+
+- [ ] **Step 1: Add directory renderer tests**
+
+Test that rendered directory includes:
+
+- Active slots.
+- Queued PRs.
+- Failed PRs.
+- Firebase install links.
+- Codemagic build links.
+- Last updated timestamp.
+
+- [ ] **Step 2: Add scheduled reconciliation**
+
+Extend the workflow:
+
+```yaml
+on:
+  schedule:
+    - cron: "17 15 * * *"
+```
+
+The scheduled job should:
+
+- List open PRs.
+- Remove stale slot labels from closed PRs if any remain.
+- Delete stale `ios-qa/pr-*` branches for closed PRs.
+- Assign queued PRs when slots are free.
+- Re-render the active build directory.
+
+- [ ] **Step 3: Decide directory home**
+
+Use a sticky issue comment if a QA tracking issue exists. If not, create a new issue titled:
+
+```text
+iOS QA PR Builds
+```
+
+Store its issue number in a GitHub Actions variable:
+
+```text
+IOS_QA_DIRECTORY_ISSUE_NUMBER
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
+```
+
+Expected: PASS / exit 0.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add .github/scripts/ios_qa_slots.py \
+  .github/scripts/tests/test_ios_qa_slots.py \
+  .github/workflows/mobile_ios_qa_allocate.yml
+git commit -m "ci(ios): reconcile qa slots and directory"
+```
+
+## Chunk 7: Stage 1 Verification
+
+### Task 11: Prove `qa01` End To End
+
+**Files:**
+
+- No source changes expected unless verification exposes issues.
+
+- [ ] **Step 1: Run local verification**
+
+Run:
+
+```bash
+python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
+ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml')"
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
+cd mobile
+flutter test test/config/build_identity_test.dart
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Trigger one trusted PR manually**
+
+Use workflow dispatch on `Mobile iOS QA Allocate` with a trusted PR number.
+
+Expected:
+
+- PR receives `ios-qa-slot-01`.
+- PR receives `ios-qa:building`.
+- Branch `ios-qa/pr-<number>` exists and points to the PR head SHA.
+- Codemagic starts `ios-qa-pr-build`.
+
+- [ ] **Step 3: Verify Firebase install**
+
+Expected:
+
+- Firebase App Distribution shows a release for `co.openvine.app.qa01`.
+- PR sticky comment includes Firebase tester link.
+- QA can install `Divine QA 01` on a registered iOS device.
+- Production/TestFlight app remains installed side by side.
+
+- [ ] **Step 4: Verify close cleanup**
+
+Close or use a throwaway test PR.
+
+Expected:
+
+- Slot labels are removed.
+- Mirror branch is deleted.
+- Directory updates.
+
+## Chunk 8: Expand To 15 Slots
+
+### Task 12: Enable Remaining Slots
+
+**Files:**
+
+- Modify: `.github/ios_qa_slots.json`
+- Possibly modify: Apple/Firebase/Codemagic external config only
+
+- [ ] **Step 1: Create remaining Apple/Firebase identities**
+
+Repeat external setup for `qa02` through `qa15`.
+
+- [ ] **Step 2: Fill real Firebase app IDs**
+
+Update `.github/ios_qa_slots.json`.
+
+- [ ] **Step 3: Run slot tests**
+
+Run:
+
+```bash
+python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+python3 -m json.tool .github/ios_qa_slots.json >/tmp/ios_qa_slots.json
+```
+
+Expected: PASS / exit 0.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add .github/ios_qa_slots.json
+git commit -m "ci(ios): enable all qa slots"
+```
+
+## Final Verification
+
+- [ ] **Run all local non-signing verification**
+
+```bash
+python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
+ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml')"
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
+cd mobile
+flutter test test/config/build_identity_test.dart
+```
+
+- [ ] **Review diff**
+
+```bash
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- .github codemagic.yaml mobile/lib mobile/scripts mobile/test docs/superpowers
+```
+
+- [ ] **Push and open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create \
+  --title "ci(ios): add QA PR build slots" \
+  --body "Adds the iOS QA PR build slot design and implementation for Ad Hoc Firebase distribution."
+```
+

--- a/docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md
+++ b/docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md
@@ -36,6 +36,8 @@ For PRs outside that trust model:
 
 Private org membership may not be visible to the default `GITHUB_TOKEN`, so the membership check needs a GitHub token with enough permission to read org membership.
 
+Codemagic API builds are started by branch or tag. To support trusted member PRs from personal forks, GitHub Actions should mirror every trusted PR head SHA to a temporary branch in `divinevideo/divine-mobile`, for example `ios-qa/pr-3407`, then ask Codemagic to build that mirror branch. This gives Codemagic a branch it can fetch from the configured repository while preserving the exact PR SHA in build metadata.
+
 ## Slot Lifecycle
 
 GitHub labels are the source of truth:
@@ -59,6 +61,7 @@ Slot assignment:
 Cleanup:
 
 - On PR close, remove `ios-qa-slot-NN`, `ios-qa:building`, `ios-qa:ready`, `ios-qa:queued`, and `ios-qa:failed`.
+- Delete the temporary mirror branch `ios-qa/pr-<number>`.
 - Update the active build directory.
 - The installed app can remain on QA devices until that slot is reused.
 - A scheduled reconciliation workflow should run daily to repair missed label/comment/directory updates.
@@ -82,9 +85,12 @@ Codemagic builds should still be per-PR cancellable or replaceable. A newer comm
 1. GitHub Actions receives a `pull_request` event, `workflow_dispatch`, or label event.
 2. The allocator checks trust, PR state, draft state, file relevance, and current labels.
 3. The allocator assigns or reuses a slot.
-4. The allocator triggers Codemagic through the Codemagic Builds API with explicit metadata:
+4. The allocator mirrors the trusted PR head SHA to `ios-qa/pr-<number>` in the base repository.
+5. The allocator triggers Codemagic through the Codemagic Builds API with branch `ios-qa/pr-<number>` and explicit metadata:
    - `PR_NUMBER`
    - `PR_HEAD_SHA`
+   - `PR_HEAD_REPO`
+   - `PR_HEAD_REF`
    - `QA_SLOT`
    - `QA_BUNDLE_ID`
    - `QA_EXTENSION_BUNDLE_ID`
@@ -92,10 +98,10 @@ Codemagic builds should still be per-PR cancellable or replaceable. A newer comm
    - `QA_DISPLAY_NAME`
    - `QA_FIREBASE_APP_ID`
    - `DEFAULT_ENV`
-5. Codemagic checks out the exact PR SHA, patches build settings for the slot, builds an Ad Hoc IPA, and runs a stale-SHA check before distribution.
-6. If the PR head SHA still matches `PR_HEAD_SHA`, Codemagic uploads the IPA to Firebase App Distribution.
-7. If the PR has moved on or closed, Codemagic skips Firebase distribution and reports a stale build.
-8. GitHub updates the sticky PR comment and the active QA directory.
+6. Codemagic checks out the mirror branch, verifies `git rev-parse HEAD` equals `PR_HEAD_SHA`, patches build settings for the slot, builds an Ad Hoc IPA, and runs another stale-SHA check before distribution.
+7. If the PR head SHA still matches `PR_HEAD_SHA`, Codemagic uploads the IPA to Firebase App Distribution.
+8. If the PR has moved on or closed, Codemagic skips Firebase distribution and reports a stale build.
+9. GitHub updates the sticky PR comment and the active QA directory.
 
 ## iOS Identity Requirements
 
@@ -205,4 +211,3 @@ Stage 2 expands to 15 slots:
 - Whether universal links and web credentials should be enabled for QA slot app IDs.
 - Whether push notifications must work in QA builds from day one.
 - Whether to add a maintainer-only override for trusted builds from non-org forks.
-

--- a/docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md
+++ b/docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md
@@ -18,6 +18,15 @@ Slots:
 
 Avoid dynamic per-PR bundle IDs. The one-time setup for 15 identities is manageable; unbounded per-PR identities would create ongoing Apple, Firebase, provisioning, entitlement, and cleanup work.
 
+## Current External Constraints Checked
+
+- [Codemagic Builds API](https://docs.codemagic.io/rest-api/builds/) starts YAML workflows with `POST /builds`, `appId`, `workflowId`, `branch`, and optional `environment.variables`.
+- [Codemagic iOS signing](https://docs.codemagic.io/yaml-code-signing/signing-ios/) recommends `distribution_type: ad_hoc` when signed iOS artifacts are distributed through a third-party service such as Firebase App Distribution.
+- [Firebase App Distribution CLI](https://firebase.google.com/docs/app-distribution/ios/distribute-cli) supports iOS IPA upload, group distribution, and returns release links including `testing_uri`; direct binary links expire quickly and should not be used as the stable QA link.
+- [Codemagic Firebase distribution](https://docs.codemagic.io/yaml-distributing/firebase-app-distribution/) marks Firebase token auth deprecated; service-account auth with `GOOGLE_APPLICATION_CREDENTIALS` is the preferred CI path.
+- [Codemagic post-publish scripts](https://docs.codemagic.io/yaml-distributing/post-publish/) run even after build failure unless the build is canceled or times out, so GitHub status notification belongs there.
+- [GitHub Security Lab pwn request guidance](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) still treats `pull_request_target` plus checkout/execution of PR-controlled code as the dangerous pattern. The allocator may inspect PR metadata and push a trusted mirror ref, but it must not execute PR code.
+
 ## Trust Model
 
 Native iOS PR builds require signing and Firebase distribution credentials, so they cannot follow the exact web-preview security model.
@@ -38,6 +47,8 @@ Private org membership may not be visible to the default `GITHUB_TOKEN`, so the 
 
 Codemagic API builds are started by branch or tag. To support trusted member PRs from personal forks, GitHub Actions should mirror every trusted PR head SHA to a temporary branch in `divinevideo/divine-mobile`, for example `ios-qa/pr-3407`, then ask Codemagic to build that mirror branch. This gives Codemagic a branch it can fetch from the configured repository while preserving the exact PR SHA in build metadata.
 
+The allocator workflow uses `pull_request_target` for secrets and write permissions, but it must check out only the base repository workflow/scripts. It may fetch and push a trusted PR head as a passive git object after the trust check; it must not run Flutter, npm, shell scripts, hooks, or any executable content from the PR inside GitHub Actions. Treat PR titles, branch names, and labels as untrusted strings: pass them through environment variables or JSON files, never by direct shell interpolation.
+
 ## Slot Lifecycle
 
 GitHub labels are the source of truth:
@@ -49,14 +60,17 @@ GitHub labels are the source of truth:
 - `ios-qa:failed`
 - `needs-ios-qa`
 
+Slot labels are the source of truth for assignment. Build result metadata is stored in the sticky PR comment as a hidden JSON state marker so reconciliation and the active directory can recover the latest built SHA, Codemagic build ID/URL, Firebase `testing_uri`, stale status, and failure reason without committing generated state.
+
 Slot assignment:
 
 1. A ready-for-review PR becomes eligible automatically.
 2. A draft PR becomes eligible only when labeled `needs-ios-qa`.
 3. If the PR already has a slot label, keep that slot and rebuild it on new commits.
-4. If it has no slot label, find the first slot not currently used by an open PR.
-5. If a slot is available, add `ios-qa-slot-NN` and `ios-qa:building`.
-6. If no slot is available, add `ios-qa:queued` and comment with the active build directory.
+4. Only slots marked enabled in `.github/ios_qa_slots.json` are assignable. Stage 1 should enable only `qa01`.
+5. If it has no slot label, find the first enabled slot not currently used by an open PR.
+6. If a slot is available, add `ios-qa-slot-NN` and `ios-qa:building`.
+7. If no slot is available, add `ios-qa:queued` and comment with the active build directory.
 
 Cleanup:
 
@@ -82,11 +96,11 @@ Codemagic builds should still be per-PR cancellable or replaceable. A newer comm
 
 ## Build Flow
 
-1. GitHub Actions receives a `pull_request` event, `workflow_dispatch`, or label event.
-2. The allocator checks trust, PR state, draft state, file relevance, and current labels.
+1. GitHub Actions receives a `pull_request_target` event, `workflow_dispatch`, schedule event, or label event.
+2. The allocator checks trust, PR state, draft state, file relevance, enabled slots, and current labels. File relevance is checked in script, not with workflow `paths`, so cleanup and manual reconciliation still run.
 3. The allocator assigns or reuses a slot.
 4. The allocator mirrors the trusted PR head SHA to `ios-qa/pr-<number>` in the base repository.
-5. The allocator triggers Codemagic through the Codemagic Builds API with branch `ios-qa/pr-<number>` and explicit metadata:
+5. The allocator triggers Codemagic through `POST /builds` with branch `ios-qa/pr-<number>`, `workflowId=ios-qa-pr-build`, explicit labels, and explicit metadata:
    - `PR_NUMBER`
    - `PR_HEAD_SHA`
    - `PR_HEAD_REPO`
@@ -98,10 +112,11 @@ Codemagic builds should still be per-PR cancellable or replaceable. A newer comm
    - `QA_DISPLAY_NAME`
    - `QA_FIREBASE_APP_ID`
    - `DEFAULT_ENV`
-6. Codemagic checks out the mirror branch, verifies `git rev-parse HEAD` equals `PR_HEAD_SHA`, patches build settings for the slot, builds an Ad Hoc IPA, and runs another stale-SHA check before distribution.
-7. If the PR head SHA still matches `PR_HEAD_SHA`, Codemagic uploads the IPA to Firebase App Distribution.
-8. If the PR has moved on or closed, Codemagic skips Firebase distribution and reports a stale build.
-9. GitHub updates the sticky PR comment and the active QA directory.
+6. The allocator stores the returned Codemagic `buildId` in the sticky PR comment state marker and labels the PR `ios-qa:building`.
+7. Codemagic checks out the mirror branch, verifies `git rev-parse HEAD` equals `PR_HEAD_SHA`, patches build settings and Firebase metadata for the slot, applies Ad Hoc signing profiles, builds an IPA, and runs another stale-SHA check before distribution.
+8. If the PR head SHA still matches `PR_HEAD_SHA`, Codemagic uploads the IPA to Firebase App Distribution.
+9. If the PR has moved on or closed, Codemagic skips Firebase distribution and reports a stale build.
+10. Codemagic updates the sticky PR comment state marker. GitHub reconciliation uses that marker plus labels and PR metadata to regenerate the active QA directory.
 
 ## iOS Identity Requirements
 
@@ -121,6 +136,8 @@ The current app has production identifiers hard-coded in places that must become
 - Xcode notification extension bundle ID.
 - Main app entitlements.
 - Notification extension entitlements.
+- `mobile/ios/Runner/GoogleService-Info.plist`.
+- `mobile/ios/firebase_app_id_file.json`.
 - Firebase iOS app ID and bundle ID.
 - Push registration app identifier.
 
@@ -130,9 +147,11 @@ Each slot should have a Firebase iOS app record so Firebase App Distribution, Cr
 
 Distribution should publish to a stable QA tester group, for example `ios-qa`.
 
-The PR comment should link to Firebase's tester install URI rather than a short-lived raw binary URL.
+The PR comment should link to Firebase's `testing_uri` rather than a short-lived raw binary URL.
 
 If a QA device is not in the Ad Hoc provisioning profile, Firebase can help collect UDIDs, but the Apple profile still must be regenerated with that device before the build can install.
+
+Firebase releases are available in App Distribution for 150 days. That is enough for active PR review, but the active directory should show last-updated time and not imply that historical PR links are permanent.
 
 ## QA Directory
 
@@ -151,7 +170,7 @@ Directory fields:
 - Codemagic build URL
 - Notes for skipped, queued, stale, or failed builds
 
-The directory should be generated from labels and PR metadata, not manually edited.
+The directory should be generated from labels, PR metadata, and sticky comment state markers, not manually edited.
 
 ## Error Handling
 
@@ -196,7 +215,8 @@ Stage 1 proves one slot end to end:
 - Configure `qa01` Apple/Firebase identity.
 - Add the build-time configuration path.
 - Add the allocator in dry-run or one-slot mode.
-- Build and distribute one trusted PR through Firebase.
+- Merge the bootstrap workflow PR so `pull_request_target`/`workflow_dispatch` exists on `main`.
+- Build and distribute one trusted throwaway PR through Firebase.
 
 Stage 2 expands to 15 slots:
 

--- a/docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md
+++ b/docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md
@@ -1,0 +1,208 @@
+# iOS QA PR Builds Design
+
+## Goal
+
+Give QA installable iOS builds for active mobile PRs without using TestFlight as the bottleneck. QA should be able to open a PR or a directory, see which build belongs to that PR, and install it on registered iOS devices.
+
+## Decision
+
+Use 15 reusable iOS QA slots. Each slot is a fixed Apple/Firebase app identity that can be installed side by side with the production app and with the other QA slots.
+
+Slots:
+
+- `qa01` through `qa15`
+- Main bundle IDs: `co.openvine.app.qa01` through `co.openvine.app.qa15`
+- Extension bundle IDs: `co.openvine.app.qa01.NotificationServiceExtension` through `co.openvine.app.qa15.NotificationServiceExtension`
+- Display names: `Divine QA 01` through `Divine QA 15`
+- App groups: `group.co.openvine.app.qa01` through `group.co.openvine.app.qa15`
+
+Avoid dynamic per-PR bundle IDs. The one-time setup for 15 identities is manageable; unbounded per-PR identities would create ongoing Apple, Firebase, provisioning, entitlement, and cleanup work.
+
+## Trust Model
+
+Native iOS PR builds require signing and Firebase distribution credentials, so they cannot follow the exact web-preview security model.
+
+Autobuild only when the PR is trusted:
+
+1. The PR head repository owner is `divinevideo`; or
+2. The PR author is an active member or owner of the `divinevideo` GitHub organization.
+
+For PRs outside that trust model:
+
+- Do not trigger Codemagic.
+- Do not expose signing, App Store Connect, or Firebase credentials.
+- Add or update a PR comment explaining that iOS QA build was skipped because the PR is outside the trusted build policy.
+- A maintainer can make the PR buildable by moving/mirroring the branch under `divinevideo`, or by using a future explicit trusted override if we choose to add one.
+
+Private org membership may not be visible to the default `GITHUB_TOKEN`, so the membership check needs a GitHub token with enough permission to read org membership.
+
+## Slot Lifecycle
+
+GitHub labels are the source of truth:
+
+- `ios-qa-slot-01` through `ios-qa-slot-15`
+- `ios-qa:building`
+- `ios-qa:ready`
+- `ios-qa:queued`
+- `ios-qa:failed`
+- `needs-ios-qa`
+
+Slot assignment:
+
+1. A ready-for-review PR becomes eligible automatically.
+2. A draft PR becomes eligible only when labeled `needs-ios-qa`.
+3. If the PR already has a slot label, keep that slot and rebuild it on new commits.
+4. If it has no slot label, find the first slot not currently used by an open PR.
+5. If a slot is available, add `ios-qa-slot-NN` and `ios-qa:building`.
+6. If no slot is available, add `ios-qa:queued` and comment with the active build directory.
+
+Cleanup:
+
+- On PR close, remove `ios-qa-slot-NN`, `ios-qa:building`, `ios-qa:ready`, `ios-qa:queued`, and `ios-qa:failed`.
+- Update the active build directory.
+- The installed app can remain on QA devices until that slot is reused.
+- A scheduled reconciliation workflow should run daily to repair missed label/comment/directory updates.
+
+## Concurrency
+
+The allocator workflow must use one global concurrency group, for example:
+
+```yaml
+concurrency:
+  group: ios-qa-slot-allocator
+  cancel-in-progress: false
+```
+
+This prevents two PR workflows from seeing the same free slot and assigning it twice.
+
+Codemagic builds should still be per-PR cancellable or replaceable. A newer commit for the same PR should supersede the older build before distribution.
+
+## Build Flow
+
+1. GitHub Actions receives a `pull_request` event, `workflow_dispatch`, or label event.
+2. The allocator checks trust, PR state, draft state, file relevance, and current labels.
+3. The allocator assigns or reuses a slot.
+4. The allocator triggers Codemagic through the Codemagic Builds API with explicit metadata:
+   - `PR_NUMBER`
+   - `PR_HEAD_SHA`
+   - `QA_SLOT`
+   - `QA_BUNDLE_ID`
+   - `QA_EXTENSION_BUNDLE_ID`
+   - `QA_APP_GROUP`
+   - `QA_DISPLAY_NAME`
+   - `QA_FIREBASE_APP_ID`
+   - `DEFAULT_ENV`
+5. Codemagic checks out the exact PR SHA, patches build settings for the slot, builds an Ad Hoc IPA, and runs a stale-SHA check before distribution.
+6. If the PR head SHA still matches `PR_HEAD_SHA`, Codemagic uploads the IPA to Firebase App Distribution.
+7. If the PR has moved on or closed, Codemagic skips Firebase distribution and reports a stale build.
+8. GitHub updates the sticky PR comment and the active QA directory.
+
+## iOS Identity Requirements
+
+Each slot needs Apple Developer setup:
+
+- App ID for the main app bundle ID.
+- App ID for the notification service extension bundle ID.
+- Ad Hoc provisioning profile for the main app.
+- Ad Hoc provisioning profile for the notification service extension.
+- App group matching the slot.
+- Push notification capability if QA builds need push behavior.
+- Associated domains if QA builds need universal links or password-manager flows.
+
+The current app has production identifiers hard-coded in places that must become slot-configurable:
+
+- Xcode main bundle ID.
+- Xcode notification extension bundle ID.
+- Main app entitlements.
+- Notification extension entitlements.
+- Firebase iOS app ID and bundle ID.
+- Push registration app identifier.
+
+## Firebase Requirements
+
+Each slot should have a Firebase iOS app record so Firebase App Distribution, Crashlytics, and app metadata line up with the slot bundle ID.
+
+Distribution should publish to a stable QA tester group, for example `ios-qa`.
+
+The PR comment should link to Firebase's tester install URI rather than a short-lived raw binary URL.
+
+If a QA device is not in the Ad Hoc provisioning profile, Firebase can help collect UDIDs, but the Apple profile still must be regenerated with that device before the build can install.
+
+## QA Directory
+
+Generate a single active-build directory from GitHub state. This can be a sticky GitHub issue, a markdown artifact committed only if needed, or a PR comment on an always-open tracking issue.
+
+Directory fields:
+
+- Slot
+- PR number and title
+- PR author
+- Draft/ready state
+- Latest built commit SHA
+- Build status
+- Firebase install link
+- Last updated time
+- Codemagic build URL
+- Notes for skipped, queued, stale, or failed builds
+
+The directory should be generated from labels and PR metadata, not manually edited.
+
+## Error Handling
+
+All slots full:
+
+- Label the PR `ios-qa:queued`.
+- Comment with the active directory and current slot occupants.
+- The daily reconciliation or close-event cleanup should assign queued PRs when slots free up.
+
+Codemagic build fails:
+
+- Replace `ios-qa:building` with `ios-qa:failed`.
+- Keep the slot assigned to the PR.
+- Update the PR comment with the Codemagic build URL and failure status.
+
+PR updates while build is running:
+
+- Keep the same slot.
+- Mark the old build stale.
+- Trigger a replacement build for the new head SHA.
+- Do not distribute the stale IPA.
+
+PR closes during build:
+
+- Release the slot labels.
+- Skip distribution if Codemagic reaches the stale/closed check.
+
+Device cannot install:
+
+- Comment should point QA to the Firebase device registration flow.
+- After UDIDs are added in Apple Developer, profiles must be regenerated and Codemagic signing assets refreshed.
+
+Trust check fails:
+
+- Do not trigger a signed build.
+- Comment with the trusted-build policy.
+
+## Rollout Plan
+
+Stage 1 proves one slot end to end:
+
+- Configure `qa01` Apple/Firebase identity.
+- Add the build-time configuration path.
+- Add the allocator in dry-run or one-slot mode.
+- Build and distribute one trusted PR through Firebase.
+
+Stage 2 expands to 15 slots:
+
+- Add the remaining 14 Apple/Firebase identities.
+- Add the full slot map.
+- Enable automatic assignment for ready PRs and `needs-ios-qa` draft PRs.
+- Add queued-state handling and daily reconciliation.
+
+## Open Decisions
+
+- Whether QA builds should use production, staging, or a selectable `DEFAULT_ENV` by default.
+- Whether universal links and web credentials should be enabled for QA slot app IDs.
+- Whether push notifications must work in QA builds from day one.
+- Whether to add a maintainer-only override for trusted builds from non-org forks.
+


### PR DESCRIPTION
Closes #3424

## Summary
- Documents the approved 15-slot iOS QA PR build design.
- Adds a detailed implementation plan covering trust checks, GitHub slot allocation, Codemagic Ad Hoc builds, Firebase distribution, stale-build handling, and rollout.

## Verification
- git diff --check
- git push pre-push hook: no merge conflicts with main; no Dart files changed, skipping tests