### PR TITLE
fix(video_editor): correct seek position handling 

### DIFF
--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -280,11 +280,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
       while (_pendingSeekPosition != null && mounted) {
         final pending = _pendingSeekPosition!;
         _pendingSeekPosition = null;
-        await _videoPlayer?.seekTo(pending);
         if (_seekEpoch != epoch) {
           _pendingSeekPosition = null;
           break;
         }
+        await _videoPlayer?.seekTo(pending);
       }
     } finally {
       // Only reset under the current epoch; a composition swap takes over ownership.
@@ -929,7 +929,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
             }
             return false;
           },
-          listener: (context, state) {
+          listener: (context, state) async {
             // See note on the trim-times listener above: skip empty
             // clip lists to avoid crashing the iOS native player.
             if (state.clips.isEmpty) return;
@@ -950,32 +950,35 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
             // release even if setClips throws.
             _isSeeking = true;
             final ownerEpoch = _seekEpoch;
-            unawaited(() async {
-              try {
-                await _videoPlayer?.setClips([
-                  for (final clip in state.clips)
-                    if (clip.video.file?.path case final path?)
-                      VideoClip(
-                        uri: path,
-                        start: clip.trimStart,
-                        end: clip.duration - clip.trimEnd,
-                      ),
-                ], startPosition: startPosition);
-              } catch (e, s) {
-                Log.error(
-                  'setClips failed on trim release: $e',
-                  name: 'VideoEditorCanvas',
-                  category: LogCategory.video,
-                  error: e,
-                  stackTrace: s,
-                );
-              } finally {
-                _lastReportedPosition = startPosition;
-                if (_seekEpoch == ownerEpoch) {
-                  _isSeeking = false;
-                }
+
+            try {
+              await _videoPlayer?.setClips([
+                for (final clip in state.clips)
+                  if (clip.video.file?.path case final path?)
+                    VideoClip(
+                      uri: path,
+                      start: clip.trimStart,
+                      end: clip.duration - clip.trimEnd,
+                    ),
+              ], startPosition: startPosition);
+              if (mounted) {
+                bloc.add(VideoEditorPositionChanged(startPosition));
+                _proVideoController.setPlayTime(startPosition);
               }
-            }());
+            } catch (e, s) {
+              Log.error(
+                'setClips failed on trim release: $e',
+                name: 'VideoEditorCanvas',
+                category: LogCategory.video,
+                error: e,
+                stackTrace: s,
+              );
+            } finally {
+              _lastReportedPosition = startPosition;
+              if (_seekEpoch == ownerEpoch) {
+                _isSeeking = false;
+              }
+            }
           },
         ),
         BlocListener<VideoEditorMainBloc, VideoEditorMainState>(

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -43,6 +43,27 @@ class VideoEditorCanvas extends StatefulWidget {
   /// Creates a [VideoEditorCanvas].
   const VideoEditorCanvas({super.key});
 
+  /// Pushes the post-`setClips` start position back into the
+  /// [VideoEditorMainBloc] and the [ProVideoController] after a trim
+  /// release.
+  ///
+  /// Skips the bloc dispatch when [trimEndAlreadyDispatched] is `true`
+  /// — the same value was already pushed pre-await — but always
+  /// updates the controller's play time so the on-screen scrubber
+  /// matches the native player's seek target.
+  @visibleForTesting
+  static void syncPositionAfterTrimRelease({
+    required VideoEditorMainBloc mainBloc,
+    required ProVideoController proVideoController,
+    required Duration startPosition,
+    required bool trimEndAlreadyDispatched,
+  }) {
+    if (!trimEndAlreadyDispatched) {
+      mainBloc.add(VideoEditorPositionChanged(startPosition));
+    }
+    proVideoController.setPlayTime(startPosition);
+  }
+
   @override
   State<VideoEditorCanvas> createState() => _VideoEditorCanvasState();
 }
@@ -960,12 +981,12 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
                     ),
               ], startPosition: startPosition);
               if (mounted) {
-                // Skip the bloc dispatch when we already pushed this position
-                // pre-await (trimEndPosition != null) — the value is identical.
-                if (trimEndPosition == null) {
-                  bloc.add(VideoEditorPositionChanged(startPosition));
-                }
-                _proVideoController.setPlayTime(startPosition);
+                VideoEditorCanvas.syncPositionAfterTrimRelease(
+                  mainBloc: bloc,
+                  proVideoController: _proVideoController,
+                  startPosition: startPosition,
+                  trimEndAlreadyDispatched: trimEndPosition != null,
+                );
               }
             } catch (e, s) {
               Log.error(

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -936,12 +936,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
 
             // Seek to the trim handle's release point when restoring the composite.
             final trimEndPosition = _consumeTrimEndStartPosition(state.clips);
-            final mainBloc = context.read<VideoEditorMainBloc>();
-            final startPosition =
-                trimEndPosition ?? mainBloc.state.currentPosition;
+            final startPosition = trimEndPosition ?? bloc.state.currentPosition;
             // Sync so subsequent re-emits read the post-seek position.
             if (trimEndPosition != null) {
-              mainBloc.add(VideoEditorPositionChanged(trimEndPosition));
+              bloc.add(VideoEditorPositionChanged(trimEndPosition));
             }
             // Composition swap back — invalidate in-flight single-clip seeks.
             _seekEpoch++;
@@ -962,7 +960,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
                     ),
               ], startPosition: startPosition);
               if (mounted) {
-                bloc.add(VideoEditorPositionChanged(startPosition));
+                // Skip the bloc dispatch when we already pushed this position
+                // pre-await (trimEndPosition != null) — the value is identical.
+                if (trimEndPosition == null) {
+                  bloc.add(VideoEditorPositionChanged(startPosition));
+                }
                 _proVideoController.setPlayTime(startPosition);
               }
             } catch (e, s) {

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
@@ -8,6 +8,7 @@ import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.d
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_canvas.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
+import 'package:pro_image_editor/pro_image_editor.dart' show ProVideoController;
 
 void main() {
   testWidgets('VideoEditorCanvas renders safely with no clips', (tester) async {
@@ -48,4 +49,84 @@ void main() {
 
     expect(tester.takeException(), isNull);
   });
+
+  group('VideoEditorCanvas.syncPositionAfterTrimRelease', () {
+    late _SpyVideoEditorMainBloc mainBloc;
+    late ProVideoController controller;
+
+    setUp(() {
+      mainBloc = _SpyVideoEditorMainBloc();
+      controller = ProVideoController(
+        videoPlayer: const SizedBox.shrink(),
+        videoDuration: Duration.zero,
+        initialResolution: Size.zero,
+        fileSize: 0,
+      );
+    });
+
+    tearDown(() {
+      mainBloc.close();
+    });
+
+    test(
+      'dispatches VideoEditorPositionChanged(startPosition) and updates '
+      'playTime when the trim-end position was not pre-dispatched',
+      () {
+        const startPosition = Duration(seconds: 2);
+
+        VideoEditorCanvas.syncPositionAfterTrimRelease(
+          mainBloc: mainBloc,
+          proVideoController: controller,
+          startPosition: startPosition,
+          trimEndAlreadyDispatched: false,
+        );
+
+        expect(
+          mainBloc.events,
+          contains(
+            isA<VideoEditorPositionChanged>().having(
+              (e) => e.position,
+              'position',
+              startPosition,
+            ),
+          ),
+        );
+        expect(controller.playTimeNotifier.value, equals(startPosition));
+      },
+    );
+
+    test(
+      'skips the bloc dispatch but still updates playTime when the '
+      'trim-end position was already pushed pre-await',
+      () {
+        const startPosition = Duration(milliseconds: 1500);
+
+        VideoEditorCanvas.syncPositionAfterTrimRelease(
+          mainBloc: mainBloc,
+          proVideoController: controller,
+          startPosition: startPosition,
+          trimEndAlreadyDispatched: true,
+        );
+
+        expect(
+          mainBloc.events.whereType<VideoEditorPositionChanged>(),
+          isEmpty,
+        );
+        expect(controller.playTimeNotifier.value, equals(startPosition));
+      },
+    );
+  });
+}
+
+/// Captures every event added to the bloc so tests can assert
+/// dispatches that don't change the resulting state value (and would
+/// therefore not appear on `bloc.stream`).
+class _SpyVideoEditorMainBloc extends VideoEditorMainBloc {
+  final List<VideoEditorMainEvent> events = [];
+
+  @override
+  void add(VideoEditorMainEvent event) {
+    events.add(event);
+    super.add(event);
+  }
 }

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
@@ -64,8 +64,8 @@ void main() {
       );
     });
 
-    tearDown(() {
-      mainBloc.close();
+    tearDown(() async {
+      await mainBloc.close();
     });
 
     test(


### PR DESCRIPTION
Closes #3464



## Description

After trimming a clip, the timeline didn’t match the position shown in the preview video. This PR ensures that both the timeline and the preview display the exact same position.


**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore