### PR TITLE
fix(social): emit optimistic like + repost counts before publish

### DIFF
--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -43,8 +43,19 @@ class VideoInteractionsBloc
        _addressableId = addressableId,
        super(VideoInteractionsState(likeCount: initialLikeCount)) {
     on<VideoInteractionsFetchRequested>(_onFetchRequested);
+    // Toggle handlers fire-and-forget the publish (see _onLikeToggled),
+    // so they return in microseconds and do not benefit from a
+    // droppable transformer. Rapid double-taps on the same video are
+    // intentionally allowed to flip-flip — end state is correct via
+    // the repository's per-event-id guards
+    // (AlreadyLikedException / AlreadyRepostedException) which
+    // surface as no-op settle events here. Different videos already
+    // use different bloc instances, so cross-video parallelism is
+    // unaffected.
     on<VideoInteractionsLikeToggled>(_onLikeToggled);
     on<VideoInteractionsRepostToggled>(_onRepostToggled);
+    on<_VideoInteractionsLikeSettled>(_onLikeSettled);
+    on<_VideoInteractionsRepostSettled>(_onRepostSettled);
     on<VideoInteractionsSubscriptionRequested>(_onSubscriptionRequested);
     on<VideoInteractionsCommentCountUpdated>(_onCommentCountUpdated);
   }
@@ -181,13 +192,15 @@ class VideoInteractionsBloc
   /// Handle like toggle request.
   ///
   /// Emits the optimistic state (flipped [isLiked] + adjusted [likeCount])
-  /// BEFORE awaiting the repository, so the heart and counter flip in the
-  /// same frame. The repository's stream tick fires during the await; the
-  /// subscription handler at [_onSubscriptionRequested] no-ops because
-  /// state.isLiked already matches, guaranteeing a single emit per tap.
+  /// and returns immediately — the publish itself runs fire-and-forget via
+  /// [_publishLike]. The handler intentionally does not await the publish
+  /// so that a slow network on this video never blocks taps on subsequent
+  /// videos (different videos use different bloc instances; this just keeps
+  /// each instance's event queue free of long-running work).
   ///
-  /// Exception paths revert both fields to the pre-tap baseline so the UI
-  /// returns to its original state if the publish fails.
+  /// When the publish settles, [_publishLike] dispatches a
+  /// [_VideoInteractionsLikeSettled] event and reconciliation happens in
+  /// [_onLikeSettled] with a fresh [Emitter].
   Future<void> _onLikeToggled(
     VideoInteractionsLikeToggled event,
     Emitter<VideoInteractionsState> emit,
@@ -206,6 +219,21 @@ class VideoInteractionsBloc
       ),
     );
 
+    unawaited(
+      _publishLike(
+        optimisticLiked: optimisticLiked,
+        wasLiked: wasLiked,
+        wasCount: wasCount,
+      ),
+    );
+  }
+
+  Future<void> _publishLike({
+    required bool optimisticLiked,
+    required bool wasLiked,
+    required int? wasCount,
+  }) async {
+    _LikeSettleOutcome outcome;
     try {
       // Pass addressable ID and target kind for proper a-tag tagging
       final isNowLiked = await _likesRepository.toggleLike(
@@ -216,37 +244,56 @@ class VideoInteractionsBloc
             ? NIP71VideoKinds.addressableShortVideo
             : null,
       );
-
-      if (isNowLiked != optimisticLiked) {
-        // Out-of-band toggle (e.g. another device flipped it mid-tap).
-        // Reconcile from the pre-tap baseline rather than current state.
-        emit(
-          state.copyWith(
-            isLiked: isNowLiked,
-            likeCount: _adjustCount(wasCount, increment: isNowLiked),
-          ),
-        );
-      }
+      outcome = isNowLiked == optimisticLiked
+          ? const _LikeSettleConfirmed()
+          : _LikeSettleOutOfBand(actualIsLiked: isNowLiked);
     } on AlreadyLikedException {
-      // Reality says we were already liked — revert to pre-tap baseline
-      // since no real transition occurred.
-      emit(state.copyWith(isLiked: true, likeCount: wasCount));
+      outcome = const _LikeSettleAlready();
     } on NotLikedException {
-      emit(state.copyWith(isLiked: false, likeCount: wasCount));
-    } catch (e) {
+      outcome = const _LikeSettleNotLiked();
+    } catch (e, stackTrace) {
       Log.error(
         'VideoInteractionsBloc: Like toggle failed for $_eventId - $e',
         name: 'VideoInteractionsBloc',
         category: LogCategory.system,
       );
+      addError(e, stackTrace);
+      outcome = _LikeSettleFailed(wasLiked: wasLiked);
+    }
 
-      emit(
-        state.copyWith(
-          isLiked: wasLiked,
-          likeCount: wasCount,
-          error: VideoInteractionsError.likeFailed,
-        ),
-      );
+    if (isClosed) return;
+    add(_VideoInteractionsLikeSettled(outcome: outcome, wasCount: wasCount));
+  }
+
+  void _onLikeSettled(
+    _VideoInteractionsLikeSettled event,
+    Emitter<VideoInteractionsState> emit,
+  ) {
+    switch (event.outcome) {
+      case _LikeSettleConfirmed():
+        // Optimistic emit already matches the publish result; no-op.
+        return;
+      case _LikeSettleOutOfBand(:final actualIsLiked):
+        // Another device flipped it mid-tap. Reconcile from the pre-tap
+        // baseline so the count doesn't double-adjust.
+        emit(
+          state.copyWith(
+            isLiked: actualIsLiked,
+            likeCount: _adjustCount(event.wasCount, increment: actualIsLiked),
+          ),
+        );
+      case _LikeSettleAlready():
+        emit(state.copyWith(isLiked: true, likeCount: event.wasCount));
+      case _LikeSettleNotLiked():
+        emit(state.copyWith(isLiked: false, likeCount: event.wasCount));
+      case _LikeSettleFailed(:final wasLiked):
+        emit(
+          state.copyWith(
+            isLiked: wasLiked,
+            likeCount: event.wasCount,
+            error: VideoInteractionsError.likeFailed,
+          ),
+        );
     }
   }
 
@@ -262,11 +309,11 @@ class VideoInteractionsBloc
 
   /// Handle repost toggle request.
   ///
-  /// Mirrors [_onLikeToggled]: the repository now writes the optimistic
-  /// record + ticks [RepostsRepository.watchRepostedAddressableIds] before
-  /// the kind-16 publish, and this handler emits the optimistic state
-  /// before awaiting, so the icon and counter flip in the same frame. The
-  /// subscription handler's early-return absorbs the follow-up stream tick.
+  /// Mirrors [_onLikeToggled]: emits the optimistic state and returns
+  /// immediately, scheduling the publish via [_publishRepost]. When the
+  /// publish settles, [_publishRepost] dispatches a
+  /// [_VideoInteractionsRepostSettled] event for reconciliation in
+  /// [_onRepostSettled].
   Future<void> _onRepostToggled(
     VideoInteractionsRepostToggled event,
     Emitter<VideoInteractionsState> emit,
@@ -296,40 +343,79 @@ class VideoInteractionsBloc
       ),
     );
 
+    unawaited(
+      _publishRepost(
+        addressableId: addressableId,
+        optimisticReposted: optimisticReposted,
+        wasReposted: wasReposted,
+        wasCount: wasCount,
+      ),
+    );
+  }
+
+  Future<void> _publishRepost({
+    required String addressableId,
+    required bool optimisticReposted,
+    required bool wasReposted,
+    required int? wasCount,
+  }) async {
+    _RepostSettleOutcome outcome;
     try {
       final isNowReposted = await _repostsRepository.toggleRepost(
         addressableId: addressableId,
         originalAuthorPubkey: _authorPubkey,
         eventId: _eventId,
       );
-
-      if (isNowReposted != optimisticReposted) {
-        // Out-of-band toggle. Reconcile from the pre-tap baseline.
-        emit(
-          state.copyWith(
-            isReposted: isNowReposted,
-            repostCount: _adjustCount(wasCount, increment: isNowReposted),
-          ),
-        );
-      }
+      outcome = isNowReposted == optimisticReposted
+          ? const _RepostSettleConfirmed()
+          : _RepostSettleOutOfBand(actualIsReposted: isNowReposted);
     } on AlreadyRepostedException {
-      emit(state.copyWith(isReposted: true, repostCount: wasCount));
+      outcome = const _RepostSettleAlready();
     } on NotRepostedException {
-      emit(state.copyWith(isReposted: false, repostCount: wasCount));
-    } catch (e) {
+      outcome = const _RepostSettleNotReposted();
+    } catch (e, stackTrace) {
       Log.error(
         'VideoInteractionsBloc: Repost toggle failed for $_eventId - $e',
         name: 'VideoInteractionsBloc',
         category: LogCategory.system,
       );
+      addError(e, stackTrace);
+      outcome = _RepostSettleFailed(wasReposted: wasReposted);
+    }
 
-      emit(
-        state.copyWith(
-          isReposted: wasReposted,
-          repostCount: wasCount,
-          error: VideoInteractionsError.repostFailed,
-        ),
-      );
+    if (isClosed) return;
+    add(_VideoInteractionsRepostSettled(outcome: outcome, wasCount: wasCount));
+  }
+
+  void _onRepostSettled(
+    _VideoInteractionsRepostSettled event,
+    Emitter<VideoInteractionsState> emit,
+  ) {
+    switch (event.outcome) {
+      case _RepostSettleConfirmed():
+        return;
+      case _RepostSettleOutOfBand(:final actualIsReposted):
+        emit(
+          state.copyWith(
+            isReposted: actualIsReposted,
+            repostCount: _adjustCount(
+              event.wasCount,
+              increment: actualIsReposted,
+            ),
+          ),
+        );
+      case _RepostSettleAlready():
+        emit(state.copyWith(isReposted: true, repostCount: event.wasCount));
+      case _RepostSettleNotReposted():
+        emit(state.copyWith(isReposted: false, repostCount: event.wasCount));
+      case _RepostSettleFailed(:final wasReposted):
+        emit(
+          state.copyWith(
+            isReposted: wasReposted,
+            repostCount: event.wasCount,
+            error: VideoInteractionsError.repostFailed,
+          ),
+        );
     }
   }
 

