### PR TITLE
fix(video-player): release pooled players earlier on background

### DIFF
--- a/mobile/packages/pooled_video_player/lib/src/controllers/player_pool.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/player_pool.dart
@@ -409,11 +409,14 @@ class PlayerPool {
     _players.clear();
     _lruOrder.clear();
 
+    final disposals = <Future<void>>[];
     for (final player in players) {
       if (!player.isDisposed) {
-        await player.dispose();
+        disposals.add(player.dispose());
       }
     }
+
+    await Future.wait(disposals);
   }
 
   /// Dispose all players and clear the pool.

--- a/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_feed.dart
+++ b/mobile/packages/pooled_video_player/lib/src/widgets/pooled_video_feed.dart
@@ -1,4 +1,5 @@
-import 'package:flutter/foundation.dart' show listEquals;
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, listEquals;
 import 'package:flutter/material.dart';
 
 import 'package:pooled_video_player/src/controllers/player_pool.dart';
@@ -151,15 +152,28 @@ class PooledVideoFeedState extends State<PooledVideoFeed>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
 
+    if (_shouldDeactivateForLifecycleState(state)) {
+      _controller.setActive(active: false);
+    }
+  }
+
+  bool _shouldDeactivateForLifecycleState(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.paused:
       case AppLifecycleState.hidden:
       case AppLifecycleState.detached:
-        _controller.setActive(active: false);
-
-      case AppLifecycleState.resumed:
+        return true;
       case AppLifecycleState.inactive:
-        break;
+        // On mobile, inactive is the first signal before background suspension.
+        return switch (defaultTargetPlatform) {
+          TargetPlatform.android || TargetPlatform.iOS => true,
+          TargetPlatform.fuchsia ||
+          TargetPlatform.linux ||
+          TargetPlatform.macOS ||
+          TargetPlatform.windows => false,
+        };
+      case AppLifecycleState.resumed:
+        return false;
     }
   }
 

--- a/mobile/packages/pooled_video_player/test/controllers/player_pool_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/player_pool_test.dart
@@ -552,6 +552,42 @@ void main() {
         });
       });
 
+      group('releaseAll', () {
+        test(
+          'starts disposing all players before awaiting any one disposal',
+          () async {
+            await pool.getPlayer('https://example.com/v1.mp4');
+            await pool.getPlayer('https://example.com/v2.mp4');
+
+            final firstDispose = Completer<void>();
+            final secondDisposeStarted = Completer<void>();
+            Future<void>? releaseFuture;
+
+            when(createdPlayers[0].dispose).thenAnswer(
+              (_) => firstDispose.future,
+            );
+            when(createdPlayers[1].dispose).thenAnswer((_) async {
+              secondDisposeStarted.complete();
+            });
+
+            addTearDown(() async {
+              if (!firstDispose.isCompleted) {
+                firstDispose.complete();
+              }
+              await releaseFuture;
+            });
+
+            releaseFuture = pool.releaseAll();
+            await Future<void>.delayed(Duration.zero);
+
+            expect(secondDisposeStarted.isCompleted, isTrue);
+
+            firstDispose.complete();
+            await releaseFuture;
+          },
+        );
+      });
+
       group('dispose', () {
         test('disposes all players', () async {
           await pool.getPlayer('https://example.com/v1.mp4');

--- a/mobile/packages/pooled_video_player/test/widgets/pooled_video_feed_test.dart
+++ b/mobile/packages/pooled_video_player/test/widgets/pooled_video_feed_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -144,6 +145,27 @@ void main() {
         await tester.pump();
 
         verify(() => controller.setActive(active: false)).called(1);
+      });
+
+      testWidgets('deactivates controller when iOS app becomes inactive', (
+        tester,
+      ) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        try {
+          final controller = createMockVideoFeedController();
+
+          await tester.pumpWidget(buildFeed(controller: controller));
+          clearInteractions(controller);
+
+          tester.binding.handleAppLifecycleStateChanged(
+            AppLifecycleState.inactive,
+          );
+          await tester.pump();
+
+          verify(() => controller.setActive(active: false)).called(1);
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
       });
     });
 


### PR DESCRIPTION
## Summary
- Start pooled player release when mobile lifecycle enters inactive so iOS gets cleanup before suspension.
- Dispose all cached pooled players concurrently during releaseAll so one slow native player cannot leave the rest holding media resources.
- Add regressions for iOS inactive deactivation and releaseAll disposal ordering.

## Tests
- flutter test test/controllers/player_pool_test.dart
- flutter test test/widgets/pooled_video_feed_test.dart
- flutter test test/controllers/video_feed_controller_test.dart --plain-name 'full deactivation clears native player pool to release file locks'
- flutter test (mobile/packages/pooled_video_player)
- flutter analyze (mobile/packages/pooled_video_player)
- pre-push hook reran changed pooled_video_player tests