### PR TITLE
ci(ios): add QA PR build slots

### DIFF
--- a/.github/ios_qa_slots.json
+++ b/.github/ios_qa_slots.json
@@ -8,7 +8,7 @@
       "extensionBundleId": "co.openvine.app.qa01.NotificationServiceExtension",
       "appGroup": "group.co.openvine.app.qa01",
       "displayName": "Divine QA 01",
-      "firebaseAppId": "1:972941478875:ios:qa01placeholder"
+      "firebaseAppId": "1:972941478875:ios:566f61de58d9d45044b5fe"
     },
     {
       "slot": "qa02",

--- a/.github/ios_qa_slots.json
+++ b/.github/ios_qa_slots.json
@@ -1,0 +1,154 @@
+{
+  "slots": [
+    {
+      "slot": "qa01",
+      "label": "ios-qa-slot-01",
+      "enabled": true,
+      "bundleId": "co.openvine.app.qa01",
+      "extensionBundleId": "co.openvine.app.qa01.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa01",
+      "displayName": "Divine QA 01",
+      "firebaseAppId": "1:972941478875:ios:qa01placeholder"
+    },
+    {
+      "slot": "qa02",
+      "label": "ios-qa-slot-02",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa02",
+      "extensionBundleId": "co.openvine.app.qa02.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa02",
+      "displayName": "Divine QA 02",
+      "firebaseAppId": ""
+    },
+    {
+      "slot": "qa03",
+      "label": "ios-qa-slot-03",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa03",
+      "extensionBundleId": "co.openvine.app.qa03.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa03",
+      "displayName": "Divine QA 03",
+      "firebaseAppId": ""
+    },
+    {
+      "slot": "qa04",
+      "label": "ios-qa-slot-04",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa04",
+      "extensionBundleId": "co.openvine.app.qa04.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa04",
+      "displayName": "Divine QA 04",
+      "firebaseAppId": ""
+    },
+    {
+      "slot": "qa05",
+      "label": "ios-qa-slot-05",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa05",
+      "extensionBundleId": "co.openvine.app.qa05.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa05",
+      "displayName": "Divine QA 05",
+      "firebaseAppId": ""
+    },
+    {
+      "slot": "qa06",
+      "label": "ios-qa-slot-06",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa06",
+      "extensionBundleId": "co.openvine.app.qa06.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa06",
+      "displayName": "Divine QA 06",
+      "firebaseAppId": ""
+    },
+    {
+      "slot": "qa07",
+      "label": "ios-qa-slot-07",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa07",
+      "extensionBundleId": "co.openvine.app.qa07.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa07",
+      "displayName": "Divine QA 07",
+      "firebaseAppId": ""
+    },
+    {
+      "slot": "qa08",
+      "label": "ios-qa-slot-08",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa08",
+      "extensionBundleId": "co.openvine.app.qa08.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa08",
+      "displayName": "Divine QA 08",
+      "firebaseAppId": ""
+    },
+    {
+      "slot": "qa09",
+      "label": "ios-qa-slot-09",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa09",
+      "extensionBundleId": "co.openvine.app.qa09.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa09",
+      "displayName": "Divine QA 09",
+      "firebaseAppId": ""
+    },
+    {
+      "slot": "qa10",
+      "label": "ios-qa-slot-10",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa10",
+      "extensionBundleId": "co.openvine.app.qa10.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa10",
+      "displayName": "Divine QA 10",
+      "firebaseAppId": ""
+    },
+    {
+      "slot": "qa11",
+      "label": "ios-qa-slot-11",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa11",
+      "extensionBundleId": "co.openvine.app.qa11.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa11",
+      "displayName": "Divine QA 11",
+      "firebaseAppId": ""
+    },
+    {
+      "slot": "qa12",
+      "label": "ios-qa-slot-12",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa12",
+      "extensionBundleId": "co.openvine.app.qa12.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa12",
+      "displayName": "Divine QA 12",
+      "firebaseAppId": ""
+    },
+    {
+      "slot": "qa13",
+      "label": "ios-qa-slot-13",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa13",
+      "extensionBundleId": "co.openvine.app.qa13.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa13",
+      "displayName": "Divine QA 13",
+      "firebaseAppId": ""
+    },
+    {
+      "slot": "qa14",
+      "label": "ios-qa-slot-14",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa14",
+      "extensionBundleId": "co.openvine.app.qa14.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa14",
+      "displayName": "Divine QA 14",
+      "firebaseAppId": ""
+    },
+    {
+      "slot": "qa15",
+      "label": "ios-qa-slot-15",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa15",
+      "extensionBundleId": "co.openvine.app.qa15.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa15",
+      "displayName": "Divine QA 15",
+      "firebaseAppId": ""
+    }
+  ]
+}

--- a/.github/scripts/ios_qa_slots.py
+++ b/.github/scripts/ios_qa_slots.py
@@ -1,0 +1,850 @@
+#!/usr/bin/env python3
+# ABOUTME: Library + CLI for the iOS QA PR build allocator and notifier.
+# ABOUTME: Pure Python with stdlib only — runs in GitHub Actions and Codemagic.
+
+"""ios_qa_slots: trust, allocation, comments, directory, and CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterable, Optional, Sequence
+
+
+STATE_MARKER_PREFIX = "<!-- divine-ios-qa-build:v1 "
+STATE_MARKER_SUFFIX = " -->"
+NEEDS_QA_LABEL = "needs-ios-qa"
+LABEL_BUILDING = "ios-qa:building"
+LABEL_READY = "ios-qa:ready"
+LABEL_QUEUED = "ios-qa:queued"
+LABEL_FAILED = "ios-qa:failed"
+STATE_LABELS = (LABEL_BUILDING, LABEL_READY, LABEL_QUEUED, LABEL_FAILED)
+TRUSTED_OWNER = "divinevideo"
+
+_SLOT_LABEL_RE = re.compile(r"^ios-qa-slot-(\d{2})$")
+_RELEVANT_PATH_PREFIXES = ("mobile/",)
+_RELEVANT_EXACT_PATHS = ("codemagic.yaml",)
+
+
+def load_slots(path: Path | str) -> list[dict]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))["slots"]
+
+
+def enabled_slots(slots: Sequence[dict]) -> list[dict]:
+    return [
+        s
+        for s in slots
+        if s.get("enabled") is True and s.get("firebaseAppId")
+    ]
+
+
+def required_labels(slots: Sequence[dict]) -> list[str]:
+    labels: list[str] = [slot["label"] for slot in slots]
+    labels.extend(STATE_LABELS)
+    labels.append(NEEDS_QA_LABEL)
+    return labels
+
+
+def is_trusted_pr(head_repo_owner: str, *, author_is_org_member: bool) -> bool:
+    if head_repo_owner == TRUSTED_OWNER:
+        return True
+    return bool(author_is_org_member)
+
+
+def is_eligible_pr(*, is_draft: bool, labels: Sequence[str]) -> bool:
+    if not is_draft:
+        return True
+    return NEEDS_QA_LABEL in labels
+
+
+def current_slot(labels: Iterable[str]) -> Optional[str]:
+    for label in labels:
+        match = _SLOT_LABEL_RE.match(label)
+        if match:
+            return f"qa{match.group(1)}"
+    return None
+
+
+def relevant_changes(changed_files: Iterable[str]) -> bool:
+    for path in changed_files:
+        if path in _RELEVANT_EXACT_PATHS:
+            return True
+        if any(path.startswith(prefix) for prefix in _RELEVANT_PATH_PREFIXES):
+            return True
+    return False
+
+
+def _has_qa_label(labels: Sequence[str]) -> bool:
+    return any(
+        _SLOT_LABEL_RE.match(label) or label in STATE_LABELS or label == NEEDS_QA_LABEL
+        for label in labels
+    )
+
+
+def decide_action(
+    *,
+    is_closed: bool,
+    has_relevant_changes: bool,
+    labels: Sequence[str],
+) -> str:
+    """Return 'allocate', 'cleanup', or 'skip'."""
+    if is_closed:
+        return "cleanup"
+    if not has_relevant_changes:
+        return "cleanup" if _has_qa_label(labels) else "skip"
+    return "allocate"
+
+
+def choose_slot(
+    slots: Sequence[dict],
+    prs: Sequence[dict],
+) -> dict[int, str]:
+    """Assign each PR a slot id (e.g. 'qa01') or the literal 'queued'.
+
+    Sort PRs by ``eligibility_at`` then ``number`` so order is deterministic.
+    Existing slot labels are preserved when the slot is still enabled.
+    """
+    enabled = enabled_slots(slots)
+    enabled_ids = {s["slot"] for s in enabled}
+    sorted_prs = sorted(prs, key=lambda p: (p["eligibility_at"], p["number"]))
+
+    occupied: dict[str, int] = {}
+    assignments: dict[int, str] = {}
+
+    # First pass: preserve still-valid slot assignments.
+    for pr in sorted_prs:
+        existing = current_slot(pr.get("labels", []))
+        if existing and existing in enabled_ids and existing not in occupied:
+            occupied[existing] = pr["number"]
+            assignments[pr["number"]] = existing
+
+    # Second pass: assign free slots in PR order.
+    for pr in sorted_prs:
+        if pr["number"] in assignments:
+            continue
+        free = next(
+            (s for s in enabled if s["slot"] not in occupied),
+            None,
+        )
+        if free is None:
+            assignments[pr["number"]] = "queued"
+        else:
+            occupied[free["slot"]] = pr["number"]
+            assignments[pr["number"]] = free["slot"]
+
+    return assignments
+
+
+def render_state_marker(state: dict[str, Any]) -> str:
+    return STATE_MARKER_PREFIX + json.dumps(state, sort_keys=True) + STATE_MARKER_SUFFIX
+
+
+def parse_state_marker(comment_body: Optional[str]) -> Optional[dict]:
+    if not comment_body:
+        return None
+    start = comment_body.find(STATE_MARKER_PREFIX)
+    if start < 0:
+        return None
+    end = comment_body.find(STATE_MARKER_SUFFIX, start + len(STATE_MARKER_PREFIX))
+    if end < 0:
+        return None
+    payload = comment_body[start + len(STATE_MARKER_PREFIX):end]
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+
+
+def extract_firebase_testing_uri(
+    distribution_json: dict[str, Any],
+) -> Optional[str]:
+    """Pull testing_uri from known Firebase CLI JSON shapes.
+
+    Recognized shapes:
+      - {"testing_uri": "..."}
+      - {"result": {"testing_uri": "..."}}
+      - {"result": {"release": {"testing_uri": "..."}}}
+
+    Returns None when only ``binary_download_uri`` is present — that link
+    expires within an hour and is not acceptable for QA comments.
+    """
+    candidates: list[Any] = [distribution_json]
+    if isinstance(distribution_json, dict):
+        result = distribution_json.get("result")
+        if isinstance(result, dict):
+            candidates.append(result)
+            release = result.get("release")
+            if isinstance(release, dict):
+                candidates.append(release)
+    for c in candidates:
+        if isinstance(c, dict):
+            uri = c.get("testing_uri")
+            if isinstance(uri, str) and uri:
+                return uri
+    return None
+
+
+def _status_heading(status: str, pr_number: int) -> str:
+    table = {
+        "ready": ("Ready", f"iOS QA build ready for PR #{pr_number}"),
+        "building": ("Building", f"Building iOS QA for PR #{pr_number}"),
+        "queued": ("Queued", f"iOS QA build queued for PR #{pr_number}"),
+        "failed": ("Failed", f"iOS QA build failed for PR #{pr_number}"),
+        "stale": ("Stale", f"iOS QA build skipped (stale) for PR #{pr_number}"),
+    }
+    label, title = table.get(status, (status.title(), f"iOS QA build {status} for PR #{pr_number}"))
+    return f"## {label} — {title}"
+
+
+def render_status_comment(
+    *,
+    status: str,
+    pr_number: int,
+    slot: Optional[str],
+    sha: str,
+    codemagic_build_url: Optional[str] = None,
+    codemagic_build_id: Optional[str] = None,
+    firebase_testing_uri: Optional[str] = None,
+    failure_reason: Optional[str] = None,
+    updated_at: Optional[str] = None,
+) -> str:
+    """Render the sticky PR comment body, including a hidden state marker."""
+    lines: list[str] = [_status_heading(status, pr_number), ""]
+    lines.append("| Field | Value |")
+    lines.append("|---|---|")
+    lines.append(f"| Slot | `{slot or 'unassigned'}` |")
+    lines.append(f"| Commit | `{sha}` |")
+    if firebase_testing_uri:
+        lines.append(f"| Install | [{firebase_testing_uri}]({firebase_testing_uri}) |")
+    if codemagic_build_url:
+        lines.append(f"| Codemagic | [{codemagic_build_url}]({codemagic_build_url}) |")
+    if failure_reason:
+        lines.append(f"| Reason | {failure_reason} |")
+    if updated_at:
+        lines.append(f"| Updated | {updated_at} |")
+    lines.append("")
+    state = {
+        "slot": slot,
+        "pr_number": pr_number,
+        "sha": sha,
+        "status": status,
+        "codemagic_build_id": codemagic_build_id,
+        "codemagic_build_url": codemagic_build_url,
+        "firebase_testing_uri": firebase_testing_uri,
+        "failure_reason": failure_reason,
+        "updated_at": updated_at,
+    }
+    lines.append(render_state_marker(state))
+    return "\n".join(lines) + "\n"
+
+
+def render_directory(
+    rows: Sequence[dict],
+    *,
+    updated_at: str,
+) -> str:
+    """Render the active QA build directory body for a tracking issue."""
+    lines: list[str] = [
+        "# iOS QA PR Builds",
+        "",
+        f"_Updated {updated_at}_",
+        "",
+        "| Slot | Status | PR | Commit | Install | Codemagic |",
+        "|---|---|---|---|---|---|",
+    ]
+    for row in rows:
+        slot = row.get("slot") or "—"
+        status = row.get("status", "unknown")
+        pr_number = row.get("pr_number")
+        sha = row.get("sha", "")
+        firebase = row.get("firebase_testing_uri")
+        codemagic = row.get("codemagic_build_url")
+        install = f"[install]({firebase})" if firebase else "—"
+        cm = f"[build]({codemagic})" if codemagic else "—"
+        lines.append(
+            f"| `{slot}` | {status} | PR #{pr_number} | `{sha}` | {install} | {cm} |",
+        )
+    return "\n".join(lines) + "\n"
+
+
+def render_codemagic_payload(
+    *,
+    app_id: str,
+    workflow_id: str,
+    branch: str,
+    pr: dict,
+    slot: dict,
+    default_env: str,
+) -> dict:
+    return {
+        "appId": app_id,
+        "workflowId": workflow_id,
+        "branch": branch,
+        "labels": [
+            f"pr-{pr['number']}",
+            slot["slot"],
+        ],
+        "environment": {
+            "variables": {
+                "PR_NUMBER": str(pr["number"]),
+                "PR_HEAD_SHA": pr["head_sha"],
+                "PR_HEAD_REPO": pr["head_repo"],
+                "PR_HEAD_REF": pr["head_ref"],
+                "QA_SLOT": slot["slot"],
+                "QA_BUNDLE_ID": slot["bundleId"],
+                "QA_EXTENSION_BUNDLE_ID": slot["extensionBundleId"],
+                "QA_APP_GROUP": slot["appGroup"],
+                "QA_DISPLAY_NAME": slot["displayName"],
+                "QA_FIREBASE_APP_ID": slot["firebaseAppId"],
+                "DEFAULT_ENV": default_env,
+                "CODEMAGIC_APP_ID": app_id,
+            },
+        },
+    }
+
+
+def cleanup_for_closed_pr(
+    *,
+    pr_number: int,
+    labels: Sequence[str],
+) -> dict:
+    to_remove = [
+        label
+        for label in labels
+        if _SLOT_LABEL_RE.match(label)
+        or label in STATE_LABELS
+        or label == NEEDS_QA_LABEL
+    ]
+    return {
+        "labels_to_remove": to_remove,
+        "mirror_branch": f"ios-qa/pr-{pr_number}",
+    }
+
+
+def label_bootstrap(slots: Sequence[dict]) -> list[dict]:
+    """Return a JSON-serialisable list of label specs."""
+    items: list[dict] = []
+    for slot in slots:
+        items.append(
+            {
+                "name": slot["label"],
+                "color": "0E8A16",
+                "description": f"iOS QA build slot {slot['slot'][2:]}",
+            },
+        )
+    items.append(
+        {
+            "name": LABEL_BUILDING,
+            "color": "FBCA04",
+            "description": "iOS QA build is running",
+        },
+    )
+    items.append(
+        {
+            "name": LABEL_READY,
+            "color": "0E8A16",
+            "description": "iOS QA build is ready for testing",
+        },
+    )
+    items.append(
+        {
+            "name": LABEL_QUEUED,
+            "color": "D4C5F9",
+            "description": "iOS QA build is waiting for a slot",
+        },
+    )
+    items.append(
+        {
+            "name": LABEL_FAILED,
+            "color": "D93F0B",
+            "description": "iOS QA build failed",
+        },
+    )
+    items.append(
+        {
+            "name": NEEDS_QA_LABEL,
+            "color": "5319E7",
+            "description": "Build this draft PR for iOS QA",
+        },
+    )
+    return items
+
+
+# --------------------------------------------------------------------------
+# GitHub API helpers (kept minimal — used by notify-github / upsert-comment)
+# --------------------------------------------------------------------------
+
+def _gh_request(
+    method: str,
+    url: str,
+    *,
+    token: str,
+    body: Optional[dict] = None,
+) -> dict:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req) as resp:
+        text = resp.read().decode("utf-8")
+        if not text:
+            return {}
+        return json.loads(text)
+
+
+def _gh_list_issue_comments(
+    repo: str,
+    issue_number: int,
+    *,
+    token: str,
+) -> list[dict]:
+    comments: list[dict] = []
+    page = 1
+    while True:
+        url = (
+            f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments"
+            f"?per_page=100&page={page}"
+        )
+        page_data = _gh_request("GET", url, token=token)
+        if not isinstance(page_data, list) or not page_data:
+            break
+        comments.extend(page_data)
+        if len(page_data) < 100:
+            break
+        page += 1
+    return comments
+
+
+def upsert_sticky_comment(
+    *,
+    repo: str,
+    issue_number: int,
+    body: str,
+    token: str,
+    marker_prefix: str = STATE_MARKER_PREFIX,
+) -> dict:
+    """Find a marker comment and PATCH it, or POST a new one."""
+    comments = _gh_list_issue_comments(repo, issue_number, token=token)
+    for comment in comments:
+        if marker_prefix in (comment.get("body") or ""):
+            url = (
+                f"https://api.github.com/repos/{repo}/issues/comments/"
+                f"{comment['id']}"
+            )
+            return _gh_request("PATCH", url, token=token, body={"body": body})
+    url = f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments"
+    return _gh_request("POST", url, token=token, body={"body": body})
+
+
+def update_pr_labels(
+    *,
+    repo: str,
+    issue_number: int,
+    add: Sequence[str] = (),
+    remove: Sequence[str] = (),
+    token: str,
+) -> None:
+    if add:
+        url = (
+            f"https://api.github.com/repos/{repo}/issues/{issue_number}/labels"
+        )
+        _gh_request("POST", url, token=token, body={"labels": list(add)})
+    for label in remove:
+        url = (
+            f"https://api.github.com/repos/{repo}/issues/{issue_number}/labels/"
+            f"{urllib.parse.quote(label)}"
+        )
+        try:
+            _gh_request("DELETE", url, token=token)
+        except urllib.error.HTTPError as exc:
+            if exc.code != 404:
+                raise
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+def _read_json_file(path: str) -> Any:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _write_json(payload: Any) -> None:
+    sys.stdout.write(json.dumps(payload, indent=2))
+    sys.stdout.write("\n")
+
+
+def cli_render_label_bootstrap(args: argparse.Namespace) -> int:
+    slots = load_slots(args.slots_file)
+    _write_json(label_bootstrap(slots))
+    return 0
+
+
+def cli_parse_firebase_distribution(args: argparse.Namespace) -> int:
+    payload = _read_json_file(args.json_file)
+    uri = extract_firebase_testing_uri(payload)
+    if args.require_testing_uri and not uri:
+        print(
+            "parse-firebase-distribution: testing_uri missing or unsupported "
+            "JSON shape (only binary_download_uri is not acceptable)",
+            file=sys.stderr,
+        )
+        return 1
+    _write_json({"testing_uri": uri})
+    return 0
+
+
+def cli_render_codemagic_payload(args: argparse.Namespace) -> int:
+    pr = _read_json_file(args.pr_json)
+    slot = _read_json_file(args.slot_json)
+    payload = render_codemagic_payload(
+        app_id=args.app_id,
+        workflow_id=args.workflow_id,
+        branch=args.branch,
+        pr=pr,
+        slot=slot,
+        default_env=args.default_env,
+    )
+    _write_json(payload)
+    return 0
+
+
+def cli_render_comment(args: argparse.Namespace) -> int:
+    firebase_uri: Optional[str] = None
+    if args.firebase_json and Path(args.firebase_json).exists():
+        firebase_uri = extract_firebase_testing_uri(_read_json_file(args.firebase_json))
+    body = render_status_comment(
+        status=args.status,
+        pr_number=args.pr_number,
+        slot=args.slot,
+        sha=args.sha,
+        codemagic_build_url=args.codemagic_build_url,
+        codemagic_build_id=args.codemagic_build_id,
+        firebase_testing_uri=firebase_uri,
+        failure_reason=args.failure_reason,
+        updated_at=args.updated_at,
+    )
+    sys.stdout.write(body)
+    return 0
+
+
+def cli_render_directory(args: argparse.Namespace) -> int:
+    rows = _read_json_file(args.rows_file)
+    body = render_directory(rows, updated_at=args.updated_at)
+    sys.stdout.write(body)
+    return 0
+
+
+def cli_cleanup(args: argparse.Namespace) -> int:
+    labels = _read_json_file(args.labels_json) if args.labels_json else []
+    payload = cleanup_for_closed_pr(pr_number=args.pr_number, labels=labels)
+    _write_json(payload)
+    return 0
+
+
+def cli_parse_comment_state(args: argparse.Namespace) -> int:
+    body = Path(args.body_file).read_text(encoding="utf-8")
+    state = parse_state_marker(body)
+    _write_json(state or {})
+    return 0
+
+
+def _eligible_for_slot(pr: dict) -> bool:
+    if pr.get("is_closed"):
+        return False
+    if not is_trusted_pr(
+        pr.get("head_repo_owner", ""),
+        author_is_org_member=bool(pr.get("author_is_org_member")),
+    ):
+        return False
+    if not is_eligible_pr(
+        is_draft=bool(pr.get("is_draft")),
+        labels=pr.get("labels", []),
+    ):
+        return False
+    if not relevant_changes(pr.get("changed_files", [])):
+        return False
+    return True
+
+
+def allocate_for_target(
+    *,
+    slots: Sequence[dict],
+    prs: Sequence[dict],
+    target_number: int,
+    target_labels_fallback: Sequence[str] = (),
+) -> dict:
+    """Compute the action for one PR given the full open-PR context.
+
+    Returns a dict with at least ``action`` (``allocate``/``skip``/``cleanup``).
+    On ``allocate`` includes ``status`` (building/queued) and ``slot``.
+    On ``cleanup`` includes ``labels_to_remove`` and ``mirror_branch``.
+    On ``skip`` includes ``reason``.
+    """
+    target = next((p for p in prs if p["number"] == target_number), None)
+    if target is None:
+        # PR not in open list — treat as closed for cleanup purposes.
+        return {
+            "action": "cleanup",
+            **cleanup_for_closed_pr(
+                pr_number=target_number,
+                labels=list(target_labels_fallback),
+            ),
+        }
+
+    labels = target.get("labels", [])
+    is_closed = bool(target.get("is_closed"))
+    has_changes = relevant_changes(target.get("changed_files", []))
+    action = decide_action(
+        is_closed=is_closed,
+        has_relevant_changes=has_changes,
+        labels=labels,
+    )
+
+    if action == "cleanup":
+        return {
+            "action": "cleanup",
+            **cleanup_for_closed_pr(pr_number=target_number, labels=labels),
+        }
+    if action == "skip":
+        return {"action": "skip", "reason": "no relevant changes"}
+
+    # action == 'allocate' — gate on trust + eligibility before competing.
+    if not is_trusted_pr(
+        target.get("head_repo_owner", ""),
+        author_is_org_member=bool(target.get("author_is_org_member")),
+    ):
+        return {"action": "skip", "reason": "not trusted"}
+    if not is_eligible_pr(
+        is_draft=bool(target.get("is_draft")),
+        labels=labels,
+    ):
+        return {"action": "skip", "reason": "draft without needs-ios-qa label"}
+
+    candidates = [
+        {
+            "number": p["number"],
+            "labels": p.get("labels", []),
+            "eligibility_at": p.get("eligibility_at", ""),
+        }
+        for p in prs
+        if _eligible_for_slot(p)
+    ]
+    assignments = choose_slot(slots, candidates)
+    slot_id = assignments.get(target_number, "queued")
+    if slot_id == "queued":
+        return {"action": "allocate", "status": "queued", "slot": None}
+    slot = next(s for s in slots if s["slot"] == slot_id)
+    return {"action": "allocate", "status": "building", "slot": slot}
+
+
+def cli_allocate(args: argparse.Namespace) -> int:
+    slots = load_slots(args.slots_file)
+    prs = _read_json_file(args.prs_file)
+    fallback_labels = (
+        args.target_labels.split(",") if args.target_labels else ()
+    )
+    payload = allocate_for_target(
+        slots=slots,
+        prs=prs,
+        target_number=args.target_number,
+        target_labels_fallback=fallback_labels,
+    )
+    _write_json(payload)
+    return 0
+
+
+def cli_reconcile(args: argparse.Namespace) -> int:
+    """Compute slot assignments across all open PRs."""
+    slots = load_slots(args.slots_file)
+    prs = _read_json_file(args.prs_file)
+    candidates = [
+        {
+            "number": p["number"],
+            "labels": p.get("labels", []),
+            "eligibility_at": p.get("eligibility_at", ""),
+        }
+        for p in prs
+        if _eligible_for_slot(p)
+    ]
+    assignments = choose_slot(slots, candidates)
+    enriched: dict[int, dict] = {}
+    for pr in prs:
+        n = pr["number"]
+        slot_id = assignments.get(n)
+        if slot_id is None:
+            # PR not eligible for a slot. Determine cleanup vs skip.
+            has_qa = _has_qa_label(pr.get("labels", []))
+            if has_qa or pr.get("is_closed"):
+                enriched[n] = {
+                    "action": "cleanup",
+                    **cleanup_for_closed_pr(
+                        pr_number=n,
+                        labels=pr.get("labels", []),
+                    ),
+                }
+            else:
+                enriched[n] = {"action": "skip"}
+        elif slot_id == "queued":
+            enriched[n] = {"action": "allocate", "status": "queued", "slot": None}
+        else:
+            slot = next(s for s in slots if s["slot"] == slot_id)
+            enriched[n] = {
+                "action": "allocate",
+                "status": "building",
+                "slot": slot,
+            }
+    _write_json({str(k): v for k, v in enriched.items()})
+    return 0
+
+
+def cli_upsert_comment(args: argparse.Namespace) -> int:
+    token = os.environ.get(args.token_env)
+    if not token:
+        print(
+            f"upsert-comment: missing {args.token_env} in environment",
+            file=sys.stderr,
+        )
+        return 1
+    body = Path(args.body_file).read_text(encoding="utf-8")
+    upsert_sticky_comment(
+        repo=args.repo,
+        issue_number=args.issue_number,
+        body=body,
+        token=token,
+        marker_prefix=args.marker_prefix,
+    )
+    return 0
+
+
+def cli_notify_github(args: argparse.Namespace) -> int:
+    token = os.environ.get(args.token_env)
+    if not token:
+        print(
+            f"notify-github: missing {args.token_env} in environment",
+            file=sys.stderr,
+        )
+        return 1
+    body = Path(args.body_file).read_text(encoding="utf-8")
+    upsert_sticky_comment(
+        repo=args.repo,
+        issue_number=args.issue_number,
+        body=body,
+        token=token,
+    )
+    add: list[str] = []
+    remove: list[str] = []
+    if args.status == "ready":
+        add.append(LABEL_READY)
+        remove.append(LABEL_BUILDING)
+    elif args.status == "failed":
+        add.append(LABEL_FAILED)
+        remove.append(LABEL_BUILDING)
+    elif args.status == "stale":
+        # Stale: keep slot label, remove building/ready/failed
+        remove.extend([LABEL_BUILDING, LABEL_READY, LABEL_FAILED])
+    update_pr_labels(
+        repo=args.repo,
+        issue_number=args.issue_number,
+        add=add,
+        remove=remove,
+        token=token,
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="ios_qa_slots")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_labels = sub.add_parser("render-label-bootstrap")
+    p_labels.add_argument("--slots-file", required=True)
+    p_labels.set_defaults(func=cli_render_label_bootstrap)
+
+    p_fb = sub.add_parser("parse-firebase-distribution")
+    p_fb.add_argument("--json-file", required=True)
+    p_fb.add_argument("--require-testing-uri", action="store_true")
+    p_fb.set_defaults(func=cli_parse_firebase_distribution)
+
+    p_cm = sub.add_parser("render-codemagic-payload")
+    p_cm.add_argument("--app-id", required=True)
+    p_cm.add_argument("--workflow-id", required=True)
+    p_cm.add_argument("--branch", required=True)
+    p_cm.add_argument("--pr-json", required=True)
+    p_cm.add_argument("--slot-json", required=True)
+    p_cm.add_argument("--default-env", default="STAGING")
+    p_cm.set_defaults(func=cli_render_codemagic_payload)
+
+    p_comment = sub.add_parser("render-comment")
+    p_comment.add_argument("--status", required=True)
+    p_comment.add_argument("--pr-number", required=True, type=int)
+    p_comment.add_argument("--slot")
+    p_comment.add_argument("--sha", required=True)
+    p_comment.add_argument("--codemagic-build-url")
+    p_comment.add_argument("--codemagic-build-id")
+    p_comment.add_argument("--firebase-json")
+    p_comment.add_argument("--failure-reason")
+    p_comment.add_argument("--updated-at")
+    p_comment.set_defaults(func=cli_render_comment)
+
+    p_dir = sub.add_parser("render-directory")
+    p_dir.add_argument("--rows-file", required=True)
+    p_dir.add_argument("--updated-at", required=True)
+    p_dir.set_defaults(func=cli_render_directory)
+
+    p_clean = sub.add_parser("cleanup")
+    p_clean.add_argument("--pr-number", required=True, type=int)
+    p_clean.add_argument("--labels-json")
+    p_clean.set_defaults(func=cli_cleanup)
+
+    p_parse_state = sub.add_parser("parse-comment-state")
+    p_parse_state.add_argument("--body-file", required=True)
+    p_parse_state.set_defaults(func=cli_parse_comment_state)
+
+    p_alloc = sub.add_parser("allocate")
+    p_alloc.add_argument("--prs-file", required=True)
+    p_alloc.add_argument("--slots-file", required=True)
+    p_alloc.add_argument("--target-number", required=True, type=int)
+    p_alloc.add_argument(
+        "--target-labels",
+        help="Comma-separated labels used for cleanup if target PR is missing.",
+    )
+    p_alloc.set_defaults(func=cli_allocate)
+
+    p_recon = sub.add_parser("reconcile")
+    p_recon.add_argument("--prs-file", required=True)
+    p_recon.add_argument("--slots-file", required=True)
+    p_recon.set_defaults(func=cli_reconcile)
+
+    p_upsert = sub.add_parser("upsert-comment")
+    p_upsert.add_argument("--repo", required=True)
+    p_upsert.add_argument("--issue-number", required=True, type=int)
+    p_upsert.add_argument("--body-file", required=True)
+    p_upsert.add_argument("--token-env", default="GITHUB_TOKEN")
+    p_upsert.add_argument("--marker-prefix", default=STATE_MARKER_PREFIX)
+    p_upsert.set_defaults(func=cli_upsert_comment)
+
+    p_notify = sub.add_parser("notify-github")
+    p_notify.add_argument("--repo", required=True)
+    p_notify.add_argument("--issue-number", required=True, type=int)
+    p_notify.add_argument("--body-file", required=True)
+    p_notify.add_argument("--status", required=True)
+    p_notify.add_argument("--token-env", default="IOS_QA_GITHUB_TOKEN")
+    p_notify.set_defaults(func=cli_notify_github)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/ios_qa_slots.py
+++ b/.github/scripts/ios_qa_slots.py
@@ -20,6 +20,7 @@ from typing import Any, Iterable, Optional, Sequence
 
 STATE_MARKER_PREFIX = "<!-- divine-ios-qa-build:v1 "
 STATE_MARKER_SUFFIX = " -->"
+DIRECTORY_MARKER_PREFIX = "<!-- divine-ios-qa-directory:v1 "
 NEEDS_QA_LABEL = "needs-ios-qa"
 LABEL_BUILDING = "ios-qa:building"
 LABEL_READY = "ios-qa:ready"
@@ -271,6 +272,12 @@ def render_directory(
         lines.append(
             f"| `{slot}` | {status} | PR #{pr_number} | `{sha}` | {install} | {cm} |",
         )
+    lines.append("")
+    lines.append(
+        DIRECTORY_MARKER_PREFIX
+        + json.dumps({"updated_at": updated_at}, sort_keys=True)
+        + STATE_MARKER_SUFFIX,
+    )
     return "\n".join(lines) + "\n"
 
 

--- a/.github/scripts/ios_qa_slots.py
+++ b/.github/scripts/ios_qa_slots.py
@@ -73,6 +73,18 @@ def current_slot(labels: Iterable[str]) -> Optional[str]:
     return None
 
 
+def slot_labels_to_remove(
+    labels: Iterable[str],
+    *,
+    keep_label: Optional[str] = None,
+) -> list[str]:
+    return [
+        label
+        for label in labels
+        if _SLOT_LABEL_RE.match(label) and label != keep_label
+    ]
+
+
 def relevant_changes(changed_files: Iterable[str]) -> bool:
     for path in changed_files:
         if path in _RELEVANT_EXACT_PATHS:
@@ -281,6 +293,40 @@ def render_directory(
     return "\n".join(lines) + "\n"
 
 
+def directory_rows_from_reconcile(
+    reconcile: dict[Any, dict],
+    prs: dict[int, dict],
+) -> list[dict]:
+    rows: list[dict] = []
+    for number_key, decision in reconcile.items():
+        if decision.get("action") != "allocate":
+            continue
+        number = int(number_key)
+        pr = prs.get(number) or {}
+        slot = decision.get("slot") or {}
+        slot_id = slot.get("slot")
+        head_sha = pr.get("head_sha", "")
+        row = {
+            "slot": slot_id,
+            "status": decision.get("status"),
+            "pr_number": number,
+            "sha": head_sha,
+            "firebase_testing_uri": None,
+            "codemagic_build_url": None,
+        }
+
+        state = pr.get("qa_comment_state") or {}
+        if isinstance(state, dict):
+            state_sha = state.get("sha")
+            state_slot = state.get("slot")
+            if state_sha == head_sha and (slot_id is None or state_slot == slot_id):
+                row["status"] = state.get("status") or row["status"]
+                row["firebase_testing_uri"] = state.get("firebase_testing_uri")
+                row["codemagic_build_url"] = state.get("codemagic_build_url")
+        rows.append(row)
+    return rows
+
+
 def render_codemagic_payload(
     *,
     app_id: str,
@@ -382,6 +428,24 @@ def label_bootstrap(slots: Sequence[dict]) -> list[dict]:
         },
     )
     return items
+
+
+def resolve_notify_status(
+    *,
+    stale: bool,
+    firebase_distribution_json_exists: bool,
+    firebase_links_json: Optional[dict[str, Any]],
+) -> dict[str, Optional[str]]:
+    if stale:
+        return {"status": "stale", "firebase_json": None}
+    testing_uri = (
+        extract_firebase_testing_uri(firebase_links_json)
+        if isinstance(firebase_links_json, dict)
+        else None
+    )
+    if firebase_distribution_json_exists and testing_uri:
+        return {"status": "ready", "firebase_json": "firebase-distribution.json"}
+    return {"status": "failed", "firebase_json": None}
 
 
 # --------------------------------------------------------------------------
@@ -552,6 +616,17 @@ def cli_render_directory(args: argparse.Namespace) -> int:
     return 0
 
 
+def cli_render_directory_rows(args: argparse.Namespace) -> int:
+    reconcile = _read_json_file(args.reconcile_file)
+    prs_payload = _read_json_file(args.prs_file)
+    prs = {
+        int(pr["number"]): pr
+        for pr in prs_payload
+    }
+    _write_json(directory_rows_from_reconcile(reconcile, prs))
+    return 0
+
+
 def cli_cleanup(args: argparse.Namespace) -> int:
     labels = _read_json_file(args.labels_json) if args.labels_json else []
     payload = cleanup_for_closed_pr(pr_number=args.pr_number, labels=labels)
@@ -566,9 +641,14 @@ def cli_parse_comment_state(args: argparse.Namespace) -> int:
     return 0
 
 
-def _eligible_for_slot(pr: dict) -> bool:
+def _eligible_for_slot(
+    pr: dict,
+    *,
+    preserve_labeled_occupants: bool = False,
+) -> bool:
     if pr.get("is_closed"):
         return False
+    labels = pr.get("labels", [])
     if not is_trusted_pr(
         pr.get("head_repo_owner", ""),
         author_is_org_member=bool(pr.get("author_is_org_member")),
@@ -576,12 +656,12 @@ def _eligible_for_slot(pr: dict) -> bool:
         return False
     if not is_eligible_pr(
         is_draft=bool(pr.get("is_draft")),
-        labels=pr.get("labels", []),
+        labels=labels,
     ):
         return False
-    if not relevant_changes(pr.get("changed_files", [])):
-        return False
-    return True
+    if relevant_changes(pr.get("changed_files", [])):
+        return True
+    return preserve_labeled_occupants and current_slot(labels) is not None
 
 
 def allocate_for_target(
@@ -645,14 +725,27 @@ def allocate_for_target(
             "eligibility_at": p.get("eligibility_at", ""),
         }
         for p in prs
-        if _eligible_for_slot(p)
+        if _eligible_for_slot(p, preserve_labeled_occupants=True)
     ]
     assignments = choose_slot(slots, candidates)
     slot_id = assignments.get(target_number, "queued")
     if slot_id == "queued":
-        return {"action": "allocate", "status": "queued", "slot": None}
+        return {
+            "action": "allocate",
+            "status": "queued",
+            "slot": None,
+            "labels_to_remove": slot_labels_to_remove(labels),
+        }
     slot = next(s for s in slots if s["slot"] == slot_id)
-    return {"action": "allocate", "status": "building", "slot": slot}
+    return {
+        "action": "allocate",
+        "status": "building",
+        "slot": slot,
+        "labels_to_remove": slot_labels_to_remove(
+            labels,
+            keep_label=slot["label"],
+        ),
+    }
 
 
 def cli_allocate(args: argparse.Namespace) -> int:
@@ -671,10 +764,12 @@ def cli_allocate(args: argparse.Namespace) -> int:
     return 0
 
 
-def cli_reconcile(args: argparse.Namespace) -> int:
+def reconcile_assignments(
+    *,
+    slots: Sequence[dict],
+    prs: Sequence[dict],
+) -> dict[int, dict]:
     """Compute slot assignments across all open PRs."""
-    slots = load_slots(args.slots_file)
-    prs = _read_json_file(args.prs_file)
     candidates = [
         {
             "number": p["number"],
@@ -703,15 +798,54 @@ def cli_reconcile(args: argparse.Namespace) -> int:
             else:
                 enriched[n] = {"action": "skip"}
         elif slot_id == "queued":
-            enriched[n] = {"action": "allocate", "status": "queued", "slot": None}
+            enriched[n] = {
+                "action": "allocate",
+                "status": "queued",
+                "slot": None,
+                "labels_to_remove": slot_labels_to_remove(pr.get("labels", [])),
+            }
         else:
             slot = next(s for s in slots if s["slot"] == slot_id)
             enriched[n] = {
                 "action": "allocate",
                 "status": "building",
                 "slot": slot,
+                "labels_to_remove": slot_labels_to_remove(
+                    pr.get("labels", []),
+                    keep_label=slot["label"],
+                ),
             }
+    return enriched
+
+
+def cli_reconcile(args: argparse.Namespace) -> int:
+    slots = load_slots(args.slots_file)
+    prs = _read_json_file(args.prs_file)
+    enriched = reconcile_assignments(slots=slots, prs=prs)
     _write_json({str(k): v for k, v in enriched.items()})
+    return 0
+
+
+def cli_resolve_notify_status(args: argparse.Namespace) -> int:
+    stale = args.stale or (
+        bool(args.stale_env)
+        and os.environ.get(args.stale_env, "").lower() == "true"
+    )
+    firebase_path = Path(args.firebase_json)
+    links_path = Path(args.firebase_links_json)
+    links_json: Optional[dict[str, Any]] = None
+    if links_path.exists() and links_path.stat().st_size > 0:
+        payload = _read_json_file(str(links_path))
+        if isinstance(payload, dict):
+            links_json = payload
+    payload = resolve_notify_status(
+        stale=stale,
+        firebase_distribution_json_exists=(
+            firebase_path.exists() and firebase_path.stat().st_size > 0
+        ),
+        firebase_links_json=links_json,
+    )
+    _write_json(payload)
     return 0
 
 
@@ -809,6 +943,11 @@ def main(argv: list[str] | None = None) -> int:
     p_dir.add_argument("--updated-at", required=True)
     p_dir.set_defaults(func=cli_render_directory)
 
+    p_dir_rows = sub.add_parser("render-directory-rows")
+    p_dir_rows.add_argument("--reconcile-file", required=True)
+    p_dir_rows.add_argument("--prs-file", required=True)
+    p_dir_rows.set_defaults(func=cli_render_directory_rows)
+
     p_clean = sub.add_parser("cleanup")
     p_clean.add_argument("--pr-number", required=True, type=int)
     p_clean.add_argument("--labels-json")
@@ -832,6 +971,19 @@ def main(argv: list[str] | None = None) -> int:
     p_recon.add_argument("--prs-file", required=True)
     p_recon.add_argument("--slots-file", required=True)
     p_recon.set_defaults(func=cli_reconcile)
+
+    p_notify_status = sub.add_parser("resolve-notify-status")
+    p_notify_status.add_argument(
+        "--firebase-json",
+        default="firebase-distribution.json",
+    )
+    p_notify_status.add_argument(
+        "--firebase-links-json",
+        default="firebase-distribution-links.json",
+    )
+    p_notify_status.add_argument("--stale", action="store_true")
+    p_notify_status.add_argument("--stale-env")
+    p_notify_status.set_defaults(func=cli_resolve_notify_status)
 
     p_upsert = sub.add_parser("upsert-comment")
     p_upsert.add_argument("--repo", required=True)

--- a/.github/scripts/tests/test_ios_qa_slots.py
+++ b/.github/scripts/tests/test_ios_qa_slots.py
@@ -393,6 +393,7 @@ class DirectoryRenderer(unittest.TestCase):
         self.assertIn("PR #10", body)
         self.assertIn("PR #11", body)
         self.assertIn("Updated", body)
+        self.assertIn(lib.DIRECTORY_MARKER_PREFIX.strip(), body)
 
 
 class CodemagicPayload(unittest.TestCase):

--- a/.github/scripts/tests/test_ios_qa_slots.py
+++ b/.github/scripts/tests/test_ios_qa_slots.py
@@ -1,0 +1,641 @@
+"""Tests for ios_qa_slots.py — pure functions and CLI surfaces."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+SCRIPT_DIR = THIS_DIR.parent
+SCRIPT_PATH = SCRIPT_DIR / "ios_qa_slots.py"
+SLOTS_JSON = SCRIPT_DIR.parent / "ios_qa_slots.json"
+
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import ios_qa_slots as lib  # noqa: E402
+
+ALL_15 = [
+    {
+        "slot": f"qa{i:02d}",
+        "label": f"ios-qa-slot-{i:02d}",
+        "enabled": True,
+        "bundleId": f"co.openvine.app.qa{i:02d}",
+        "extensionBundleId": f"co.openvine.app.qa{i:02d}.NotificationServiceExtension",
+        "appGroup": f"group.co.openvine.app.qa{i:02d}",
+        "displayName": f"Divine QA {i:02d}",
+        "firebaseAppId": f"1:972941478875:ios:fakeqa{i:02d}",
+    }
+    for i in range(1, 16)
+]
+
+
+class TrustChecks(unittest.TestCase):
+    def test_internal_pr_trusted(self):
+        self.assertTrue(lib.is_trusted_pr("divinevideo", author_is_org_member=False))
+
+    def test_org_member_fork_trusted(self):
+        self.assertTrue(lib.is_trusted_pr("contributor", author_is_org_member=True))
+
+    def test_outside_fork_non_member_not_trusted(self):
+        self.assertFalse(
+            lib.is_trusted_pr("contributor", author_is_org_member=False),
+        )
+
+
+class EligibilityChecks(unittest.TestCase):
+    def test_non_draft_eligible(self):
+        self.assertTrue(lib.is_eligible_pr(is_draft=False, labels=[]))
+
+    def test_draft_with_needs_label_eligible(self):
+        self.assertTrue(
+            lib.is_eligible_pr(is_draft=True, labels=["needs-ios-qa", "wip"]),
+        )
+
+    def test_draft_without_needs_label_not_eligible(self):
+        self.assertFalse(lib.is_eligible_pr(is_draft=True, labels=["wip"]))
+
+
+class CurrentSlot(unittest.TestCase):
+    def test_returns_slot_for_label(self):
+        self.assertEqual(
+            lib.current_slot(["docs", "ios-qa-slot-03", "ios-qa:building"]),
+            "qa03",
+        )
+
+    def test_returns_none_when_no_slot_label(self):
+        self.assertIsNone(lib.current_slot(["docs", "needs-ios-qa"]))
+
+
+class RelevantChanges(unittest.TestCase):
+    def test_mobile_change_is_relevant(self):
+        self.assertTrue(lib.relevant_changes(["mobile/lib/main.dart"]))
+
+    def test_codemagic_yaml_is_relevant(self):
+        self.assertTrue(lib.relevant_changes(["codemagic.yaml"]))
+
+    def test_unrelated_change_is_not_relevant(self):
+        self.assertFalse(
+            lib.relevant_changes(["README.md", "docs/foo.md"]),
+        )
+
+
+class DecideAction(unittest.TestCase):
+    def test_closed_pr_always_cleanup(self):
+        action = lib.decide_action(
+            is_closed=True,
+            has_relevant_changes=False,
+            labels=["ios-qa-slot-01", "ios-qa:ready"],
+        )
+        self.assertEqual(action, "cleanup")
+
+    def test_open_no_changes_no_qa_label_skip(self):
+        action = lib.decide_action(
+            is_closed=False,
+            has_relevant_changes=False,
+            labels=["docs"],
+        )
+        self.assertEqual(action, "skip")
+
+    def test_open_no_changes_with_qa_label_cleanup(self):
+        action = lib.decide_action(
+            is_closed=False,
+            has_relevant_changes=False,
+            labels=["ios-qa-slot-02", "ios-qa:ready"],
+        )
+        self.assertEqual(action, "cleanup")
+
+    def test_open_with_changes_allocate(self):
+        action = lib.decide_action(
+            is_closed=False,
+            has_relevant_changes=True,
+            labels=[],
+        )
+        self.assertEqual(action, "allocate")
+
+
+class EnabledSlots(unittest.TestCase):
+    def test_filters_out_disabled(self):
+        slots = [
+            {**ALL_15[0], "enabled": False},
+            ALL_15[1],
+        ]
+        result = lib.enabled_slots(slots)
+        self.assertEqual([s["slot"] for s in result], ["qa02"])
+
+    def test_filters_out_empty_firebase_app_id(self):
+        slots = [
+            {**ALL_15[0], "firebaseAppId": ""},
+            ALL_15[1],
+        ]
+        result = lib.enabled_slots(slots)
+        self.assertEqual([s["slot"] for s in result], ["qa02"])
+
+
+class ChooseSlot(unittest.TestCase):
+    def test_first_free_enabled_slot_assigned(self):
+        slots = ALL_15[:3]
+        result = lib.choose_slot(
+            slots,
+            [{"number": 1, "labels": [], "eligibility_at": "2026-01-01"}],
+        )
+        self.assertEqual(result, {1: "qa01"})
+
+    def test_existing_slot_label_preserved(self):
+        slots = ALL_15[:3]
+        result = lib.choose_slot(
+            slots,
+            [
+                {
+                    "number": 1,
+                    "labels": ["ios-qa-slot-02"],
+                    "eligibility_at": "2026-01-01",
+                },
+            ],
+        )
+        self.assertEqual(result, {1: "qa02"})
+
+    def test_disabled_slot_label_replaced(self):
+        # PR has slot label for qa10 but qa10 is disabled now: should reassign
+        slots = ALL_15[:3]
+        result = lib.choose_slot(
+            slots,
+            [
+                {
+                    "number": 1,
+                    "labels": ["ios-qa-slot-10"],
+                    "eligibility_at": "2026-01-01",
+                },
+            ],
+        )
+        self.assertEqual(result, {1: "qa01"})
+
+    def test_queued_when_all_slots_occupied(self):
+        slots = ALL_15[:2]
+        result = lib.choose_slot(
+            slots,
+            [
+                {
+                    "number": 1,
+                    "labels": ["ios-qa-slot-01"],
+                    "eligibility_at": "2026-01-01",
+                },
+                {
+                    "number": 2,
+                    "labels": ["ios-qa-slot-02"],
+                    "eligibility_at": "2026-01-02",
+                },
+                {"number": 3, "labels": [], "eligibility_at": "2026-01-03"},
+            ],
+        )
+        self.assertEqual(result, {1: "qa01", 2: "qa02", 3: "queued"})
+
+    def test_queued_ordering_oldest_eligibility_first(self):
+        slots = ALL_15[:1]
+        result = lib.choose_slot(
+            slots,
+            [
+                {"number": 9, "labels": [], "eligibility_at": "2026-01-02"},
+                {"number": 5, "labels": [], "eligibility_at": "2026-01-01"},
+            ],
+        )
+        self.assertEqual(result, {5: "qa01", 9: "queued"})
+
+    def test_queued_ordering_tiebreak_by_pr_number(self):
+        slots = ALL_15[:1]
+        result = lib.choose_slot(
+            slots,
+            [
+                {"number": 9, "labels": [], "eligibility_at": "2026-01-01"},
+                {"number": 5, "labels": [], "eligibility_at": "2026-01-01"},
+            ],
+        )
+        self.assertEqual(result, {5: "qa01", 9: "queued"})
+
+
+class StateMarker(unittest.TestCase):
+    def test_round_trip_preserves_full_payload(self):
+        state = {
+            "slot": "qa01",
+            "pr_number": 123,
+            "sha": "abcdef0123456789abcdef0123456789abcdef01",
+            "status": "ready",
+            "codemagic_build_id": "build-xyz",
+            "codemagic_build_url": "https://codemagic.io/app/X/build/Y",
+            "firebase_testing_uri": "https://appdistribution.firebase.google.com/testing/abc",
+            "failure_reason": None,
+            "updated_at": "2026-04-26T16:30:00Z",
+        }
+        rendered = lib.render_state_marker(state)
+        body = "Comment body\n" + rendered + "\nmore stuff"
+        self.assertEqual(lib.parse_state_marker(body), state)
+
+    def test_returns_none_when_marker_missing(self):
+        self.assertIsNone(lib.parse_state_marker("just text, no marker"))
+
+    def test_full_sha_never_truncated_in_marker(self):
+        state = {
+            "sha": "abcdef0123456789abcdef0123456789abcdef01",
+            "slot": "qa01",
+            "pr_number": 1,
+            "status": "ready",
+        }
+        marker = lib.render_state_marker(state)
+        self.assertIn("abcdef0123456789abcdef0123456789abcdef01", marker)
+
+
+class RequiredLabels(unittest.TestCase):
+    def test_returns_all_15_slots_plus_4_states_plus_needs(self):
+        labels = lib.required_labels(ALL_15)
+        for i in range(1, 16):
+            self.assertIn(f"ios-qa-slot-{i:02d}", labels)
+        for state in (
+            "ios-qa:building",
+            "ios-qa:ready",
+            "ios-qa:queued",
+            "ios-qa:failed",
+        ):
+            self.assertIn(state, labels)
+        self.assertIn("needs-ios-qa", labels)
+        self.assertEqual(len(labels), 20)
+
+
+class FirebaseDistributionParser(unittest.TestCase):
+    def test_top_level_testing_uri(self):
+        self.assertEqual(
+            lib.extract_firebase_testing_uri({"testing_uri": "https://x"}),
+            "https://x",
+        )
+
+    def test_result_wrapper(self):
+        self.assertEqual(
+            lib.extract_firebase_testing_uri(
+                {"result": {"testing_uri": "https://x"}},
+            ),
+            "https://x",
+        )
+
+    def test_result_release_wrapper(self):
+        self.assertEqual(
+            lib.extract_firebase_testing_uri(
+                {"result": {"release": {"testing_uri": "https://x"}}},
+            ),
+            "https://x",
+        )
+
+    def test_rejects_only_binary_download_uri(self):
+        self.assertIsNone(
+            lib.extract_firebase_testing_uri(
+                {"binary_download_uri": "https://expires.in/1h"},
+            ),
+        )
+        self.assertIsNone(
+            lib.extract_firebase_testing_uri(
+                {"result": {"binary_download_uri": "https://x"}},
+            ),
+        )
+
+    def test_rejects_when_uri_missing(self):
+        self.assertIsNone(lib.extract_firebase_testing_uri({"result": {}}))
+
+
+class StatusCommentRenderer(unittest.TestCase):
+    SHA = "abcdef0123456789abcdef0123456789abcdef01"
+
+    def test_includes_full_sha_pr_slot_links_and_marker(self):
+        body = lib.render_status_comment(
+            status="ready",
+            pr_number=42,
+            slot="qa01",
+            sha=self.SHA,
+            codemagic_build_url="https://codemagic.io/app/X/build/Y",
+            firebase_testing_uri="https://appdist.firebase.google.com/testing/Z",
+        )
+        self.assertIn(self.SHA, body)
+        self.assertIn("qa01", body)
+        self.assertIn("PR #42", body)
+        self.assertIn("https://appdist.firebase.google.com/testing/Z", body)
+        self.assertIn("https://codemagic.io/app/X/build/Y", body)
+        self.assertIn(lib.STATE_MARKER_PREFIX.strip(), body)
+
+    def test_failed_status_renders_reason(self):
+        body = lib.render_status_comment(
+            status="failed",
+            pr_number=42,
+            slot="qa01",
+            sha=self.SHA,
+            codemagic_build_url="https://codemagic.io/app/X/build/Y",
+            failure_reason="Codemagic build failed",
+        )
+        self.assertIn("Codemagic build failed", body)
+
+    def test_stale_status_does_not_require_firebase_uri(self):
+        body = lib.render_status_comment(
+            status="stale",
+            pr_number=42,
+            slot="qa01",
+            sha=self.SHA,
+            codemagic_build_url="https://codemagic.io/app/X/build/Y",
+        )
+        self.assertIn("stale", body.lower())
+
+
+class CleanupForClosedPr(unittest.TestCase):
+    def test_returns_labels_to_remove_and_branch_to_delete(self):
+        result = lib.cleanup_for_closed_pr(
+            pr_number=42,
+            labels=[
+                "ios-qa-slot-03",
+                "ios-qa:ready",
+                "needs-ios-qa",
+                "documentation",
+            ],
+        )
+        self.assertEqual(
+            sorted(result["labels_to_remove"]),
+            sorted(["ios-qa-slot-03", "ios-qa:ready", "needs-ios-qa"]),
+        )
+        self.assertEqual(result["mirror_branch"], "ios-qa/pr-42")
+        self.assertNotIn("documentation", result["labels_to_remove"])
+
+
+class DirectoryRenderer(unittest.TestCase):
+    SHA1 = "1111111111111111111111111111111111111111"
+    SHA2 = "2222222222222222222222222222222222222222"
+
+    def test_lists_active_queued_failed_with_links(self):
+        rows = [
+            {
+                "slot": "qa01",
+                "pr_number": 10,
+                "sha": self.SHA1,
+                "status": "ready",
+                "firebase_testing_uri": "https://fb/Z",
+                "codemagic_build_url": "https://cm/Y",
+            },
+            {
+                "slot": None,
+                "pr_number": 11,
+                "sha": self.SHA2,
+                "status": "queued",
+                "firebase_testing_uri": None,
+                "codemagic_build_url": None,
+            },
+        ]
+        body = lib.render_directory(rows, updated_at="2026-04-26T17:00:00Z")
+        self.assertIn(self.SHA1, body)
+        self.assertIn(self.SHA2, body)
+        self.assertIn("qa01", body)
+        self.assertIn("https://fb/Z", body)
+        self.assertIn("https://cm/Y", body)
+        self.assertIn("PR #10", body)
+        self.assertIn("PR #11", body)
+        self.assertIn("Updated", body)
+
+
+class CodemagicPayload(unittest.TestCase):
+    def test_includes_required_environment_variables(self):
+        slot = ALL_15[0]
+        pr = {
+            "number": 7,
+            "head_sha": "deadbeef" * 5,
+            "head_repo": "fork/divine-mobile",
+            "head_ref": "feature-x",
+        }
+        payload = lib.render_codemagic_payload(
+            app_id="codemagic-app",
+            workflow_id="ios-qa-pr-build",
+            branch="ios-qa/pr-7",
+            pr=pr,
+            slot=slot,
+            default_env="STAGING",
+        )
+        self.assertEqual(payload["appId"], "codemagic-app")
+        self.assertEqual(payload["workflowId"], "ios-qa-pr-build")
+        self.assertEqual(payload["branch"], "ios-qa/pr-7")
+        env = payload["environment"]["variables"]
+        for key in (
+            "PR_NUMBER",
+            "PR_HEAD_SHA",
+            "PR_HEAD_REPO",
+            "PR_HEAD_REF",
+            "QA_SLOT",
+            "QA_BUNDLE_ID",
+            "QA_EXTENSION_BUNDLE_ID",
+            "QA_APP_GROUP",
+            "QA_DISPLAY_NAME",
+            "QA_FIREBASE_APP_ID",
+            "DEFAULT_ENV",
+            "CODEMAGIC_APP_ID",
+        ):
+            self.assertIn(key, env, f"missing env var {key}")
+        self.assertEqual(env["QA_SLOT"], "qa01")
+        self.assertEqual(env["DEFAULT_ENV"], "STAGING")
+        self.assertEqual(env["PR_HEAD_SHA"], pr["head_sha"])
+
+
+class CliRenderLabelBootstrap(unittest.TestCase):
+    def test_outputs_jsonl_for_workflow(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "render-label-bootstrap",
+                "--slots-file",
+                str(SLOTS_JSON),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        labels = json.loads(result.stdout)
+        self.assertEqual(len(labels), 20)
+        names = {item["name"] for item in labels}
+        self.assertIn("needs-ios-qa", names)
+        needs = next(item for item in labels if item["name"] == "needs-ios-qa")
+        self.assertEqual(needs["color"], "5319E7")
+        self.assertTrue(needs.get("description"))
+
+
+class CliParseFirebaseDistribution(unittest.TestCase):
+    def test_extracts_uri_from_result_release(self):
+        import tempfile
+
+        firebase_json = {
+            "result": {
+                "release": {
+                    "testing_uri": "https://appdist.firebase.google.com/testing/abc",
+                },
+            },
+        }
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fp:
+            json.dump(firebase_json, fp)
+            path = fp.name
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "parse-firebase-distribution",
+                "--json-file",
+                path,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        out = json.loads(result.stdout)
+        self.assertEqual(
+            out["testing_uri"],
+            "https://appdist.firebase.google.com/testing/abc",
+        )
+
+    def test_require_testing_uri_fails_when_only_binary_link(self):
+        import tempfile
+
+        firebase_json = {"result": {"binary_download_uri": "https://expires.in/1h"}}
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fp:
+            json.dump(firebase_json, fp)
+            path = fp.name
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "parse-firebase-distribution",
+                "--json-file",
+                path,
+                "--require-testing-uri",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(result.returncode, 0)
+
+
+class AllocateForTarget(unittest.TestCase):
+    SLOTS = ALL_15[:2]
+
+    def _trusted_open_pr(self, **overrides):
+        base = {
+            "number": 1,
+            "is_draft": False,
+            "is_closed": False,
+            "labels": [],
+            "head_repo_owner": "divinevideo",
+            "author_is_org_member": True,
+            "changed_files": ["mobile/lib/main.dart"],
+            "eligibility_at": "2026-01-01T00:00:00Z",
+        }
+        base.update(overrides)
+        return base
+
+    def test_internal_pr_with_changes_gets_first_slot(self):
+        prs = [self._trusted_open_pr(number=42)]
+        result = lib.allocate_for_target(
+            slots=self.SLOTS,
+            prs=prs,
+            target_number=42,
+        )
+        self.assertEqual(result["action"], "allocate")
+        self.assertEqual(result["status"], "building")
+        self.assertEqual(result["slot"]["slot"], "qa01")
+
+    def test_outside_fork_non_member_skipped(self):
+        prs = [
+            self._trusted_open_pr(
+                number=42,
+                head_repo_owner="random",
+                author_is_org_member=False,
+            ),
+        ]
+        result = lib.allocate_for_target(
+            slots=self.SLOTS,
+            prs=prs,
+            target_number=42,
+        )
+        self.assertEqual(result["action"], "skip")
+        self.assertIn("trusted", result["reason"])
+
+    def test_pr_without_relevant_changes_with_qa_label_cleans_up(self):
+        prs = [
+            self._trusted_open_pr(
+                number=42,
+                changed_files=["docs/foo.md"],
+                labels=["ios-qa-slot-01", "ios-qa:ready"],
+            ),
+        ]
+        result = lib.allocate_for_target(
+            slots=self.SLOTS,
+            prs=prs,
+            target_number=42,
+        )
+        self.assertEqual(result["action"], "cleanup")
+        self.assertEqual(result["mirror_branch"], "ios-qa/pr-42")
+        self.assertIn("ios-qa-slot-01", result["labels_to_remove"])
+
+    def test_pr_without_relevant_changes_without_qa_label_skipped(self):
+        prs = [
+            self._trusted_open_pr(
+                number=42,
+                changed_files=["docs/foo.md"],
+            ),
+        ]
+        result = lib.allocate_for_target(
+            slots=self.SLOTS,
+            prs=prs,
+            target_number=42,
+        )
+        self.assertEqual(result["action"], "skip")
+
+    def test_target_not_in_open_list_treated_as_cleanup(self):
+        result = lib.allocate_for_target(
+            slots=self.SLOTS,
+            prs=[],
+            target_number=99,
+            target_labels_fallback=["ios-qa-slot-04", "ios-qa:building"],
+        )
+        self.assertEqual(result["action"], "cleanup")
+        self.assertIn("ios-qa-slot-04", result["labels_to_remove"])
+
+    def test_third_pr_queued_when_two_slots_full(self):
+        prs = [
+            self._trusted_open_pr(
+                number=1,
+                labels=["ios-qa-slot-01"],
+                eligibility_at="2026-01-01T00:00:00Z",
+            ),
+            self._trusted_open_pr(
+                number=2,
+                labels=["ios-qa-slot-02"],
+                eligibility_at="2026-01-02T00:00:00Z",
+            ),
+            self._trusted_open_pr(
+                number=3,
+                eligibility_at="2026-01-03T00:00:00Z",
+            ),
+        ]
+        result = lib.allocate_for_target(
+            slots=self.SLOTS,
+            prs=prs,
+            target_number=3,
+        )
+        self.assertEqual(result["action"], "allocate")
+        self.assertEqual(result["status"], "queued")
+        self.assertIsNone(result["slot"])
+
+    def test_draft_without_needs_label_skipped(self):
+        prs = [
+            self._trusted_open_pr(number=42, is_draft=True),
+        ]
+        result = lib.allocate_for_target(
+            slots=self.SLOTS,
+            prs=prs,
+            target_number=42,
+        )
+        self.assertEqual(result["action"], "skip")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_ios_qa_slots.py
+++ b/.github/scripts/tests/test_ios_qa_slots.py
@@ -626,6 +626,58 @@ class AllocateForTarget(unittest.TestCase):
         self.assertEqual(result["status"], "queued")
         self.assertIsNone(result["slot"])
 
+    def test_existing_slot_label_occupies_slot_even_when_non_target_files_unknown(self):
+        prs = [
+            self._trusted_open_pr(
+                number=1,
+                labels=["ios-qa-slot-01", "ios-qa:building"],
+                changed_files=[],
+                eligibility_at="2026-01-01T00:00:00Z",
+            ),
+            self._trusted_open_pr(
+                number=2,
+                labels=[],
+                changed_files=["mobile/lib/main.dart"],
+                eligibility_at="2026-01-02T00:00:00Z",
+            ),
+        ]
+        result = lib.allocate_for_target(
+            slots=self.SLOTS,
+            prs=prs,
+            target_number=2,
+        )
+        self.assertEqual(result["action"], "allocate")
+        self.assertEqual(result["status"], "building")
+        self.assertEqual(result["slot"]["slot"], "qa02")
+
+    def test_reassignment_reports_stale_slot_labels_to_remove(self):
+        prs = [
+            self._trusted_open_pr(
+                number=42,
+                labels=["ios-qa-slot-10", "ios-qa:failed"],
+            ),
+        ]
+        result = lib.allocate_for_target(
+            slots=self.SLOTS,
+            prs=prs,
+            target_number=42,
+        )
+        self.assertEqual(result["action"], "allocate")
+        self.assertEqual(result["slot"]["slot"], "qa01")
+        self.assertEqual(result["labels_to_remove"], ["ios-qa-slot-10"])
+
+    def test_reconcile_cleans_up_labeled_pr_without_relevant_changes(self):
+        prs = [
+            self._trusted_open_pr(
+                number=42,
+                labels=["ios-qa-slot-01", "ios-qa:ready"],
+                changed_files=["docs/foo.md"],
+            ),
+        ]
+        result = lib.reconcile_assignments(slots=self.SLOTS, prs=prs)
+        self.assertEqual(result[42]["action"], "cleanup")
+        self.assertIn("ios-qa-slot-01", result[42]["labels_to_remove"])
+
     def test_draft_without_needs_label_skipped(self):
         prs = [
             self._trusted_open_pr(number=42, is_draft=True),
@@ -636,6 +688,91 @@ class AllocateForTarget(unittest.TestCase):
             target_number=42,
         )
         self.assertEqual(result["action"], "skip")
+
+
+class NotifyStatus(unittest.TestCase):
+    def test_stale_status_ignores_firebase_files(self):
+        result = lib.resolve_notify_status(
+            stale=True,
+            firebase_distribution_json_exists=True,
+            firebase_links_json={"testing_uri": "https://appdist.firebase/x"},
+        )
+        self.assertEqual(result, {"status": "stale", "firebase_json": None})
+
+    def test_missing_parsed_testing_uri_reports_failed_even_with_distribution_json(self):
+        result = lib.resolve_notify_status(
+            stale=False,
+            firebase_distribution_json_exists=True,
+            firebase_links_json=None,
+        )
+        self.assertEqual(result, {"status": "failed", "firebase_json": None})
+
+    def test_valid_parsed_testing_uri_reports_ready(self):
+        result = lib.resolve_notify_status(
+            stale=False,
+            firebase_distribution_json_exists=True,
+            firebase_links_json={"testing_uri": "https://appdist.firebase/x"},
+        )
+        self.assertEqual(
+            result,
+            {"status": "ready", "firebase_json": "firebase-distribution.json"},
+        )
+
+
+class DirectoryRows(unittest.TestCase):
+    SHA = "abcdef0123456789abcdef0123456789abcdef01"
+
+    def test_uses_matching_sticky_comment_state_for_ready_links(self):
+        reconcile = {
+            42: {
+                "action": "allocate",
+                "status": "building",
+                "slot": {"slot": "qa01"},
+            },
+        }
+        prs = {
+            42: {
+                "head_sha": self.SHA,
+                "qa_comment_state": {
+                    "slot": "qa01",
+                    "sha": self.SHA,
+                    "status": "ready",
+                    "firebase_testing_uri": "https://appdist.firebase/x",
+                    "codemagic_build_url": "https://codemagic.io/app/a/build/b",
+                },
+            },
+        }
+        rows = lib.directory_rows_from_reconcile(reconcile, prs)
+        self.assertEqual(rows[0]["status"], "ready")
+        self.assertEqual(rows[0]["firebase_testing_uri"], "https://appdist.firebase/x")
+        self.assertEqual(
+            rows[0]["codemagic_build_url"],
+            "https://codemagic.io/app/a/build/b",
+        )
+
+    def test_ignores_sticky_comment_state_for_old_sha(self):
+        reconcile = {
+            42: {
+                "action": "allocate",
+                "status": "building",
+                "slot": {"slot": "qa01"},
+            },
+        }
+        prs = {
+            42: {
+                "head_sha": self.SHA,
+                "qa_comment_state": {
+                    "slot": "qa01",
+                    "sha": "1111111111111111111111111111111111111111",
+                    "status": "ready",
+                    "firebase_testing_uri": "https://appdist.firebase/old",
+                    "codemagic_build_url": "https://codemagic.io/app/a/build/old",
+                },
+            },
+        }
+        rows = lib.directory_rows_from_reconcile(reconcile, prs)
+        self.assertEqual(rows[0]["status"], "building")
+        self.assertIsNone(rows[0]["firebase_testing_uri"])
 
 
 if __name__ == "__main__":

--- a/.github/workflows/mobile_ios_qa_allocate.yml
+++ b/.github/workflows/mobile_ios_qa_allocate.yml
@@ -1,0 +1,329 @@
+# ABOUTME: Trusted iOS QA slot allocator. Mirrors trusted PR heads to base
+# ABOUTME: branches and triggers Codemagic Ad Hoc builds. Uses pull_request_target
+# ABOUTME: but never checks out or executes PR-controlled code (pwn-request safe).
+
+name: Mobile iOS QA Allocate
+
+on:
+  pull_request_target:
+    branches: [main]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - converted_to_draft
+      - closed
+      - labeled
+      - unlabeled
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to allocate
+        required: true
+        type: number
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: ios-qa-slot-allocator
+  cancel-in-progress: false
+
+env:
+  PYTHON_VERSION: "3.12"
+  SLOTS_FILE: .github/ios_qa_slots.json
+  ALLOCATOR_SCRIPT: .github/scripts/ios_qa_slots.py
+
+jobs:
+  allocate:
+    name: Allocate iOS QA slot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base scripts only
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Resolve target PR number
+        id: target
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISPATCH_INPUT: ${{ github.event.inputs.pr_number }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ -n "${DISPATCH_INPUT}" ]; then
+            number="${DISPATCH_INPUT}"
+          else
+            number="${EVENT_PR_NUMBER}"
+          fi
+          if [ -z "${number}" ]; then
+            echo "::error::No target PR number resolved"; exit 1
+          fi
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+
+      - name: Bootstrap labels (idempotent)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 "${ALLOCATOR_SCRIPT}" render-label-bootstrap \
+            --slots-file "${SLOTS_FILE}" \
+            > "${RUNNER_TEMP}/labels.json"
+          python3 - "${RUNNER_TEMP}/labels.json" <<'PY'
+          import json, os, subprocess, sys
+          labels = json.load(open(sys.argv[1], encoding="utf-8"))
+          repo = os.environ["GITHUB_REPOSITORY"]
+          for label in labels:
+              subprocess.run(
+                  [
+                      "gh", "label", "create", label["name"],
+                      "--repo", repo,
+                      "--color", label["color"],
+                      "--description", label["description"],
+                      "--force",
+                  ],
+                  check=False,
+              )
+          PY
+
+      - name: Build open PR context
+        id: context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_TOKEN: ${{ secrets.DIVINEVIDEO_ORG_READ_TOKEN }}
+          TARGET_NUMBER: ${{ steps.target.outputs.number }}
+        run: |
+          set -euo pipefail
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/pulls?state=open&per_page=100" \
+            > "${RUNNER_TEMP}/open-prs.json"
+          # Always include the target PR even if closed (cleanup).
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${TARGET_NUMBER}" \
+            > "${RUNNER_TEMP}/target-pr.json"
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/pulls/${TARGET_NUMBER}/files?per_page=300" \
+            > "${RUNNER_TEMP}/target-files.json"
+          python3 - <<'PY'
+          import json, os, urllib.request, urllib.error
+
+          tmp = os.environ["RUNNER_TEMP"]
+          target_number = int(os.environ["TARGET_NUMBER"])
+          org_token = os.environ.get("ORG_TOKEN", "")
+          gh_token = os.environ["GH_TOKEN"]
+
+          open_prs = json.load(open(f"{tmp}/open-prs.json", encoding="utf-8"))
+          target_raw = json.load(open(f"{tmp}/target-pr.json", encoding="utf-8"))
+          target_files = json.load(open(f"{tmp}/target-files.json", encoding="utf-8"))
+
+          def is_org_member(login: str, token: str) -> bool:
+              if not token or not login:
+                  return False
+              url = f"https://api.github.com/orgs/divinevideo/members/{login}"
+              req = urllib.request.Request(url)
+              req.add_header("Authorization", f"Bearer {token}")
+              req.add_header("Accept", "application/vnd.github+json")
+              try:
+                  with urllib.request.urlopen(req) as resp:
+                      return resp.status == 204
+              except urllib.error.HTTPError as exc:
+                  if exc.code == 302:
+                      return False
+                  return False
+              except urllib.error.URLError:
+                  return False
+
+          def to_pr_record(raw, files):
+              head = raw.get("head") or {}
+              repo = head.get("repo") or {}
+              owner = (repo.get("owner") or {}).get("login", "")
+              author = (raw.get("user") or {}).get("login", "")
+              labels = [l["name"] for l in raw.get("labels", []) or []]
+              return {
+                  "number": raw["number"],
+                  "is_draft": bool(raw.get("draft")),
+                  "is_closed": raw.get("state") == "closed",
+                  "labels": labels,
+                  "head_sha": head.get("sha", ""),
+                  "head_repo": repo.get("full_name", ""),
+                  "head_repo_owner": owner,
+                  "head_ref": head.get("ref", ""),
+                  "author": author,
+                  "author_is_org_member": (
+                      owner == "divinevideo"
+                      or is_org_member(author, org_token)
+                  ),
+                  "changed_files": [f["filename"] for f in (files or [])],
+                  "eligibility_at": raw.get("created_at", ""),
+              }
+
+          # Build records for all open PRs by re-fetching their files in batch
+          # only if they hold a slot label or are the target. Other open PRs
+          # don't need files because we only need their slot/label state.
+          target_record = to_pr_record(target_raw, target_files)
+          records = [target_record]
+          for raw in open_prs:
+              if raw["number"] == target_number:
+                  continue
+              # For non-target PRs we still need to know if they hold slots.
+              # Skip the changed_files fetch — they already won/lost slots in
+              # a prior allocator run, so an empty list is sufficient context.
+              records.append(to_pr_record(raw, []))
+
+          json.dump(records, open(f"{tmp}/all-prs.json", "w", encoding="utf-8"))
+          json.dump(target_record, open(f"{tmp}/target-record.json", "w", encoding="utf-8"))
+          PY
+
+      - name: Compute action
+        id: action
+        env:
+          TARGET_NUMBER: ${{ steps.target.outputs.number }}
+        run: |
+          set -euo pipefail
+          # Fallback labels: pulled from target-record so cleanup works even
+          # if the PR vanished from the open list between fetches.
+          fallback="$(python3 -c "import json; print(','.join(json.load(open('${RUNNER_TEMP}/target-record.json'))['labels']))")"
+          python3 "${ALLOCATOR_SCRIPT}" allocate \
+            --slots-file "${SLOTS_FILE}" \
+            --prs-file "${RUNNER_TEMP}/all-prs.json" \
+            --target-number "${TARGET_NUMBER}" \
+            --target-labels "${fallback}" \
+            > "${RUNNER_TEMP}/allocation.json"
+          action=$(python3 -c "import json; print(json.load(open('${RUNNER_TEMP}/allocation.json'))['action'])")
+          status=$(python3 -c "import json; d=json.load(open('${RUNNER_TEMP}/allocation.json')); print(d.get('status',''))")
+          slot=$(python3 -c "import json; d=json.load(open('${RUNNER_TEMP}/allocation.json')); s=d.get('slot') or {}; print(s.get('slot',''))")
+          slot_label=$(python3 -c "import json; d=json.load(open('${RUNNER_TEMP}/allocation.json')); s=d.get('slot') or {}; print(s.get('label',''))")
+          {
+            echo "action=${action}"
+            echo "status=${status}"
+            echo "slot=${slot}"
+            echo "slot_label=${slot_label}"
+          } >> "$GITHUB_OUTPUT"
+          cat "${RUNNER_TEMP}/allocation.json"
+
+      - name: Cleanup PR
+        if: steps.action.outputs.action == 'cleanup'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_NUMBER: ${{ steps.target.outputs.number }}
+        run: |
+          set -euo pipefail
+          # Remove iOS QA labels.
+          python3 - <<'PY'
+          import json, os, subprocess, sys
+          alloc = json.load(open(f"{os.environ['RUNNER_TEMP']}/allocation.json"))
+          repo = os.environ["GITHUB_REPOSITORY"]
+          number = os.environ["TARGET_NUMBER"]
+          for label in alloc.get("labels_to_remove", []):
+              subprocess.run(
+                  ["gh", "issue", "edit", number, "--repo", repo,
+                   "--remove-label", label],
+                  check=False,
+              )
+          PY
+          # Delete mirror branch.
+          mirror=$(python3 -c "import json; print(json.load(open('${RUNNER_TEMP}/allocation.json')).get('mirror_branch',''))")
+          if [ -n "${mirror}" ]; then
+            git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+              ":refs/heads/${mirror}" || true
+          fi
+
+      - name: Mirror PR head to base repo
+        if: steps.action.outputs.action == 'allocate' && steps.action.outputs.status == 'building'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_NUMBER: ${{ steps.target.outputs.number }}
+        run: |
+          set -euo pipefail
+          # Fetch PR head (read-only) and push to a base-repo branch. We never
+          # checkout, build, or otherwise execute FETCH_HEAD's contents here.
+          git fetch --no-tags origin "pull/${TARGET_NUMBER}/head"
+          git push --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "FETCH_HEAD:refs/heads/ios-qa/pr-${TARGET_NUMBER}"
+
+      - name: Trigger Codemagic build
+        if: steps.action.outputs.action == 'allocate' && steps.action.outputs.status == 'building'
+        id: codemagic
+        env:
+          CODEMAGIC_APP_ID: ${{ secrets.CODEMAGIC_APP_ID }}
+          CODEMAGIC_API_TOKEN: ${{ secrets.CODEMAGIC_API_TOKEN }}
+          DEFAULT_ENV: ${{ vars.IOS_QA_DEFAULT_ENV || 'STAGING' }}
+          TARGET_NUMBER: ${{ steps.target.outputs.number }}
+        run: |
+          set -euo pipefail
+          # Extract slot and target PR record into separate files.
+          python3 -c "import json; d=json.load(open('${RUNNER_TEMP}/allocation.json')); json.dump(d['slot'], open('${RUNNER_TEMP}/slot.json','w'))"
+          python3 -c "import json; r=json.load(open('${RUNNER_TEMP}/target-record.json')); json.dump({'number': r['number'], 'head_sha': r['head_sha'], 'head_repo': r['head_repo'], 'head_ref': r['head_ref']}, open('${RUNNER_TEMP}/pr.json','w'))"
+          python3 "${ALLOCATOR_SCRIPT}" render-codemagic-payload \
+            --app-id "${CODEMAGIC_APP_ID}" \
+            --workflow-id ios-qa-pr-build \
+            --branch "ios-qa/pr-${TARGET_NUMBER}" \
+            --pr-json "${RUNNER_TEMP}/pr.json" \
+            --slot-json "${RUNNER_TEMP}/slot.json" \
+            --default-env "${DEFAULT_ENV}" \
+            > "${RUNNER_TEMP}/codemagic-payload.json"
+          curl --fail-with-body \
+            -H "Content-Type: application/json" \
+            -H "x-auth-token: ${CODEMAGIC_API_TOKEN}" \
+            --data @"${RUNNER_TEMP}/codemagic-payload.json" \
+            -X POST https://api.codemagic.io/builds \
+            > "${RUNNER_TEMP}/codemagic-response.json"
+          build_id=$(python3 -c "import json; print(json.load(open('${RUNNER_TEMP}/codemagic-response.json')).get('buildId',''))")
+          echo "build_id=${build_id}" >> "$GITHUB_OUTPUT"
+          echo "build_url=https://codemagic.io/app/${CODEMAGIC_APP_ID}/build/${build_id}" >> "$GITHUB_OUTPUT"
+
+      - name: Apply slot + state labels and update sticky comment
+        if: steps.action.outputs.action == 'allocate'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_NUMBER: ${{ steps.target.outputs.number }}
+          SLOT_LABEL: ${{ steps.action.outputs.slot_label }}
+          ALLOC_STATUS: ${{ steps.action.outputs.status }}
+          CM_BUILD_ID: ${{ steps.codemagic.outputs.build_id }}
+          CM_BUILD_URL: ${{ steps.codemagic.outputs.build_url }}
+        run: |
+          set -euo pipefail
+          repo="${GITHUB_REPOSITORY}"
+          # Remove competing state labels so we never have two states.
+          for stale in ios-qa:building ios-qa:ready ios-qa:queued ios-qa:failed; do
+            gh issue edit "${TARGET_NUMBER}" --repo "${repo}" \
+              --remove-label "${stale}" || true
+          done
+          if [ -n "${SLOT_LABEL}" ]; then
+            gh issue edit "${TARGET_NUMBER}" --repo "${repo}" \
+              --add-label "${SLOT_LABEL}"
+          fi
+          if [ "${ALLOC_STATUS}" = "building" ]; then
+            gh issue edit "${TARGET_NUMBER}" --repo "${repo}" --add-label "ios-qa:building"
+          else
+            gh issue edit "${TARGET_NUMBER}" --repo "${repo}" --add-label "ios-qa:queued"
+          fi
+          # Build sticky comment.
+          head_sha=$(python3 -c "import json; print(json.load(open('${RUNNER_TEMP}/target-record.json'))['head_sha'])")
+          slot_arg=$(python3 -c "import json; d=json.load(open('${RUNNER_TEMP}/allocation.json')); s=d.get('slot') or {}; print(s.get('slot','unassigned'))")
+          updated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          python3 "${ALLOCATOR_SCRIPT}" render-comment \
+            --status "${ALLOC_STATUS}" \
+            --pr-number "${TARGET_NUMBER}" \
+            --slot "${slot_arg}" \
+            --sha "${head_sha}" \
+            --codemagic-build-id "${CM_BUILD_ID}" \
+            --codemagic-build-url "${CM_BUILD_URL}" \
+            --updated-at "${updated_at}" \
+            > "${RUNNER_TEMP}/comment.md"
+          GH_TOKEN_FOR_LIB="${GH_TOKEN}" \
+          python3 "${ALLOCATOR_SCRIPT}" upsert-comment \
+            --repo "${repo}" \
+            --issue-number "${TARGET_NUMBER}" \
+            --body-file "${RUNNER_TEMP}/comment.md" \
+            --token-env GH_TOKEN_FOR_LIB

--- a/.github/workflows/mobile_ios_qa_allocate.yml
+++ b/.github/workflows/mobile_ios_qa_allocate.yml
@@ -304,6 +304,10 @@ jobs:
             gh issue edit "${TARGET_NUMBER}" --repo "${repo}" \
               --remove-label "${stale}" || true
           done
+          for stale_slot in $(python3 -c "import json; print(' '.join(json.load(open('${RUNNER_TEMP}/allocation.json')).get('labels_to_remove', [])))"); do
+            gh issue edit "${TARGET_NUMBER}" --repo "${repo}" \
+              --remove-label "${stale_slot}" || true
+          done
           if [ -n "${SLOT_LABEL}" ]; then
             gh issue edit "${TARGET_NUMBER}" --repo "${repo}" \
               --add-label "${SLOT_LABEL}"
@@ -384,11 +388,22 @@ jobs:
             "repos/${GITHUB_REPOSITORY}/pulls?state=open&per_page=100" \
             > "${RUNNER_TEMP}/open-prs.json"
           python3 - <<'PY'
-          import json, os, subprocess, urllib.error, urllib.request
+          import importlib.util
+          import json
+          import os
+          import subprocess
+          import urllib.error
+          import urllib.request
 
           tmp = os.environ["RUNNER_TEMP"]
           gh_token = os.environ["GH_TOKEN"]
           org_token = os.environ.get("ORG_TOKEN", "")
+          repo_slug = os.environ["GITHUB_REPOSITORY"]
+          script_path = os.environ["ALLOCATOR_SCRIPT"]
+          spec = importlib.util.spec_from_file_location("ios_qa_slots", script_path)
+          slot_lib = importlib.util.module_from_spec(spec)
+          assert spec.loader is not None
+          spec.loader.exec_module(slot_lib)
 
           def is_org_member(login: str) -> bool:
               if not org_token or not login:
@@ -409,11 +424,25 @@ jobs:
               out = subprocess.check_output(
                   [
                       "gh", "api", "--paginate",
-                      f"repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{number}/files?per_page=300",
+                      f"repos/{repo_slug}/pulls/{number}/files?per_page=300",
                   ],
                   text=True,
               )
               return [f["filename"] for f in json.loads(out)]
+
+          def fetch_qa_comment_state(number: int):
+              out = subprocess.check_output(
+                  [
+                      "gh", "api",
+                      f"repos/{repo_slug}/issues/{number}/comments?per_page=100",
+                  ],
+                  text=True,
+              )
+              for comment in json.loads(out):
+                  state = slot_lib.parse_state_marker(comment.get("body") or "")
+                  if state:
+                      return state
+              return None
 
           open_prs = json.load(open(f"{tmp}/open-prs.json", encoding="utf-8"))
           records = []
@@ -437,6 +466,7 @@ jobs:
                       owner == "divinevideo" or is_org_member(author)
                   ),
                   "changed_files": fetch_files(raw["number"]),
+                  "qa_comment_state": fetch_qa_comment_state(raw["number"]),
                   "eligibility_at": raw.get("created_at", ""),
               })
           json.dump(records, open(f"{tmp}/all-prs.json", "w", encoding="utf-8"))
@@ -509,6 +539,9 @@ jobs:
                   status = decision.get("status")
                   slot = decision.get("slot") or {}
                   slot_label = slot.get("label")
+                  for stale_slot in decision.get("labels_to_remove", []):
+                      if has_label(pr, stale_slot):
+                          gh_label("remove", number, stale_slot)
                   # Drop competing state labels.
                   for sl in state_labels:
                       if has_label(pr, sl) and sl != f"ios-qa:{status}":
@@ -588,28 +621,10 @@ jobs:
           DIRECTORY_ISSUE: ${{ vars.IOS_QA_DIRECTORY_ISSUE_NUMBER }}
         run: |
           set -euo pipefail
-          python3 - <<'PY'
-          import json, os, subprocess
-          tmp = os.environ["RUNNER_TEMP"]
-          recon = json.load(open(f"{tmp}/reconcile.json", encoding="utf-8"))
-          prs = {p["number"]: p for p in json.load(open(f"{tmp}/all-prs.json", encoding="utf-8"))}
-          rows = []
-          for number_str, decision in recon.items():
-              number = int(number_str)
-              pr = prs.get(number) or {}
-              if decision.get("action") != "allocate":
-                  continue
-              slot = decision.get("slot") or {}
-              rows.append({
-                  "slot": slot.get("slot"),
-                  "status": decision.get("status"),
-                  "pr_number": number,
-                  "sha": pr.get("head_sha", ""),
-                  "firebase_testing_uri": None,
-                  "codemagic_build_url": None,
-              })
-          json.dump(rows, open(f"{tmp}/rows.json", "w", encoding="utf-8"))
-          PY
+          python3 "${ALLOCATOR_SCRIPT}" render-directory-rows \
+            --reconcile-file "${RUNNER_TEMP}/reconcile.json" \
+            --prs-file "${RUNNER_TEMP}/all-prs.json" \
+            > "${RUNNER_TEMP}/rows.json"
           updated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           python3 "${ALLOCATOR_SCRIPT}" render-directory \
             --rows-file "${RUNNER_TEMP}/rows.json" \

