### PR TITLE
fix(profile): remove generic NIP-05 checkmark badges

### DIFF
--- a/mobile/lib/widgets/special_profile_checkmark.dart
+++ b/mobile/lib/widgets/special_profile_checkmark.dart
@@ -1,0 +1,60 @@
+// ABOUTME: Hosts explicit exceptions for profile checkmark display.
+// ABOUTME: Keeps special-case badges separate from generic NIP-05 validation.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:models/models.dart';
+
+const _kirstenSwaseyProfileHost = 'kirstenswasey.divine.video';
+
+bool shouldShowSpecialProfileCheckmark(UserProfile? profile) {
+  if (profile == null) return false;
+  return _matchesKirstenSwaseyProfile(profile.nip05) ||
+      _matchesKirstenSwaseyProfile(profile.displayNip05);
+}
+
+bool _matchesKirstenSwaseyProfile(String? identifier) {
+  final host = _hostFromProfileIdentifier(identifier);
+  return host == _kirstenSwaseyProfileHost;
+}
+
+String? _hostFromProfileIdentifier(String? identifier) {
+  if (identifier == null) return null;
+  final value = identifier.trim().toLowerCase();
+  if (value.isEmpty) return null;
+
+  final uri = Uri.tryParse(value);
+  if ((uri?.hasScheme ?? false) && uri!.host.isNotEmpty) {
+    return uri.host;
+  }
+
+  final atIndex = value.indexOf('@');
+  final hostLikeValue = atIndex == -1 ? value : value.substring(atIndex + 1);
+  return hostLikeValue.split('/').first;
+}
+
+class SpecialProfileCheckmark extends StatelessWidget {
+  const SpecialProfileCheckmark({
+    super.key,
+    this.iconSize = 10,
+    this.padding = 2,
+  });
+
+  final double iconSize;
+  final double padding;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(start: 4),
+      child: Container(
+        padding: EdgeInsets.all(padding),
+        decoration: const BoxDecoration(
+          color: VineTheme.info,
+          shape: BoxShape.circle,
+        ),
+        child: Icon(Icons.check, color: VineTheme.whiteText, size: iconSize),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/user_name.dart
+++ b/mobile/lib/widgets/user_name.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/widgets/special_profile_checkmark.dart';
 
 class UserName extends ConsumerWidget {
   const UserName._({
@@ -76,10 +77,13 @@ class UserName extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     late String displayName;
+    UserProfile? resolvedProfile;
     if (userProfile case final userProfile?) {
+      resolvedProfile = userProfile;
       displayName = userProfile.betterDisplayName(anonymousName);
     } else {
       final profileAsync = ref.watch(userProfileReactiveProvider(pubkey!));
+      resolvedProfile = profileAsync.value;
 
       // Use embedded name from REST API as fallback, then generated name.
       final fallbackName =
@@ -124,6 +128,8 @@ class UserName extends ConsumerWidget {
                   overflow: overflow ?? TextOverflow.ellipsis,
                 ),
         ),
+        if (shouldShowSpecialProfileCheckmark(resolvedProfile))
+          const SpecialProfileCheckmark(),
       ],
     );
   }

--- a/mobile/lib/widgets/user_name.dart
+++ b/mobile/lib/widgets/user_name.dart
@@ -2,9 +2,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
-import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
-import 'package:openvine/services/nip05_verification_service.dart';
 
 class UserName extends ConsumerWidget {
   const UserName._({
@@ -78,13 +76,10 @@ class UserName extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     late String displayName;
-    late String effectivePubkey;
     if (userProfile case final userProfile?) {
       displayName = userProfile.betterDisplayName(anonymousName);
-      effectivePubkey = userProfile.pubkey;
     } else {
       final profileAsync = ref.watch(userProfileReactiveProvider(pubkey!));
-      effectivePubkey = pubkey!;
 
       // Use embedded name from REST API as fallback, then generated name.
       final fallbackName =
@@ -98,15 +93,6 @@ class UserName extends ConsumerWidget {
         AsyncError() => fallbackName,
       };
     }
-
-    // Watch NIP-05 verification status using pattern matching
-    final verificationAsync = ref.watch(
-      nip05VerificationProvider(effectivePubkey),
-    );
-    final showCheckmark = switch (verificationAsync) {
-      AsyncData(:final value) => value == Nip05VerificationStatus.verified,
-      _ => false,
-    };
 
     // Note: Strikethrough for failed NIP-05 verification is now shown on the
     // NIP-05 identifier itself (in _UniqueIdentifier), not on the display name.
@@ -138,20 +124,6 @@ class UserName extends ConsumerWidget {
                   overflow: overflow ?? TextOverflow.ellipsis,
                 ),
         ),
-
-        if (showCheckmark)
-          Container(
-            padding: const EdgeInsets.all(2),
-            decoration: const BoxDecoration(
-              color: VineTheme.info,
-              shape: BoxShape.circle,
-            ),
-            child: const Icon(
-              Icons.check,
-              color: VineTheme.whiteText,
-              size: 10,
-            ),
-          ),
       ],
     );
   }

--- a/mobile/lib/widgets/video_explore_tile.dart
+++ b/mobile/lib/widgets/video_explore_tile.dart
@@ -10,6 +10,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:openvine/widgets/proofmode_badge_row.dart';
+import 'package:openvine/widgets/special_profile_checkmark.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -139,6 +140,7 @@ class _CreatorInfo extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final profileAsync = ref.watch(userProfileReactiveProvider(pubkey));
+    final profile = profileAsync.value;
 
     final displayName = switch (profileAsync) {
       AsyncData(:final value) when value != null => value.bestDisplayName,
@@ -176,6 +178,8 @@ class _CreatorInfo extends ConsumerWidget {
               overflow: TextOverflow.ellipsis,
             ),
           ),
+          if (shouldShowSpecialProfileCheckmark(profile))
+            const SpecialProfileCheckmark(iconSize: 8, padding: 1),
         ],
       ),
     );

--- a/mobile/lib/widgets/video_explore_tile.dart
+++ b/mobile/lib/widgets/video_explore_tile.dart
@@ -6,10 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
-import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
-import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:openvine/widgets/proofmode_badge_row.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
@@ -148,14 +146,6 @@ class _CreatorInfo extends ConsumerWidget {
       AsyncLoading() => 'Loading...',
     };
 
-    // Use actual NIP-05 verification provider — only show badge when DNS
-    // lookup confirms the pubkey owns the claimed identifier (NIP-05 spec).
-    final verificationAsync = ref.watch(nip05VerificationProvider(pubkey));
-    final isNip05Verified = switch (verificationAsync) {
-      AsyncData(:final value) => value == Nip05VerificationStatus.verified,
-      _ => false,
-    };
-
     return GestureDetector(
       onTap: () {
         Log.verbose(
@@ -186,22 +176,6 @@ class _CreatorInfo extends ConsumerWidget {
               overflow: TextOverflow.ellipsis,
             ),
           ),
-          // Add NIP-05 verification badge if verified
-          if (isNip05Verified) ...[
-            const SizedBox(width: 4),
-            Container(
-              padding: const EdgeInsets.all(1),
-              decoration: const BoxDecoration(
-                color: VineTheme.info,
-                shape: BoxShape.circle,
-              ),
-              child: const Icon(
-                Icons.check,
-                color: VineTheme.whiteText,
-                size: 8,
-              ),
-            ),
-          ],
         ],
       ),
     );

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -38,6 +38,7 @@ import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/clickable_hashtag_text.dart';
 import 'package:openvine/widgets/share_video_menu.dart';
+import 'package:openvine/widgets/special_profile_checkmark.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/video_feed_item/actions/actions.dart';
@@ -1543,6 +1544,10 @@ class VideoOverlayActions extends ConsumerWidget {
                                             ),
                                           ),
                                         ),
+                                        if (shouldShowSpecialProfileCheckmark(
+                                          profile,
+                                        ))
+                                          const SpecialProfileCheckmark(),
                                       ],
                                     ),
                                     Text(

--- a/mobile/lib/widgets/video_feed_item/video_feed_item.dart
+++ b/mobile/lib/widgets/video_feed_item/video_feed_item.dart
@@ -18,7 +18,6 @@ import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/providers/active_video_provider.dart'; // For isVideoActiveProvider (router-driven)
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/individual_video_providers.dart'; // For individualVideoControllerProvider only
-import 'package:openvine/providers/nip05_verification_provider.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart'; // For hasVisibleOverlayProvider (modal pause/resume)
 import 'package:openvine/providers/subtitle_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
@@ -30,7 +29,6 @@ import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/liked_videos_screen_router.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
-import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/services/visibility_tracker.dart';
 import 'package:openvine/ui/overlay_policy.dart';
@@ -1545,11 +1543,6 @@ class VideoOverlayActions extends ConsumerWidget {
                                             ),
                                           ),
                                         ),
