### PR TITLE
fix(reports): require description when Other report reason is selected

### DIFF
--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1890,6 +1890,8 @@
     "reportCancel": "إلغاء",
     "reportSubmit": "إبلاغ",
     "reportSelectReason": "يُرجى اختيار سبب للإبلاغ عن هذا المحتوى",
+    "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+    "reportDetailsRequired": "Please describe the issue",
     "reportReasonSpam": "محتوى غير مرغوب فيه أو مزعج",
     "reportReasonHarassment": "تحرُّش أو تنمُّر أو تهديدات",
     "reportReasonViolence": "محتوى عنيف أو متطرف",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1891,6 +1891,8 @@
     "reportCancel": "Abbrechen",
     "reportSubmit": "Melden",
     "reportSelectReason": "Bitte wähl einen Grund für die Meldung dieses Inhalts",
+    "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+    "reportDetailsRequired": "Please describe the issue",
     "reportReasonSpam": "Spam oder unerwünschte Inhalte",
     "reportReasonHarassment": "Belästigung, Mobbing oder Drohungen",
     "reportReasonViolence": "Gewalttätige oder extremistische Inhalte",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1944,6 +1944,7 @@
   "reportCancel": "Cancel",
   "reportSubmit": "Report",
   "reportSelectReason": "Please select a reason for reporting this content",
+  "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
   "reportReasonSpam": "Spam or Unwanted Content",
   "reportReasonHarassment": "Harassment, Bullying, or Threats",
   "reportReasonViolence": "Violent or Extremist Content",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1945,6 +1945,7 @@
   "reportSubmit": "Report",
   "reportSelectReason": "Please select a reason for reporting this content",
   "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+  "reportDetailsRequired": "Please describe the issue",
   "reportReasonSpam": "Spam or Unwanted Content",
   "reportReasonHarassment": "Harassment, Bullying, or Threats",
   "reportReasonViolence": "Violent or Extremist Content",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1891,6 +1891,8 @@
     "reportCancel": "Cancelar",
     "reportSubmit": "Reportar",
     "reportSelectReason": "Elegí un motivo para reportar este contenido",
+    "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+    "reportDetailsRequired": "Please describe the issue",
     "reportReasonSpam": "Spam o contenido no deseado",
     "reportReasonHarassment": "Acoso, bullying o amenazas",
     "reportReasonViolence": "Contenido violento o extremista",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1891,6 +1891,8 @@
     "reportCancel": "Annuler",
     "reportSubmit": "Signaler",
     "reportSelectReason": "Sélectionne une raison pour signaler ce contenu",
+    "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+    "reportDetailsRequired": "Please describe the issue",
     "reportReasonSpam": "Spam ou contenu indésirable",
     "reportReasonHarassment": "Harcèlement, intimidation ou menaces",
     "reportReasonViolence": "Contenu violent ou extrémiste",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1890,6 +1890,8 @@
     "reportCancel": "Batal",
     "reportSubmit": "Laporkan",
     "reportSelectReason": "Silakan pilih alasan untuk melaporkan konten ini",
+    "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+    "reportDetailsRequired": "Please describe the issue",
     "reportReasonSpam": "Spam atau Konten Tidak Diinginkan",
     "reportReasonHarassment": "Pelecehan, Perundungan, atau Ancaman",
     "reportReasonViolence": "Konten Kekerasan atau Ekstremis",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1891,6 +1891,8 @@
     "reportCancel": "Annulla",
     "reportSubmit": "Segnala",
     "reportSelectReason": "Seleziona un motivo per segnalare questo contenuto",
+    "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+    "reportDetailsRequired": "Please describe the issue",
     "reportReasonSpam": "Spam o contenuto indesiderato",
     "reportReasonHarassment": "Molestie, bullismo o minacce",
     "reportReasonViolence": "Contenuto violento o estremista",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1890,6 +1890,8 @@
     "reportCancel": "キャンセル",
     "reportSubmit": "報告",
     "reportSelectReason": "報告する理由を選んでね",