--- a/.github/workflows/mobile_ios_qa_allocate.yml
+++ b/.github/workflows/mobile_ios_qa_allocate.yml
@@ -20,8 +20,12 @@ on:
     inputs:
       pr_number:
         description: PR number to allocate
-        required: true
+        required: false
         type: number
+  schedule:
+    # Daily reconciliation pass to clean up stale PRs, promote queued PRs
+    # into freed slots, and refresh the directory issue.
+    - cron: "17 15 * * *"
 
 permissions:
   contents: write
@@ -39,6 +43,7 @@ env:
 
 jobs:
   allocate:
+    if: github.event_name != 'schedule'
     name: Allocate iOS QA slot
     runs-on: ubuntu-latest
     steps:
@@ -326,4 +331,294 @@ jobs:
             --repo "${repo}" \
             --issue-number "${TARGET_NUMBER}" \
             --body-file "${RUNNER_TEMP}/comment.md" \
+            --token-env GH_TOKEN_FOR_LIB
+
+  reconcile:
+    if: github.event_name == 'schedule'
+    name: Reconcile iOS QA slots
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base scripts only
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Bootstrap labels (idempotent)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 "${ALLOCATOR_SCRIPT}" render-label-bootstrap \
+            --slots-file "${SLOTS_FILE}" \
+            > "${RUNNER_TEMP}/labels.json"
+          python3 - "${RUNNER_TEMP}/labels.json" <<'PY'
+          import json, os, subprocess, sys
+          labels = json.load(open(sys.argv[1], encoding="utf-8"))
+          repo = os.environ["GITHUB_REPOSITORY"]
+          for label in labels:
+              subprocess.run(
+                  [
+                      "gh", "label", "create", label["name"],
+                      "--repo", repo,
+                      "--color", label["color"],
+                      "--description", label["description"],
+                      "--force",
+                  ],
+                  check=False,
+              )
+          PY
+
+      - name: Build all-PR context with changed files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_TOKEN: ${{ secrets.DIVINEVIDEO_ORG_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/pulls?state=open&per_page=100" \
+            > "${RUNNER_TEMP}/open-prs.json"
+          python3 - <<'PY'
+          import json, os, subprocess, urllib.error, urllib.request
+
+          tmp = os.environ["RUNNER_TEMP"]
+          gh_token = os.environ["GH_TOKEN"]
+          org_token = os.environ.get("ORG_TOKEN", "")
+
+          def is_org_member(login: str) -> bool:
+              if not org_token or not login:
+                  return False
+              url = f"https://api.github.com/orgs/divinevideo/members/{login}"
+              req = urllib.request.Request(url)
+              req.add_header("Authorization", f"Bearer {org_token}")
+              req.add_header("Accept", "application/vnd.github+json")
+              try:
+                  with urllib.request.urlopen(req) as resp:
+                      return resp.status == 204
+              except urllib.error.HTTPError:
+                  return False
+              except urllib.error.URLError:
+                  return False
+
+          def fetch_files(number: int) -> list[str]:
+              out = subprocess.check_output(
+                  [
+                      "gh", "api", "--paginate",
+                      f"repos/{os.environ['GITHUB_REPOSITORY']}/pulls/{number}/files?per_page=300",
+                  ],
+                  text=True,
+              )
+              return [f["filename"] for f in json.loads(out)]
+
+          open_prs = json.load(open(f"{tmp}/open-prs.json", encoding="utf-8"))
+          records = []
+          for raw in open_prs:
+              head = raw.get("head") or {}
+              repo = head.get("repo") or {}
+              owner = (repo.get("owner") or {}).get("login", "")
+              author = (raw.get("user") or {}).get("login", "")
+              labels = [l["name"] for l in raw.get("labels", []) or []]
+              records.append({
+                  "number": raw["number"],
+                  "is_draft": bool(raw.get("draft")),
+                  "is_closed": False,
+                  "labels": labels,
+                  "head_sha": head.get("sha", ""),
+                  "head_repo": repo.get("full_name", ""),
+                  "head_repo_owner": owner,
+                  "head_ref": head.get("ref", ""),
+                  "author": author,
+                  "author_is_org_member": (
+                      owner == "divinevideo" or is_org_member(author)
+                  ),
+                  "changed_files": fetch_files(raw["number"]),
+                  "eligibility_at": raw.get("created_at", ""),
+              })
+          json.dump(records, open(f"{tmp}/all-prs.json", "w", encoding="utf-8"))
+          PY
+
+      - name: Compute reconciliation
+        run: |
+          set -euo pipefail
+          python3 "${ALLOCATOR_SCRIPT}" reconcile \
+            --slots-file "${SLOTS_FILE}" \
+            --prs-file "${RUNNER_TEMP}/all-prs.json" \
+            > "${RUNNER_TEMP}/reconcile.json"
+          cat "${RUNNER_TEMP}/reconcile.json"
+
+      - name: Apply reconciliation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CODEMAGIC_APP_ID: ${{ secrets.CODEMAGIC_APP_ID }}
+          CODEMAGIC_API_TOKEN: ${{ secrets.CODEMAGIC_API_TOKEN }}
+          DEFAULT_ENV: ${{ vars.IOS_QA_DEFAULT_ENV || 'STAGING' }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os, subprocess, urllib.request
+
+          tmp = os.environ["RUNNER_TEMP"]
+          repo = os.environ["GITHUB_REPOSITORY"]
+          gh_token = os.environ["GH_TOKEN"]
+          cm_app_id = os.environ.get("CODEMAGIC_APP_ID", "")
+          cm_token = os.environ.get("CODEMAGIC_API_TOKEN", "")
+          default_env = os.environ.get("DEFAULT_ENV", "STAGING")
+
+          reconcile = json.load(open(f"{tmp}/reconcile.json", encoding="utf-8"))
+          all_prs = {p["number"]: p for p in json.load(
+              open(f"{tmp}/all-prs.json", encoding="utf-8"),
+          )}
+          state_labels = {"ios-qa:building", "ios-qa:ready", "ios-qa:queued", "ios-qa:failed"}
+
+          def gh_label(action, number, label):
+              flag = "--add-label" if action == "add" else "--remove-label"
+              subprocess.run(
+                  ["gh", "issue", "edit", str(number), "--repo", repo, flag, label],
+                  check=False,
+              )
+
+          def has_label(pr, label):
+              return label in pr.get("labels", [])
+
+          for number_str, decision in reconcile.items():
+              number = int(number_str)
+              pr = all_prs.get(number)
+              action = decision.get("action")
+              if action == "skip":
+                  continue
+              if action == "cleanup":
+                  for label in decision.get("labels_to_remove", []):
+                      gh_label("remove", number, label)
+                  mirror = decision.get("mirror_branch")
+                  if mirror:
+                      subprocess.run(
+                          [
+                              "git", "push",
+                              f"https://x-access-token:{gh_token}@github.com/{repo}.git",
+                              f":refs/heads/{mirror}",
+                          ],
+                          check=False,
+                      )
+                  continue
+              if action == "allocate":
+                  status = decision.get("status")
+                  slot = decision.get("slot") or {}
+                  slot_label = slot.get("label")
+                  # Drop competing state labels.
+                  for sl in state_labels:
+                      if has_label(pr, sl) and sl != f"ios-qa:{status}":
+                          gh_label("remove", number, sl)
+                  if status == "queued":
+                      if not has_label(pr, "ios-qa:queued"):
+                          gh_label("add", number, "ios-qa:queued")
+                      continue
+                  if status != "building":
+                      continue
+                  # Building.
+                  if slot_label and not has_label(pr, slot_label):
+                      gh_label("add", number, slot_label)
+                  already_in_flight = any(
+                      has_label(pr, sl)
+                      for sl in ("ios-qa:building", "ios-qa:ready")
+                  )
+                  if already_in_flight:
+                      continue
+                  if not (cm_app_id and cm_token):
+                      continue
+                  # Newly promoted PR — trigger Codemagic.
+                  payload = {
+                      "appId": cm_app_id,
+                      "workflowId": "ios-qa-pr-build",
+                      "branch": f"ios-qa/pr-{number}",
+                      "labels": [f"pr-{number}", slot["slot"]],
+                      "environment": {
+                          "variables": {
+                              "PR_NUMBER": str(number),
+                              "PR_HEAD_SHA": pr["head_sha"],
+                              "PR_HEAD_REPO": pr["head_repo"],
+                              "PR_HEAD_REF": pr["head_ref"],
+                              "QA_SLOT": slot["slot"],
+                              "QA_BUNDLE_ID": slot["bundleId"],
+                              "QA_EXTENSION_BUNDLE_ID": slot["extensionBundleId"],
+                              "QA_APP_GROUP": slot["appGroup"],
+                              "QA_DISPLAY_NAME": slot["displayName"],
+                              "QA_FIREBASE_APP_ID": slot["firebaseAppId"],
+                              "DEFAULT_ENV": default_env,
+                              "CODEMAGIC_APP_ID": cm_app_id,
+                          },
+                      },
+                  }
+                  # Mirror branch in case it was deleted previously.
+                  subprocess.run(
+                      [
+                          "git", "fetch", "--no-tags", "origin",
+                          f"pull/{number}/head",
+                      ],
+                      check=True,
+                  )
+                  subprocess.run(
+                      [
+                          "git", "push", "--force",
+                          f"https://x-access-token:{gh_token}@github.com/{repo}.git",
+                          f"FETCH_HEAD:refs/heads/ios-qa/pr-{number}",
+                      ],
+                      check=True,
+                  )
+                  req = urllib.request.Request(
+                      "https://api.codemagic.io/builds",
+                      data=json.dumps(payload).encode("utf-8"),
+                      method="POST",
+                  )
+                  req.add_header("Content-Type", "application/json")
+                  req.add_header("x-auth-token", cm_token)
+                  with urllib.request.urlopen(req) as resp:
+                      resp_body = json.loads(resp.read().decode("utf-8"))
+                  gh_label("add", number, "ios-qa:building")
+          PY
+
+      - name: Render and upsert directory
+        if: ${{ vars.IOS_QA_DIRECTORY_ISSUE_NUMBER != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DIRECTORY_ISSUE: ${{ vars.IOS_QA_DIRECTORY_ISSUE_NUMBER }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json, os, subprocess
+          tmp = os.environ["RUNNER_TEMP"]
+          recon = json.load(open(f"{tmp}/reconcile.json", encoding="utf-8"))
+          prs = {p["number"]: p for p in json.load(open(f"{tmp}/all-prs.json", encoding="utf-8"))}
+          rows = []
+          for number_str, decision in recon.items():
+              number = int(number_str)
+              pr = prs.get(number) or {}
+              if decision.get("action") != "allocate":
+                  continue
+              slot = decision.get("slot") or {}
+              rows.append({
+                  "slot": slot.get("slot"),
+                  "status": decision.get("status"),
+                  "pr_number": number,
+                  "sha": pr.get("head_sha", ""),
+                  "firebase_testing_uri": None,
+                  "codemagic_build_url": None,
+              })
+          json.dump(rows, open(f"{tmp}/rows.json", "w", encoding="utf-8"))
+          PY
+          updated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          python3 "${ALLOCATOR_SCRIPT}" render-directory \
+            --rows-file "${RUNNER_TEMP}/rows.json" \
+            --updated-at "${updated_at}" \
+            > "${RUNNER_TEMP}/directory.md"
+          GH_TOKEN_FOR_LIB="${GH_TOKEN}" \
+          python3 "${ALLOCATOR_SCRIPT}" upsert-comment \
+            --repo "${GITHUB_REPOSITORY}" \
+            --issue-number "${DIRECTORY_ISSUE}" \
+            --body-file "${RUNNER_TEMP}/directory.md" \
+            --marker-prefix "<!-- divine-ios-qa-directory:v1 " \
             --token-env GH_TOKEN_FOR_LIB

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -328,6 +328,189 @@ definitions:
         fi
         adb install "$APK_PATH"
         echo "App installed on Android emulator"
+    - &validate_ios_qa_env
+      name: Validate iOS QA environment
+      script: |
+        set -eu
+        for name in \
+          PR_NUMBER PR_HEAD_SHA PR_HEAD_REPO PR_HEAD_REF \
+          QA_SLOT QA_BUNDLE_ID QA_EXTENSION_BUNDLE_ID QA_APP_GROUP \
+          QA_DISPLAY_NAME QA_FIREBASE_APP_ID DEFAULT_ENV \
+          CODEMAGIC_APP_ID IOS_QA_GITHUB_TOKEN QA_FIREBASE_GROUP_ALIAS
+        do
+          eval "value=\${$name:-}"
+          if [ -z "$value" ]; then
+            echo "Missing required iOS QA variable: $name"
+            exit 1
+          fi
+        done
+        # Make IOS_QA_GITHUB_TOKEN available as GH_TOKEN for gh CLI usage.
+        echo "GH_TOKEN=$IOS_QA_GITHUB_TOKEN" >> "$CM_ENV"
+    - &verify_ios_qa_head
+      name: Verify mirrored PR SHA
+      script: |
+        set -eu
+        ACTUAL_SHA="$(git rev-parse HEAD)"
+        if [ "$ACTUAL_SHA" != "$PR_HEAD_SHA" ]; then
+          echo "Stale mirror branch: expected $PR_HEAD_SHA, got $ACTUAL_SHA"
+          exit 1
+        fi
+    - &write_firebase_credentials
+      name: Write Firebase service-account credentials
+      script: |
+        set -eu
+        if [ -n "${FIREBASE_SERVICE_ACCOUNT:-}" ]; then
+          : "${GOOGLE_APPLICATION_CREDENTIALS:=$CM_BUILD_DIR/firebase_credentials.json}"
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT" \
+            > "$GOOGLE_APPLICATION_CREDENTIALS"
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS" \
+            >> "$CM_ENV"
+          exit 0
+        fi
+        if [ -n "${FIREBASE_TOKEN:-}" ]; then
+          echo "Using deprecated FIREBASE_TOKEN fallback. Prefer FIREBASE_SERVICE_ACCOUNT."
+          exit 0
+        fi
+        echo "Missing FIREBASE_SERVICE_ACCOUNT or FIREBASE_TOKEN"
+        exit 1
+    - &configure_ios_qa_slot
+      name: Configure iOS QA slot
+      script: |
+        set -eu
+        python3 scripts/ci/configure_ios_qa_slot.py \
+          --project-root . \
+          --bundle-id "$QA_BUNDLE_ID" \
+          --extension-bundle-id "$QA_EXTENSION_BUNDLE_ID" \
+          --app-group "$QA_APP_GROUP" \
+          --display-name "$QA_DISPLAY_NAME" \
+          --firebase-ios-app-id "$QA_FIREBASE_APP_ID"
+    - &build_ios_qa
+      name: Build iOS QA IPA
+      script: |
+        set -eu
+        flutter build ipa --release --build-number="$PROJECT_BUILD_NUMBER" \
+          --dart-define=ZENDESK_APP_ID="$ZENDESK_APP_ID" \
+          --dart-define=ZENDESK_CLIENT_ID="$ZENDESK_CLIENT_ID" \
+          --dart-define=ZENDESK_URL="$ZENDESK_URL" \
+          --dart-define=DEFAULT_ENV="$DEFAULT_ENV" \
+          --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT="$PROOFMODE_SIGNING_SERVER_ENDPOINT" \
+          --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN="$PROOFMODE_SIGNING_SERVER_TOKEN" \
+          --dart-define=IOS_BUNDLE_ID="$QA_BUNDLE_ID" \
+          --dart-define=PUSH_APP_IDENTIFIER="$QA_BUNDLE_ID" \
+          --dart-define=FIREBASE_IOS_APP_ID="$QA_FIREBASE_APP_ID" \
+          --export-options-plist=/Users/builder/export_options.plist
+    - &verify_ios_qa_pr_current
+      name: Verify PR is still current before distribution
+      script: |
+        set -eu
+        pr_json="pr-current.json"
+        curl --fail-with-body \
+          -H "Authorization: Bearer $IOS_QA_GITHUB_TOKEN" \
+          -H "Accept: application/vnd.github+json" \
+          "https://api.github.com/repos/$CM_REPO_SLUG/pulls/$PR_NUMBER" \
+          > "$pr_json"
+        python3 - "$pr_json" <<'PY'
+        import json
+        import os
+        import sys
+
+        with open(sys.argv[1], encoding="utf-8") as fp:
+            pr = json.load(fp)
+        expected = os.environ["PR_HEAD_SHA"]
+        actual = pr["head"]["sha"]
+        if pr["state"] != "open" or actual != expected:
+            with open(os.environ["CM_ENV"], "a", encoding="utf-8") as env_fp:
+                env_fp.write("STALE_IOS_QA_BUILD=true\n")
+            print(
+                f"Stale PR build: state={pr['state']} expected={expected} "
+                f"actual={actual}",
+            )
+        PY
+    - &distribute_ios_qa_firebase
+      name: Distribute iOS QA build to Firebase
+      script: |
+        set -eu
+        if [ "${STALE_IOS_QA_BUILD:-}" = "true" ]; then
+          echo "Skipping Firebase distribution for stale iOS QA build"
+          exit 0
+        fi
+        npm install -g firebase-tools
+        IPA_PATH="$(ls build/ios/ipa/*.ipa | head -1)"
+        firebase_token_args=""
+        if [ -n "${FIREBASE_TOKEN:-}" ] && [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
+          firebase_token_args="--token $FIREBASE_TOKEN"
+        fi
+        firebase appdistribution:distribute "$IPA_PATH" \
+          --app "$QA_FIREBASE_APP_ID" \
+          --groups "$QA_FIREBASE_GROUP_ALIAS" \
+          --release-notes "PR #$PR_NUMBER $PR_HEAD_SHA ($QA_SLOT)" \
+          --json \
+          $firebase_token_args \
+          > firebase-distribution.json
+        python3 ../.github/scripts/ios_qa_slots.py parse-firebase-distribution \
+          --json-file firebase-distribution.json \
+          --require-testing-uri \
+          > firebase-distribution-links.json
+    - &notify_ios_qa_github
+      name: Notify GitHub about iOS QA build
+      script: |
+        set -u
+        missing_context=""
+        for name in IOS_QA_GITHUB_TOKEN CM_REPO_SLUG PR_NUMBER; do
+          eval "value=\${$name:-}"
+          if [ -z "$value" ]; then
+            missing_context="$missing_context $name"
+          fi
+        done
+        if [ -n "$missing_context" ]; then
+          echo "Cannot update GitHub for iOS QA build; missing:$missing_context"
+          exit 0
+        fi
+        status="ready"
+        firebase_json="firebase-distribution.json"
+        if [ "${STALE_IOS_QA_BUILD:-}" = "true" ]; then
+          status="stale"
+          firebase_json=""
+        elif [ ! -s "$firebase_json" ]; then
+          status="failed"
+          firebase_json=""
+        fi
+        if [ -n "${CODEMAGIC_APP_ID:-}" ] && [ -n "${CM_BUILD_ID:-}" ]; then
+          codemagic_build_url="https://codemagic.io/app/$CODEMAGIC_APP_ID/build/$CM_BUILD_ID"
+        else
+          codemagic_build_url="Codemagic build URL unavailable"
+        fi
+        qa_slot="${QA_SLOT:-unknown}"
+        pr_head_sha="${PR_HEAD_SHA:-unknown}"
+        updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        if [ -n "$firebase_json" ]; then
+          python3 ../.github/scripts/ios_qa_slots.py render-comment \
+            --status "$status" \
+            --pr-number "$PR_NUMBER" \
+            --slot "$qa_slot" \
+            --sha "$pr_head_sha" \
+            --codemagic-build-id "${CM_BUILD_ID:-}" \
+            --codemagic-build-url "$codemagic_build_url" \
+            --firebase-json "$firebase_json" \
+            --updated-at "$updated_at" \
+            > ios-qa-comment.md
+        else
+          python3 ../.github/scripts/ios_qa_slots.py render-comment \
+            --status "$status" \
+            --pr-number "$PR_NUMBER" \
+            --slot "$qa_slot" \
+            --sha "$pr_head_sha" \
+            --codemagic-build-id "${CM_BUILD_ID:-}" \
+            --codemagic-build-url "$codemagic_build_url" \
+            --updated-at "$updated_at" \
+            > ios-qa-comment.md
+        fi
+        python3 ../.github/scripts/ios_qa_slots.py notify-github \
+          --repo "$CM_REPO_SLUG" \
+          --issue-number "$PR_NUMBER" \
+          --token-env IOS_QA_GITHUB_TOKEN \
+          --status "$status" \
+          --body-file ios-qa-comment.md
 workflows:
   ios-build:
     name: iOS Build
@@ -605,3 +788,63 @@ workflows:
     artifacts:
       - build/app/outputs/flutter-apk/app-debug.apk
       - ~/.maestro/tests/**
+
+  ios-qa-pr-build:
+    # Builds an Ad Hoc IPA for one QA slot (qa01-qa15) on a mirrored PR head
+    # branch (ios-qa/pr-N) and distributes it through Firebase App Distribution.
+    # Triggered by .github/workflows/mobile_ios_qa_allocate.yml via the Builds
+    # API; never run from `triggering.events`. Slot identity arrives in
+    # environment.variables and the slot patch runs before code signing so
+    # xcode-project use-profiles binds the QA-specific provisioning profiles.
+    name: iOS QA PR Build
+    working_directory: mobile
+    max_build_duration: 60
+    instance_type: mac_mini_m2
+    integrations:
+      app_store_connect: API key for Codemagic
+    environment:
+      flutter: 3.41.1
+      xcode: latest
+      cocoapods: default
+      groups:
+        - zendesk_credentials
+        - proofmode_credentials
+        - github_credentials
+        - firebase_app_distribution
+        - ios_qa_signing
+      vars:
+        QA_FIREBASE_GROUP_ALIAS: ios-qa
+      ios_signing:
+        distribution_type: ad_hoc
+        bundle_identifier: $QA_BUNDLE_ID
+    cache:
+      cache_paths:
+        - $HOME/Library/Caches/CocoaPods
+        - $HOME/.pub-cache
+    triggering:
+      events: []
+    scripts:
+      - *validate_ios_qa_env
+      - *verify_ios_qa_head
+      - *write_firebase_credentials
+      - *install_flutterfire
+      - *enable_spm
+      - *flutter_pub_get
+      - *prepare_ios_spm_packages
+      - *configure_ios_qa_slot
+      - *setup_code_signing_xcode
+      - *pod_install
+      - *build_ios_qa
+      - *verify_ios_qa_pr_current
+      - *distribute_ios_qa_firebase
+    artifacts:
+      - build/ios/ipa/*.ipa
+      - build/ios/archive/Runner.xcarchive/dSYMs/**
+      - /tmp/xcodebuild_logs/*.log
+      - firebase-distribution.json
+      - firebase-distribution-links.json
+      - pr-current.json
+      - ios-qa-comment.md
+    publishing:
+      scripts:
+        - *notify_ios_qa_github

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -466,15 +466,23 @@ definitions:
           echo "Cannot update GitHub for iOS QA build; missing:$missing_context"
           exit 0
         fi
-        status="ready"
-        firebase_json="firebase-distribution.json"
-        if [ "${STALE_IOS_QA_BUILD:-}" = "true" ]; then
-          status="stale"
-          firebase_json=""
-        elif [ ! -s "$firebase_json" ]; then
-          status="failed"
-          firebase_json=""
-        fi
+        python3 ../.github/scripts/ios_qa_slots.py resolve-notify-status \
+          --firebase-json firebase-distribution.json \
+          --firebase-links-json firebase-distribution-links.json \
+          --stale-env STALE_IOS_QA_BUILD \
+          > ios-qa-notify-state.json
+        status="$(python3 - <<'PY'
+        import json
+        with open("ios-qa-notify-state.json", encoding="utf-8") as fp:
+            print(json.load(fp)["status"])
+        PY
+        )"
+        firebase_json="$(python3 - <<'PY'
+        import json
+        with open("ios-qa-notify-state.json", encoding="utf-8") as fp:
+            print(json.load(fp).get("firebase_json") or "")
+        PY
+        )"
         if [ -n "${CODEMAGIC_APP_ID:-}" ] && [ -n "${CM_BUILD_ID:-}" ]; then
           codemagic_build_url="https://codemagic.io/app/$CODEMAGIC_APP_ID/build/$CM_BUILD_ID"
         else
@@ -843,6 +851,7 @@ workflows:
       - /tmp/xcodebuild_logs/*.log
       - firebase-distribution.json
       - firebase-distribution-links.json
+      - ios-qa-notify-state.json
       - pr-current.json
       - ios-qa-comment.md
     publishing:

--- a/docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md
+++ b/docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md
@@ -16,17 +16,24 @@
 - Existing iOS Codemagic workflow: `codemagic.yaml`
 - Existing web PR preview workflows: `.github/workflows/mobile_pr_preview_build.yml`, `.github/workflows/mobile_pr_preview_deploy.yml`
 - Existing web preview comment renderer: `.github/scripts/mobile_pr_preview_comment.py`
+- External docs checked on 2026-04-26:
+  - [Codemagic Builds API](https://docs.codemagic.io/rest-api/builds/): `POST /builds` accepts `appId`, `workflowId`, `branch`, `environment.variables`, and returns `buildId`.
+  - [Codemagic iOS signing](https://docs.codemagic.io/yaml-code-signing/signing-ios/): Firebase/App Distribution uses Ad Hoc signing; bundle-identifier based signing also fetches matching extension profiles.
+  - [Firebase App Distribution CLI](https://firebase.google.com/docs/app-distribution/ios/distribute-cli): use the stable `testing_uri` for testers; direct binary links expire quickly.
+  - [Codemagic Firebase distribution](https://docs.codemagic.io/yaml-distributing/firebase-app-distribution/): prefer Firebase service-account auth over deprecated Firebase token auth.
+  - [Codemagic post-publish scripts](https://docs.codemagic.io/yaml-distributing/post-publish/): post-publish scripts run even after build failure unless the build is canceled or times out; use them for GitHub status notification.
+  - [GitHub Security Lab pwn request guidance](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/): `pull_request_target` must not execute PR-controlled code in a privileged context.
 
 ## File Structure
 
 - Create: `.github/ios_qa_slots.json`
-  - Slot table for `qa01` through `qa15`: bundle IDs, extension bundle IDs, app groups, display names, and Firebase app IDs.
+  - Slot table for `qa01` through `qa15`: enabled flag, bundle IDs, extension bundle IDs, app groups, display names, and Firebase app IDs.
 - Create: `.github/scripts/ios_qa_slots.py`
-  - Pure Python logic for trust decisions, slot parsing, slot allocation, comment rendering, and directory rendering.
+  - Pure Python logic for trust decisions, slot parsing, slot allocation, sticky comment state markers, comment rendering, and directory rendering.
 - Create: `.github/scripts/tests/test_ios_qa_slots.py`
-  - Unit tests for slot selection, trust, labels, stale states, and rendered comments.
+  - Unit tests for slot selection, trust, labels, sticky state markers, stale states, queued ordering, and rendered comments.
 - Create: `.github/workflows/mobile_ios_qa_allocate.yml`
-  - Trusted metadata workflow. Uses `pull_request_target`, never checks out PR code, mirrors trusted PR heads to `ios-qa/pr-<number>`, assigns slots, triggers Codemagic, and cleans up on close.
+  - Trusted metadata workflow. Uses `pull_request_target`, checks out only base-repo scripts, never executes PR code, mirrors trusted PR heads to `ios-qa/pr-<number>`, assigns slots, triggers Codemagic, and cleans up on close.
 - Create: `mobile/lib/config/build_identity.dart`
   - Build-time identity values shared by Firebase options and push registration.
 - Modify: `mobile/lib/firebase_options.dart`
@@ -36,11 +43,11 @@
 - Create: `mobile/test/config/build_identity_test.dart`
   - Tests default production identity and QA identity under `--dart-define`.
 - Create: `mobile/scripts/ci/configure_ios_qa_slot.py`
-  - Patch iOS project build settings and entitlements for one QA slot.
+  - Patch iOS project build settings, entitlements, `GoogleService-Info.plist`, and `firebase_app_id_file.json` for one QA slot. Supports a no-write dry-run diff for the real project check.
 - Create: `mobile/scripts/ci/tests/test_configure_ios_qa_slot.py`
-  - Unit tests for project/entitlement patching using temporary fixtures.
+  - Unit tests for project, entitlement, and Firebase metadata patching using temporary fixtures.
 - Modify: `codemagic.yaml`
-  - Add an `ios-qa-pr-build` workflow using Ad Hoc signing, slot configuration, stale checks, Firebase distribution, and GitHub notification.
+  - Add an `ios-qa-pr-build` workflow using Ad Hoc signing, slot configuration before signing-profile application, stale checks, Firebase service-account distribution, and GitHub notification.
 
 ## Chunk 0: External Setup Checklist
 
@@ -94,12 +101,13 @@ ios_qa_signing
 Expected secrets:
 
 ```text
-GITHUB_TOKEN or GH_TOKEN with PR comment permissions
-FIREBASE_TOKEN or service-account auth usable by firebase-tools
+IOS_QA_GITHUB_TOKEN with PR comment/label permissions and pull request read permissions
+FIREBASE_SERVICE_ACCOUNT JSON with Firebase App Distribution Admin role
+GOOGLE_APPLICATION_CREDENTIALS=$CM_BUILD_DIR/firebase_credentials.json
 QA_FIREBASE_GROUP_ALIAS=ios-qa
 ```
 
-Codemagic must also have access to the Ad Hoc signing certificate and `qa01` provisioning profiles.
+Use Firebase token auth only as a temporary fallback; Codemagic's Firebase App Distribution docs mark token auth deprecated. Codemagic must also have access to the Ad Hoc signing certificate and `qa01` provisioning profiles.
 
 - [ ] **Step 5: Configure GitHub secrets**
 
@@ -113,6 +121,17 @@ DIVINEVIDEO_ORG_READ_TOKEN
 
 `DIVINEVIDEO_ORG_READ_TOKEN` must be able to check active org membership for private members.
 
+- [ ] **Step 6: Configure GitHub variables**
+
+Add:
+
+```text
+IOS_QA_DIRECTORY_ISSUE_NUMBER
+IOS_QA_DEFAULT_ENV=STAGING
+```
+
+If there is not yet a QA tracking issue, create one titled `iOS QA PR Builds` and store its issue number in `IOS_QA_DIRECTORY_ISSUE_NUMBER`.
+
 ## Chunk 1: Build-Time App Identity
 
 ### Task 1: Add Identity Defaults And Tests
@@ -122,7 +141,7 @@ DIVINEVIDEO_ORG_READ_TOKEN
 - Create: `mobile/lib/config/build_identity.dart`
 - Create: `mobile/test/config/build_identity_test.dart`
 
-- [ ] **Step 1: Write the default identity test**
+- [ ] **Step 1: Write the identity test**
 
 Create `mobile/test/config/build_identity_test.dart`:
 
@@ -131,10 +150,23 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/config/build_identity.dart';
 
 void main() {
-  test('uses production iOS identity by default', () {
-    expect(BuildIdentity.iosBundleId, 'co.openvine.app');
-    expect(BuildIdentity.pushAppIdentifier, 'co.openvine.app');
-    expect(BuildIdentity.firebaseIosAppId, '1:972941478875:ios:f61272b3cf485df244b5fe');
+  test('uses iOS identity from dart defines with production defaults', () {
+    const expectedBundleId = String.fromEnvironment(
+      'EXPECTED_IOS_BUNDLE_ID',
+      defaultValue: 'co.openvine.app',
+    );
+    const expectedPushAppIdentifier = String.fromEnvironment(
+      'EXPECTED_PUSH_APP_IDENTIFIER',
+      defaultValue: expectedBundleId,
+    );
+    const expectedFirebaseAppId = String.fromEnvironment(
+      'EXPECTED_FIREBASE_IOS_APP_ID',
+      defaultValue: '1:972941478875:ios:f61272b3cf485df244b5fe',
+    );
+
+    expect(BuildIdentity.iosBundleId, expectedBundleId);
+    expect(BuildIdentity.pushAppIdentifier, expectedPushAppIdentifier);
+    expect(BuildIdentity.firebaseIosAppId, expectedFirebaseAppId);
   });
 }
 ```
@@ -146,6 +178,13 @@ Run:
 ```bash
 cd mobile
 flutter test test/config/build_identity_test.dart
+flutter test test/config/build_identity_test.dart \
+  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
+  --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
 ```
 
 Expected: FAIL because `BuildIdentity` does not exist.
@@ -196,41 +235,9 @@ cd mobile
 flutter test test/config/build_identity_test.dart \
   --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
   --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
-  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
-```
-
-Expected: FAIL until the test is extended for override mode.
-
-- [ ] **Step 6: Extend the test for override mode**
-
-Append to `mobile/test/config/build_identity_test.dart`:
-
-```dart
-  test('can use QA identity from dart defines', () {
-    const expectedBundleId = String.fromEnvironment('EXPECTED_IOS_BUNDLE_ID');
-    const expectedFirebaseAppId = String.fromEnvironment(
-      'EXPECTED_FIREBASE_IOS_APP_ID',
-    );
-
-    if (expectedBundleId.isEmpty && expectedFirebaseAppId.isEmpty) {
-      return;
-    }
-
-    expect(BuildIdentity.iosBundleId, expectedBundleId);
-    expect(BuildIdentity.pushAppIdentifier, expectedBundleId);
-    expect(BuildIdentity.firebaseIosAppId, expectedFirebaseAppId);
-  });
-```
-
-Run:
-
-```bash
-cd mobile
-flutter test test/config/build_identity_test.dart \
-  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
-  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
   --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
   --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
   --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
 ```
 
@@ -291,6 +298,7 @@ flutter test test/config/build_identity_test.dart \
   --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
   --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
   --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
   --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
 ```
 
@@ -323,8 +331,12 @@ Create tests that copy minimal fixtures into a temp directory and verify:
 
 - `PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app;` changes to `co.openvine.app.qa01`.
 - `PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.NotificationServiceExtension;` changes to `co.openvine.app.qa01.NotificationServiceExtension`.
+- `PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.RunnerTests;` does not change.
 - `INFOPLIST_KEY_CFBundleDisplayName = divine;` changes to `"Divine QA 01";`.
 - `group.co.openvine.app` changes to `group.co.openvine.app.qa01` in both entitlements files.
+- `BUNDLE_ID` in `Runner/GoogleService-Info.plist` changes to `co.openvine.app.qa01`.
+- `GOOGLE_APP_ID` in `Runner/GoogleService-Info.plist` and `ios/firebase_app_id_file.json` changes to the slot Firebase app ID.
+- `--dry-run` prints a unified diff and leaves fixture files unchanged.
 - Missing required arguments fail with a non-zero exit.
 
 Run:
@@ -352,9 +364,10 @@ The script should accept:
 --extension-bundle-id co.openvine.app.qa01.NotificationServiceExtension
 --app-group group.co.openvine.app.qa01
 --display-name "Divine QA 01"
+--firebase-ios-app-id 1:972941478875:ios:qa01placeholder
 ```
 
-Use `plistlib` for entitlements. Patch `Runner.xcodeproj/project.pbxproj` as text, but keep replacements narrow and fail if an expected production identifier is not found.
+Use `plistlib` for entitlements and Firebase plist/JSON metadata. Patch `Runner.xcodeproj/project.pbxproj` as text, but keep replacements narrow, do not change RunnerTests bundle IDs, and fail if an expected production identifier is not found. The script must support `--dry-run` for the real-project check.
 
 - [ ] **Step 2: Run script tests**
 
@@ -376,28 +389,26 @@ python3 mobile/scripts/ci/configure_ios_qa_slot.py \
   --bundle-id co.openvine.app.qa01 \
   --extension-bundle-id co.openvine.app.qa01.NotificationServiceExtension \
   --app-group group.co.openvine.app.qa01 \
-  --display-name "Divine QA 01"
-
-git diff -- mobile/ios/Runner.xcodeproj/project.pbxproj \
-  mobile/ios/Runner/Runner.entitlements \
-  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements
+  --display-name "Divine QA 01" \
+  --firebase-ios-app-id 1:972941478875:ios:qa01placeholder \
+  --dry-run
 ```
 
-Expected: diff shows only bundle ID, display name, and app group changes.
-
-- [ ] **Step 4: Revert the dry-run project changes**
+Expected: stdout diff shows only bundle ID, display name, app group, Firebase bundle ID, and Firebase app ID changes. `git diff -- mobile/ios` is empty after the command.
 
 Run:
 
 ```bash
-git checkout -- mobile/ios/Runner.xcodeproj/project.pbxproj \
+git diff --exit-code -- mobile/ios/Runner.xcodeproj/project.pbxproj \
   mobile/ios/Runner/Runner.entitlements \
-  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements
+  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements \
+  mobile/ios/Runner/GoogleService-Info.plist \
+  mobile/ios/firebase_app_id_file.json
 ```
 
-This checkout is only for changes made by this dry-run step.
+Expected: exits 0.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 4: Commit**
 
 Run:
 
@@ -417,7 +428,7 @@ git commit -m "build(ios): add qa slot project patcher"
 
 - [ ] **Step 1: Add slot map**
 
-Create `.github/ios_qa_slots.json` with all 15 slots. Use the real Firebase app IDs as they are created. For slots not created yet, set `firebaseAppId` to an empty string and keep the allocator disabled for those slots.
+Create `.github/ios_qa_slots.json` with all 15 slots. Use the real Firebase app IDs as they are created. For slots not created yet, set `enabled` to `false` and `firebaseAppId` to an empty string. Stage 1 should enable only `qa01`.
 
 ```json
 {
@@ -425,10 +436,21 @@ Create `.github/ios_qa_slots.json` with all 15 slots. Use the real Firebase app 
     {
       "slot": "qa01",
       "label": "ios-qa-slot-01",
+      "enabled": true,
       "bundleId": "co.openvine.app.qa01",
       "extensionBundleId": "co.openvine.app.qa01.NotificationServiceExtension",
       "appGroup": "group.co.openvine.app.qa01",
       "displayName": "Divine QA 01",
+      "firebaseAppId": "1:972941478875:ios:qa01placeholder"
+    },
+    {
+      "slot": "qa02",
+      "label": "ios-qa-slot-02",
+      "enabled": false,
+      "bundleId": "co.openvine.app.qa02",
+      "extensionBundleId": "co.openvine.app.qa02.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa02",
+      "displayName": "Divine QA 02",
       "firebaseAppId": ""
     }
   ]
@@ -461,11 +483,15 @@ Cover:
 - Not trusted for outside fork and non-member.
 - Draft PR without `needs-ios-qa` is not eligible.
 - Draft PR with `needs-ios-qa` is eligible.
+- PRs with no changes under `mobile/**` or `codemagic.yaml` are skipped but still cleaned up if labels already exist.
 - Existing slot label is preserved.
-- First free slot is assigned.
-- Queued state when all configured slots are occupied.
+- First free enabled slot is assigned.
+- Disabled slots and slots with empty `firebaseAppId` are not assigned.
+- Queued state when all enabled slots are occupied.
+- Queued PRs are ordered by oldest `needs-ios-qa`/ready eligibility timestamp, then PR number for deterministic reconciliation.
 - Closed PR cleanup returns labels to remove and mirror branch to delete.
-- Comment renderer includes slot, PR, SHA, Firebase testing URI, and Codemagic URL.
+- Sticky state marker round-trips JSON for slot, PR number, full commit SHA, status, Codemagic build ID/URL, Firebase `testing_uri`, and failure reason.
+- Comment renderer includes slot, PR, full SHA, Firebase testing URI, and Codemagic URL. Do not truncate Nostr IDs; commit SHAs may be shortened only for display if the full SHA remains in the hidden state marker and table.
 
 Run:
 
@@ -488,10 +514,13 @@ Required functions:
 
 ```python
 def load_slots(path): ...
+def enabled_slots(slots): ...
 def is_trusted_pr(head_repo_owner, author_is_org_member): ...
 def is_eligible_pr(is_draft, labels): ...
 def current_slot(labels): ...
 def choose_slot(slots, open_prs): ...
+def render_state_marker(state): ...
+def parse_state_marker(comment_body): ...
 def render_status_comment(...): ...
 def render_directory(...): ...
 ```
@@ -505,9 +534,13 @@ allocate
 render-comment
 render-directory
 cleanup
+parse-comment-state
+render-codemagic-payload
+upsert-comment
+notify-github
 ```
 
-The workflow can pass event JSON paths and write outputs to `$GITHUB_OUTPUT`.
+The workflow can pass event JSON paths and write outputs to `$GITHUB_OUTPUT`. Use JSON files for PR metadata to avoid shell interpolation of untrusted PR titles, branch names, labels, or author names.
 
 - [ ] **Step 3: Run tests**
 
@@ -551,14 +584,13 @@ on:
   pull_request_target:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, closed, labeled, unlabeled]
-    paths:
-      - "mobile/**"
-      - "codemagic.yaml"
   workflow_dispatch:
     inputs:
       pr_number:
         required: true
 ```
+
+Do not use workflow `paths` filters here. The script should decide whether the PR touches mobile/Codemagic files so close events, manual dispatches, and scheduled reconciliation cannot be skipped by path filtering.
 
 Permissions:
 
@@ -587,40 +619,65 @@ Expected trusted condition:
 head repo owner is divinevideo OR author is active divinevideo org member/owner
 ```
 
+For `workflow_dispatch`, fetch the PR metadata with the GitHub API by `pr_number` and write it to a JSON file consumed by `.github/scripts/ios_qa_slots.py`.
+
 - [ ] **Step 3: Mirror trusted PR head to base repo**
 
 For trusted eligible PRs:
 
 ```bash
-git fetch origin "pull/${PR_NUMBER}/head"
-git push origin "FETCH_HEAD:refs/heads/ios-qa/pr-${PR_NUMBER}" --force
+git fetch --no-tags origin "pull/${PR_NUMBER}/head"
+git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+  "FETCH_HEAD:refs/heads/ios-qa/pr-${PR_NUMBER}" --force
 ```
 
 For closed PRs:
 
 ```bash
-git push origin ":refs/heads/ios-qa/pr-${PR_NUMBER}" || true
+git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+  ":refs/heads/ios-qa/pr-${PR_NUMBER}" || true
 ```
+
+The checkout step must use the base repository only, with `persist-credentials: false`. Fetching the PR head is allowed only after the trust check and only for mirroring; no step may run code from `FETCH_HEAD`.
 
 - [ ] **Step 4: Trigger Codemagic**
 
-Use the Codemagic Builds API with:
+Use the Codemagic Builds API with `appId`, `workflowId`, `branch`, labels, and `environment.variables`:
+
+```bash
+payload_file="${RUNNER_TEMP}/codemagic-ios-qa-build.json"
+python3 .github/scripts/ios_qa_slots.py render-codemagic-payload \
+  --app-id "$CODEMAGIC_APP_ID" \
+  --workflow-id ios-qa-pr-build \
+  --branch "ios-qa/pr-${PR_NUMBER}" \
+  --pr-json "$RUNNER_TEMP/pr.json" \
+  --slot-json "$RUNNER_TEMP/slot.json" \
+  --default-env "${IOS_QA_DEFAULT_ENV:-STAGING}" \
+  > "$payload_file"
+
+curl --fail-with-body \
+  -H "Content-Type: application/json" \
+  -H "x-auth-token: ${CODEMAGIC_API_TOKEN}" \
+  --data @"$payload_file" \
+  -X POST https://api.codemagic.io/builds \
+  > "$RUNNER_TEMP/codemagic-response.json"
+```
+
+The payload must include these `environment.variables`:
 
 ```text
-workflow_id=ios-qa-pr-build
-branch=ios-qa/pr-<number>
-environment variables:
-  PR_NUMBER
-  PR_HEAD_SHA
-  PR_HEAD_REPO
-  PR_HEAD_REF
-  QA_SLOT
-  QA_BUNDLE_ID
-  QA_EXTENSION_BUNDLE_ID
-  QA_APP_GROUP
-  QA_DISPLAY_NAME
-  QA_FIREBASE_APP_ID
-  DEFAULT_ENV
+PR_NUMBER
+PR_HEAD_SHA
+PR_HEAD_REPO
+PR_HEAD_REF
+QA_SLOT
+QA_BUNDLE_ID
+QA_EXTENSION_BUNDLE_ID
+QA_APP_GROUP
+QA_DISPLAY_NAME
+QA_FIREBASE_APP_ID
+DEFAULT_ENV
+CODEMAGIC_APP_ID
 ```
 
 Use `CODEMAGIC_APP_ID` and `CODEMAGIC_API_TOKEN` from GitHub secrets.
@@ -632,8 +689,9 @@ The workflow should:
 - Add or preserve `ios-qa-slot-NN`.
 - Add `ios-qa:building` when a build is triggered.
 - Add `ios-qa:queued` when no slot is available.
-- Add a sticky comment with a hidden marker `<!-- divine-ios-qa-build -->`.
+- Add or update a sticky comment with a hidden marker `<!-- divine-ios-qa-build:v1 ... -->` containing JSON state.
 - Avoid duplicate comments.
+- Store the Codemagic `buildId` returned by `POST /builds` in the hidden state marker.
 
 - [ ] **Step 6: Validate workflow YAML**
 
@@ -668,24 +726,64 @@ git commit -m "ci(ios): allocate qa slots for trusted prs"
 Add reusable scripts:
 
 ```yaml
+- &validate_ios_qa_env
+  name: Validate iOS QA environment
+  script: |
+    set -eu
+    for name in \
+      PR_NUMBER PR_HEAD_SHA PR_HEAD_REPO PR_HEAD_REF \
+      QA_SLOT QA_BUNDLE_ID QA_EXTENSION_BUNDLE_ID QA_APP_GROUP \
+      QA_DISPLAY_NAME QA_FIREBASE_APP_ID DEFAULT_ENV \
+      CODEMAGIC_APP_ID IOS_QA_GITHUB_TOKEN QA_FIREBASE_GROUP_ALIAS
+    do
+      eval "value=\${$name:-}"
+      if [ -z "$value" ]; then
+        echo "Missing required iOS QA variable: $name"
+        exit 1
+      fi
+    done
+    echo "GH_TOKEN=$IOS_QA_GITHUB_TOKEN" >> "$CM_ENV"
+
 - &configure_ios_qa_slot
   name: Configure iOS QA slot
   script: |
+    set -eu
     python3 scripts/ci/configure_ios_qa_slot.py \
       --project-root . \
       --bundle-id "$QA_BUNDLE_ID" \
       --extension-bundle-id "$QA_EXTENSION_BUNDLE_ID" \
       --app-group "$QA_APP_GROUP" \
-      --display-name "$QA_DISPLAY_NAME"
+      --display-name "$QA_DISPLAY_NAME" \
+      --firebase-ios-app-id "$QA_FIREBASE_APP_ID"
 
 - &verify_ios_qa_head
   name: Verify mirrored PR SHA
   script: |
+    set -eu
     ACTUAL_SHA="$(git rev-parse HEAD)"
     if [ "$ACTUAL_SHA" != "$PR_HEAD_SHA" ]; then
       echo "Stale mirror branch: expected $PR_HEAD_SHA, got $ACTUAL_SHA"
       exit 1
     fi
+
+- &write_firebase_credentials
+  name: Write Firebase service-account credentials
+  script: |
+    set -eu
+    if [ -n "${FIREBASE_SERVICE_ACCOUNT:-}" ]; then
+      : "${GOOGLE_APPLICATION_CREDENTIALS:=$CM_BUILD_DIR/firebase_credentials.json}"
+      printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$GOOGLE_APPLICATION_CREDENTIALS"
+      echo "GOOGLE_APPLICATION_CREDENTIALS=$GOOGLE_APPLICATION_CREDENTIALS" >> "$CM_ENV"
+      exit 0
+    fi
+
+    if [ -n "${FIREBASE_TOKEN:-}" ]; then
+      echo "Using deprecated FIREBASE_TOKEN fallback. Prefer FIREBASE_SERVICE_ACCOUNT."
+      exit 0
+    fi
+
+    echo "Missing FIREBASE_SERVICE_ACCOUNT or FIREBASE_TOKEN"
+    exit 1
 ```
 
 - [ ] **Step 2: Add QA build script**
@@ -696,6 +794,7 @@ Build with slot dart defines:
 - &build_ios_qa
   name: Build iOS QA IPA
   script: |
+    set -eu
     flutter build ipa --release --build-number="$PROJECT_BUILD_NUMBER" \
       --dart-define=ZENDESK_APP_ID="$ZENDESK_APP_ID" \
       --dart-define=ZENDESK_CLIENT_ID="$ZENDESK_CLIENT_ID" \
@@ -717,18 +816,40 @@ Install Firebase CLI if needed, distribute the IPA, and capture JSON output:
 - &distribute_ios_qa_firebase
   name: Distribute iOS QA build to Firebase
   script: |
+    set -eu
+    if [ "${STALE_IOS_QA_BUILD:-}" = "true" ]; then
+      echo "Skipping Firebase distribution for stale iOS QA build"
+      exit 0
+    fi
+
     npm install -g firebase-tools
     IPA_PATH="$(ls build/ios/ipa/*.ipa | head -1)"
+    firebase_token_args=""
+    if [ -n "${FIREBASE_TOKEN:-}" ] && [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
+      firebase_token_args="--token $FIREBASE_TOKEN"
+    fi
     firebase appdistribution:distribute "$IPA_PATH" \
       --app "$QA_FIREBASE_APP_ID" \
       --groups "$QA_FIREBASE_GROUP_ALIAS" \
       --release-notes "PR #$PR_NUMBER $PR_HEAD_SHA ($QA_SLOT)" \
-      --json > "$CM_BUILD_DIR/firebase-distribution.json"
+      --json \
+      $firebase_token_args \
+      > firebase-distribution.json
+
+    python3 - <<'PY'
+    import json
+    from pathlib import Path
+
+    path = Path("firebase-distribution.json")
+    data = json.loads(path.read_text())
+    if not data.get("testing_uri"):
+        raise SystemExit("Firebase distribution JSON did not include testing_uri")
+    PY
 ```
 
 - [ ] **Step 4: Add stale PR check before distribution**
 
-Before Firebase distribution, call GitHub API using `GH_TOKEN` and verify:
+Before Firebase distribution, call GitHub API using `IOS_QA_GITHUB_TOKEN` and verify:
 
 ```text
 PR is open
@@ -737,9 +858,95 @@ PR head SHA equals PR_HEAD_SHA
 
 If stale, exit 0 after notifying GitHub with stale status. Do not upload the IPA.
 
+Add a reusable script:
+
+```yaml
+- &verify_ios_qa_pr_current
+  name: Verify PR is still current before distribution
+  script: |
+    set -eu
+    pr_json="pr-current.json"
+    curl --fail-with-body \
+      -H "Authorization: Bearer $IOS_QA_GITHUB_TOKEN" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/$CM_REPO_SLUG/pulls/$PR_NUMBER" \
+      > "$pr_json"
+
+    python3 - "$pr_json" <<'PY'
+    import json
+    import os
+    import sys
+
+    pr = json.load(open(sys.argv[1], encoding="utf-8"))
+    expected = os.environ["PR_HEAD_SHA"]
+    actual = pr["head"]["sha"]
+    if pr["state"] != "open" or actual != expected:
+        print(f"STALE_IOS_QA_BUILD=true", file=open(os.environ["CM_ENV"], "a", encoding="utf-8"))
+        print(f"Stale PR build: state={pr['state']} expected={expected} actual={actual}")
+        raise SystemExit(0)
+    PY
+```
+
+Make `*distribute_ios_qa_firebase` skip upload when `STALE_IOS_QA_BUILD=true`, then run the GitHub notification script with `status=stale`.
+
 - [ ] **Step 5: Add GitHub notification script**
 
-After Firebase distribution, parse `firebase-distribution.json`, extract the tester URI, and update the sticky PR comment. If Firebase CLI JSON shape differs, adapt the parser and document the observed output in the commit.
+Add this as a Codemagic post-publish script so it runs even when the main build fails. After Firebase distribution, parse `firebase-distribution.json`, extract `testing_uri`, and update the sticky PR comment. If `STALE_IOS_QA_BUILD=true`, update the same sticky comment with stale status and do not require a Firebase JSON file. If Firebase CLI JSON shape differs, adapt the parser and document the observed output in the commit.
+
+The notification script should:
+
+- Replace `ios-qa:building` with `ios-qa:ready` on successful distribution.
+- Replace `ios-qa:building` with `ios-qa:failed` on build/distribution failure.
+- Keep the slot label on ready, stale, and failed states.
+- Preserve a hidden JSON state marker with full commit SHA, Codemagic build URL, Firebase `testing_uri`, and updated timestamp.
+- Use `IOS_QA_GITHUB_TOKEN`/`GH_TOKEN` from Codemagic, not a GitHub Actions token.
+
+Add a reusable script:
+
+```yaml
+- &notify_ios_qa_github
+  name: Notify GitHub about iOS QA build
+  script: |
+    set -eu
+    status="ready"
+    firebase_json="firebase-distribution.json"
+    if [ "${STALE_IOS_QA_BUILD:-}" = "true" ]; then
+      status="stale"
+      firebase_json=""
+    elif [ ! -s "$firebase_json" ]; then
+      status="failed"
+      firebase_json=""
+    fi
+    codemagic_build_url="https://codemagic.io/app/$CODEMAGIC_APP_ID/build/$CM_BUILD_ID"
+
+    if [ -n "$firebase_json" ]; then
+      python3 ../.github/scripts/ios_qa_slots.py render-comment \
+        --status "$status" \
+        --pr-number "$PR_NUMBER" \
+        --slot "$QA_SLOT" \
+        --sha "$PR_HEAD_SHA" \
+        --codemagic-build-url "$codemagic_build_url" \
+        --firebase-json "$firebase_json" \
+        > ios-qa-comment.md
+    else
+      python3 ../.github/scripts/ios_qa_slots.py render-comment \
+        --status "$status" \
+        --pr-number "$PR_NUMBER" \
+        --slot "$QA_SLOT" \
+        --sha "$PR_HEAD_SHA" \
+        --codemagic-build-url "$codemagic_build_url" \
+        > ios-qa-comment.md
+    fi
+
+    python3 ../.github/scripts/ios_qa_slots.py notify-github \
+      --repo "$CM_REPO_SLUG" \
+      --issue-number "$PR_NUMBER" \
+      --token-env IOS_QA_GITHUB_TOKEN \
+      --status "$status" \
+      --body-file ios-qa-comment.md
+```
+
+Implement marker-based update-or-create in this task: list existing issue comments, find `<!-- divine-ios-qa-build:v1`, patch that comment when present, and create only when absent. The same mode should update labels for `ready`, `failed`, and `stale` statuses.
 
 - [ ] **Step 6: Add `ios-qa-pr-build` workflow**
 
@@ -763,27 +970,40 @@ ios-qa-pr-build:
       - github_credentials
       - firebase_app_distribution
       - ios_qa_signing
+    vars:
+      QA_FIREBASE_GROUP_ALIAS: ios-qa
     ios_signing:
       distribution_type: ad_hoc
       bundle_identifier: $QA_BUNDLE_ID
   triggering:
     events: []
   scripts:
+    - *validate_ios_qa_env
     - *verify_ios_qa_head
-    - *setup_code_signing_xcode
+    - *write_firebase_credentials
     - *install_flutterfire
     - *enable_spm
+    - *flutter_pub_get
     - *prepare_ios_spm_packages
     - *configure_ios_qa_slot
+    - *setup_code_signing_xcode
     - *pod_install
     - *build_ios_qa
+    - *verify_ios_qa_pr_current
     - *distribute_ios_qa_firebase
   artifacts:
     - build/ios/ipa/*.ipa
     - build/ios/archive/Runner.xcarchive/dSYMs/**
     - /tmp/xcodebuild_logs/*.log
     - firebase-distribution.json
+    - pr-current.json
+    - ios-qa-comment.md
+  publishing:
+    scripts:
+      - *notify_ios_qa_github
 ```
+
+The slot patch must run before `*setup_code_signing_xcode`; otherwise `xcode-project use-profiles` can bind production profiles to the unpatched project.
 
 If Codemagic does not accept `$QA_BUNDLE_ID` in `ios_signing.bundle_identifier`, replace this with 15 generated workflows or a script-level `app-store-connect fetch-signing-files` approach after proving the constraint in a dry run.
 
@@ -823,9 +1043,11 @@ Test that rendered directory includes:
 - Active slots.
 - Queued PRs.
 - Failed PRs.
+- Stale builds superseded by newer commits.
 - Firebase install links.
 - Codemagic build links.
 - Last updated timestamp.
+- Build metadata recovered from sticky comment state markers.
 
 - [ ] **Step 2: Add scheduled reconciliation**
 
@@ -842,7 +1064,8 @@ The scheduled job should:
 - List open PRs.
 - Remove stale slot labels from closed PRs if any remain.
 - Delete stale `ios-qa/pr-*` branches for closed PRs.
-- Assign queued PRs when slots are free.
+- Assign queued PRs when slots are free, using deterministic queued ordering from the slot library.
+- Refresh stale/building states whose Codemagic build has finished without a post-publish update.
 - Re-render the active build directory.
 
 - [ ] **Step 3: Decide directory home**
@@ -889,6 +1112,8 @@ git commit -m "ci(ios): reconcile qa slots and directory"
 
 - No source changes expected unless verification exposes issues.
 
+GitHub only runs `pull_request_target` and `workflow_dispatch` workflows that exist on `main`. Do not treat the bootstrap PR as fully end-to-end verified until this workflow has been merged or otherwise exists on `main`; use a throwaway trusted mobile PR for the live `qa01` proof.
+
 - [ ] **Step 1: Run local verification**
 
 Run:
@@ -898,15 +1123,35 @@ python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
 python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
 ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml')"
 ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
+python3 mobile/scripts/ci/configure_ios_qa_slot.py \
+  --project-root mobile \
+  --bundle-id co.openvine.app.qa01 \
+  --extension-bundle-id co.openvine.app.qa01.NotificationServiceExtension \
+  --app-group group.co.openvine.app.qa01 \
+  --display-name "Divine QA 01" \
+  --firebase-ios-app-id 1:972941478875:ios:qa01placeholder \
+  --dry-run >/tmp/ios-qa-slot-dry-run.diff
+git diff --exit-code -- mobile/ios/Runner.xcodeproj/project.pbxproj \
+  mobile/ios/Runner/Runner.entitlements \
+  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements \
+  mobile/ios/Runner/GoogleService-Info.plist \
+  mobile/ios/firebase_app_id_file.json
 cd mobile
 flutter test test/config/build_identity_test.dart
+flutter test test/config/build_identity_test.dart \
+  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
+  --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
 ```
 
 Expected: all pass.
 
-- [ ] **Step 2: Trigger one trusted PR manually**
+- [ ] **Step 2: Trigger one trusted throwaway PR manually**
 
-Use workflow dispatch on `Mobile iOS QA Allocate` with a trusted PR number.
+After the bootstrap workflow exists on `main`, use workflow dispatch on `Mobile iOS QA Allocate` with a trusted throwaway PR number.
 
 Expected:
 
@@ -914,13 +1159,15 @@ Expected:
 - PR receives `ios-qa:building`.
 - Branch `ios-qa/pr-<number>` exists and points to the PR head SHA.
 - Codemagic starts `ios-qa-pr-build`.
+- PR sticky comment contains `<!-- divine-ios-qa-build:v1` with the full PR head SHA and Codemagic build ID.
 
 - [ ] **Step 3: Verify Firebase install**
 
 Expected:
 
 - Firebase App Distribution shows a release for `co.openvine.app.qa01`.
-- PR sticky comment includes Firebase tester link.
+- PR sticky comment includes Firebase `testing_uri`.
+- PR label changes from `ios-qa:building` to `ios-qa:ready`.
 - QA can install `Divine QA 01` on a registered iOS device.
 - Production/TestFlight app remains installed side by side.
 
@@ -933,6 +1180,7 @@ Expected:
 - Slot labels are removed.
 - Mirror branch is deleted.
 - Directory updates.
+- A still-running Codemagic build skips distribution when it reaches the stale/closed check.
 
 ## Chunk 8: Expand To 15 Slots
 
@@ -947,9 +1195,9 @@ Expected:
 
 Repeat external setup for `qa02` through `qa15`.
 
-- [ ] **Step 2: Fill real Firebase app IDs**
+- [ ] **Step 2: Fill real Firebase app IDs and enable slots**
 
-Update `.github/ios_qa_slots.json`.
+Update `.github/ios_qa_slots.json` with each real Firebase app ID and set `enabled: true` only after the matching Apple identifiers, App Group, Ad Hoc profiles, Firebase app, and Codemagic signing assets exist.
 
 - [ ] **Step 3: Run slot tests**
 
@@ -999,4 +1247,3 @@ gh pr create \
   --title "ci(ios): add QA PR build slots" \
   --body "Adds the iOS QA PR build slot design and implementation for Ad Hoc Firebase distribution."
 ```
-

--- a/docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md
+++ b/docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md
@@ -536,7 +536,7 @@ Cover:
 Run:
 
 ```bash
-python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+PYTHONPATH=.github/scripts python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'
 ```
 
 Expected: FAIL because `ios_qa_slots.py` does not exist.
@@ -591,7 +591,7 @@ The workflow can pass event JSON paths and write outputs to `$GITHUB_OUTPUT`. Us
 Run:
 
 ```bash
-python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+PYTHONPATH=.github/scripts python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'
 ```
 
 Expected: PASS.
@@ -758,7 +758,7 @@ Run:
 
 ```bash
 ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
-python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+PYTHONPATH=.github/scripts python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'
 ```
 
 Expected: both commands exit 0.
@@ -1163,7 +1163,7 @@ IOS_QA_DIRECTORY_ISSUE_NUMBER
 Run:
 
 ```bash
-python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+PYTHONPATH=.github/scripts python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'
 ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
 ```
 
@@ -1195,7 +1195,7 @@ GitHub only runs `pull_request_target` and `workflow_dispatch` workflows that ex
 Run:
 
 ```bash
-python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+PYTHONPATH=.github/scripts python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'
 python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
 ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml')"
 ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
@@ -1280,7 +1280,7 @@ Update `.github/ios_qa_slots.json` with each real Firebase app ID and set `enabl
 Run:
 
 ```bash
-python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+PYTHONPATH=.github/scripts python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'
 python3 -m json.tool .github/ios_qa_slots.json >/tmp/ios_qa_slots.json
 ```
 
@@ -1300,7 +1300,7 @@ git commit -m "ci(ios): enable all qa slots"
 - [ ] **Run all local non-signing verification**
 
 ```bash
-python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+PYTHONPATH=.github/scripts python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'
 python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
 ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml')"
 ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"

--- a/docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md
+++ b/docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md
@@ -132,6 +132,44 @@ IOS_QA_DEFAULT_ENV=STAGING
 
 If there is not yet a QA tracking issue, create one titled `iOS QA PR Builds` and store its issue number in `IOS_QA_DIRECTORY_ISSUE_NUMBER`.
 
+- [ ] **Step 7: Bootstrap GitHub labels**
+
+Create or update the labels the allocator uses before enabling the workflow. The repo does not currently have `ios-qa*` labels, so this must be idempotent and part of rollout.
+
+Run:
+
+```bash
+for n in $(seq -w 1 15); do
+  gh label create "ios-qa-slot-$n" \
+    --color "0E8A16" \
+    --description "iOS QA build slot $n" \
+    --force
+done
+
+gh label create "ios-qa:building" \
+  --color "FBCA04" \
+  --description "iOS QA build is running" \
+  --force
+gh label create "ios-qa:ready" \
+  --color "0E8A16" \
+  --description "iOS QA build is ready for testing" \
+  --force
+gh label create "ios-qa:queued" \
+  --color "D4C5F9" \
+  --description "iOS QA build is waiting for a slot" \
+  --force
+gh label create "ios-qa:failed" \
+  --color "D93F0B" \
+  --description "iOS QA build failed" \
+  --force
+gh label create "needs-ios-qa" \
+  --color "5319E7" \
+  --description "Build this draft PR for iOS QA" \
+  --force
+```
+
+Expected: command exits 0 and `gh label list --limit 300 | rg '^ios-qa|^needs-ios-qa'` shows all 20 labels.
+
 ## Chunk 1: Build-Time App Identity
 
 ### Task 1: Add Identity Defaults And Tests
@@ -491,6 +529,8 @@ Cover:
 - Queued PRs are ordered by oldest `needs-ios-qa`/ready eligibility timestamp, then PR number for deterministic reconciliation.
 - Closed PR cleanup returns labels to remove and mirror branch to delete.
 - Sticky state marker round-trips JSON for slot, PR number, full commit SHA, status, Codemagic build ID/URL, Firebase `testing_uri`, and failure reason.
+- Required-label renderer returns all 15 slot labels plus `ios-qa:building`, `ios-qa:ready`, `ios-qa:queued`, `ios-qa:failed`, and `needs-ios-qa`.
+- Firebase distribution parser extracts `testing_uri` from known Firebase CLI JSON shapes: top-level, `result`, and `result.release`. It rejects JSON that only has `binary_download_uri`.
 - Comment renderer includes slot, PR, full SHA, Firebase testing URI, and Codemagic URL. Do not truncate Nostr IDs; commit SHAs may be shortened only for display if the full SHA remains in the hidden state marker and table.
 
 Run:
@@ -521,6 +561,8 @@ def current_slot(labels): ...
 def choose_slot(slots, open_prs): ...
 def render_state_marker(state): ...
 def parse_state_marker(comment_body): ...
+def required_labels(slots): ...
+def extract_firebase_testing_uri(firebase_distribution_json): ...
 def render_status_comment(...): ...
 def render_directory(...): ...
 ```
@@ -538,6 +580,8 @@ parse-comment-state
 render-codemagic-payload
 upsert-comment
 notify-github
+render-label-bootstrap
+parse-firebase-distribution
 ```
 
 The workflow can pass event JSON paths and write outputs to `$GITHUB_OUTPUT`. Use JSON files for PR metadata to avoid shell interpolation of untrusted PR titles, branch names, labels, or author names.
@@ -609,7 +653,22 @@ concurrency:
   cancel-in-progress: false
 ```
 
-- [ ] **Step 2: Add trust check**
+- [ ] **Step 2: Add idempotent label bootstrap**
+
+The workflow should ensure labels exist before it tries to apply them. Add a step that renders the required labels from `.github/scripts/ios_qa_slots.py render-label-bootstrap`, then creates/updates them through the GitHub API or `gh label create --force`.
+
+Expected labels:
+
+```text
+ios-qa-slot-01 through ios-qa-slot-15
+ios-qa:building
+ios-qa:ready
+ios-qa:queued
+ios-qa:failed
+needs-ios-qa
+```
+
+- [ ] **Step 3: Add trust check**
 
 The workflow should call the GitHub org membership API using `DIVINEVIDEO_ORG_READ_TOKEN` when `head.repo.owner.login != "divinevideo"`.
 
@@ -621,7 +680,7 @@ head repo owner is divinevideo OR author is active divinevideo org member/owner
 
 For `workflow_dispatch`, fetch the PR metadata with the GitHub API by `pr_number` and write it to a JSON file consumed by `.github/scripts/ios_qa_slots.py`.
 
-- [ ] **Step 3: Mirror trusted PR head to base repo**
+- [ ] **Step 4: Mirror trusted PR head to base repo**
 
 For trusted eligible PRs:
 
@@ -640,7 +699,7 @@ git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
 
 The checkout step must use the base repository only, with `persist-credentials: false`. Fetching the PR head is allowed only after the trust check and only for mirroring; no step may run code from `FETCH_HEAD`.
 
-- [ ] **Step 4: Trigger Codemagic**
+- [ ] **Step 5: Trigger Codemagic**
 
 Use the Codemagic Builds API with `appId`, `workflowId`, `branch`, labels, and `environment.variables`:
 
@@ -682,7 +741,7 @@ CODEMAGIC_APP_ID
 
 Use `CODEMAGIC_APP_ID` and `CODEMAGIC_API_TOKEN` from GitHub secrets.
 
-- [ ] **Step 5: Update labels and comments**
+- [ ] **Step 6: Update labels and comments**
 
 The workflow should:
 
@@ -693,7 +752,7 @@ The workflow should:
 - Avoid duplicate comments.
 - Store the Codemagic `buildId` returned by `POST /builds` in the hidden state marker.
 
-- [ ] **Step 6: Validate workflow YAML**
+- [ ] **Step 7: Validate workflow YAML**
 
 Run:
 
@@ -704,7 +763,7 @@ python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
 
 Expected: both commands exit 0.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 8: Commit**
 
 Run:
 
@@ -836,16 +895,13 @@ Install Firebase CLI if needed, distribute the IPA, and capture JSON output:
       $firebase_token_args \
       > firebase-distribution.json
 
-    python3 - <<'PY'
-    import json
-    from pathlib import Path
-
-    path = Path("firebase-distribution.json")
-    data = json.loads(path.read_text())
-    if not data.get("testing_uri"):
-        raise SystemExit("Firebase distribution JSON did not include testing_uri")
-    PY
+    python3 ../.github/scripts/ios_qa_slots.py parse-firebase-distribution \
+      --json-file firebase-distribution.json \
+      --require-testing-uri \
+      > firebase-distribution-links.json
 ```
+
+`parse-firebase-distribution` must support the Firebase CLI JSON shapes observed in tests: top-level links, `result` links, and `result.release` links. It must fail when only `binary_download_uri` is present, because that link expires after one hour and is not acceptable for QA comments.
 
 - [ ] **Step 4: Add stale PR check before distribution**
 
@@ -900,6 +956,7 @@ The notification script should:
 - Keep the slot label on ready, stale, and failed states.
 - Preserve a hidden JSON state marker with full commit SHA, Codemagic build URL, Firebase `testing_uri`, and updated timestamp.
 - Use `IOS_QA_GITHUB_TOKEN`/`GH_TOKEN` from Codemagic, not a GitHub Actions token.
+- Tolerate early build failures before validation has run. If the minimum GitHub context (`IOS_QA_GITHUB_TOKEN`, `CM_REPO_SLUG`, `PR_NUMBER`) is missing, log the missing keys and exit 0 instead of masking the original build failure.
 
 Add a reusable script:
 
@@ -907,7 +964,19 @@ Add a reusable script:
 - &notify_ios_qa_github
   name: Notify GitHub about iOS QA build
   script: |
-    set -eu
+    set -u
+    missing_context=""
+    for name in IOS_QA_GITHUB_TOKEN CM_REPO_SLUG PR_NUMBER; do
+      eval "value=\${$name:-}"
+      if [ -z "$value" ]; then
+        missing_context="$missing_context $name"
+      fi
+    done
+    if [ -n "$missing_context" ]; then
+      echo "Cannot update GitHub for iOS QA build; missing:$missing_context"
+      exit 0
+    fi
+
     status="ready"
     firebase_json="firebase-distribution.json"
     if [ "${STALE_IOS_QA_BUILD:-}" = "true" ]; then
@@ -917,14 +986,20 @@ Add a reusable script:
       status="failed"
       firebase_json=""
     fi
-    codemagic_build_url="https://codemagic.io/app/$CODEMAGIC_APP_ID/build/$CM_BUILD_ID"
+    if [ -n "${CODEMAGIC_APP_ID:-}" ] && [ -n "${CM_BUILD_ID:-}" ]; then
+      codemagic_build_url="https://codemagic.io/app/$CODEMAGIC_APP_ID/build/$CM_BUILD_ID"
+    else
+      codemagic_build_url="Codemagic build URL unavailable"
+    fi
+    qa_slot="${QA_SLOT:-unknown}"
+    pr_head_sha="${PR_HEAD_SHA:-unknown}"
 
     if [ -n "$firebase_json" ]; then
       python3 ../.github/scripts/ios_qa_slots.py render-comment \
         --status "$status" \
         --pr-number "$PR_NUMBER" \
-        --slot "$QA_SLOT" \
-        --sha "$PR_HEAD_SHA" \
+        --slot "$qa_slot" \
+        --sha "$pr_head_sha" \
         --codemagic-build-url "$codemagic_build_url" \
         --firebase-json "$firebase_json" \
         > ios-qa-comment.md
@@ -932,8 +1007,8 @@ Add a reusable script:
       python3 ../.github/scripts/ios_qa_slots.py render-comment \
         --status "$status" \
         --pr-number "$PR_NUMBER" \
-        --slot "$QA_SLOT" \
-        --sha "$PR_HEAD_SHA" \
+        --slot "$qa_slot" \
+        --sha "$pr_head_sha" \
         --codemagic-build-url "$codemagic_build_url" \
         > ios-qa-comment.md
     fi
@@ -996,6 +1071,7 @@ ios-qa-pr-build:
     - build/ios/archive/Runner.xcarchive/dSYMs/**
     - /tmp/xcodebuild_logs/*.log
     - firebase-distribution.json
+    - firebase-distribution-links.json
     - pr-current.json
     - ios-qa-comment.md
   publishing:
@@ -1228,8 +1304,29 @@ python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
 python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
 ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml')"
 ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
+python3 mobile/scripts/ci/configure_ios_qa_slot.py \
+  --project-root mobile \
+  --bundle-id co.openvine.app.qa01 \
+  --extension-bundle-id co.openvine.app.qa01.NotificationServiceExtension \
+  --app-group group.co.openvine.app.qa01 \
+  --display-name "Divine QA 01" \
+  --firebase-ios-app-id 1:972941478875:ios:qa01placeholder \
+  --dry-run >/tmp/ios-qa-slot-dry-run.diff
+git diff --exit-code -- mobile/ios/Runner.xcodeproj/project.pbxproj \
+  mobile/ios/Runner/Runner.entitlements \
+  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements \
+  mobile/ios/Runner/GoogleService-Info.plist \
+  mobile/ios/firebase_app_id_file.json
 cd mobile
 flutter test test/config/build_identity_test.dart
+flutter test test/config/build_identity_test.dart \
+  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
+  --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
+cd ..
 ```
 
 - [ ] **Review diff**

--- a/docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md
+++ b/docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md
@@ -1,0 +1,1002 @@
+# iOS QA PR Builds Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an automated iOS QA distribution lane where trusted mobile PRs get reusable side-by-side Ad Hoc builds published through Firebase App Distribution.
+
+**Architecture:** GitHub Actions owns trust checks, slot allocation, labels, mirror branches, comments, and the active build directory. Codemagic owns the signed Ad Hoc IPA build for a specific QA slot. The Flutter app and iOS project read build identity from explicit build-time inputs so one codebase can produce production and `qa01` through `qa15` apps.
+
+**Tech Stack:** GitHub Actions, Python 3 standard library tests, Codemagic YAML, Flutter/Dart compile-time environment values, Xcode project/entitlements patching, Firebase App Distribution CLI, Apple Ad Hoc signing.
+
+---
+
+## Source Documents
+
+- Design spec: `docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md`
+- Existing iOS Codemagic workflow: `codemagic.yaml`
+- Existing web PR preview workflows: `.github/workflows/mobile_pr_preview_build.yml`, `.github/workflows/mobile_pr_preview_deploy.yml`
+- Existing web preview comment renderer: `.github/scripts/mobile_pr_preview_comment.py`
+
+## File Structure
+
+- Create: `.github/ios_qa_slots.json`
+  - Slot table for `qa01` through `qa15`: bundle IDs, extension bundle IDs, app groups, display names, and Firebase app IDs.
+- Create: `.github/scripts/ios_qa_slots.py`
+  - Pure Python logic for trust decisions, slot parsing, slot allocation, comment rendering, and directory rendering.
+- Create: `.github/scripts/tests/test_ios_qa_slots.py`
+  - Unit tests for slot selection, trust, labels, stale states, and rendered comments.
+- Create: `.github/workflows/mobile_ios_qa_allocate.yml`
+  - Trusted metadata workflow. Uses `pull_request_target`, never checks out PR code, mirrors trusted PR heads to `ios-qa/pr-<number>`, assigns slots, triggers Codemagic, and cleans up on close.
+- Create: `mobile/lib/config/build_identity.dart`
+  - Build-time identity values shared by Firebase options and push registration.
+- Modify: `mobile/lib/firebase_options.dart`
+  - Use build-time iOS Firebase app ID and bundle ID while preserving production defaults.
+- Modify: `mobile/lib/services/push_notification_service.dart`
+  - Use build-time push app identifier while preserving `co.openvine.app` by default.
+- Create: `mobile/test/config/build_identity_test.dart`
+  - Tests default production identity and QA identity under `--dart-define`.
+- Create: `mobile/scripts/ci/configure_ios_qa_slot.py`
+  - Patch iOS project build settings and entitlements for one QA slot.
+- Create: `mobile/scripts/ci/tests/test_configure_ios_qa_slot.py`
+  - Unit tests for project/entitlement patching using temporary fixtures.
+- Modify: `codemagic.yaml`
+  - Add an `ios-qa-pr-build` workflow using Ad Hoc signing, slot configuration, stale checks, Firebase distribution, and GitHub notification.
+
+## Chunk 0: External Setup Checklist
+
+This chunk is a prerequisite. Do not start build automation until `qa01` exists in Apple Developer, Firebase, Codemagic, and GitHub secrets.
+
+- [ ] **Step 1: Create Apple identifiers for `qa01`**
+
+Create:
+
+```text
+co.openvine.app.qa01
+co.openvine.app.qa01.NotificationServiceExtension
+group.co.openvine.app.qa01
+```
+
+Enable the capabilities needed by the main app and extension. At minimum include app groups. Add push notifications and associated domains only if QA must test those flows in stage 1.
+
+- [ ] **Step 2: Create Ad Hoc provisioning profiles for `qa01`**
+
+Create profiles for:
+
+```text
+co.openvine.app.qa01
+co.openvine.app.qa01.NotificationServiceExtension
+```
+
+Include the current QA device UDIDs. Remember Apple device limits: Ad Hoc devices are capped per product family per membership year.
+
+- [ ] **Step 3: Create Firebase iOS app for `qa01`**
+
+Create a Firebase iOS app with bundle ID:
+
+```text
+co.openvine.app.qa01
+```
+
+Record its Firebase app ID for `.github/ios_qa_slots.json`.
+
+- [ ] **Step 4: Configure Codemagic environment groups**
+
+Add or confirm groups:
+
+```text
+zendesk_credentials
+proofmode_credentials
+github_credentials
+firebase_app_distribution
+ios_qa_signing
+```
+
+Expected secrets:
+
+```text
+GITHUB_TOKEN or GH_TOKEN with PR comment permissions
+FIREBASE_TOKEN or service-account auth usable by firebase-tools
+QA_FIREBASE_GROUP_ALIAS=ios-qa
+```
+
+Codemagic must also have access to the Ad Hoc signing certificate and `qa01` provisioning profiles.
+
+- [ ] **Step 5: Configure GitHub secrets**
+
+Add:
+
+```text
+CODEMAGIC_APP_ID
+CODEMAGIC_API_TOKEN
+DIVINEVIDEO_ORG_READ_TOKEN
+```
+
+`DIVINEVIDEO_ORG_READ_TOKEN` must be able to check active org membership for private members.
+
+## Chunk 1: Build-Time App Identity
+
+### Task 1: Add Identity Defaults And Tests
+
+**Files:**
+
+- Create: `mobile/lib/config/build_identity.dart`
+- Create: `mobile/test/config/build_identity_test.dart`
+
+- [ ] **Step 1: Write the default identity test**
+
+Create `mobile/test/config/build_identity_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/config/build_identity.dart';
+
+void main() {
+  test('uses production iOS identity by default', () {
+    expect(BuildIdentity.iosBundleId, 'co.openvine.app');
+    expect(BuildIdentity.pushAppIdentifier, 'co.openvine.app');
+    expect(BuildIdentity.firebaseIosAppId, '1:972941478875:ios:f61272b3cf485df244b5fe');
+  });
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/config/build_identity_test.dart
+```
+
+Expected: FAIL because `BuildIdentity` does not exist.
+
+- [ ] **Step 3: Add the build identity implementation**
+
+Create `mobile/lib/config/build_identity.dart`:
+
+```dart
+// ABOUTME: Centralizes build-time app identity for production and QA slot builds.
+// ABOUTME: Values default to production and can be overridden by CI dart-defines.
+
+class BuildIdentity {
+  static const iosBundleId = String.fromEnvironment(
+    'IOS_BUNDLE_ID',
+    defaultValue: 'co.openvine.app',
+  );
+
+  static const pushAppIdentifier = String.fromEnvironment(
+    'PUSH_APP_IDENTIFIER',
+    defaultValue: iosBundleId,
+  );
+
+  static const firebaseIosAppId = String.fromEnvironment(
+    'FIREBASE_IOS_APP_ID',
+    defaultValue: '1:972941478875:ios:f61272b3cf485df244b5fe',
+  );
+}
+```
+
+- [ ] **Step 4: Run the default identity test**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/config/build_identity_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the QA override test command**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/config/build_identity_test.dart \
+  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
+```
+
+Expected: FAIL until the test is extended for override mode.
+
+- [ ] **Step 6: Extend the test for override mode**
+
+Append to `mobile/test/config/build_identity_test.dart`:
+
+```dart
+  test('can use QA identity from dart defines', () {
+    const expectedBundleId = String.fromEnvironment('EXPECTED_IOS_BUNDLE_ID');
+    const expectedFirebaseAppId = String.fromEnvironment(
+      'EXPECTED_FIREBASE_IOS_APP_ID',
+    );
+
+    if (expectedBundleId.isEmpty && expectedFirebaseAppId.isEmpty) {
+      return;
+    }
+
+    expect(BuildIdentity.iosBundleId, expectedBundleId);
+    expect(BuildIdentity.pushAppIdentifier, expectedBundleId);
+    expect(BuildIdentity.firebaseIosAppId, expectedFirebaseAppId);
+  });
+```
+
+Run:
+
+```bash
+cd mobile
+flutter test test/config/build_identity_test.dart \
+  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
+  --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
+```
+
+Expected: PASS.
+
+### Task 2: Wire Identity Into Firebase And Push
+
+**Files:**
+
+- Modify: `mobile/lib/firebase_options.dart`
+- Modify: `mobile/lib/services/push_notification_service.dart`
+- Test: `mobile/test/config/build_identity_test.dart`
+
+- [ ] **Step 1: Update Firebase iOS options**
+
+Modify `mobile/lib/firebase_options.dart`:
+
+```dart
+import 'package:openvine/config/build_identity.dart';
+```
+
+Then change the iOS options:
+
+```dart
+  static const FirebaseOptions ios = FirebaseOptions(
+    apiKey: 'AIzaSyChiPGndRdZwsMoLqnel2WSocROmoKLdB4',
+    appId: BuildIdentity.firebaseIosAppId,
+    messagingSenderId: '972941478875',
+    projectId: 'openvine-co',
+    storageBucket: 'openvine-co.firebasestorage.app',
+    iosBundleId: BuildIdentity.iosBundleId,
+  );
+```
+
+- [ ] **Step 2: Update push app identifier**
+
+Modify `mobile/lib/services/push_notification_service.dart`:
+
+```dart
+import 'package:openvine/config/build_identity.dart';
+```
+
+Then change:
+
+```dart
+static const pushAppIdentifier = BuildIdentity.pushAppIdentifier;
+```
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+cd mobile
+flutter test test/config/build_identity_test.dart
+flutter test test/config/build_identity_test.dart \
+  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
+  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
+  --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
+  --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add mobile/lib/config/build_identity.dart \
+  mobile/lib/firebase_options.dart \
+  mobile/lib/services/push_notification_service.dart \
+  mobile/test/config/build_identity_test.dart
+git commit -m "feat(ios): make app identity build configurable"
+```
+
+## Chunk 2: iOS Slot Project Patching
+
+### Task 3: Add Patch Script Tests
+
+**Files:**
+
+- Create: `mobile/scripts/ci/tests/test_configure_ios_qa_slot.py`
+- Create later: `mobile/scripts/ci/configure_ios_qa_slot.py`
+
+- [ ] **Step 1: Write failing Python tests**
+
+Create tests that copy minimal fixtures into a temp directory and verify:
+
+- `PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app;` changes to `co.openvine.app.qa01`.
+- `PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.NotificationServiceExtension;` changes to `co.openvine.app.qa01.NotificationServiceExtension`.
+- `INFOPLIST_KEY_CFBundleDisplayName = divine;` changes to `"Divine QA 01";`.
+- `group.co.openvine.app` changes to `group.co.openvine.app.qa01` in both entitlements files.
+- Missing required arguments fail with a non-zero exit.
+
+Run:
+
+```bash
+python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
+```
+
+Expected: FAIL because `configure_ios_qa_slot.py` does not exist.
+
+### Task 4: Implement Project Patching Script
+
+**Files:**
+
+- Create: `mobile/scripts/ci/configure_ios_qa_slot.py`
+- Test: `mobile/scripts/ci/tests/test_configure_ios_qa_slot.py`
+
+- [ ] **Step 1: Implement the script**
+
+The script should accept:
+
+```text
+--project-root mobile
+--bundle-id co.openvine.app.qa01
+--extension-bundle-id co.openvine.app.qa01.NotificationServiceExtension
+--app-group group.co.openvine.app.qa01
+--display-name "Divine QA 01"
+```
+
+Use `plistlib` for entitlements. Patch `Runner.xcodeproj/project.pbxproj` as text, but keep replacements narrow and fail if an expected production identifier is not found.
+
+- [ ] **Step 2: Run script tests**
+
+Run:
+
+```bash
+python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run a local dry check on the real project**
+
+Run from repo root:
+
+```bash
+python3 mobile/scripts/ci/configure_ios_qa_slot.py \
+  --project-root mobile \
+  --bundle-id co.openvine.app.qa01 \
+  --extension-bundle-id co.openvine.app.qa01.NotificationServiceExtension \
+  --app-group group.co.openvine.app.qa01 \
+  --display-name "Divine QA 01"
+
+git diff -- mobile/ios/Runner.xcodeproj/project.pbxproj \
+  mobile/ios/Runner/Runner.entitlements \
+  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements
+```
+
+Expected: diff shows only bundle ID, display name, and app group changes.
+
+- [ ] **Step 4: Revert the dry-run project changes**
+
+Run:
+
+```bash
+git checkout -- mobile/ios/Runner.xcodeproj/project.pbxproj \
+  mobile/ios/Runner/Runner.entitlements \
+  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements
+```
+
+This checkout is only for changes made by this dry-run step.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add mobile/scripts/ci/configure_ios_qa_slot.py \
+  mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
+git commit -m "build(ios): add qa slot project patcher"
+```
+
+## Chunk 3: Slot Allocation Library
+
+### Task 5: Add Slot Map
+
+**Files:**
+
+- Create: `.github/ios_qa_slots.json`
+
+- [ ] **Step 1: Add slot map**
+
+Create `.github/ios_qa_slots.json` with all 15 slots. Use the real Firebase app IDs as they are created. For slots not created yet, set `firebaseAppId` to an empty string and keep the allocator disabled for those slots.
+
+```json
+{
+  "slots": [
+    {
+      "slot": "qa01",
+      "label": "ios-qa-slot-01",
+      "bundleId": "co.openvine.app.qa01",
+      "extensionBundleId": "co.openvine.app.qa01.NotificationServiceExtension",
+      "appGroup": "group.co.openvine.app.qa01",
+      "displayName": "Divine QA 01",
+      "firebaseAppId": ""
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Validate JSON**
+
+Run:
+
+```bash
+python3 -m json.tool .github/ios_qa_slots.json >/tmp/ios_qa_slots.json
+```
+
+Expected: command exits 0.
+
+### Task 6: Add Slot Library Tests
+
+**Files:**
+
+- Create: `.github/scripts/tests/test_ios_qa_slots.py`
+- Create later: `.github/scripts/ios_qa_slots.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Cover:
+
+- Trusted when `head_repo_owner == "divinevideo"`.
+- Trusted when membership API result is active member.
+- Not trusted for outside fork and non-member.
+- Draft PR without `needs-ios-qa` is not eligible.
+- Draft PR with `needs-ios-qa` is eligible.
+- Existing slot label is preserved.
+- First free slot is assigned.
+- Queued state when all configured slots are occupied.
+- Closed PR cleanup returns labels to remove and mirror branch to delete.
+- Comment renderer includes slot, PR, SHA, Firebase testing URI, and Codemagic URL.
+
+Run:
+
+```bash
+python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+```
+
+Expected: FAIL because `ios_qa_slots.py` does not exist.
+
+### Task 7: Implement Slot Library
+
+**Files:**
+
+- Create: `.github/scripts/ios_qa_slots.py`
+- Test: `.github/scripts/tests/test_ios_qa_slots.py`
+
+- [ ] **Step 1: Implement pure functions first**
+
+Required functions:
+
+```python
+def load_slots(path): ...
+def is_trusted_pr(head_repo_owner, author_is_org_member): ...
+def is_eligible_pr(is_draft, labels): ...
+def current_slot(labels): ...
+def choose_slot(slots, open_prs): ...
+def render_status_comment(...): ...
+def render_directory(...): ...
+```
+
+- [ ] **Step 2: Add CLI modes**
+
+CLI modes:
+
+```text
+allocate
+render-comment
+render-directory
+cleanup
+```
+
+The workflow can pass event JSON paths and write outputs to `$GITHUB_OUTPUT`.
+
+- [ ] **Step 3: Run tests**
+
+Run:
+
+```bash
+python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add .github/ios_qa_slots.json \
+  .github/scripts/ios_qa_slots.py \
+  .github/scripts/tests/test_ios_qa_slots.py
+git commit -m "ci(ios): add qa slot allocation logic"
+```
+
+## Chunk 4: GitHub Allocator Workflow
+
+### Task 8: Add Trusted Allocator Workflow
+
+**Files:**
+
+- Create: `.github/workflows/mobile_ios_qa_allocate.yml`
+- Modify: `.github/scripts/ios_qa_slots.py` if CLI gaps appear
+- Test: `.github/scripts/tests/test_ios_qa_slots.py`
+
+- [ ] **Step 1: Add workflow skeleton**
+
+Use `pull_request_target` so secrets are available, but never check out or execute PR code in this workflow.
+
+Triggers:
+
+```yaml
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, closed, labeled, unlabeled]
+    paths:
+      - "mobile/**"
+      - "codemagic.yaml"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        required: true
+```
+
+Permissions:
+
+```yaml
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+```
+
+Concurrency:
+
+```yaml
+concurrency:
+  group: ios-qa-slot-allocator
+  cancel-in-progress: false
+```
+
+- [ ] **Step 2: Add trust check**
+
+The workflow should call the GitHub org membership API using `DIVINEVIDEO_ORG_READ_TOKEN` when `head.repo.owner.login != "divinevideo"`.
+
+Expected trusted condition:
+
+```text
+head repo owner is divinevideo OR author is active divinevideo org member/owner
+```
+
+- [ ] **Step 3: Mirror trusted PR head to base repo**
+
+For trusted eligible PRs:
+
+```bash
+git fetch origin "pull/${PR_NUMBER}/head"
+git push origin "FETCH_HEAD:refs/heads/ios-qa/pr-${PR_NUMBER}" --force
+```
+
+For closed PRs:
+
+```bash
+git push origin ":refs/heads/ios-qa/pr-${PR_NUMBER}" || true
+```
+
+- [ ] **Step 4: Trigger Codemagic**
+
+Use the Codemagic Builds API with:
+
+```text
+workflow_id=ios-qa-pr-build
+branch=ios-qa/pr-<number>
+environment variables:
+  PR_NUMBER
+  PR_HEAD_SHA
+  PR_HEAD_REPO
+  PR_HEAD_REF
+  QA_SLOT
+  QA_BUNDLE_ID
+  QA_EXTENSION_BUNDLE_ID
+  QA_APP_GROUP
+  QA_DISPLAY_NAME
+  QA_FIREBASE_APP_ID
+  DEFAULT_ENV
+```
+
+Use `CODEMAGIC_APP_ID` and `CODEMAGIC_API_TOKEN` from GitHub secrets.
+
+- [ ] **Step 5: Update labels and comments**
+
+The workflow should:
+
+- Add or preserve `ios-qa-slot-NN`.
+- Add `ios-qa:building` when a build is triggered.
+- Add `ios-qa:queued` when no slot is available.
+- Add a sticky comment with a hidden marker `<!-- divine-ios-qa-build -->`.
+- Avoid duplicate comments.
+
+- [ ] **Step 6: Validate workflow YAML**
+
+Run:
+
+```bash
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
+python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add .github/workflows/mobile_ios_qa_allocate.yml .github/scripts/ios_qa_slots.py
+git commit -m "ci(ios): allocate qa slots for trusted prs"
+```
+
+## Chunk 5: Codemagic QA Build Workflow
+
+### Task 9: Add iOS QA Workflow
+
+**Files:**
+
+- Modify: `codemagic.yaml`
+
+- [ ] **Step 1: Add QA scripts**
+
+Add reusable scripts:
+
+```yaml
+- &configure_ios_qa_slot
+  name: Configure iOS QA slot
+  script: |
+    python3 scripts/ci/configure_ios_qa_slot.py \
+      --project-root . \
+      --bundle-id "$QA_BUNDLE_ID" \
+      --extension-bundle-id "$QA_EXTENSION_BUNDLE_ID" \
+      --app-group "$QA_APP_GROUP" \
+      --display-name "$QA_DISPLAY_NAME"
+
+- &verify_ios_qa_head
+  name: Verify mirrored PR SHA
+  script: |
+    ACTUAL_SHA="$(git rev-parse HEAD)"
+    if [ "$ACTUAL_SHA" != "$PR_HEAD_SHA" ]; then
+      echo "Stale mirror branch: expected $PR_HEAD_SHA, got $ACTUAL_SHA"
+      exit 1
+    fi
+```
+
+- [ ] **Step 2: Add QA build script**
+
+Build with slot dart defines:
+
+```yaml
+- &build_ios_qa
+  name: Build iOS QA IPA
+  script: |
+    flutter build ipa --release --build-number="$PROJECT_BUILD_NUMBER" \
+      --dart-define=ZENDESK_APP_ID="$ZENDESK_APP_ID" \
+      --dart-define=ZENDESK_CLIENT_ID="$ZENDESK_CLIENT_ID" \
+      --dart-define=ZENDESK_URL="$ZENDESK_URL" \
+      --dart-define=DEFAULT_ENV="$DEFAULT_ENV" \
+      --dart-define=PROOFMODE_SIGNING_SERVER_ENDPOINT="$PROOFMODE_SIGNING_SERVER_ENDPOINT" \
+      --dart-define=PROOFMODE_SIGNING_SERVER_TOKEN="$PROOFMODE_SIGNING_SERVER_TOKEN" \
+      --dart-define=IOS_BUNDLE_ID="$QA_BUNDLE_ID" \
+      --dart-define=PUSH_APP_IDENTIFIER="$QA_BUNDLE_ID" \
+      --dart-define=FIREBASE_IOS_APP_ID="$QA_FIREBASE_APP_ID" \
+      --export-options-plist=/Users/builder/export_options.plist
+```
+
+- [ ] **Step 3: Add Firebase distribution script**
+
+Install Firebase CLI if needed, distribute the IPA, and capture JSON output:
+
+```yaml
+- &distribute_ios_qa_firebase
+  name: Distribute iOS QA build to Firebase
+  script: |
+    npm install -g firebase-tools
+    IPA_PATH="$(ls build/ios/ipa/*.ipa | head -1)"
+    firebase appdistribution:distribute "$IPA_PATH" \
+      --app "$QA_FIREBASE_APP_ID" \
+      --groups "$QA_FIREBASE_GROUP_ALIAS" \
+      --release-notes "PR #$PR_NUMBER $PR_HEAD_SHA ($QA_SLOT)" \
+      --json > "$CM_BUILD_DIR/firebase-distribution.json"
+```
+
+- [ ] **Step 4: Add stale PR check before distribution**
+
+Before Firebase distribution, call GitHub API using `GH_TOKEN` and verify:
+
+```text
+PR is open
+PR head SHA equals PR_HEAD_SHA
+```
+
+If stale, exit 0 after notifying GitHub with stale status. Do not upload the IPA.
+
+- [ ] **Step 5: Add GitHub notification script**
+
+After Firebase distribution, parse `firebase-distribution.json`, extract the tester URI, and update the sticky PR comment. If Firebase CLI JSON shape differs, adapt the parser and document the observed output in the commit.
+
+- [ ] **Step 6: Add `ios-qa-pr-build` workflow**
+
+Add workflow:
+
+```yaml
+ios-qa-pr-build:
+  name: iOS QA PR Build
+  working_directory: mobile
+  max_build_duration: 60
+  instance_type: mac_mini_m2
+  integrations:
+    app_store_connect: API key for Codemagic
+  environment:
+    flutter: 3.41.1
+    xcode: latest
+    cocoapods: default
+    groups:
+      - zendesk_credentials
+      - proofmode_credentials
+      - github_credentials
+      - firebase_app_distribution
+      - ios_qa_signing
+    ios_signing:
+      distribution_type: ad_hoc
+      bundle_identifier: $QA_BUNDLE_ID
+  triggering:
+    events: []
+  scripts:
+    - *verify_ios_qa_head
+    - *setup_code_signing_xcode
+    - *install_flutterfire
+    - *enable_spm
+    - *prepare_ios_spm_packages
+    - *configure_ios_qa_slot
+    - *pod_install
+    - *build_ios_qa
+    - *distribute_ios_qa_firebase
+  artifacts:
+    - build/ios/ipa/*.ipa
+    - build/ios/archive/Runner.xcarchive/dSYMs/**
+    - /tmp/xcodebuild_logs/*.log
+    - firebase-distribution.json
+```
+
+If Codemagic does not accept `$QA_BUNDLE_ID` in `ios_signing.bundle_identifier`, replace this with 15 generated workflows or a script-level `app-store-connect fetch-signing-files` approach after proving the constraint in a dry run.
+
+- [ ] **Step 7: Validate YAML**
+
+Run:
+
+```bash
+ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml')"
+```
+
+Expected: exits 0.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add codemagic.yaml
+git commit -m "ci(ios): add qa pr codemagic workflow"
+```
+
+## Chunk 6: Directory And Reconciliation
+
+### Task 10: Add Active Directory And Cleanup
+
+**Files:**
+
+- Modify: `.github/scripts/ios_qa_slots.py`
+- Modify: `.github/workflows/mobile_ios_qa_allocate.yml`
+- Test: `.github/scripts/tests/test_ios_qa_slots.py`
+
+- [ ] **Step 1: Add directory renderer tests**
+
+Test that rendered directory includes:
+
+- Active slots.
+- Queued PRs.
+- Failed PRs.
+- Firebase install links.
+- Codemagic build links.
+- Last updated timestamp.
+
+- [ ] **Step 2: Add scheduled reconciliation**
+
+Extend the workflow:
+
+```yaml
+on:
+  schedule:
+    - cron: "17 15 * * *"
+```
+
+The scheduled job should:
+
+- List open PRs.
+- Remove stale slot labels from closed PRs if any remain.
+- Delete stale `ios-qa/pr-*` branches for closed PRs.
+- Assign queued PRs when slots are free.
+- Re-render the active build directory.
+
+- [ ] **Step 3: Decide directory home**
+
+Use a sticky issue comment if a QA tracking issue exists. If not, create a new issue titled:
+
+```text
+iOS QA PR Builds
+```
+
+Store its issue number in a GitHub Actions variable:
+
+```text
+IOS_QA_DIRECTORY_ISSUE_NUMBER
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
+```
+
+Expected: PASS / exit 0.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add .github/scripts/ios_qa_slots.py \
+  .github/scripts/tests/test_ios_qa_slots.py \
+  .github/workflows/mobile_ios_qa_allocate.yml
+git commit -m "ci(ios): reconcile qa slots and directory"
+```
+
+## Chunk 7: Stage 1 Verification
+
+### Task 11: Prove `qa01` End To End
+
+**Files:**
+
+- No source changes expected unless verification exposes issues.
+
+- [ ] **Step 1: Run local verification**
+
+Run:
+
+```bash
+python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
+ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml')"
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
+cd mobile
+flutter test test/config/build_identity_test.dart
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Trigger one trusted PR manually**
+
+Use workflow dispatch on `Mobile iOS QA Allocate` with a trusted PR number.
+
+Expected:
+
+- PR receives `ios-qa-slot-01`.
+- PR receives `ios-qa:building`.
+- Branch `ios-qa/pr-<number>` exists and points to the PR head SHA.
+- Codemagic starts `ios-qa-pr-build`.
+
+- [ ] **Step 3: Verify Firebase install**
+
+Expected:
+
+- Firebase App Distribution shows a release for `co.openvine.app.qa01`.
+- PR sticky comment includes Firebase tester link.
+- QA can install `Divine QA 01` on a registered iOS device.
+- Production/TestFlight app remains installed side by side.
+
+- [ ] **Step 4: Verify close cleanup**
+
+Close or use a throwaway test PR.
+
+Expected:
+
+- Slot labels are removed.
+- Mirror branch is deleted.
+- Directory updates.
+
+## Chunk 8: Expand To 15 Slots
+
+### Task 12: Enable Remaining Slots
+
+**Files:**
+
+- Modify: `.github/ios_qa_slots.json`
+- Possibly modify: Apple/Firebase/Codemagic external config only
+
+- [ ] **Step 1: Create remaining Apple/Firebase identities**
+
+Repeat external setup for `qa02` through `qa15`.
+
+- [ ] **Step 2: Fill real Firebase app IDs**
+
+Update `.github/ios_qa_slots.json`.
+
+- [ ] **Step 3: Run slot tests**
+
+Run:
+
+```bash
+python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+python3 -m json.tool .github/ios_qa_slots.json >/tmp/ios_qa_slots.json
+```
+
+Expected: PASS / exit 0.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add .github/ios_qa_slots.json
+git commit -m "ci(ios): enable all qa slots"
+```
+
+## Final Verification
+
+- [ ] **Run all local non-signing verification**
+
+```bash
+python3 -m unittest .github/scripts/tests/test_ios_qa_slots.py
+python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
+ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml')"
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
+cd mobile
+flutter test test/config/build_identity_test.dart
+```
+
+- [ ] **Review diff**
+
+```bash
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- .github codemagic.yaml mobile/lib mobile/scripts mobile/test docs/superpowers
+```
+
+- [ ] **Push and open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create \
+  --title "ci(ios): add QA PR build slots" \
+  --body "Adds the iOS QA PR build slot design and implementation for Ad Hoc Firebase distribution."
+```
+

--- a/docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md
+++ b/docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md
@@ -36,6 +36,8 @@ For PRs outside that trust model:
 
 Private org membership may not be visible to the default `GITHUB_TOKEN`, so the membership check needs a GitHub token with enough permission to read org membership.
 
+Codemagic API builds are started by branch or tag. To support trusted member PRs from personal forks, GitHub Actions should mirror every trusted PR head SHA to a temporary branch in `divinevideo/divine-mobile`, for example `ios-qa/pr-3407`, then ask Codemagic to build that mirror branch. This gives Codemagic a branch it can fetch from the configured repository while preserving the exact PR SHA in build metadata.
+
 ## Slot Lifecycle
 
 GitHub labels are the source of truth:
@@ -59,6 +61,7 @@ Slot assignment:
 Cleanup:
 
 - On PR close, remove `ios-qa-slot-NN`, `ios-qa:building`, `ios-qa:ready`, `ios-qa:queued`, and `ios-qa:failed`.
+- Delete the temporary mirror branch `ios-qa/pr-<number>`.
 - Update the active build directory.
 - The installed app can remain on QA devices until that slot is reused.
 - A scheduled reconciliation workflow should run daily to repair missed label/comment/directory updates.
@@ -82,9 +85,12 @@ Codemagic builds should still be per-PR cancellable or replaceable. A newer comm
 1. GitHub Actions receives a `pull_request` event, `workflow_dispatch`, or label event.
 2. The allocator checks trust, PR state, draft state, file relevance, and current labels.
 3. The allocator assigns or reuses a slot.
-4. The allocator triggers Codemagic through the Codemagic Builds API with explicit metadata:
+4. The allocator mirrors the trusted PR head SHA to `ios-qa/pr-<number>` in the base repository.
+5. The allocator triggers Codemagic through the Codemagic Builds API with branch `ios-qa/pr-<number>` and explicit metadata:
    - `PR_NUMBER`
    - `PR_HEAD_SHA`
+   - `PR_HEAD_REPO`
+   - `PR_HEAD_REF`
    - `QA_SLOT`
    - `QA_BUNDLE_ID`
    - `QA_EXTENSION_BUNDLE_ID`
@@ -92,10 +98,10 @@ Codemagic builds should still be per-PR cancellable or replaceable. A newer comm
    - `QA_DISPLAY_NAME`
    - `QA_FIREBASE_APP_ID`
    - `DEFAULT_ENV`
-5. Codemagic checks out the exact PR SHA, patches build settings for the slot, builds an Ad Hoc IPA, and runs a stale-SHA check before distribution.
-6. If the PR head SHA still matches `PR_HEAD_SHA`, Codemagic uploads the IPA to Firebase App Distribution.
-7. If the PR has moved on or closed, Codemagic skips Firebase distribution and reports a stale build.
-8. GitHub updates the sticky PR comment and the active QA directory.
+6. Codemagic checks out the mirror branch, verifies `git rev-parse HEAD` equals `PR_HEAD_SHA`, patches build settings for the slot, builds an Ad Hoc IPA, and runs another stale-SHA check before distribution.
+7. If the PR head SHA still matches `PR_HEAD_SHA`, Codemagic uploads the IPA to Firebase App Distribution.
+8. If the PR has moved on or closed, Codemagic skips Firebase distribution and reports a stale build.
+9. GitHub updates the sticky PR comment and the active QA directory.
 
 ## iOS Identity Requirements
 
@@ -205,4 +211,3 @@ Stage 2 expands to 15 slots:
 - Whether universal links and web credentials should be enabled for QA slot app IDs.
 - Whether push notifications must work in QA builds from day one.
 - Whether to add a maintainer-only override for trusted builds from non-org forks.
-

--- a/docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md
+++ b/docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md
@@ -18,6 +18,15 @@ Slots:
 
 Avoid dynamic per-PR bundle IDs. The one-time setup for 15 identities is manageable; unbounded per-PR identities would create ongoing Apple, Firebase, provisioning, entitlement, and cleanup work.
 
+## Current External Constraints Checked
+
+- [Codemagic Builds API](https://docs.codemagic.io/rest-api/builds/) starts YAML workflows with `POST /builds`, `appId`, `workflowId`, `branch`, and optional `environment.variables`.
+- [Codemagic iOS signing](https://docs.codemagic.io/yaml-code-signing/signing-ios/) recommends `distribution_type: ad_hoc` when signed iOS artifacts are distributed through a third-party service such as Firebase App Distribution.
+- [Firebase App Distribution CLI](https://firebase.google.com/docs/app-distribution/ios/distribute-cli) supports iOS IPA upload, group distribution, and returns release links including `testing_uri`; direct binary links expire quickly and should not be used as the stable QA link.
+- [Codemagic Firebase distribution](https://docs.codemagic.io/yaml-distributing/firebase-app-distribution/) marks Firebase token auth deprecated; service-account auth with `GOOGLE_APPLICATION_CREDENTIALS` is the preferred CI path.
+- [Codemagic post-publish scripts](https://docs.codemagic.io/yaml-distributing/post-publish/) run even after build failure unless the build is canceled or times out, so GitHub status notification belongs there.
+- [GitHub Security Lab pwn request guidance](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) still treats `pull_request_target` plus checkout/execution of PR-controlled code as the dangerous pattern. The allocator may inspect PR metadata and push a trusted mirror ref, but it must not execute PR code.
+
 ## Trust Model
 
 Native iOS PR builds require signing and Firebase distribution credentials, so they cannot follow the exact web-preview security model.
@@ -38,6 +47,8 @@ Private org membership may not be visible to the default `GITHUB_TOKEN`, so the 
 
 Codemagic API builds are started by branch or tag. To support trusted member PRs from personal forks, GitHub Actions should mirror every trusted PR head SHA to a temporary branch in `divinevideo/divine-mobile`, for example `ios-qa/pr-3407`, then ask Codemagic to build that mirror branch. This gives Codemagic a branch it can fetch from the configured repository while preserving the exact PR SHA in build metadata.
 
+The allocator workflow uses `pull_request_target` for secrets and write permissions, but it must check out only the base repository workflow/scripts. It may fetch and push a trusted PR head as a passive git object after the trust check; it must not run Flutter, npm, shell scripts, hooks, or any executable content from the PR inside GitHub Actions. Treat PR titles, branch names, and labels as untrusted strings: pass them through environment variables or JSON files, never by direct shell interpolation.
+
 ## Slot Lifecycle
 
 GitHub labels are the source of truth:
@@ -49,14 +60,17 @@ GitHub labels are the source of truth:
 - `ios-qa:failed`
 - `needs-ios-qa`
 
+Slot labels are the source of truth for assignment. Build result metadata is stored in the sticky PR comment as a hidden JSON state marker so reconciliation and the active directory can recover the latest built SHA, Codemagic build ID/URL, Firebase `testing_uri`, stale status, and failure reason without committing generated state.
+
 Slot assignment:
 
 1. A ready-for-review PR becomes eligible automatically.
 2. A draft PR becomes eligible only when labeled `needs-ios-qa`.
 3. If the PR already has a slot label, keep that slot and rebuild it on new commits.
-4. If it has no slot label, find the first slot not currently used by an open PR.
-5. If a slot is available, add `ios-qa-slot-NN` and `ios-qa:building`.
-6. If no slot is available, add `ios-qa:queued` and comment with the active build directory.
+4. Only slots marked enabled in `.github/ios_qa_slots.json` are assignable. Stage 1 should enable only `qa01`.
+5. If it has no slot label, find the first enabled slot not currently used by an open PR.
+6. If a slot is available, add `ios-qa-slot-NN` and `ios-qa:building`.
+7. If no slot is available, add `ios-qa:queued` and comment with the active build directory.
 
 Cleanup:
 
@@ -82,11 +96,11 @@ Codemagic builds should still be per-PR cancellable or replaceable. A newer comm
 
 ## Build Flow
 
-1. GitHub Actions receives a `pull_request` event, `workflow_dispatch`, or label event.
-2. The allocator checks trust, PR state, draft state, file relevance, and current labels.
+1. GitHub Actions receives a `pull_request_target` event, `workflow_dispatch`, schedule event, or label event.
+2. The allocator checks trust, PR state, draft state, file relevance, enabled slots, and current labels. File relevance is checked in script, not with workflow `paths`, so cleanup and manual reconciliation still run.
 3. The allocator assigns or reuses a slot.
 4. The allocator mirrors the trusted PR head SHA to `ios-qa/pr-<number>` in the base repository.
-5. The allocator triggers Codemagic through the Codemagic Builds API with branch `ios-qa/pr-<number>` and explicit metadata:
+5. The allocator triggers Codemagic through `POST /builds` with branch `ios-qa/pr-<number>`, `workflowId=ios-qa-pr-build`, explicit labels, and explicit metadata:
    - `PR_NUMBER`
    - `PR_HEAD_SHA`
    - `PR_HEAD_REPO`
@@ -98,10 +112,11 @@ Codemagic builds should still be per-PR cancellable or replaceable. A newer comm
    - `QA_DISPLAY_NAME`
    - `QA_FIREBASE_APP_ID`
    - `DEFAULT_ENV`
-6. Codemagic checks out the mirror branch, verifies `git rev-parse HEAD` equals `PR_HEAD_SHA`, patches build settings for the slot, builds an Ad Hoc IPA, and runs another stale-SHA check before distribution.
-7. If the PR head SHA still matches `PR_HEAD_SHA`, Codemagic uploads the IPA to Firebase App Distribution.
-8. If the PR has moved on or closed, Codemagic skips Firebase distribution and reports a stale build.
-9. GitHub updates the sticky PR comment and the active QA directory.
+6. The allocator stores the returned Codemagic `buildId` in the sticky PR comment state marker and labels the PR `ios-qa:building`.
+7. Codemagic checks out the mirror branch, verifies `git rev-parse HEAD` equals `PR_HEAD_SHA`, patches build settings and Firebase metadata for the slot, applies Ad Hoc signing profiles, builds an IPA, and runs another stale-SHA check before distribution.
+8. If the PR head SHA still matches `PR_HEAD_SHA`, Codemagic uploads the IPA to Firebase App Distribution.
+9. If the PR has moved on or closed, Codemagic skips Firebase distribution and reports a stale build.
+10. Codemagic updates the sticky PR comment state marker. GitHub reconciliation uses that marker plus labels and PR metadata to regenerate the active QA directory.
 
 ## iOS Identity Requirements
 
@@ -121,6 +136,8 @@ The current app has production identifiers hard-coded in places that must become
 - Xcode notification extension bundle ID.
 - Main app entitlements.
 - Notification extension entitlements.
+- `mobile/ios/Runner/GoogleService-Info.plist`.
+- `mobile/ios/firebase_app_id_file.json`.
 - Firebase iOS app ID and bundle ID.
 - Push registration app identifier.
 
@@ -130,9 +147,11 @@ Each slot should have a Firebase iOS app record so Firebase App Distribution, Cr
 
 Distribution should publish to a stable QA tester group, for example `ios-qa`.
 
-The PR comment should link to Firebase's tester install URI rather than a short-lived raw binary URL.
+The PR comment should link to Firebase's `testing_uri` rather than a short-lived raw binary URL.
 
 If a QA device is not in the Ad Hoc provisioning profile, Firebase can help collect UDIDs, but the Apple profile still must be regenerated with that device before the build can install.
+
+Firebase releases are available in App Distribution for 150 days. That is enough for active PR review, but the active directory should show last-updated time and not imply that historical PR links are permanent.
 
 ## QA Directory
 
@@ -151,7 +170,7 @@ Directory fields:
 - Codemagic build URL
 - Notes for skipped, queued, stale, or failed builds
 
-The directory should be generated from labels and PR metadata, not manually edited.
+The directory should be generated from labels, PR metadata, and sticky comment state markers, not manually edited.
 
 ## Error Handling
 
@@ -196,7 +215,8 @@ Stage 1 proves one slot end to end:
 - Configure `qa01` Apple/Firebase identity.
 - Add the build-time configuration path.
 - Add the allocator in dry-run or one-slot mode.
-- Build and distribute one trusted PR through Firebase.
+- Merge the bootstrap workflow PR so `pull_request_target`/`workflow_dispatch` exists on `main`.
+- Build and distribute one trusted throwaway PR through Firebase.
 
 Stage 2 expands to 15 slots:
 

--- a/docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md
+++ b/docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md
@@ -1,0 +1,208 @@
+# iOS QA PR Builds Design
+
+## Goal
+
+Give QA installable iOS builds for active mobile PRs without using TestFlight as the bottleneck. QA should be able to open a PR or a directory, see which build belongs to that PR, and install it on registered iOS devices.
+
+## Decision
+
+Use 15 reusable iOS QA slots. Each slot is a fixed Apple/Firebase app identity that can be installed side by side with the production app and with the other QA slots.
+
+Slots:
+
+- `qa01` through `qa15`
+- Main bundle IDs: `co.openvine.app.qa01` through `co.openvine.app.qa15`
+- Extension bundle IDs: `co.openvine.app.qa01.NotificationServiceExtension` through `co.openvine.app.qa15.NotificationServiceExtension`
+- Display names: `Divine QA 01` through `Divine QA 15`
+- App groups: `group.co.openvine.app.qa01` through `group.co.openvine.app.qa15`
+
+Avoid dynamic per-PR bundle IDs. The one-time setup for 15 identities is manageable; unbounded per-PR identities would create ongoing Apple, Firebase, provisioning, entitlement, and cleanup work.
+
+## Trust Model
+
+Native iOS PR builds require signing and Firebase distribution credentials, so they cannot follow the exact web-preview security model.
+
+Autobuild only when the PR is trusted:
+
+1. The PR head repository owner is `divinevideo`; or
+2. The PR author is an active member or owner of the `divinevideo` GitHub organization.
+
+For PRs outside that trust model:
+
+- Do not trigger Codemagic.
+- Do not expose signing, App Store Connect, or Firebase credentials.
+- Add or update a PR comment explaining that iOS QA build was skipped because the PR is outside the trusted build policy.
+- A maintainer can make the PR buildable by moving/mirroring the branch under `divinevideo`, or by using a future explicit trusted override if we choose to add one.
+
+Private org membership may not be visible to the default `GITHUB_TOKEN`, so the membership check needs a GitHub token with enough permission to read org membership.
+
+## Slot Lifecycle
+
+GitHub labels are the source of truth:
+
+- `ios-qa-slot-01` through `ios-qa-slot-15`
+- `ios-qa:building`
+- `ios-qa:ready`
+- `ios-qa:queued`
+- `ios-qa:failed`
+- `needs-ios-qa`
+
+Slot assignment:
+
+1. A ready-for-review PR becomes eligible automatically.
+2. A draft PR becomes eligible only when labeled `needs-ios-qa`.
+3. If the PR already has a slot label, keep that slot and rebuild it on new commits.
+4. If it has no slot label, find the first slot not currently used by an open PR.
+5. If a slot is available, add `ios-qa-slot-NN` and `ios-qa:building`.
+6. If no slot is available, add `ios-qa:queued` and comment with the active build directory.
+
+Cleanup:
+
+- On PR close, remove `ios-qa-slot-NN`, `ios-qa:building`, `ios-qa:ready`, `ios-qa:queued`, and `ios-qa:failed`.
+- Update the active build directory.
+- The installed app can remain on QA devices until that slot is reused.
+- A scheduled reconciliation workflow should run daily to repair missed label/comment/directory updates.
+
+## Concurrency
+
+The allocator workflow must use one global concurrency group, for example:
+
+```yaml
+concurrency:
+  group: ios-qa-slot-allocator
+  cancel-in-progress: false
+```
+
+This prevents two PR workflows from seeing the same free slot and assigning it twice.
+
+Codemagic builds should still be per-PR cancellable or replaceable. A newer commit for the same PR should supersede the older build before distribution.
+
+## Build Flow
+
+1. GitHub Actions receives a `pull_request` event, `workflow_dispatch`, or label event.
+2. The allocator checks trust, PR state, draft state, file relevance, and current labels.
+3. The allocator assigns or reuses a slot.
+4. The allocator triggers Codemagic through the Codemagic Builds API with explicit metadata:
+   - `PR_NUMBER`
+   - `PR_HEAD_SHA`
+   - `QA_SLOT`
+   - `QA_BUNDLE_ID`
+   - `QA_EXTENSION_BUNDLE_ID`
+   - `QA_APP_GROUP`
+   - `QA_DISPLAY_NAME`
+   - `QA_FIREBASE_APP_ID`
+   - `DEFAULT_ENV`
+5. Codemagic checks out the exact PR SHA, patches build settings for the slot, builds an Ad Hoc IPA, and runs a stale-SHA check before distribution.
+6. If the PR head SHA still matches `PR_HEAD_SHA`, Codemagic uploads the IPA to Firebase App Distribution.
+7. If the PR has moved on or closed, Codemagic skips Firebase distribution and reports a stale build.
+8. GitHub updates the sticky PR comment and the active QA directory.
+
+## iOS Identity Requirements
+
+Each slot needs Apple Developer setup:
+
+- App ID for the main app bundle ID.
+- App ID for the notification service extension bundle ID.
+- Ad Hoc provisioning profile for the main app.
+- Ad Hoc provisioning profile for the notification service extension.
+- App group matching the slot.
+- Push notification capability if QA builds need push behavior.
+- Associated domains if QA builds need universal links or password-manager flows.
+
+The current app has production identifiers hard-coded in places that must become slot-configurable:
+
+- Xcode main bundle ID.
+- Xcode notification extension bundle ID.
+- Main app entitlements.
+- Notification extension entitlements.
+- Firebase iOS app ID and bundle ID.
+- Push registration app identifier.
+
+## Firebase Requirements
+
+Each slot should have a Firebase iOS app record so Firebase App Distribution, Crashlytics, and app metadata line up with the slot bundle ID.
+
+Distribution should publish to a stable QA tester group, for example `ios-qa`.
+
+The PR comment should link to Firebase's tester install URI rather than a short-lived raw binary URL.
+
+If a QA device is not in the Ad Hoc provisioning profile, Firebase can help collect UDIDs, but the Apple profile still must be regenerated with that device before the build can install.
+
+## QA Directory
+
+Generate a single active-build directory from GitHub state. This can be a sticky GitHub issue, a markdown artifact committed only if needed, or a PR comment on an always-open tracking issue.
+
+Directory fields:
+
+- Slot
+- PR number and title
+- PR author
+- Draft/ready state
+- Latest built commit SHA
+- Build status
+- Firebase install link
+- Last updated time
+- Codemagic build URL
+- Notes for skipped, queued, stale, or failed builds
+
+The directory should be generated from labels and PR metadata, not manually edited.
+
+## Error Handling
+
+All slots full:
+
+- Label the PR `ios-qa:queued`.
+- Comment with the active directory and current slot occupants.
+- The daily reconciliation or close-event cleanup should assign queued PRs when slots free up.
+
+Codemagic build fails:
+
+- Replace `ios-qa:building` with `ios-qa:failed`.
+- Keep the slot assigned to the PR.
+- Update the PR comment with the Codemagic build URL and failure status.
+
+PR updates while build is running:
+
+- Keep the same slot.
+- Mark the old build stale.
+- Trigger a replacement build for the new head SHA.
+- Do not distribute the stale IPA.
+
+PR closes during build:
+
+- Release the slot labels.
+- Skip distribution if Codemagic reaches the stale/closed check.
+
+Device cannot install:
+
+- Comment should point QA to the Firebase device registration flow.
+- After UDIDs are added in Apple Developer, profiles must be regenerated and Codemagic signing assets refreshed.
+
+Trust check fails:
+
+- Do not trigger a signed build.
+- Comment with the trusted-build policy.
+
+## Rollout Plan
+
+Stage 1 proves one slot end to end:
+
+- Configure `qa01` Apple/Firebase identity.
+- Add the build-time configuration path.
+- Add the allocator in dry-run or one-slot mode.
+- Build and distribute one trusted PR through Firebase.
+
+Stage 2 expands to 15 slots:
+
+- Add the remaining 14 Apple/Firebase identities.
+- Add the full slot map.
+- Enable automatic assignment for ready PRs and `needs-ios-qa` draft PRs.
+- Add queued-state handling and daily reconciliation.
+
+## Open Decisions
+
+- Whether QA builds should use production, staging, or a selectable `DEFAULT_ENV` by default.
+- Whether universal links and web credentials should be enabled for QA slot app IDs.
+- Whether push notifications must work in QA builds from day one.
+- Whether to add a maintainer-only override for trusted builds from non-org forks.
+

--- a/mobile/lib/config/build_identity.dart
+++ b/mobile/lib/config/build_identity.dart
@@ -1,0 +1,19 @@
+// ABOUTME: Centralizes build-time app identity for production and QA slot builds.
+// ABOUTME: Values default to production and can be overridden by CI dart-defines.
+
+class BuildIdentity {
+  static const iosBundleId = String.fromEnvironment(
+    'IOS_BUNDLE_ID',
+    defaultValue: 'co.openvine.app',
+  );
+
+  static const pushAppIdentifier = String.fromEnvironment(
+    'PUSH_APP_IDENTIFIER',
+    defaultValue: iosBundleId,
+  );
+
+  static const firebaseIosAppId = String.fromEnvironment(
+    'FIREBASE_IOS_APP_ID',
+    defaultValue: '1:972941478875:ios:f61272b3cf485df244b5fe',
+  );
+}

--- a/mobile/lib/firebase_options.dart
+++ b/mobile/lib/firebase_options.dart
@@ -4,6 +4,7 @@
 import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
 import 'package:flutter/foundation.dart'
     show TargetPlatform, defaultTargetPlatform, kIsWeb;
+import 'package:openvine/config/build_identity.dart';
 
 /// Default [FirebaseOptions] for use with your Firebase apps.
 ///
@@ -60,11 +61,11 @@ class DefaultFirebaseOptions {
 
   static const FirebaseOptions ios = FirebaseOptions(
     apiKey: 'AIzaSyChiPGndRdZwsMoLqnel2WSocROmoKLdB4',
-    appId: '1:972941478875:ios:f61272b3cf485df244b5fe',
+    appId: BuildIdentity.firebaseIosAppId,
     messagingSenderId: '972941478875',
     projectId: 'openvine-co',
     storageBucket: 'openvine-co.firebasestorage.app',
-    iosBundleId: 'co.openvine.app',
+    iosBundleId: BuildIdentity.iosBundleId,
   );
 
   static const FirebaseOptions macos = FirebaseOptions(

--- a/mobile/lib/services/push_notification_service.dart
+++ b/mobile/lib/services/push_notification_service.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/config/build_identity.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/models/notification_preferences.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -34,7 +35,7 @@ class PushNotificationService {
   static const pushPreferencesKind = 3083;
 
   /// App bundle identifier used in registration events.
-  static const pushAppIdentifier = 'co.openvine.app';
+  static const String pushAppIdentifier = BuildIdentity.pushAppIdentifier;
 
   /// Number of days until a registration event expires.
   static const pushTokenExpirationDays = 90;

--- a/mobile/scripts/ci/configure_ios_qa_slot.py
+++ b/mobile/scripts/ci/configure_ios_qa_slot.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# ABOUTME: Patches the iOS Runner project for one QA slot identity.
+# ABOUTME: Used by Codemagic before code signing to target a non-production
+# ABOUTME: bundle id, app group, display name, and Firebase iOS app id while
+# ABOUTME: leaving the production project untouched on disk via --dry-run.
+
+"""Patch iOS project for a QA slot."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import sys
+from pathlib import Path
+
+PRODUCTION_BUNDLE_ID = "co.openvine.app"
+PRODUCTION_EXTENSION_BUNDLE_ID = "co.openvine.app.NotificationServiceExtension"
+PRODUCTION_APP_GROUP = "group.co.openvine.app"
+PRODUCTION_DISPLAY_NAME_PATTERN = "INFOPLIST_KEY_CFBundleDisplayName = divine;"
+PRODUCTION_FIREBASE_APP_ID = "1:972941478875:ios:f61272b3cf485df244b5fe"
+
+
+class PatchError(RuntimeError):
+    """Raised when an expected production marker is missing from a file."""
+
+
+def patch_pbxproj(
+    text: str,
+    *,
+    bundle_id: str,
+    extension_bundle_id: str,
+    display_name: str,
+) -> str:
+    """Return pbxproj text with QA slot identity applied.
+
+    Replacement order matters: extension first, then main bundle. The main
+    bundle pattern is anchored on a trailing semicolon so it never matches
+    ``co.openvine.app.NotificationServiceExtension;`` or
+    ``co.openvine.app.RunnerTests;``.
+    """
+    ext_search = f"= {PRODUCTION_EXTENSION_BUNDLE_ID};"
+    if ext_search not in text:
+        raise PatchError(
+            "Expected extension bundle marker not found in pbxproj: "
+            f"{ext_search!r}",
+        )
+    text = text.replace(ext_search, f"= {extension_bundle_id};")
+
+    main_search = f"= {PRODUCTION_BUNDLE_ID};"
+    if main_search not in text:
+        raise PatchError(
+            "Expected main bundle marker not found in pbxproj: "
+            f"{main_search!r}",
+        )
+    text = text.replace(main_search, f"= {bundle_id};")
+
+    if PRODUCTION_DISPLAY_NAME_PATTERN not in text:
+        raise PatchError(
+            "Expected display-name marker not found in pbxproj: "
+            f"{PRODUCTION_DISPLAY_NAME_PATTERN!r}",
+        )
+    text = text.replace(
+        PRODUCTION_DISPLAY_NAME_PATTERN,
+        f'INFOPLIST_KEY_CFBundleDisplayName = "{display_name}";',
+    )
+    return text
+
+
+def patch_entitlements(text: str, *, app_group: str) -> str:
+    """Return entitlements XML with the production app group replaced."""
+    needle = f"<string>{PRODUCTION_APP_GROUP}</string>"
+    occurrences = text.count(needle)
+    if occurrences != 1:
+        raise PatchError(
+            f"Expected exactly 1 occurrence of {needle!r} in entitlements, "
+            f"found {occurrences}",
+        )
+    return text.replace(needle, f"<string>{app_group}</string>")
+
+
+def _patch_plist_string(
+    text: str,
+    *,
+    key: str,
+    expected: str,
+    new_value: str,
+) -> str:
+    pattern = re.compile(
+        r"(<key>" + re.escape(key) + r"</key>\s*<string>)"
+        + re.escape(expected)
+        + r"(</string>)",
+    )
+    new_text, count = pattern.subn(
+        lambda m: m.group(1) + new_value + m.group(2),
+        text,
+    )
+    if count != 1:
+        raise PatchError(
+            f"Expected exactly 1 plist value for {key}={expected!r}, "
+            f"found {count}",
+        )
+    return new_text
+
+
+def patch_google_service_info(
+    text: str,
+    *,
+    bundle_id: str,
+    firebase_app_id: str,
+) -> str:
+    """Return GoogleService-Info.plist text with slot identity applied."""
+    text = _patch_plist_string(
+        text,
+        key="BUNDLE_ID",
+        expected=PRODUCTION_BUNDLE_ID,
+        new_value=bundle_id,
+    )
+    text = _patch_plist_string(
+        text,
+        key="GOOGLE_APP_ID",
+        expected=PRODUCTION_FIREBASE_APP_ID,
+        new_value=firebase_app_id,
+    )
+    return text
+
+
+def patch_firebase_app_id_json(text: str, *, firebase_app_id: str) -> str:
+    """Return firebase_app_id_file.json text with slot Firebase app id."""
+    pattern = re.compile(
+        r'("GOOGLE_APP_ID"\s*:\s*")'
+        + re.escape(PRODUCTION_FIREBASE_APP_ID)
+        + r'(")',
+    )
+    new_text, count = pattern.subn(
+        lambda m: m.group(1) + firebase_app_id + m.group(2),
+        text,
+    )
+    if count != 1:
+        raise PatchError(
+            "Expected exactly 1 GOOGLE_APP_ID value in firebase_app_id_file.json, "
+            f"found {count}",
+        )
+    return new_text
+
+
+def _emit_diff(path: Path, old: str, new: str) -> None:
+    if old == new:
+        return
+    diff = difflib.unified_diff(
+        old.splitlines(keepends=True),
+        new.splitlines(keepends=True),
+        fromfile=str(path),
+        tofile=f"{path} (patched)",
+    )
+    sys.stdout.writelines(diff)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Patch iOS project for a QA slot identity.",
+    )
+    parser.add_argument("--project-root", required=True, type=Path)
+    parser.add_argument("--bundle-id", required=True)
+    parser.add_argument("--extension-bundle-id", required=True)
+    parser.add_argument("--app-group", required=True)
+    parser.add_argument("--display-name", required=True)
+    parser.add_argument("--firebase-ios-app-id", required=True)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print unified diff to stdout without writing files.",
+    )
+    return parser.parse_args(argv)
+
+
+def run(args: argparse.Namespace) -> int:
+    root: Path = args.project_root
+    pbxproj_path = root / "ios/Runner.xcodeproj/project.pbxproj"
+    runner_ent_path = root / "ios/Runner/Runner.entitlements"
+    ext_ent_path = (
+        root
+        / "ios/NotificationServiceExtension/NotificationServiceExtension.entitlements"
+    )
+    google_plist_path = root / "ios/Runner/GoogleService-Info.plist"
+    firebase_json_path = root / "ios/firebase_app_id_file.json"
+
+    plans: list[tuple[Path, str, str]] = []
+
+    pbx_old = pbxproj_path.read_text(encoding="utf-8")
+    pbx_new = patch_pbxproj(
+        pbx_old,
+        bundle_id=args.bundle_id,
+        extension_bundle_id=args.extension_bundle_id,
+        display_name=args.display_name,
+    )
+    plans.append((pbxproj_path, pbx_old, pbx_new))
+
+    runner_ent_old = runner_ent_path.read_text(encoding="utf-8")
+    runner_ent_new = patch_entitlements(runner_ent_old, app_group=args.app_group)
+    plans.append((runner_ent_path, runner_ent_old, runner_ent_new))
+
+    ext_ent_old = ext_ent_path.read_text(encoding="utf-8")
+    ext_ent_new = patch_entitlements(ext_ent_old, app_group=args.app_group)
+    plans.append((ext_ent_path, ext_ent_old, ext_ent_new))
+
+    google_old = google_plist_path.read_text(encoding="utf-8")
+    google_new = patch_google_service_info(
+        google_old,
+        bundle_id=args.bundle_id,
+        firebase_app_id=args.firebase_ios_app_id,
+    )
+    plans.append((google_plist_path, google_old, google_new))
+
+    firebase_old = firebase_json_path.read_text(encoding="utf-8")
+    firebase_new = patch_firebase_app_id_json(
+        firebase_old,
+        firebase_app_id=args.firebase_ios_app_id,
+    )
+    plans.append((firebase_json_path, firebase_old, firebase_new))
+
+    # Cosmetic — make sure Firebase JSON stays valid JSON.
+    json.loads(firebase_new)
+
+    if args.dry_run:
+        for path, old, new in plans:
+            _emit_diff(path, old, new)
+        return 0
+
+    for path, _old, new in plans:
+        path.write_text(new, encoding="utf-8")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        return run(args)
+    except PatchError as exc:
+        print(f"configure_ios_qa_slot: {exc}", file=sys.stderr)
+        return 1
+    except FileNotFoundError as exc:
+        print(f"configure_ios_qa_slot: missing file: {exc.filename}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mobile/scripts/ci/tests/fixtures/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements
+++ b/mobile/scripts/ci/tests/fixtures/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.co.openvine.app</string>
+    </array>
+</dict>
+</plist>

--- a/mobile/scripts/ci/tests/fixtures/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/scripts/ci/tests/fixtures/ios/Runner.xcodeproj/project.pbxproj
@@ -1,0 +1,78 @@
+// !$*UTF8*$!
+{
+/* Begin XCBuildConfiguration section */
+		97C147061CF9000F007C117D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				INFOPLIST_KEY_CFBundleDisplayName = divine;
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		97C147071CF9000F007C117D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				INFOPLIST_KEY_CFBundleDisplayName = divine;
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app;
+			};
+			name = Release;
+		};
+		97C147081CF9000F007C117D /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				INFOPLIST_KEY_CFBundleDisplayName = divine;
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app;
+			};
+			name = Profile;
+		};
+		331C8088294A63A400263BE5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.RunnerTests;
+			};
+			name = Debug;
+		};
+		331C8089294A63A400263BE5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.RunnerTests;
+			};
+			name = Release;
+		};
+		331C808A294A63A400263BE5 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.RunnerTests;
+			};
+			name = Profile;
+		};
+		AB1C147061CF9000F007C117E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = NotificationServiceExtension/NotificationServiceExtension.entitlements;
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.NotificationServiceExtension;
+			};
+			name = Debug;
+		};
+		AB1C147071CF9000F007C117E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = NotificationServiceExtension/NotificationServiceExtension.entitlements;
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.NotificationServiceExtension;
+			};
+			name = Release;
+		};
+		AB1C147081CF9000F007C117E /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = NotificationServiceExtension/NotificationServiceExtension.entitlements;
+				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.NotificationServiceExtension;
+			};
+			name = Profile;
+		};
+/* End XCBuildConfiguration section */
+}

--- a/mobile/scripts/ci/tests/fixtures/ios/Runner/GoogleService-Info.plist
+++ b/mobile/scripts/ci/tests/fixtures/ios/Runner/GoogleService-Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyChiPGndRdZwsMoLqnel2WSocROmoKLdB4</string>
+	<key>GCM_SENDER_ID</key>
+	<string>972941478875</string>
+	<key>BUNDLE_ID</key>
+	<string>co.openvine.app</string>
+	<key>PROJECT_ID</key>
+	<string>openvine-co</string>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:972941478875:ios:f61272b3cf485df244b5fe</string>
+</dict>
+</plist>

--- a/mobile/scripts/ci/tests/fixtures/ios/Runner/Runner.entitlements
+++ b/mobile/scripts/ci/tests/fixtures/ios/Runner/Runner.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.co.openvine.app</string>
+	</array>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/mobile/scripts/ci/tests/fixtures/ios/firebase_app_id_file.json
+++ b/mobile/scripts/ci/tests/fixtures/ios/firebase_app_id_file.json
@@ -1,0 +1,7 @@
+{
+  "file_generated_by": "FlutterFire CLI",
+  "purpose": "FirebaseAppID & ProjectID for this Firebase app in this directory",
+  "GOOGLE_APP_ID": "1:972941478875:ios:f61272b3cf485df244b5fe",
+  "FIREBASE_PROJECT_ID": "openvine-co",
+  "GCM_SENDER_ID": "972941478875"
+}

--- a/mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
+++ b/mobile/scripts/ci/tests/test_configure_ios_qa_slot.py
@@ -1,0 +1,181 @@
+"""Tests for configure_ios_qa_slot.py."""
+
+import json
+import plistlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+THIS_DIR = Path(__file__).resolve().parent
+SCRIPT_PATH = THIS_DIR.parent / "configure_ios_qa_slot.py"
+FIXTURE_DIR = THIS_DIR / "fixtures" / "ios"
+
+SLOT_BUNDLE_ID = "co.openvine.app.qa01"
+SLOT_EXT_BUNDLE_ID = "co.openvine.app.qa01.NotificationServiceExtension"
+SLOT_APP_GROUP = "group.co.openvine.app.qa01"
+SLOT_DISPLAY_NAME = "Divine QA 01"
+SLOT_FIREBASE_APP_ID = "1:972941478875:ios:qa01placeholder"
+
+
+class ConfigureIosQaSlotTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="ios-qa-slot-test-"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        ios_dst = self.tmp / "ios"
+        ios_dst.mkdir(parents=True)
+        for src in FIXTURE_DIR.rglob("*"):
+            if src.is_file():
+                rel = src.relative_to(FIXTURE_DIR)
+                dst = ios_dst / rel
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dst)
+
+    def _run(self, *extra_args, expect_returncode=0):
+        cmd = [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--project-root",
+            str(self.tmp),
+            "--bundle-id",
+            SLOT_BUNDLE_ID,
+            "--extension-bundle-id",
+            SLOT_EXT_BUNDLE_ID,
+            "--app-group",
+            SLOT_APP_GROUP,
+            "--display-name",
+            SLOT_DISPLAY_NAME,
+            "--firebase-ios-app-id",
+            SLOT_FIREBASE_APP_ID,
+            *extra_args,
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        self.assertEqual(
+            result.returncode,
+            expect_returncode,
+            msg=(
+                f"unexpected returncode={result.returncode}\n"
+                f"stdout: {result.stdout}\nstderr: {result.stderr}"
+            ),
+        )
+        return result
+
+    def _pbxproj_text(self):
+        return (self.tmp / "ios/Runner.xcodeproj/project.pbxproj").read_text(
+            encoding="utf-8",
+        )
+
+    def test_patches_main_bundle_id(self):
+        self._run()
+        text = self._pbxproj_text()
+        self.assertIn(f"PRODUCT_BUNDLE_IDENTIFIER = {SLOT_BUNDLE_ID};", text)
+        self.assertNotIn("PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app;", text)
+
+    def test_patches_extension_bundle_id(self):
+        self._run()
+        text = self._pbxproj_text()
+        self.assertIn(
+            f"PRODUCT_BUNDLE_IDENTIFIER = {SLOT_EXT_BUNDLE_ID};",
+            text,
+        )
+        self.assertNotIn(
+            "PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.NotificationServiceExtension;",
+            text,
+        )
+
+    def test_does_not_patch_runner_tests_bundle_id(self):
+        self._run()
+        text = self._pbxproj_text()
+        self.assertIn(
+            "PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app.RunnerTests;",
+            text,
+        )
+        # Critical: must NOT have produced co.openvine.app.qa01.RunnerTests
+        self.assertNotIn(
+            f"{SLOT_BUNDLE_ID}.RunnerTests",
+            text,
+        )
+
+    def test_patches_display_name_with_quotes(self):
+        self._run()
+        text = self._pbxproj_text()
+        self.assertIn(
+            f'INFOPLIST_KEY_CFBundleDisplayName = "{SLOT_DISPLAY_NAME}";',
+            text,
+        )
+        self.assertNotIn("INFOPLIST_KEY_CFBundleDisplayName = divine;", text)
+
+    def test_patches_runner_app_group(self):
+        self._run()
+        path = self.tmp / "ios/Runner/Runner.entitlements"
+        with path.open("rb") as fp:
+            data = plistlib.load(fp)
+        groups = data["com.apple.security.application-groups"]
+        self.assertIn(SLOT_APP_GROUP, groups)
+        self.assertNotIn("group.co.openvine.app", groups)
+
+    def test_patches_extension_app_group(self):
+        self._run()
+        path = (
+            self.tmp
+            / "ios/NotificationServiceExtension/NotificationServiceExtension.entitlements"
+        )
+        with path.open("rb") as fp:
+            data = plistlib.load(fp)
+        groups = data["com.apple.security.application-groups"]
+        self.assertIn(SLOT_APP_GROUP, groups)
+        self.assertNotIn("group.co.openvine.app", groups)
+
+    def test_patches_google_service_info(self):
+        self._run()
+        path = self.tmp / "ios/Runner/GoogleService-Info.plist"
+        with path.open("rb") as fp:
+            data = plistlib.load(fp)
+        self.assertEqual(data["BUNDLE_ID"], SLOT_BUNDLE_ID)
+        self.assertEqual(data["GOOGLE_APP_ID"], SLOT_FIREBASE_APP_ID)
+
+    def test_patches_firebase_app_id_json(self):
+        self._run()
+        path = self.tmp / "ios/firebase_app_id_file.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(data["GOOGLE_APP_ID"], SLOT_FIREBASE_APP_ID)
+
+    def test_dry_run_prints_diff_and_leaves_files_unchanged(self):
+        before = {
+            p.relative_to(self.tmp): p.read_bytes()
+            for p in (self.tmp / "ios").rglob("*")
+            if p.is_file()
+        }
+        result = self._run("--dry-run")
+        self.assertIn("---", result.stdout)
+        self.assertIn("+++", result.stdout)
+        self.assertIn(SLOT_BUNDLE_ID, result.stdout)
+        self.assertIn(SLOT_FIREBASE_APP_ID, result.stdout)
+        after = {
+            p.relative_to(self.tmp): p.read_bytes()
+            for p in (self.tmp / "ios").rglob("*")
+            if p.is_file()
+        }
+        self.assertEqual(before, after)
+
+    def test_missing_required_arg_fails(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--project-root", str(self.tmp)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_missing_production_marker_in_pbxproj_fails(self):
+        # Wipe the marker and confirm script fails fast rather than silently no-op.
+        pbx = self.tmp / "ios/Runner.xcodeproj/project.pbxproj"
+        pbx.write_text("// empty pbxproj\n", encoding="utf-8")
+        self._run(expect_returncode=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mobile/test/config/build_identity_test.dart
+++ b/mobile/test/config/build_identity_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/config/build_identity.dart';
+
+void main() {
+  test('uses iOS identity from dart defines with production defaults', () {
+    const expectedBundleId = String.fromEnvironment(
+      'EXPECTED_IOS_BUNDLE_ID',
+      defaultValue: 'co.openvine.app',
+    );
+    const expectedPushAppIdentifier = String.fromEnvironment(
+      'EXPECTED_PUSH_APP_IDENTIFIER',
+      defaultValue: expectedBundleId,
+    );
+    const expectedFirebaseAppId = String.fromEnvironment(
+      'EXPECTED_FIREBASE_IOS_APP_ID',
+      defaultValue: '1:972941478875:ios:f61272b3cf485df244b5fe',
+    );
+
+    expect(BuildIdentity.iosBundleId, equals(expectedBundleId));
+    expect(BuildIdentity.pushAppIdentifier, equals(expectedPushAppIdentifier));
+    expect(BuildIdentity.firebaseIosAppId, equals(expectedFirebaseAppId));
+  });
+}


### PR DESCRIPTION
## Summary

Implements the iOS QA PR build pipeline planned in `docs/superpowers/plans/2026-04-26-ios-qa-pr-builds.md` and specced in `docs/superpowers/specs/2026-04-26-ios-qa-pr-builds-design.md` (replaces the doc-only PR #3423).

15 reusable QA slots (`qa01`..`qa15`) ship with this PR; only `qa01` is enabled. Each slot is a fixed Apple/Firebase identity that installs side-by-side with production and the other slots, so QA does not need TestFlight in the loop.

## What's in this PR

- **Build-time identity (`mobile/lib/config/build_identity.dart`)** — `IOS_BUNDLE_ID`, `PUSH_APP_IDENTIFIER`, `FIREBASE_IOS_APP_ID` flow through `--dart-define` with production defaults. Wired into `firebase_options.dart` and `push_notification_service.dart`.
- **Slot project patcher (`mobile/scripts/ci/configure_ios_qa_slot.py`)** — retargets `Runner.xcodeproj`, entitlements, `GoogleService-Info.plist`, and `firebase_app_id_file.json` for one slot. Anchored on production markers, leaves `co.openvine.app.RunnerTests` alone, supports `--dry-run`. 11 unit tests with fixtures.
- **Slot library (`.github/ios_qa_slots.json` + `.github/scripts/ios_qa_slots.py`)** — pure Python (stdlib only) library + CLI for trust check, eligibility, slot allocation, sticky-comment state markers, status comment and directory rendering, Codemagic payload, and Firebase distribution JSON parsing across 3 known shapes. 51 tests.
- **Trusted allocator workflow (`.github/workflows/mobile_ios_qa_allocate.yml`)** — `pull_request_target` so secrets are available, but only checks out main-branch scripts (`persist-credentials: false`) and never executes PR-controlled code. Mirrors trusted PR heads to `ios-qa/pr-N`, triggers Codemagic via the Builds API, and upserts a sticky PR comment. Includes a daily cron `reconcile` job that promotes queued PRs into freed slots and refreshes the directory issue.
- **Codemagic `ios-qa-pr-build` workflow (`codemagic.yaml`)** — Ad Hoc signing for `\$QA_BUNDLE_ID`, slot patch before `xcode-project use-profiles`, mirror-SHA verification, stale-PR check before distribution, Firebase service-account distribution preferred over deprecated token auth, and a post-publish notify script that always runs.
- **Plan + spec docs** — kept in `docs/superpowers/` so future work (adding a slot, debugging a stuck queue) has the design in tree.

## What's NOT in this PR (your turn — Chunk 0)

The plan's Chunk 0 external setup must complete before any builds succeed. Tracked in #3424:

1. Apple identifiers + Ad Hoc provisioning for `qa01` (`co.openvine.app.qa01`, `.NotificationServiceExtension`, `group.co.openvine.app.qa01`).
2. Firebase iOS app for `co.openvine.app.qa01` — copy the real Firebase app id into `.github/ios_qa_slots.json` to replace the `qa01placeholder`.
3. Codemagic env groups (`firebase_app_distribution`, `ios_qa_signing`) and signing assets, plus `IOS_QA_GITHUB_TOKEN` and `FIREBASE_SERVICE_ACCOUNT`.
4. GitHub repo secrets `CODEMAGIC_APP_ID`, `CODEMAGIC_API_TOKEN`, `DIVINEVIDEO_ORG_READ_TOKEN`.
5. GitHub repo variables `IOS_QA_DIRECTORY_ISSUE_NUMBER`, optional `IOS_QA_DEFAULT_ENV`.
6. Run the `gh label create` script from the plan's Chunk 0 Step 7 (or rely on the workflow's idempotent bootstrap step on first run).

After 1–6 land, run `Mobile iOS QA Allocate` via `workflow_dispatch` for a throwaway trusted mobile PR to prove `qa01` end-to-end (Chunk 7 of the plan).

## Verification

```
PYTHONPATH=.github/scripts python3 -m unittest discover -s .github/scripts/tests -p 'test_*.py'    # 51 tests
python3 -m unittest mobile/scripts/ci/tests/test_configure_ios_qa_slot.py                          # 11 tests
ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml')"
ruby -e "require 'yaml'; YAML.load_file('.github/workflows/mobile_ios_qa_allocate.yml')"
actionlint .github/workflows/mobile_ios_qa_allocate.yml
python3 mobile/scripts/ci/configure_ios_qa_slot.py --project-root mobile \
  --bundle-id co.openvine.app.qa01 --extension-bundle-id co.openvine.app.qa01.NotificationServiceExtension \
  --app-group group.co.openvine.app.qa01 --display-name "Divine QA 01" \
  --firebase-ios-app-id 1:972941478875:ios:qa01placeholder --dry-run
git diff --exit-code -- mobile/ios/Runner.xcodeproj/project.pbxproj mobile/ios/Runner/Runner.entitlements \
  mobile/ios/NotificationServiceExtension/NotificationServiceExtension.entitlements \
  mobile/ios/Runner/GoogleService-Info.plist mobile/ios/firebase_app_id_file.json
cd mobile && flutter test test/config/build_identity_test.dart
flutter test test/config/build_identity_test.dart \
  --dart-define=IOS_BUNDLE_ID=co.openvine.app.qa01 \
  --dart-define=PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
  --dart-define=FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder \
  --dart-define=EXPECTED_IOS_BUNDLE_ID=co.openvine.app.qa01 \
  --dart-define=EXPECTED_PUSH_APP_IDENTIFIER=co.openvine.app.qa01 \
  --dart-define=EXPECTED_FIREBASE_IOS_APP_ID=1:972941478875:ios:qa01placeholder
```

All pass locally.

## Test plan

- [ ] Reviewer can read the plan + spec docs and reproduce the architectural decisions
- [ ] Local verification commands above all exit 0
- [ ] After merge, complete Chunk 0 external setup
- [ ] Trigger `workflow_dispatch` on `Mobile iOS QA Allocate` for a throwaway trusted mobile PR
- [ ] Confirm sticky PR comment lands with `<!-- divine-ios-qa-build:v1` marker, full SHA, `qa01` slot, Codemagic build link
- [ ] Confirm Firebase release for `co.openvine.app.qa01` shows up under the `ios-qa` testers group
- [ ] Confirm closing the test PR cleans up labels and deletes the `ios-qa/pr-<N>` mirror branch

Closes #3424.