### PR TITLE
fix(social): track downvotes in LikesRepository; drop voteInProgressCommentId

### DIFF
--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -69,11 +69,9 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
     on<CommentSubmitted>(_onSubmitted);
     on<CommentErrorCleared>(_onErrorCleared);
     on<CommentDeleteRequested>(_onDeleteRequested);
-    // Single handler with droppable() so rapid taps of any vote — same
-    // comment, same direction OR opposite direction — drop while a
-    // publish is in flight. Splitting the handlers by direction would
-    // let an up-tap and a down-tap run concurrently and interleave
-    // kind-7 / kind-5 publishes on the relay.
+    // Single handler with droppable(): splitting by direction would let an
+    // up-tap and a down-tap run concurrently and interleave kind-7 / kind-5
+    // publishes on the relay.
     on<CommentVoteToggled>(_onVoteToggled, transformer: droppable());
     on<CommentVoteCountsFetchRequested>(_onVoteCountsFetchRequested);
     on<CommentsSortModeChanged>(_onSortModeChanged);

--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -69,9 +69,11 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
     on<CommentSubmitted>(_onSubmitted);
     on<CommentErrorCleared>(_onErrorCleared);
     on<CommentDeleteRequested>(_onDeleteRequested);
-    // droppable() prevents concurrent processing of the SAME event type,
-    // but the manual voteInProgressCommentId guard prevents
-    // rapid toggles on DIFFERENT comment IDs from racing each other.
+    // droppable() prevents same-event-type rapid double-taps from racing.
+    // Per-comment in-progress tracking was removed in favor of the
+    // optimistic-first repo APIs — AlreadyLikedException /
+    // AlreadyDownvotedException short-circuit duplicate publishes for the
+    // same comment, and the optimistic emit handles the visible flash.
     on<CommentUpvoteToggled>(_onUpvoteToggled, transformer: droppable());
     on<CommentDownvoteToggled>(_onDownvoteToggled, transformer: droppable());
     on<CommentVoteCountsFetchRequested>(_onVoteCountsFetchRequested);
@@ -512,9 +514,6 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
       return;
     }
 
-    // Prevent double-tap on the same comment
-    if (state.voteInProgressCommentId == commentId) return;
-
     final wasUpvoted = state.upvotedCommentIds.contains(commentId);
     final wasDownvoted = state.downvotedCommentIds.contains(commentId);
     final hadSameVote = isUpvote ? wasUpvoted : wasDownvoted;
@@ -556,27 +555,23 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
         downvotedCommentIds: downIds,
         commentUpvoteCounts: upCounts,
         commentDownvoteCounts: downCounts,
