### PR TITLE
fix(notifications): land on the post when a mention has no referenced event

### DIFF
--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -258,7 +258,8 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
 
     final shouldAutoOpenComments =
         notificationKind == NotificationKind.comment ||
-        notificationKind == NotificationKind.reply;
+        notificationKind == NotificationKind.reply ||
+        notificationKind == NotificationKind.mention;
     final videoForNav = video;
 
     context.push(

--- a/mobile/lib/screens/notifications_screen.dart
+++ b/mobile/lib/screens/notifications_screen.dart
@@ -693,7 +693,9 @@ class _NotificationTabContentState
       return;
     }
 
-    final shouldAutoOpenComments = notificationType == NotificationType.comment;
+    final shouldAutoOpenComments =
+        notificationType == NotificationType.comment ||
+        notificationType == NotificationType.mention;
     final videoForNav = video;
 
     // Navigate to video player using the pooled playback path

--- a/mobile/lib/services/notification_model_converter.dart
+++ b/mobile/lib/services/notification_model_converter.dart
@@ -23,6 +23,15 @@ NotificationModel notificationModelFromRelayApi(
     hasTargetEvent: relay.referencedEventId != null,
   );
 
+  // For mentions, the relay sometimes leaves `referenced_event_id` empty
+  // (e.g. mentions inside a NIP-22 comment). Fall back to the source event so
+  // navigation has a target to resolve — `NotificationTargetResolver` walks
+  // its `E` / `e` tags back to the root video. Without this, mention taps
+  // route to the mentioner's profile (#3168).
+  final targetEventId = type == NotificationType.mention
+      ? (relay.referencedEventId ?? _nonEmpty(relay.sourceEventId))
+      : relay.referencedEventId;
+
   return NotificationModel(
     id: relay.id,
     type: type,
@@ -32,12 +41,14 @@ NotificationModel notificationModelFromRelayApi(
     message: message,
     timestamp: relay.sourceCreatedAt ?? relay.createdAt,
     isRead: relay.read,
-    targetEventId: relay.referencedEventId,
+    targetEventId: targetEventId,
     targetVideoUrl: targetVideoUrl,
     targetVideoThumbnail: targetVideoThumbnail,
     metadata: _buildMetadata(relay, type),
   );
 }
+
+String? _nonEmpty(String value) => value.isEmpty ? null : value;
 
 /// Map relay notification type string to [NotificationType] enum
 NotificationType _mapNotificationType(String relayType, int sourceKind) {

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -244,7 +244,7 @@ class NotificationRepository {
         actor: actor,
         timestamp: n.createdAt,
         isRead: n.read,
-        targetEventId: n.referencedEventId,
+        targetEventId: _resolveTargetEventId(n, kind),
         commentText: _truncateComment(n.content, kind),
       );
     }).toList();
@@ -346,6 +346,24 @@ class NotificationRepository {
       displayName: profile?.bestDisplayName ?? 'Unknown user',
       pictureUrl: profile?.picture,
     );
+  }
+
+  /// Resolves the navigation target for a notification.
+  ///
+  /// Mentions sometimes arrive with no `referenced_event_id` (e.g. a mention
+  /// inside a NIP-22 comment). Fall back to the source event so taps still
+  /// land on the post — the UI's resolver walks `E` / `e` tags back to the
+  /// root video. Without this, mention taps route to the mentioner's
+  /// profile (#3168).
+  static String? _resolveTargetEventId(
+    RelayNotification n,
+    NotificationKind kind,
+  ) {
+    if (kind == NotificationKind.mention) {
+      final source = n.sourceEventId;
+      return n.referencedEventId ?? (source.isEmpty ? null : source);
+    }
+    return n.referencedEventId;
   }
 
   /// Maps a relay notification type string + source kind to

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -698,6 +698,65 @@ void main() {
       });
     });
 
+    group('mention navigation target (#3168)', () {
+      test(
+        'mention falls back to sourceEventId when referencedEventId is null',
+        () async {
+          stubNotifications([
+            makeNotification(
+              notificationType: 'mention',
+              sourceKind: 1,
+              sourceEventId: 'mention_evt_1',
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.first as SingleNotification;
+          expect(item.type, equals(NotificationKind.mention));
+          // Without the fallback, targetEventId would be null and the UI
+          // would have nothing to navigate to, leaving avatar tap as the
+          // only working route — straight to the mentioner's profile.
+          expect(item.targetEventId, equals('mention_evt_1'));
+        },
+      );
+
+      test(
+        'mention prefers referencedEventId when both are present',
+        () async {
+          stubNotifications([
+            makeNotification(
+              notificationType: 'mention',
+              sourceKind: 1,
+              sourceEventId: 'mention_evt_1',
+              referencedEventId: 'video_root',
+            ),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.first as SingleNotification;
+          expect(item.targetEventId, equals('video_root'));
+        },
+      );
+
+      test(
+        'non-mention notifications keep null targetEventId when '
+        'referencedEventId is null',
+        () async {
+          stubNotifications([
+            makeNotification(sourceEventId: 'reaction_evt'),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.first as SingleNotification;
+          expect(item.type, equals(NotificationKind.like));
+          expect(item.targetEventId, isNull);
+        },
+      );
+    });
+
     group('comment text truncation', () {
       test('truncates comment text > 50 chars', () async {
         final longComment = 'A' * 60;

--- a/mobile/test/services/notification_model_converter_test.dart
+++ b/mobile/test/services/notification_model_converter_test.dart
@@ -201,5 +201,74 @@ void main() {
       // Model.id should be the actual notification ID from the API
       expect(model.id, 'real-notification-id-123');
     });
+
+    group('mention navigation target (#3168)', () {
+      test(
+        'falls back to sourceEventId when referencedEventId is null',
+        () {
+          final relay = makeRelayNotification(
+            notificationType: 'mention',
+            sourceKind: 1,
+            referencedEventId: null,
+          );
+
+          final model = notificationModelFromRelayApi(relay, actorName: 'Bob');
+
+          expect(model.type, NotificationType.mention);
+          // Without the fallback, navigationAction would be 'open_profile'
+          // and the user would land on Bob's profile instead of the post.
+          expect(model.targetEventId, equals(relay.sourceEventId));
+          expect(model.navigationAction, equals('open_video'));
+          expect(model.navigationTarget, equals(relay.sourceEventId));
+        },
+      );
+
+      test(
+        'prefers referencedEventId when both are present',
+        () {
+          final relay = makeRelayNotification(
+            notificationType: 'mention',
+            sourceKind: 1,
+            referencedEventId: 'root-video-event',
+          );
+
+          final model = notificationModelFromRelayApi(relay, actorName: 'Bob');
+
+          expect(model.type, NotificationType.mention);
+          expect(model.targetEventId, equals('root-video-event'));
+          expect(model.navigationTarget, equals('root-video-event'));
+        },
+      );
+
+      test(
+        'leaves targetEventId null when both ids are missing',
+        () {
+          final relay = RelayNotification(
+            id: 'notif-1',
+            sourcePubkey:
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            sourceEventId: '',
+            sourceKind: 1,
+            notificationType: 'mention',
+            createdAt: DateTime.utc(2026, 4, 27, 10),
+            read: false,
+          );
+
+          final model = notificationModelFromRelayApi(relay, actorName: 'Bob');
+
+          expect(model.type, NotificationType.mention);
+          expect(model.targetEventId, isNull);
+        },
+      );
+
+      test('does not affect non-mention notifications', () {
+        final relay = makeRelayNotification(referencedEventId: null);
+
+        final model = notificationModelFromRelayApi(relay, actorName: 'Alice');
+
+        expect(model.type, NotificationType.like);
+        expect(model.targetEventId, isNull);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Description

PR #3431 routed mention taps to the post when the relay populated `referenced_event_id`, but kept the actor's-profile fallback for the null case. Mentions where the relay returns `referenced_event_id == null` (e.g. a mention inside a NIP-22 comment) still send the user to the mentioner's profile.

For mention notifications only, the converter and BLoC repository now fall back to `source_event_id` when `referenced_event_id` is null. `NotificationTargetResolver` already walks the source event's NIP-22 `E` and NIP-10 `e` tags back to the root video, so passing the comment/reply event resolves to the correct post. Mentions also auto-open the comments overlay so the user lands near where they were mentioned.

The fix is applied in both the legacy path (`notification_model_converter`, used by the Inbox today via `NotificationsScreen`) and the BLoC path (`notification_repository`, used by the new `NotificationsView`), matching the mid-flight migration. Like-grouping is untouched and still keys on `referencedEventId` only.

**Related Issue:** Closes #3168

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] \`flutter analyze lib test integration_test\` clean from \`mobile/\`
- [x] \`flutter analyze\` clean inside \`mobile/packages/notification_repository\`
- [x] \`flutter test test/services/notification_model_converter_test.dart\` — 14/14 (4 new mention-fallback cases)
- [x] \`flutter test\` inside \`notification_repository\` — 30/30 (3 new mention-fallback cases)
- [x] \`flutter test test/models/notification_model_test.dart test/screens/notifications_screen_test.dart\` — 22/22, no regressions
- [x] \`flutter test test/notifications/\` — 48/48, no regressions
- [ ] Manual on Android: tap a mention notification with no \`referenced_event_id\` from the relay → lands on the post with comments open, not the mentioner's profile

## Follow-ups (not in this PR)

- Backend: have the relay populate \`referenced_event_id\` for every mention whose source event has a discoverable root video, so the frontend fallback becomes purely defensive.
- Push notification handler in \`mobile/lib/main.dart\` reads \`referencedEventId\` from FCM data but only logs it; navigation is not wired. Separate bug, separate PR.