### PR TITLE
fix(comments): cancel throttle refill timer when subscription cancels

### DIFF
--- a/mobile/lib/blocs/comments/comments_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_bloc.dart
@@ -1015,18 +1015,11 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
     void Function(Object)? onError,
   }) {
     var budget = maxPerSecond;
-    Timer? refillTimer;
+    final refillTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      budget = maxPerSecond;
+    });
 
-    void startRefill() {
-      refillTimer?.cancel();
-      refillTimer = Timer.periodic(const Duration(seconds: 1), (_) {
-        budget = maxPerSecond;
-      });
-    }
-
-    startRefill();
-
-    return stream.listen(
+    final subscription = stream.listen(
       (event) {
         if (budget > 0) {
           budget--;
@@ -1034,10 +1027,9 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
         }
       },
       onError: onError,
-      onDone: () {
-        refillTimer?.cancel();
-      },
+      onDone: refillTimer.cancel,
     );
+    return _ThrottledSubscription<T>(subscription, refillTimer);
   }
 
   @override
@@ -1100,4 +1092,42 @@ class CommentsBloc extends Bloc<CommentsEvent, CommentsState> {
 
     return lastBatchCount >= _pageSize;
   }
+}
+
+/// Wraps a [StreamSubscription] so that cancelling it also cancels the
+/// throttle's refill [Timer]. Without this wrapper the periodic timer is only
+/// cleaned up via the source stream's `onDone`, leaking one timer per
+/// comments-sheet open/close cycle.
+class _ThrottledSubscription<T> implements StreamSubscription<T> {
+  _ThrottledSubscription(this._inner, this._refillTimer);
+
+  final StreamSubscription<T> _inner;
+  final Timer _refillTimer;
+
+  @override
+  Future<void> cancel() {
+    _refillTimer.cancel();
+    return _inner.cancel();
+  }
+
+  @override
+  void onData(void Function(T data)? handleData) => _inner.onData(handleData);
+
+  @override
+  void onError(Function? handleError) => _inner.onError(handleError);
+
+  @override
+  void onDone(void Function()? handleDone) => _inner.onDone(handleDone);
+
+  @override
+  bool get isPaused => _inner.isPaused;
+
+  @override
+  void pause([Future<void>? resumeSignal]) => _inner.pause(resumeSignal);
+
+  @override
+  void resume() => _inner.resume();
+
+  @override
+  Future<E> asFuture<E>([E? futureValue]) => _inner.asFuture<E>(futureValue);
 }

--- a/mobile/test/blocs/comments/comments_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_bloc_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:likes_repository/likes_repository.dart';
@@ -3066,6 +3067,49 @@ void main() {
           await streamController.close();
         },
       );
+
+      test('cancels throttle refill timer when bloc.close() is called', () {
+        final streamController = StreamController<Comment>.broadcast();
+
+        when(
+          () => mockCommentsRepository.watchComments(
+            rootEventId: any(named: 'rootEventId'),
+            rootEventKind: any(named: 'rootEventKind'),
+            rootAddressableId: any(named: 'rootAddressableId'),
+            since: any(named: 'since'),
+            onEose: any(named: 'onEose'),
+          ),
+        ).thenAnswer((_) => streamController.stream);
+
+        when(
+          () => mockCommentsRepository.loadComments(
+            rootEventId: any(named: 'rootEventId'),
+            rootEventKind: any(named: 'rootEventKind'),
+            rootAddressableId: any(named: 'rootAddressableId'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) async => CommentThread.empty(validId('root')));
+
+        fakeAsync((fake) {
+          final bloc = createBloc()..add(const CommentsLoadRequested());
+          fake.flushMicrotasks();
+
+          // The throttle's per-second refill timer should be running.
+          expect(fake.periodicTimerCount, equals(1));
+
+          // bloc.close() awaits _commentStreamSubscription.cancel() — the
+          // wrapper synchronously cancels the refill timer before delegating
+          // to the inner subscription's cancel.
+          unawaited(bloc.close());
+          fake.flushMicrotasks();
+
+          // No orphan periodic timer left behind.
+          expect(fake.periodicTimerCount, equals(0));
+
+          streamController.close();
+          fake.flushMicrotasks();
+        });
+      });
 
       test('throttles comments exceeding rate limit', () async {
         final streamController = StreamController<Comment>.broadcast();


### PR DESCRIPTION
## Summary

Closes #3482.

`CommentsBloc._throttledListen` (`mobile/lib/blocs/comments/comments_bloc.dart`) creates a `Timer.periodic(Duration(seconds: 1))` to refill the per-second event budget on the comment-stream listener. Previously the timer was only cancelled via the source stream's `onDone`. When `CommentsBloc.close()` cancels `_commentStreamSubscription` (the common path — user dismisses the comments sheet), `onDone` does not fire on the cancelled subscription, so the periodic timer was orphaned. Each comments-sheet open/close cycle leaked one timer.

## Fix

Wrap the returned `StreamSubscription` in a small `_ThrottledSubscription<T>` that cancels the refill timer in its own `cancel()` before delegating to the inner subscription. Both lifecycle paths now clean up the timer:

- Source stream signals `onDone` → existing path, unchanged.
- Caller cancels the subscription → new path, fixes the leak.

## Regression test

Added `cancels throttle refill timer when bloc.close() is called` in `mobile/test/blocs/comments/comments_bloc_test.dart`. Uses `fakeAsync.periodicTimerCount` to assert no orphan timer remains after `bloc.close()`.

Verified the test fails on the unfixed code: removing the `_ThrottledSubscription` wrap and returning the raw `stream.listen(...)` directly causes the assertion `expect(fake.periodicTimerCount, equals(0))` to fail with `Actual: <1>`.

## Test plan

- [x] `dart format` — no changes
- [x] `flutter analyze lib test integration_test` — 0 issues
- [x] `flutter test test/blocs/comments/comments_bloc_test.dart` — 108/108 (was 107, +1 for the new regression test)
- [x] `flutter test test/blocs/comments/comments_bloc_test.dart --test-randomize-ordering-seed random` — 108/108
- [x] Reverted the wrapper locally; confirmed the new test fails with `Actual: <1>` and passes again with the wrapper restored