### PR TITLE
feat(text_sanitizer): add text sanitization utilities

### DIFF
--- a/.github/workflows/text_sanitizer.yaml
+++ b/.github/workflows/text_sanitizer.yaml
@@ -1,0 +1,26 @@
+# ABOUTME: CI workflow for the text_sanitizer package.
+# ABOUTME: Runs tests, formatting, and analysis only when text_sanitizer files change.
+
+name: Text Sanitizer CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "mobile/packages/text_sanitizer/**"
+      - ".github/workflows/text_sanitizer.yaml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "mobile/packages/text_sanitizer/**"
+      - ".github/workflows/text_sanitizer.yaml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
+    with:
+      working_directory: "mobile/packages/text_sanitizer"

--- a/mobile/lib/screens/feed/feed_video_overlay.dart
+++ b/mobile/lib/screens/feed/feed_video_overlay.dart
@@ -346,7 +346,7 @@ class _AuthorInfoSection extends ConsumerWidget {
                   MetadataExpandedSheet.show(context, video);
                 },
                 child: Text(
-                  video.title!.trim(),
+                  video.displayTitle!.trim(),
                   style: VineTheme.labelMediumFont().copyWith(
                     shadows: VineTheme.buttonShadows,
                   ),
@@ -377,7 +377,7 @@ class _AuthorInfoSection extends ConsumerWidget {
                   MetadataExpandedSheet.show(context, video);
                 },
                 child: ClickableHashtagText(
-                  text: video.content.trim(),
+                  text: video.displayContent.trim(),
                   style: VineTheme.bodySmallFont().copyWith(
                     shadows: VineTheme.buttonShadows,
                   ),

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -604,7 +604,8 @@ class _VideoInfoSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final hasDescription = (video.title ?? video.content).isNotEmpty;
+    final hasDescription =
+        (video.displayTitle ?? video.displayContent).isNotEmpty;
 
     // Always show the info section with username (using bestDisplayName
     // fallback). UserName.fromPubKey handles fallback to truncated npub when
@@ -650,9 +651,10 @@ class _VideoInfoSection extends StatelessWidget {
               identifier: 'video_thumbnail_description_$index',
               container: true,
               explicitChildNodes: true,
-              label: 'Video description: ${video.title ?? video.content}',
+              label:
+                  'Video description: ${video.displayTitle ?? video.displayContent}',
               child: Text(
-                video.title ?? video.content,
+                video.displayTitle ?? video.displayContent,
                 style: VineTheme.bodyMediumFont().copyWith(
                   decoration: TextDecoration.none,
                   shadows: const [

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -193,7 +193,7 @@ class _ShareVideoMenuState extends ConsumerState<ShareVideoMenu> {
               ),
               if (widget.video.title != null)
                 Text(
-                  widget.video.title ?? '',
+                  widget.video.displayTitle ?? '',
                   style: const TextStyle(
                     color: VineTheme.secondaryText,
                     fontSize: 14,

--- a/mobile/lib/widgets/video_explore_tile.dart
+++ b/mobile/lib/widgets/video_explore_tile.dart
@@ -100,7 +100,7 @@ class VideoExploreTile extends ConsumerWidget {
                       const SizedBox(height: 4),
                       if (video.title != null) ...[
                         Text(
-                          video.title ?? '',
+                          video.displayTitle ?? '',
                           style: const TextStyle(
                             color: VineTheme.whiteText,
                             fontSize: 14,

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
@@ -174,8 +174,8 @@ class _TitleSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final title = video.title;
-    final description = video.content;
+    final title = video.displayTitle;
+    final description = video.displayContent;
     final hasContent =
         (title != null && title.isNotEmpty) || description.isNotEmpty;
 

--- a/mobile/packages/models/lib/src/profile_search_result.dart
+++ b/mobile/packages/models/lib/src/profile_search_result.dart
@@ -145,7 +145,13 @@ class ProfileSearchResult {
   final int? videoCount;
 
   /// Get the best display name available.
-  String get bestDisplayName => stripZalgo(displayName ?? name ?? pubkey);
+  ///
+  /// Sanitizes [displayName] and [name] against zalgo overflow; the [pubkey]
+  /// hex fallback is returned as-is (hex contains no combining characters).
+  String get bestDisplayName {
+    final source = displayName ?? name;
+    return source != null ? stripZalgo(source) : pubkey;
+  }
 
   /// Converts this [ProfileSearchResult] to a [UserProfile] for app use.
   ///

--- a/mobile/packages/models/lib/src/profile_search_result.dart
+++ b/mobile/packages/models/lib/src/profile_search_result.dart
@@ -3,6 +3,7 @@
 
 import 'package:meta/meta.dart';
 import 'package:models/src/user_profile.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 
 /// Profile result from Funnelcake search API.
 ///
@@ -144,7 +145,7 @@ class ProfileSearchResult {
   final int? videoCount;
 
   /// Get the best display name available.
-  String get bestDisplayName => displayName ?? name ?? pubkey;
+  String get bestDisplayName => stripZalgo(displayName ?? name ?? pubkey);
 
   /// Converts this [ProfileSearchResult] to a [UserProfile] for app use.
   ///

--- a/mobile/packages/models/lib/src/user_profile.dart
+++ b/mobile/packages/models/lib/src/user_profile.dart
@@ -12,6 +12,7 @@ import 'dart:math';
 import 'package:meta/meta.dart';
 import 'package:models/src/user_profile_result.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 import 'package:unique_names_generator/unique_names_generator.dart';
 
 /// Model representing a Nostr user profile from kind 0 events
@@ -171,8 +172,8 @@ class UserProfile {
   /// If [anonymousPlaceholder] is provided, it takes priority over the
   /// generated name when no display name or name is set.
   String betterDisplayName(String? anonymousPlaceholder) {
-    if (displayName?.isNotEmpty ?? false) return displayName!;
-    if (name?.isNotEmpty ?? false) return name!;
+    if (displayName?.isNotEmpty ?? false) return stripZalgo(displayName!);
+    if (name?.isNotEmpty ?? false) return stripZalgo(name!);
     if (anonymousPlaceholder != null) return anonymousPlaceholder;
     return defaultDisplayName;
   }
@@ -223,8 +224,8 @@ class UserProfile {
   ///
   /// Falls back to [defaultDisplayName] when no display name or name is set.
   String get bestDisplayName {
-    if (displayName?.isNotEmpty ?? false) return displayName!;
-    if (name?.isNotEmpty ?? false) return name!;
+    if (displayName?.isNotEmpty ?? false) return stripZalgo(displayName!);
+    if (name?.isNotEmpty ?? false) return stripZalgo(name!);
     return defaultDisplayName;
   }
 

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -10,6 +10,7 @@ import 'package:meta/meta.dart';
 import 'package:models/src/nip71_video_kinds.dart';
 import 'package:models/src/video_attribution.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
 
 part 'video_event.g.dart';
 
@@ -821,6 +822,12 @@ class VideoEvent {
   /// For addressable events (Kind 34236), returns the vineId (d tag).
   /// Falls back to event id for non-addressable events.
   String get stableId => vineId ?? id;
+
+  /// Zalgo-safe video content for display.
+  String get displayContent => stripZalgo(content);
+
+  /// Zalgo-safe video title for display. Returns `null` when no title is set.
+  String? get displayTitle => title != null ? stripZalgo(title!) : null;
 
   /// Total likes combining original Vine likes and live Nostr reactions.
   int get totalLikes => (originalLikes ?? 0) + (nostrLikeCount ?? 0);

--- a/mobile/packages/models/pubspec.yaml
+++ b/mobile/packages/models/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
   meta: ^1.17.0
   nostr_sdk:
     path: ../nostr_sdk
+  text_sanitizer:
+    path: ../text_sanitizer
   unique_names_generator: ^3.0.0
 
 dev_dependencies:

--- a/mobile/packages/models/test/src/profile_search_result_test.dart
+++ b/mobile/packages/models/test/src/profile_search_result_test.dart
@@ -309,6 +309,25 @@ void main() {
 
         expect(result.bestDisplayName, equals(testPubkey));
       });
+
+      test('strips zalgo combining marks from displayName', () {
+        const result = ProfileSearchResult(
+          pubkey: testPubkey,
+          displayName: 'A\u0300\u0301\u0302\u0303\u0304',
+          name: 'username',
+        );
+
+        expect(result.bestDisplayName, equals('A\u0300\u0301'));
+      });
+
+      test('strips zalgo combining marks from name fallback', () {
+        const result = ProfileSearchResult(
+          pubkey: testPubkey,
+          name: 'B\u0300\u0301\u0302\u0303',
+        );
+
+        expect(result.bestDisplayName, equals('B\u0300\u0301'));
+      });
     });
 
     group('toUserProfile', () {

--- a/mobile/packages/models/test/src/user_profile_test.dart
+++ b/mobile/packages/models/test/src/user_profile_test.dart
@@ -364,6 +364,57 @@ void main() {
 
         expect(profile1.bestDisplayName, equals(profile2.bestDisplayName));
       });
+
+      test('strips zalgo combining marks from displayName', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          displayName: 'A\u0300\u0301\u0302\u0303\u0304',
+          name: 'username',
+        );
+
+        expect(profile.bestDisplayName, equals('A\u0300\u0301'));
+      });
+
+      test('strips zalgo combining marks from name fallback', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          name: 'B\u0300\u0301\u0302\u0303',
+        );
+
+        expect(profile.bestDisplayName, equals('B\u0300\u0301'));
+      });
+    });
+
+    group('betterDisplayName', () {
+      test('strips zalgo from displayName', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          displayName: 'X\u0300\u0301\u0302\u0303',
+        );
+
+        expect(profile.betterDisplayName(null), equals('X\u0300\u0301'));
+      });
+
+      test('strips zalgo from name fallback', () {
+        final profile = UserProfile(
+          pubkey: testPubkey,
+          rawData: const {},
+          createdAt: testCreatedAt,
+          eventId: testEventId,
+          name: 'Y\u0300\u0301\u0302\u0303',
+        );
+
+        expect(profile.betterDisplayName(null), equals('Y\u0300\u0301'));
+      });
     });
 
     group('generatedNameFor', () {

--- a/mobile/packages/models/test/src/video_event_display_test.dart
+++ b/mobile/packages/models/test/src/video_event_display_test.dart
@@ -1,0 +1,51 @@
+// ABOUTME: Tests for VideoEvent.displayTitle and displayContent zalgo-safe
+// ABOUTME: getters that protect UI from combining-character overflow.
+
+import 'package:models/models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  VideoEvent build({String? title, String content = ''}) => VideoEvent(
+    id: 'a' * 64,
+    pubkey: 'b' * 64,
+    createdAt: 1735689600,
+    content: content,
+    timestamp: DateTime.utc(2026),
+    title: title,
+  );
+
+  group('VideoEvent.displayTitle', () {
+    test('returns null when title is null', () {
+      expect(build().displayTitle, isNull);
+    });
+
+    test('returns title unchanged when no zalgo present', () {
+      expect(build(title: 'Hello').displayTitle, equals('Hello'));
+    });
+
+    test('strips excessive combining marks from title', () {
+      // o + 5 combining chars → only first 2 kept
+      expect(
+        build(title: 'o\u0300\u0301\u0302\u0303\u0304').displayTitle,
+        equals('o\u0300\u0301'),
+      );
+    });
+  });
+
+  group('VideoEvent.displayContent', () {
+    test('returns empty string for empty content', () {
+      expect(build().displayContent, equals(''));
+    });
+
+    test('returns content unchanged when no zalgo present', () {
+      expect(build(content: 'caption').displayContent, equals('caption'));
+    });
+
+    test('strips excessive combining marks from content', () {
+      expect(
+        build(content: 'a\u0300\u0301\u0302\u0303').displayContent,
+        equals('a\u0300\u0301'),
+      );
+    });
+  });
+}

--- a/mobile/packages/text_sanitizer/analysis_options.yaml
+++ b/mobile/packages/text_sanitizer/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:very_good_analysis/analysis_options.yaml

--- a/mobile/packages/text_sanitizer/lib/src/text_sanitizer.dart
+++ b/mobile/packages/text_sanitizer/lib/src/text_sanitizer.dart
@@ -1,0 +1,38 @@
+// ABOUTME: Sanitizes user-generated text for safe display in UI widgets.
+
+/// Caps combining diacritical characters per grapheme cluster to prevent Zalgo
+/// text from overflowing layout bounds.
+///
+/// Allows up to [maxCombining] combining chars per base character (default 2),
+/// which covers all legitimate accented scripts including Vietnamese
+/// (e.g. ổ = o + circumflex + hook = 2 combining chars). Zalgo text typically
+/// stacks 10–50 combining chars per base character.
+///
+/// Safe for both NFC and NFD-encoded text: NFC precomposed characters (e.g.
+/// U+00E9 é) contain no combining chars and pass through unchanged.
+String stripZalgo(String text, {int maxCombining = 2}) {
+  final result = StringBuffer();
+  final runes = text.runes.toList();
+  var i = 0;
+  while (i < runes.length) {
+    result.writeCharCode(runes[i]);
+    i++;
+    var kept = 0;
+    while (i < runes.length && _isCombining(runes[i])) {
+      if (kept < maxCombining) {
+        result.writeCharCode(runes[i]);
+        kept++;
+      }
+      i++;
+    }
+  }
+  return result.toString();
+}
+
+bool _isCombining(int cp) =>
+    (cp >= 0x0300 && cp <= 0x036F) ||
+    cp == 0x0489 ||
+    (cp >= 0x1AB0 && cp <= 0x1AFF) ||
+    (cp >= 0x1DC0 && cp <= 0x1DFF) ||
+    (cp >= 0x20D0 && cp <= 0x20FF) ||
+    (cp >= 0xFE20 && cp <= 0xFE2F);

--- a/mobile/packages/text_sanitizer/lib/text_sanitizer.dart
+++ b/mobile/packages/text_sanitizer/lib/text_sanitizer.dart
@@ -1,0 +1,4 @@
+/// Utilities for sanitizing user-generated text before display.
+library;
+
+export 'src/text_sanitizer.dart';

--- a/mobile/packages/text_sanitizer/pubspec.yaml
+++ b/mobile/packages/text_sanitizer/pubspec.yaml
@@ -1,0 +1,12 @@
+name: text_sanitizer
+description: Utilities for sanitizing user-generated text before display.
+version: 0.1.0+1
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.11.0
+
+dev_dependencies:
+  test: ^1.26.3
+  very_good_analysis: ^10.2.0

--- a/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
+++ b/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
@@ -1,0 +1,63 @@
+import 'package:test/test.dart';
+import 'package:text_sanitizer/text_sanitizer.dart';
+
+void main() {
+  group(stripZalgo, () {
+    test('returns empty string unchanged', () {
+      expect(stripZalgo(''), equals(''));
+    });
+
+    test('returns plain ASCII unchanged', () {
+      expect(stripZalgo('hello'), equals('hello'));
+    });
+
+    test('preserves NFC precomposed accented characters', () {
+      // U+00E9 é — single codepoint, no combining chars
+      expect(stripZalgo('\u00E9'), equals('\u00E9'));
+    });
+
+    test('preserves NFD accented character with one combining char', () {
+      // e + U+0301 (combining acute) — legitimate single accent
+      expect(stripZalgo('e\u0301'), equals('e\u0301'));
+    });
+
+    test('preserves two combining chars per base (Vietnamese ổ)', () {
+      // o + U+0302 (circumflex) + U+0309 (hook above) — 2 combining chars
+      expect(stripZalgo('o\u0302\u0309'), equals('o\u0302\u0309'));
+    });
+
+    test('strips combining chars beyond the default cap of 2', () {
+      // o + 5 combining chars — only first 2 kept
+      const zalgo = 'o\u0300\u0301\u0302\u0303\u0304';
+      expect(stripZalgo(zalgo), equals('o\u0300\u0301'));
+    });
+
+    test('strips combining chars from all Unicode combining blocks', () {
+      // Each assertion hits a distinct branch of _isCombining.
+      // U+0300–U+036F: Combining Diacritical Marks
+      expect(stripZalgo('a\u0300\u0301\u0302'), equals('a\u0300\u0301'));
+      // U+0489: Combining Cyrillic Millions Sign
+      expect(stripZalgo('а\u0489\u0489\u0489'), equals('а\u0489\u0489'));
+      // U+1AB0–U+1AFF: Combining Diacritical Marks Extended
+      expect(stripZalgo('a\u1AB0\u1AB1\u1AB2'), equals('a\u1AB0\u1AB1'));
+      // U+1DC0–U+1DFF: Combining Diacritical Marks Supplement
+      expect(stripZalgo('a\u1DC0\u1DC1\u1DC2'), equals('a\u1DC0\u1DC1'));
+      // U+20D0–U+20FF: Combining Diacritical Marks for Symbols
+      expect(stripZalgo('a\u20D0\u20D1\u20D2'), equals('a\u20D0\u20D1'));
+      // U+FE20–U+FE2F: Combining Half Marks
+      expect(stripZalgo('a\uFE20\uFE21\uFE22'), equals('a\uFE20\uFE21'));
+    });
+
+    test('respects custom maxCombining parameter', () {
+      const input = 'a\u0300\u0301\u0302';
+      expect(stripZalgo(input, maxCombining: 1), equals('a\u0300'));
+      expect(stripZalgo(input, maxCombining: 3), equals('a\u0300\u0301\u0302'));
+    });
+
+    test('handles multi-character string with mixed content', () {
+      // 'é' NFC + zalgo 'S' + plain 'i'
+      final input = '\u00E9S\u0300\u0301\u0302i';
+      expect(stripZalgo(input), equals('\u00E9S\u0300\u0301i'));
+    });
+  });
+}

--- a/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
+++ b/mobile/packages/text_sanitizer/test/src/text_sanitizer_test.dart
@@ -56,7 +56,7 @@ void main() {
 
     test('handles multi-character string with mixed content', () {
       // 'é' NFC + zalgo 'S' + plain 'i'
-      final input = '\u00E9S\u0300\u0301\u0302i';
+      const input = '\u00E9S\u0300\u0301\u0302i';
       expect(stripZalgo(input), equals('\u00E9S\u0300\u0301i'));
     });
   });

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -61,6 +61,7 @@ workspace:
   - packages/reposts_repository
   - packages/sound_service
   - packages/sounds_repository
+  - packages/text_sanitizer
   - packages/time_formatter
   - packages/tv_static_effect
   - packages/unified_logger


### PR DESCRIPTION
Closes #3458


## Description

Zalgo text (Unicode combining diacritics stacked 10–50 deep per character) causes vertical overflow in feed and profile UI. This PR adds a dedicated text_sanitizer package that caps combining chars at 2 per grapheme cluster — safe for all real scripts including Vietnamese (ổ = exactly 2 combining chars) and NFD-encoded text.


| Before | After |
| ------ | ----- |
|     <img width="320px"  alt="image" src="https://github.com/user-attachments/assets/cbdd09ac-0ce5-4f24-a420-d7f0d2738b96" /> |  <img width="320px"  src="https://github.com/user-attachments/assets/808c06d6-6356-48ec-8b4b-1d9fdbac6969" /> |

**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore