### PR TITLE
fix(comments): guard add() in CommentsBloc against post-close race

### DIFF
--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -149,7 +149,9 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
         ),
       );
 
-      add(const CommentVoteCountsFetchRequested());
+      if (!isClosed) {
+        add(const CommentVoteCountsFetchRequested());
+      }
     } catch (e) {
       Log.error(
         'Error loading comments: $e',
@@ -229,7 +231,9 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
         ),
       );
 
-      add(const CommentVoteCountsFetchRequested());
+      if (!isClosed) {
+        add(const CommentVoteCountsFetchRequested());
+      }
 
       Log.info(
         'Loaded ${thread.comments.length} more comments '
@@ -978,7 +982,9 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
         stream,
         maxPerSecond: _maxCommentsPerSecond,
         onData: (comment) {
-          add(NewCommentReceived(comment));
+          if (!isClosed) {
+            add(NewCommentReceived(comment));
+          }
         },
         onError: (Object e) {
           Log.warning(

--- a/mobile/test/blocs/comments/comments_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_bloc_test.dart
@@ -16,6 +16,7 @@ import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/services/content_moderation_service.dart';
 import 'package:openvine/services/content_reporting_service.dart';
 import 'package:profile_repository/profile_repository.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _MockCommentsRepository extends Mock implements CommentsRepository {}
 
@@ -355,6 +356,54 @@ void main() {
 
           await streamController.close();
           await bloc.close();
+        },
+      );
+
+      test(
+        'does not log "Cannot add new events after calling close" '
+        'when bloc closes before loadComments completes',
+        () async {
+          final loadCompleter = Completer<CommentThread>();
+
+          when(
+            () => mockCommentsRepository.loadComments(
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer((_) => loadCompleter.future);
+
+          await LogCaptureService().clearAllLogs();
+
+          final bloc = createBloc()..add(const CommentsLoadRequested());
+
+          // Let the handler reach the await point.
+          await Future<void>.delayed(const Duration(milliseconds: 25));
+
+          // User dismisses the comments sheet — bloc closes before
+          // loadComments resolves.
+          await bloc.close();
+
+          // Now resolve the load. The handler resumes against a closed bloc
+          // and the follow-up CommentVoteCountsFetchRequested dispatch
+          // must be guarded by isClosed.
+          loadCompleter.complete(CommentThread.empty(validId('root')));
+
+          // Yield so the resumed continuation runs.
+          await Future<void>.delayed(const Duration(milliseconds: 25));
+
+          final hasCloseError = LogCaptureService()
+              .getRecentLogs(minLevel: LogLevel.error)
+              .any(
+                (entry) =>
+                    entry.name == 'CommentsBloc' &&
+                    entry.message.contains(
+                      'Cannot add new events after calling close',
+                    ),
+              );
+          expect(hasCloseError, isFalse);
+          expect(bloc.isClosed, isTrue);
         },
       );
     });
@@ -2968,6 +3017,56 @@ void main() {
         await streamController.close();
         await bloc.close();
       });
+
+      test(
+        'does not throw if a streamed comment arrives after close',
+        () async {
+          final streamController = StreamController<Comment>.broadcast();
+
+          when(
+            () => mockCommentsRepository.watchComments(
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+              since: any(named: 'since'),
+              onEose: any(named: 'onEose'),
+            ),
+          ).thenAnswer((_) => streamController.stream);
+
+          when(
+            () => mockCommentsRepository.loadComments(
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer((_) async => CommentThread.empty(validId('root')));
+
+          final bloc = createBloc()..add(const CommentsLoadRequested());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          await bloc.close();
+
+          // A late event from the relay arrives after the user dismissed
+          // the sheet. The throttled listener may still deliver it briefly
+          // depending on cancel timing — the bloc must drop it without
+          // throwing "Cannot add new events after calling close".
+          streamController.add(
+            Comment(
+              id: validId('late'),
+              content: 'Late comment',
+              authorPubkey: validId('lateAuthor'),
+              createdAt: DateTime.now(),
+              rootEventId: validId('root'),
+              rootAuthorPubkey: validId('author'),
+            ),
+          );
+          await Future<void>.delayed(const Duration(milliseconds: 25));
+
+          expect(bloc.isClosed, isTrue);
+          await streamController.close();
+        },
+      );
 
       test('throttles comments exceeding rate limit', () async {
         final streamController = StreamController<Comment>.broadcast();


### PR DESCRIPTION
## Summary

- Guard the three unguarded `add()` call sites in `CommentsBloc` with `if (!isClosed)` so dismissing the comments sheet mid-load no longer logs `Error loading comments: Bad state: Cannot add new events after calling close` — one of the noisy errors captured in #3162's diagnostic logs.
- Mirrors the existing `isClosed` guard already used by the `onEose` callback in `_startWatchingComments`.
- Adds a regression test that hooks into `unified_logger`'s `LogCaptureService` to assert the error log no longer fires when the user closes the sheet while `loadComments` is in flight, plus a defense-in-depth test for the stream-after-close path.

## What this does and does not fix

`#3162` is a Zendesk-forwarded report covering several symptoms — like-button spinner, comments entry box not loading, and a noisy error log. The underlying environmental cause (slow remote signing via `login.divine.video/api/nostr` after a stale local key was archived, plus relay timeouts) is a separate concern. This PR only addresses the bloc-side race that produces the `Cannot add new events after calling close` log line; the like spin and the comments-load timeout remain to be tackled separately (likely via a Keycast RPC timeout + clearer auth-failure UX).

## Why the bug is observable

When the user dismisses the comments sheet while `_commentsRepository.loadComments(...)` is still awaiting:

1. `bloc.close()` runs, closes the event controller via `super.close()`, and marks the bloc as closed.
2. The await resumes. `emit(...)` silently no-ops on the canceled emitter.
3. `add(const CommentVoteCountsFetchRequested())` is unguarded and throws `StateError(\"Cannot add new events after calling close\")`.
4. The bloc's own `try/catch` catches it and logs `Error loading comments: Bad state: ...` — the line we see in the bug report.

Same shape applies to `_onLoadMoreRequested` and to the throttled stream listener's `onData`.

## Test plan

- [x] `flutter test test/blocs/comments/comments_bloc_test.dart` — all 109 tests pass locally.
- [x] Confirmed the new regression test fails on `main` (the unguarded code) and passes with the fix.
- [x] `flutter analyze lib test integration_test` — 0 issues.
- [x] `dart format` — no changes.

Closes #3162 partially — see \"What this does and does not fix\" above.