### PR TITLE
fix(profile_repository): cap name-server HTTP calls at 10s timeout

### DIFF
--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -21,6 +21,11 @@ const _usernameClaimUrl = 'https://names.divine.video/api/username/claim';
 const _usernameCheckUrl = 'https://names.divine.video/api/username/check';
 const _keycastNip05Url = 'https://login.divine.video/.well-known/nostr.json';
 
+// Caps name-server HTTP calls so a slow or unreachable endpoint surfaces a
+// fast UsernameClaimError / UsernameCheckError instead of waiting on the
+// platform's TCP timeout (~20s on Android).
+const _nameServerHttpTimeout = Duration(seconds: 10);
+
 // TODO(search): Move ProfileSearchFilter to a shared package
 // (e.g., search_utils) when we need to reuse search logic across
 // multiple repositories.
@@ -549,14 +554,16 @@ class ProfileRepository {
 
     final Response response;
     try {
-      response = await _httpClient.post(
-        Uri.parse(_usernameClaimUrl),
-        headers: {
-          'Authorization': authHeader,
-          'Content-Type': 'application/json',
-        },
-        body: payload,
-      );
+      response = await _httpClient
+          .post(
+            Uri.parse(_usernameClaimUrl),
+            headers: {
+              'Authorization': authHeader,
+              'Content-Type': 'application/json',
+            },
+            body: payload,
+          )
+          .timeout(_nameServerHttpTimeout);
 
       // Parse server error message if available
       String? serverError;
@@ -625,9 +632,9 @@ class ProfileRepository {
     // Server-side check using the name-server API which validates format
     // and checks availability in one call.
     try {
-      final response = await _httpClient.get(
-        Uri.parse('$_usernameCheckUrl/$normalizedUsername'),
-      );
+      final response = await _httpClient
+          .get(Uri.parse('$_usernameCheckUrl/$normalizedUsername'))
+          .timeout(_nameServerHttpTimeout);
 
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
@@ -639,9 +646,9 @@ class ProfileRepository {
           // Also check keycast (login.divine.video) — username must be
           // available on both the name server and the login server.
           try {
-            final keycastResponse = await _httpClient.get(
-              Uri.parse('$_keycastNip05Url?name=$normalizedUsername'),
-            );
+            final keycastResponse = await _httpClient
+                .get(Uri.parse('$_keycastNip05Url?name=$normalizedUsername'))
+                .timeout(_nameServerHttpTimeout);
             if (keycastResponse.statusCode == 200) {
               final keycastData =
                   jsonDecode(keycastResponse.body) as Map<String, dynamic>;

--- a/mobile/packages/profile_repository/pubspec.yaml
+++ b/mobile/packages/profile_repository/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 resolution: workspace
 
 dev_dependencies:
+  fake_async: ^1.3.3
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 // Hide Drift table class to avoid collision with ProfileStats domain model.
 import 'package:db_client/db_client.dart' hide Filter, ProfileStats;
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:http/http.dart';
@@ -3290,6 +3291,56 @@ void main() {
           ),
         );
       });
+
+      test('returns UsernameClaimError when the POST exceeds the timeout', () {
+        fakeAsync((async) {
+          when(
+            () => mockNostrClient.createNip98AuthHeader(
+              url: any(named: 'url'),
+              method: any(named: 'method'),
+              payload: any(named: 'payload'),
+            ),
+          ).thenAnswer((_) => Future.value('authHeader'));
+          when(
+            () => mockHttpClient.post(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            ),
+          ).thenAnswer((_) async {
+            // Simulates an unresponsive name server: never resolves within
+            // the repository's _nameServerHttpTimeout (10s).
+            await Future<void>.delayed(const Duration(minutes: 5));
+            return Response('unused', 200);
+          });
+
+          UsernameClaimResult? result;
+          unawaited(
+            profileRepository
+                .claimUsername(username: 'username')
+                .then((r) => result = r),
+          );
+
+          // Below the 10s repository timeout — call still pending.
+          async
+            ..elapse(const Duration(seconds: 9))
+            ..flushMicrotasks();
+          expect(result, isNull);
+
+          // Crosses the 10s repository timeout.
+          async
+            ..elapse(const Duration(seconds: 2))
+            ..flushMicrotasks();
+          expect(
+            result,
+            isA<UsernameClaimError>().having(
+              (e) => e.message,
+              'message',
+              contains('TimeoutException'),
+            ),
+          );
+        });
+      });
     });
 
     group('UsernameClaimResult', () {
@@ -3686,6 +3737,50 @@ void main() {
 
         expect(result, equals(const UsernameTaken()));
       });
+
+      test(
+        'returns UsernameCheckError when the GET exceeds the timeout',
+        () {
+          fakeAsync((async) {
+            when(
+              () => mockHttpClient.get(
+                Uri.parse(
+                  'https://names.divine.video/api/username/check/testuser',
+                ),
+              ),
+            ).thenAnswer((_) async {
+              // Simulates an unresponsive name server: never resolves within
+              // the repository's _nameServerHttpTimeout (10s).
+              await Future<void>.delayed(const Duration(minutes: 5));
+              return Response('unused', 200);
+            });
+
+            UsernameAvailabilityResult? result;
+            unawaited(
+              profileRepository
+                  .checkUsernameAvailability(username: 'testuser')
+                  .then((r) => result = r),
+            );
+
+            async
+              ..elapse(const Duration(seconds: 9))
+              ..flushMicrotasks();
+            expect(result, isNull);
+
+            async
+              ..elapse(const Duration(seconds: 2))
+              ..flushMicrotasks();
+            expect(
+              result,
+              isA<UsernameCheckError>().having(
+                (e) => e.message,
+                'message',
+                contains('TimeoutException'),
+              ),
+            );
+          });
+        },
+      );
     });
 
     group('UsernameAvailabilityResult', () {


### PR DESCRIPTION
Relates to #3152 and #3161.

## Description

Hardens the three `names.divine.video` HTTP calls in
`profile_repository.dart` against a slow or unresponsive name-server
by adding an explicit 10s `.timeout(_nameServerHttpTimeout)`. Without
this, when the endpoint stops responding the call hangs until the
platform's TCP timeout (~20s on Android), surfacing as a long wait
followed by a generic error.

**Defense-in-depth, not a fix for the reported tickets.** A deeper
investigation revealed that the actual symptom in the linked tickets —
"can't save username, error after waiting" — is reproduced by a
*different* failure mode: kind 0 profile publish fails fast when no
relays are connected, and the BLoC short-circuits before reaching
the username claim path that this PR touches. Field log evidence
shows the BLoC emitting `ProfilePublishFailedException` within
~400ms per attempt — not a 20-second TCP hang. The "20 seconds" in
the original report was almost certainly cumulative across multiple
retries, not a single network timeout.

This PR still ships on its own merits — it eliminates a real, if
rare, 20-second hang for any user whose `names.divine.video`
specifically is degraded — and lays groundwork for the proper fix
which now tracks separately in #3469.

## Why this is not a fix for the reported tickets

`ProfileEditorBloc._saveProfile` runs in three steps:

1. Publish kind 0 profile event via Nostr relays.
2. (Skipped if no username.)
3. POST `/api/username/claim` to `names.divine.video` to bind the
   username to the user's pubkey.

If step 1 throws, the BLoC emits `ProfileEditorError.publishFailed`
and **returns before step 3 runs**
(`profile_editor_bloc.dart:392-419`). Step 1 throws
`ProfilePublishFailedException` whenever
`NostrClient.sendProfile()` returns null, which it does when no
relays are connected after a single reconnection attempt
(`nostr_client.dart:254-262`).

The duplicate ticket's log buffer captures the failing branch
directly:

```
17:36:21  ❌ No connected relays - cannot create subscription
17:37:08  ❌ Failed to publish profile: ProfilePublishFailedException
17:37:13  ❌ Failed to publish profile: ProfilePublishFailedException
...
17:38:02.589  📝 saveProfile: displayName=bhecky, username=bhecky
17:38:02.995  ❌ Failed to publish profile: ProfilePublishFailedException  (406 ms)
```

Each individual attempt fails in well under a second. The HTTP claim
path this PR touches is never reached. The proper fix (BLoC
distinguishing "no relays connected" from generic publish failure
and surfacing an actionable error) tracks in #3469.

## What changed

- New constant `_nameServerHttpTimeout = Duration(seconds: 10)` in
  `profile_repository.dart`, alongside the existing URL constants.
- `claimUsername()` POST and `checkUsernameAvailability()`'s two
  GETs now chain `.timeout(_nameServerHttpTimeout)`.
- Added `fake_async` as a dev dep (matches `follow_repository` and
  `videos_repository`).
- Two new tests in `profile_repository_test.dart` lock in the
  timeout behavior using `fakeAsync`:
  - `claimUsername` returns `UsernameClaimError` containing
    `TimeoutException` once virtual time crosses 10s.
  - `checkUsernameAvailability` does the same for
    `UsernameCheckError`.

## Why 10s

Comfortable above P99 for a sub-1KB JSON request to a CDN-fronted
endpoint, well below the ~20s Android TCP timeout that surfaces
today. Tunable in one place if real-world traffic shows otherwise.

## Test plan

Unit:

- [x] `flutter test packages/profile_repository/test/src/profile_repository_test.dart` — 167/167 pass (incl. 2 new timeout tests)
- [x] `flutter test test/blocs/profile_editor` — 67/67 pass (consumer)
- [x] `flutter analyze` clean at package and `mobile/lib test integration_test` level

Real-device sanity (Android, against prod `names.divine.video`):

- [x] Fresh claim of an unused username → success in ~2.7s, NIP-05 set on profile.
- [x] Re-saving the same username already owned by the pubkey → success in ~2.2s. Confirms server idempotency — re-claiming a name owned by your own pubkey returns 200, so a hypothetical lost-response scenario does not strand the user.

Slow-server simulation (proxy-throttle the name-server endpoint to
respond past 10s) — to be done by reviewer / QA. Expected: error
appears at ~10s rather than ~20s, same error variant as today.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue) — fixes a latent timeout gap; does not auto-close the user-reported tickets.

## Out of scope / follow-ups

- **Real fix for the user-reported tickets.** Tracked in #3469 — the
  BLoC needs to distinguish "no relays connected" from generic
  publish failure and either retry reconnection more aggressively
  or surface an actionable error to the user. Optional but stronger:
  switch `sendProfile` to `publishEventAwaitOk` so we know the kind
  0 actually persisted on at least one relay.
- **Partial-save flap.** `_saveProfile` publishes kind 0 *before*
  claiming. On claim failure the BLoC re-publishes kind 0 to roll
  back. This PR shortens the failure window from ~20s to ~10s but
  does not change the ordering. The cleaner long-term fix is to
  claim first, then publish kind 0.
- `app_providers.dart` `Client()` is unchanged. The `http` package's
  `Client()` factory does not accept a `timeout` parameter, so a
  per-call `.timeout(...)` is the correct minimal fix.