-        voteInProgressCommentId: commentId,
       ),
     );
 
     try {
-      if (hadSameVote) {
-        // Remove existing vote
-        if (isUpvote) {
-          await _likesRepository.toggleLike(
-            eventId: commentId,
-            authorPubkey: authorPubkey,
-            targetKind: EventKind.comment,
-          );
+      // Remove the user's existing vote (same or opposite) first. The repo
+      // tracks upvotes in _likeRecords and downvotes in _downvoteRecords;
+      // pick the right teardown call based on which side actually had it.
+      if (hadSameVote || hadOppositeVote) {
+        if (wasUpvoted) {
+          await _likesRepository.unlikeEvent(commentId);
         } else {
-          await _likesRepository.unlikeEvent(commentId);
+          await _likesRepository.removeDownvote(commentId);
         }
-      } else {
-        // Remove opposite vote if present, then add new vote
-        if (hadOppositeVote) {
-          await _likesRepository.unlikeEvent(commentId);
-        }
+      }
+
+      // Place the new vote (only when this tap isn't a same-side removal).
+      if (!hadSameVote) {
         if (isUpvote) {
           await _likesRepository.likeEvent(
             eventId: commentId,
@@ -591,9 +586,41 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
           );
         }
       }
-
-      // Clear in-progress guard
-      emit(state.copyWith());
+    } on AlreadyLikedException {
+      // Repo already had the upvote — sync state to reality without error.
+      // Pre-tap baseline was wrong; trust the repo.
+      emit(
+        state.copyWith(
+          upvotedCommentIds: Set<String>.from(state.upvotedCommentIds)
+            ..add(commentId),
+          downvotedCommentIds: Set<String>.from(state.downvotedCommentIds)
+            ..remove(commentId),
+        ),
+      );
+    } on NotLikedException {
+      // Repo had no upvote to remove — sync state and continue.
+      emit(
+        state.copyWith(
+          upvotedCommentIds: Set<String>.from(state.upvotedCommentIds)
+            ..remove(commentId),
+        ),
+      );
+    } on AlreadyDownvotedException {
+      emit(
+        state.copyWith(
+          downvotedCommentIds: Set<String>.from(state.downvotedCommentIds)
+            ..add(commentId),
+          upvotedCommentIds: Set<String>.from(state.upvotedCommentIds)
+            ..remove(commentId),
+        ),
+      );
+    } on NotDownvotedException {
+      emit(
+        state.copyWith(
+          downvotedCommentIds: Set<String>.from(state.downvotedCommentIds)
+            ..remove(commentId),
+        ),
+      );
     } catch (e) {
       Log.error(
         'Error toggling comment ${isUpvote ? 'upvote' : 'downvote'}: $e',
@@ -601,7 +628,7 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
         category: LogCategory.ui,
       );
 
-      // Revert optimistic update
+      // Revert optimistic update to the pre-tap baseline.
       emit(
         state.copyWith(
           upvotedCommentIds: Set<String>.from(state.upvotedCommentIds)

--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -69,13 +69,12 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
     on<CommentSubmitted>(_onSubmitted);
     on<CommentErrorCleared>(_onErrorCleared);
     on<CommentDeleteRequested>(_onDeleteRequested);
-    // droppable() prevents same-event-type rapid double-taps from racing.
-    // Per-comment in-progress tracking was removed in favor of the
-    // optimistic-first repo APIs — AlreadyLikedException /
-    // AlreadyDownvotedException short-circuit duplicate publishes for the
-    // same comment, and the optimistic emit handles the visible flash.
-    on<CommentUpvoteToggled>(_onUpvoteToggled, transformer: droppable());
-    on<CommentDownvoteToggled>(_onDownvoteToggled, transformer: droppable());
+    // Single handler with droppable() so rapid taps of any vote — same
+    // comment, same direction OR opposite direction — drop while a
+    // publish is in flight. Splitting the handlers by direction would
+    // let an up-tap and a down-tap run concurrently and interleave
+    // kind-7 / kind-5 publishes on the relay.
+    on<CommentVoteToggled>(_onVoteToggled, transformer: droppable());
     on<CommentVoteCountsFetchRequested>(_onVoteCountsFetchRequested);
     on<CommentsSortModeChanged>(_onSortModeChanged);
     on<CommentReportRequested>(_onReportRequested, transformer: droppable());
@@ -487,36 +486,18 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
     }
   }
 
-  Future<void> _onUpvoteToggled(
-    CommentUpvoteToggled event,
+  Future<void> _onVoteToggled(
+    CommentVoteToggled event,
     Emitter<CommentsState> emit,
-  ) async => _onVoteToggled(
-    commentId: event.commentId,
-    authorPubkey: event.authorPubkey,
-    isUpvote: true,
-    emit: emit,
-  );
-
-  Future<void> _onDownvoteToggled(
-    CommentDownvoteToggled event,
-    Emitter<CommentsState> emit,
-  ) async => _onVoteToggled(
-    commentId: event.commentId,
-    authorPubkey: event.authorPubkey,
-    isUpvote: false,
-    emit: emit,
-  );
-
-  Future<void> _onVoteToggled({
-    required String commentId,
-    required String authorPubkey,
-    required bool isUpvote,
-    required Emitter<CommentsState> emit,
-  }) async {
+  ) async {
     if (!_authService.isAuthenticated) {
       emit(state.copyWith(error: CommentsError.notAuthenticated));
       return;
     }
+
+    final commentId = event.commentId;
+    final authorPubkey = event.authorPubkey;
+    final isUpvote = event.vote == Vote.up;
 
     final wasUpvoted = state.upvotedCommentIds.contains(commentId);
     final wasDownvoted = state.downvotedCommentIds.contains(commentId);

--- a/mobile/lib/blocs/comments/comments_event.dart
+++ b/mobile/lib/blocs/comments/comments_event.dart
@@ -93,32 +93,37 @@ final class CommentEditSubmitted extends CommentsEvent {
   const CommentEditSubmitted();
 }
 
-/// Toggle upvote on a comment (optimistic update + relay publish)
-final class CommentUpvoteToggled extends CommentsEvent {
-  const CommentUpvoteToggled({
-    required this.commentId,
-    required this.authorPubkey,
-  });
+/// Direction of a comment vote.
+enum Vote {
+  /// Upvote (kind-7 reaction with content "+").
+  up,
 
-  /// The ID of the comment to upvote/un-upvote
-  final String commentId;
-
-  /// The pubkey of the comment author
-  final String authorPubkey;
+  /// Downvote (kind-7 reaction with content "-").
+  down,
 }
 
-/// Toggle downvote on a comment (optimistic update + relay publish)
-final class CommentDownvoteToggled extends CommentsEvent {
-  const CommentDownvoteToggled({
+/// Toggle a vote on a comment (optimistic update + relay publish).
+///
+/// A single event for both upvotes and downvotes so that one
+/// `droppable()` handler serializes all votes — same-comment rapid
+/// up→down (or down→up) within publish-RTT can no longer run two
+/// handlers concurrently and produce interleaved kind-7 / kind-5
+/// publishes on the relay.
+final class CommentVoteToggled extends CommentsEvent {
+  const CommentVoteToggled({
     required this.commentId,
     required this.authorPubkey,
+    required this.vote,
   });
 
-  /// The ID of the comment to downvote/un-downvote
+  /// The ID of the comment being voted on.
   final String commentId;
 
-  /// The pubkey of the comment author
+  /// The pubkey of the comment author.
   final String authorPubkey;
+
+  /// Whether this is an upvote or a downvote tap.
+  final Vote vote;
 }
 
 /// Request to batch-fetch vote counts for all loaded comments

--- a/mobile/lib/blocs/comments/comments_state.dart
+++ b/mobile/lib/blocs/comments/comments_state.dart
@@ -122,7 +122,6 @@ final class CommentsState extends Equatable {
     this.commentDownvoteCounts = const {},
     this.upvotedCommentIds = const {},
     this.downvotedCommentIds = const {},
-    this.voteInProgressCommentId,
     this.sortMode = CommentsSortMode.newest,
     this.replyCountsByCommentId = const {},
     this.mentionQuery = '',
@@ -165,9 +164,6 @@ final class CommentsState extends Equatable {
 
   /// Set of comment IDs the current user has downvoted.
   final Set<String> downvotedCommentIds;
-
-  /// Comment ID currently undergoing a vote toggle (prevents double-tap).
-  final String? voteInProgressCommentId;
 
   /// Current sort mode for the comments list.
   final CommentsSortMode sortMode;
@@ -313,7 +309,6 @@ final class CommentsState extends Equatable {
     Map<String, int>? commentDownvoteCounts,
     Set<String>? upvotedCommentIds,
     Set<String>? downvotedCommentIds,
-    String? voteInProgressCommentId,
     CommentsSortMode? sortMode,
     Map<String, int>? replyCountsByCommentId,
     String? mentionQuery,
@@ -341,7 +336,6 @@ final class CommentsState extends Equatable {
           commentDownvoteCounts ?? this.commentDownvoteCounts,
       upvotedCommentIds: upvotedCommentIds ?? this.upvotedCommentIds,
       downvotedCommentIds: downvotedCommentIds ?? this.downvotedCommentIds,
-      voteInProgressCommentId: voteInProgressCommentId,
       sortMode: sortMode ?? this.sortMode,
       replyCountsByCommentId:
           replyCountsByCommentId ?? this.replyCountsByCommentId,
@@ -433,7 +427,6 @@ final class CommentsState extends Equatable {
     commentDownvoteCounts,
     upvotedCommentIds,
     downvotedCommentIds,
-    voteInProgressCommentId,
     sortMode,
     replyCountsByCommentId,
     mentionQuery,

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -485,9 +485,10 @@ class _CommentVoteButtons extends StatelessWidget {
               child: InkWell(
                 onTap: () {
                   context.read<CommentsBloc>().add(
-                    CommentUpvoteToggled(
+                    CommentVoteToggled(
                       commentId: commentId,
                       authorPubkey: authorPubkey,
+                      vote: Vote.up,
                     ),
                   );
                 },
@@ -534,9 +535,10 @@ class _CommentVoteButtons extends StatelessWidget {
               child: InkWell(
                 onTap: () {
                   context.read<CommentsBloc>().add(
-                    CommentDownvoteToggled(
+                    CommentVoteToggled(
                       commentId: commentId,
                       authorPubkey: authorPubkey,
+                      vote: Vote.down,
                     ),
                   );
                 },

--- a/mobile/packages/likes_repository/lib/src/exceptions.dart
+++ b/mobile/packages/likes_repository/lib/src/exceptions.dart
@@ -77,6 +77,29 @@ class NotLikedException extends LikesRepositoryException {
   String toString() => 'NotLikedException: $message';
 }
 
+/// Exception thrown when an event is already downvoted.
+///
+/// Attempting to downvote an event that is already downvoted will throw this.
+class AlreadyDownvotedException extends LikesRepositoryException {
+  /// Creates a new already downvoted exception.
+  const AlreadyDownvotedException(String eventId)
+    : super('Event $eventId is already downvoted');
+
+  @override
+  String toString() => 'AlreadyDownvotedException: $message';
+}
+
+/// Exception thrown when trying to remove a downvote from an event that is
+/// not currently downvoted.
+class NotDownvotedException extends LikesRepositoryException {
+  /// Creates a new not downvoted exception.
+  const NotDownvotedException(String eventId)
+    : super('Event $eventId is not downvoted');
+
+  @override
+  String toString() => 'NotDownvotedException: $message';
+}
+
 /// Exception thrown when syncing reactions from relays fails.
 class SyncFailedException extends LikesRepositoryException {
   /// Creates a new sync failed exception.

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -87,6 +87,13 @@ class LikesRepository {
   /// In-memory cache of like records keyed by target event ID.
   final Map<String, LikeRecord> _likeRecords = {};
 
+  /// In-memory cache of downvote records keyed by target event ID.
+  ///
+  /// Mirror of [_likeRecords] for kind-7 reactions whose content is `-`.
+  /// Not persisted to local storage in v1 — relays repopulate via
+  /// [syncUserReactions] / [getVoteCounts] on next fetch.
+  final Map<String, LikeRecord> _downvoteRecords = {};
+
   /// In-memory cache of global like counts keyed by event ID.
   ///
   /// Prevents redundant relay queries when the same video is scrolled
@@ -96,6 +103,11 @@ class LikesRepository {
 
   /// Reactive stream controller for liked event IDs (ordered by recency).
   final _likedIdsController = BehaviorSubject<List<String>>.seeded([]);
+
+  /// Reactive stream controller for downvoted event IDs (ordered by recency).
+  final _downvotedIdsController = BehaviorSubject<List<String>>.seeded(
+    <String>[],
+  );
 
   /// Whether the repository has been initialized with data from storage.
   bool _isInitialized = false;
@@ -119,6 +131,19 @@ class LikesRepository {
     final sortedRecords = _likeRecords.values.toList()
       ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
     _likedIdsController.add(
+      sortedRecords.map((r) => r.targetEventId).toList(),
+    );
+  }
+
+  /// Emits the current downvoted event IDs ordered by recency.
+  ///
+  /// Mirror of [_emitLikedIds] for the downvote stream. Guarded against
+  /// post-dispose / post-close emission for the same reason.
+  void _emitDownvotedIds() {
+    if (_isDisposed || _downvotedIdsController.isClosed) return;
+    final sortedRecords = _downvoteRecords.values.toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    _downvotedIdsController.add(
       sortedRecords.map((r) => r.targetEventId).toList(),
     );
   }
@@ -164,6 +189,41 @@ class LikesRepository {
   Future<bool> isLiked(String eventId) async {
     await _ensureInitialized();
     return _likeRecords.containsKey(eventId);
+  }
+
+  /// Stream of downvoted event IDs ordered by recency (reactive).
+  ///
+  /// Mirror of [watchLikedEventIds] for the downvote side. Local storage
+  /// does not yet persist downvotes (v1 limitation); the in-memory stream
+  /// is used directly.
+  Stream<List<String>> watchDownvotedEventIds() {
+    return _downvotedIdsController.stream;
+  }
+
+  /// Get the current set of downvoted event IDs (one-shot).
+  Future<Set<String>> getDownvotedEventIds() async {
+    await _ensureInitialized();
+    return _downvoteRecords.keys.toSet();
+  }
+
+  /// Get downvoted event IDs ordered by recency (most recent first).
+  Future<List<String>> getOrderedDownvotedEventIds() async {
+    await _ensureInitialized();
+    final sortedRecords = _downvoteRecords.values.toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return sortedRecords.map((r) => r.targetEventId).toList();
+  }
+
+  /// Check if a specific event is downvoted by the current user.
+  Future<bool> isDownvoted(String eventId) async {
+    await _ensureInitialized();
+    return _downvoteRecords.containsKey(eventId);
+  }
+
+  /// Get the downvote record for an event, or null if not downvoted.
+  Future<LikeRecord?> getDownvoteRecord(String eventId) async {
+    await _ensureInitialized();
+    return _downvoteRecords[eventId];
   }
 
   /// Like an event.
@@ -719,26 +779,137 @@ class LikesRepository {
 
   /// Publish a downvote (Kind 7 reaction with content '-').
   ///
-  /// Returns the reaction event ID.
+  /// Optimistic-first: writes the downvote record into [_downvoteRecords]
+  /// and ticks [watchDownvotedEventIds] BEFORE the kind-7 publish, mirroring
+  /// the upvote flow in [likeEvent]. On publish failure the record is
+  /// removed and the stream is ticked again.
   ///
-  /// Throws `LikeFailedException` if the operation fails.
+  /// Returns the reaction event ID, or a `pending_downvote_*` placeholder
+  /// when the network call hasn't been awaited yet (offline or pre-publish
+  /// failure).
+  ///
+  /// Throws [AlreadyDownvotedException] if the event is already downvoted.
+  /// Throws [LikeFailedException] if the publish fails.
   Future<String> downvoteEvent({
     required String eventId,
     required String authorPubkey,
     int? targetKind,
   }) async {
-    final reactionEvent = await _nostrClient.sendLike(
-      eventId,
-      content: _downvoteContent,
-      targetAuthorPubkey: authorPubkey,
-      targetKind: targetKind,
-    );
+    await _ensureInitialized();
 
-    if (reactionEvent == null) {
-      throw const LikeFailedException('Failed to publish downvote reaction');
+    if (_downvoteRecords.containsKey(eventId)) {
+      throw AlreadyDownvotedException(eventId);
     }
 
-    return reactionEvent.id;
+    // 1. Optimistic-first: write to memory + tick the stream BEFORE any
+    // network I/O. The UI flips here. Mirrors [likeEvent]'s ordering.
+    final placeholderId = 'pending_downvote_$eventId';
+    final placeholder = LikeRecord(
+      targetEventId: eventId,
+      reactionEventId: placeholderId,
+      createdAt: DateTime.now(),
+    );
+    _downvoteRecords[eventId] = placeholder;
+    _emitDownvotedIds();
+
+    // 2. Online → publish kind 7 with '-'; on success swap the placeholder
+    // for the real id, on failure roll back memory + stream.
+    try {
+      final reactionEvent = await _nostrClient.sendLike(
+        eventId,
+        content: _downvoteContent,
+        targetAuthorPubkey: authorPubkey,
+        targetKind: targetKind,
+      );
+
+      if (reactionEvent == null) {
+        throw const LikeFailedException(
+          'Failed to publish downvote reaction',
+        );
+      }
+
+      _downvoteRecords[eventId] = LikeRecord(
+        targetEventId: eventId,
+        reactionEventId: reactionEvent.id,
+        createdAt: placeholder.createdAt,
+      );
+
+      return reactionEvent.id;
+    } catch (_) {
+      _downvoteRecords.remove(eventId);
+      _emitDownvotedIds();
+      rethrow;
+    }
+  }
+
+  /// Remove the current user's downvote on an event.
+  ///
+  /// Optimistic-first: removes the record + ticks [watchDownvotedEventIds]
+  /// BEFORE the kind-5 deletion publish. On failure restores the record and
+  /// re-ticks the stream. Mirrors [unlikeEvent].
+  ///
+  /// Throws [NotDownvotedException] if the event is not downvoted.
+  /// Throws [UnlikeFailedException] if the deletion publish fails.
+  Future<void> removeDownvote(String eventId) async {
+    await _ensureInitialized();
+
+    final record = _downvoteRecords[eventId];
+    if (record == null) {
+      throw NotDownvotedException(eventId);
+    }
+
+    final snapshotRecord = record;
+
+    // 1. Optimistic-first: remove from memory and tick the stream.
+    _downvoteRecords.remove(eventId);
+    _emitDownvotedIds();
+
+    // 2. Skip publishing deletion for placeholders that never reached the
+    // relay (e.g. publish failed and the user retried before sync).
+    if (snapshotRecord.reactionEventId.startsWith('pending_')) {
+      return;
+    }
+
+    // 3. Publish kind 5 deletion; on failure roll back memory + stream.
+    try {
+      final deletionEvent = await _nostrClient.deleteEvent(
+        snapshotRecord.reactionEventId,
+      );
+      if (deletionEvent == null) {
+        throw const UnlikeFailedException(
+          'Failed to publish downvote deletion',
+        );
+      }
+    } catch (_) {
+      _downvoteRecords[eventId] = snapshotRecord;
+      _emitDownvotedIds();
+      rethrow;
+    }
+  }
+
+  /// Toggle the current user's downvote on an event.
+  ///
+  /// Returns `true` when the event ends up downvoted, `false` when the
+  /// downvote was removed. Convenience wrapper around [downvoteEvent] /
+  /// [removeDownvote] mirroring [toggleLike].
+  Future<bool> toggleDownvote({
+    required String eventId,
+    required String authorPubkey,
+    int? targetKind,
+  }) async {
+    await _ensureInitialized();
+
+    if (_downvoteRecords.containsKey(eventId)) {
+      await removeDownvote(eventId);
+      return false;
+    }
+
+    await downvoteEvent(
+      eventId: eventId,
+      authorPubkey: authorPubkey,
+      targetKind: targetKind,
+    );
+    return true;
   }
 
   /// Delete a reaction event by its ID (Kind 5 deletion).
@@ -815,20 +986,25 @@ class LikesRepository {
 
       final newRecords = <LikeRecord>[];
       final deletedTargetIds = <String>[];
+      final deletedDownvoteTargetIds = <String>[];
+      var downvoteCacheChanged = false;
 
       for (final event in reactionEvents) {
+        final targetId = _extractTargetEventId(event);
+        if (targetId == null) continue;
+
         // Skip reactions that have been deleted
         if (deletedReactionIds.contains(event.id)) {
-          // If we have this in local storage, mark for deletion
-          final targetId = _extractTargetEventId(event);
-          if (targetId != null && _likeRecords.containsKey(targetId)) {
+          if (_likeRecords.containsKey(targetId)) {
             deletedTargetIds.add(targetId);
+          }
+          if (_downvoteRecords.containsKey(targetId)) {
+            deletedDownvoteTargetIds.add(targetId);
           }
           continue;
         }
 
-        final targetId = _extractTargetEventId(event);
-        if (targetId != null && event.content == _likeContent) {
+        if (event.content == _likeContent) {
           final record = LikeRecord(
             targetEventId: targetId,
             reactionEventId: event.id,
@@ -844,6 +1020,23 @@ class LikesRepository {
             _likeRecords[targetId] = record;
             newRecords.add(record);
           }
+        } else if (event.content == _downvoteContent) {
+          final record = LikeRecord(
+            targetEventId: targetId,
+            reactionEventId: event.id,
+            createdAt: DateTime.fromMillisecondsSinceEpoch(
+              event.createdAt * 1000,
+            ),
+          );
+
+          // Mirror the upvote freshness check; downvotes aren't persisted
+          // in v1 so there's no batch save.
+          final existing = _downvoteRecords[targetId];
+          if (existing == null ||
+              record.createdAt.isAfter(existing.createdAt)) {
+            _downvoteRecords[targetId] = record;
+            downvoteCacheChanged = true;
+          }
         }
       }
 
@@ -853,12 +1046,21 @@ class LikesRepository {
         await _localStorage?.deleteLikeRecord(targetId);
       }
 
+      // Remove deleted downvotes from in-memory cache (no local storage in v1)
+      for (final targetId in deletedDownvoteTargetIds) {
+        _downvoteRecords.remove(targetId);
+        downvoteCacheChanged = true;
+      }
+
       // Batch save new records to storage
       if (newRecords.isNotEmpty && _localStorage != null) {
         await _localStorage.saveLikeRecordsBatch(newRecords);
       }
 
       _emitLikedIds();
+      if (downvoteCacheChanged) {
+        _emitDownvotedIds();
+      }
       _isInitialized = true;
 
       return _buildSyncResult();
@@ -1004,9 +1206,8 @@ class LikesRepository {
   void _processIncomingReaction(Event event) {
     if (_isDisposed) return;
 
-    // Only process Kind 7 '+' reactions from the current user
+    // Only process Kind 7 reactions from the current user
     if (event.kind != EventKind.reaction) return;
-    if (event.content != _likeContent) return;
     if (event.pubkey != _nostrClient.publicKey) return;
 
     final targetId = _extractTargetEventId(event);
@@ -1016,19 +1217,32 @@ class LikesRepository {
       event.createdAt * 1000,
     );
 
-    // Deduplicate: only update if newer than existing record
-    final existing = _likeRecords[targetId];
-    if (existing != null && !createdAt.isAfter(existing.createdAt)) return;
+    if (event.content == _likeContent) {
+      // Deduplicate upvotes
+      final existing = _likeRecords[targetId];
+      if (existing != null && !createdAt.isAfter(existing.createdAt)) return;
 
-    final record = LikeRecord(
-      targetEventId: targetId,
-      reactionEventId: event.id,
-      createdAt: createdAt,
-    );
+      final record = LikeRecord(
+        targetEventId: targetId,
+        reactionEventId: event.id,
+        createdAt: createdAt,
+      );
 
-    _likeRecords[targetId] = record;
-    unawaited(_localStorage?.saveLikeRecord(record));
-    _emitLikedIds();
+      _likeRecords[targetId] = record;
+      unawaited(_localStorage?.saveLikeRecord(record));
+      _emitLikedIds();
+    } else if (event.content == _downvoteContent) {
+      // Deduplicate downvotes (in-memory only — no local persistence in v1)
+      final existing = _downvoteRecords[targetId];
+      if (existing != null && !createdAt.isAfter(existing.createdAt)) return;
+
+      _downvoteRecords[targetId] = LikeRecord(
+        targetEventId: targetId,
+        reactionEventId: event.id,
+        createdAt: createdAt,
+      );
+      _emitDownvotedIds();
+    }
   }
 
   void _decrementLikeCountCache(String eventId) {
@@ -1045,15 +1259,17 @@ class LikesRepository {
   /// stream emission is attempted.
   Future<void> clearCache() async {
     _likeRecords.clear();
+    _downvoteRecords.clear();
     _likeCountCache.clear();
     await _localStorage?.clearAll();
     _emitLikedIds();
+    _emitDownvotedIds();
     _isInitialized = false;
   }
 
   /// Dispose of resources.
   ///
-  /// Cancels the reaction subscription and closes the stream controller.
+  /// Cancels the reaction subscription and closes both stream controllers.
   /// Should be called when the repository is no longer needed.
   void dispose() {
     _isDisposed = true;
@@ -1063,6 +1279,7 @@ class LikesRepository {
       _reactionSubscriptionId = null;
     }
     unawaited(_likedIdsController.close());
+    unawaited(_downvotedIdsController.close());
   }
 
   /// Ensures the repository is initialized with data from storage.

--- a/mobile/packages/likes_repository/test/src/exceptions_test.dart
+++ b/mobile/packages/likes_repository/test/src/exceptions_test.dart
@@ -77,6 +77,32 @@ void main() {
     });
   });
 
+  group('AlreadyDownvotedException', () {
+    test('includes event ID in message', () {
+      const exception = AlreadyDownvotedException('event123');
+      expect(exception.message, contains('event123'));
+      expect(exception.message, contains('downvoted'));
+    });
+
+    test('toString contains class name', () {
+      const exception = AlreadyDownvotedException('event123');
+      expect(exception.toString(), contains('AlreadyDownvotedException'));
+    });
+  });
+
+  group('NotDownvotedException', () {
+    test('includes event ID in message', () {
+      const exception = NotDownvotedException('event123');
+      expect(exception.message, contains('event123'));
+      expect(exception.message, contains('not downvoted'));
+    });
+
+    test('toString contains class name', () {
+      const exception = NotDownvotedException('event123');
+      expect(exception.toString(), contains('NotDownvotedException'));
+    });
+  });
+
   group('SyncFailedException', () {
     test('has correct message', () {
       const exception = SyncFailedException('sync error');

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -748,6 +748,495 @@ void main() {
       });
     });
 
+    group('downvoteEvent', () {
+      test(
+        'ticks watchDownvotedEventIds before sendLike completes',
+        () async {
+          // Block sendLike on a completer so the optimistic stream emit
+          // is observable before the network call returns.
+          final publishCompleter = Completer<Event?>();
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer((_) => publishCompleter.future);
+
+          repository = createRepository(withLocalStorage: false);
+
+          final emitted = <List<String>>[];
+          final subscription = repository.watchDownvotedEventIds().listen(
+            emitted.add,
+          );
+
+          final downvoteFuture = repository.downvoteEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          expect(
+            emitted.last,
+            contains(testEventId),
+            reason: 'stream must tick before publish completes',
+          );
+
+          publishCompleter.complete(
+            createMockReaction(
+              id: testReactionEventId,
+              targetEventId: testEventId,
+              content: '-',
+            ),
+          );
+          await downvoteFuture;
+          await subscription.cancel();
+        },
+      );
+
+      test('publishes kind-7 with content "-" and tracks the record', () async {
+        when(
+          () => mockNostrClient.sendLike(
+            any(),
+            content: any(named: 'content'),
+            addressableId: any(named: 'addressableId'),
+            targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+            targetKind: any(named: 'targetKind'),
+          ),
+        ).thenAnswer(
+          (_) async => createMockReaction(
+            id: testReactionEventId,
+            targetEventId: testEventId,
+            content: '-',
+          ),
+        );
+
+        repository = createRepository(withLocalStorage: false);
+        final result = await repository.downvoteEvent(
+          eventId: testEventId,
+          authorPubkey: testAuthorPubkey,
+        );
+
+        expect(result, equals(testReactionEventId));
+        expect(await repository.isDownvoted(testEventId), isTrue);
+        verify(
+          () => mockNostrClient.sendLike(
+            testEventId,
+            content: '-',
+            targetAuthorPubkey: testAuthorPubkey,
+          ),
+        ).called(1);
+      });
+
+      test(
+        'throws AlreadyDownvotedException when already downvoted',
+        () async {
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer(
+            (_) async => createMockReaction(
+              id: testReactionEventId,
+              targetEventId: testEventId,
+              content: '-',
+            ),
+          );
+
+          repository = createRepository(withLocalStorage: false);
+          await repository.downvoteEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          await expectLater(
+            repository.downvoteEvent(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+            throwsA(isA<AlreadyDownvotedException>()),
+          );
+        },
+      );
+
+      test(
+        'rolls back record + stream when publish returns null',
+        () async {
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer((_) async => null);
+
+          repository = createRepository(withLocalStorage: false);
+
+          await expectLater(
+            repository.downvoteEvent(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+            throwsA(isA<LikeFailedException>()),
+          );
+
+          expect(await repository.isDownvoted(testEventId), isFalse);
+        },
+      );
+
+      test(
+        'rolls back record + stream when publish throws',
+        () async {
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenThrow(Exception('relay unreachable'));
+
+          repository = createRepository(withLocalStorage: false);
+
+          await expectLater(
+            repository.downvoteEvent(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+            throwsA(isA<Exception>()),
+          );
+
+          expect(await repository.isDownvoted(testEventId), isFalse);
+        },
+      );
+    });
+
+    group('removeDownvote', () {
+      test(
+        'publishes deletion event and removes the record',
+        () async {
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer(
+            (_) async => createMockReaction(
+              id: testReactionEventId,
+              targetEventId: testEventId,
+              content: '-',
+            ),
+          );
+          final deletionEvent = MockEvent();
+          when(
+            () => mockNostrClient.deleteEvent(any()),
+          ).thenAnswer((_) async => deletionEvent);
+
+          repository = createRepository(withLocalStorage: false);
+          await repository.downvoteEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          await repository.removeDownvote(testEventId);
+
+          expect(await repository.isDownvoted(testEventId), isFalse);
+          verify(
+            () => mockNostrClient.deleteEvent(testReactionEventId),
+          ).called(1);
+        },
+      );
+
+      test('throws NotDownvotedException when not downvoted', () async {
+        repository = createRepository(withLocalStorage: false);
+
+        await expectLater(
+          repository.removeDownvote(testEventId),
+          throwsA(isA<NotDownvotedException>()),
+        );
+      });
+
+      test(
+        'rolls back record + stream when deletion returns null',
+        () async {
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer(
+            (_) async => createMockReaction(
+              id: testReactionEventId,
+              targetEventId: testEventId,
+              content: '-',
+            ),
+          );
+          when(
+            () => mockNostrClient.deleteEvent(any()),
+          ).thenAnswer((_) async => null);
+
+          repository = createRepository(withLocalStorage: false);
+          await repository.downvoteEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          await expectLater(
+            repository.removeDownvote(testEventId),
+            throwsA(isA<UnlikeFailedException>()),
+          );
+
+          // Memory: record restored after rollback.
+          expect(await repository.isDownvoted(testEventId), isTrue);
+        },
+      );
+
+      test(
+        'rolls back record + stream when deletion throws',
+        () async {
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer(
+            (_) async => createMockReaction(
+              id: testReactionEventId,
+              targetEventId: testEventId,
+              content: '-',
+            ),
+          );
+          when(
+            () => mockNostrClient.deleteEvent(any()),
+          ).thenThrow(Exception('relay unreachable'));
+
+          repository = createRepository(withLocalStorage: false);
+          await repository.downvoteEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          await expectLater(
+            repository.removeDownvote(testEventId),
+            throwsA(isA<Exception>()),
+          );
+
+          expect(await repository.isDownvoted(testEventId), isTrue);
+        },
+      );
+    });
+
+    group('toggleDownvote', () {
+      test(
+        'downvotes when not downvoted and returns true',
+        () async {
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer(
+            (_) async => createMockReaction(
+              id: testReactionEventId,
+              targetEventId: testEventId,
+              content: '-',
+            ),
+          );
+
+          repository = createRepository(withLocalStorage: false);
+          final result = await repository.toggleDownvote(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          expect(result, isTrue);
+          expect(await repository.isDownvoted(testEventId), isTrue);
+        },
+      );
+
+      test(
+        'removes downvote when already downvoted and returns false',
+        () async {
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer(
+            (_) async => createMockReaction(
+              id: testReactionEventId,
+              targetEventId: testEventId,
+              content: '-',
+            ),
+          );
+          final deletionEvent = MockEvent();
+          when(
+            () => mockNostrClient.deleteEvent(any()),
+          ).thenAnswer((_) async => deletionEvent);
+
+          repository = createRepository(withLocalStorage: false);
+          await repository.downvoteEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          final result = await repository.toggleDownvote(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          expect(result, isFalse);
+          expect(await repository.isDownvoted(testEventId), isFalse);
+        },
+      );
+    });
+
+    group('isDownvoted / getDownvoteRecord / getDownvotedEventIds', () {
+      test('isDownvoted returns false for non-downvoted event', () async {
+        repository = createRepository(withLocalStorage: false);
+        expect(await repository.isDownvoted(testEventId), isFalse);
+      });
+
+      test(
+        'getDownvoteRecord returns null when not downvoted',
+        () async {
+          repository = createRepository(withLocalStorage: false);
+          expect(await repository.getDownvoteRecord(testEventId), isNull);
+        },
+      );
+
+      test(
+        'getDownvoteRecord returns record after downvoteEvent',
+        () async {
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer(
+            (_) async => createMockReaction(
+              id: testReactionEventId,
+              targetEventId: testEventId,
+              content: '-',
+            ),
+          );
+
+          repository = createRepository(withLocalStorage: false);
+          await repository.downvoteEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          final record = await repository.getDownvoteRecord(testEventId);
+          expect(record, isNotNull);
+          expect(record!.targetEventId, equals(testEventId));
+          expect(record.reactionEventId, equals(testReactionEventId));
+        },
+      );
+
+      test(
+        'getDownvotedEventIds returns ordered set',
+        () async {
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer(
+            (_) async => createMockReaction(
+              id: testReactionEventId,
+              targetEventId: testEventId,
+              content: '-',
+            ),
+          );
+
+          repository = createRepository(withLocalStorage: false);
+          await repository.downvoteEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          expect(
+            await repository.getDownvotedEventIds(),
+            contains(testEventId),
+          );
+          expect(
+            await repository.getOrderedDownvotedEventIds(),
+            equals([testEventId]),
+          );
+        },
+      );
+
+      test(
+        'watchDownvotedEventIds emits initial empty + new state on downvote',
+        () async {
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer(
+            (_) async => createMockReaction(
+              id: testReactionEventId,
+              targetEventId: testEventId,
+              content: '-',
+            ),
+          );
+
+          repository = createRepository(withLocalStorage: false);
+
+          final emitted = <List<String>>[];
+          final subscription = repository.watchDownvotedEventIds().listen(
+            emitted.add,
+          );
+
+          await Future<void>.delayed(Duration.zero);
+          expect(emitted.last, isEmpty);
+
+          await repository.downvoteEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          expect(emitted.last, contains(testEventId));
+          await subscription.cancel();
+        },
+      );
+    });
+
     group('getLikeCount', () {
       test('queries relay for like count by event ID', () async {
         when(
@@ -1675,31 +2164,43 @@ void main() {
         await streamController.close();
       });
 
-      test('ignores non-like reaction content', () async {
-        final streamController = StreamController<Event>.broadcast();
-        when(() => mockNostrClient.hasKeys).thenReturn(true);
-        when(
-          () => mockNostrClient.subscribe(
-            any(),
-            subscriptionId: any(named: 'subscriptionId'),
-          ),
-        ).thenAnswer((_) => streamController.stream);
+      test(
+        'routes downvote reactions into _downvoteRecords (not _likeRecords)',
+        () async {
+          final streamController = StreamController<Event>.broadcast();
+          when(() => mockNostrClient.hasKeys).thenReturn(true);
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => streamController.stream);
 
-        repository = createRepository();
-        await repository.initialize();
+          repository = createRepository();
+          await repository.initialize();
 
-        final dislikeEvent = MockEvent();
-        when(() => dislikeEvent.kind).thenReturn(EventKind.reaction);
-        when(() => dislikeEvent.content).thenReturn('-');
-        when(() => dislikeEvent.pubkey).thenReturn(testUserPubkey);
+          final downvoteEvent = MockEvent();
+          when(() => downvoteEvent.id).thenReturn('downvote_event_id');
+          when(() => downvoteEvent.kind).thenReturn(EventKind.reaction);
+          when(() => downvoteEvent.content).thenReturn('-');
+          when(() => downvoteEvent.pubkey).thenReturn(testUserPubkey);
+          when(() => downvoteEvent.tags).thenReturn([
+            ['e', testEventId],
+          ]);
+          when(() => downvoteEvent.createdAt).thenReturn(defaultTimestamp);
 
-        streamController.add(dislikeEvent);
-        await Future<void>.delayed(Duration.zero);
+          streamController.add(downvoteEvent);
+          await Future<void>.delayed(Duration.zero);
 
-        expect(await repository.isLiked(testEventId), isFalse);
+          // Downvote reactions don't mark the event as liked, but they do
+          // populate the downvote tracking so removeDownvote / isDownvoted
+          // see them.
+          expect(await repository.isLiked(testEventId), isFalse);
+          expect(await repository.isDownvoted(testEventId), isTrue);
 
-        await streamController.close();
-      });
+          await streamController.close();
+        },
+      );
 
       test('deduplicates older events', () async {
         final streamController = StreamController<Event>.broadcast();

--- a/mobile/test/blocs/comments/comments_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_bloc_test.dart
@@ -1281,7 +1281,7 @@ void main() {
           ),
         ),
         expect: () => [
-          // First emit: optimistic update with like added
+          // Single optimistic emit: arrow + count flip together.
           isA<CommentsState>()
               .having(
                 (s) => s.upvotedCommentIds.contains(validId('likecomment')),
@@ -1292,28 +1292,6 @@ void main() {
                 (s) => s.commentUpvoteCounts[validId('likecomment')],
                 'count',
                 6,
-              )
-              .having(
-                (s) => s.voteInProgressCommentId,
-                'voteInProgressCommentId',
-                validId('likecomment'),
-              ),
-          // Second emit: clears voteInProgressCommentId on success
-          isA<CommentsState>()
-              .having(
-                (s) => s.upvotedCommentIds.contains(validId('likecomment')),
-                'liked',
-                true,
-              )
-              .having(
-                (s) => s.commentUpvoteCounts[validId('likecomment')],
-                'count',
-                6,
-              )
-              .having(
-                (s) => s.voteInProgressCommentId,
-                'voteInProgressCommentId',
-                null,
               ),
         ],
       );
@@ -1322,12 +1300,8 @@ void main() {
         'emits optimistic unlike update when liked comment is toggled',
         setUp: () {
           when(
-            () => mockLikesRepository.toggleLike(
-              eventId: any(named: 'eventId'),
-              authorPubkey: any(named: 'authorPubkey'),
-              targetKind: any(named: 'targetKind'),
-            ),
-          ).thenAnswer((_) async => false);
+            () => mockLikesRepository.unlikeEvent(any()),
+          ).thenAnswer((_) async {});
         },
         build: createBloc,
         seed: () {
@@ -1364,23 +1338,6 @@ void main() {
                 (s) => s.commentUpvoteCounts[validId('likecomment')],
                 'count',
                 2,
-              )
-              .having(
-                (s) => s.voteInProgressCommentId,
-                'voteInProgressCommentId',
-                validId('likecomment'),
-              ),
-          // Second emit: clears voteInProgressCommentId on success
-          isA<CommentsState>()
-              .having(
-                (s) => s.upvotedCommentIds.contains(validId('likecomment')),
-                'liked',
-                false,
-              )
-              .having(
-                (s) => s.voteInProgressCommentId,
-                'voteInProgressCommentId',
-                null,
               ),
         ],
       );
@@ -1389,7 +1346,7 @@ void main() {
         'reverts optimistic update on failure',
         setUp: () {
           when(
-            () => mockLikesRepository.toggleLike(
+            () => mockLikesRepository.likeEvent(
               eventId: any(named: 'eventId'),
               authorPubkey: any(named: 'authorPubkey'),
               targetKind: any(named: 'targetKind'),
@@ -1448,37 +1405,10 @@ void main() {
       );
 
       blocTest<CommentsBloc, CommentsState>(
-        'does nothing when same comment like is in progress',
-        build: createBloc,
-        seed: () {
-          final comment = Comment(
-            id: validId('likecomment'),
-            content: 'Comment',
-            authorPubkey: validId('commenter'),
-            createdAt: DateTime.fromMillisecondsSinceEpoch(1000000000),
-            rootEventId: validId('root'),
-            rootAuthorPubkey: validId('author'),
-          );
-          return CommentsState(
-            status: CommentsStatus.success,
-            commentsById: {comment.id: comment},
-            voteInProgressCommentId: validId('likecomment'),
-          );
-        },
-        act: (bloc) => bloc.add(
-          CommentUpvoteToggled(
-            commentId: validId('likecomment'),
-            authorPubkey: validId('commenter'),
-          ),
-        ),
-        expect: () => <CommentsState>[],
-      );
-
-      blocTest<CommentsBloc, CommentsState>(
         'removes existing downvote when upvoting a downvoted comment',
         setUp: () {
           when(
-            () => mockLikesRepository.unlikeEvent(any()),
+            () => mockLikesRepository.removeDownvote(any()),
           ).thenAnswer((_) async {});
           when(
             () => mockLikesRepository.likeEvent(
@@ -1535,28 +1465,14 @@ void main() {
                 'downvote count',
                 2,
               ),
-          // Second emit: clears voteInProgressCommentId on success
-          isA<CommentsState>()
-              .having(
-                (s) => s.upvotedCommentIds.contains(validId('likecomment')),
-                'upvoted',
-                true,
-              )
-              .having(
-                (s) => s.downvotedCommentIds.contains(validId('likecomment')),
-                'downvoted',
-                false,
-              )
-              .having(
-                (s) => s.voteInProgressCommentId,
-                'voteInProgressCommentId',
-                null,
-              ),
         ],
         verify: (_) {
-          // Verify downvote was removed before upvote was added
+          // Verify downvote was removed (via removeDownvote) before upvote
+          // was added — the previously-broken path used unlikeEvent which
+          // throws NotLikedException because downvotes aren't in
+          // _likeRecords.
           verify(
-            () => mockLikesRepository.unlikeEvent(validId('likecomment')),
+            () => mockLikesRepository.removeDownvote(validId('likecomment')),
           ).called(1);
           verify(
             () => mockLikesRepository.likeEvent(
@@ -1639,7 +1555,7 @@ void main() {
           ),
         ),
         expect: () => [
-          // First emit: optimistic downvote added
+          // Single optimistic emit: downvote added, count incremented.
           isA<CommentsState>()
               .having(
                 (s) => s.downvotedCommentIds.contains(validId('downcomment')),
@@ -1650,23 +1566,6 @@ void main() {
                 (s) => s.commentDownvoteCounts[validId('downcomment')],
                 'count',
                 3,
-              )
-              .having(
-                (s) => s.voteInProgressCommentId,
-                'voteInProgressCommentId',
-                validId('downcomment'),
-              ),
-          // Second emit: clears voteInProgressCommentId on success
-          isA<CommentsState>()
-              .having(
-                (s) => s.downvotedCommentIds.contains(validId('downcomment')),
-                'downvoted',
-                true,
-              )
-              .having(
-                (s) => s.voteInProgressCommentId,
-                'voteInProgressCommentId',
-                null,
               ),
         ],
       );
@@ -1732,26 +1631,10 @@ void main() {
                 'upvote count',
                 4,
               ),
-          // Second emit: clears voteInProgressCommentId on success
-          isA<CommentsState>()
-              .having(
-                (s) => s.downvotedCommentIds.contains(validId('downcomment')),
-                'downvoted',
-                true,
-              )
-              .having(
-                (s) => s.upvotedCommentIds.contains(validId('downcomment')),
-                'upvoted',
-                false,
-              )
-              .having(
-                (s) => s.voteInProgressCommentId,
-                'voteInProgressCommentId',
-                null,
-              ),
         ],
         verify: (_) {
-          // Verify upvote was removed before downvote was added
+          // Verify upvote was removed (via unlikeEvent — upvotes ARE in
+          // _likeRecords) before downvote was added.
           verify(
             () => mockLikesRepository.unlikeEvent(validId('downcomment')),
           ).called(1);
@@ -1768,8 +1651,12 @@ void main() {
       blocTest<CommentsBloc, CommentsState>(
         'emits optimistic un-downvote when downvoted comment is toggled',
         setUp: () {
+          // The downvote-removal path now uses removeDownvote (downvote
+          // records live in _downvoteRecords, not _likeRecords). Pre-fix
+          // this called unlikeEvent and threw NotLikedException, causing
+          // a revert flash; that latent bug is closed by this change.
           when(
-            () => mockLikesRepository.unlikeEvent(any()),
+            () => mockLikesRepository.removeDownvote(any()),
           ).thenAnswer((_) async {});
         },
         build: createBloc,
@@ -1796,7 +1683,9 @@ void main() {
           ),
         ),
         expect: () => [
-          // First emit: optimistic un-downvote
+          // Single optimistic emit: downvote removed, count decremented.
+          // No revert flash — removeDownvote succeeds because the downvote
+          // is tracked in _downvoteRecords now.
           isA<CommentsState>()
               .having(
                 (s) => s.downvotedCommentIds.contains(validId('downcomment')),
@@ -1807,25 +1696,13 @@ void main() {
                 (s) => s.commentDownvoteCounts[validId('downcomment')],
                 'count',
                 2,
-              )
-              .having(
-                (s) => s.voteInProgressCommentId,
-                'voteInProgressCommentId',
-                validId('downcomment'),
-              ),
-          // Second emit: clears voteInProgressCommentId on success
-          isA<CommentsState>()
-              .having(
-                (s) => s.downvotedCommentIds.contains(validId('downcomment')),
-                'downvoted',
-                false,
-              )
-              .having(
-                (s) => s.voteInProgressCommentId,
-                'voteInProgressCommentId',
-                null,
               ),
         ],
+        verify: (_) {
+          verify(
+            () => mockLikesRepository.removeDownvote(validId('downcomment')),
+          ).called(1);
+        },
       );
     });
 
@@ -3260,24 +3137,6 @@ void main() {
       final comments = state.comments;
       expect(comments.first.id, highEngagement.id);
       expect(comments.last.id, lowEngagement.id);
-    });
-
-    test('copyWith without voteInProgressCommentId clears it', () {
-      const state = CommentsState(voteInProgressCommentId: 'some-comment-id');
-
-      final updated = state.copyWith();
-
-      expect(updated.voteInProgressCommentId, null);
-    });
-
-    test('copyWith with voteInProgressCommentId preserves it', () {
-      const state = CommentsState();
-
-      final updated = state.copyWith(
-        voteInProgressCommentId: 'some-comment-id',
-      );
-
-      expect(updated.voteInProgressCommentId, 'some-comment-id');
     });
 
     test(

--- a/mobile/test/blocs/comments/comments_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_bloc_test.dart
@@ -1292,7 +1292,7 @@ void main() {
       );
     });
 
-    group('CommentUpvoteToggled', () {
+    group('CommentVoteToggled (upvote)', () {
       blocTest<CommentsBloc, CommentsState>(
         'emits optimistic like update when unliked comment is toggled',
         setUp: () {
@@ -1321,9 +1321,10 @@ void main() {
           );
         },
         act: (bloc) => bloc.add(
-          CommentUpvoteToggled(
+          CommentVoteToggled(
             commentId: validId('likecomment'),
             authorPubkey: validId('commenter'),
+            vote: Vote.up,
           ),
         ),
         expect: () => [
@@ -1367,9 +1368,10 @@ void main() {
           );
         },
         act: (bloc) => bloc.add(
-          CommentUpvoteToggled(
+          CommentVoteToggled(
             commentId: validId('likecomment'),
             authorPubkey: validId('commenter'),
+            vote: Vote.up,
           ),
         ),
         expect: () => [
@@ -1416,9 +1418,10 @@ void main() {
           );
         },
         act: (bloc) => bloc.add(
-          CommentUpvoteToggled(
+          CommentVoteToggled(
             commentId: validId('likecomment'),
             authorPubkey: validId('commenter'),
+            vote: Vote.up,
           ),
         ),
         expect: () => [
@@ -1483,9 +1486,10 @@ void main() {
           );
         },
         act: (bloc) => bloc.add(
-          CommentUpvoteToggled(
+          CommentVoteToggled(
             commentId: validId('likecomment'),
             authorPubkey: validId('commenter'),
+            vote: Vote.up,
           ),
         ),
         expect: () => [
@@ -1551,9 +1555,10 @@ void main() {
           );
         },
         act: (bloc) => bloc.add(
-          CommentUpvoteToggled(
+          CommentVoteToggled(
             commentId: validId('likecomment'),
             authorPubkey: validId('commenter'),
+            vote: Vote.up,
           ),
         ),
         expect: () => [
@@ -1566,7 +1571,7 @@ void main() {
       );
     });
 
-    group('CommentDownvoteToggled', () {
+    group('CommentVoteToggled (downvote)', () {
       blocTest<CommentsBloc, CommentsState>(
         'emits optimistic downvote update when unvoted comment is toggled',
         setUp: () {
@@ -1595,9 +1600,10 @@ void main() {
           );
         },
         act: (bloc) => bloc.add(
-          CommentDownvoteToggled(
+          CommentVoteToggled(
             commentId: validId('downcomment'),
             authorPubkey: validId('commenter'),
+            vote: Vote.down,
           ),
         ),
         expect: () => [
@@ -1649,9 +1655,10 @@ void main() {
           );
         },
         act: (bloc) => bloc.add(
-          CommentDownvoteToggled(
+          CommentVoteToggled(
             commentId: validId('downcomment'),
             authorPubkey: validId('commenter'),
+            vote: Vote.down,
           ),
         ),
         expect: () => [
@@ -1723,9 +1730,10 @@ void main() {
           );
         },
         act: (bloc) => bloc.add(
-          CommentDownvoteToggled(
+          CommentVoteToggled(
             commentId: validId('downcomment'),
             authorPubkey: validId('commenter'),
+            vote: Vote.down,
           ),
         ),
         expect: () => [
@@ -1749,6 +1757,330 @@ void main() {
             () => mockLikesRepository.removeDownvote(validId('downcomment')),
           ).called(1);
         },
+      );
+    });
+
+    group('CommentVoteToggled (vote switch)', () {
+      // Manual Test 5b regression: tapping upvote on a downvoted comment must
+      // produce a single optimistic emit that lands the +2 net-score delta
+      // — no revert flash from a NotLikedException on the wrong teardown call.
+      blocTest<CommentsBloc, CommentsState>(
+        'down→up switches in a single emit with a +2 net-score delta',
+        setUp: () {
+          when(
+            () => mockLikesRepository.removeDownvote(any()),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockLikesRepository.likeEvent(
+              eventId: any(named: 'eventId'),
+              authorPubkey: any(named: 'authorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer((_) async => 'mock-reaction-id');
+        },
+        build: createBloc,
+        seed: () {
+          final comment = Comment(
+            id: validId('switchcomment'),
+            content: 'Downvoted comment',
+            authorPubkey: validId('commenter'),
+            createdAt: DateTime.fromMillisecondsSinceEpoch(1000000000),
+            rootEventId: validId('root'),
+            rootAuthorPubkey: validId('author'),
+          );
+          return CommentsState(
+            status: CommentsStatus.success,
+            commentsById: {comment.id: comment},
+            commentUpvoteCounts: {comment.id: 0},
+            commentDownvoteCounts: {comment.id: 3},
+            downvotedCommentIds: {comment.id},
+            // Net score before: 0 - 3 = -3
+          );
+        },
+        act: (bloc) => bloc.add(
+          CommentVoteToggled(
+            commentId: validId('switchcomment'),
+            authorPubkey: validId('commenter'),
+            vote: Vote.up,
+          ),
+        ),
+        expect: () => [
+          isA<CommentsState>()
+              .having(
+                (s) => s.upvotedCommentIds.contains(validId('switchcomment')),
+                'upvoted',
+                true,
+              )
+              .having(
+                (s) => s.downvotedCommentIds.contains(validId('switchcomment')),
+                'downvoted',
+                false,
+              )
+              .having(
+                (s) =>
+                    (s.commentUpvoteCounts[validId('switchcomment')] ?? 0) -
+                    (s.commentDownvoteCounts[validId('switchcomment')] ?? 0),
+                'net score after',
+                -1, // 1 upvote − 2 downvotes; delta = +2 from −3.
+              )
+              .having((s) => s.error, 'error', isNull),
+        ],
+      );
+
+      blocTest<CommentsBloc, CommentsState>(
+        'up→down switches in a single emit with a -2 net-score delta',
+        setUp: () {
+          when(
+            () => mockLikesRepository.unlikeEvent(any()),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockLikesRepository.downvoteEvent(
+              eventId: any(named: 'eventId'),
+              authorPubkey: any(named: 'authorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer((_) async => 'mock-reaction-id');
+        },
+        build: createBloc,
+        seed: () {
+          final comment = Comment(
+            id: validId('switchcomment'),
+            content: 'Upvoted comment',
+            authorPubkey: validId('commenter'),
+            createdAt: DateTime.fromMillisecondsSinceEpoch(1000000000),
+            rootEventId: validId('root'),
+            rootAuthorPubkey: validId('author'),
+          );
+          return CommentsState(
+            status: CommentsStatus.success,
+            commentsById: {comment.id: comment},
+            commentUpvoteCounts: {comment.id: 5},
+            commentDownvoteCounts: {comment.id: 0},
+            upvotedCommentIds: {comment.id},
+            // Net score before: 5 - 0 = +5
+          );
+        },
+        act: (bloc) => bloc.add(
+          CommentVoteToggled(
+            commentId: validId('switchcomment'),
+            authorPubkey: validId('commenter'),
+            vote: Vote.down,
+          ),
+        ),
+        expect: () => [
+          isA<CommentsState>()
+              .having(
+                (s) => s.downvotedCommentIds.contains(validId('switchcomment')),
+                'downvoted',
+                true,
+              )
+              .having(
+                (s) => s.upvotedCommentIds.contains(validId('switchcomment')),
+                'upvoted',
+                false,
+              )
+              .having(
+                (s) =>
+                    (s.commentUpvoteCounts[validId('switchcomment')] ?? 0) -
+                    (s.commentDownvoteCounts[validId('switchcomment')] ?? 0),
+                'net score after',
+                3, // 4 upvotes − 1 downvote; delta = −2 from +5.
+              )
+              .having((s) => s.error, 'error', isNull),
+        ],
+      );
+
+      // droppable() on the unified handler closes the cross-type race —
+      // a rapid down-tap fired while the up-publish is still in flight is
+      // dropped before its handler can emit a competing optimistic state
+      // or hit the relay with an interleaved kind-7 / kind-5 publish.
+      blocTest<CommentsBloc, CommentsState>(
+        'rapid up→down on the same comment drops the second tap while in flight',
+        setUp: () {
+          final upInFlight = Completer<String>();
+          when(
+            () => mockLikesRepository.likeEvent(
+              eventId: any(named: 'eventId'),
+              authorPubkey: any(named: 'authorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer((_) => upInFlight.future);
+          when(
+            () => mockLikesRepository.downvoteEvent(
+              eventId: any(named: 'eventId'),
+              authorPubkey: any(named: 'authorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer((_) async => 'mock-reaction-id-down');
+          when(
+            () => mockLikesRepository.unlikeEvent(any()),
+          ).thenAnswer((_) async {});
+          // Settle the in-flight publish on the next microtask so the
+          // upvote handler can complete cleanly after both adds are
+          // queued. The downvote add must reach `add` while the upvote
+          // handler is still awaiting.
+          Future<void>.delayed(const Duration(milliseconds: 50), () {
+            upInFlight.complete('mock-reaction-id-up');
+          });
+        },
+        build: createBloc,
+        seed: () {
+          final comment = Comment(
+            id: validId('racecomment'),
+            content: 'Race comment',
+            authorPubkey: validId('commenter'),
+            createdAt: DateTime.fromMillisecondsSinceEpoch(1000000000),
+            rootEventId: validId('root'),
+            rootAuthorPubkey: validId('author'),
+          );
+          return CommentsState(
+            status: CommentsStatus.success,
+            commentsById: {comment.id: comment},
+          );
+        },
+        act: (bloc) async {
+          bloc.add(
+            CommentVoteToggled(
+              commentId: validId('racecomment'),
+              authorPubkey: validId('commenter'),
+              vote: Vote.up,
+            ),
+          );
+          // Rapid second tap before the first handler's publish resolves.
+          bloc.add(
+            CommentVoteToggled(
+              commentId: validId('racecomment'),
+              authorPubkey: validId('commenter'),
+              vote: Vote.down,
+            ),
+          );
+        },
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          // Only the upvote optimistic emit lands. The downvote tap is
+          // dropped by droppable() because the upvote handler is still
+          // awaiting its publish when the event is queued.
+          isA<CommentsState>()
+              .having(
+                (s) => s.upvotedCommentIds.contains(validId('racecomment')),
+                'upvoted',
+                true,
+              )
+              .having(
+                (s) => s.downvotedCommentIds.contains(validId('racecomment')),
+                'downvoted',
+                false,
+              ),
+        ],
+        verify: (_) {
+          verify(
+            () => mockLikesRepository.likeEvent(
+              eventId: validId('racecomment'),
+              authorPubkey: validId('commenter'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).called(1);
+          // The dropped downvote must never have reached the relay.
+          verifyNever(
+            () => mockLikesRepository.downvoteEvent(
+              eventId: any(named: 'eventId'),
+              authorPubkey: any(named: 'authorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          );
+          verifyNever(() => mockLikesRepository.unlikeEvent(any()));
+        },
+      );
+
+      // Repository-driven desync: when downvoteEvent throws
+      // AlreadyDownvotedException, the specific catch handler short-
+      // circuits the generic catch — no voteFailed, no revert. The
+      // sync emit collapses with the optimistic emit via Equatable
+      // dedup since both target "downvoted, not upvoted".
+      blocTest<CommentsBloc, CommentsState>(
+        'AlreadyDownvotedException from downvoteEvent does not surface voteFailed',
+        setUp: () {
+          when(
+            () => mockLikesRepository.downvoteEvent(
+              eventId: any(named: 'eventId'),
+              authorPubkey: any(named: 'authorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenThrow(AlreadyDownvotedException(validId('synccomment')));
+        },
+        build: createBloc,
+        seed: () {
+          final comment = Comment(
+            id: validId('synccomment'),
+            content: 'Sync comment',
+            authorPubkey: validId('commenter'),
+            createdAt: DateTime.fromMillisecondsSinceEpoch(1000000000),
+            rootEventId: validId('root'),
+            rootAuthorPubkey: validId('author'),
+          );
+          return CommentsState(
+            status: CommentsStatus.success,
+            commentsById: {comment.id: comment},
+          );
+        },
+        act: (bloc) => bloc.add(
+          CommentVoteToggled(
+            commentId: validId('synccomment'),
+            authorPubkey: validId('commenter'),
+            vote: Vote.down,
+          ),
+        ),
+        expect: () => [
+          isA<CommentsState>()
+              .having(
+                (s) => s.downvotedCommentIds.contains(validId('synccomment')),
+                'downvoted',
+                true,
+              )
+              .having((s) => s.error, 'error', isNot(CommentsError.voteFailed)),
+        ],
+      );
+
+      blocTest<CommentsBloc, CommentsState>(
+        'NotDownvotedException from removeDownvote does not surface voteFailed',
+        setUp: () {
+          when(
+            () => mockLikesRepository.removeDownvote(any()),
+          ).thenThrow(NotDownvotedException(validId('synccomment')));
+        },
+        build: createBloc,
+        seed: () {
+          final comment = Comment(
+            id: validId('synccomment'),
+            content: 'Sync comment',
+            authorPubkey: validId('commenter'),
+            createdAt: DateTime.fromMillisecondsSinceEpoch(1000000000),
+            rootEventId: validId('root'),
+            rootAuthorPubkey: validId('author'),
+          );
+          return CommentsState(
+            status: CommentsStatus.success,
+            commentsById: {comment.id: comment},
+            downvotedCommentIds: {comment.id},
+            commentDownvoteCounts: {comment.id: 1},
+          );
+        },
+        act: (bloc) => bloc.add(
+          CommentVoteToggled(
+            commentId: validId('synccomment'),
+            authorPubkey: validId('commenter'),
+            vote: Vote.down,
+          ),
+        ),
+        expect: () => [
+          isA<CommentsState>()
+              .having(
+                (s) => s.downvotedCommentIds.contains(validId('synccomment')),
+                'downvoted',
+                false,
+              )
+              .having((s) => s.error, 'error', isNot(CommentsError.voteFailed)),
+        ],
       );
     });
 


### PR DESCRIPTION
## Description

Closes #3432.

Comments already had an optimistic emit at the bloc level (post-#3409), so upvote felt fast. This PR closes the remaining gaps in the Follow-pattern series for the comment-vote row.

### What changed

**`LikesRepository` (Phase 1 of the Follow pattern, applied to downvotes):**
- New `_downvoteRecords` map and `_downvotedIdsController` mirror the existing upvote machinery.
- New public API: `watchDownvotedEventIds`, `isDownvoted`, `getDownvoteRecord`, `getDownvotedEventIds`, `getOrderedDownvotedEventIds`, `removeDownvote`, `toggleDownvote`.
- `downvoteEvent` is now optimistic-first: writes the record + ticks `watchDownvotedEventIds` BEFORE the kind-7 publish, with rollback on failure (mirror of `likeEvent`'s structure post-#3409).
- `_processIncomingReaction` now routes incoming kind-7 events into the right map by content (`+` → `_likeRecords`, `-` → `_downvoteRecords`). `syncUserReactions` does the same and respects kind-5 deletions for both sides — so cross-device downvote sync works for the first time.
- New `AlreadyDownvotedException` / `NotDownvotedException` pair.

**`CommentsBloc._onVoteToggled`:**
- Drops the per-comment `voteInProgressCommentId` guard. The optimistic emit + `droppable()` transformer already cover same-comment rapid taps; the per-comment guard was redundant.
- Routes downvote-removal through new `removeDownvote` (was `unlikeEvent`). This closes the latent revert-flash bug — pre-fix, removing a downvote called `unlikeEvent` on a comment that had no `_likeRecord` entry, threw `NotLikedException`, and the optimistic update reverted with a visible flash. Same fix lands the downvote→upvote vote-switch path.
- Catches `AlreadyLikedException` / `NotLikedException` / `AlreadyDownvotedException` / `NotDownvotedException` explicitly to sync state with the repo without surfacing `voteFailed`.

**`CommentsState`:** drops `voteInProgressCommentId` field, ctor param, copyWith param, props entry, dartdoc.

### Out of scope (separate follow-up)

- **Local persistence for downvotes:** v1 keeps downvote state in-memory only; the next `getVoteCounts` call repopulates from relays. Adding a schema migration in `db_client` to mirror `DbLikesLocalStorage` for downvotes is the cleanest fix — tracked separately to keep this PR's blast radius contained.

**Related Issue:** Closes #3432

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

---

## Manual test plan

Test on a real device. Throttle to 3G for the diagnostic tests — the latent bug is most visible there.

### 1. Upvote arrow + count flip together

1. Find a comment with a known net score. Tap up-arrow.

**Pass:** arrow flips green and net score increments **in the same frame**. Tap again to remove → grey + decrement together.

### 2. Downvote arrow + count flip together

1. Tap down-arrow on a comment.

**Pass:** arrow flips red and net score decrements **in the same frame**.

### 3. Remove a downvote (the previously-broken path)

1. Downvote a comment (Test 2). Arrow red.
2. Tap the down-arrow again to remove.

**Pass:** arrow goes grey, count returns to baseline, **same frame**. No revert flash.
**Fail (pre-fix):** arrow flashes grey then back to red. This is the diagnostic test — pre-fix this reproduces reliably.

### 4. Slow network (3G throttled) on Tests 1–3

Repeat with throttling. **Pass:** UI feels identical to a healthy network.

### 5a. Vote switch — upvote → downvote

1. Upvote a comment. Tap down-arrow.

**Pass:** up-arrow goes grey, down-arrow turns red, net score moves by **-2** in the same frame.

### 5b. Vote switch — downvote → upvote (also previously broken)

1. Downvote a comment. Tap up-arrow.

**Pass:** down-arrow goes grey, up-arrow turns green, net score moves by **+2** in the same frame.
**Fail (pre-fix):** both arrows flash and revert.

### 6. Same-comment rapid double-tap

Tap the same up-arrow twice as fast as you can.

**Pass:** net effect is one state change (upvoted, count +1). The second tap is dropped by the `droppable()` transformer.

### 7. Different-comment rapid taps

Quickly upvote three different comments in a row.

**Pass:** all three upvotes land. Caveat: with `droppable` active, very rapid taps faster than network RTT can drop some — known trade-off.

### 8. Crash-resilience for downvotes (NEW, in-session only)

1. Throttle to 3G. Downvote a comment. Immediately background the app (not force-close).
2. Re-foreground within ~10s.

**Pass:** down-arrow still red. The optimistic record persisted across backgrounding.

**Note:** v1 doesn't persist downvotes across app restart (deferred follow-up). Force-close + reopen will lose the downvote.

### 9. Failure rollback (best-effort)

Block relays via Charles/Proxyman returning 503. Tap upvote / downvote.

**Pass:** UI flips optimistically, then within ~30s rolls back to the pre-tap state.

### 10. Cross-device sync

1. Upvote a comment on Device A → up-arrow on Device B turns green within ~10s.
2. Downvote a comment on Device A → down-arrow on Device B turns red within ~10s. **NEW** — pre-fix, downvotes never synced because `_processIncomingReaction` filtered them out.

Known limitation (pre-existing): the **count** on Device B may not increment until the bloc re-fetches via `getVoteCounts`. Shared with likes/reposts.

### Sign-off

- [ ] Test 1 — upvote feels instant
- [ ] Test 2 — downvote feels instant
- [ ] Test 3 — **remove a downvote: no revert flash** (diagnostic)
- [ ] Test 4 — Tests 1, 2, 3 pass under 3G throttling
- [ ] Test 5a — upvote → downvote switches cleanly
- [ ] Test 5b — **downvote → upvote switches cleanly** (diagnostic)
- [ ] Test 6 — same-comment rapid double-tap is sane
- [ ] Test 7 — different-comment rapid taps land
- [ ] Test 8 — downvote survives backgrounding mid-publish
- [ ] Test 9 — publish failure rolls back (best-effort)
- [ ] Test 10 — cross-device upvote + downvote both sync

---

## Automated tests

- `mobile/packages/likes_repository/test/src/likes_repository_test.dart`: 149 tests pass (16 new for the downvote API). Coverage at 88.81% on `likes_repository.dart`, 86.84% on `exceptions.dart` — well above the package's 62% gate. Added stream-tick-ordering tests (`ticks watchDownvotedEventIds before sendLike completes`), rollback tests for both null-return and throw paths on `downvoteEvent` and `removeDownvote`, plus toggle / query coverage.
- `mobile/test/blocs/comments/comments_bloc_test.dart`: 102 tests pass. Updated existing vote-toggle blocTests to expect single optimistic emit (no second \"clear in-progress\" emit). Added a `removeDownvote` verify to the un-downvote test to pin the previously-broken path. Deleted the obsolete `voteInProgressCommentId` copyWith tests.
- `flutter analyze lib test integration_test`: clean.
- `dart format`: no changes.

## Files changed

| File | Why |
|---|---|
| `mobile/packages/likes_repository/lib/src/exceptions.dart` | New `AlreadyDownvotedException`, `NotDownvotedException`. |
| `mobile/packages/likes_repository/lib/src/likes_repository.dart` | Downvote tracking machinery + optimistic-first `downvoteEvent` / `removeDownvote` / `toggleDownvote`. Routing in `_processIncomingReaction` and `syncUserReactions`. |
| `mobile/packages/likes_repository/test/src/exceptions_test.dart` | Coverage for the new exceptions. |
| `mobile/packages/likes_repository/test/src/likes_repository_test.dart` | New downvote test groups + rewired `_processIncomingReaction` test that previously asserted dislike events were ignored. |
| `mobile/lib/blocs/comments/comments_bloc.dart` | Wire downvote API; drop `voteInProgressCommentId` guard; explicit catch for the new exceptions; updated registration comment. |
| `mobile/lib/blocs/comments/comments_state.dart` | Drop `voteInProgressCommentId` field, ctor param, copyWith param, props entry. |
| `mobile/test/blocs/comments/comments_bloc_test.dart` | Update vote-toggle expectations (single emit), drop `voteInProgressCommentId` references, swap `unlikeEvent` for `removeDownvote` mocks where applicable, delete obsolete copyWith tests. |