### PR TITLE
fix(video_editor): resolve incorrect thumbnails for trimmed clips when not selected

### DIFF
--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -222,15 +222,16 @@ class _VideoEditorTimelineClipStripState
 
     for (final clip in widget.clips) {
       final clipPx = _clipWidth(clip);
-      final durationMs = clip.duration.inMilliseconds;
-      if (clipPx <= 0 || durationMs <= 0) continue;
+      final trimmedMs = clip.trimmedDuration.inMilliseconds;
+      if (clipPx <= 0 || trimmedMs <= 0) continue;
 
       final slotCount = (clipPx / TimelineConstants.thumbnailWidth)
           .ceil()
           .clamp(1, 1000);
       final timestamps = <Duration>[];
       for (var i = 0; i < slotCount; i++) {
-        final centerMs = durationMs * (i + 0.5) / slotCount;
+        final centerMs =
+            clip.trimStart.inMilliseconds + trimmedMs * (i + 0.5) / slotCount;
         timestamps.add(Duration(milliseconds: centerMs.round()));
       }
       result[clip.id] = timestamps;
@@ -577,6 +578,7 @@ class _VideoEditorTimelineClipStripState
                   dragClipWidth: _dragClipWidth,
                   effectiveLocalX: _effectiveLocalX,
                   dragFingerRatio: _dragFingerRatio,
+                  pixelsPerSecond: widget.pixelsPerSecond,
                 ),
             ],
           ),
@@ -717,6 +719,7 @@ class _NonTrimmingClipPositions extends StatelessWidget {
                 index: i,
                 total: orderedClips.length,
                 clipWidth: layout.widths[i],
+                pixelsPerSecond: pixelsPerSecond,
                 thumbnailNotifier: thumbnails[orderedClips[i].id],
                 onReorder: onReorder,
                 onTap: onClipTapped,
@@ -740,6 +743,7 @@ class _DraggedClipPosition extends StatelessWidget {
     required this.dragClipWidth,
     required this.effectiveLocalX,
     required this.dragFingerRatio,
+    required this.pixelsPerSecond,
   });
 
   final List<DivineVideoClip> orderedClips;
@@ -753,6 +757,7 @@ class _DraggedClipPosition extends StatelessWidget {
   final double dragClipWidth;
   final double effectiveLocalX;
   final double dragFingerRatio;
+  final double pixelsPerSecond;
 
   @override
   Widget build(BuildContext context) {
@@ -769,7 +774,7 @@ class _DraggedClipPosition extends StatelessWidget {
       child: _DraggedClipTile(
         clip: orderedClips[dragIndex!],
         index: dragIndex!,
-        fullWidth: layout.widths[dragIndex!],
+        pixelsPerSecond: pixelsPerSecond,
         thumbnailNotifier: thumbnails[orderedClips[dragIndex!].id],
       ),
     );

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -145,13 +145,13 @@ class _DraggedClipTile extends StatelessWidget {
   const _DraggedClipTile({
     required this.clip,
     required this.index,
-    required this.fullWidth,
+    required this.pixelsPerSecond,
     required this.thumbnailNotifier,
   });
 
   final DivineVideoClip clip;
   final int index;
-  final double fullWidth;
+  final double pixelsPerSecond;
   final ValueNotifier<List<StripThumbnail>> thumbnailNotifier;
 
   @override
@@ -168,7 +168,9 @@ class _DraggedClipTile extends StatelessWidget {
         ),
         child: _ClipTile(
           clip: clip,
-          fullWidth: fullWidth,
+          fullWidth: clip.durationInSeconds * pixelsPerSecond,
+          trimStartOffset:
+              clip.trimStart.inMilliseconds / 1000.0 * pixelsPerSecond,
           thumbnailNotifier: thumbnailNotifier,
         ),
       ),
@@ -182,6 +184,7 @@ class _AccessibleClipTile extends StatelessWidget {
     required this.index,
     required this.total,
     required this.clipWidth,
+    required this.pixelsPerSecond,
     required this.thumbnailNotifier,
     required this.onReorder,
     this.onTap,
@@ -191,6 +194,7 @@ class _AccessibleClipTile extends StatelessWidget {
   final int index;
   final int total;
   final double clipWidth;
+  final double pixelsPerSecond;
   final ValueNotifier<List<StripThumbnail>> thumbnailNotifier;
   final void Function(int from, int to) onReorder;
   final ValueChanged<int>? onTap;
@@ -224,7 +228,9 @@ class _AccessibleClipTile extends StatelessWidget {
         },
         child: _ClipTile(
           clip: clip,
-          fullWidth: clipWidth,
+          fullWidth: clip.durationInSeconds * pixelsPerSecond,
+          trimStartOffset:
+              clip.trimStart.inMilliseconds / 1000.0 * pixelsPerSecond,
           thumbnailNotifier: thumbnailNotifier,
         ),
       ),

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
@@ -196,10 +196,77 @@ void main() {
         expect(find.byType(VideoEditorTimelineClipStrip), findsOneWidget);
       });
     });
