### PR TITLE
fix: revert incorrect pushed commits to the video-editor

### DIFF
--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1377,9 +1377,6 @@ class _CanvasFitter extends ConsumerWidget {
     );
     if (clip == null) return const SizedBox.shrink();
     final scope = VideoEditorScope.of(context);
-    final isSubEditorOpen = context.select(
-      (VideoEditorMainBloc bloc) => bloc.state.isSubEditorOpen,
-    );
 
     return LayoutBuilder(
       builder: (_, constraints) {
@@ -1425,7 +1422,6 @@ class _CanvasFitter extends ConsumerWidget {
         return _OverlayCutArea(
           child: HitTestExpander(
             visibleSize: targetSize,
-            enabled: !isSubEditorOpen,
             child: Center(
               child: SizedBox.fromSize(
                 size: targetSize,
@@ -1488,60 +1484,51 @@ class _OverlayCutArea extends ConsumerWidget {
           children: [
             child,
 
-            BlocSelector<VideoEditorMainBloc, VideoEditorMainState, bool>(
-              selector: (state) => state.isLayerInteractionActive,
-              builder: (context, isLayerInteractionActive) {
-                return IgnorePointer(
-                  child: AnimatedOpacity(
-                    opacity: isLayerInteractionActive ? 0 : 1,
-                    duration: const Duration(milliseconds: 200),
-                    child: Stack(
-                      fit: StackFit.expand,
-                      clipBehavior: .none,
-                      children: [
-                        // Top bar — extends up into the safe area so there
-                        // is no uncovered strip above the scrim when the
-                        // canvas is padded below the status bar.
-                        if (verticalGap > 0 || safeArea.top > 0)
-                          Positioned(
-                            top: -safeArea.top,
-                            left: 0,
-                            right: 0,
-                            height: verticalGap + safeArea.top,
-                            child: ColoredBox(color: overlayColor),
-                          ),
-                        // Bottom bar
-                        if (verticalGap > 0)
-                          Positioned(
-                            bottom: 0,
-                            left: 0,
-                            right: 0,
-                            height: verticalGap,
-                            child: ColoredBox(color: overlayColor),
-                          ),
-                        // Left bar
-                        if (horizontalGap > 0)
-                          Positioned(
-                            top: 0,
-                            bottom: 0,
-                            left: 0,
-                            width: horizontalGap,
-                            child: ColoredBox(color: overlayColor),
-                          ),
-                        // Right bar
-                        if (horizontalGap > 0)
-                          Positioned(
-                            top: 0,
-                            bottom: 0,
-                            right: 0,
-                            width: horizontalGap,
-                            child: ColoredBox(color: overlayColor),
-                          ),
-                      ],
+            IgnorePointer(
+              child: Stack(
+                fit: StackFit.expand,
+                clipBehavior: .none,
+                children: [
+                  // Top bar — extends up into the safe area so there
+                  // is no uncovered strip above the scrim when the
+                  // canvas is padded below the status bar.
+                  if (verticalGap > 0 || safeArea.top > 0)
+                    Positioned(
+                      top: -safeArea.top,
+                      left: 0,
+                      right: 0,
+                      height: verticalGap + safeArea.top,
+                      child: ColoredBox(color: overlayColor),
                     ),
-                  ),
-                );
-              },
+                  // Bottom bar
+                  if (verticalGap > 0)
+                    Positioned(
+                      bottom: 0,
+                      left: 0,
+                      right: 0,
+                      height: verticalGap,
+                      child: ColoredBox(color: overlayColor),
+                    ),
+                  // Left bar
+                  if (horizontalGap > 0)
+                    Positioned(
+                      top: 0,
+                      bottom: 0,
+                      left: 0,
+                      width: horizontalGap,
+                      child: ColoredBox(color: overlayColor),
+                    ),
+                  // Right bar
+                  if (horizontalGap > 0)
+                    Positioned(
+                      top: 0,
+                      bottom: 0,
+                      right: 0,
+                      width: horizontalGap,
+                      child: ColoredBox(color: overlayColor),
+                    ),
+                ],
+              ),
             ),
           ],
         );
@@ -1570,7 +1557,6 @@ class HitTestExpander extends SingleChildRenderObjectWidget {
   const HitTestExpander({
     required this.visibleSize,
     required Widget super.child,
-    this.enabled = true,
     super.key,
   });
 
@@ -1579,15 +1565,12 @@ class HitTestExpander extends SingleChildRenderObjectWidget {
   /// onto its nearest edge before being forwarded.
   final Size visibleSize;
 
-  /// Whether hits outside [visibleSize] should be clamped into the child.
-  final bool enabled;
-
   // The render object is a true implementation detail; the widget is
   // only public for `@visibleForTesting`.
   @override
   // ignore: library_private_types_in_public_api
   _RenderHitTestExpander createRenderObject(BuildContext context) {
-    return _RenderHitTestExpander(visibleSize: visibleSize, enabled: enabled);
+    return _RenderHitTestExpander(visibleSize: visibleSize);
   }
 
   @override
@@ -1596,16 +1579,13 @@ class HitTestExpander extends SingleChildRenderObjectWidget {
     // ignore: library_private_types_in_public_api
     _RenderHitTestExpander renderObject,
   ) {
-    renderObject
-      ..visibleSize = visibleSize
-      ..enabled = enabled;
+    renderObject.visibleSize = visibleSize;
   }
 }
 
 class _RenderHitTestExpander extends RenderProxyBox {
-  _RenderHitTestExpander({required Size visibleSize, required bool enabled})
-    : _visibleSize = visibleSize,
-      _enabled = enabled;
+  _RenderHitTestExpander({required Size visibleSize})
+    : _visibleSize = visibleSize;
 
   /// Symmetric 1 px inset applied when clamping a hit position onto
   /// the visible rect. Required because downstream transforms
@@ -1624,15 +1604,8 @@ class _RenderHitTestExpander extends RenderProxyBox {
     // [visibleSize] — only [hitTest] does, and that runs per-event.
   }
 
-  bool _enabled;
-  set enabled(bool value) {
-    if (value == _enabled) return;
-    _enabled = value;
-  }
-
   @override
   bool hitTest(BoxHitTestResult result, {required Offset position}) {
-    if (!_enabled) return super.hitTest(result, position: position);
     final c = child;
     if (c == null) return false;
     final left = (size.width - _visibleSize.width) / 2;

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_player.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_player.dart
@@ -28,7 +28,7 @@ class VideoEditorPlayer extends StatelessWidget {
       clipper: _RoundedRectClipper(
         bodySize: bodySize,
         targetAspectRatio: targetAspectRatio.value,
-        borderRadius: canvasBorderRadiusForAspectRatio(targetAspectRatio),
+        borderRadius: VideoEditorConstants.canvasRadius,
       ),
       child: AspectRatio(
         aspectRatio: aspectRatio,
@@ -39,13 +39,6 @@ class VideoEditorPlayer extends StatelessWidget {
       ),
     );
   }
-}
-
-@visibleForTesting
-double canvasBorderRadiusForAspectRatio(model.AspectRatio targetAspectRatio) {
-  return targetAspectRatio == model.AspectRatio.square
-      ? 0
-      : VideoEditorConstants.canvasRadius;
 }
 
 class _RoundedRectClipper extends CustomClipper<Path> {

--- a/mobile/test/widgets/video_editor/main_editor/hit_test_expander_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/hit_test_expander_test.dart
@@ -145,40 +145,5 @@ void main() {
       await tester.tapAt(expanderRect.topLeft + const Offset(10, 10));
       expect(hits, 2);
     });
-
-    testWidgets('does not clamp scrim taps when disabled', (tester) async {
-      var hits = 0;
-      await tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: Center(
-            child: SizedBox.fromSize(
-              size: const Size(200, 200),
-              child: HitTestExpander(
-                visibleSize: const Size(100, 100),
-                enabled: false,
-                child: Center(
-                  child: SizedBox.fromSize(
-                    size: const Size(100, 100),
-                    child: Listener(
-                      behavior: HitTestBehavior.opaque,
-                      onPointerDown: (_) => hits++,
-                      child: const SizedBox.expand(),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      );
-
-      final expanderRect = tester.getRect(find.byType(HitTestExpander));
-      await tester.tapAt(expanderRect.topLeft + const Offset(10, 10));
-      expect(hits, 0);
-
-      await tester.tapAt(tester.getCenter(find.byType(Listener)));
-      expect(hits, 1);
-    });
   });
 }

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_player_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_player_test.dart
@@ -1,27 +1,9 @@
 import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:models/models.dart' as model show AspectRatio;
-import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_player.dart';
 
 void main() {
-  group(canvasBorderRadiusForAspectRatio, () {
-    test('keeps square previews unrounded', () {
-      expect(
-        canvasBorderRadiusForAspectRatio(model.AspectRatio.square),
-        equals(0),
-      );
-    });
-
-    test('rounds non-square previews', () {
-      expect(
-        canvasBorderRadiusForAspectRatio(model.AspectRatio.vertical),
-        equals(VideoEditorConstants.canvasRadius),
-      );
-    });
-  });
-
   group(computeClipSize, () {
     group('square (1:1) target', () {
       test('clips tall widget to square using width as shortest side', () {


### PR DESCRIPTION
Closes #3454

## Description

This PR fix pushed commits to working PRs.

- In PR #3398, commit [7d14373](https://github.com/divinevideo/divine-mobile/pull/3398/commits/7d143732db7c62cd47087efd855eaf20189e6299) removed the border radius on square videos. This is incorrect because all videos must have a small border radius, just like in Figma.
- In PR #3404, commit [a3cde67](https://github.com/divinevideo/divine-mobile/pull/3404/commits/a3cde6798b47bba5f8c85d45479590dee76688c2) added logic to enable or disable hit tests, but this is unnecessary because there is no scenario where we need it, especially since we work with an internal Navigator widget. It also added incorrect logic that removes the outside overlay when a user moves a layer. This only adds performance cost through animated opacity for something that is intended to show users when content will be outside the video.

**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore