### PR TITLE
fix(video-player): release pooled players on background

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -280,7 +280,7 @@ class FullscreenFeedContent extends ConsumerStatefulWidget {
 }
 
 class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
-    with RouteAware {
+    with RouteAware, WidgetsBindingObserver {
   VideoFeedController? _controller;
   List<VideoItem>? _lastPooledVideos;
   late final ValueNotifier<double> _pagePosition;
@@ -306,17 +306,27 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     final initialIndex = context.read<FullscreenFeedBloc>().state.currentIndex;
     _pagePosition = ValueNotifier<double>(initialIndex.toDouble());
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     routeObserver.unsubscribe(this);
     _controller?.dispose();
     _pagePosition.dispose();
     unawaited(_autoAdvanceCubit.close());
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) return;
+    if (ModalRoute.of(context)?.isCurrent ?? false) {
+      _controller?.setActive(active: true);
+    }
   }
 
   // RouteAware callbacks: pause when another route is pushed on top,

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -193,6 +193,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
       context.read<VideoFeedBloc>().add(const VideoFeedAutoRefreshRequested());
+      _syncControllerPlaybackState(resumeIfHome: true);
     }
   }
 

--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
@@ -462,6 +462,16 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     // MARK: - State broadcasting
 
     private func sendStateUpdate() {
+        if !Thread.isMainThread {
+            DispatchQueue.main.async { [weak self] in
+                self?.sendStateUpdate()
+            }
+            return
+        }
+        sendStateUpdateOnMain()
+    }
+
+    private func sendStateUpdateOnMain() {
         guard let player, let sink = eventSink else { return }
 
         let currentTime = CMTimeGetSeconds(player.currentTime())

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
@@ -433,6 +433,16 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     // MARK: - State broadcasting
 
     private func sendStateUpdate() {
+        if !Thread.isMainThread {
+            DispatchQueue.main.async { [weak self] in
+                self?.sendStateUpdate()
+            }
+            return
+        }
+        sendStateUpdateOnMain()
+    }
+
+    private func sendStateUpdateOnMain() {
         guard let player, let sink = eventSink else { return }
 
         let currentTime = CMTimeGetSeconds(player.currentTime())
@@ -611,4 +621,3 @@ private extension CGSize {
         width.isFinite && height.isFinite && width > 0 && height > 0
     }
 }
-

--- a/mobile/packages/divine_video_player/test/src/apple_threading_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_threading_contract_test.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Apple native player threading contract', () {
+    for (final platform in ['ios', 'macos']) {
+      test('$platform sends Flutter event updates on the main thread', () {
+        final source = _appleSourceFile(platform).readAsStringSync();
+
+        expect(
+          source,
+          contains('Thread.isMainThread'),
+          reason:
+              'FlutterEventSink must not be called from AVFoundation/KVO '
+              'callback queues.',
+        );
+        expect(source, contains('DispatchQueue.main.async'));
+        expect(source, contains('sendStateUpdateOnMain'));
+      });
+    }
+  });
+}
+
+File _appleSourceFile(String platform) {
+  final packageRelative = File(
+    '$platform/Classes/DivineVideoPlayerInstance.swift',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    '$platform/Classes/DivineVideoPlayerInstance.swift',
+  );
+}

--- a/mobile/packages/pooled_video_player/lib/src/controllers/player_pool.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/player_pool.dart
@@ -400,11 +400,11 @@ class PlayerPool {
     }
   }
 
-  /// Dispose all players and clear the pool.
-  Future<void> dispose() async {
-    if (_isDisposed) return;
-    _isDisposed = true;
-
+  /// Release all cached players while keeping the pool reusable.
+  ///
+  /// Used when the app fully deactivates so native media resources do not
+  /// remain open while iOS is suspending the process.
+  Future<void> releaseAll() async {
     final players = _players.values.toList();
     _players.clear();
     _lruOrder.clear();
@@ -414,6 +414,14 @@ class PlayerPool {
         await player.dispose();
       }
     }
+  }
+
+  /// Dispose all players and clear the pool.
+  Future<void> dispose() async {
+    if (_isDisposed) return;
+    _isDisposed = true;
+
+    await releaseAll();
   }
 
   /// Creates a new [PooledPlayer] for [url].