+
+    group('trimmed clips', () {
+      testWidgets('renders trimmed clip without error', (tester) async {
+        final clips = [
+          _createTestClip(
+            id: 'trimmed',
+            seconds: 5,
+            trimStartMs: 1000,
+            trimEndMs: 500,
+          ),
+        ];
+
+        await tester.pumpWidget(buildWidget(clips: clips, totalWidth: 400));
+
+        expect(find.byType(VideoEditorTimelineClipStrip), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets(
+        'multi-clip strip with trimmed clips renders both tiles',
+        (tester) async {
+          final clips = [
+            // trimmedDuration = 5s - 2s - 1s = 2s
+            _createTestClip(
+              id: 'a',
+              seconds: 5,
+              trimStartMs: 2000,
+              trimEndMs: 1000,
+            ),
+            _createTestClip(id: 'b', seconds: 3),
+          ];
+
+          await tester.pumpWidget(
+            buildWidget(
+              clips: clips,
+            ),
+          );
+
+          expect(find.byType(ClipRRect), findsNWidgets(2));
+          expect(tester.takeException(), isNull);
+        },
+      );
+
+      testWidgets('fully trimmed clip does not crash the strip', (
+        tester,
+      ) async {
+        // trimStart + trimEnd == duration → trimmedDuration == zero;
+        // the strip should skip this clip gracefully.
+        final clips = [
+          _createTestClip(id: 'normal', seconds: 3),
+          _createTestClip(
+            id: 'over_trimmed',
+            trimStartMs: 1000,
+            trimEndMs: 1000,
+          ),
+        ];
+
+        await tester.pumpWidget(buildWidget(clips: clips, totalWidth: 400));
+
+        expect(tester.takeException(), isNull);
+      });
+    });
   });
 }
 
-DivineVideoClip _createTestClip({required String id, int seconds = 2}) {
+DivineVideoClip _createTestClip({
+  required String id,
+  int seconds = 2,
+  int trimStartMs = 0,
+  int trimEndMs = 0,
+}) {
   return DivineVideoClip(
     id: id,
     video: EditorVideo.file('/tmp/test_$id.mp4'),
@@ -207,5 +274,7 @@ DivineVideoClip _createTestClip({required String id, int seconds = 2}) {
     recordedAt: DateTime(2025),
     originalAspectRatio: 9 / 16,
     targetAspectRatio: .vertical,
+    trimStart: Duration(milliseconds: trimStartMs),
+    trimEnd: Duration(milliseconds: trimEndMs),
   );
 }


### PR DESCRIPTION

## Description

This PR resolves an issue where trimmed clips showed incorrect thumbnails after the clip was no longer selected. For example, if a clip was trimmed to start at 2 seconds, it still displayed thumbnails starting from 0 seconds instead of 2 seconds.


**Related Issue:** Closes #3406

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore