### PR TITLE
fix(notifications): port consolidated unread badge logic to NotificationFeedBloc

### DIFF
--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -185,7 +185,7 @@ class NotificationFeedBloc
       if (n.id != event.notificationId || n.isRead) return n;
       return switch (n) {
         SingleNotification() => n.copyWith(isRead: true),
-        GroupedNotification() => n,
+        GroupedNotification() => n.copyWith(isRead: true),
       };
     }).toList();
 
@@ -206,11 +206,23 @@ class NotificationFeedBloc
   }
 
   /// Handle mark all as read.
+  ///
+  /// Flips `isRead: true` on every visible notification so the derived
+  /// [NotificationFeedState.unreadBadgeCount] drops to 0 immediately,
+  /// then mirrors the same on the server-truth [state.unreadCount].
   Future<void> _onMarkAllRead(
     NotificationFeedMarkAllRead event,
     Emitter<NotificationFeedState> emit,
   ) async {
-    emit(state.copyWith(unreadCount: 0));
+    final updated = state.notifications.map((n) {
+      if (n.isRead) return n;
+      return switch (n) {
+        SingleNotification() => n.copyWith(isRead: true),
+        GroupedNotification() => n.copyWith(isRead: true),
+      };
+    }).toList();
+
+    emit(state.copyWith(notifications: updated, unreadCount: 0));
 
     unawaited(_notificationRepository.markAllAsRead());
   }

--- a/mobile/lib/notifications/bloc/notification_feed_state.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_state.dart
@@ -34,7 +34,11 @@ final class NotificationFeedState extends Equatable {
   /// The list of enriched, grouped notification items.
   final List<NotificationItem> notifications;
 
-  /// Total unread count reported by the server.
+  /// Server-reported unread count.
+  ///
+  /// Held as the diagnostic source — the inbox badge derives from
+  /// [unreadBadgeCount] instead so Kind 3 republish duplicates do not
+  /// inflate the user-visible counter past the consolidated list.
   final int unreadCount;
 
   /// Whether more pages are available for pagination.
@@ -42,6 +46,20 @@ final class NotificationFeedState extends Equatable {
 
   /// Whether a load-more operation is in progress.
   final bool isLoadingMore;
+
+  /// Inbox unread badge count, derived from the consolidated visible list.
+  ///
+  /// The server reports one row per Kind 3 republish per follower — so the
+  /// same N followers can produce 2N+ rows after a few contact-list edits,
+  /// even though [NotificationRepository] has already merged them on screen
+  /// via `_consolidateFollows`. Counting unread items in the
+  /// post-consolidation list keeps the badge in sync with what the user
+  /// actually sees.
+  ///
+  // TODO(funnelcake#234): Revert to [unreadCount] once server-side Kind 3
+  // republish dedup ships and the visible list and server count agree
+  // again. Tracking: divinevideo/divine-funnelcake#234.
+  int get unreadBadgeCount => notifications.where((n) => !n.isRead).length;
 
   /// Create a copy with updated values.
   NotificationFeedState copyWith({

--- a/mobile/packages/models/lib/src/notification_item.dart
+++ b/mobile/packages/models/lib/src/notification_item.dart
@@ -159,6 +159,29 @@ class GroupedNotification extends NotificationItem {
   /// Total number of actors in this group.
   final int totalCount;
 
+  /// Returns a copy with the given fields replaced.
+  GroupedNotification copyWith({
+    String? id,
+    NotificationKind? type,
+    List<ActorInfo>? actors,
+    int? totalCount,
+    DateTime? timestamp,
+    bool? isRead,
+    String? targetEventId,
+    String? videoTitle,
+  }) {
+    return GroupedNotification(
+      id: id ?? this.id,
+      type: type ?? this.type,
+      actors: actors ?? this.actors,
+      totalCount: totalCount ?? this.totalCount,
+      timestamp: timestamp ?? this.timestamp,
+      isRead: isRead ?? this.isRead,
+      targetEventId: targetEventId ?? this.targetEventId,
+      videoTitle: videoTitle ?? this.videoTitle,
+    );
+  }
+
   @override
   String get message {
     if (actors.isEmpty) return 'Someone liked your video';

--- a/mobile/packages/models/test/src/notification_item_test.dart
+++ b/mobile/packages/models/test/src/notification_item_test.dart
@@ -404,6 +404,56 @@ void main() {
 
       expect(a, equals(b));
     });
+
+    test('copyWith updates only the specified fields', () {
+      const originalActors = [
+        ActorInfo(pubkey: _pubkeyAlice, displayName: 'alice'),
+      ];
+      const newActors = [
+        ActorInfo(pubkey: _pubkeyBob, displayName: 'bob'),
+        ActorInfo(pubkey: _pubkeyCarol, displayName: 'carol'),
+      ];
+
+      final original = GroupedNotification(
+        id: 'group_1',
+        type: NotificationKind.like,
+        actors: originalActors,
+        totalCount: 1,
+        timestamp: DateTime(2026, 4, 6),
+        targetEventId: _eventId,
+        videoTitle: 'My Video',
+      );
+
+      final updated = original.copyWith(
+        isRead: true,
+        actors: newActors,
+        totalCount: 2,
+      );
+
+      expect(updated.isRead, isTrue);
+      expect(updated.actors, equals(newActors));
+      expect(updated.totalCount, equals(2));
+      // Untouched fields stay the same.
+      expect(updated.id, equals(original.id));
+      expect(updated.type, equals(original.type));
+      expect(updated.timestamp, equals(original.timestamp));
+      expect(updated.targetEventId, equals(original.targetEventId));
+      expect(updated.videoTitle, equals(original.videoTitle));
+    });
+
+    test('copyWith with no arguments returns an equal instance', () {
+      final original = GroupedNotification(
+        id: 'group_1',
+        type: NotificationKind.like,
+        actors: const [
+          ActorInfo(pubkey: _pubkeyAlice, displayName: 'alice'),
+        ],
+        totalCount: 1,
+        timestamp: DateTime(2026, 4, 6),
+      );
+
+      expect(original.copyWith(), equals(original));
+    });
   });
 
   group('pattern matching', () {

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -387,6 +387,7 @@ void main() {
         seed: () => NotificationFeedState(
           status: NotificationFeedStatus.loaded,
           notifications: [_single(isRead: true)],
+          // ignore: avoid_redundant_argument_values
           unreadCount: 0,
         ),
         act: (bloc) => bloc.add(NotificationFeedMarkAllRead()),

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -324,6 +324,29 @@ void main() {
           ),
         ],
       );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'marks a tapped grouped notification as read and decrements unread',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.markAsRead(any()),
+          ).thenAnswer((_) async {});
+        },
+        build: createBloc,
+        seed: () => NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          notifications: [_grouped()],
+          unreadCount: 1,
+        ),
+        act: (bloc) =>
+            bloc.add(NotificationFeedItemTapped('group_like_video1')),
+        expect: () => [
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [_grouped(isRead: true)],
+          ),
+        ],
+      );
     });
 
     group('NotificationFeedMarkAllRead', () {
@@ -337,20 +360,14 @@ void main() {
         build: createBloc,
         seed: () => NotificationFeedState(
           status: NotificationFeedStatus.loaded,
-          notifications: [
-            _single(),
-            _grouped(),
-          ],
+          notifications: [_single(), _grouped()],
           unreadCount: 5,
         ),
         act: (bloc) => bloc.add(NotificationFeedMarkAllRead()),
         expect: () => [
           NotificationFeedState(
             status: NotificationFeedStatus.loaded,
-            notifications: [
-              _single(isRead: true),
-              _grouped(isRead: true),
-            ],
+            notifications: [_single(isRead: true), _grouped(isRead: true)],
           ),
         ],
         verify: (bloc) {
@@ -370,6 +387,7 @@ void main() {
         seed: () => NotificationFeedState(
           status: NotificationFeedStatus.loaded,
           notifications: [_single(isRead: true)],
+          unreadCount: 0,
         ),
         act: (bloc) => bloc.add(NotificationFeedMarkAllRead()),
         expect: () => <NotificationFeedState>[],
@@ -425,46 +443,40 @@ void main() {
     });
 
     group('unreadBadgeCount', () {
-      test(
-        'derives from the consolidated unread list, not the server-reported '
-        'unreadCount inflated by Kind 3 republishes',
-        () {
-          // Repository already consolidated 5 raw follow rows from 2 distinct
-          // pubkeys down to 2 visible items, but the server still reports
-          // unreadCount: 5 (funnelcake#234). The badge must follow the list.
-          final state = NotificationFeedState(
-            status: NotificationFeedStatus.loaded,
-            notifications: [
-              _single(
-                id: 'follow_a',
-                type: NotificationKind.follow,
-                pubkey: 'follower_a',
-              ),
-              _single(
-                id: 'follow_b',
-                type: NotificationKind.follow,
-                pubkey: 'follower_b',
-              ),
-            ],
-            unreadCount: 5,
-          );
+      test('derives from the consolidated unread list, not the server-reported '
+          'unreadCount inflated by Kind 3 republishes', () {
+        // Repository already consolidated 5 raw follow rows from 2 distinct
+        // pubkeys down to 2 visible items, but the server still reports
+        // unreadCount: 5 (funnelcake#234). The badge must follow the list.
+        final state = NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          notifications: [
+            _single(
+              id: 'follow_a',
+              type: NotificationKind.follow,
+              pubkey: 'follower_a',
+            ),
+            _single(
+              id: 'follow_b',
+              type: NotificationKind.follow,
+              pubkey: 'follower_b',
+            ),
+          ],
+          unreadCount: 5,
+        );
 
-          expect(state.unreadBadgeCount, 2);
-        },
-      );
+        expect(state.unreadBadgeCount, 2);
+      });
 
-      test(
-        'drops to 0 when notifications list is empty even if server reports '
-        'unread items',
-        () {
-          const state = NotificationFeedState(
-            status: NotificationFeedStatus.loaded,
-            unreadCount: 42,
-          );
+      test('drops to 0 when notifications list is empty even if server reports '
+          'unread items', () {
+        const state = NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          unreadCount: 42,
+        );
 
-          expect(state.unreadBadgeCount, 0);
-        },
-      );
+        expect(state.unreadBadgeCount, 0);
+      });
 
       test('excludes already-read notifications', () {
         final state = NotificationFeedState(

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -328,7 +328,7 @@ void main() {
 
     group('NotificationFeedMarkAllRead', () {
       blocTest<NotificationFeedBloc, NotificationFeedState>(
-        'sets unread count to 0',
+        'flips isRead on every notification and zeros unread count',
         setUp: () {
           when(
             () => mockNotificationRepo.markAllAsRead(),
@@ -337,16 +337,45 @@ void main() {
         build: createBloc,
         seed: () => NotificationFeedState(
           status: NotificationFeedStatus.loaded,
-          notifications: [_single()],
+          notifications: [
+            _single(),
+            _grouped(),
+          ],
           unreadCount: 5,
         ),
         act: (bloc) => bloc.add(NotificationFeedMarkAllRead()),
         expect: () => [
           NotificationFeedState(
             status: NotificationFeedStatus.loaded,
-            notifications: [_single()],
+            notifications: [
+              _single(isRead: true),
+              _grouped(isRead: true),
+            ],
           ),
         ],
+        verify: (bloc) {
+          // Derived badge reflects the flipped list immediately.
+          expect(bloc.state.unreadBadgeCount, 0);
+        },
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'is a no-op when everything is already read and the count is zero',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.markAllAsRead(),
+          ).thenAnswer((_) async {});
+        },
+        build: createBloc,
+        seed: () => NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          notifications: [_single(isRead: true)],
+        ),
+        act: (bloc) => bloc.add(NotificationFeedMarkAllRead()),
+        expect: () => <NotificationFeedState>[],
+        verify: (_) {
+          verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+        },
       );
     });
 
@@ -393,6 +422,77 @@ void main() {
         expect: () => <NotificationFeedState>[],
         errors: () => [isA<Exception>()],
       );
+    });
+
+    group('unreadBadgeCount', () {
+      test(
+        'derives from the consolidated unread list, not the server-reported '
+        'unreadCount inflated by Kind 3 republishes',
+        () {
+          // Repository already consolidated 5 raw follow rows from 2 distinct
+          // pubkeys down to 2 visible items, but the server still reports
+          // unreadCount: 5 (funnelcake#234). The badge must follow the list.
+          final state = NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              _single(
+                id: 'follow_a',
+                type: NotificationKind.follow,
+                pubkey: 'follower_a',
+              ),
+              _single(
+                id: 'follow_b',
+                type: NotificationKind.follow,
+                pubkey: 'follower_b',
+              ),
+            ],
+            unreadCount: 5,
+          );
+
+          expect(state.unreadBadgeCount, 2);
+        },
+      );
+
+      test(
+        'drops to 0 when notifications list is empty even if server reports '
+        'unread items',
+        () {
+          const state = NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            unreadCount: 42,
+          );
+
+          expect(state.unreadBadgeCount, 0);
+        },
+      );
+
+      test('excludes already-read notifications', () {
+        final state = NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          notifications: [
+            _single(id: 'unread_1'),
+            _single(id: 'unread_2', pubkey: 'def'),
+            _single(id: 'read_1', pubkey: 'ghi', isRead: true),
+          ],
+          unreadCount: 3,
+        );
+
+        expect(state.unreadBadgeCount, 2);
+      });
+
+      test('counts unread grouped notifications alongside singles', () {
+        final state = NotificationFeedState(
+          status: NotificationFeedStatus.loaded,
+          notifications: [
+            _single(),
+            _grouped(),
+            _grouped(id: 'group2', targetEventId: 'video2', isRead: true),
+          ],
+        );
+
+        // Two unread (one single + one grouped), one read group excluded.
+        expect(state.unreadBadgeCount, 2);
+      });
     });
 
     group('realtime blocklist filtering', () {


### PR DESCRIPTION
## Description

PR #3472 corrected the inbox unread badge on the **Riverpod** notifications path by deriving the count from the consolidated visible list instead of `state.unreadCount` (which the server inflates whenever a follower republishes Kind 3 — every contact-list edit emits one notification row per existing follow, and `unread_count` counts each duplicate).

The same gap existed in `NotificationFeedBloc` — the gated/off migration target. This PR ports the contract so flipping the migration gate cannot reintroduce the mismatch.

**Related Issue:** Closes #3487
**Upstream tracking:** [divinevideo/divine-funnelcake#234](https://github.com/divinevideo/divine-funnelcake/issues/234) (server-side Kind 3 republish dedup — still OPEN; the new `unreadBadgeCount` getter carries the same `TODO(funnelcake#234)` revert pointer as the Riverpod path)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Changes

- `NotificationFeedState.unreadBadgeCount` — new derived getter that counts unread items in the post-consolidation list. `unreadCount` stays as the server-truth diagnostic / revert target.
- `_onMarkAllRead` now flips `isRead: true` on every visible notification so the derived badge clears immediately, matching `RelayNotifications.markAllAsRead`.
- `_onItemTapped` flips `isRead` on tapped `GroupedNotification` rows too (previously a no-op on grouped items).
- New `GroupedNotification.copyWith`, mirroring `SingleNotification.copyWith`, so the BLoC can flip read state on either subtype.

## Test plan

### Automated

- [x] Four new `unreadBadgeCount` cases mirror PR #3472's contract: 5 follow rows from 2 distinct pubkeys + server `unreadCount: 5` → 2; empty list + server `unreadCount: 42` → 0; mixed read/unread → only unread; grouped + single mix with one read group excluded → 2.
- [x] `_onMarkAllRead` now asserts the list flip (singles + grouped) and the no-op case (already-read).
- [x] New `GroupedNotification.copyWith` tests in `models`.
- [x] `dart format` / `flutter analyze lib test integration_test` clean.
- [x] `flutter test test/notifications` — 53 / 53 pass.
- [x] `flutter test packages/notification_repository` — 44 / 44 pass.
- [x] `flutter test packages/models` (notification_item_test.dart) — 29 / 29 pass.

### Manual (real device)

The inbox badge UI currently still reads the Riverpod provider (the path PR #3472 already fixed); the BLoC contract is verified by unit tests until the migration cutover. What you can directly observe on device today is the **list behavior**:

1. **Mark-all-read clears unread dots.** Generate fresh unread notifications, open the inbox → Notifications tab. Every "unread" dot disappears immediately. Pop and re-open — items stay read, no flicker back.
2. **Tapping a grouped notification clears its dot.** Find a "X and N others liked your video" row, tap it. Dot disappears, navigation occurs, dot stays cleared after back-nav.
3. **Tapping a single notification still clears its dot** (regression check). Standard behavior unchanged.
4. **Real-time arrival adds an unread row.** With the screen foregrounded, have someone like / follow / comment on you. New row appears at top with an unread dot; tapping clears it.
5. **Kind 3 republish dedup** (regression check). Have a teammate follow → unfollow → follow you in quick succession, then pull-to-refresh. Single row, not three.

To eyeball the badge digit itself before the migration cutover, temporarily swap `relayNotificationUnreadCountProvider` in `mobile/lib/screens/inbox/inbox_view.dart:63` for a `BlocSelector<NotificationFeedBloc, NotificationFeedState, int>(selector: (s) => s.unreadBadgeCount, …)`. **Do not commit this** — it's a local probe; revert before pushing.

### Failure signals to watch for

| Symptom on device | Likely cause |
|---|---|
| Unread dots persist after opening notifications | `_onMarkAllRead` not flipping `isRead` (regression in this PR) |
| Tapping grouped notif doesn't clear its dot | `GroupedNotification.copyWith` not wired into `_onItemTapped` |
| Tapping single notif doesn't clear its dot | Regression in pre-existing `SingleNotification` path |
| Multiple rows from the same user after a Kind 3 burst | `_consolidateFollows` regression in `notification_repository` (out of scope for this PR — rare; flag separately) |
| Badge digit on bottom nav doesn't match list | Today: Riverpod path issue (not this PR). After migration: `NotificationFeedBloc.state.unreadBadgeCount` consumer is wired wrong. |