--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -69,11 +69,17 @@ class VideoInteractionsBloc
         _likesRepository.watchLikedEventIds(),
         onData: (likedIds) {
           final isLiked = likedIds.contains(_eventId);
+          // Load-bearing: when [_onLikeToggled] has already emitted its
+          // optimistic state, state.isLiked matches and we no-op here.
+          // This guarantees a single bloc emit per tap and avoids the
+          // double-count race that would otherwise happen if both
+          // handlers adjusted likeCount.
           if (isLiked == state.isLiked) return state;
 
-          // Only sync like status here — count is owned by _onLikeToggled.
-          // This prevents a double-count race where both this subscription
-          // and the toggle handler adjust likeCount for the same action.
+          // Sync like status only — count is owned by _onLikeToggled.
+          // External sources (cross-device sync via the repo's reaction
+          // subscription) can flip isLiked here, but likeCount is left
+          // alone; cross-device count drift is tracked as a follow-up.
           return state.copyWith(isLiked: isLiked);
         },
       ),
@@ -82,6 +88,9 @@ class VideoInteractionsBloc
           _repostsRepository.watchRepostedAddressableIds(),
           onData: (repostedIds) {
             final isReposted = repostedIds.contains(_addressableId);
+            // Load-bearing for the same reason as the likes branch: the
+            // repost toggle handler emits optimistically before awaiting,
+            // and this early-return absorbs the follow-up stream tick.
             if (isReposted == state.isReposted) return state;
 
             return state.copyWith(isReposted: isReposted);
@@ -171,16 +180,32 @@ class VideoInteractionsBloc
 
   /// Handle like toggle request.
   ///
-  /// The repository writes the optimistic record and ticks the
-  /// watchLikedEventIds stream before the network call, so the heart flips
-  /// via the subscription in [_onSubscriptionRequested] before the await
-  /// here returns. This handler updates only [VideoInteractionsState.likeCount]
-  /// (which the subscription deliberately does not touch — see the comment
-  /// on [_onSubscriptionRequested]) and reconciles after publish.
+  /// Emits the optimistic state (flipped [isLiked] + adjusted [likeCount])
+  /// BEFORE awaiting the repository, so the heart and counter flip in the
+  /// same frame. The repository's stream tick fires during the await; the
+  /// subscription handler at [_onSubscriptionRequested] no-ops because
+  /// state.isLiked already matches, guaranteeing a single emit per tap.
+  ///
+  /// Exception paths revert both fields to the pre-tap baseline so the UI
+  /// returns to its original state if the publish fails.
   Future<void> _onLikeToggled(
     VideoInteractionsLikeToggled event,
     Emitter<VideoInteractionsState> emit,
   ) async {
+    final wasLiked = state.isLiked;
+    final wasCount = state.likeCount;
+    final optimisticLiked = !wasLiked;
+
+    emit(
+      state.copyWith(
+        isLiked: optimisticLiked,
+        // copyWith treats null as "no change", so when the count hasn't
+        // been fetched yet we leave it null (don't synthesize a 0).
+        likeCount: _adjustCount(wasCount, increment: optimisticLiked),
+        clearError: true,
+      ),
+    );
+
     try {
       // Pass addressable ID and target kind for proper a-tag tagging
       final isNowLiked = await _likesRepository.toggleLike(
@@ -192,20 +217,22 @@ class VideoInteractionsBloc
             : null,
       );
 
-      final currentCount = state.likeCount ?? 0;
-      final newCount = isNowLiked ? currentCount + 1 : currentCount - 1;
-
-      emit(
-        state.copyWith(
-          isLiked: isNowLiked,
-          likeCount: newCount < 0 ? 0 : newCount,
-          clearError: true,
-        ),
-      );
+      if (isNowLiked != optimisticLiked) {
+        // Out-of-band toggle (e.g. another device flipped it mid-tap).
+        // Reconcile from the pre-tap baseline rather than current state.
+        emit(
+          state.copyWith(
+            isLiked: isNowLiked,
+            likeCount: _adjustCount(wasCount, increment: isNowLiked),
+          ),
+        );
+      }
     } on AlreadyLikedException {
-      emit(state.copyWith(isLiked: true, clearError: true));
+      // Reality says we were already liked — revert to pre-tap baseline
+      // since no real transition occurred.
+      emit(state.copyWith(isLiked: true, likeCount: wasCount));
     } on NotLikedException {
-      emit(state.copyWith(isLiked: false, clearError: true));
+      emit(state.copyWith(isLiked: false, likeCount: wasCount));
     } catch (e) {
       Log.error(
         'VideoInteractionsBloc: Like toggle failed for $_eventId - $e',
@@ -213,20 +240,40 @@ class VideoInteractionsBloc
         category: LogCategory.system,
       );
 
-      emit(state.copyWith(error: VideoInteractionsError.likeFailed));
+      emit(
+        state.copyWith(
+          isLiked: wasLiked,
+          likeCount: wasCount,
+          error: VideoInteractionsError.likeFailed,
+        ),
+      );
     }
   }
 
+  /// Adjusts a possibly-null count by +1/-1 with a zero floor.
+  ///
+  /// Returns null when [count] is null so callers can pass the result to
+  /// [VideoInteractionsState.copyWith] without overwriting an unset count.
+  static int? _adjustCount(int? count, {required bool increment}) {
+    if (count == null) return null;
+    final raw = increment ? count + 1 : count - 1;
+    return raw < 0 ? 0 : raw;
+  }
+
   /// Handle repost toggle request.
+  ///
+  /// Mirrors [_onLikeToggled]: the repository now writes the optimistic
+  /// record + ticks [RepostsRepository.watchRepostedAddressableIds] before
+  /// the kind-16 publish, and this handler emits the optimistic state
+  /// before awaiting, so the icon and counter flip in the same frame. The
+  /// subscription handler's early-return absorbs the follow-up stream tick.
   Future<void> _onRepostToggled(
     VideoInteractionsRepostToggled event,
     Emitter<VideoInteractionsState> emit,
   ) async {
-    // Prevent double-taps
-    if (state.isRepostInProgress) return;
-
-    // Cannot repost non-addressable events (missing d-tag)
-    if (_addressableId == null) {
+    // Cannot repost non-addressable events (missing d-tag).
+    final addressableId = _addressableId;
+    if (addressableId == null) {
       Log.warning(
         'VideoInteractionsBloc: Cannot repost - no addressable ID for '
         '$_eventId',
@@ -237,34 +284,38 @@ class VideoInteractionsBloc
       return;
     }
 
-    emit(state.copyWith(isRepostInProgress: true, clearError: true));
+    final wasReposted = state.isReposted;
+    final wasCount = state.repostCount;
+    final optimisticReposted = !wasReposted;
+
+    emit(
+      state.copyWith(
+        isReposted: optimisticReposted,
+        repostCount: _adjustCount(wasCount, increment: optimisticReposted),
+        clearError: true,
+      ),
+    );
 
     try {
-      final currentCount = state.repostCount ?? 0;
       final isNowReposted = await _repostsRepository.toggleRepost(
-        addressableId: _addressableId,
+        addressableId: addressableId,
         originalAuthorPubkey: _authorPubkey,
         eventId: _eventId,
-        currentCount: currentCount,
       );
 
-      // Update local state with new repost status and adjusted count
-      final newCount = isNowReposted ? currentCount + 1 : currentCount - 1;
-      final safeCount = newCount < 0 ? 0 : newCount;
-
-      emit(
-        state.copyWith(
-          isReposted: isNowReposted,
-          repostCount: safeCount,
-          isRepostInProgress: false,
-        ),
-      );
+      if (isNowReposted != optimisticReposted) {
+        // Out-of-band toggle. Reconcile from the pre-tap baseline.
+        emit(
+          state.copyWith(
+            isReposted: isNowReposted,
+            repostCount: _adjustCount(wasCount, increment: isNowReposted),
+          ),
+        );
+      }
     } on AlreadyRepostedException {
-      // Already reposted - just update state to reflect reality
-      emit(state.copyWith(isReposted: true, isRepostInProgress: false));
+      emit(state.copyWith(isReposted: true, repostCount: wasCount));
     } on NotRepostedException {
-      // Not reposted - just update state to reflect reality
-      emit(state.copyWith(isReposted: false, isRepostInProgress: false));
+      emit(state.copyWith(isReposted: false, repostCount: wasCount));
     } catch (e) {
       Log.error(
         'VideoInteractionsBloc: Repost toggle failed for $_eventId - $e',
@@ -274,7 +325,8 @@ class VideoInteractionsBloc
 
       emit(
         state.copyWith(
-          isRepostInProgress: false,
+          isReposted: wasReposted,
+          repostCount: wasCount,
           error: VideoInteractionsError.repostFailed,
         ),
       );

--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -121,6 +121,17 @@ class VideoInteractionsBloc
     if (state.status == VideoInteractionsStatus.success) return;
     if (state.status == VideoInteractionsStatus.loading) return;
 
+    // Snapshot the interactive fields. Fetch and toggle handlers run
+    // concurrently (default transformer). If a tap lands while we await
+    // the relay round-trips below, state.* drifts from the snapshot and
+    // the fetched values are stale relative to the user's intent — pass
+    // null to copyWith for any drifted field so the optimistic flip
+    // survives.
+    final preFetchIsLiked = state.isLiked;
+    final preFetchLikeCount = state.likeCount;
+    final preFetchIsReposted = state.isReposted;
+    final preFetchRepostCount = state.repostCount;
+
     emit(state.copyWith(status: VideoInteractionsStatus.loading));
 
     try {
@@ -163,10 +174,14 @@ class VideoInteractionsBloc
       emit(
         state.copyWith(
           status: VideoInteractionsStatus.success,
-          isLiked: isLiked,
-          likeCount: likeCount,
-          isReposted: isReposted,
-          repostCount: repostCount,
+          isLiked: state.isLiked == preFetchIsLiked ? isLiked : null,
+          likeCount: state.likeCount == preFetchLikeCount ? likeCount : null,
+          isReposted: state.isReposted == preFetchIsReposted
+              ? isReposted
+              : null,
+          repostCount: state.repostCount == preFetchRepostCount
+              ? repostCount
+              : null,
           commentCount: commentCount,
           clearError: true,
         ),

--- a/mobile/lib/blocs/video_interactions/video_interactions_event.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_event.dart
@@ -54,3 +54,125 @@ class VideoInteractionsCommentCountUpdated extends VideoInteractionsEvent {
   @override
   List<Object?> get props => [commentCount];
 }
+
+/// Internal event dispatched when a fire-and-forget like publish settles.
+///
+/// `_onLikeToggled` emits the optimistic state and returns immediately,
+/// scheduling the publish via [Future]. When the publish settles, the
+/// publisher dispatches this event so the bloc can reconcile state
+/// inside a normal handler with a real [Emitter].
+class _VideoInteractionsLikeSettled extends VideoInteractionsEvent {
+  const _VideoInteractionsLikeSettled({
+    required this.outcome,
+    required this.wasCount,
+  });
+
+  final _LikeSettleOutcome outcome;
+  final int? wasCount;
+
+  @override
+  List<Object?> get props => [outcome, wasCount];
+}
+
+/// Internal event dispatched when a fire-and-forget repost publish settles.
+class _VideoInteractionsRepostSettled extends VideoInteractionsEvent {
+  const _VideoInteractionsRepostSettled({
+    required this.outcome,
+    required this.wasCount,
+  });
+
+  final _RepostSettleOutcome outcome;
+  final int? wasCount;
+
+  @override
+  List<Object?> get props => [outcome, wasCount];
+}
+
+/// Outcome of a fire-and-forget like publish.
+sealed class _LikeSettleOutcome extends Equatable {
+  const _LikeSettleOutcome();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+/// Publish succeeded; repository now agrees with the optimistic state.
+class _LikeSettleConfirmed extends _LikeSettleOutcome {
+  const _LikeSettleConfirmed();
+}
+
+/// Publish succeeded but the repository ended up in a different state
+/// (e.g. another device flipped the like mid-tap).
+class _LikeSettleOutOfBand extends _LikeSettleOutcome {
+  const _LikeSettleOutOfBand({required this.actualIsLiked});
+
+  final bool actualIsLiked;
+
+  @override
+  List<Object?> get props => [actualIsLiked];
+}
+
+/// Repository reported the event was already liked — the optimistic flip
+/// to liked is correct, no transition occurred.
+class _LikeSettleAlready extends _LikeSettleOutcome {
+  const _LikeSettleAlready();
+}
+
+/// Repository reported the event was not liked — the optimistic flip to
+/// unliked is correct, no transition occurred.
+class _LikeSettleNotLiked extends _LikeSettleOutcome {
+  const _LikeSettleNotLiked();
+}
+
+/// Publish threw an unexpected error — revert to the pre-tap baseline.
+class _LikeSettleFailed extends _LikeSettleOutcome {
+  const _LikeSettleFailed({required this.wasLiked});
+
+  final bool wasLiked;
+
+  @override
+  List<Object?> get props => [wasLiked];
+}
+
+/// Outcome of a fire-and-forget repost publish.
+sealed class _RepostSettleOutcome extends Equatable {
+  const _RepostSettleOutcome();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+/// Publish succeeded; repository now agrees with the optimistic state.
+class _RepostSettleConfirmed extends _RepostSettleOutcome {
+  const _RepostSettleConfirmed();
+}
+
+/// Publish succeeded but the repository ended up in a different state.
+class _RepostSettleOutOfBand extends _RepostSettleOutcome {
+  const _RepostSettleOutOfBand({required this.actualIsReposted});
+
+  final bool actualIsReposted;
+
+  @override
+  List<Object?> get props => [actualIsReposted];
+}
+
+/// Repository reported the video was already reposted.
+class _RepostSettleAlready extends _RepostSettleOutcome {
+  const _RepostSettleAlready();
+}
+
+/// Repository reported the video was not reposted.
+class _RepostSettleNotReposted extends _RepostSettleOutcome {
+  const _RepostSettleNotReposted();
+}
+
+/// Publish threw an unexpected error — revert to the pre-tap baseline.
+class _RepostSettleFailed extends _RepostSettleOutcome {
+  const _RepostSettleFailed({required this.wasReposted});
+
+  final bool wasReposted;
+
+  @override
+  List<Object?> get props => [wasReposted];
+}

--- a/mobile/lib/blocs/video_interactions/video_interactions_state.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_state.dart
@@ -26,12 +26,13 @@ enum VideoInteractionsStatus {
 /// - [isReposted]: Whether the current user has reposted this video
 /// - [repostCount]: Total number of reposts on this video
 /// - [commentCount]: Total number of comments on this video
-/// - [isRepostInProgress]: Whether a repost/unrepost operation is in progress
 /// - [isCommentsInProgress]: Whether a comments operation is in progress
 ///
-/// Like-toggle no longer carries an in-progress flag: the repository writes
-/// the optimistic record + emits before the network call, so the heart flips
-/// immediately and rolls back on failure. See LikesRepository.likeEvent.
+/// Like-toggle and repost-toggle no longer carry in-progress flags: their
+/// repositories write the optimistic record + emit before the network call,
+/// and this bloc emits the optimistic count + status before awaiting, so the
+/// UI flips immediately and rolls back on failure. See
+/// [LikesRepository.likeEvent] and [RepostsRepository.repostVideo].
 class VideoInteractionsState extends Equatable {
   const VideoInteractionsState({
     this.status = VideoInteractionsStatus.initial,
@@ -40,7 +41,6 @@ class VideoInteractionsState extends Equatable {
     this.isReposted = false,
     this.repostCount,
     this.commentCount,
-    this.isRepostInProgress = false,
     this.isCommentsInProgress = false,
     this.error,
   });
@@ -66,9 +66,6 @@ class VideoInteractionsState extends Equatable {
   /// Null if not yet fetched.
   final int? commentCount;
 
-  /// Whether a repost/unrepost operation is currently in progress.
-  final bool isRepostInProgress;
-
   /// Whether a comments operation is currently in progress.
   final bool isCommentsInProgress;
 
@@ -91,7 +88,6 @@ class VideoInteractionsState extends Equatable {
     bool? isReposted,
     int? repostCount,
     int? commentCount,
-    bool? isRepostInProgress,
     bool? isCommentsInProgress,
     VideoInteractionsError? error,
     bool clearError = false,
@@ -103,7 +99,6 @@ class VideoInteractionsState extends Equatable {
       isReposted: isReposted ?? this.isReposted,
       repostCount: repostCount ?? this.repostCount,
       commentCount: commentCount ?? this.commentCount,
-      isRepostInProgress: isRepostInProgress ?? this.isRepostInProgress,
       isCommentsInProgress: isCommentsInProgress ?? this.isCommentsInProgress,
       error: clearError ? null : (error ?? this.error),
     );
@@ -117,7 +112,6 @@ class VideoInteractionsState extends Equatable {
     isReposted,
     repostCount,
     commentCount,
-    isRepostInProgress,
     isCommentsInProgress,
     error,
   ];

--- a/mobile/lib/widgets/video_feed_item/actions/repost_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/repost_action_button.dart
@@ -37,11 +37,10 @@ class RepostActionButton extends StatelessWidget {
     return BlocSelector<
       VideoInteractionsBloc,
       VideoInteractionsState,
-      ({bool isReposted, bool isInProgress, int count})
+      ({bool isReposted, int count})
     >(
       selector: (state) => (
         isReposted: state.isReposted,
-        isInProgress: state.isRepostInProgress,
         count:
             state.repostCount ??
             (video.reposterPubkeys?.length ?? 0) + (video.originalReposts ?? 0),
@@ -49,7 +48,6 @@ class RepostActionButton extends StatelessWidget {
       builder: (context, data) {
         return _ActionButton(
           isReposted: data.isReposted,
-          isRepostInProgress: data.isInProgress,
           totalReposts: data.count,
           onInteracted: onInteracted,
         );
@@ -61,13 +59,11 @@ class RepostActionButton extends StatelessWidget {
 class _ActionButton extends StatelessWidget {
   const _ActionButton({
     this.isReposted = false,
-    this.isRepostInProgress = false,
     this.totalReposts = 1,
     this.onInteracted,
   });
 
   final bool isReposted;
-  final bool isRepostInProgress;
   final int totalReposts;
   final VoidCallback? onInteracted;
 
@@ -80,7 +76,6 @@ class _ActionButton extends StatelessWidget {
           ? context.l10n.videoActionRemoveRepost
           : context.l10n.videoActionRepost,
       iconColor: isReposted ? VineTheme.vineGreen : VineTheme.whiteText,
-      isLoading: isRepostInProgress,
       count: totalReposts,
       labelWhenZero: context.l10n.videoActionRepostLabel,
       onPressed: () {

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -258,7 +258,31 @@ class RepostsRepository {
       throw AlreadyRepostedException(addressableId);
     }
 
-    // Check if offline and queue if needed
+    // Snapshot for rollback if the network publish fails
+    final previousCount = _localCountCache[addressableId];
+
+    // 1. Optimistic-first: write to memory + local storage and tick the
+    // watchRepostedAddressableIds stream BEFORE any network I/O. The UI
+    // flips here. Mirrors LikesRepository.likeEvent's order-of-operations
+    // so reposts match the Follow pattern — local DB first, network confirms.
+    // Storage write is awaited so the placeholder survives an app crash
+    // before sync; PendingActionService (offline) and executeRepostAction
+    // (sync) reconcile the placeholder ID with the real repost event ID.
+    final placeholderId = 'pending_repost_$addressableId';
+    final placeholder = RepostRecord(
+      addressableId: addressableId,
+      repostEventId: placeholderId,
+      originalAuthorPubkey: originalAuthorPubkey,
+      createdAt: DateTime.now(),
+    );
+    _repostRecords[addressableId] = placeholder;
+    await _localStorage?.saveRepostRecord(placeholder);
+    if (previousCount != null) {
+      _cacheRepostCount(addressableId, previousCount + 1);
+    }
+    _emitRepostedIds();
+
+    // 2. Offline → leave the optimistic state in place; queue replays later
     if (_isOnline != null && !_isOnline() && _queueOfflineAction != null) {
       await _queueOfflineAction(
         isRepost: true,
@@ -266,48 +290,44 @@ class RepostsRepository {
         originalAuthorPubkey: originalAuthorPubkey,
         eventId: eventId,
       );
-
-      // Create optimistic local record with placeholder ID
-      final placeholderId = 'pending_repost_$addressableId';
-      final record = RepostRecord(
-        addressableId: addressableId,
-        repostEventId: placeholderId,
-        originalAuthorPubkey: originalAuthorPubkey,
-        createdAt: DateTime.now(),
-      );
-
-      _repostRecords[addressableId] = record;
-      await _localStorage?.saveRepostRecord(record);
-      _emitRepostedIds();
-
       return placeholderId;
     }
 
-    // Create and publish Kind 16 generic repost event
-    final sentEvent = await _nostrClient.sendGenericRepost(
-      addressableId: addressableId,
-      targetKind: EventKind.videoVertical,
-      authorPubkey: originalAuthorPubkey,
-      eventId: eventId,
-    );
+    // 3. Online → publish kind 16; on success swap placeholder for real id,
+    // on failure roll back memory + DB + count + stream.
+    try {
+      final sentEvent = await _nostrClient.sendGenericRepost(
+        addressableId: addressableId,
+        targetKind: EventKind.videoVertical,
+        authorPubkey: originalAuthorPubkey,
+        eventId: eventId,
+      );
 
-    if (sentEvent == null) {
-      throw const RepostFailedException('Failed to publish repost to relays');
+      if (sentEvent == null) {
+        throw const RepostFailedException(
+          'Failed to publish repost to relays',
+        );
+      }
+
+      final confirmed = RepostRecord(
+        addressableId: addressableId,
+        repostEventId: sentEvent.id,
+        originalAuthorPubkey: originalAuthorPubkey,
+        createdAt: placeholder.createdAt,
+      );
+      _repostRecords[addressableId] = confirmed;
+      await _localStorage?.saveRepostRecord(confirmed);
+
+      return sentEvent.id;
+    } catch (_) {
+      _repostRecords.remove(addressableId);
+      await _localStorage?.deleteRepostRecord(addressableId);
+      if (previousCount != null) {
+        _cacheRepostCount(addressableId, previousCount);
+      }
+      _emitRepostedIds();
+      rethrow;
     }
-
-    // Create and store the repost record
-    final record = RepostRecord(
-      addressableId: addressableId,
-      repostEventId: sentEvent.id,
-      originalAuthorPubkey: originalAuthorPubkey,
-      createdAt: DateTime.now(),
-    );
-
-    _repostRecords[addressableId] = record;
-    await _localStorage?.saveRepostRecord(record);
-    _emitRepostedIds();
-
-    return sentEvent.id;
   }
 
   /// Execute a repost action directly (for use by sync service).
@@ -361,7 +381,8 @@ class RepostsRepository {
   Future<void> unrepostVideo(String addressableId) async {
     await _ensureInitialized();
 
-    // Try in-memory cache first, then fall back to database
+    // Try in-memory cache first, then fall back to database.
+    // This handles the case where the cache hasn't been populated yet.
     var record = _repostRecords[addressableId];
     if (record == null && _localStorage != null) {
       record = await _localStorage.getRepostRecord(addressableId);
@@ -371,40 +392,55 @@ class RepostsRepository {
       throw NotRepostedException(addressableId);
     }
 
-    // Check if offline and queue if needed
+    // Snapshot for rollback if the network publish fails
+    final snapshotRecord = record;
+    final previousCount = _localCountCache[addressableId];
+
+    // 1. Optimistic-first: remove from memory + local storage and tick the
+    // watchRepostedAddressableIds stream BEFORE any network I/O (mirror of
+    // repostVideo).
+    _repostRecords.remove(addressableId);
+    await _localStorage?.deleteRepostRecord(addressableId);
+    if (previousCount != null) {
+      _cacheRepostCount(addressableId, previousCount - 1);
+    }
+    _emitRepostedIds();
+
+    // 2. Offline → leave the optimistic state in place; queue replays later
     if (_isOnline != null && !_isOnline() && _queueOfflineAction != null) {
       await _queueOfflineAction(
         isRepost: false,
         addressableId: addressableId,
-        originalAuthorPubkey: record.originalAuthorPubkey,
+        originalAuthorPubkey: snapshotRecord.originalAuthorPubkey,
       );
-
-      // Remove from cache and storage optimistically
-      _repostRecords.remove(addressableId);
-      await _localStorage?.deleteRepostRecord(addressableId);
-      _emitRepostedIds();
-
       return;
     }
 
-    // Skip publishing deletion if this was a pending repost that never synced
-    if (!record.repostEventId.startsWith('pending_')) {
-      // Publish Kind 5 deletion event via NostrClient
-      final deletionEvent = await _nostrClient.deleteEvent(
-        record.repostEventId,
-      );
+    // 3. Online → publish kind 5 (skipped for never-synced placeholders);
+    // on failure roll back memory + DB + count + stream.
+    if (snapshotRecord.repostEventId.startsWith('pending_')) {
+      // Pending repost never reached the relay; nothing to delete on the wire.
+      return;
+    }
 
+    try {
+      final deletionEvent = await _nostrClient.deleteEvent(
+        snapshotRecord.repostEventId,
+      );
       if (deletionEvent == null) {
         throw const UnrepostFailedException(
           'Failed to publish unrepost deletion',
         );
       }
+    } catch (_) {
+      _repostRecords[addressableId] = snapshotRecord;
+      await _localStorage?.saveRepostRecord(snapshotRecord);
+      if (previousCount != null) {
+        _cacheRepostCount(addressableId, previousCount);
+      }
+      _emitRepostedIds();
+      rethrow;
     }
-
-    // Remove from cache and storage
-    _repostRecords.remove(addressableId);
-    await _localStorage?.deleteRepostRecord(addressableId);
-    _emitRepostedIds();
   }
 
   /// Execute an unrepost action directly (for use by sync service).
@@ -458,18 +494,15 @@ class RepostsRepository {
   /// - [addressableId]: The addressable ID of the video (kind:pubkey:d-tag)
   /// - [originalAuthorPubkey]: The pubkey of the video's author
   /// - [eventId]: Optional event ID for better relay compatibility
-  /// - [currentCount]: The current repost count displayed in the UI. When
-  ///   provided, the repository caches the adjusted count (incremented or
-  ///   decremented) so that future [getRepostCount] calls return the correct
-  ///   value instead of a stale NIP-45 COUNT from relays.
   ///
   /// This is a convenience method that combines [isReposted], [repostVideo],
-  /// and [unrepostVideo].
+  /// and [unrepostVideo]. Local count cache is maintained inside those
+  /// methods, so the displayed count survives BLoC recreation without the
+  /// caller needing to thread it through.
   Future<bool> toggleRepost({
     required String addressableId,
     required String originalAuthorPubkey,
     String? eventId,
-    int? currentCount,
   }) async {
     await _ensureInitialized();
 
@@ -481,9 +514,6 @@ class RepostsRepository {
 
     if (isCurrentlyReposted) {
       await unrepostVideo(addressableId);
-      if (currentCount != null) {
-        _cacheRepostCount(addressableId, currentCount - 1);
-      }
       return false;
     } else {
       await repostVideo(
@@ -491,9 +521,6 @@ class RepostsRepository {
         originalAuthorPubkey: originalAuthorPubkey,
         eventId: eventId,
       );
-      if (currentCount != null) {
-        _cacheRepostCount(addressableId, currentCount + 1);
-      }
       return true;
     }
   }

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -296,19 +296,91 @@ void main() {
         ).called(1);
       });
 
-      test('saves repost record to local storage', () async {
-        final repository = RepostsRepository(
-          nostrClient: mockNostrClient,
-          localStorage: mockLocalStorage,
-        );
+      test(
+        'saves placeholder then confirmed record to local storage',
+        () async {
+          final captured = <RepostRecord>[];
+          when(
+            () => mockLocalStorage.saveRepostRecord(any()),
+          ).thenAnswer((invocation) async {
+            captured.add(
+              invocation.positionalArguments[0] as RepostRecord,
+            );
+          });
 
-        await repository.repostVideo(
-          addressableId: testAddressableId,
-          originalAuthorPubkey: testAuthorPubkey,
-        );
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+          );
 
-        verify(() => mockLocalStorage.saveRepostRecord(any())).called(1);
-      });
+          await repository.repostVideo(
+            addressableId: testAddressableId,
+            originalAuthorPubkey: testAuthorPubkey,
+          );
+
+          // Optimistic-first: placeholder is persisted before publish so the
+          // record survives an app crash mid-publish; confirmed record swaps
+          // the placeholder id for the real reaction id once relays return.
+          expect(captured, hasLength(2));
+          expect(
+            captured[0].repostEventId,
+            startsWith('pending_repost_'),
+          );
+          expect(captured[1].repostEventId, equals(testRepostEventId));
+        },
+      );
+
+      test(
+        'ticks watchRepostedAddressableIds before sendGenericRepost completes',
+        () async {
+          // Make sendGenericRepost block until we tell it to complete, so we
+          // can assert the stream tick races ahead of the network publish.
+          final publishCompleter = Completer<Event?>();
+          when(
+            () => mockNostrClient.sendGenericRepost(
+              addressableId: any(named: 'addressableId'),
+              targetKind: any(named: 'targetKind'),
+              authorPubkey: any(named: 'authorPubkey'),
+              content: any(named: 'content'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) => publishCompleter.future);
+
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+          );
+
+          final emitted = <Set<String>>[];
+          final subscription = repository.watchRepostedAddressableIds().listen(
+            emitted.add,
+          );
+
+          final repostFuture = repository.repostVideo(
+            addressableId: testAddressableId,
+            originalAuthorPubkey: testAuthorPubkey,
+          );
+
+          // Yield so the optimistic stream tick is delivered to listeners.
+          await Future<void>.delayed(Duration.zero);
+
+          expect(
+            emitted.last,
+            contains(testAddressableId),
+            reason: 'stream must tick before publish completes',
+          );
+
+          publishCompleter.complete(
+            createMockEvent(
+              id: testRepostEventId,
+              kind: EventKind.genericRepost,
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            ),
+          );
+          await repostFuture;
+          await subscription.cancel();
+        },
+      );
 
       test('throws AlreadyRepostedException when already reposted', () async {
         final repository = RepostsRepository(
@@ -330,7 +402,7 @@ void main() {
       });
 
       test(
-        'throws RepostFailedException when sendGenericRepost fails',
+        'throws RepostFailedException when sendGenericRepost returns null',
         () async {
           when(
             () => mockNostrClient.sendGenericRepost(
@@ -347,13 +419,101 @@ void main() {
             nostrClient: mockNostrClient,
           );
 
-          expect(
-            () => repository.repostVideo(
+          await expectLater(
+            repository.repostVideo(
               addressableId: testAddressableId,
               originalAuthorPubkey: testAuthorPubkey,
             ),
             throwsA(isA<RepostFailedException>()),
           );
+        },
+      );
+
+      test(
+        'rolls back record + count + stream when publish returns null',
+        () async {
+          when(
+            () => mockNostrClient.countEvents(any()),
+          ).thenAnswer(
+            (_) async => const CountResult(count: 4),
+          );
+          when(
+            () => mockNostrClient.sendGenericRepost(
+              addressableId: any(named: 'addressableId'),
+              targetKind: any(named: 'targetKind'),
+              authorPubkey: any(named: 'authorPubkey'),
+              content: any(named: 'content'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async => null);
+
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+          );
+
+          // Seed count cache with the relay value so the rollback has
+          // something to restore to.
+          await repository.getRepostCount(testAddressableId);
+
+          await expectLater(
+            repository.repostVideo(
+              addressableId: testAddressableId,
+              originalAuthorPubkey: testAuthorPubkey,
+            ),
+            throwsA(isA<RepostFailedException>()),
+          );
+
+          // Memory + storage: record is gone after rollback.
+          expect(repository.isRepostedSync(testAddressableId), isFalse);
+          verify(
+            () => mockLocalStorage.deleteRepostRecord(testAddressableId),
+          ).called(1);
+
+          // Count cache: restored to pre-tap value (no second relay query).
+          final count = await repository.getRepostCount(testAddressableId);
+          expect(count, equals(4));
+          verify(() => mockNostrClient.countEvents(any())).called(1);
+        },
+      );
+
+      test(
+        'rolls back record + count + stream when publish throws',
+        () async {
+          when(
+            () => mockNostrClient.countEvents(any()),
+          ).thenAnswer(
+            (_) async => const CountResult(count: 4),
+          );
+          when(
+            () => mockNostrClient.sendGenericRepost(
+              addressableId: any(named: 'addressableId'),
+              targetKind: any(named: 'targetKind'),
+              authorPubkey: any(named: 'authorPubkey'),
+              content: any(named: 'content'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenThrow(Exception('relay unreachable'));
+
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+          );
+          await repository.getRepostCount(testAddressableId);
+
+          await expectLater(
+            repository.repostVideo(
+              addressableId: testAddressableId,
+              originalAuthorPubkey: testAuthorPubkey,
+            ),
+            throwsA(isA<Exception>()),
+          );
+
+          expect(repository.isRepostedSync(testAddressableId), isFalse);
+          final count = await repository.getRepostCount(testAddressableId);
+          expect(count, equals(4));
         },
       );
     });
@@ -451,6 +611,122 @@ void main() {
           throwsA(isA<UnrepostFailedException>()),
         );
       });
+
+      test(
+        'ticks watchRepostedAddressableIds before deleteEvent completes',
+        () async {
+          // Seed a record by reposting first.
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+          );
+          await repository.repostVideo(
+            addressableId: testAddressableId,
+            originalAuthorPubkey: testAuthorPubkey,
+          );
+
+          final deleteCompleter = Completer<Event?>();
+          when(
+            () => mockNostrClient.deleteEvent(any()),
+          ).thenAnswer((_) => deleteCompleter.future);
+
+          final emitted = <Set<String>>[];
+          final subscription = repository.watchRepostedAddressableIds().listen(
+            emitted.add,
+          );
+
+          final unrepostFuture = repository.unrepostVideo(testAddressableId);
+          await Future<void>.delayed(Duration.zero);
+
+          expect(
+            emitted.last,
+            isNot(contains(testAddressableId)),
+            reason: 'stream must tick the removal before deleteEvent completes',
+          );
+
+          deleteCompleter.complete(
+            createMockEvent(
+              id: 'deletion_event_id',
+              kind: EventKind.eventDeletion,
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+            ),
+          );
+          await unrepostFuture;
+          await subscription.cancel();
+        },
+      );
+
+      test(
+        'rolls back record + count + stream when deletion returns null',
+        () async {
+          when(
+            () => mockNostrClient.countEvents(any()),
+          ).thenAnswer(
+            (_) async => const CountResult(count: 7),
+          );
+          when(
+            () => mockNostrClient.deleteEvent(any()),
+          ).thenAnswer((_) async => null);
+
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+          );
+
+          // Seed a record + count cache so the rollback has something to
+          // restore. countEvents mock returns 7 for the seed; after the
+          // optimistic increment inside repostVideo it becomes 8.
+          await repository.getRepostCount(testAddressableId);
+          await repository.repostVideo(
+            addressableId: testAddressableId,
+            originalAuthorPubkey: testAuthorPubkey,
+          );
+
+          await expectLater(
+            repository.unrepostVideo(testAddressableId),
+            throwsA(isA<UnrepostFailedException>()),
+          );
+
+          // Memory: record restored after rollback.
+          expect(repository.isRepostedSync(testAddressableId), isTrue);
+          // Count cache: restored to the pre-unrepost value (8 after
+          // the repost increment), no extra relay query.
+          final count = await repository.getRepostCount(testAddressableId);
+          expect(count, equals(8));
+          verify(() => mockNostrClient.countEvents(any())).called(1);
+        },
+      );
+
+      test(
+        'rolls back record + count + stream when deletion throws',
+        () async {
+          when(
+            () => mockNostrClient.countEvents(any()),
+          ).thenAnswer(
+            (_) async => const CountResult(count: 7),
+          );
+          when(
+            () => mockNostrClient.deleteEvent(any()),
+          ).thenThrow(Exception('relay unreachable'));
+
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+          );
+          await repository.getRepostCount(testAddressableId);
+          await repository.repostVideo(
+            addressableId: testAddressableId,
+            originalAuthorPubkey: testAuthorPubkey,
+          );
+
+          await expectLater(
+            repository.unrepostVideo(testAddressableId),
+            throwsA(isA<Exception>()),
+          );
+
+          expect(repository.isRepostedSync(testAddressableId), isTrue);
+          final count = await repository.getRepostCount(testAddressableId);
+          expect(count, equals(8));
+        },
+      );
     });
 
     group('toggleRepost', () {
@@ -547,26 +823,36 @@ void main() {
         expect(count, equals(0));
       });
 
-      test('returns cached count when available after toggleRepost', () async {
+      test('returns cached count incremented after toggleRepost', () async {
+        when(
+          () => mockNostrClient.countEvents(any()),
+        ).thenAnswer((_) async => const CountResult(count: 6));
+
         final repository = RepostsRepository(
           nostrClient: mockNostrClient,
         );
 
-        // Trigger a repost with currentCount: 6 → caches 6+1=7
+        // Seed cache via relay query so the repost can increment it.
+        await repository.getRepostCount(testAddressableId);
+
+        // toggleRepost → repostVideo bumps cache from 6 → 7.
         await repository.toggleRepost(
           addressableId: testAddressableId,
           originalAuthorPubkey: testAuthorPubkey,
-          currentCount: 6,
         );
 
         final count = await repository.getRepostCount(testAddressableId);
 
         expect(count, equals(7));
-        verifyNever(() => mockNostrClient.countEvents(any()));
+        // Only the seed call hits the relay; the post-toggle read is cached.
+        verify(() => mockNostrClient.countEvents(any())).called(1);
       });
 
       test('cached count clamps to zero for negative values', () async {
-        // Set up a repost record so unrepost succeeds
+        // countEvents returns 0 so the seeded cache starts at 0.
+        when(
+          () => mockNostrClient.countEvents(any()),
+        ).thenAnswer((_) async => const CountResult(count: 0));
         when(
           () => mockNostrClient.deleteEvent(any()),
         ).thenAnswer(
@@ -581,18 +867,18 @@ void main() {
           nostrClient: mockNostrClient,
         );
 
-        // First repost so there's something to unrepost
+        // Create a record (cache stays unseeded until getRepostCount runs).
         await repository.repostVideo(
           addressableId: testAddressableId,
           originalAuthorPubkey: testAuthorPubkey,
         );
 
-        // Trigger an unrepost with currentCount: 0 → caches max(0, 0-1) = 0
-        await repository.toggleRepost(
-          addressableId: testAddressableId,
-          originalAuthorPubkey: testAuthorPubkey,
-          currentCount: 0,
-        );
+        // Seed cache to 0 — this is the pathological state where the
+        // displayed count is already at floor before the unrepost.
+        await repository.getRepostCount(testAddressableId);
+
+        // unrepostVideo: previousCount = 0, would cache max(0, -1) = 0.
+        await repository.unrepostVideo(testAddressableId);
 
         final count = await repository.getRepostCount(testAddressableId);
 
@@ -660,22 +946,22 @@ void main() {
             nostrClient: mockNostrClient,
           );
 
-          // First call hits relay
+          // First call hits relay and seeds the cache at 10.
           final relayCount = await repository.getRepostCount(testAddressableId);
           expect(relayCount, equals(10));
 
-          // Repost with currentCount: 10 → caches 11
+          // toggleRepost → repostVideo bumps the cached count to 11.
           await repository.toggleRepost(
             addressableId: testAddressableId,
             originalAuthorPubkey: testAuthorPubkey,
-            currentCount: 10,
           );
 
-          // Second call uses cache (11 from repost)
+          // Second call uses the cache (11 from the increment).
           final cachedCount = await repository.getRepostCount(
             testAddressableId,
           );
           expect(cachedCount, equals(11));
+          verify(() => mockNostrClient.countEvents(any())).called(1);
         },
       );
 
@@ -690,18 +976,20 @@ void main() {
           nostrClient: mockNostrClient,
         );
 
-        // Repost with currentCount: 4 → caches 5
+        // Seed cache via getRepostCount, then bump it via toggleRepost.
+        await repository.getRepostCount(testAddressableId);
         await repository.toggleRepost(
           addressableId: testAddressableId,
           originalAuthorPubkey: testAuthorPubkey,
-          currentCount: 4,
         );
         await repository.clearCache();
 
+        // Post-clear, the cache is empty so getRepostCount queries relay
+        // again and returns 10.
         final count = await repository.getRepostCount(testAddressableId);
 
         expect(count, equals(10));
-        verify(() => mockNostrClient.countEvents(any())).called(1);
+        verify(() => mockNostrClient.countEvents(any())).called(2);
       });
     });
 

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -78,7 +78,6 @@ void main() {
       expect(bloc.state.isReposted, isFalse);
       expect(bloc.state.repostCount, isNull);
       expect(bloc.state.commentCount, isNull);
-      expect(bloc.state.isRepostInProgress, isFalse);
       expect(bloc.state.error, isNull);
       bloc.close();
     });
@@ -508,7 +507,7 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'emits error when toggle fails with generic exception',
+        'emits optimistic flip then rollback when toggle throws',
         setUp: () {
           when(
             () => mockLikesRepository.toggleLike(
@@ -523,9 +522,87 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoInteractionsLikeToggled()),
         expect: () => [
+          // Optimistic flip lands first so the heart updates immediately.
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isLiked: true,
+          ),
+          // Rollback after the publish failure restores the pre-tap heart
+          // state and surfaces the error.
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
             error: VideoInteractionsError.likeFailed,
+          ),
+        ],
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        'rolls back like + count to baseline when toggle throws',
+        setUp: () {
+          when(
+            () => mockLikesRepository.toggleLike(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+          ).thenThrow(Exception('Network error'));
+        },
+        build: createBloc,
+        seed: () => const VideoInteractionsState(
+          status: VideoInteractionsStatus.success,
+          likeCount: 10,
+        ),
+        act: (bloc) => bloc.add(const VideoInteractionsLikeToggled()),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isLiked: true,
+            likeCount: 11,
+          ),
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            likeCount: 10,
+            error: VideoInteractionsError.likeFailed,
+          ),
+        ],
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        'subscription stream tick during toggle does not double-emit',
+        setUp: () {
+          when(
+            () => mockLikesRepository.toggleLike(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+          ).thenAnswer((_) async {
+            // Repository ticks the stream BEFORE returning, mirroring
+            // LikesRepository.likeEvent's optimistic-first ordering. The
+            // bloc's optimistic emit has already set state.isLiked=true,
+            // so the subscription handler's early-return absorbs this.
+            likedIdsController.add([testEventId]);
+            await Future<void>.delayed(Duration.zero);
+            return true;
+          });
+        },
+        build: createBloc,
+        seed: () => const VideoInteractionsState(
+          status: VideoInteractionsStatus.success,
+          likeCount: 10,
+        ),
+        act: (bloc) async {
+          bloc.add(const VideoInteractionsSubscriptionRequested());
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+          bloc.add(const VideoInteractionsLikeToggled());
+        },
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          // Exactly one emit: optimistic flip with both fields. The
+          // stream tick that follows is absorbed by the subscription
+          // handler's early-return guard.
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isLiked: true,
+            likeCount: 11,
           ),
         ],
       );
@@ -540,7 +617,6 @@ void main() {
               addressableId: testAddressableId,
               originalAuthorPubkey: testAuthorPubkey,
               eventId: testEventId,
-              currentCount: 5,
             ),
           ).thenAnswer((_) async => true);
         },
@@ -551,11 +627,7 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoInteractionsRepostToggled()),
         expect: () => [
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
-            repostCount: 5,
-            isRepostInProgress: true,
-          ),
+          // Single optimistic emit: icon + count flip together.
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
             isReposted: true,
@@ -572,7 +644,6 @@ void main() {
               addressableId: testAddressableId,
               originalAuthorPubkey: testAuthorPubkey,
               eventId: testEventId,
-              currentCount: 5,
             ),
           ).thenAnswer((_) async => false);
         },
@@ -584,12 +655,6 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoInteractionsRepostToggled()),
         expect: () => [
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
-            isReposted: true,
-            repostCount: 5,
-            isRepostInProgress: true,
-          ),
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
             repostCount: 4,
@@ -605,7 +670,6 @@ void main() {
               addressableId: testAddressableId,
               originalAuthorPubkey: testAuthorPubkey,
               eventId: testEventId,
-              currentCount: 0,
             ),
           ).thenAnswer((_) async => false);
         },
@@ -619,26 +683,9 @@ void main() {
         expect: () => [
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
-            isReposted: true,
-            repostCount: 0,
-            isRepostInProgress: true,
-          ),
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
             repostCount: 0,
           ),
         ],
-      );
-
-      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'does not toggle when operation already in progress',
-        build: () => createBloc(addressableId: testAddressableId),
-        seed: () => const VideoInteractionsState(
-          status: VideoInteractionsStatus.success,
-          isRepostInProgress: true,
-        ),
-        act: (bloc) => bloc.add(const VideoInteractionsRepostToggled()),
-        expect: () => <VideoInteractionsState>[],
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
@@ -657,14 +704,13 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'handles AlreadyRepostedException by updating state to reposted',
+        'handles AlreadyRepostedException by leaving state reposted',
         setUp: () {
           when(
             () => mockRepostsRepository.toggleRepost(
               addressableId: testAddressableId,
               originalAuthorPubkey: testAuthorPubkey,
               eventId: testEventId,
-              currentCount: 0,
             ),
           ).thenThrow(const AlreadyRepostedException(testAddressableId));
         },
@@ -674,10 +720,8 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoInteractionsRepostToggled()),
         expect: () => [
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
-            isRepostInProgress: true,
-          ),
+          // Optimistic flip stands; the rollback emit produces the same
+          // state and is deduped by Equatable.
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
             isReposted: true,
@@ -686,14 +730,13 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'handles NotRepostedException by updating state to not reposted',
+        'handles NotRepostedException by leaving state not-reposted',
         setUp: () {
           when(
             () => mockRepostsRepository.toggleRepost(
               addressableId: testAddressableId,
               originalAuthorPubkey: testAuthorPubkey,
               eventId: testEventId,
-              currentCount: 0,
             ),
           ).thenThrow(const NotRepostedException(testAddressableId));
         },
@@ -704,40 +747,75 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoInteractionsRepostToggled()),
         expect: () => [
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
-            isReposted: true,
-            isRepostInProgress: true,
-          ),
           const VideoInteractionsState(status: VideoInteractionsStatus.success),
         ],
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'emits error when toggle fails with generic exception',
+        'emits optimistic flip then rollback when toggle throws',
         setUp: () {
           when(
             () => mockRepostsRepository.toggleRepost(
               addressableId: testAddressableId,
               originalAuthorPubkey: testAuthorPubkey,
               eventId: testEventId,
-              currentCount: 0,
             ),
           ).thenThrow(Exception('Network error'));
         },
         build: () => createBloc(addressableId: testAddressableId),
         seed: () => const VideoInteractionsState(
           status: VideoInteractionsStatus.success,
+          repostCount: 5,
         ),
         act: (bloc) => bloc.add(const VideoInteractionsRepostToggled()),
         expect: () => [
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
-            isRepostInProgress: true,
+            isReposted: true,
+            repostCount: 6,
           ),
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
+            repostCount: 5,
             error: VideoInteractionsError.repostFailed,
+          ),
+        ],
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        'subscription stream tick during toggle does not double-emit',
+        setUp: () {
+          when(
+            () => mockRepostsRepository.toggleRepost(
+              addressableId: testAddressableId,
+              originalAuthorPubkey: testAuthorPubkey,
+              eventId: testEventId,
+            ),
+          ).thenAnswer((_) async {
+            // Repository ticks the stream BEFORE returning. The bloc's
+            // optimistic emit already set state.isReposted=true, so the
+            // subscription handler's early-return absorbs the tick.
+            repostedIdsController.add({testAddressableId});
+            await Future<void>.delayed(Duration.zero);
+            return true;
+          });
+        },
+        build: () => createBloc(addressableId: testAddressableId),
+        seed: () => const VideoInteractionsState(
+          status: VideoInteractionsStatus.success,
+          repostCount: 5,
+        ),
+        act: (bloc) async {
+          bloc.add(const VideoInteractionsSubscriptionRequested());
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+          bloc.add(const VideoInteractionsRepostToggled());
+        },
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isReposted: true,
+            repostCount: 6,
           ),
         ],
       );

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -345,6 +345,69 @@ void main() {
           verifyNever(() => mockLikesRepository.isLiked(any()));
         },
       );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        'preserves optimistic toggle when tap lands mid-fetch',
+        setUp: () {
+          // Pre-fetch repository state: not liked, count from initial seed.
+          when(
+            () => mockLikesRepository.isLiked(testEventId),
+          ).thenAnswer((_) async => false);
+          // Hold the fetch open via a slow comment count so the tap can
+          // land between the loading emit and the success emit. Without
+          // the pre-fetch snapshot guard in [_onFetchRequested], the
+          // success emit overwrites isLiked + likeCount with stale relay
+          // values and the heart bounces back off.
+          when(
+            () => mockCommentsRepository.getCommentsCount(testEventId),
+          ).thenAnswer((_) async {
+            await Future<void>.delayed(const Duration(milliseconds: 30));
+            return 0;
+          });
+          when(
+            () => mockRepostsRepository.getRepostCountByEventId(testEventId),
+          ).thenAnswer((_) async => 0);
+          when(
+            () => mockLikesRepository.toggleLike(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+          ).thenAnswer((_) async => true);
+        },
+        build: () => createBloc(initialLikeCount: 10),
+        act: (bloc) async {
+          bloc.add(const VideoInteractionsFetchRequested());
+          // Let the fetch handler reach its first await on isLiked +
+          // schedule the slow comments query, but not finish.
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+          bloc.add(const VideoInteractionsLikeToggled());
+        },
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          // Fetch enters loading. Seeded likeCount=10 carries through.
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.loading,
+            likeCount: 10,
+          ),
+          // Tap lands while fetch awaits relay round-trips.
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.loading,
+            isLiked: true,
+            likeCount: 11,
+          ),
+          // Fetch resolves: isLiked + likeCount drifted from the
+          // pre-fetch baseline (false, 10) to the optimistic values
+          // (true, 11), so the success emit MUST preserve them and only
+          // apply the untouched commentCount + repostCount.
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isLiked: true,
+            likeCount: 11,
+            repostCount: 0,
+            commentCount: 0,
+          ),
+        ],
+      );
     });
 
     group('VideoInteractionsLikeToggled', () {

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -606,6 +606,226 @@ void main() {
           ),
         ],
       );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        'optimistic emit lands before publish settles (fire-and-forget)',
+        setUp: () {
+          // Hold toggleLike open on a Completer so the publish never
+          // settles within the test window. The bloc handler must still
+          // emit the optimistic state and return — proving that the
+          // network publish does not block the bloc's event queue.
+          final completer = Completer<bool>();
+          when(
+            () => mockLikesRepository.toggleLike(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+          ).thenAnswer((_) => completer.future);
+        },
+        build: createBloc,
+        seed: () => const VideoInteractionsState(
+          status: VideoInteractionsStatus.success,
+          likeCount: 10,
+        ),
+        act: (bloc) => bloc.add(const VideoInteractionsLikeToggled()),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isLiked: true,
+            likeCount: 11,
+          ),
+        ],
+        verify: (bloc) {
+          // Settle event has not been dispatched (publish still pending),
+          // but state already reflects the optimistic flip.
+          expect(bloc.state.isLiked, isTrue);
+          expect(bloc.state.likeCount, 11);
+        },
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        'out-of-band toggle reconciles count from pre-tap baseline',
+        setUp: () {
+          // User taps to like (optimistic: isLiked=true, count=11), but
+          // the repository ends up with isLiked=false (e.g., another
+          // device unliked mid-tap). Reconciliation in [_onLikeSettled]
+          // applies _adjustCount to the pre-tap baseline (wasCount=10),
+          // not the already-incremented current count (11). With
+          // currentCount we would emit (false, 10) — incorrect because
+          // another transition was missed. With wasCount we emit
+          // (false, 9), reflecting the canonical decrement from the
+          // baseline.
+          when(
+            () => mockLikesRepository.toggleLike(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+          ).thenAnswer((_) async => false);
+        },
+        build: createBloc,
+        seed: () => const VideoInteractionsState(
+          status: VideoInteractionsStatus.success,
+          likeCount: 10,
+        ),
+        act: (bloc) => bloc.add(const VideoInteractionsLikeToggled()),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isLiked: true,
+            likeCount: 11,
+          ),
+          // Anchored on wasCount=10, not the optimistic 11.
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            likeCount: 9,
+          ),
+        ],
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        'closed bloc does not dispatch settle event after publish resolves',
+        setUp: () {
+          // Simulates scroll-away: user taps, immediately the feed item
+          // disposes its bloc, and the publish settles afterward. The
+          // unawaited future must check isClosed before dispatching a
+          // _VideoInteractionsLikeSettled event — otherwise add() on a
+          // closed bloc throws StateError.
+          when(
+            () => mockLikesRepository.toggleLike(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+          ).thenAnswer((_) async {
+            await Future<void>.delayed(const Duration(milliseconds: 5));
+            return true;
+          });
+        },
+        build: createBloc,
+        seed: () => const VideoInteractionsState(
+          status: VideoInteractionsStatus.success,
+          likeCount: 10,
+        ),
+        act: (bloc) async {
+          bloc.add(const VideoInteractionsLikeToggled());
+          // Close before the publish has had a chance to resolve.
+          await bloc.close();
+        },
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          // Only the optimistic emit. The settle event would be a no-op
+          // on a closed bloc, but we must guard against it being
+          // dispatched at all (StateError on add to closed bloc).
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isLiked: true,
+            likeCount: 11,
+          ),
+        ],
+      );
+
+      test('two blocs run in parallel — neither blocks the other', () async {
+        // The architectural invariant rabble called out: a slow publish
+        // on video A must not block tapping like on video B. Different
+        // videos use different bloc instances; this test pins the
+        // contract by keeping both publishes pending and asserting that
+        // both blocs emit their optimistic state independently.
+        final completerA = Completer<bool>();
+        final completerB = Completer<bool>();
+        final mockLikesA = _MockLikesRepository();
+        final mockLikesB = _MockLikesRepository();
+        final mockCommentsA = _MockCommentsRepository();
+        final mockCommentsB = _MockCommentsRepository();
+        final mockRepostsA = _MockRepostsRepository();
+        final mockRepostsB = _MockRepostsRepository();
+        final likedStreamA = StreamController<List<String>>.broadcast();
+        final likedStreamB = StreamController<List<String>>.broadcast();
+        final repostedStreamA = StreamController<Set<String>>.broadcast();
+        final repostedStreamB = StreamController<Set<String>>.broadcast();
+        addTearDown(() async {
+          await likedStreamA.close();
+          await likedStreamB.close();
+          await repostedStreamA.close();
+          await repostedStreamB.close();
+        });
+
+        // ignore_for_file: unnecessary_lambdas
+        // The closures below cannot be tear-offs because thenAnswer
+        // requires a Function(Invocation), but the captured locals are
+        // variable references that the analyzer cannot prove constant.
+        when(
+          () => mockLikesA.watchLikedEventIds(),
+        ).thenAnswer((_) => likedStreamA.stream);
+        when(
+          () => mockLikesB.watchLikedEventIds(),
+        ).thenAnswer((_) => likedStreamB.stream);
+        when(
+          () => mockRepostsA.watchRepostedAddressableIds(),
+        ).thenAnswer((_) => repostedStreamA.stream);
+        when(
+          () => mockRepostsB.watchRepostedAddressableIds(),
+        ).thenAnswer((_) => repostedStreamB.stream);
+
+        when(
+          () => mockLikesA.toggleLike(
+            eventId: 'event-a',
+            authorPubkey: testAuthorPubkey,
+          ),
+        ).thenAnswer((_) => completerA.future);
+        when(
+          () => mockLikesB.toggleLike(
+            eventId: 'event-b',
+            authorPubkey: testAuthorPubkey,
+          ),
+        ).thenAnswer((_) => completerB.future);
+
+        final blocA = VideoInteractionsBloc(
+          eventId: 'event-a',
+          authorPubkey: testAuthorPubkey,
+          likesRepository: mockLikesA,
+          commentsRepository: mockCommentsA,
+          repostsRepository: mockRepostsA,
+        );
+        final blocB = VideoInteractionsBloc(
+          eventId: 'event-b',
+          authorPubkey: testAuthorPubkey,
+          likesRepository: mockLikesB,
+          commentsRepository: mockCommentsB,
+          repostsRepository: mockRepostsB,
+        );
+        addTearDown(() async {
+          await blocA.close();
+          await blocB.close();
+        });
+
+        // Tap like on A (publish never resolves), then on B.
+        blocA.add(const VideoInteractionsLikeToggled());
+        blocB.add(const VideoInteractionsLikeToggled());
+
+        // Allow both event loops to drain.
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        // Both blocs already reflect the optimistic flip even though
+        // neither publish has settled.
+        expect(blocA.state.isLiked, isTrue, reason: 'bloc A should flip');
+        expect(blocB.state.isLiked, isTrue, reason: 'bloc B should flip');
+        expect(completerA.isCompleted, isFalse);
+        expect(completerB.isCompleted, isFalse);
+
+        // Both repositories were called — neither call queued behind the
+        // other.
+        verify(
+          () => mockLikesA.toggleLike(
+            eventId: 'event-a',
+            authorPubkey: testAuthorPubkey,
+          ),
+        ).called(1);
+        verify(
+          () => mockLikesB.toggleLike(
+            eventId: 'event-b',
+            authorPubkey: testAuthorPubkey,
+          ),
+        ).called(1);
+      });
     });
 
     group('VideoInteractionsRepostToggled', () {
@@ -818,6 +1038,37 @@ void main() {
             repostCount: 6,
           ),
         ],
+      );
+
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        'optimistic emit lands before publish settles (fire-and-forget)',
+        setUp: () {
+          final completer = Completer<bool>();
+          when(
+            () => mockRepostsRepository.toggleRepost(
+              addressableId: testAddressableId,
+              originalAuthorPubkey: testAuthorPubkey,
+              eventId: testEventId,
+            ),
+          ).thenAnswer((_) => completer.future);
+        },
+        build: () => createBloc(addressableId: testAddressableId),
+        seed: () => const VideoInteractionsState(
+          status: VideoInteractionsStatus.success,
+          repostCount: 5,
+        ),
+        act: (bloc) => bloc.add(const VideoInteractionsRepostToggled()),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isReposted: true,
+            repostCount: 6,
+          ),
+        ],
+        verify: (bloc) {
+          expect(bloc.state.isReposted, isTrue);
+          expect(bloc.state.repostCount, 6);
+        },
       );
     });
 


### PR DESCRIPTION
## Description

Closes #3429.

The like button's heart flipped instantly via the repository's stream tick (post-#3409), but the count next to it lagged by the kind-7 publish RTT — two bloc emits separated by network. Repost was a step behind: both the icon and the count waited on publish, and an extra `isRepostInProgress` flag gated the handler.

### What changed

**BLoC (Approach A — optimistic emit before await):**
- `VideoInteractionsBloc._onLikeToggled` and `_onRepostToggled` now emit the flipped status + adjusted count in a **single optimistic emit BEFORE awaiting** the repository, so the heart/icon and the counter flip in the same frame.
- The stream tick that fires later (when the repo writes its local record) is absorbed by the subscription handler's early-return — `state.isLiked`/`state.isReposted` already matches.
- Exception paths revert both fields to the pre-tap baseline. Existing `AlreadyLikedException`/`AlreadyRepostedException` still short-circuit duplicate publishes (no in-progress flag needed).

**Repository (Follow pattern for reposts, Phase 1 of #3409 carried to reposts):**
- `RepostsRepository.repostVideo` / `unrepostVideo` now mirror `LikesRepository.likeEvent` / `unlikeEvent`: write the optimistic record + bump count cache + tick `watchRepostedAddressableIds` **BEFORE** the kind-16 publish or kind-5 deletion, with rollback on failure (memory + DB + cache + stream).
- The local DB now survives an app crash mid-publish (was a quiet bug pre-fix).
- `toggleRepost` no longer takes `currentCount` — count caching is internal to `repostVideo`/`unrepostVideo`.

**State + UI cleanup:**
- Drops `VideoInteractionsState.isRepostInProgress` and the matching `BlocSelector` wiring on `RepostActionButton`. The repost button no longer flashes a spinner during publish — same UX `LikeActionButton` got in #3409.

### Out of scope (filed as separate follow-ups)

- **Cross-device-sync count drift** — the bloc's stream subscription updates `isLiked`/`isReposted` from external sources but does not adjust the count. Pre-existing, not a regression.
- **Double-tap UX** — rapid double-tap shows a brief `+1`/`-1` flash. End state correct. Single-line `transformer: droppable()` fix if product wants it smoother.

**Related Issue:** Closes #3429

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

---

## Manual test plan

Test on a real device. Throttle to 3G for the diagnostic tests — the bug is most visible there.

### 1. Like counter is instant (the original report)

1. Find a video you haven't liked. Note the count (e.g. "12").
2. Tap the heart once.

**Pass:** heart flips red filled, count goes "12" → "13" with **no perceptible gap**.
**Fail:** heart flips first; count lags one or more frames.

3. Tap again to unlike → heart and count drop together.

### 2. Repost counter is instant (bonus: no spinner anymore)

1. Find a video you haven't reposted. Note the count.
2. Tap repost.

**Pass:** icon flips green and count increments by 1, in the same frame. **No loading spinner** appears.
**Fail:** icon flips but count lags, or a spinner appears between tap and confirmation.

3. Tap again to undo → icon and count back together.

### 3. Slow network (3G throttled) — the most diagnostic test

Enable 3G throttling (iOS: Network Link Conditioner; Android: dev options) and repeat tests 1 and 2.

**Pass:** UI feels identical to a healthy network — flip is instant. The publish itself is slower (visible in Charles/Proxyman) but the user-visible feedback isn't.
**Fail:** any lag between icon flip and counter update. Pre-fix this was very visible here.

### 4. Already-liked / reposted state seeds correctly on app open

1. Like / repost a video.
2. Force-close the app.
3. Re-open and scroll to the same video.

**Pass:** heart filled / repost icon green from the **first frame**. (Confirms the local DB seed path still works after the repo restructure.)

### 5. Crash-resilience for reposts (NEW)

This was a quiet pre-existing bug for reposts — the local DB only got written after the network publish, so a crash mid-publish lost the optimistic state. The repo restructure fixes it.

**Option A — Airplane-mode:**
1. Note repost count on a video.
2. Enable airplane mode.
3. Tap repost → icon goes green, count increments.
4. Force-close the app.
5. Re-open in airplane mode, scroll to the same video.

**Pass:** repost icon **still green**. Local DB persisted the optimistic record before the offline queue.
**Fail (pre-fix):** icon back to white.

6. Disable airplane mode → pending action service syncs the publish within ~1 minute.

**Option B — Slow network + force-quit:**
Same idea but with 3G throttling and a tap-then-immediately-force-close sequence.

### 6. Failure rollback (best-effort, hard to trigger)

1. Block all relay traffic (proxy returning 503, or airplane mode without offline queue).
2. Tap like or repost.

**Pass:** UI flips optimistically, then within 1–30s rolls back to the pre-tap state. No user-visible error message today, but the icon/counter both revert.

### 7. Cross-device sync (sanity check; partial — not a regression)

1. Like / repost on Device A.
2. On Device B (same account), scroll to the same video.

**Pass:** within 1–10s, the heart / repost icon on Device B updates.
**Known limitation (separate follow-up issue planned):** the **count** on Device B may not increment until the bloc re-fetches. Pre-existing.

### 8. Double-tap behavior (acceptable, not a regression)

Find a video, double-tap the like button as fast as you can.

**Expected:** heart briefly flips on (count +1) then off (count -1). End state matches start. Visual flash is acceptable per the brainstorm. If product wants smoother UX, the fix is `transformer: droppable()` on the toggle event registrations — single-line addition.

### Sign-off

- [ ] Test 1 passes on healthy network
- [ ] Test 2 passes on healthy network
- [ ] Test 3 passes on 3G-throttled network
- [ ] Test 4 — already-liked/reposted state seeds correctly
- [ ] Test 5 — repost survives force-close mid-publish
- [ ] Test 6 — failure rollback observed (best-effort)
- [ ] Test 7 — cross-device icon sync works; count drift expected
- [ ] Test 8 — double-tap behavior acceptable

---

## Automated tests

- `mobile/packages/reposts_repository/test/src/reposts_repository_test.dart`: 110 tests pass; coverage holds at **100%** across all 5 source files in `lib/`. Added stream-tick-ordering tests (`ticks watchRepostedAddressableIds before sendGenericRepost completes`, plus the unrepost mirror) and rollback tests for both null-return and throw paths on `repostVideo` and `unrepostVideo`.
- `mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart`: 41 tests pass. Added regression tests `subscription stream tick during toggle does not double-emit` for both like and repost — pin the load-bearing early-return guard in `_onSubscriptionRequested`.
- `flutter analyze lib test integration_test`: clean.
- `dart format`: no changes.

## Files changed

| File | Why |
|---|---|
| `mobile/packages/reposts_repository/lib/src/reposts_repository.dart` | `repostVideo`/`unrepostVideo` optimistic-first; drop `currentCount` from `toggleRepost`. |
| `mobile/packages/reposts_repository/test/src/reposts_repository_test.dart` | New stream-tick + rollback tests; update existing tests for new emit ordering and dropped `currentCount`. |
| `mobile/lib/blocs/video_interactions/video_interactions_bloc.dart` | Approach A in both toggle handlers; load-bearing-comments on subscription early-returns; new `_adjustCount` helper. |
| `mobile/lib/blocs/video_interactions/video_interactions_state.dart` | Drop `isRepostInProgress`. |
| `mobile/lib/widgets/video_feed_item/actions/repost_action_button.dart` | Drop loading wiring. |
| `mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart` | Update repost test expectations; new stream-tick regression tests for both like + repost. |