--- a/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/video_feed_controller.dart
@@ -873,20 +873,28 @@ class VideoFeedController extends ChangeNotifier {
   /// When `active: true`, resumes playback. If players were retained, playback
   /// resumes instantly. Otherwise, the preload window is reloaded.
   void setActive({required bool active, bool retainCurrentPlayer = false}) {
-    if (_isActive == active) return;
+    if (_isActive == active) {
+      if (!active && !retainCurrentPlayer) {
+        _releaseAllPlayers(releaseFromPool: true);
+      }
+      return;
+    }
     _isActive = active;
 
     if (!active) {
       _pauseVideo(_currentIndex);
       if (retainCurrentPlayer) {
         // Only pause current, release other players outside current index
+        final currentUrl = _videoUrlAt(_currentIndex);
         _loadedPlayers.keys
-            .where((idx) => idx != _currentIndex)
+            .where(
+              (idx) => idx != _currentIndex && _videoUrlAt(idx) != currentUrl,
+            )
             .toList()
-            .forEach(_releasePlayer);
+            .forEach((idx) => _releasePlayer(idx, releaseFromPool: true));
       } else {
         // Release all players to free memory
-        _releaseAllPlayers();
+        _releaseAllPlayers(releaseFromPool: true);
       }
     } else {
       // Clear any manual pause so playback resumes with audio
@@ -903,8 +911,14 @@ class VideoFeedController extends ChangeNotifier {
     notifyListeners();
   }
 
-  void _releaseAllPlayers() {
+  String? _videoUrlAt(int index) =>
+      index >= 0 && index < _videos.length ? _videos[index].url : null;
+
+  void _releaseAllPlayers({bool releaseFromPool = false}) {
     _loadedPlayers.keys.toList().forEach(_releasePlayer);
+    if (releaseFromPool) {
+      unawaited(pool.releaseAll());
+    }
   }
 
   /// Play the current video (user-initiated resume).
@@ -2192,7 +2206,9 @@ class VideoFeedController extends ChangeNotifier {
     _positionTimers.remove(index);
   }
 
-  void _releasePlayer(int index) {
+  void _releasePlayer(int index, {bool releaseFromPool = false}) {
+    final url = _videoUrlAt(index);
+
     // Unblock any pending preload wait for this index.
     _completeReady(index);
 
@@ -2235,6 +2251,10 @@ class VideoFeedController extends ChangeNotifier {
     // skip the force-seek-zero and reproduce the original bug.
     _userVisitedIndices.remove(index);
     _notifyIndex(index);
+
+    if (releaseFromPool && url != null) {
+      unawaited(pool.release(url));
+    }
   }
 
   /// Emits a one-line summary of diagnostic counters and the final source

--- a/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_feed.dart
+++ b/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_feed.dart
@@ -88,7 +88,8 @@ class PooledVideoFeed extends StatefulWidget {
 }
 
 /// State for [PooledVideoFeed].
-class PooledVideoFeedState extends State<PooledVideoFeed> {
+class PooledVideoFeedState extends State<PooledVideoFeed>
+    with WidgetsBindingObserver {
   late VideoFeedController _controller;
   late PageController _pageController;
   late PlayerPool _effectivePool;
@@ -113,6 +114,7 @@ class PooledVideoFeedState extends State<PooledVideoFeed> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _currentIndex = widget.initialIndex;
     _pageController = PageController(initialPage: _currentIndex);
     _pageController.addListener(_onScrollChanged);
@@ -143,6 +145,22 @@ class PooledVideoFeedState extends State<PooledVideoFeed> {
         _controller.play();
       }
     });
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+
+    switch (state) {
+      case AppLifecycleState.paused:
+      case AppLifecycleState.hidden:
+      case AppLifecycleState.detached:
+        _controller.setActive(active: false);
+
+      case AppLifecycleState.resumed:
+      case AppLifecycleState.inactive:
+        break;
+    }
   }
 
   void _onScrollChanged() {
@@ -242,6 +260,7 @@ class PooledVideoFeedState extends State<PooledVideoFeed> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _controller.removeListener(_onControllerChanged);
     _pageController
       ..removeListener(_onScrollChanged)

--- a/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/video_feed_controller_test.dart
@@ -848,6 +848,28 @@ void main() {
         );
 
         test(
+          'full deactivation clears native player pool to release file locks',
+          () async {
+            final controller = VideoFeedController(
+              videos: createTestVideos(),
+              pool: pool,
+              preloadBehind: 0,
+            );
+
+            await Future<void>.delayed(const Duration(milliseconds: 100));
+
+            expect(pool.playerCount, equals(3));
+
+            controller.setActive(active: false);
+            await Future<void>.delayed(Duration.zero);
+
+            expect(pool.playerCount, equals(0));
+
+            addTearDown(controller.dispose);
+          },
+        );
+
+        test(
           'retainCurrentPlayer defaults to false (releases all)',
           () async {
             final controller = VideoFeedController(

--- a/mobile/packages/pooled_video_player/test/widgets/pooled_video_feed_test.dart
+++ b/mobile/packages/pooled_video_player/test/widgets/pooled_video_feed_test.dart
@@ -129,6 +129,22 @@ void main() {
 
         controller.dispose();
       });
+
+      testWidgets('deactivates controller when app backgrounds', (
+        tester,
+      ) async {
+        final controller = createMockVideoFeedController();
+
+        await tester.pumpWidget(buildFeed(controller: controller));
+        clearInteractions(controller);
+
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.paused,
+        );
+        await tester.pump();
+
+        verify(() => controller.setActive(active: false)).called(1);
+      });
     });
 
     group('PageView', () {

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -376,6 +376,35 @@ void main() {
         expect(find.byType(PooledVideoFeed), findsOneWidget);
       });
 
+      testWidgets('resumes playback when app resumes on current route', (
+        tester,
+      ) async {
+        final videos = createTestVideos();
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: FullscreenFeedState(
+              status: FullscreenFeedStatus.ready,
+              videos: videos,
+            ),
+          ),
+        );
+        await tester.pump();
+
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.paused,
+        );
+        await tester.pump();
+        clearInteractions(defaultController);
+
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+        await tester.pump();
+
+        verify(() => defaultController.setActive(active: true)).called(1);
+      });
+
       testWidgets(
         'shows the category title in the fullscreen app bar when provided',
         (tester) async {

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -334,6 +334,26 @@ void main() {
       verify(() => videoFeedController.setActive(active: true)).called(1);
     });
 
+    testWidgets('resumes playback when app resumes on home with no overlay', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      clearInteractions(videoFeedBloc);
+      clearInteractions(videoFeedController);
+
+      tester.binding.handleAppLifecycleStateChanged(
+        AppLifecycleState.resumed,
+      );
+      await tester.pump();
+
+      verify(
+        () => videoFeedBloc.add(const VideoFeedAutoRefreshRequested()),
+      ).called(1);
+      verify(() => videoFeedController.setActive(active: true)).called(1);
+    });
+
     testWidgets('does not resume when videos load while overlay is open', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary
- Treat the uploaded TestFlight crash as an iOS suspension kill: the crash log and feedback JSON are build 664 and show `RUNNINGBOARD 0xdead10cc`, not a normal Crashlytics-reportable exception.
- Release pooled `media_kit`/mpv players from `PlayerPool` when native pooled feeds background or fully deactivate, so cached native players do not keep media/file resources open during suspension.
- Resume home/fullscreen feeds through their owning screens on app resume, preserving existing overlay/tab/route guards.
- Keep the Apple `divine_video_player` event-sink dispatch change from the first pass as a defensive main-thread boundary for native state updates.

## Test Plan
- [x] `flutter test` from `mobile/packages/pooled_video_player`
- [x] `flutter analyze` from `mobile/packages/pooled_video_player`
- [x] `flutter test test/screens/feed/video_feed_page_test.dart test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart` from `mobile/`
- [x] `flutter analyze lib/screens/feed/video_feed_page.dart lib/screens/feed/pooled_fullscreen_video_feed_screen.dart test/screens/feed/video_feed_page_test.dart test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart` from `mobile/`
- [x] `flutter test` from `mobile/packages/divine_video_player`
- [x] `flutter analyze` from `mobile/packages/divine_video_player`
- [x] pre-commit hook: format + full mobile analyze
- [x] pre-push hook: changed-file tests

## Notes
- The supplied TestFlight files identify build 664, so they do not prove build 665 contains this exact patch. The termination reason does explain why there were no Dart logs and no Crashlytics entry.
- A device/TestFlight build is still needed to confirm backgrounding no longer produces the OS-level kill.