+    "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+    "reportDetailsRequired": "Please describe the issue",
     "reportReasonSpam": "スパムや迷惑なコンテンツ",
     "reportReasonHarassment": "嫌がらせ、いじめ、脅迫",
     "reportReasonViolence": "暴力的・過激なコンテンツ",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1179,6 +1179,8 @@
     "reportCancel": "취소",
     "reportSubmit": "신고",
     "reportSelectReason": "이 콘텐츠를 신고하는 이유를 선택해 주세요",
+    "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+    "reportDetailsRequired": "Please describe the issue",
     "reportReasonSpam": "스팸 또는 원치 않는 콘텐츠",
     "reportReasonHarassment": "괴롭힘, 따돌림, 협박",
     "reportReasonViolence": "폭력적이거나 극단적인 콘텐츠",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1891,6 +1891,8 @@
     "reportCancel": "Annuleren",
     "reportSubmit": "Melden",
     "reportSelectReason": "Selecteer een reden om deze inhoud te melden",
+    "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+    "reportDetailsRequired": "Please describe the issue",
     "reportReasonSpam": "Spam of ongewenste inhoud",
     "reportReasonHarassment": "Intimidatie, pesten of bedreigingen",
     "reportReasonViolence": "Gewelddadige of extremistische inhoud",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1891,6 +1891,8 @@
     "reportCancel": "Anuluj",
     "reportSubmit": "Zgłoś",
     "reportSelectReason": "Wybierz powód zgłoszenia tej treści",
+    "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+    "reportDetailsRequired": "Please describe the issue",
     "reportReasonSpam": "Spam lub niechciana treść",
     "reportReasonHarassment": "Nagabywanie, zniesławianie lub groźby",
     "reportReasonViolence": "Treści brutalne lub ekstremistyczne",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1891,6 +1891,8 @@
     "reportCancel": "Cancelar",
     "reportSubmit": "Denunciar",
     "reportSelectReason": "Selecione um motivo para denunciar este conteúdo",
+    "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+    "reportDetailsRequired": "Please describe the issue",
     "reportReasonSpam": "Spam ou conteúdo indesejado",
     "reportReasonHarassment": "Assédio, bullying ou ameaças",
     "reportReasonViolence": "Conteúdo violento ou extremista",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1891,6 +1891,8 @@
     "reportCancel": "Anulează",
     "reportSubmit": "Raportează",
     "reportSelectReason": "Alege un motiv pentru raportarea acestui conținut",
+    "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+    "reportDetailsRequired": "Please describe the issue",
     "reportReasonSpam": "Spam sau conținut nedorit",
     "reportReasonHarassment": "Hărțuire, bullying sau amenințări",
     "reportReasonViolence": "Conținut violent sau extremist",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1891,6 +1891,8 @@
     "reportCancel": "Avbryt",
     "reportSubmit": "Rapportera",
     "reportSelectReason": "Välj en anledning för att rapportera det här innehållet",
+    "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+    "reportDetailsRequired": "Please describe the issue",
     "reportReasonSpam": "Skräppost eller ovälkommet innehåll",
     "reportReasonHarassment": "Trakasserier, mobbning eller hot",
     "reportReasonViolence": "Våldsamt eller extremistiskt innehåll",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1890,6 +1890,8 @@
     "reportCancel": "İptal",
     "reportSubmit": "Bildir",
     "reportSelectReason": "Lütfen bu içeriği bildirmek için bir sebep seç",
+    "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+    "reportDetailsRequired": "Please describe the issue",
     "reportReasonSpam": "Spam veya İstenmeyen İçerik",
     "reportReasonHarassment": "Taciz, Zorbalık veya Tehdit",
     "reportReasonViolence": "Şiddet veya Aşırı İçerik",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -6764,6 +6764,12 @@ abstract class AppLocalizations {
   /// **'Please select a reason for reporting this content'**
   String get reportSelectReason;
 
+  /// No description provided for @reportOtherRequiresDetails.
+  ///
+  /// In en, this message translates to:
+  /// **'Please describe the issue when selecting Other'**
+  String get reportOtherRequiresDetails;
+
   /// No description provided for @reportReasonSpam.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -6770,6 +6770,12 @@ abstract class AppLocalizations {
   /// **'Please describe the issue when selecting Other'**
   String get reportOtherRequiresDetails;
 
+  /// No description provided for @reportDetailsRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'Please describe the issue'**
+  String get reportDetailsRequired;
+
   /// No description provided for @reportReasonSpam.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3785,6 +3785,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get reportSelectReason => 'يُرجى اختيار سبب للإبلاغ عن هذا المحتوى';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => 'محتوى غير مرغوب فيه أو مزعج';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3789,6 +3789,9 @@ class AppLocalizationsAr extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'محتوى غير مرغوب فيه أو مزعج';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3874,6 +3874,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Bitte wähl einen Grund für die Meldung dieses Inhalts';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => 'Spam oder unerwünschte Inhalte';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3878,6 +3878,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'Spam oder unerwünschte Inhalte';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3835,6 +3835,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'Spam or Unwanted Content';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3831,6 +3831,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Please select a reason for reporting this content';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => 'Spam or Unwanted Content';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3870,6 +3870,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Elegí un motivo para reportar este contenido';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => 'Spam o contenido no deseado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3874,6 +3874,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'Spam o contenido no deseado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3884,6 +3884,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'Spam ou contenu indésirable';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3880,6 +3880,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Sélectionne une raison pour signaler ce contenu';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => 'Spam ou contenu indésirable';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3801,6 +3801,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Silakan pilih alasan untuk melaporkan konten ini';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => 'Spam atau Konten Tidak Diinginkan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3805,6 +3805,9 @@ class AppLocalizationsId extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'Spam atau Konten Tidak Diinginkan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3872,6 +3872,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'Spam o contenuto indesiderato';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3868,6 +3868,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Seleziona un motivo per segnalare questo contenuto';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => 'Spam o contenuto indesiderato';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3648,6 +3648,9 @@ class AppLocalizationsJa extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'スパムや迷惑なコンテンツ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3644,6 +3644,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get reportSelectReason => '報告する理由を選んでね';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => 'スパムや迷惑なコンテンツ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3657,6 +3657,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get reportSelectReason => '이 콘텐츠를 신고하는 이유를 선택해 주세요';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => '스팸 또는 원치 않는 콘텐츠';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3661,6 +3661,9 @@ class AppLocalizationsKo extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => '스팸 또는 원치 않는 콘텐츠';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3842,6 +3842,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Selecteer een reden om deze inhoud te melden';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => 'Spam of ongewenste inhoud';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3846,6 +3846,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'Spam of ongewenste inhoud';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3937,6 +3937,9 @@ class AppLocalizationsPl extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'Spam lub niechciana treść';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3933,6 +3933,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get reportSelectReason => 'Wybierz powód zgłoszenia tej treści';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => 'Spam lub niechciana treść';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3857,6 +3857,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'Spam ou conteúdo indesejado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3853,6 +3853,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Selecione um motivo para denunciar este conteúdo';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => 'Spam ou conteúdo indesejado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3939,6 +3939,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Alege un motiv pentru raportarea acestui conținut';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => 'Spam sau conținut nedorit';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3943,6 +3943,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'Spam sau conținut nedorit';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3826,6 +3826,9 @@ class AppLocalizationsSv extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'Skräppost eller ovälkommet innehåll';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3822,6 +3822,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Välj en anledning för att rapportera det här innehållet';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => 'Skräppost eller ovälkommet innehåll';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3817,6 +3817,9 @@ class AppLocalizationsTr extends AppLocalizations {
       'Please describe the issue when selecting Other';
 
   @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'Spam veya İstenmeyen İçerik';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3813,6 +3813,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Lütfen bu içeriği bildirmek için bir sebep seç';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
   String get reportReasonSpam => 'Spam veya İstenmeyen İçerik';
 
   @override

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -87,7 +87,9 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
                 enableInteractiveSelection: true,
                 style: const TextStyle(color: VineTheme.whiteText),
                 decoration: InputDecoration(
-                  labelText: l10n.reportAdditionalDetails,
+                  labelText: _selectedReason == ContentFilterReason.other
+                      ? l10n.reportDetailsRequired
+                      : l10n.reportAdditionalDetails,
                   labelStyle: const TextStyle(color: VineTheme.secondaryText),
                 ),
                 maxLines: 3,

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -135,6 +135,16 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
       );
       return;
     }
+    if (_selectedReason == ContentFilterReason.other &&
+        _detailsController.text.trim().isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(context.l10n.reportOtherRequiresDetails),
+          backgroundColor: VineTheme.error,
+        ),
+      );
+      return;
+    }
     _submitReport();
   }
 

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -181,6 +181,31 @@ void main() {
       },
     );
 
+    testWidgets(
+      'Submit button shows error when Other selected without details',
+      (tester) async {
+        await tester.binding.setSurfaceSize(const Size(800, 1200));
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        // Select "Other"
+        await tester.tap(find.text('Other Policy Violation'));
+        await tester.pumpAndSettle();
+
+        // Tap Report without entering details
+        final reportButton = find.widgetWithText(TextButton, 'Report');
+        await tester.tap(reportButton);
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('Please describe the issue when selecting Other'),
+          findsOneWidget,
+          reason: 'Should require details when Other is selected',
+        );
+      },
+    );
+
     testWidgets('Block user checkbox is visible and can be toggled', (
       tester,
     ) async {

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -553,6 +553,36 @@ void main() {
         ),
       ).called(1);
     });
+
+    testWidgets('Other reason with details submits successfully', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(800, 1200));
+      await openReportDialog(tester);
+
+      // Select Other
+      await tester.tap(find.text('Other Policy Violation'));
+      await tester.pumpAndSettle();
+
+      // Enter details
+      await tester.enterText(find.byType(TextField), 'Custom report details');
+      await tester.pumpAndSettle();
+
+      // Tap Report
+      await tester.tap(find.widgetWithText(TextButton, 'Report'));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockReportingService.reportContent(
+          eventId: any(named: 'eventId'),
+          authorPubkey: any(named: 'authorPubkey'),
+          reason: ContentFilterReason.other,
+          details: 'Custom report details',
+          additionalContext: any(named: 'additionalContext'),
+          hashtags: any(named: 'hashtags'),
+        ),
+      ).called(1);
+    });
   });
 
   group('$ReportConfirmationDialog', () {


### PR DESCRIPTION
Closes #3477

## Summary

- When a user selects "Other" as the report reason, the details text field is now required before submission
- TextField label dynamically changes from "Additional details (optional)" to "Please describe the issue" when Other is selected, so the requirement is visible before the user taps submit
- Validation snackbar shown if the user tries to submit Other without a description
- Two new tests: negative (Other without details blocked) and positive (Other with details submits)

Relates to relay admin category discussion — the "Other" bucket is only useful for moderation if reporters explain what they're flagging.

## Localization note

Two new l10n strings added to `app_en.arb`: `reportOtherRequiresDetails` and `reportDetailsRequired`. Non-English locales currently fall back to the English text. I'm not familiar with the localization workflow for this repo and did not want to submit machine-translated strings I couldn't verify myself. These two strings will need translation in the other 14 ARB files.

## Test plan

- [x] `flutter test test/widgets/report_content_dialog_test.dart` — 24 tests pass
- [x] `flutter analyze` — no issues
- [ ] Manual: open report dialog, select Other, tap Report without entering details — snackbar error appears
- [ ] Manual: select Other, confirm label changes to "Please describe the issue"
- [ ] Manual: enter details, tap Report — submits successfully
- [ ] Manual: select a non-Other reason — label shows "Additional details (optional)", submits without details