### PR TITLE
perf(video-editor): improve the general video-editor performance

### DIFF
--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -39,15 +39,10 @@ import 'package:unified_logger/unified_logger.dart';
 ///
 /// Wraps [ProImageEditor] and configures it for video editing with custom
 /// styling and callbacks that dispatch events to [VideoEditorMainBloc].
-class VideoEditorCanvas extends StatefulWidget {
+class VideoEditorCanvas extends StatelessWidget {
   /// Creates a [VideoEditorCanvas].
   const VideoEditorCanvas({super.key});
 
-  @override
-  State<VideoEditorCanvas> createState() => _VideoEditorCanvasState();
-}
-
-class _VideoEditorCanvasState extends State<VideoEditorCanvas> {
   @override
   Widget build(BuildContext context) {
     final isSubEditorOpen = context.select(
@@ -64,12 +59,24 @@ class _VideoEditorCanvasState extends State<VideoEditorCanvas> {
           bloc.add(const VideoEditorMainSubEditorClosed());
         }
       },
-      child: Padding(
-        padding: .only(top: MediaQuery.viewPaddingOf(context).top),
-        child: _CanvasFitter(
-          builder: (bodySize, renderSize) =>
-              _VideoEditor(renderSize: renderSize, bodySize: bodySize),
-        ),
+      // Const child: Flutter detects identical() widget and skips the
+      // rebuild cascade (_CanvasFitter → LayoutBuilder → _VideoEditorState)
+      // when only isSubEditorOpen changes.
+      child: const _CanvasBody(),
+    );
+  }
+}
+
+class _CanvasBody extends StatelessWidget {
+  const _CanvasBody();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: .only(top: MediaQuery.viewPaddingOf(context).top),
+      child: _CanvasFitter(
+        builder: (bodySize, renderSize) =>
+            _VideoEditor(renderSize: renderSize, bodySize: bodySize),
       ),
     );
   }

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -115,6 +115,12 @@ class _VideoEditorTimelineClipStripState
   /// for. Used to ensure each split is processed exactly once.
   ClipSplitEvent? _lastSeededSplit;
 
+  /// Memoized slot-timestamp result — only recomputed when [widget.clips]
+  /// identity or [widget.pixelsPerSecond] changes.
+  List<DivineVideoClip>? _prevSlotClips;
+  double? _prevSlotPps;
+  Map<String, List<Duration>> _cachedSlotTimestamps = const {};
+
   static const double _reorderSize = TimelineConstants.thumbnailStripHeight;
 
   // Auto-scroll state.