-                                        // Use actual NIP-05 verification —
-                                        // only show badge when DNS lookup
-                                        // confirms the pubkey owns the claimed
-                                        // identifier (NIP-05 spec).
-                                        _Nip05Badge(pubkey: video.pubkey),
                                       ],
                                     ),
                                     Text(
@@ -1932,39 +1925,6 @@ class VideoRepostHeader extends ConsumerWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-/// NIP-05 verification badge that watches the actual verification provider.
-///
-/// Only shows the blue checkmark when DNS lookup confirms the pubkey
-/// owns the claimed NIP-05 identifier, per the NIP-05 spec.
-class _Nip05Badge extends ConsumerWidget {
-  const _Nip05Badge({required this.pubkey});
-
-  final String pubkey;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final verificationAsync = ref.watch(nip05VerificationProvider(pubkey));
-    final isVerified = switch (verificationAsync) {
-      AsyncData(:final value) => value == Nip05VerificationStatus.verified,
-      _ => false,
-    };
-
-    if (!isVerified) return const SizedBox.shrink();
-
-    return Padding(
-      padding: const EdgeInsetsDirectional.only(start: 4),
-      child: Container(
-        padding: const EdgeInsets.all(2),
-        decoration: const BoxDecoration(
-          color: VineTheme.info,
-          shape: BoxShape.circle,
-        ),
-        child: const Icon(Icons.check, color: VineTheme.whiteText, size: 10),
       ),
     );
   }

--- a/mobile/test/widgets/user_name_nip05_test.dart
+++ b/mobile/test/widgets/user_name_nip05_test.dart
@@ -1,0 +1,49 @@
+// ABOUTME: Tests UserName NIP-05 display behavior
+// ABOUTME: Ensures valid NIP-05 does not render a verification checkmark
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/providers/nip05_verification_provider.dart';
+import 'package:openvine/services/nip05_verification_service.dart';
+import 'package:openvine/widgets/user_name.dart';
+
+void main() {
+  const pubkey =
+      'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+
+  Widget buildSubject() {
+    return ProviderScope(
+      overrides: [
+        nip05VerificationProvider.overrideWith(
+          (ref, pubkey) async => Nip05VerificationStatus.verified,
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: UserName.fromUserProfile(
+              UserProfile(
+                pubkey: pubkey,
+                name: 'Alice',
+                nip05: 'alice@example.com',
+                rawData: const {},
+                createdAt: DateTime(2026),
+                eventId: 'kind0_event_id',
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('does not show a checkmark for verified NIP-05', (tester) async {
+    await tester.pumpWidget(buildSubject());
+    await tester.pump();
+
+    expect(find.text('Alice'), findsOneWidget);
+    expect(find.byIcon(Icons.check), findsNothing);
+  });
+}

--- a/mobile/test/widgets/user_name_nip05_test.dart
+++ b/mobile/test/widgets/user_name_nip05_test.dart
@@ -13,7 +13,7 @@ void main() {
   const pubkey =
       'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
 
-  Widget buildSubject() {
+  Widget buildSubject({String nip05 = 'alice@example.com'}) {
     return ProviderScope(
       overrides: [
         nip05VerificationProvider.overrideWith(
@@ -27,7 +27,7 @@ void main() {
               UserProfile(
                 pubkey: pubkey,
                 name: 'Alice',
-                nip05: 'alice@example.com',
+                nip05: nip05,
                 rawData: const {},
                 createdAt: DateTime(2026),
                 eventId: 'kind0_event_id',
@@ -45,5 +45,27 @@ void main() {
 
     expect(find.text('Alice'), findsOneWidget);
     expect(find.byIcon(Icons.check), findsNothing);
+  });
+
+  testWidgets('shows a checkmark for Kirsten Swasey special profile', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildSubject(nip05: '_@kirstenswasey.divine.video'),
+    );
+    await tester.pump();
+
+    expect(find.text('Alice'), findsOneWidget);
+    expect(find.byIcon(Icons.check), findsOneWidget);
+  });
+
+  testWidgets('matches the Kirsten Swasey profile URL host', (tester) async {
+    await tester.pumpWidget(
+      buildSubject(nip05: 'http://kirstenswasey.divine.video'),
+    );
+    await tester.pump();
+
+    expect(find.text('Alice'), findsOneWidget);
+    expect(find.byIcon(Icons.check), findsOneWidget);
   });
 }

--- a/mobile/test/widgets/video_explore_tile_nip05_test.dart
+++ b/mobile/test/widgets/video_explore_tile_nip05_test.dart
@@ -155,6 +155,20 @@ void main() {
 
         expect(find.byIcon(Icons.check), findsNothing);
       });
+
+      testWidgets('shows checkmark for Kirsten Swasey special profile', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildSubject(
+            verificationStatus: Nip05VerificationStatus.verified,
+            nip05: '_@kirstenswasey.divine.video',
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byIcon(Icons.check), findsOneWidget);
+      });
     });
   });
 }

--- a/mobile/test/widgets/video_explore_tile_nip05_test.dart
+++ b/mobile/test/widgets/video_explore_tile_nip05_test.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Tests that VideoExploreTile only shows NIP-05 badge for verified users
-// ABOUTME: Ensures blue checkmark requires actual DNS verification, not just a claim
+// ABOUTME: Tests that VideoExploreTile does not show NIP-05 checkmarks
+// ABOUTME: Ensures valid NIP-05 does not look like account verification
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -88,8 +88,8 @@ void main() {
   }
 
   group(VideoExploreTile, () {
-    group('NIP-05 badge', () {
-      testWidgets('shows blue checkmark when NIP-05 is verified', (
+    group('NIP-05 checkmark', () {
+      testWidgets('does not show checkmark when NIP-05 is verified', (
         tester,
       ) async {
         await tester.pumpWidget(
@@ -100,7 +100,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.byIcon(Icons.check), findsOneWidget);
+        expect(find.byIcon(Icons.check), findsNothing);
       });
 
       testWidgets('does not show checkmark when NIP-05 verification fails', (

--- a/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
@@ -177,6 +177,53 @@ void main() {
   });
 
   testWidgets(
+    'author line shows checkmark for Kirsten Swasey special profile',
+    (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        testProviderScope(
+          additionalOverrides: [
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+            userProfileReactiveProvider.overrideWith((ref, pubkey) async* {
+              yield UserProfile(
+                pubkey: pubkey,
+                name: 'Alice',
+                nip05: '_@kirstenswasey.divine.video',
+                rawData: const {},
+                createdAt: DateTime(2026),
+                eventId: 'kind0_event_id',
+              );
+            }),
+            nip05VerificationProvider.overrideWith(
+              (ref, pubkey) async => Nip05VerificationStatus.verified,
+            ),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: BlocProvider<VideoInteractionsBloc>.value(
+                value: mockInteractionsBloc,
+                child: VideoOverlayActions(
+                  video: testVideo,
+                  isVisible: true,
+                  isActive: true,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.text('Alice'), findsOneWidget);
+      expect(find.byIcon(Icons.check), findsOneWidget);
+    },
+  );
+
+  testWidgets(
     'does not render a dedicated captions button in the action rail',
     (tester) async {
       final subtitleVideo = testVideo.copyWith(

--- a/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_overlay_actions_description_test.dart
@@ -10,6 +10,9 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/nip05_verification_provider.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/services/nip05_verification_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/utils/string_utils.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
@@ -127,6 +130,50 @@ void main() {
       ),
       findsOneWidget,
     );
+  });
+
+  testWidgets('author line does not show checkmark for verified NIP-05', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      testProviderScope(
+        additionalOverrides: [
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          userProfileReactiveProvider.overrideWith((ref, pubkey) async* {
+            yield UserProfile(
+              pubkey: pubkey,
+              name: 'Alice',
+              nip05: 'alice@example.com',
+              rawData: const {},
+              createdAt: DateTime(2026),
+              eventId: 'kind0_event_id',
+            );
+          }),
+          nip05VerificationProvider.overrideWith(
+            (ref, pubkey) async => Nip05VerificationStatus.verified,
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: BlocProvider<VideoInteractionsBloc>.value(
+              value: mockInteractionsBloc,
+              child: VideoOverlayActions(
+                video: testVideo,
+                isVisible: true,
+                isActive: true,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Alice'), findsOneWidget);
+    expect(find.byIcon(Icons.check), findsNothing);
   });
 
   testWidgets(


### PR DESCRIPTION
Closes #3447

## Summary
- remove generic NIP-05-driven checkmark badges from creator names in explore tiles, feed author metadata, and UserName
- keep valid NIP-05 as identifier text where the app already showed it
- add an explicit special-profile checkmark exception for kirstenswasey.divine.video
- add regression coverage for generic verified NIP-05 no longer rendering check icons and for the Kirsten Swasey exception

## Test Plan
- [x] flutter analyze lib/widgets/special_profile_checkmark.dart lib/widgets/video_explore_tile.dart lib/widgets/user_name.dart lib/widgets/video_feed_item/video_feed_item.dart test/widgets/video_explore_tile_nip05_test.dart test/widgets/user_name_nip05_test.dart test/widgets/video_feed_item/video_overlay_actions_description_test.dart
- [x] flutter test test/widgets/video_explore_tile_nip05_test.dart test/widgets/user_name_nip05_test.dart test/widgets/video_feed_item/video_overlay_actions_description_test.dart
- [x] mobile/scripts/golden.sh verify
- [x] pre-commit hook: dart format + flutter analyze
- [x] pre-push hook: changed-file widget tests