### PR TITLE
fix(video_editor): adjust stripe dimensions in outside area painter  

### DIFF
--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:divine_ui/divine_ui.dart';
@@ -292,8 +293,17 @@ class _TimelineOutsideAreaPainter extends CustomPainter {
     canvas.clipRect(Offset.zero & size);
     canvas.transform(_stripeTransformStorage);
 
-    final drawHeight = (size.height * 3).ceilToDouble();
-    final drawWidth = (size.width * 3).ceilToDouble();
+    // After rotation the visible rect's bounding box in rotated coords is
+    // bounded by its diagonal, regardless of which side is longer. Use the
+    // diagonal for both extents so stripes fully cover the rect even when
+    // the widget becomes very narrow (zoom-in) or very tall.
+    final diagonal = math
+        .sqrt(
+          size.width * size.width + size.height * size.height,
+        )
+        .ceilToDouble();
+    final drawHeight = diagonal;
+    final drawWidth = diagonal;
     final startX = -drawWidth - ((-drawWidth) % _stripeGap);
     for (var x = startX; x <= drawWidth; x += _stripeGap) {
       canvas.drawLine(

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
@@ -293,22 +293,17 @@ class _TimelineOutsideAreaPainter extends CustomPainter {
     canvas.clipRect(Offset.zero & size);
     canvas.transform(_stripeTransformStorage);
 
-    // After rotation the visible rect's bounding box in rotated coords is
-    // bounded by its diagonal, regardless of which side is longer. Use the
-    // diagonal for both extents so stripes fully cover the rect even when
-    // the widget becomes very narrow (zoom-in) or very tall.
-    final diagonal = math
+    // Diagonal covers the rotated bounding box for any aspect ratio.
+    final extent = math
         .sqrt(
           size.width * size.width + size.height * size.height,
         )
         .ceilToDouble();
-    final drawHeight = diagonal;
-    final drawWidth = diagonal;
-    final startX = -drawWidth - ((-drawWidth) % _stripeGap);
-    for (var x = startX; x <= drawWidth; x += _stripeGap) {
+    final startX = -extent - ((-extent) % _stripeGap);
+    for (var x = startX; x <= extent; x += _stripeGap) {
       canvas.drawLine(
-        Offset(x, -drawHeight),
-        Offset(x, drawHeight),
+        Offset(x, -extent),
+        Offset(x, extent),
         stripePaint,
       );
     }


### PR DESCRIPTION
Closes #3479


## Description

If the user zoomed in a lot on the timeline, the outside stripes didn’t cover the entire timeline anymore.


**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore