### PR TITLE
fix(video_player): improve seek handling and preroll functionality

### DIFF
--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
@@ -15,6 +15,10 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private var eventSink: FlutterEventSink?
     private var timeObserver: Any?
     private var statusObservation: NSKeyValueObservation?
+    /// One-shot KVO that defers a preroll request until the AVPlayer's
+    /// own `status` becomes `.readyToPlay`. Calling `preroll(atRate:)`
+    /// before that throws `NSInvalidArgumentException`.
+    private var pendingPrerollObservation: NSKeyValueObservation?
 
     // MARK: - Texture rendering
 
@@ -69,6 +73,24 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             guard let self, !self.firstFrameRendered else { return }
             self.firstFrameRendered = true
             self.sendStateUpdate()
+        }
+        // Recovery for compositor dead zones: if copyPixelBuffer returns
+        // nil for the full 600 ms force window, the seek landed on a time
+        // with no renderable frame (e.g. exact millisecond boundary between
+        // two composition segments). Retry with a small tolerance so
+        // AVFoundation picks the nearest actual decodable frame.
+        output.onSeekStuck = { [weak self] stuckTime in
+            guard let self else { return }
+            self.player?.seek(
+                to: stuckTime,
+                toleranceBefore: CMTime(value: 1, timescale: 10),
+                toleranceAfter: CMTime(value: 1, timescale: 10)
+            ) { [weak self] _ in
+                guard let self else { return }
+                let actualTime = self.player?.currentTime() ?? stuckTime
+                self.textureOutput?.forceRefresh(for: actualTime)
+                self.safePreroll(at: actualTime)
+            }
         }
         textureOutput = output
         return output.textureId
@@ -152,6 +174,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 if let existing = self.player {
                     existing.replaceCurrentItem(with: playerItem)
                     await existing.seek(to: startTime, toleranceBefore: .zero, toleranceAfter: .zero)
+                    self.textureOutput?.forceRefresh(for: startTime)
                 } else {
                     let newPlayer = AVPlayer(playerItem: playerItem)
                     self.player = newPlayer
@@ -161,7 +184,14 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     if startPositionMs > 0 {
                         await newPlayer.seek(to: startTime, toleranceBefore: .zero, toleranceAfter: .zero)
                     }
+                    self.textureOutput?.forceRefresh(for: startTime)
                 }
+
+                // Preroll the composition output so the texture has a real
+                // frame at startTime even while the player is paused.
+                // Deferred via safePreroll — preroll throws if called
+                // before AVPlayer.status reaches .readyToPlay.
+                self.safePreroll(at: startTime)
 
                 self.observeEnd(for: self.player!.currentItem!)
                 self.currentStatus = "ready"
@@ -278,7 +308,18 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
         let time = CMTime(value: Int64(positionMs), timescale: 1000)
         player?.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] _ in
-            self?.syncAudioOverlays()
+            guard let self else {
+                result(nil)
+                return
+            }
+            self.textureOutput?.forceRefresh(for: time)
+            self.syncAudioOverlays()
+            // Preroll primes the AVPlayer output pipeline at the new seek
+            // position. Without this, a paused player near a clip boundary
+            // will keep returning the pre-seek pixel buffer from
+            // copyPixelBuffer, leaving the texture frozen until play() is
+            // pressed. safePreroll defers if status is not yet ready.
+            self.safePreroll(at: time)
             result(nil)
         }
     }
@@ -410,6 +451,34 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         ) { [weak self] _ in
             self?.syncAudioOverlays()
             self?.sendStateUpdate()
+        }
+    }
+
+    /// Calls `AVPlayer.preroll(atRate:)` only when the player is in a
+    /// state that legally accepts it. If `player.status` is not yet
+    /// `.readyToPlay`, defers the call via a one-shot KVO. No-op when
+    /// `player.rate != 0` (preroll is only useful for paused playback).
+    private func safePreroll(at time: CMTime) {
+        guard let player = self.player else { return }
+        guard player.rate == 0 else { return }
+        if player.status == .readyToPlay {
+            player.preroll(atRate: 1.0) { [weak self] prerolled in
+                if prerolled { self?.textureOutput?.forceRefresh(for: time) }
+            }
+            return
+        }
+        pendingPrerollObservation?.invalidate()
+        pendingPrerollObservation = player.observe(
+            \.status,
+            options: [.new]
+        ) { [weak self] obsPlayer, _ in
+            guard obsPlayer.status == .readyToPlay else { return }
+            self?.pendingPrerollObservation?.invalidate()
+            self?.pendingPrerollObservation = nil
+            guard obsPlayer.rate == 0 else { return }
+            obsPlayer.preroll(atRate: 1.0) { [weak self] prerolled in
+                if prerolled { self?.textureOutput?.forceRefresh(for: time) }
+            }
         }
     }
 
@@ -615,6 +684,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
         statusObservation?.invalidate()
         statusObservation = nil
+        pendingPrerollObservation?.invalidate()
+        pendingPrerollObservation = nil
         NotificationCenter.default.removeObserver(self)
         textureOutput?.dispose()
         textureOutput = nil

--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
@@ -86,7 +86,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             ) { [weak self] _ in
                 guard let self else { return }
                 let actualTime = self.player?.currentTime() ?? stuckTime
-                self.textureOutput?.forceRefresh(for: actualTime)
+                self.textureOutput?.forceRefresh(for: actualTime, isRetry: true)
                 self.safePreroll(at: actualTime)
             }
         }
@@ -452,7 +452,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     /// Calls `AVPlayer.preroll(atRate:)` only when the player is ready;
     /// otherwise defers via a one-shot KVO on `status`. No-op while
     /// `player.rate != 0` (preroll is only useful when paused).
+    ///
+    /// Must be called on the main thread — `pendingPrerollObservation`
+    /// is mutated here without synchronization. All current callers
+    /// (setClips Task @MainActor, MethodChannel callbacks, seek
+    /// completion handlers) are already main-queue.
     private func safePreroll(at time: CMTime) {
+        assert(Thread.isMainThread, "safePreroll must be called on the main thread")
         guard let player = self.player else { return }
         guard player.rate == 0 else { return }
         if player.status == .readyToPlay {

--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
@@ -15,9 +15,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private var eventSink: FlutterEventSink?
     private var timeObserver: Any?
     private var statusObservation: NSKeyValueObservation?
-    /// One-shot KVO that defers a preroll request until the AVPlayer's
-    /// own `status` becomes `.readyToPlay`. Calling `preroll(atRate:)`
-    /// before that throws `NSInvalidArgumentException`.
+    /// One-shot KVO that defers `preroll(atRate:)` until `player.status`
+    /// is `.readyToPlay`; calling earlier throws `NSInvalidArgumentException`.
     private var pendingPrerollObservation: NSKeyValueObservation?
 
     // MARK: - Texture rendering
@@ -74,11 +73,10 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             self.firstFrameRendered = true
             self.sendStateUpdate()
         }
-        // Recovery for compositor dead zones: if copyPixelBuffer returns
-        // nil for the full 600 ms force window, the seek landed on a time
-        // with no renderable frame (e.g. exact millisecond boundary between
-        // two composition segments). Retry with a small tolerance so
-        // AVFoundation picks the nearest actual decodable frame.
+        // Recovery for compositor dead zones: if the 600 ms force window
+        // delivers no frame, the seek landed on a time with no renderable
+        // frame (e.g. exact boundary between composition segments). Retry
+        // with a small tolerance to snap to the nearest decodable frame.
         output.onSeekStuck = { [weak self] stuckTime in
             guard let self else { return }
             self.player?.seek(
@@ -187,10 +185,9 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                     self.textureOutput?.forceRefresh(for: startTime)
                 }
 
-                // Preroll the composition output so the texture has a real
-                // frame at startTime even while the player is paused.
-                // Deferred via safePreroll — preroll throws if called
-                // before AVPlayer.status reaches .readyToPlay.
+                // Preroll so the texture has a real frame at startTime
+                // even while paused. Deferred via safePreroll because
+                // preroll throws before status reaches .readyToPlay.
                 self.safePreroll(at: startTime)
 
                 self.observeEnd(for: self.player!.currentItem!)
@@ -314,11 +311,9 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             }
             self.textureOutput?.forceRefresh(for: time)
             self.syncAudioOverlays()
-            // Preroll primes the AVPlayer output pipeline at the new seek
-            // position. Without this, a paused player near a clip boundary
-            // will keep returning the pre-seek pixel buffer from
-            // copyPixelBuffer, leaving the texture frozen until play() is
-            // pressed. safePreroll defers if status is not yet ready.
+            // Preroll primes the output pipeline at the new position;
+            // without it a paused player near a clip boundary keeps
+            // returning the pre-seek buffer until play() is pressed.
             self.safePreroll(at: time)
             result(nil)
         }
@@ -454,10 +449,9 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
     }
 
-    /// Calls `AVPlayer.preroll(atRate:)` only when the player is in a
-    /// state that legally accepts it. If `player.status` is not yet
-    /// `.readyToPlay`, defers the call via a one-shot KVO. No-op when
-    /// `player.rate != 0` (preroll is only useful for paused playback).
+    /// Calls `AVPlayer.preroll(atRate:)` only when the player is ready;
+    /// otherwise defers via a one-shot KVO on `status`. No-op while
+    /// `player.rate != 0` (preroll is only useful when paused).
     private func safePreroll(at time: CMTime) {
         guard let player = self.player else { return }
         guard player.rate == 0 else { return }

--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
@@ -369,7 +369,16 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         let targetTime = CMTime(seconds: clipOffsets[index], preferredTimescale: 600)
         player?.seek(to: targetTime, toleranceBefore: .zero, toleranceAfter: .zero) {
             [weak self] _ in
-            self?.syncAudioOverlays()
+            guard let self else {
+                result(nil)
+                return
+            }
+            self.textureOutput?.forceRefresh(for: targetTime)
+            self.syncAudioOverlays()
+            // Same stuck-frame guard as handleSeekTo: a paused player
+            // landing on a clip boundary keeps returning the pre-seek
+            // buffer until preroll primes the output pipeline.
+            self.safePreroll(at: targetTime)
             result(nil)
         }
     }

--- a/mobile/packages/divine_video_player/ios/Classes/VideoTextureOutput.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/VideoTextureOutput.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Flutter
+import QuartzCore
 
 /// Bridges an `AVPlayer` to Flutter's texture system.
 ///
@@ -28,14 +29,21 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
     /// Window during which the display link bypasses `hasNewPixelBuffer`
     /// and tries `copyPixelBuffer` on every tick. Covers the GOP-decode
     /// stall after an exact seek (up to ~500 ms on long-GOP clips).
-    private var forceRefreshDeadline: Date = .distantPast
+    /// Uses `CACurrentMediaTime()` (monotonic) so NTP/TZ clock jumps
+    /// can't collapse or extend the window.
+    private var forceRefreshDeadline: CFTimeInterval = 0
 
     /// Failed `copyPixelBuffer` ticks within the current force window.
     /// Non-zero at expiry means the compositor is stuck at this time.
     private var forceWindowFailCount = 0
 
+    /// Marks the current force window as a tolerant-seek retry. When
+    /// `true`, expiry without a frame does NOT fire `onSeekStuck` again,
+    /// preventing an infinite retry loop on persistently broken content.
+    private var forceWindowIsRetry = false
+
     /// Fired when the force window expires without a frame; caller should
-    /// retry the seek with tolerance.
+    /// retry the seek with tolerance. Suppressed for retry windows.
     var onSeekStuck: ((CMTime) -> Void)?
 
     init(
@@ -87,10 +95,13 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
     /// Opens a 600 ms force window after a seek and requests a delegate
     /// notification, so the texture updates even while paused. Pass the
     /// exact seek target — used directly in `outputMediaDataWillChange`.
-    func forceRefresh(for seekTime: CMTime) {
+    /// Pass `isRetry: true` for a tolerant-seek retry; suppresses
+    /// `onSeekStuck` on expiry to break recovery loops.
+    func forceRefresh(for seekTime: CMTime, isRetry: Bool = false) {
         pendingSeekTime = seekTime
-        forceRefreshDeadline = Date(timeIntervalSinceNow: 0.6)
+        forceRefreshDeadline = CACurrentMediaTime() + 0.6
         forceWindowFailCount = 0
+        forceWindowIsRetry = isRetry
         videoOutput?.requestNotificationOfMediaDataChange(withAdvanceInterval: 0)
     }
 
@@ -126,7 +137,7 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
             return
         }
         pendingSeekTime = .invalid
-        forceRefreshDeadline = .distantPast
+        forceRefreshDeadline = 0
         forceWindowFailCount = 0
         deliverFrame(pixelBuffer)
     }
@@ -179,13 +190,13 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
 
         let itemTime = player.currentTime()
 
-        if Date() < forceRefreshDeadline {
+        if CACurrentMediaTime() < forceRefreshDeadline {
             if let pixelBuffer = output.copyPixelBuffer(
                 forItemTime: itemTime,
                 itemTimeForDisplay: nil
             ) {
                 pendingSeekTime = .invalid
-                forceRefreshDeadline = .distantPast
+                forceRefreshDeadline = 0
                 forceWindowFailCount = 0
                 deliverFrame(pixelBuffer)
             } else {
@@ -196,9 +207,13 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
 
         if forceWindowFailCount > 0 {
             let stuckTime = itemTime
+            let wasRetry = forceWindowIsRetry
             forceWindowFailCount = 0
-            DispatchQueue.main.async { [weak self] in
-                self?.onSeekStuck?(stuckTime)
+            forceWindowIsRetry = false
+            if !wasRetry {
+                DispatchQueue.main.async { [weak self] in
+                    self?.onSeekStuck?(stuckTime)
+                }
             }
         }
 

--- a/mobile/packages/divine_video_player/ios/Classes/VideoTextureOutput.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/VideoTextureOutput.swift
@@ -6,7 +6,7 @@ import Flutter
 /// Uses `AVPlayerItemVideoOutput` to pull `CVPixelBuffer` frames from
 /// the player and exposes them via the `FlutterTexture` protocol.
 /// A `CADisplayLink` drives the frame polling loop.
-final class VideoTextureOutput: NSObject, FlutterTexture {
+final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPullDelegate {
 
     private let registry: FlutterTextureRegistry
     private var onFirstFrame: (() -> Void)?
@@ -19,6 +19,34 @@ final class VideoTextureOutput: NSObject, FlutterTexture {
     private var latestPixelBuffer: CVPixelBuffer?
     private var hasDeliveredFirstFrame = false
     private weak var player: AVPlayer?
+    /// Tracks the item the output is currently attached to so we can
+    /// remove it before attaching to a new item.
+    private weak var attachedItem: AVPlayerItem?
+    /// The exact CMTime passed to the most recent forceRefresh call.
+    /// Used in outputMediaDataWillChange so we request the frame at the
+    /// precise seek target rather than player.currentTime(), which can
+    /// differ when a new seek is already in flight.
+    private var pendingSeekTime: CMTime = .invalid
+
+    /// Deadline until which the display link bypasses `hasNewPixelBuffer`
+    /// and calls `copyPixelBuffer` directly on every tick.
+    ///
+    /// AVFoundation must decode all frames from the nearest keyframe
+    /// to the seek target before it can serve a pixel buffer. For clips
+    /// with long GOPs (up to ~2 s keyframe interval), this stall can
+    /// last 300–500 ms. During that window `hasNewPixelBuffer` stays
+    /// false, freezing the Flutter texture. A 600 ms force window covers
+    /// any realistic GOP length at both 60 Hz and 120 Hz (ProMotion).
+    private var forceRefreshDeadline: Date = .distantPast
+
+    /// Number of display-link ticks that failed `copyPixelBuffer` inside
+    /// the current force window. Non-zero when the window expires means
+    /// the compositor is permanently stuck at this seek position.
+    private var forceWindowFailCount = 0
+
+    /// Called when the force window expires without delivering a frame.
+    /// Provides the stuck CMTime so the caller can retry with tolerance.
+    var onSeekStuck: ((CMTime) -> Void)?
 
     init(
         registry: FlutterTextureRegistry,
@@ -39,9 +67,9 @@ final class VideoTextureOutput: NSObject, FlutterTexture {
     /// Attaches the video output to a player item so frames can be
     /// pulled from it.
     func attach(to item: AVPlayerItem) {
-        // Remove previous output if any.
-        if let old = videoOutput {
-            item.remove(old)
+        // Remove the old output from the item it was actually added to.
+        if let old = videoOutput, let prev = attachedItem {
+            prev.remove(old)
         }
 
         let attrs: [String: Any] = [
@@ -51,9 +79,12 @@ final class VideoTextureOutput: NSObject, FlutterTexture {
         let output = AVPlayerItemVideoOutput(
             pixelBufferAttributes: attrs
         )
+        output.setDelegate(self, queue: .main)
         item.add(output)
         videoOutput = output
+        attachedItem = item
         hasDeliveredFirstFrame = false
+        pendingSeekTime = .invalid
     }
 
     /// Attaches the display-link driven polling loop to the player.
@@ -61,6 +92,60 @@ final class VideoTextureOutput: NSObject, FlutterTexture {
     func attachPlayer(_ player: AVPlayer) {
         self.player = player
         startDisplayLink()
+    }
+
+    /// Opens a 600 ms window after a seek during which the display link
+    /// bypasses `hasNewPixelBuffer`. Also fires a delegate notification
+    /// so the frame arrives even when the player is fully paused.
+    ///
+    /// Pass the exact seek target so outputMediaDataWillChange can use
+    /// it directly instead of player.currentTime(), which might already
+    /// reflect a newer seek.
+    func forceRefresh(for seekTime: CMTime) {
+        pendingSeekTime = seekTime
+        forceRefreshDeadline = Date(timeIntervalSinceNow: 0.6)
+        forceWindowFailCount = 0
+        videoOutput?.requestNotificationOfMediaDataChange(withAdvanceInterval: 0)
+    }
+
+    // MARK: - AVPlayerItemOutputPullDelegate
+
+    /// Called after a seek flushes the output queue.
+    func outputSequenceWasFlushed(_ output: AVPlayerItemOutput) {
+        (output as? AVPlayerItemVideoOutput)?
+            .requestNotificationOfMediaDataChange(withAdvanceInterval: 0)
+    }
+
+    /// Called when the compositor has a decoded frame ready.
+    ///
+    /// Fires even when the player is fully paused — it is the most
+    /// reliable path for frames after exact seeks on a paused
+    /// `AVMutableComposition` with `AVVideoComposition`.
+    func outputMediaDataWillChange(_ sender: AVPlayerItemOutput) {
+        guard let videoOutput = sender as? AVPlayerItemVideoOutput else {
+            return
+        }
+        // Prefer the stored seek target. Fall back to currentTime only if
+        // we have no pending seek (e.g. notification from outputSequenceWasFlushed).
+        let targetTime: CMTime
+        if pendingSeekTime.isValid {
+            targetTime = pendingSeekTime
+        } else if let p = player {
+            targetTime = p.currentTime()
+        } else {
+            return
+        }
+        guard let pixelBuffer = videoOutput.copyPixelBuffer(
+            forItemTime: targetTime,
+            itemTimeForDisplay: nil
+        ) else {
+            videoOutput.requestNotificationOfMediaDataChange(withAdvanceInterval: 0)
+            return
+        }
+        pendingSeekTime = .invalid
+        forceRefreshDeadline = .distantPast
+        forceWindowFailCount = 0
+        deliverFrame(pixelBuffer)
     }
 
     /// Cleans up display link and unregisters the texture.
@@ -96,24 +181,51 @@ final class VideoTextureOutput: NSObject, FlutterTexture {
         displayLink = nil
     }
 
+    private func deliverFrame(_ pixelBuffer: CVPixelBuffer) {
+        latestPixelBuffer = pixelBuffer
+        registry.textureFrameAvailable(textureId)
+        if !hasDeliveredFirstFrame {
+            hasDeliveredFirstFrame = true
+            onFirstFrame?()
+        }
+    }
+
     @objc private func onDisplayLink() {
         guard let output = videoOutput,
               let player else { return }
 
         let itemTime = player.currentTime()
+
+        if Date() < forceRefreshDeadline {
+            if let pixelBuffer = output.copyPixelBuffer(
+                forItemTime: itemTime,
+                itemTimeForDisplay: nil
+            ) {
+                pendingSeekTime = .invalid
+                forceRefreshDeadline = .distantPast
+                forceWindowFailCount = 0
+                deliverFrame(pixelBuffer)
+            } else {
+                forceWindowFailCount += 1
+            }
+            return
+        }
+
+        if forceWindowFailCount > 0 {
+            let stuckTime = itemTime
+            forceWindowFailCount = 0
+            DispatchQueue.main.async { [weak self] in
+                self?.onSeekStuck?(stuckTime)
+            }
+        }
+
         guard output.hasNewPixelBuffer(forItemTime: itemTime) else { return }
 
         if let pixelBuffer = output.copyPixelBuffer(
             forItemTime: itemTime,
             itemTimeForDisplay: nil
         ) {
-            latestPixelBuffer = pixelBuffer
-            registry.textureFrameAvailable(textureId)
-
-            if !hasDeliveredFirstFrame {
-                hasDeliveredFirstFrame = true
-                onFirstFrame?()
-            }
+            deliverFrame(pixelBuffer)
         }
     }
 }

--- a/mobile/packages/divine_video_player/ios/Classes/VideoTextureOutput.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/VideoTextureOutput.swift
@@ -19,33 +19,23 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
     private var latestPixelBuffer: CVPixelBuffer?
     private var hasDeliveredFirstFrame = false
     private weak var player: AVPlayer?
-    /// Tracks the item the output is currently attached to so we can
-    /// remove it before attaching to a new item.
+    /// Item the output is currently attached to, so we can detach cleanly.
     private weak var attachedItem: AVPlayerItem?
-    /// The exact CMTime passed to the most recent forceRefresh call.
-    /// Used in outputMediaDataWillChange so we request the frame at the
-    /// precise seek target rather than player.currentTime(), which can
-    /// differ when a new seek is already in flight.
+    /// Exact seek target from the most recent `forceRefresh`; preferred over
+    /// `player.currentTime()` because a newer seek may already be in flight.
     private var pendingSeekTime: CMTime = .invalid
 
-    /// Deadline until which the display link bypasses `hasNewPixelBuffer`
-    /// and calls `copyPixelBuffer` directly on every tick.
-    ///
-    /// AVFoundation must decode all frames from the nearest keyframe
-    /// to the seek target before it can serve a pixel buffer. For clips
-    /// with long GOPs (up to ~2 s keyframe interval), this stall can
-    /// last 300–500 ms. During that window `hasNewPixelBuffer` stays
-    /// false, freezing the Flutter texture. A 600 ms force window covers
-    /// any realistic GOP length at both 60 Hz and 120 Hz (ProMotion).
+    /// Window during which the display link bypasses `hasNewPixelBuffer`
+    /// and tries `copyPixelBuffer` on every tick. Covers the GOP-decode
+    /// stall after an exact seek (up to ~500 ms on long-GOP clips).
     private var forceRefreshDeadline: Date = .distantPast
 
-    /// Number of display-link ticks that failed `copyPixelBuffer` inside
-    /// the current force window. Non-zero when the window expires means
-    /// the compositor is permanently stuck at this seek position.
+    /// Failed `copyPixelBuffer` ticks within the current force window.
+    /// Non-zero at expiry means the compositor is stuck at this time.
     private var forceWindowFailCount = 0
 
-    /// Called when the force window expires without delivering a frame.
-    /// Provides the stuck CMTime so the caller can retry with tolerance.
+    /// Fired when the force window expires without a frame; caller should
+    /// retry the seek with tolerance.
     var onSeekStuck: ((CMTime) -> Void)?
 
     init(
@@ -94,13 +84,9 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
         startDisplayLink()
     }
 
-    /// Opens a 600 ms window after a seek during which the display link
-    /// bypasses `hasNewPixelBuffer`. Also fires a delegate notification
-    /// so the frame arrives even when the player is fully paused.
-    ///
-    /// Pass the exact seek target so outputMediaDataWillChange can use
-    /// it directly instead of player.currentTime(), which might already
-    /// reflect a newer seek.
+    /// Opens a 600 ms force window after a seek and requests a delegate
+    /// notification, so the texture updates even while paused. Pass the
+    /// exact seek target — used directly in `outputMediaDataWillChange`.
     func forceRefresh(for seekTime: CMTime) {
         pendingSeekTime = seekTime
         forceRefreshDeadline = Date(timeIntervalSinceNow: 0.6)
@@ -116,17 +102,14 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
             .requestNotificationOfMediaDataChange(withAdvanceInterval: 0)
     }
 
-    /// Called when the compositor has a decoded frame ready.
-    ///
-    /// Fires even when the player is fully paused — it is the most
-    /// reliable path for frames after exact seeks on a paused
-    /// `AVMutableComposition` with `AVVideoComposition`.
+    /// Fires even on a paused player — most reliable frame path after an
+    /// exact seek on an `AVMutableComposition` with `AVVideoComposition`.
     func outputMediaDataWillChange(_ sender: AVPlayerItemOutput) {
         guard let videoOutput = sender as? AVPlayerItemVideoOutput else {
             return
         }
-        // Prefer the stored seek target. Fall back to currentTime only if
-        // we have no pending seek (e.g. notification from outputSequenceWasFlushed).
+        // Prefer the stored seek target; fall back to currentTime only when
+        // there's no pending seek (e.g. notification from a flush).
         let targetTime: CMTime
         if pendingSeekTime.isValid {
             targetTime = pendingSeekTime

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
@@ -345,7 +345,16 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
         let targetTime = CMTime(seconds: clipOffsets[index], preferredTimescale: 600)
         player?.seek(to: targetTime, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] _ in
-            self?.syncAudioOverlays()
+            guard let self else {
+                result(nil)
+                return
+            }
+            self.textureOutput?.forceRefresh(for: targetTime)
+            self.syncAudioOverlays()
+            // Same stuck-frame guard as handleSeekTo: a paused player
+            // landing on a clip boundary keeps returning the pre-seek
+            // buffer until preroll primes the output pipeline.
+            self.safePreroll(at: targetTime)
             result(nil)
         }
     }

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
@@ -86,7 +86,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             ) { [weak self] _ in
                 guard let self else { return }
                 let actualTime = self.player?.currentTime() ?? stuckTime
-                self.textureOutput?.forceRefresh(for: actualTime)
+                self.textureOutput?.forceRefresh(for: actualTime, isRetry: true)
                 self.safePreroll(at: actualTime)
             }
         }
@@ -409,7 +409,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     /// Calls `AVPlayer.preroll(atRate:)` only when the player is ready;
     /// otherwise defers via a one-shot KVO on `status`. No-op while
     /// `player.rate != 0` (preroll is only useful when paused).
+    ///
+    /// Must be called on the main thread — `pendingPrerollObservation`
+    /// is mutated here without synchronization. All current callers
+    /// (setClips Task @MainActor, MethodChannel callbacks, seek
+    /// completion handlers) are already main-queue.
     private func safePreroll(at time: CMTime) {
+        assert(Thread.isMainThread, "safePreroll must be called on the main thread")
         guard let player = self.player else { return }
         guard player.rate == 0 else { return }
         if player.status == .readyToPlay {

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
@@ -15,6 +15,9 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private var eventSink: FlutterEventSink?
     private var timeObserver: Any?
     private var statusObservation: NSKeyValueObservation?
+    /// One-shot KVO that defers `preroll(atRate:)` until `player.status`
+    /// is `.readyToPlay`; calling earlier throws `NSInvalidArgumentException`.
+    private var pendingPrerollObservation: NSKeyValueObservation?
 
     // MARK: - Texture rendering
 
@@ -69,6 +72,23 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             guard let self, !self.firstFrameRendered else { return }
             self.firstFrameRendered = true
             self.sendStateUpdate()
+        }
+        // Recovery for compositor dead zones: if the 600 ms force window
+        // delivers no frame, the seek landed on a time with no renderable
+        // frame (e.g. exact boundary between composition segments). Retry
+        // with a small tolerance to snap to the nearest decodable frame.
+        output.onSeekStuck = { [weak self] stuckTime in
+            guard let self else { return }
+            self.player?.seek(
+                to: stuckTime,
+                toleranceBefore: CMTime(value: 1, timescale: 10),
+                toleranceAfter: CMTime(value: 1, timescale: 10)
+            ) { [weak self] _ in
+                guard let self else { return }
+                let actualTime = self.player?.currentTime() ?? stuckTime
+                self.textureOutput?.forceRefresh(for: actualTime)
+                self.safePreroll(at: actualTime)
+            }
         }
         textureOutput = output
         return output.textureId
@@ -144,13 +164,20 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 if let existing = self.player {
                     existing.replaceCurrentItem(with: playerItem)
                     await existing.seek(to: .zero)
+                    self.textureOutput?.forceRefresh(for: .zero)
                 } else {
                     let newPlayer = AVPlayer(playerItem: playerItem)
                     self.player = newPlayer
                     self.textureOutput?.attachPlayer(newPlayer)
                     self.addTimeObserver()
                     self.observeStatus()
+                    self.textureOutput?.forceRefresh(for: .zero)
                 }
+
+                // Preroll so the texture has a real frame at the start
+                // even while paused. Deferred via safePreroll because
+                // preroll throws before status reaches .readyToPlay.
+                self.safePreroll(at: .zero)
 
                 self.observeEnd(for: self.player!.currentItem!)
                 self.currentStatus = "ready"
@@ -260,7 +287,16 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
         let time = CMTime(value: Int64(positionMs), timescale: 1000)
         player?.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { [weak self] _ in
-            self?.syncAudioOverlays()
+            guard let self else {
+                result(nil)
+                return
+            }
+            self.textureOutput?.forceRefresh(for: time)
+            self.syncAudioOverlays()
+            // Preroll primes the output pipeline at the new position;
+            // without it a paused player near a clip boundary keeps
+            // returning the pre-seek buffer until play() is pressed.
+            self.safePreroll(at: time)
             result(nil)
         }
     }
@@ -368,6 +404,33 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             isPlaying: player.rate > 0,
             speed: speed
         )
+    }
+
+    /// Calls `AVPlayer.preroll(atRate:)` only when the player is ready;
+    /// otherwise defers via a one-shot KVO on `status`. No-op while
+    /// `player.rate != 0` (preroll is only useful when paused).
+    private func safePreroll(at time: CMTime) {
+        guard let player = self.player else { return }
+        guard player.rate == 0 else { return }
+        if player.status == .readyToPlay {
+            player.preroll(atRate: 1.0) { [weak self] prerolled in
+                if prerolled { self?.textureOutput?.forceRefresh(for: time) }
+            }
+            return
+        }
+        pendingPrerollObservation?.invalidate()
+        pendingPrerollObservation = player.observe(
+            \.status,
+            options: [.new]
+        ) { [weak self] obsPlayer, _ in
+            guard obsPlayer.status == .readyToPlay else { return }
+            self?.pendingPrerollObservation?.invalidate()
+            self?.pendingPrerollObservation = nil
+            guard obsPlayer.rate == 0 else { return }
+            obsPlayer.preroll(atRate: 1.0) { [weak self] prerolled in
+                if prerolled { self?.textureOutput?.forceRefresh(for: time) }
+            }
+        }
     }
 
     // MARK: - Observers
@@ -582,6 +645,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
         statusObservation?.invalidate()
         statusObservation = nil
+        pendingPrerollObservation?.invalidate()
+        pendingPrerollObservation = nil
         NotificationCenter.default.removeObserver(self)
         player?.pause()
         player?.replaceCurrentItem(with: nil)

--- a/mobile/packages/divine_video_player/macos/Classes/VideoTextureOutput.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/VideoTextureOutput.swift
@@ -6,7 +6,7 @@ import FlutterMacOS
 /// Uses `AVPlayerItemVideoOutput` to pull `CVPixelBuffer` frames from
 /// the player and exposes them via the `FlutterTexture` protocol.
 /// A timer drives the frame polling loop (macOS has no `CADisplayLink`).
-final class VideoTextureOutput: NSObject, FlutterTexture {
+final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPullDelegate {
 
     private let registry: FlutterTextureRegistry
     private var onFirstFrame: (() -> Void)?
@@ -19,6 +19,24 @@ final class VideoTextureOutput: NSObject, FlutterTexture {
     private var latestPixelBuffer: CVPixelBuffer?
     private var hasDeliveredFirstFrame = false
     private weak var player: AVPlayer?
+    /// Item the output is currently attached to, so we can detach cleanly.
+    private weak var attachedItem: AVPlayerItem?
+    /// Exact seek target from the most recent `forceRefresh`; preferred over
+    /// `player.currentTime()` because a newer seek may already be in flight.
+    private var pendingSeekTime: CMTime = .invalid
+
+    /// Window during which the poll loop bypasses `hasNewPixelBuffer`
+    /// and tries `copyPixelBuffer` on every tick. Covers the GOP-decode
+    /// stall after an exact seek (up to ~500 ms on long-GOP clips).
+    private var forceRefreshDeadline: Date = .distantPast
+
+    /// Failed `copyPixelBuffer` ticks within the current force window.
+    /// Non-zero at expiry means the compositor is stuck at this time.
+    private var forceWindowFailCount = 0
+
+    /// Fired when the force window expires without a frame; caller should
+    /// retry the seek with tolerance.
+    var onSeekStuck: ((CMTime) -> Void)?
 
     init(
         registry: FlutterTextureRegistry,
@@ -38,9 +56,9 @@ final class VideoTextureOutput: NSObject, FlutterTexture {
     /// Attaches the video output to a player item so frames can be
     /// pulled from it.
     func attach(to item: AVPlayerItem) {
-        // Remove previous output if any.
-        if let old = videoOutput {
-            item.remove(old)
+        // Remove the old output from the item it was actually added to.
+        if let old = videoOutput, let prev = attachedItem {
+            prev.remove(old)
         }
 
         let attrs: [String: Any] = [
@@ -50,9 +68,12 @@ final class VideoTextureOutput: NSObject, FlutterTexture {
         let output = AVPlayerItemVideoOutput(
             pixelBufferAttributes: attrs
         )
+        output.setDelegate(self, queue: .main)
         item.add(output)
         videoOutput = output
+        attachedItem = item
         hasDeliveredFirstFrame = false
+        pendingSeekTime = .invalid
     }
 
     /// Attaches the polling loop to the player.
@@ -60,6 +81,53 @@ final class VideoTextureOutput: NSObject, FlutterTexture {
     func attachPlayer(_ player: AVPlayer) {
         self.player = player
         startPolling()
+    }
+
+    /// Opens a 600 ms force window after a seek and requests a delegate
+    /// notification, so the texture updates even while paused. Pass the
+    /// exact seek target — used directly in `outputMediaDataWillChange`.
+    func forceRefresh(for seekTime: CMTime) {
+        pendingSeekTime = seekTime
+        forceRefreshDeadline = Date(timeIntervalSinceNow: 0.6)
+        forceWindowFailCount = 0
+        videoOutput?.requestNotificationOfMediaDataChange(withAdvanceInterval: 0)
+    }
+
+    // MARK: - AVPlayerItemOutputPullDelegate
+
+    /// Called after a seek flushes the output queue.
+    func outputSequenceWasFlushed(_ output: AVPlayerItemOutput) {
+        (output as? AVPlayerItemVideoOutput)?
+            .requestNotificationOfMediaDataChange(withAdvanceInterval: 0)
+    }
+
+    /// Fires even on a paused player — most reliable frame path after an
+    /// exact seek on an `AVMutableComposition` with `AVVideoComposition`.
+    func outputMediaDataWillChange(_ sender: AVPlayerItemOutput) {
+        guard let videoOutput = sender as? AVPlayerItemVideoOutput else {
+            return
+        }
+        // Prefer the stored seek target; fall back to currentTime only when
+        // there's no pending seek (e.g. notification from a flush).
+        let targetTime: CMTime
+        if pendingSeekTime.isValid {
+            targetTime = pendingSeekTime
+        } else if let p = player {
+            targetTime = p.currentTime()
+        } else {
+            return
+        }
+        guard let pixelBuffer = videoOutput.copyPixelBuffer(
+            forItemTime: targetTime,
+            itemTimeForDisplay: nil
+        ) else {
+            videoOutput.requestNotificationOfMediaDataChange(withAdvanceInterval: 0)
+            return
+        }
+        pendingSeekTime = .invalid
+        forceRefreshDeadline = .distantPast
+        forceWindowFailCount = 0
+        deliverFrame(pixelBuffer)
     }
 
     /// Cleans up the timer and unregisters the texture.
@@ -101,19 +169,46 @@ final class VideoTextureOutput: NSObject, FlutterTexture {
               let player else { return }
 
         let itemTime = player.currentTime()
+
+        if Date() < forceRefreshDeadline {
+            if let pixelBuffer = output.copyPixelBuffer(
+                forItemTime: itemTime,
+                itemTimeForDisplay: nil
+            ) {
+                pendingSeekTime = .invalid
+                forceRefreshDeadline = .distantPast
+                forceWindowFailCount = 0
+                deliverFrame(pixelBuffer)
+            } else {
+                forceWindowFailCount += 1
+            }
+            return
+        }
+
+        if forceWindowFailCount > 0 {
+            let stuckTime = itemTime
+            forceWindowFailCount = 0
+            DispatchQueue.main.async { [weak self] in
+                self?.onSeekStuck?(stuckTime)
+            }
+        }
+
         guard output.hasNewPixelBuffer(forItemTime: itemTime) else { return }
 
         if let pixelBuffer = output.copyPixelBuffer(
             forItemTime: itemTime,
             itemTimeForDisplay: nil
         ) {
-            latestPixelBuffer = pixelBuffer
-            registry.textureFrameAvailable(textureId)
+            deliverFrame(pixelBuffer)
+        }
+    }
 
-            if !hasDeliveredFirstFrame {
-                hasDeliveredFirstFrame = true
-                onFirstFrame?()
-            }
+    private func deliverFrame(_ pixelBuffer: CVPixelBuffer) {
+        latestPixelBuffer = pixelBuffer
+        registry.textureFrameAvailable(textureId)
+        if !hasDeliveredFirstFrame {
+            hasDeliveredFirstFrame = true
+            onFirstFrame?()
         }
     }
 }

--- a/mobile/packages/divine_video_player/macos/Classes/VideoTextureOutput.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/VideoTextureOutput.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import FlutterMacOS
+import QuartzCore
 
 /// Bridges an `AVPlayer` to Flutter's texture system on macOS.
 ///
@@ -28,14 +29,21 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
     /// Window during which the poll loop bypasses `hasNewPixelBuffer`
     /// and tries `copyPixelBuffer` on every tick. Covers the GOP-decode
     /// stall after an exact seek (up to ~500 ms on long-GOP clips).
-    private var forceRefreshDeadline: Date = .distantPast
+    /// Uses `CACurrentMediaTime()` (monotonic) so NTP/TZ clock jumps
+    /// can't collapse or extend the window.
+    private var forceRefreshDeadline: CFTimeInterval = 0
 
     /// Failed `copyPixelBuffer` ticks within the current force window.
     /// Non-zero at expiry means the compositor is stuck at this time.
     private var forceWindowFailCount = 0
 
+    /// Marks the current force window as a tolerant-seek retry. When
+    /// `true`, expiry without a frame does NOT fire `onSeekStuck` again,
+    /// preventing an infinite retry loop on persistently broken content.
+    private var forceWindowIsRetry = false
+
     /// Fired when the force window expires without a frame; caller should
-    /// retry the seek with tolerance.
+    /// retry the seek with tolerance. Suppressed for retry windows.
     var onSeekStuck: ((CMTime) -> Void)?
 
     init(
@@ -86,10 +94,13 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
     /// Opens a 600 ms force window after a seek and requests a delegate
     /// notification, so the texture updates even while paused. Pass the
     /// exact seek target — used directly in `outputMediaDataWillChange`.
-    func forceRefresh(for seekTime: CMTime) {
+    /// Pass `isRetry: true` for a tolerant-seek retry; suppresses
+    /// `onSeekStuck` on expiry to break recovery loops.
+    func forceRefresh(for seekTime: CMTime, isRetry: Bool = false) {
         pendingSeekTime = seekTime
-        forceRefreshDeadline = Date(timeIntervalSinceNow: 0.6)
+        forceRefreshDeadline = CACurrentMediaTime() + 0.6
         forceWindowFailCount = 0
+        forceWindowIsRetry = isRetry
         videoOutput?.requestNotificationOfMediaDataChange(withAdvanceInterval: 0)
     }
 
@@ -125,7 +136,7 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
             return
         }
         pendingSeekTime = .invalid
-        forceRefreshDeadline = .distantPast
+        forceRefreshDeadline = 0
         forceWindowFailCount = 0
         deliverFrame(pixelBuffer)
     }
@@ -170,13 +181,13 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
 
         let itemTime = player.currentTime()
 
-        if Date() < forceRefreshDeadline {
+        if CACurrentMediaTime() < forceRefreshDeadline {
             if let pixelBuffer = output.copyPixelBuffer(
                 forItemTime: itemTime,
                 itemTimeForDisplay: nil
             ) {
                 pendingSeekTime = .invalid
-                forceRefreshDeadline = .distantPast
+                forceRefreshDeadline = 0
                 forceWindowFailCount = 0
                 deliverFrame(pixelBuffer)
             } else {
@@ -187,9 +198,13 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
 
         if forceWindowFailCount > 0 {
             let stuckTime = itemTime
+            let wasRetry = forceWindowIsRetry
             forceWindowFailCount = 0
-            DispatchQueue.main.async { [weak self] in
-                self?.onSeekStuck?(stuckTime)
+            forceWindowIsRetry = false
+            if !wasRetry {
+                DispatchQueue.main.async { [weak self] in
+                    self?.onSeekStuck?(stuckTime)
+                }
             }
         }
 


### PR DESCRIPTION
Closes #3467

## Description

Resolved an issue where, when a user had multiple clips and slowly scrolled from one clip to the next, the video preview would get stuck on iOS at that position until the user scrolled back to the first clip.

### Incidental fix

`VideoTextureOutput.attach(to:)` (iOS + macOS) now detaches the previous output via `prev.remove(old)` instead of `item.remove(old)`. The old call was a silent no-op because `old` had been added to the previous item, not the new one — flagging here so future bisects don't conflate this with the seek-stuck fix.

**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