@@ -159,10 +165,17 @@ class _VideoEditorTimelineClipStripState
   }
 
   void _syncThumbnails() {
+    final clips = widget.clips;
+    final pps = widget.pixelsPerSecond;
+    if (!identical(_prevSlotClips, clips) || _prevSlotPps != pps) {
+      _prevSlotClips = clips;
+      _prevSlotPps = pps;
+      _cachedSlotTimestamps = _computeSlotTimestamps();
+    }
     _thumbnails.sync(
-      clips: widget.clips,
+      clips: clips,
       devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
-      priorityTimestamps: _computeSlotTimestamps(),
+      priorityTimestamps: _cachedSlotTimestamps,
     );
   }
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -379,6 +379,8 @@ class _ClipContainer extends StatelessWidget {
     final slotWidth = contentWidth < displayWidth
         ? math.max(TimelineConstants.thumbnailWidth, displayWidth / count)
         : TimelineConstants.thumbnailWidth;
+    final dpr = MediaQuery.devicePixelRatioOf(context);
+    final cacheH = (TimelineConstants.thumbnailStripHeight * dpr).round();
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -387,6 +389,7 @@ class _ClipContainer extends StatelessWidget {
             width: slotWidth,
             height: TimelineConstants.thumbnailStripHeight,
             child: _ThumbnailImage(
+              cacheHeight: cacheH,
               thumbnailPath: clip.thumbnailPath,
               stripThumbnailPath: _thumbnailForSlot(i, count),
             ),
@@ -397,8 +400,13 @@ class _ClipContainer extends StatelessWidget {
 }
 
 class _ThumbnailImage extends StatelessWidget {
-  const _ThumbnailImage({required this.thumbnailPath, this.stripThumbnailPath});
+  const _ThumbnailImage({
+    required this.cacheHeight,
+    required this.thumbnailPath,
+    this.stripThumbnailPath,
+  });
 
+  final int cacheHeight;
   final String? thumbnailPath;
   final String? stripThumbnailPath;
 
@@ -408,6 +416,7 @@ class _ThumbnailImage extends StatelessWidget {
         ? Image.file(
             File(thumbnailPath!),
             fit: BoxFit.cover,
+            cacheHeight: cacheHeight,
             excludeFromSemantics: true,
             errorBuilder: (_, _, _) =>
                 const ColoredBox(color: VineTheme.surfaceContainerHigh),
@@ -419,6 +428,7 @@ class _ThumbnailImage extends StatelessWidget {
     return Image.file(
       File(stripThumbnailPath!),
       fit: BoxFit.cover,
+      cacheHeight: cacheHeight,
       gaplessPlayback: true,
       excludeFromSemantics: true,
       errorBuilder: (_, _, _) => fallback,

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_item.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_item.dart
@@ -195,18 +195,20 @@ class _SoundContent extends StatelessWidget {
                     minWidth: 0,
                     maxWidth: waveformWidth,
                     alignment: .centerLeft,
-                    child: SizedBox(
-                      width: waveformWidth,
-                      child: CustomPaint(
-                        painter: StereoWaveformPainter(
-                          leftChannel: leftChannel ?? Float32List(0),
-                          rightChannel: rightChannel,
-                          progress: 1,
-                          activeColor: VineTheme.accentPurple,
-                          inactiveColor: VineTheme.accentPurple,
-                          audioDuration: effectiveMax,
-                          maxDuration: effectiveMax,
-                          barWidth: TimelineConstants.soundWaveformBarWidth,
+                    child: RepaintBoundary(
+                      child: SizedBox(
+                        width: waveformWidth,
+                        child: CustomPaint(
+                          painter: StereoWaveformPainter(
+                            leftChannel: leftChannel ?? Float32List(0),
+                            rightChannel: rightChannel,
+                            progress: 1,
+                            activeColor: VineTheme.accentPurple,
+                            inactiveColor: VineTheme.accentPurple,
+                            audioDuration: effectiveMax,
+                            maxDuration: effectiveMax,
+                            barWidth: TimelineConstants.soundWaveformBarWidth,
+                          ),
                         ),
                       ),
                     ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strip.dart
@@ -232,15 +232,8 @@ class _TimelineOverlayStripState extends State<TimelineOverlayStrip> {
               return TimelineDropIndicatorLine(lineY: y);
             },
           ),
-          // Each item always lives in a ValueListenableBuilder with a
-          // stable key — ValueKey(item.id) — so its element is never
-          // unmounted when _draggingId changes.  Unmounting would kill
-          // the active GestureRecognizer mid-gesture (first long-press
-          // gives haptic but move is swallowed).
-          //
-          // For non-dragged items the builder returns the pre-built
-          // `child` widget.  Flutter detects the identical instance and
-          // skips rebuilding that subtree on every drag-move frame.
+          // Stable ValueKey + child: keeps elements mounted across
+          // drag-state changes and reuses non-dragged subtrees.
           for (final item in sortedItems)
             ValueListenableBuilder<_DragPos>(
               key: ValueKey(item.id),

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strip.dart
@@ -137,11 +137,9 @@ class _TimelineOverlayStripState extends State<TimelineOverlayStrip> {
   /// The item currently being dragged, or `null`.
   String? _draggingId;
 
-  /// Snapped horizontal position (item start ms) returned by the snap controller.
-  int _snappedStartMs = 0;
-
-  /// Accumulated vertical drag offset in pixels.
-  double _dragDeltaY = 0;
+  /// Live drag position — updated every gesture frame via the notifier
+  /// so only the dragged item and drop indicator rebuild, not the full strip.
+  final _dragPosition = ValueNotifier<_DragPos>(_DragPos.zero);
 
   /// The row the item was on when the drag started.
   int _dragStartRow = 0;
@@ -182,11 +180,14 @@ class _TimelineOverlayStripState extends State<TimelineOverlayStrip> {
   void didUpdateWidget(TimelineOverlayStrip oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.pixelsPerSecond != widget.pixelsPerSecond) {
-      _dragSnap = TimelineSnapController(
-        direction: SnapEdgeDirection.positive,
-        pixelsPerSecond: widget.pixelsPerSecond,
-      );
+      _dragSnap.pixelsPerSecond = widget.pixelsPerSecond;
     }
+  }
+
+  @override
+  void dispose() {
+    _dragPosition.dispose();
+    super.dispose();
   }
 
   double get _trimExpansion => widget.selectedItemId != null
@@ -213,7 +214,7 @@ class _TimelineOverlayStripState extends State<TimelineOverlayStrip> {
     if (widget.items.isEmpty) return const SizedBox.shrink();
 
     final displayRowCount = widget.isCollapsed ? 1 : widget.rowCount;
-    final dropIndicatorLineY = _dropIndicatorLineY();
+    final sortedItems = _sortedItems();
 
     return SizedBox(
       width: widget.totalWidth,
@@ -221,33 +222,76 @@ class _TimelineOverlayStripState extends State<TimelineOverlayStrip> {
       child: Stack(
         clipBehavior: .none,
         children: [
-          // Drop indicator line — only visible during drag.
-          if (dropIndicatorLineY != null)
-            TimelineDropIndicatorLine(lineY: dropIndicatorLineY),
-          // Paint selected item last so its trim handles are never
-          // obscured by adjacent items.
-          for (final item in _sortedItems())
-            TimelineOverlayPositionedItem(
+          // Drop indicator — rebuilt only when drag position changes,
+          // not on every parent setState (drag start / end only).
+          ValueListenableBuilder<_DragPos>(
+            valueListenable: _dragPosition,
+            builder: (context, _, __) {
+              final y = _dropIndicatorLineY();
+              if (y == null) return const SizedBox.shrink();
+              return TimelineDropIndicatorLine(lineY: y);
+            },
+          ),
+          // Each item always lives in a ValueListenableBuilder with a
+          // stable key — ValueKey(item.id) — so its element is never
+          // unmounted when _draggingId changes.  Unmounting would kill
+          // the active GestureRecognizer mid-gesture (first long-press
+          // gives haptic but move is swallowed).
+          //
+          // For non-dragged items the builder returns the pre-built
+          // `child` widget.  Flutter detects the identical instance and
+          // skips rebuilding that subtree on every drag-move frame.
+          for (final item in sortedItems)
+            ValueListenableBuilder<_DragPos>(
               key: ValueKey(item.id),
-              item: item,
-              isDragging: _draggingId == item.id,
-              isSelected: widget.selectedItemId == item.id,
-              snappedStartMs: _snappedStartMs,
-              dragDeltaY: _dragDeltaY,
-              rowHeight: _effectiveRowHeight,
-              pixelsPerSecond: widget.pixelsPerSecond,
-              totalDuration: widget.totalDuration,
-              color: widget.color,
-              isCollapsed: widget.isCollapsed,
-              trimExpansion: _trimExpansion,
-              snapPointsMs: widget.snapPointsMs,
-              onTrimChanged: widget.onTrimChanged,
-              onTrimDragChanged: widget.onTrimDragChanged,
-              onTap: () => widget.onItemTapped?.call(item),
-              onLongPressStart: () => _onLongPressStart(item),
-              onLongPressMoveUpdate: (details) =>
-                  _onLongPressMoveUpdate(details, item, displayRowCount),
-              onLongPressEnd: () => _onLongPressEnd(item),
+              valueListenable: _dragPosition,
+              builder: (context, pos, child) {
+                if (_draggingId == item.id) {
+                  return TimelineOverlayPositionedItem(
+                    item: item,
+                    isDragging: true,
+                    isSelected: widget.selectedItemId == item.id,
+                    snappedStartMs: pos.startMs,
+                    dragDeltaY: pos.deltaY,
+                    rowHeight: _effectiveRowHeight,
+                    pixelsPerSecond: widget.pixelsPerSecond,
+                    totalDuration: widget.totalDuration,
+                    color: widget.color,
+                    isCollapsed: widget.isCollapsed,
+                    trimExpansion: _trimExpansion,
+                    snapPointsMs: widget.snapPointsMs,
+                    onTrimChanged: widget.onTrimChanged,
+                    onTrimDragChanged: widget.onTrimDragChanged,
+                    onTap: () => widget.onItemTapped?.call(item),
+                    onLongPressStart: () => _onLongPressStart(item),
+                    onLongPressMoveUpdate: (details) =>
+                        _onLongPressMoveUpdate(details, item, displayRowCount),
+                    onLongPressEnd: () => _onLongPressEnd(item),
+                  );
+                }
+                return child!;
+              },
+              child: TimelineOverlayPositionedItem(
+                item: item,
+                isDragging: false,
+                isSelected: widget.selectedItemId == item.id,
+                snappedStartMs: 0,
+                dragDeltaY: 0,
+                rowHeight: _effectiveRowHeight,
+                pixelsPerSecond: widget.pixelsPerSecond,
+                totalDuration: widget.totalDuration,
+                color: widget.color,
+                isCollapsed: widget.isCollapsed,
+                trimExpansion: _trimExpansion,
+                snapPointsMs: widget.snapPointsMs,
+                onTrimChanged: widget.onTrimChanged,
+                onTrimDragChanged: widget.onTrimDragChanged,
+                onTap: () => widget.onItemTapped?.call(item),
+                onLongPressStart: () => _onLongPressStart(item),
+                onLongPressMoveUpdate: (details) =>
+                    _onLongPressMoveUpdate(details, item, displayRowCount),
+                onLongPressEnd: () => _onLongPressEnd(item),
+              ),
             ),
         ],
       ),
@@ -261,11 +305,12 @@ class _TimelineOverlayStripState extends State<TimelineOverlayStrip> {
     if (draggedItem.isEmpty) return null;
 
     final item = draggedItem.first;
+    final pos = _dragPosition.value;
 
     final maxStartMs = (widget.totalDuration - item.duration).inMilliseconds;
-    final newStartMs = _snappedStartMs.clamp(0, maxStartMs);
+    final newStartMs = pos.startMs.clamp(0, maxStartMs);
 
-    final rowDelta = (_dragDeltaY / _effectiveRowHeight).round();
+    final rowDelta = (pos.deltaY / _effectiveRowHeight).round();
     final unclampedRow = _dragStartRow + rowDelta;
     final targetRow = math.max(0, unclampedRow);
 
@@ -276,7 +321,7 @@ class _TimelineOverlayStripState extends State<TimelineOverlayStrip> {
     if (unclampedRow < 0) {
       insertAbove = true;
     } else {
-      final subRowOffset = _dragDeltaY / _effectiveRowHeight - rowDelta;
+      final subRowOffset = pos.deltaY / _effectiveRowHeight - rowDelta;
       insertAbove = subRowOffset < 0;
     }
     return (
@@ -332,11 +377,13 @@ class _TimelineOverlayStripState extends State<TimelineOverlayStrip> {
       item.startTime.inMilliseconds,
       initialExcludeMs: item.startTime.inMilliseconds,
     );
+    _dragPosition.value = _DragPos(
+      startMs: item.startTime.inMilliseconds,
+      deltaY: 0,
+    );
     setState(() {
       _draggingId = item.id;
-      _snappedStartMs = item.startTime.inMilliseconds;
       _prevDragOffsetX = 0;
-      _dragDeltaY = 0;
       _scrollCompensationY = 0;
       _dragStartRow = item.row;
     });
@@ -396,10 +443,10 @@ class _TimelineOverlayStripState extends State<TimelineOverlayStrip> {
       startTime: Duration(milliseconds: clampedStartMs),
     );
 
-    setState(() {
-      _snappedStartMs = clampedStartMs;
-      _dragDeltaY = details.offsetFromOrigin.dy + _scrollCompensationY;
-    });
+    _dragPosition.value = _DragPos(
+      startMs: clampedStartMs,
+      deltaY: details.offsetFromOrigin.dy + _scrollCompensationY,
+    );
   }
 
   void _onLongPressEnd(TimelineOverlayItem item) {
@@ -418,11 +465,10 @@ class _TimelineOverlayStripState extends State<TimelineOverlayStrip> {
     _dragSnap.reset();
     setState(() {
       _draggingId = null;
-      _snappedStartMs = 0;
       _prevDragOffsetX = 0;
-      _dragDeltaY = 0;
       _scrollCompensationY = 0;
     });
+    _dragPosition.value = _DragPos.zero;
     widget.onDragEnded?.call();
   }
 
@@ -500,4 +546,17 @@ class _TimelineOverlayStripState extends State<TimelineOverlayStrip> {
     _dragSnap.compensateScroll(target - before);
     return true;
   }
+}
+
+/// Immutable drag position used by [_TimelineOverlayStripState._dragPosition].
+class _DragPos {
+  const _DragPos({required this.startMs, required this.deltaY});
+
+  static const zero = _DragPos(startMs: 0, deltaY: 0);
+
+  /// Horizontal position: snapped item start in milliseconds.
+  final int startMs;
+
+  /// Vertical position: cumulative drag delta in pixels.
+  final double deltaY;
 }

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strip.dart
@@ -226,7 +226,7 @@ class _TimelineOverlayStripState extends State<TimelineOverlayStrip> {
           // not on every parent setState (drag start / end only).
           ValueListenableBuilder<_DragPos>(
             valueListenable: _dragPosition,
-            builder: (context, _, __) {
+            builder: (context, _, _) {
               final y = _dropIndicatorLineY();
               if (y == null) return const SizedBox.shrink();
               return TimelineDropIndicatorLine(lineY: y);

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strips.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strips.dart
@@ -10,7 +10,7 @@ import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_edito
 ///
 /// Extracted into its own widget so that overlay state changes only rebuild
 /// the overlay strips — not the clip strip or ruler.
-class TimelineOverlayStrips extends StatelessWidget {
+class TimelineOverlayStrips extends StatefulWidget {
   const TimelineOverlayStrips({
     required this.totalWidth,
     required this.pixelsPerSecond,
@@ -41,19 +41,30 @@ class TimelineOverlayStrips extends StatelessWidget {
   final VoidCallback? onDragEnded;
 
   @override
-  Widget build(BuildContext context) {
-    final (:items, :selectedItemId, :collapsedTypes) = context.select(
-      (TimelineOverlayBloc b) => (
-        items: b.state.items,
-        selectedItemId: b.state.selectedItemId,
-        collapsedTypes: b.state.collapsedTypes,
-      ),
-    );
+  State<TimelineOverlayStrips> createState() => _TimelineOverlayStripsState();
+}
 
+class _TimelineOverlayStripsState extends State<TimelineOverlayStrips> {
+  // -- cached inputs (change detection) ------------------------------------
+  List<TimelineOverlayItem>? _prevItems;
+  String? _prevSelectedId;
+  List<int>? _prevClipEdgesMs;
+
+  // -- cached bucket-split results -----------------------------------------
+  var _soundItems = const <TimelineOverlayItem>[];
+  var _filterItems = const <TimelineOverlayItem>[];
+  var _layerItems = const <TimelineOverlayItem>[];
+  var _soundRowCount = 0;
+  var _filterRowCount = 0;
+  var _layerRowCount = 0;
+
+  // -- cached snap-point list -----------------------------------------------
+  var _snapPointsMs = const <int>[];
+
+  void _rebuildBuckets(List<TimelineOverlayItem> items) {
     final soundItems = <TimelineOverlayItem>[];
     final filterItems = <TimelineOverlayItem>[];
     final layerItems = <TimelineOverlayItem>[];
-
     var maxSoundRow = -1;
     var maxFilterRow = -1;
     var maxLayerRow = -1;
@@ -72,36 +83,19 @@ class TimelineOverlayStrips extends StatelessWidget {
       }
     }
 
-    final soundRowCount = maxSoundRow + 1;
-    final filterRowCount = maxFilterRow + 1;
-    final layerRowCount = maxLayerRow + 1;
+    _soundItems = soundItems;
+    _filterItems = filterItems;
+    _layerItems = layerItems;
+    _soundRowCount = maxSoundRow + 1;
+    _filterRowCount = maxFilterRow + 1;
+    _layerRowCount = maxLayerRow + 1;
+  }
 
-    final stripConfigs = [
-      (
-        items: soundItems,
-        rowCount: soundRowCount,
-        type: TimelineOverlayType.sound,
-        color: VineTheme.accentVioletBackground,
-        rowHeight: TimelineConstants.soundOverlayRowHeight,
-      ),
-      (
-        items: filterItems,
-        rowCount: filterRowCount,
-        type: TimelineOverlayType.filter,
-        color: VineTheme.success,
-        rowHeight: TimelineConstants.overlayRowHeight,
-      ),
-      (
-        items: layerItems,
-        rowCount: layerRowCount,
-        type: TimelineOverlayType.layer,
-        color: VineTheme.primary,
-        rowHeight: TimelineConstants.overlayRowHeight,
-      ),
-    ];
-
-    // Build snap points from all overlay item edges + clip edges +
-    // playhead, excluding the selected item so it doesn't snap to itself.
+  void _rebuildSnapPoints(
+    List<TimelineOverlayItem> items,
+    String? selectedItemId,
+    List<int> clipEdgesMs,
+  ) {
     final snapSet = <int>{};
     for (final item in items) {
       if (item.id == selectedItemId) continue;
@@ -109,8 +103,59 @@ class TimelineOverlayStrips extends StatelessWidget {
       snapSet.add(item.endTime.inMilliseconds);
     }
     snapSet.addAll(clipEdgesMs);
-    snapSet.add(playheadPosition.value.inMilliseconds);
-    final snapPointsMs = snapSet.toList();
+    snapSet.add(widget.playheadPosition.value.inMilliseconds);
+    _snapPointsMs = snapSet.toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final (:items, :selectedItemId, :collapsedTypes) = context.select(
+      (TimelineOverlayBloc b) => (
+        items: b.state.items,
+        selectedItemId: b.state.selectedItemId,
+        collapsedTypes: b.state.collapsedTypes,
+      ),
+    );
+
+    // Rebuild buckets only when the items list changes.
+    final itemsDirty = !identical(items, _prevItems);
+    if (itemsDirty) {
+      _rebuildBuckets(items);
+      _prevItems = items;
+    }
+
+    // Rebuild snap points when items, selection, or clip edges change.
+    if (itemsDirty ||
+        _prevSelectedId != selectedItemId ||
+        !identical(widget.clipEdgesMs, _prevClipEdgesMs)) {
+      _rebuildSnapPoints(items, selectedItemId, widget.clipEdgesMs);
+      _prevSelectedId = selectedItemId;
+      _prevClipEdgesMs = widget.clipEdgesMs;
+    }
+
+    final stripConfigs = [
+      (
+        items: _soundItems,
+        rowCount: _soundRowCount,
+        type: TimelineOverlayType.sound,
+        color: VineTheme.accentVioletBackground,
+        rowHeight: TimelineConstants.soundOverlayRowHeight,
+      ),
+      (
+        items: _filterItems,
+        rowCount: _filterRowCount,
+        type: TimelineOverlayType.filter,
+        color: VineTheme.success,
+        rowHeight: TimelineConstants.overlayRowHeight,
+      ),
+      (
+        items: _layerItems,
+        rowCount: _layerRowCount,
+        type: TimelineOverlayType.layer,
+        color: VineTheme.primary,
+        rowHeight: TimelineConstants.overlayRowHeight,
+      ),
+    ];
 
     return Padding(
       padding: const .only(top: TimelineConstants.overlayStripGap),
@@ -124,21 +169,21 @@ class TimelineOverlayStrips extends StatelessWidget {
               TimelineOverlayStrip(
                 items: config.items,
                 rowCount: config.rowCount,
-                totalWidth: totalWidth,
-                pixelsPerSecond: pixelsPerSecond,
-                totalDuration: totalDuration,
+                totalWidth: widget.totalWidth,
+                pixelsPerSecond: widget.pixelsPerSecond,
+                totalDuration: widget.totalDuration,
                 color: config.color,
                 rowHeight: config.rowHeight,
                 isCollapsed: collapsedTypes.contains(config.type),
                 selectedItemId: selectedItemId,
-                snapPointsMs: snapPointsMs,
-                onItemTapped: onItemTapped,
-                onItemMoved: onItemMoved,
-                onItemMoving: onItemMoving,
-                onTrimChanged: onItemTrimmed,
-                onTrimDragChanged: onTrimDragChanged,
-                onDragStarted: onDragStarted,
-                onDragEnded: onDragEnded,
+                snapPointsMs: _snapPointsMs,
+                onItemTapped: widget.onItemTapped,
+                onItemMoved: widget.onItemMoved,
+                onItemMoving: widget.onItemMoving,
+                onTrimChanged: widget.onItemTrimmed,
+                onTrimDragChanged: widget.onTrimDragChanged,
+                onDragStarted: widget.onDragStarted,
+                onDragEnded: widget.onDragEnded,
               ),
         ],
       ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_positioned_item.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_positioned_item.dart
@@ -221,14 +221,8 @@ class _TrimmableOverlayTileState extends State<_TrimmableOverlayTile> {
   void didUpdateWidget(_TrimmableOverlayTile oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.pixelsPerSecond != widget.pixelsPerSecond) {
-      _leftSnap = TimelineSnapController(
-        direction: SnapEdgeDirection.positive,
-        pixelsPerSecond: widget.pixelsPerSecond,
-      );
-      _rightSnap = TimelineSnapController(
-        direction: SnapEdgeDirection.negative,
-        pixelsPerSecond: widget.pixelsPerSecond,
-      );
+      _leftSnap.pixelsPerSecond = widget.pixelsPerSecond;
+      _rightSnap.pixelsPerSecond = widget.pixelsPerSecond;
     }
   }
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/timeline_snap_controller.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/timeline_snap_controller.dart
@@ -39,6 +39,10 @@ class TimelineSnapController {
   });
 
   final SnapEdgeDirection direction;
+
+  /// Mutable so callers can reuse a single controller across pinch-zoom
+  /// changes instead of allocating a new instance on every zoom step.
+  /// Updating mid-gesture preserves the accumulated drag state.
   double pixelsPerSecond;
 
   // ---------------------------------------------------------------------------

--- a/mobile/lib/widgets/video_editor/timeline_editor/timeline_snap_controller.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/timeline_snap_controller.dart
@@ -39,7 +39,7 @@ class TimelineSnapController {
   });
 
   final SnapEdgeDirection direction;
-  final double pixelsPerSecond;
+  double pixelsPerSecond;
 
   // ---------------------------------------------------------------------------
   // State

--- a/mobile/lib/widgets/video_editor/timeline_editor/timeline_snap_controller.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/timeline_snap_controller.dart
@@ -42,7 +42,13 @@ class TimelineSnapController {
 
   /// Mutable so callers can reuse a single controller across pinch-zoom
   /// changes instead of allocating a new instance on every zoom step.
-  /// Updating mid-gesture preserves the accumulated drag state.
+  ///
+  /// Note: the dead-zone math assumes [pixelsPerSecond] is **stable for the
+  /// duration of a single drag** — `_acc` and `_catchAcc` are stored in
+  /// pixels at the pps that was active when they were captured. In practice
+  /// this holds because pinch-zoom (two fingers) and long-press drag (one
+  /// finger) cannot overlap; if that ever changes, call [begin] again on
+  /// the new pps to reset the accumulators.
   double pixelsPerSecond;
 
   // ---------------------------------------------------------------------------

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -661,19 +661,17 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
   }
 
   void _onPointerUp(PointerUpEvent event) {
+    final wasPinching = _isPinching;
     _pointerPositions.remove(event.pointer);
-    if (_pointerPositions.length < 2) {
-      _pinchBaseDistance = 0;
-      setState(() {});
-    }
+    _pinchBaseDistance = 0;
+    if (wasPinching && !_isPinching) setState(() {});
   }
 
   void _onPointerCancel(PointerCancelEvent event) {
+    final wasPinching = _isPinching;
     _pointerPositions.remove(event.pointer);
-    if (_pointerPositions.length < 2) {
-      _pinchBaseDistance = 0;
-      setState(() {});
-    }
+    _pinchBaseDistance = 0;
+    if (wasPinching && !_isPinching) setState(() {});
   }
 
   double _currentPointerDistance() {

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
@@ -52,19 +52,6 @@ class VideoEditorTimelineBody extends StatelessWidget {
 
   static const _scrollBottomPadding = 100;
 
-  /// Computes cumulative clip-boundary positions in milliseconds.
-  /// Each clip edge (start of first clip + end of each clip) creates a
-  /// potential snap target for overlay items.
-  static List<int> _clipEdgesMs(List<DivineVideoClip> clips) {
-    final edges = <int>[0];
-    var runningMs = 0;
-    for (final clip in clips) {
-      runningMs += clip.trimmedDuration.inMilliseconds;
-      edges.add(runningMs);
-    }
-    return edges;
-  }
-
   final ValueChanged<List<DivineVideoClip>>? onReorder;
   final ValueChanged<bool>? onReorderChanged;
   final String? trimmingClipId;
@@ -103,6 +90,7 @@ class VideoEditorTimelineBody extends StatelessWidget {
         : overlayTrimExpand;
     final showMaxDurationOverlays =
         !isReordering && totalDuration > VideoEditorConstants.maxDuration;
+    final outsideExtendWidth = MediaQuery.sizeOf(context).width / 2;
 
     return HitExpandedBox(
       expandLeft: trimExpand,
@@ -115,6 +103,7 @@ class VideoEditorTimelineBody extends StatelessWidget {
           _TimelineMaxDurationStripeOverlay(
             pixelsPerSecond: pixelsPerSecond,
             visible: showMaxDurationOverlays,
+            outsideExtendWidth: outsideExtendWidth,
           ),
 
           Column(
@@ -125,28 +114,32 @@ class VideoEditorTimelineBody extends StatelessWidget {
               AnimatedOpacity(
                 opacity: isReordering ? 0.0 : 1.0,
                 duration: const Duration(milliseconds: 200),
-                child: VideoEditorTimelineRulesIndicator(
-                  totalDuration: totalDuration,
-                  pixelsPerSecond: pixelsPerSecond,
-                  scrollController: scrollController,
-                  scrollPadding: scrollPadding,
+                child: RepaintBoundary(
+                  child: VideoEditorTimelineRulesIndicator(
+                    totalDuration: totalDuration,
+                    pixelsPerSecond: pixelsPerSecond,
+                    scrollController: scrollController,
+                    scrollPadding: scrollPadding,
+                  ),
                 ),
               ),
               const SizedBox(height: 4),
 
               /// Video-Clips
-              VideoEditorTimelineClipStrip(
-                clips: clips,
-                totalWidth: totalWidth,
-                pixelsPerSecond: pixelsPerSecond,
-                scrollController: scrollController,
-                isInteracting: isInteracting,
-                onReorder: onReorder,
-                onReorderChanged: onReorderChanged,
-                trimmingClipId: trimmingClipId,
-                onTrimChanged: onTrimChanged,
-                onTrimDragChanged: onTrimDragChanged,
-                onClipTapped: onClipTapped,
+              RepaintBoundary(
+                child: VideoEditorTimelineClipStrip(
+                  clips: clips,
+                  totalWidth: totalWidth,
+                  pixelsPerSecond: pixelsPerSecond,
+                  scrollController: scrollController,
+                  isInteracting: isInteracting,
+                  onReorder: onReorder,
+                  onReorderChanged: onReorderChanged,
+                  trimmingClipId: trimmingClipId,
+                  onTrimChanged: onTrimChanged,
+                  onTrimDragChanged: onTrimDragChanged,
+                  onClipTapped: onClipTapped,
+                ),
               ),
 
               /// Layers, Filters and Audio-Tracks
@@ -166,19 +159,21 @@ class VideoEditorTimelineBody extends StatelessWidget {
                       ),
                       child: IgnorePointer(
                         ignoring: isReordering,
-                        child: TimelineOverlayStrips(
-                          totalWidth: totalWidth,
-                          pixelsPerSecond: pixelsPerSecond,
-                          totalDuration: totalDuration,
-                          clipEdgesMs: _clipEdgesMs(clips),
-                          playheadPosition: playheadPosition,
-                          onItemTapped: onOverlayItemTapped,
-                          onItemMoved: onOverlayItemMoved,
-                          onItemMoving: onOverlayItemMoving,
-                          onItemTrimmed: onOverlayItemTrimmed,
-                          onTrimDragChanged: onOverlayTrimDragChanged,
-                          onDragStarted: onOverlayDragStarted,
-                          onDragEnded: onOverlayDragEnded,
+                        child: RepaintBoundary(
+                          child: _CachedOverlayStrips(
+                            clips: clips,
+                            totalWidth: totalWidth,
+                            pixelsPerSecond: pixelsPerSecond,
+                            totalDuration: totalDuration,
+                            playheadPosition: playheadPosition,
+                            onItemTapped: onOverlayItemTapped,
+                            onItemMoved: onOverlayItemMoved,
+                            onItemMoving: onOverlayItemMoving,
+                            onItemTrimmed: onOverlayItemTrimmed,
+                            onTrimDragChanged: onOverlayTrimDragChanged,
+                            onDragStarted: onOverlayDragStarted,
+                            onDragEnded: onOverlayDragEnded,
+                          ),
                         ),
                       ),
                     ),
@@ -190,9 +185,101 @@ class VideoEditorTimelineBody extends StatelessWidget {
           _TimelineMaxDurationDimOverlay(
             pixelsPerSecond: pixelsPerSecond,
             visible: showMaxDurationOverlays,
+            outsideExtendWidth: outsideExtendWidth,
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Wraps [TimelineOverlayStrips] and memoizes the clip-edge snap-point list
+/// so the same [List<int>] reference is passed on every parent rebuild,
+/// avoiding redundant bucket-split and snap-set recomputation downstream.
+class _CachedOverlayStrips extends StatefulWidget {
+  const _CachedOverlayStrips({
+    required this.clips,
+    required this.totalWidth,
+    required this.pixelsPerSecond,
+    required this.totalDuration,
+    required this.playheadPosition,
+    this.onItemTapped,
+    this.onItemMoved,
+    this.onItemMoving,
+    this.onItemTrimmed,
+    this.onTrimDragChanged,
+    this.onDragStarted,
+    this.onDragEnded,
+  });
+
+  final List<DivineVideoClip> clips;
+  final double totalWidth;
+  final double pixelsPerSecond;
+  final Duration totalDuration;
+  final ValueNotifier<Duration> playheadPosition;
+  final ValueChanged<TimelineOverlayItem>? onItemTapped;
+  final OverlayMoveCallback? onItemMoved;
+  final OverlayMovingCallback? onItemMoving;
+  final OverlayTrimCallback? onItemTrimmed;
+  final ValueChanged<bool>? onTrimDragChanged;
+  final ValueChanged<TimelineOverlayItem>? onDragStarted;
+  final VoidCallback? onDragEnded;
+
+  @override
+  State<_CachedOverlayStrips> createState() => _CachedOverlayStripsState();
+}
+
+class _CachedOverlayStripsState extends State<_CachedOverlayStrips> {
+  late List<int> _clipEdgesMs;
+
+  @override
+  void initState() {
+    super.initState();
+    _clipEdgesMs = _computeEdges(widget.clips);
+  }
+
+  @override
+  void didUpdateWidget(_CachedOverlayStrips old) {
+    super.didUpdateWidget(old);
+    if (!identical(old.clips, widget.clips) &&
+        !_sameEdges(old.clips, widget.clips)) {
+      _clipEdgesMs = _computeEdges(widget.clips);
+    }
+  }
+
+  static List<int> _computeEdges(List<DivineVideoClip> clips) {
+    final edges = <int>[0];
+    var ms = 0;
+    for (final clip in clips) {
+      ms += clip.trimmedDuration.inMilliseconds;
+      edges.add(ms);
+    }
+    return edges;
+  }
+
+  static bool _sameEdges(List<DivineVideoClip> a, List<DivineVideoClip> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i].trimmedDuration != b[i].trimmedDuration) return false;
+    }
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TimelineOverlayStrips(
+      totalWidth: widget.totalWidth,
+      pixelsPerSecond: widget.pixelsPerSecond,
+      totalDuration: widget.totalDuration,
+      clipEdgesMs: _clipEdgesMs,
+      playheadPosition: widget.playheadPosition,
+      onItemTapped: widget.onItemTapped,
+      onItemMoved: widget.onItemMoved,
+      onItemMoving: widget.onItemMoving,
+      onItemTrimmed: widget.onItemTrimmed,
+      onTrimDragChanged: widget.onTrimDragChanged,
+      onDragStarted: widget.onDragStarted,
+      onDragEnded: widget.onDragEnded,
     );
   }
 }
@@ -201,15 +288,15 @@ class _TimelineMaxDurationStripeOverlay extends StatelessWidget {
   const _TimelineMaxDurationStripeOverlay({
     required this.pixelsPerSecond,
     required this.visible,
+    required this.outsideExtendWidth,
   });
 
   final double pixelsPerSecond;
   final bool visible;
+  final double outsideExtendWidth;
 
   @override
   Widget build(BuildContext context) {
-    final outsideExtendWidth = MediaQuery.sizeOf(context).width / 2;
-
     return Positioned(
       left:
           VideoEditorConstants.maxDuration.inMilliseconds /
@@ -221,7 +308,6 @@ class _TimelineMaxDurationStripeOverlay extends StatelessWidget {
       child: IgnorePointer(
         child: Visibility(
           visible: visible,
-          maintainState: true,
           child: const CustomPaint(
             painter: _TimelineOutsideAreaPainter(
               stripeColor: VineTheme.onSurfaceDisabled,
@@ -238,15 +324,15 @@ class _TimelineMaxDurationDimOverlay extends StatelessWidget {
   const _TimelineMaxDurationDimOverlay({
     required this.pixelsPerSecond,
     required this.visible,
+    required this.outsideExtendWidth,
   });
 
   final double pixelsPerSecond;
   final bool visible;
+  final double outsideExtendWidth;
 
   @override
   Widget build(BuildContext context) {
-    final outsideExtendWidth = MediaQuery.sizeOf(context).width / 2;
-
     return Positioned(
       left:
           VideoEditorConstants.maxDuration.inMilliseconds /
@@ -258,7 +344,6 @@ class _TimelineMaxDurationDimOverlay extends StatelessWidget {
       child: IgnorePointer(
         child: Visibility(
           visible: visible,
-          maintainState: true,
           child: ColoredBox(
             color: VineTheme.surfaceContainerHigh.withValues(alpha: 0.3),
             child: const SizedBox.expand(),

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_rules_indicator.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_rules_indicator.dart
@@ -87,11 +87,14 @@ class _RulerPainter extends CustomPainter {
 
   /// Laid-out [TextPainter] instances keyed by label string.
   ///
-  /// [_labelStyle] is static and never changes, so cached painters
-  /// are valid for the lifetime of the app. This avoids creating and
-  /// laying out a new [TextPainter] for every visible label on every
-  /// scroll frame (~600–1200 allocations/sec at 60 Hz).
+  /// Safe only while [_labelStyle] is a compile-time-stable constant —
+  /// cached painters become invalid the moment the style changes.
+  /// Avoids creating and laying out a new [TextPainter] for every
+  /// visible label on every scroll frame (~600–1200 allocations/sec
+  /// at 60 Hz). Bounded to [_tpCacheMax] to cap native paragraph
+  /// memory; oldest entries are evicted and disposed.
   static final Map<String, TextPainter> _tpCache = {};
+  static const int _tpCacheMax = 256;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -130,10 +133,16 @@ class _RulerPainter extends CustomPainter {
 
       final tp = _tpCache.putIfAbsent(
         label,
-        () => TextPainter(
-          text: TextSpan(text: label, style: _labelStyle),
-          textDirection: TextDirection.ltr,
-        )..layout(),
+        () {
+          if (_tpCache.length >= _tpCacheMax) {
+            final oldestKey = _tpCache.keys.first;
+            _tpCache.remove(oldestKey)?.dispose();
+          }
+          return TextPainter(
+            text: TextSpan(text: label, style: _labelStyle),
+            textDirection: TextDirection.ltr,
+          )..layout();
+        },
       );
 
       tp.paint(canvas, Offset(x, centerY - tp.height / 2));

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_rules_indicator.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_rules_indicator.dart
@@ -85,6 +85,14 @@ class _RulerPainter extends CustomPainter {
     color: VineTheme.onSurfaceMuted,
   ).copyWith(fontFeatures: [const FontFeature.tabularFigures()]);
 
+  /// Laid-out [TextPainter] instances keyed by label string.
+  ///
+  /// [_labelStyle] is static and never changes, so cached painters
+  /// are valid for the lifetime of the app. This avoids creating and
+  /// laying out a new [TextPainter] for every visible label on every
+  /// scroll frame (~600–1200 allocations/sec at 60 Hz).
+  static final Map<String, TextPainter> _tpCache = {};
+
   @override
   void paint(Canvas canvas, Size size) {
     final totalSeconds = totalDuration.inMilliseconds / 1000.0;
@@ -120,10 +128,13 @@ class _RulerPainter extends CustomPainter {
       final x = i * stepPx;
       final label = _formatLabel(i * frameStep);
 
-      final tp = TextPainter(
-        text: TextSpan(text: label, style: _labelStyle),
-        textDirection: TextDirection.ltr,
-      )..layout();
+      final tp = _tpCache.putIfAbsent(
+        label,
+        () => TextPainter(
+          text: TextSpan(text: label, style: _labelStyle),
+          textDirection: TextDirection.ltr,
+        )..layout(),
+      );
 
       tp.paint(canvas, Offset(x, centerY - tp.height / 2));
     }

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -2,7 +2,6 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
@@ -27,14 +26,14 @@ const _switchDuration = Duration(milliseconds: 240);
 /// - A main editor area that displays the video with proper aspect ratio
 /// - Overlay controls positioned on top of the video
 /// - A bottom bar for additional controls (e.g., timeline, tools)
-class VideoEditorScaffold extends ConsumerWidget {
+class VideoEditorScaffold extends StatelessWidget {
   /// Creates a [VideoEditorScaffold].
   const VideoEditorScaffold({required this.isLoading, super.key});
 
   final bool isLoading;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: VideoEditorConstants.uiOverlayStyle,
       child: Scaffold(
@@ -203,16 +202,17 @@ class _BottomActions extends StatelessWidget {
   }
 }
 
+/// Decides whether the FAB should be visible. Keeps the visibility check in
+/// a dedicated widget so that [_AddElementFabContent] is only rebuilt when
+/// it actually needs to render — not on every hide/show state change.
 class _AddElementFab extends StatelessWidget {
   const _AddElementFab();
 
   @override
   Widget build(BuildContext context) {
-    final (:isSubEditorOpen, :isTimelineHiddenByUser) = context.select(
-      (VideoEditorMainBloc b) => (
-        isSubEditorOpen: b.state.isSubEditorOpen,
-        isTimelineHiddenByUser: b.state.isTimelineHiddenByUser,
-      ),
+    final shouldHide = context.select(
+      (VideoEditorMainBloc b) =>
+          b.state.isSubEditorOpen || b.state.isTimelineHiddenByUser,
     );
     final hasSelectedOverlay = context.select(
       (TimelineOverlayBloc b) => b.state.selectedItemId != null,
@@ -221,13 +221,19 @@ class _AddElementFab extends StatelessWidget {
       (ClipEditorBloc b) => b.state.isEditing,
     );
 
-    if (isSubEditorOpen ||
-        hasSelectedOverlay ||
-        isClipEditing ||
-        isTimelineHiddenByUser) {
+    if (shouldHide || hasSelectedOverlay || isClipEditing) {
       return const SizedBox.shrink();
     }
 
+    return const _AddElementFabContent();
+  }
+}
+
+class _AddElementFabContent extends StatelessWidget {
+  const _AddElementFabContent();
+
+  @override
+  Widget build(BuildContext context) {
     return Semantics(
       button: true,
       label: context.l10n.videoEditorAddElementSemanticLabel,


### PR DESCRIPTION
Closes #3474


## Description

This PR improves the performance in the video-editor.

### Behavior note

Pinch-zoom on a 3→2-finger transition now ends the pinch entirely rather than continuing against a stale baseline. The user lifts to one finger and re-pinches to resume. The old path silently mismatched the baseline against a different finger pair and produced a zoom jump.

**Related Issue:** Closes #3149
## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
