### PR TITLE
feat(reports): add NIP-32 l/L tags to restore app-level report categorization

### DIFF
--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -361,6 +361,8 @@ class ContentReportingService {
         ['e', eventId, nip56Type],
         ['p', authorPubkey, nip56Type],
         ['client', 'diVine'],
+        ['L', 'social.nos.ontology'],
+        ['l', 'NS-${reason.name}', 'social.nos.ontology'],
       ];
 
       // Add hashtags as 't' tags

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -87,6 +87,9 @@ class ContentReport {
 /// Service for reporting inappropriate content
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
 class ContentReportingService {
+  static const String _reportLabelNamespace = 'social.nos.ontology';
+  static const String _reportLabelPrefix = 'NS-';
+
   ContentReportingService({
     required NostrClient nostrService,
     required AuthService authService,
@@ -361,8 +364,10 @@ class ContentReportingService {
         ['e', eventId, nip56Type],
         ['p', authorPubkey, nip56Type],
         ['client', 'diVine'],
-        ['L', 'social.nos.ontology'],
-        ['l', 'NS-${reason.name}', 'social.nos.ontology'],
+        ['L', _reportLabelNamespace],
+        // These label values are a cross-repo wire contract consumed by
+        // divine-web and divine-relay-manager.
+        ['l', _toNip32ReportLabel(reason), _reportLabelNamespace],
       ];
 
       // Add hashtags as 't' tags
@@ -439,6 +444,23 @@ class ContentReportingService {
       ContentFilterReason.csam => 'illegal',
       ContentFilterReason.aiGenerated => 'other',
       ContentFilterReason.other => 'other',
+    };
+  }
+
+  /// Maps app-level [ContentFilterReason] to the NIP-32 label value used by
+  /// downstream moderation UIs.
+  String _toNip32ReportLabel(ContentFilterReason reason) {
+    return switch (reason) {
+      ContentFilterReason.spam => '${_reportLabelPrefix}spam',
+      ContentFilterReason.harassment => '${_reportLabelPrefix}harassment',
+      ContentFilterReason.violence => '${_reportLabelPrefix}violence',
+      ContentFilterReason.sexualContent => '${_reportLabelPrefix}sexualContent',
+      ContentFilterReason.copyright => '${_reportLabelPrefix}copyright',
+      ContentFilterReason.falseInformation =>
+        '${_reportLabelPrefix}falseInformation',
+      ContentFilterReason.csam => '${_reportLabelPrefix}csam',
+      ContentFilterReason.aiGenerated => '${_reportLabelPrefix}aiGenerated',
+      ContentFilterReason.other => '${_reportLabelPrefix}other',
     };
   }
 

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -242,8 +242,7 @@ void main() {
           tags: any(named: 'tags'),
         ),
       ).thenAnswer((invocation) async {
-        final tags =
-            invocation.namedArguments[#tags] as List<List<String>>;
+        final tags = invocation.namedArguments[#tags] as List<List<String>>;
         capturedTags.add(tags);
         return createTestEvent(
           pubkey: testPublicKey,
@@ -258,12 +257,14 @@ void main() {
           any(),
           targetRelays: any(named: 'targetRelays'),
         ),
-      ).thenAnswer((_) async => createTestEvent(
-            pubkey: testPublicKey,
-            kind: 1984,
-            tags: [],
-            content: 'test',
-          ));
+      ).thenAnswer(
+        (_) async => createTestEvent(
+          pubkey: testPublicKey,
+          kind: 1984,
+          tags: [],
+          content: 'test',
+        ),
+      );
 
       for (final reason in ContentFilterReason.values) {
         await service.reportContent(

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -232,6 +232,80 @@ void main() {
       ).called(reasons.length);
     });
 
+    test('reportContent() includes NIP-32 l/L tags for each reason', () async {
+      final capturedTags = <List<List<String>>>[];
+
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((invocation) async {
+        final tags =
+            invocation.namedArguments[#tags] as List<List<String>>;
+        capturedTags.add(tags);
+        return createTestEvent(
+          pubkey: testPublicKey,
+          kind: 1984,
+          tags: tags,
+          content: 'test',
+        );
+      });
+
+      when(
+        () => mockNostrService.publishEvent(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) async => createTestEvent(
+            pubkey: testPublicKey,
+            kind: 1984,
+            tags: [],
+            content: 'test',
+          ));
+
+      for (final reason in ContentFilterReason.values) {
+        await service.reportContent(
+          eventId: 'event_${reason.name}',
+          authorPubkey: 'author_${reason.name}',
+          reason: reason,
+          details: 'Test ${reason.name}',
+        );
+      }
+
+      expect(
+        capturedTags.length,
+        ContentFilterReason.values.length,
+        reason: 'Should have captured tags for each reason',
+      );
+
+      for (var i = 0; i < ContentFilterReason.values.length; i++) {
+        final reason = ContentFilterReason.values[i];
+        final tags = capturedTags[i];
+
+        final lNamespaceTag = tags.firstWhere(
+          (t) => t[0] == 'L',
+          orElse: () => [],
+        );
+        expect(
+          lNamespaceTag,
+          ['L', 'social.nos.ontology'],
+          reason: 'Missing L namespace tag for ${reason.name}',
+        );
+
+        final lTag = tags.firstWhere(
+          (t) => t[0] == 'l',
+          orElse: () => [],
+        );
+        expect(
+          lTag,
+          ['l', 'NS-${reason.name}', 'social.nos.ontology'],
+          reason: 'Missing or incorrect l tag for ${reason.name}',
+        );
+      }
+    });
+
     test('reportContent() specifically tests aiGenerated reason', () async {
       // Arrange
       final reportEvent = createTestEvent(

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -233,6 +233,18 @@ void main() {
     });
 
     test('reportContent() includes NIP-32 l/L tags for each reason', () async {
+      const expectedNip32Labels = {
+        ContentFilterReason.spam: 'NS-spam',
+        ContentFilterReason.harassment: 'NS-harassment',
+        ContentFilterReason.violence: 'NS-violence',
+        ContentFilterReason.sexualContent: 'NS-sexualContent',
+        ContentFilterReason.copyright: 'NS-copyright',
+        ContentFilterReason.falseInformation: 'NS-falseInformation',
+        ContentFilterReason.csam: 'NS-csam',
+        ContentFilterReason.aiGenerated: 'NS-aiGenerated',
+        ContentFilterReason.other: 'NS-other',
+      };
+
       final capturedTags = <List<List<String>>>[];
 
       when(
@@ -276,8 +288,8 @@ void main() {
       }
 
       expect(
-        capturedTags.length,
-        ContentFilterReason.values.length,
+        capturedTags,
+        hasLength(ContentFilterReason.values.length),
         reason: 'Should have captured tags for each reason',
       );
 
@@ -285,25 +297,38 @@ void main() {
         final reason = ContentFilterReason.values[i];
         final tags = capturedTags[i];
 
-        final lNamespaceTag = tags.firstWhere(
-          (t) => t[0] == 'L',
-          orElse: () => [],
-        );
+        final eTags = tags.where((t) => t[0] == 'e').toList();
+        expect(eTags, hasLength(1), reason: 'Missing e tag for ${reason.name}');
+
+        final pTags = tags.where((t) => t[0] == 'p').toList();
+        expect(pTags, hasLength(1), reason: 'Missing p tag for ${reason.name}');
+
+        final clientTags = tags.where((t) => t[0] == 'client').toList();
         expect(
-          lNamespaceTag,
-          ['L', 'social.nos.ontology'],
-          reason: 'Missing L namespace tag for ${reason.name}',
+          clientTags,
+          hasLength(1),
+          reason: 'Missing client tag for ${reason.name}',
         );
 
-        final lTag = tags.firstWhere(
-          (t) => t[0] == 'l',
-          orElse: () => [],
-        );
+        final lNamespaceTags = tags.where((t) => t[0] == 'L').toList();
         expect(
-          lTag,
-          ['l', 'NS-${reason.name}', 'social.nos.ontology'],
-          reason: 'Missing or incorrect l tag for ${reason.name}',
+          lNamespaceTags,
+          hasLength(1),
+          reason: 'Expected exactly one L tag for ${reason.name}',
         );
+        expect(lNamespaceTags.single, ['L', 'social.nos.ontology']);
+
+        final lTags = tags.where((t) => t[0] == 'l').toList();
+        expect(
+          lTags,
+          hasLength(1),
+          reason: 'Expected exactly one l tag for ${reason.name}',
+        );
+        expect(lTags.single, [
+          'l',
+          expectedNip32Labels[reason]!,
+          'social.nos.ontology',
+        ], reason: 'Missing or incorrect l tag for ${reason.name}');
       }
     });
 


### PR DESCRIPTION
## Summary

- Adds NIP-32 label tags (`L` namespace + `l` label) to Kind 1984 report events
- Preserves the app-level reason (csam, harassment, violence, etc.) that was lost when NIP-56 standard types were adopted in March
- Matches divine-web's existing `social.nos.ontology` namespace convention
- Regression test captures tags for every ContentFilterReason and asserts correct l/L structure

## Problem

The March NIP-56 compliance change correctly moved report types to e/p tag 3rd elements, but removed the `['report', reason.name]` tag without a replacement. CSAM, violence, and copyright all collapse to `illegal` under NIP-56. Relay-manager lost the ability to show category-specific filter chips (e.g., CSAM).

## Approach

NIP-56 explicitly supports supplementary NIP-32 l/L tags for finer qualification. The new tags sit alongside the spec-compliant e/p tags without modifying them.

## Status

Draft. Liz asked to hold for Rabble's assent on the approach before moving forward.

## Related

- Closes #3488
- CSAM naming question: #3489
- Relay-manager CATEGORY_LABELS: divinevideo/divine-relay-manager#49 (separate PR)
- divine-web alignment: divinevideo/divine-web#280

## Localization note

No new l10n strings.

## Test plan

- [x] Regression test: l/L tags verified for all 9 ContentFilterReason values
- [x] Existing tests pass (14 pre-existing + 1 new = 15 total)
- [ ] Manual: file test report from simulator, verify category chip in relay-manager