### PR TITLE
feat(video_recorder): implement long press functionality for classic-recording

### DIFF
--- a/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_stack.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_recorder_provider.dart';
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_actions_bottom.dart';
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_actions_top.dart';
@@ -12,6 +13,31 @@ class VideoRecorderClassicStack extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(
+      videoRecorderProvider.select(
+        (p) => (
+          isRecording: p.isRecording,
+          canRecord: p.canRecord,
+          isCameraInitialized: p.isCameraInitialized,
+          recorderMode: p.recorderMode,
+        ),
+      ),
+    );
+
+    final hasRemainingDuration = ref.watch(
+      clipManagerProvider.select(
+        (p) => p.remainingDuration > const Duration(milliseconds: 30),
+      ),
+    );
+
+    final notifier = ref.read(videoRecorderProvider.notifier);
+
+    final isEnabled =
+        (state.canRecord &&
+            state.isCameraInitialized &&
+            (hasRemainingDuration || !state.recorderMode.hasRecordingLimit)) ||
+        state.isRecording;
+
     return SafeArea(
       bottom: false,
       child: Column(
@@ -33,17 +59,16 @@ class VideoRecorderClassicStack extends ConsumerWidget {
                     child: Semantics(
                       button: true,
                       liveRegion: true,
-                      label:
-                          ref.watch(
-                            videoRecorderProvider.select((s) => s.isRecording),
-                          )
+                      label: state.isRecording
                           ? context.l10n.videoRecorderRecordingTapToStopLabel
                           : context.l10n.videoRecorderTapToStartLabel,
                       child: GestureDetector(
                         behavior: .opaque,
-                        onTap: ref
-                            .read(videoRecorderProvider.notifier)
-                            .toggleRecording,
+                        onTap: isEnabled ? notifier.toggleRecording : null,
+                        onLongPressStart: isEnabled
+                            ? (_) => notifier.startRecording()
+                            : null,
+                        onLongPressUp: notifier.stopRecording,
                         child: const IgnorePointer(
                           child: VideoRecorderCameraPreview(
                             enableTapToFocus: false,

--- a/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/classic/video_recorder_classic_stack_test.dart
@@ -13,6 +13,7 @@ import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_cla
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_stack.dart';
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_top_bar.dart';
 import 'package:openvine/widgets/video_recorder/preview/video_recorder_camera_preview.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 
 import '../../../../mocks/mock_camera_service.dart';
 
@@ -132,9 +133,18 @@ void main() {
         await tester.pumpWidget(buildWidget());
         await tester.pumpAndSettle();
 
+        final l10n = lookupAppLocalizations(const Locale('en'));
         expect(
-          find.bySemanticsLabel('Tap anywhere to start recording'),
+          find.bySemanticsLabel(l10n.videoRecorderTapToStartLabel),
           findsOneWidget,
+        );
+        expect(
+          find.bySemanticsLabel(
+            lookupAppLocalizations(
+              const Locale('de'),
+            ).videoRecorderTapToStartLabel,
+          ),
+          findsNothing,
         );
       });
 
@@ -144,10 +154,91 @@ void main() {
         );
         await tester.pumpAndSettle();
 
+        final l10n = lookupAppLocalizations(const Locale('en'));
         expect(
-          find.bySemanticsLabel('Recording. Tap anywhere to stop'),
+          find.bySemanticsLabel(l10n.videoRecorderRecordingTapToStopLabel),
           findsOneWidget,
         );
+        expect(
+          find.bySemanticsLabel(
+            lookupAppLocalizations(
+              const Locale('de'),
+            ).videoRecorderRecordingTapToStopLabel,
+          ),
+          findsNothing,
+        );
+      });
+    });
+
+    group('long press', () {
+      testWidgets('long press on preview calls startRecording', (tester) async {
+        late _TestVideoRecorderNotifier notifier;
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              videoRecorderProvider.overrideWith(() {
+                notifier = _TestVideoRecorderNotifier(mockCamera);
+                return notifier;
+              }),
+              clipManagerProvider.overrideWith(
+                () => _TestClipManagerNotifier(clips: []),
+              ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(body: VideoRecorderClassicStack()),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.longPress(
+          find.ancestor(
+            of: find.byType(VideoRecorderCameraPreview),
+            matching: find.byType(GestureDetector),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(notifier.startRecordingCalled, isTrue);
+      });
+
+      testWidgets('long press release on preview calls stopRecording', (
+        tester,
+      ) async {
+        late _TestVideoRecorderNotifier notifier;
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              videoRecorderProvider.overrideWith(() {
+                notifier = _TestVideoRecorderNotifier(mockCamera);
+                return notifier;
+              }),
+              clipManagerProvider.overrideWith(
+                () => _TestClipManagerNotifier(clips: []),
+              ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(body: VideoRecorderClassicStack()),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.longPress(
+          find.ancestor(
+            of: find.byType(VideoRecorderCameraPreview),
+            matching: find.byType(GestureDetector),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(notifier.stopRecordingCalled, isTrue);
       });
     });
   });
@@ -161,6 +252,9 @@ class _TestVideoRecorderNotifier extends VideoRecorderNotifier {
 
   final VideoRecorderState recordingState;
 
+  var startRecordingCalled = false;
+  var stopRecordingCalled = false;
+
   @override
   VideoRecorderProviderState build() {
     return VideoRecorderProviderState(
@@ -168,6 +262,16 @@ class _TestVideoRecorderNotifier extends VideoRecorderNotifier {
       isCameraInitialized: true,
       canRecord: true,
     );
+  }
+
+  @override
+  Future<void> startRecording() async {
+    startRecordingCalled = true;
+  }
+
+  @override
+  Future<void> stopRecording([EditorVideo? result]) async {
+    stopRecordingCalled = true;
   }
 }
 


### PR DESCRIPTION
Closes #3460



## Description

Implement the long-press functionality in the classic recording mode. Users requested this on Discord [here](https://discord.com/channels/1470168817589158040/1470168819208294422/1498217744342974544)

**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore