### PR TITLE
fix(notifications): route mention taps to the post, not the mentioner's profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Git worktrees
 .worktrees/
+worktrees/
 
 # Flutter repo-specific
 /bin/cache/

--- a/mobile/packages/models/lib/src/notification_model.dart
+++ b/mobile/packages/models/lib/src/notification_model.dart
@@ -137,9 +137,9 @@ class NotificationModel extends Equatable {
       case NotificationType.like:
       case NotificationType.comment:
       case NotificationType.repost:
+      case NotificationType.mention:
         return targetEventId != null ? 'open_video' : 'open_profile';
       case NotificationType.follow:
-      case NotificationType.mention:
         return 'open_profile';
       case NotificationType.system:
         return 'none';
@@ -152,9 +152,9 @@ class NotificationModel extends Equatable {
       case NotificationType.like:
       case NotificationType.comment:
       case NotificationType.repost:
+      case NotificationType.mention:
         return targetEventId ?? actorPubkey;
       case NotificationType.follow:
-      case NotificationType.mention:
         return actorPubkey;
       case NotificationType.system:
         return null;

--- a/mobile/test/models/notification_model_test.dart
+++ b/mobile/test/models/notification_model_test.dart
@@ -71,7 +71,15 @@ void main() {
         expect(notification.navigationAction, equals('open_profile'));
       });
 
-      test('returns open_profile for mention', () {
+      test('returns open_video for mention with targetEventId', () {
+        final notification = createNotification(
+          type: NotificationType.mention,
+          eventId: targetEventId,
+        );
+        expect(notification.navigationAction, equals('open_video'));
+      });
+
+      test('returns open_profile for mention without targetEventId', () {
         final notification = createNotification(type: NotificationType.mention);
         expect(notification.navigationAction, equals('open_profile'));
       });
@@ -127,7 +135,15 @@ void main() {
         expect(notification.navigationTarget, equals(actorPubkey));
       });
 
-      test('returns actorPubkey for mention', () {
+      test('returns targetEventId for mention with targetEventId', () {
+        final notification = createNotification(
+          type: NotificationType.mention,
+          eventId: targetEventId,
+        );
+        expect(notification.navigationTarget, equals(targetEventId));
+      });
+
+      test('returns actorPubkey for mention without targetEventId', () {
         final notification = createNotification(type: NotificationType.mention);
         expect(notification.navigationTarget, equals(actorPubkey));
       });


### PR DESCRIPTION
## Summary

- Bug report (Martin Montero, app v665): tapping a mention notification opens the mentioner's profile instead of the post where they were mentioned. Refresh does not help.
- Logs confirm the legacy tap path:
  ```
  [NotificationsScreen] 🔔 Notification clicked: open_profile -> d95aa8fc…
  [NotificationsScreen] Navigating to profile: d95aa8fc…
  ```
- The Inbox still uses the legacy `NotificationsScreen` (`mobile/lib/screens/inbox/inbox_view.dart:92` — "Keep Inbox on the proven relay-provider notifications path until the BLoC migration matches production"), which dispatches via `notification.navigationAction` / `navigationTarget`.

## Root cause

`mobile/packages/models/lib/src/notification_model.dart` grouped `mention` with `follow`, hard-coding navigation to `open_profile` + `actorPubkey` regardless of `targetEventId`. The other reply-style kinds (`like`, `comment`, `repost`) correctly route to the referenced post when `targetEventId` is present.

The relay→model converter (`notification_model_converter.dart:35`) does populate `targetEventId` from `relay.referencedEventId` for mentions, so the data was already there — the model just ignored it. The video resolver (`NotificationTargetResolver`) already walks NIP-22 `E` and NIP-10 `e` tags back to the root video, so a mention inside a comment will still land on the right post.

## Fix

Move `NotificationType.mention` into the `like`/`comment`/`repost` switch arm so it returns:
- `'open_video'` + `targetEventId` when present
- `'open_profile'` + `actorPubkey` as a fallback when no event reference is attached

Two stale tests in `notification_model_test.dart` that pinned the old behavior were replaced with the with/without-targetEventId pair used for the other reply kinds.

## Test plan

- [x] `flutter test test/models/notification_model_test.dart` (23/23 passing, including new mention coverage)
- [x] `flutter test test/services/notification_model_converter_test.dart test/screens/notifications_screen_test.dart` (no regressions)
- [x] `flutter analyze` clean on changed files
- [ ] Manual verification on device: tap a mention notification → lands on the post, not the mentioner's profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)