### PR TITLE
fix(profile): add Rabble checkmark exception

### DIFF
--- a/mobile/lib/widgets/special_profile_checkmark.dart
+++ b/mobile/lib/widgets/special_profile_checkmark.dart
@@ -5,17 +5,20 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:models/models.dart';
 
-const _kirstenSwaseyProfileHost = 'kirstenswasey.divine.video';
+const _specialProfileHosts = {
+  'kirstenswasey.divine.video',
+  'rabble.divine.video',
+};
 
 bool shouldShowSpecialProfileCheckmark(UserProfile? profile) {
   if (profile == null) return false;
-  return _matchesKirstenSwaseyProfile(profile.nip05) ||
-      _matchesKirstenSwaseyProfile(profile.displayNip05);
+  return _matchesSpecialProfile(profile.nip05) ||
+      _matchesSpecialProfile(profile.displayNip05);
 }
 
-bool _matchesKirstenSwaseyProfile(String? identifier) {
+bool _matchesSpecialProfile(String? identifier) {
   final host = _hostFromProfileIdentifier(identifier);
-  return host == _kirstenSwaseyProfileHost;
+  return _specialProfileHosts.contains(host);
 }
 
 String? _hostFromProfileIdentifier(String? identifier) {

--- a/mobile/test/widgets/user_name_nip05_test.dart
+++ b/mobile/test/widgets/user_name_nip05_test.dart
@@ -68,4 +68,12 @@ void main() {
     expect(find.text('Alice'), findsOneWidget);
     expect(find.byIcon(Icons.check), findsOneWidget);
   });
+
+  testWidgets('shows a checkmark for Rabble special profile', (tester) async {
+    await tester.pumpWidget(buildSubject(nip05: '_@rabble.divine.video'));
+    await tester.pump();
+
+    expect(find.text('Alice'), findsOneWidget);
+    expect(find.byIcon(Icons.check), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Closes #3450

## Summary
- add rabble.divine.video to the explicit special-profile checkmark allowlist
- keep generic valid NIP-05 profiles from receiving checkmarks
- add regression coverage for the Rabble special profile

## Test Plan
- [x] flutter analyze lib/widgets/special_profile_checkmark.dart test/widgets/user_name_nip05_test.dart
- [x] flutter test test/widgets/video_explore_tile_nip05_test.dart test/widgets/user_name_nip05_test.dart test/widgets/video_feed_item/video_overlay_actions_description_test.dart
- [x] mobile/scripts/golden.sh verify
- [x] pre-commit hook: dart format + flutter analyze
- [x] pre-push hook: changed-file widget tests