### PR TITLE
fix(router): stop normalizing /invites away to /home

### DIFF
--- a/mobile/lib/providers/active_video_provider.dart
+++ b/mobile/lib/providers/active_video_provider.dart
@@ -116,6 +116,7 @@ final activeVideoIdProvider = Provider<String?>((ref) {
     case RouteType.nostrSettings:
     case RouteType.blueskySettings:
     case RouteType.editProfile:
+    case RouteType.invites:
     case RouteType.clips:
     case RouteType.clipsNoSound:
     case RouteType.drafts:

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -1055,6 +1055,7 @@ int tabIndexFromLocation(String loc) {
       return 3; // Liked videos keeps profile tab active
     case 'search':
     case 'apps':
+    case 'invites':
     case 'settings':
     case 'relay-settings':
     case 'relay-diagnostic':

--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -37,6 +37,7 @@ import 'package:openvine/screens/settings/app_language_screen.dart';
 import 'package:openvine/screens/settings/bluesky_settings_screen.dart';
 import 'package:openvine/screens/settings/content_preferences_screen.dart';
 import 'package:openvine/screens/settings/general_settings_screen.dart';
+import 'package:openvine/screens/settings/invites_screen.dart';
 import 'package:openvine/screens/settings/legal_screen.dart';
 import 'package:openvine/screens/settings/nostr_settings_screen.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
@@ -63,6 +64,7 @@ enum RouteType {
   videoEditor, // Video editor screen
   videoMetadata, // Video editor meta screen
   importKey,
+  invites, // Invite codes share/list screen
   settings,
   relaySettings, // Relay configuration screen
   relayDiagnostic, // Relay connectivity diagnostics
@@ -291,6 +293,9 @@ RouteContext parseRoute(String path) {
     case 'general-settings':
       return const RouteContext(type: RouteType.generalSettings);
 
+    case 'invites':
+      return const RouteContext(type: RouteType.invites);
+
     case 'app-language':
       return const RouteContext(type: RouteType.appLanguage);
 
@@ -512,6 +517,9 @@ String buildRoute(RouteContext context) {
 
     case RouteType.generalSettings:
       return GeneralSettingsScreen.path;
+
+    case RouteType.invites:
+      return InvitesScreen.path;
 
     case RouteType.appLanguage:
       return AppLanguageScreen.path;

--- a/mobile/test/router/route_coverage_test.dart
+++ b/mobile/test/router/route_coverage_test.dart
@@ -21,6 +21,7 @@ import 'package:openvine/screens/profile_setup_screen.dart';
 import 'package:openvine/screens/relay_diagnostic_screen.dart';
 import 'package:openvine/screens/relay_settings_screen.dart';
 import 'package:openvine/screens/safety_settings_screen.dart';
+import 'package:openvine/screens/settings/invites_screen.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/screens/video_editor/video_editor_screen.dart';
@@ -93,6 +94,18 @@ void main() {
           expect(context.type, RouteType.safetySettings);
         },
       );
+
+      // Regression: /invites used to fall through to RouteType.home, which
+      // caused routeNormalizationProvider to rewrite /invites → /home/0 the
+      // moment the user tapped the "you have N invites to share" notification.
+      test('${InvitesScreen.path} parses to RouteType.invites', () {
+        final context = parseRoute(InvitesScreen.path);
+        expect(context.type, RouteType.invites);
+      });
+
+      test('${InvitesScreen.path} is treated as a non-tab route', () {
+        expect(tabIndexFromLocation(InvitesScreen.path), -1);
+      });
     });
 
     group('Profile editing routes parse to RouteType.editProfile', () {
@@ -364,6 +377,7 @@ void main() {
       'category gallery': CategoryGalleryScreen.locationFor('animals'),
       'settings': SettingsScreen.path,
       'relay settings': RelaySettingsScreen.path,
+      'invites': InvitesScreen.path,
     };
 
     for (final entry in roundTripCases.entries) {
@@ -396,6 +410,7 @@ void main() {
         RouteType.videoEditor: VideoEditorScreen.path,
         RouteType.videoMetadata: VideoMetadataScreen.path,
         RouteType.importKey: KeyImportScreen.path,
+        RouteType.invites: InvitesScreen.path,
         RouteType.settings: SettingsScreen.path,
         RouteType.relaySettings: RelaySettingsScreen.path,
         RouteType.relayDiagnostic: RelayDiagnosticScreen.path,


### PR DESCRIPTION
Closes #3497

## Summary

- `routeNormalizationProvider` was rewriting `/invites` to `/home/0` every time the user tapped the "you have N invites to share" notification card. The push to `/invites` succeeded, briefly rendered the screen, then the normalizer fired and the user landed on the video feed instead of the invite code list.
- Root cause: `parseRoute` in `page_context_provider.dart` had no `case 'invites'`, so it fell through to `RouteType.home`. `routeNormalizationProvider` does `buildRoute(parseRoute(loc))` and redirects when the canonical path differs from the current location, so any unmapped top-level path is silently bounced to the default.
- Added `RouteType.invites`, the matching `parseRoute` / `buildRoute` cases, treated `/invites` as a non-tab route in `tabIndexFromLocation` so the bottom nav hides like other settings sub-screens, and covered the new exhaustive switch arm in `active_video_provider.dart`.
- Added regression tests to `route_coverage_test.dart` (parseRoute, non-tab classification, and round-trip — exactly what the normalization provider checks).

## Diagnostic logs from the user (showing the redirect)

```
[INFO] [ScreenAnalytics] 📱 Screen load started: invites
[DEBUG] [PageLoadObserver] ui: Page push tracked: invites
[INFO] [VideoStopNavigatorObserver] 📱 Navigation didPush to route: invites - stopped all videos
[DEBUG] [Nip98AuthService] 📱 Creating new NIP-98 auth GET https://invite.divine.video/v1/invite-status
[INFO] [RouteNormalizationProvider] 🔄 Normalizing route from /invites to /home/0   ← bug
[DEBUG] [AppRouter] auth: Router redirect: location=/home/0, authState=authenticated
[DEBUG] [PageLoadObserver] ui: Page pop tracked: invites
```

## Test plan

- [x] `flutter analyze lib test` — clean (one pre-existing pubspec sort warning in an unrelated package).
- [x] `flutter test test/router/` — 117 passing, 65 pre-existing skips.
- [x] New tests cover the bug shape:
  - `parseRoute(InvitesScreen.path)` → `RouteType.invites`
  - `tabIndexFromLocation(InvitesScreen.path)` → `-1`
  - `buildRoute(parseRoute(InvitesScreen.path))` → `/invites` (round-trip survives normalization)
- [ ] Manual: tap "you have N invites to share" in the inbox → InvitesScreen opens and stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)