### PR TITLE
test(comments): drop wall-clock waits from post-close race regression tests

### DIFF
--- a/mobile/test/blocs/comments/comments_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_bloc_test.dart
@@ -378,20 +378,16 @@ void main() {
 
           final bloc = createBloc()..add(const CommentsLoadRequested());
 
-          // Let the handler reach the await point.
-          await Future<void>.delayed(const Duration(milliseconds: 25));
+          // Drive the handler to its `await loadComments(...)` point.
+          await pumpEventQueue();
 
-          // User dismisses the comments sheet — bloc closes before
-          // loadComments resolves.
+          // User dismisses the sheet before the load resolves.
           await bloc.close();
 
-          // Now resolve the load. The handler resumes against a closed bloc
-          // and the follow-up CommentVoteCountsFetchRequested dispatch
-          // must be guarded by isClosed.
+          // The load now resolves against a closed bloc; the resumed
+          // continuation must be guarded by `if (!isClosed)`.
           loadCompleter.complete(CommentThread.empty(validId('root')));
-
-          // Yield so the resumed continuation runs.
-          await Future<void>.delayed(const Duration(milliseconds: 25));
+          await pumpEventQueue();
 
           final hasCloseError = LogCaptureService()
               .getRecentLogs(minLevel: LogLevel.error)
@@ -3043,7 +3039,10 @@ void main() {
           ).thenAnswer((_) async => CommentThread.empty(validId('root')));
 
           final bloc = createBloc()..add(const CommentsLoadRequested());
-          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          // Let _onLoadRequested run, _startWatchingComments() subscribe,
+          // and the awaited loadComments resolve.
+          await pumpEventQueue();
 
           await bloc.close();
 
@@ -3061,7 +3060,7 @@ void main() {
               rootAuthorPubkey: validId('author'),
             ),
           );
-          await Future<void>.delayed(const Duration(milliseconds: 25));
+          await pumpEventQueue();
 
           expect(bloc.isClosed, isTrue);
           await streamController.close();


### PR DESCRIPTION
## Summary

Closes #3480.

Converts the two CommentsBloc post-close-race regression tests added in #3455 to use `pumpEventQueue()` instead of `await Future<void>.delayed(Duration(milliseconds: 25 | 50))`. Same regression intent, same assertions, zero wall-clock dependence.

## Why pumpEventQueue and not fakeAsync

The issue text asks for `fakeAsync`. I tried that first. It does not work here:

> bloc 9.2.0's `close()` Future never resolves inside `fakeAsync`. Verified with a minimal probe — even an idle bloc with no events dispatched stays at `isClosed=false` after `unawaited(bloc.close()); fake.elapse(Duration(seconds: 1));`. Root cause: `StreamController.broadcast().close()` uses internal SDK scheduling that fake_async's zone overrides do not intercept.

`mobile/test/blocs/email_verification/email_verification_cubit_test.dart` works around this by calling `cubit.close()` without ever asserting `cubit.isClosed`. Our tests _do_ assert `bloc.isClosed`, so the same workaround would weaken the regression coverage.

`pumpEventQueue()` (from `flutter_test`, already used at `mobile/test/providers/overlay_visibility_provider_test.dart:197, 209, 227, 242`, `app_lifecycle_provider_test.dart:63, 113`, `explore_active_video_test.dart:86, 140, 209, 220`) is a deterministic 20-tick event-loop drain. It satisfies the issue's "deterministic scheduling" intent (no wall-clock waits) and is compatible with bloc's close path.

## Late-stream assertion stays scoped to "no throw"

Per the issue's explicit guidance, the late-stream test continues to assert only `bloc.isClosed == true` — no delivery guarantee was added.

## Regression-intent verification

Locally reverted each guard in `mobile/lib/blocs/comments/comments_bloc.dart` and reran the relevant tests:

- **Guard at line 152** (`if (!isClosed) { add(const CommentVoteCountsFetchRequested()); }`) reverted → test 1 (`does not log "Cannot add new events after calling close" when bloc closes before loadComments completes`) **fails** with `Expected: false, Actual: <true>` on the `hasCloseError` assertion. ✓ Regression caught.
- **Guard at line 984** (`if (!isClosed) { add(NewCommentReceived(comment)); }`) reverted → test 2 (`does not throw if a streamed comment arrives after close`) **passes**. ✓ As designed — the merged PR #3455 explicitly described this as "defense-in-depth" for the stream-after-close path; the listener is already cancelled by the time the late event is pushed, so the production guard is not directly exercised. The test pins "no crash on late stream activity" rather than guard execution, consistent with the issue's "scoped to no throw" requirement.

## Out of scope (not touched here)

- 13 other `Future<void>.delayed` calls in adjacent tests in the same file (lines 337, 339, 353, 2860, 2863, 2867, 2870, 2930, 2995, 2997, 3009, 3094, 3109) predate #3455 and are outside this issue's scope.
- The throttle's `Timer.periodic` in `_throttledListen` (`comments_bloc.dart:1011-1041`) is only cancelled by stream `onDone`, not by subscription cancel — small latent prod orphan-timer bug. Will file as a separate issue.

## Test plan

- [x] `dart format test/blocs/comments/comments_bloc_test.dart` — no changes
- [x] `flutter analyze lib test integration_test` — 0 issues
- [x] `flutter test test/blocs/comments/comments_bloc_test.dart` — 107/107 pass
- [x] `flutter test test/blocs/comments/comments_bloc_test.dart --test-randomize-ordering-seed random` — 107/107 pass
- [x] Reverted each guard locally; confirmed regression-intent results above