### PR TITLE
chore(preview): minimize outdated preview comments in PRs

### DIFF
--- a/.github/workflows/mobile_pr_preview_deploy.yml
+++ b/.github/workflows/mobile_pr_preview_deploy.yml
@@ -97,6 +97,35 @@ jobs:
             echo "configured=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Minimize outdated preview comments
+        if: ${{ steps.freshness.outputs.deployable == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = Number('${{ steps.metadata.outputs.pr_number }}');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const previewComments = comments.filter(
+              (c) => c.body && c.body.includes('## Mobile PR Preview') &&
+                     c.user && c.user.type === 'Bot',
+            );
+
+            for (const comment of previewComments) {
+              await github.graphql(`
+                mutation($id: ID!) {
+                  minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+                    minimizedComment { isMinimized }
+                  }
+                }
+              `, { id: comment.node_id });
+            }
+
+            core.info(`Minimized ${previewComments.length} outdated preview comment(s).`);
+
       - name: Render blocked preview comment
         if: ${{ steps.freshness.outputs.deployable == 'true' && steps.secrets.outputs.configured != 'true' }}
         id: blocked_comment

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1624,6 +1624,7 @@ class _RenderHitTestExpander extends RenderProxyBox {
     // [visibleSize] — only [hitTest] does, and that runs per-event.
   }
 
+  // FIXME Test-PR
   bool _enabled;
   set enabled(bool value) {
     if (value == _enabled) return;

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1624,7 +1624,7 @@ class _RenderHitTestExpander extends RenderProxyBox {
     // [visibleSize] — only [hitTest] does, and that runs per-event.
   }
 
-  // FIXME Test-PR
+  // FIXME Test-PR 1.0
   bool _enabled;
   set enabled(bool value) {
     if (value == _enabled) return;

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1624,7 +1624,6 @@ class _RenderHitTestExpander extends RenderProxyBox {
     // [visibleSize] — only [hitTest] does, and that runs per-event.
   }
 
-  // FIXME Test-PR 1.0
   bool _enabled;
   set enabled(bool value) {
     if (value == _enabled) return;


### PR DESCRIPTION
Closes #3462


## Description

Adds a new step to the Mobile PR Preview Deploy workflow that minimizes all previous "Mobile PR Preview" bot comments on a PR (via GitHub GraphQL `minimizeComment` with classifier `OUTDATED`) before posting a new one. This prevents the accumulation of multiple fully-expanded preview comments on long-running PRs. No changes to the Python script or the build workflow.

**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore