### PR TITLE
fix(notifications): derive inbox badge from consolidated unread list

### DIFF
--- a/mobile/lib/providers/relay_notifications_provider.dart
+++ b/mobile/lib/providers/relay_notifications_provider.dart
@@ -1060,11 +1060,26 @@ RelayNotificationApiService relayNotificationApiService(Ref ref) {
   );
 }
 
-/// Provider to get current unread notification count
+/// Provider to get the inbox unread badge count.
+///
+/// Derives from the consolidated visible list, not the server's raw
+/// `unreadCount`. The server reports one row per Kind 3 republish per
+/// follower — so the same N followers can produce 2N+ rows after a few
+/// contact-list edits, even though `_consolidateFollowNotifications`
+/// has already merged them on screen. Counting unread items in the
+/// post-consolidation list keeps the badge in sync with what the user
+/// actually sees.
+///
+// TODO(funnelcake#234): Revert to `state.unreadCount` once server-side
+// Kind 3 republish dedup ships and the visible list and server count
+// agree again. Tracking: divinevideo/divine-funnelcake#234.
 @riverpod
 int relayNotificationUnreadCount(Ref ref) {
   final asyncState = ref.watch(relayNotificationsProvider);
-  return asyncState.whenOrNull(data: (state) => state.unreadCount) ?? 0;
+  return asyncState.whenOrNull(
+        data: (state) => state.notifications.where((n) => !n.isRead).length,
+      ) ??
+      0;
 }
 
 /// Provider to check if notifications are loading

--- a/mobile/lib/providers/relay_notifications_provider.g.dart
+++ b/mobile/lib/providers/relay_notifications_provider.g.dart
@@ -168,18 +168,54 @@ final class RelayNotificationApiServiceProvider
 String _$relayNotificationApiServiceHash() =>
     r'8a7a6103fecbdfe08649ef6869a43fd27aa4f410';
 
-/// Provider to get current unread notification count
+/// Provider to get the inbox unread badge count.
+///
+/// Derives from the consolidated visible list, not the server's raw
+/// `unreadCount`. The server reports one row per Kind 3 republish per
+/// follower — so the same N followers can produce 2N+ rows after a few
+/// contact-list edits, even though `_consolidateFollowNotifications`
+/// has already merged them on screen. Counting unread items in the
+/// post-consolidation list keeps the badge in sync with what the user
+/// actually sees.
+///
+// TODO(funnelcake#234): Revert to `state.unreadCount` once server-side
+// Kind 3 republish dedup ships and the visible list and server count
+// agree again. Tracking: divinevideo/divine-funnelcake#234.
 
 @ProviderFor(relayNotificationUnreadCount)
 const relayNotificationUnreadCountProvider =
     RelayNotificationUnreadCountProvider._();
 
-/// Provider to get current unread notification count
+/// Provider to get the inbox unread badge count.
+///
+/// Derives from the consolidated visible list, not the server's raw
+/// `unreadCount`. The server reports one row per Kind 3 republish per
+/// follower — so the same N followers can produce 2N+ rows after a few
+/// contact-list edits, even though `_consolidateFollowNotifications`
+/// has already merged them on screen. Counting unread items in the
+/// post-consolidation list keeps the badge in sync with what the user
+/// actually sees.
+///
+// TODO(funnelcake#234): Revert to `state.unreadCount` once server-side
+// Kind 3 republish dedup ships and the visible list and server count
+// agree again. Tracking: divinevideo/divine-funnelcake#234.
 
 final class RelayNotificationUnreadCountProvider
     extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
-  /// Provider to get current unread notification count
+  /// Provider to get the inbox unread badge count.
+  ///
+  /// Derives from the consolidated visible list, not the server's raw
+  /// `unreadCount`. The server reports one row per Kind 3 republish per
+  /// follower — so the same N followers can produce 2N+ rows after a few
+  /// contact-list edits, even though `_consolidateFollowNotifications`
+  /// has already merged them on screen. Counting unread items in the
+  /// post-consolidation list keeps the badge in sync with what the user
+  /// actually sees.
+  ///
+  // TODO(funnelcake#234): Revert to `state.unreadCount` once server-side
+  // Kind 3 republish dedup ships and the visible list and server count
+  // agree again. Tracking: divinevideo/divine-funnelcake#234.
   const RelayNotificationUnreadCountProvider._()
     : super(
         from: null,
@@ -214,7 +250,7 @@ final class RelayNotificationUnreadCountProvider
 }
 
 String _$relayNotificationUnreadCountHash() =>
-    r'ef90b461acd34548961a32c49924d10e62764927';
+    r'655a7aa957d76849af10895bb85dc0689f528c03';
 
 /// Provider to check if notifications are loading
 

--- a/mobile/test/providers/relay_notifications_provider_test.dart
+++ b/mobile/test/providers/relay_notifications_provider_test.dart
@@ -899,32 +899,133 @@ void main() {
     });
 
     group('Helper Providers', () {
-      test('relayNotificationUnreadCount returns correct count', () async {
-        when(
-          () => mockApiService.getNotifications(
-            pubkey: any(named: 'pubkey'),
-            types: any(named: 'types'),
-            unreadOnly: any(named: 'unreadOnly'),
-            limit: any(named: 'limit'),
-            before: any(named: 'before'),
-          ),
-        ).thenAnswer(
-          (_) async =>
-              const NotificationsResponse(notifications: [], unreadCount: 42),
-        );
+      test(
+        'relayNotificationUnreadCount derives from the consolidated unread list, '
+        'not the server-reported count',
+        () async {
+          // Server returns 5 follow rows from 2 distinct pubkeys (Kind 3
+          // republish bug — funnelcake#234) and reports unreadCount: 5.
+          // After follow consolidation the visible list has 2 rows; the
+          // badge must reflect what the user sees, not what the server says.
+          when(
+            () => mockApiService.getNotifications(
+              pubkey: any(named: 'pubkey'),
+              types: any(named: 'types'),
+              unreadOnly: any(named: 'unreadOnly'),
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer(
+            (_) async => NotificationsResponse(
+              notifications: [
+                createMockRelayNotification(
+                  id: 'follow_a_1',
+                  notificationType: 'follow',
+                  sourcePubkey: 'follower_a',
+                  createdAtSeconds: 1700000100,
+                ),
+                createMockRelayNotification(
+                  id: 'follow_a_2',
+                  notificationType: 'follow',
+                  sourcePubkey: 'follower_a',
+                  createdAtSeconds: 1700000200,
+                ),
+                createMockRelayNotification(
+                  id: 'follow_a_3',
+                  notificationType: 'follow',
+                  sourcePubkey: 'follower_a',
+                  createdAtSeconds: 1700000300,
+                ),
+                createMockRelayNotification(
+                  id: 'follow_b_1',
+                  notificationType: 'follow',
+                  sourcePubkey: 'follower_b',
+                  createdAtSeconds: 1700000150,
+                ),
+                createMockRelayNotification(
+                  id: 'follow_b_2',
+                  notificationType: 'follow',
+                  sourcePubkey: 'follower_b',
+                  createdAtSeconds: 1700000250,
+                ),
+              ],
+              unreadCount: 5,
+            ),
+          );
 
-        final container = createTestContainer();
+          final container = createTestContainer();
+          await waitForLoadComplete(container);
 
-        // Wait for provider to load
-        await waitForLoadComplete(container);
+          final unreadCount = container.read(
+            relayNotificationUnreadCountProvider,
+          );
 
-        final unreadCount = container.read(
-          relayNotificationUnreadCountProvider,
-        );
-        expect(unreadCount, 42);
+          // 2 distinct pubkeys after consolidation, both unread.
+          expect(unreadCount, 2);
 
-        container.dispose();
-      });
+          container.dispose();
+        },
+      );
+
+      test(
+        'relayNotificationUnreadCount drops to 0 when notifications list is empty '
+        'even if server reports unread items',
+        () async {
+          when(
+            () => mockApiService.getNotifications(
+              pubkey: any(named: 'pubkey'),
+              types: any(named: 'types'),
+              unreadOnly: any(named: 'unreadOnly'),
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer(
+            (_) async => const NotificationsResponse(
+              notifications: [],
+              unreadCount: 42,
+            ),
+          );
+
+          final container = createTestContainer();
+          await waitForLoadComplete(container);
+
+          expect(container.read(relayNotificationUnreadCountProvider), 0);
+
+          container.dispose();
+        },
+      );
+
+      test(
+        'relayNotificationUnreadCount excludes already-read notifications',
+        () async {
+          when(
+            () => mockApiService.getNotifications(
+              pubkey: any(named: 'pubkey'),
+              types: any(named: 'types'),
+              unreadOnly: any(named: 'unreadOnly'),
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer(
+            (_) async => NotificationsResponse(
+              notifications: [
+                createMockRelayNotification(id: 'unread_1'),
+                createMockRelayNotification(id: 'unread_2'),
+                createMockRelayNotification(id: 'read_1', read: true),
+              ],
+              unreadCount: 3,
+            ),
+          );
+
+          final container = createTestContainer();
+          await waitForLoadComplete(container);
+
+          // 2 unread out of 3, regardless of server's unreadCount.
+          expect(container.read(relayNotificationUnreadCountProvider), 2);
+
+          container.dispose();
+        },
+      );
 
       test('relayNotificationsLoading reflects loading state', () async {
         when(


### PR DESCRIPTION
## Description

The inbox segmented-toggle badge was reading `state.unreadCount`, which the provider sets straight from the server's `response.unreadCount`. After Kind 3 republishes — every follow/unfollow republishes the entire NIP-02 contact list — the server emits one notification row per existing follow, all with fresh `source_created_at` and distinct `source_event_id` values, and `unread_count` counts every duplicate. The visible list has been deduped per source pubkey since [#2774](https://github.com/divinevideo/divine-mobile/pull/2774) (`_consolidateFollowNotifications`), so badge and list disagree — users with 9 followers were seeing 20+ on the badge.

This PR derives the badge from the consolidated unread list instead. Server-truth `state.unreadCount` is left in place as the diagnostic source and as the revert target once funnelcake#234 ships.

**Related Issue:** Relates to #3151
**Upstream tracking:** [divinevideo/divine-funnelcake#234](https://github.com/divinevideo/divine-funnelcake/issues/234) (server-side Kind 3 republish dedup — still OPEN)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Notes

- Issue #3151 stays open: this PR addresses the badge mismatch only. The duplicate-rows complaint ("notifications stay for a long time") and the source-asymmetry between profile follower count and notifications feed remain blocked on funnelcake#234.
- Same gap exists in the gated-off BLoC stack at [`notification_feed_bloc.dart`](mobile/lib/notifications/bloc/notification_feed_bloc.dart) — preemptive port can land in a follow-up once this merges so the migration does not reintroduce the bug.

## Test plan

- [x] New unit test: 5 follow rows from 2 distinct pubkeys + `unreadCount: 5` → derived provider returns 2.
- [x] New unit test: empty notifications list + server `unreadCount: 42` → derived returns 0.
- [x] New unit test: mixed read/unread → derived counts only unread.
- [x] `dart format` / `flutter analyze` clean on changed files.
- [x] `flutter test test/providers/relay_notifications_provider_test.dart` — 39 / 39 pass.