### PR TITLE
fix(feed): prevent 2 px caption overflow on video action buttons

### DIFF
--- a/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
@@ -10,12 +10,8 @@ import 'package:openvine/utils/string_utils.dart';
 /// Base widget for video overlay action buttons (like, comment, repost, share).
 ///
 /// Matches Figma node `15314:53971`: a 48x48 fully tappable container with a
-/// 24 icon centered over an 8 px gap and a label/small caption beneath it.
-/// The 48x48 spec is enforced as a *minimum* size — the whole region captures
-/// the tap, but the column is allowed to grow past 48 px on the main axis
-/// when caption metrics push the natural height higher (Inter's intrinsic
-/// line box edges past the strut by ~2 px) or when system text scaling is
-/// in effect, so the content never clips.
+/// 24 icon over an 8 px gap and a label/small caption. 48x48 is a *minimum* —
+/// the column may grow past it so caption text never clips.
 ///
 /// Example usage:
 /// ```dart

--- a/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/video_action_button.dart
@@ -11,7 +11,11 @@ import 'package:openvine/utils/string_utils.dart';
 ///
 /// Matches Figma node `15314:53971`: a 48x48 fully tappable container with a
 /// 24 icon centered over an 8 px gap and a label/small caption beneath it.
-/// The entire 48x48 region captures the tap — not just the icon.
+/// The 48x48 spec is enforced as a *minimum* size — the whole region captures
+/// the tap, but the column is allowed to grow past 48 px on the main axis
+/// when caption metrics push the natural height higher (Inter's intrinsic
+/// line box edges past the strut by ~2 px) or when system text scaling is
+/// in effect, so the content never clips.
 ///
 /// Example usage:
 /// ```dart
@@ -83,10 +87,11 @@ class VideoActionButton extends StatelessWidget {
         onTap: isLoading ? null : onPressed,
         child: SizedBox(
           width: 48,
-          height: 48,
-          child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(minHeight: 48),
             child: Column(
               mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 if (isLoading)
                   const SizedBox.square(

--- a/mobile/test/widgets/video_feed_item/actions/video_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/video_action_button_test.dart
@@ -71,10 +71,39 @@ void main() {
         // One GestureDetector wraps the whole tap target.
         expect(find.byType(GestureDetector), findsOneWidget);
 
-        // Tap target is exactly 48x48 regardless of child content.
+        // No-caption state collapses to the 48x48 minimum.
         final size = tester.getSize(find.byType(GestureDetector));
         expect(size, equals(const Size(48, 48)));
       });
+
+      testWidgets(
+        '$GestureDetector grows past 48 without overflow when a caption renders',
+        (tester) async {
+          // Caption-rendered case: Inter's intrinsic line box pushes the
+          // column ~2 px past the 48 px Figma spec; minHeight: 48 lets the
+          // column grow instead of overflowing. Width stays clamped to 48.
+          await tester.pumpWidget(buildSubject(count: 14));
+
+          expect(tester.takeException(), isNull);
+
+          final size = tester.getSize(find.byType(GestureDetector));
+          expect(size.width, equals(48));
+          expect(size.height, greaterThanOrEqualTo(48));
+        },
+      );
+
+      testWidgets(
+        '$GestureDetector grows past 48 without overflow when [labelWhenZero] renders',
+        (tester) async {
+          await tester.pumpWidget(buildSubject(labelWhenZero: 'Like'));
+
+          expect(tester.takeException(), isNull);
+
+          final size = tester.getSize(find.byType(GestureDetector));
+          expect(size.width, equals(48));
+          expect(size.height, greaterThanOrEqualTo(48));
+        },
+      );
     });
 
     group('count display', () {


### PR DESCRIPTION
## Summary

- `VideoActionButton` wrapped its content in a fixed `SizedBox(48, 48)`, but Inter's intrinsic line metrics push `VineTheme.labelSmallFont`'s caption line box ~2 px past the 16 px strut, so each button on the For You right rail (Like / Comment / Repost / Share / About) overflowed by 2 px on the bottom whenever a caption was visible.
- Relaxed the inner constraint to a 48 px **minimum** height while keeping the width clamped to exactly 48: `SizedBox(width: 48) > ConstrainedBox(minHeight: 48) > Column(min, center)`. The button stays exactly 48 × 48 with no caption and grows to ~50 px only when a caption renders. The 48 px a11y tap-target minimum is preserved everywhere.
- Added two regression tests (`count > 0` and `labelWhenZero`) asserting no `RenderFlex` exception and `width == 48`, `height >= 48`. The existing `'48x48 tap target'` test still passes for the no-caption default path.

Closes #3451

## Test plan

- [ ] From `mobile/`: `flutter test test/widgets/video_feed_item/actions/` — all 66 tests should pass.
- [ ] On a debug build (iOS or Android), open the **For You** feed and confirm the red `BOTTOM OVERFLOWED BY 2.0 PX` ribbons no longer appear on the right-rail interaction buttons.
- [ ] Tap each of Like / Comment / Repost / Share / About and verify the existing actions still fire (the 48 px tap target is preserved).
- [ ] (Optional) Crank iOS Dynamic Type to the largest setting — buttons should now grow gracefully instead of clipping.