### PR TITLE
feat(feeds): PopularNow uses sort=watching, surfaces classic Vines

### DIFF
--- a/mobile/lib/providers/popular_now_feed_provider.dart
+++ b/mobile/lib/providers/popular_now_feed_provider.dart
@@ -1,5 +1,5 @@
-// ABOUTME: PopularNow feed provider showing newest videos with REST API + Nostr fallback
-// ABOUTME: Tries Funnelcake REST API first, falls back to Nostr subscription if unavailable
+// ABOUTME: PopularNow feed provider showing what's being watched right now
+// ABOUTME: Tries Funnelcake REST API (sort=watching, 24h view count) first, Nostr fallback
 
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/constants/app_constants.dart';
@@ -91,7 +91,7 @@ class PopularNowFeed extends _$PopularNowFeed {
       );
 
       try {
-        final stats = await client.getRecentVideos();
+        final stats = await client.getWatchingVideos();
         final apiVideos = stats.toVideoEvents();
         if (apiVideos.isNotEmpty) {
           _usingRestApi = true;
@@ -231,7 +231,7 @@ class PopularNowFeed extends _$PopularNowFeed {
         );
 
         // Use cursor (before parameter) for pagination
-        final stats = await client.getRecentVideos(before: _nextCursor);
+        final stats = await client.getWatchingVideos(before: _nextCursor);
         final apiVideos = stats.toVideoEvents();
 
         if (!ref.mounted) return;
@@ -396,7 +396,7 @@ class PopularNowFeed extends _$PopularNowFeed {
     if (_usingRestApi) {
       try {
         final client = ref.read(funnelcakeApiClientProvider);
-        final stats = await client.getRecentVideos();
+        final stats = await client.getWatchingVideos();
         final apiVideos = stats.toVideoEvents();
 
         // Check if provider is still mounted after async gap

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -324,6 +324,66 @@ class FunnelcakeApiClient {
     }
   }
 
+  /// Fetches videos sorted by 24-hour CDN view count with NO age decay.
+  ///
+  /// Surfaces what people are looking at right now — including classic
+  /// Vines getting current attention. Backed by Funnelcake's
+  /// `?sort=watching` mode (see funnelcake#305 + funnelcake#307).
+  ///
+  /// [limit] is the maximum number of videos to return (defaults to 50).
+  /// [before] is an optional Unix timestamp cursor for pagination.
+  ///
+  /// Throws:
+  /// - [FunnelcakeNotConfiguredException] if the API is not configured.
+  /// - [FunnelcakeApiException] if the request fails with a non-success status.
+  /// - [FunnelcakeTimeoutException] if the request times out.
+  /// - [FunnelcakeException] for other errors.
+  Future<List<VideoStats>> getWatchingVideos({
+    int limit = 50,
+    int? before,
+  }) async {
+    if (!isAvailable) {
+      throw const FunnelcakeNotConfiguredException();
+    }
+
+    final queryParams = _videoQueryParameters({
+      'sort': 'watching',
+      'limit': limit.toString(),
+    });
+    if (before != null) {
+      queryParams['before'] = before.toString();
+    }
+
+    final uri = Uri.parse(
+      '$_baseUrl/api/videos',
+    ).replace(queryParameters: queryParams);
+
+    try {
+      final response = await _get(uri);
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as List<dynamic>;
+
+        return data
+            .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
+            .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
+            .toList();
+      } else {
+        throw FunnelcakeApiException(
+          message: 'Failed to fetch watching videos',
+          statusCode: response.statusCode,
+          url: uri.toString(),
+        );
+      }
+    } on TimeoutException {
+      throw FunnelcakeTimeoutException(uri.toString());
+    } on FunnelcakeException {
+      rethrow;
+    } catch (e) {
+      throw FunnelcakeException('Failed to fetch watching videos: $e');
+    }
+  }
+
   /// Fetches the home feed for a specific user.
   ///
   /// Returns videos from accounts the user follows, with cursor-based


### PR DESCRIPTION
Closes #3501

## Summary
PopularNow feed has been misnamed — it actually called \`getRecentVideos()\` (sort=recent), returning newest uploads instead of most-watched.

This swaps it to use Funnelcake's new \`?sort=watching\` (24h CDN+relay view count, NO age decay) so classic Vines getting current attention surface alongside fresh uploads.

## Changes
- \`mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart\`: add \`getWatchingVideos({int limit, int? before})\`. Same shape as \`getRecentVideos\`/\`getTrendingVideos\`, just hits \`?sort=watching\`.
- \`mobile/lib/providers/popular_now_feed_provider.dart\`: 3 call sites swapped (initial load, \`loadMore\` cursor pagination, \`refresh\`).
- File ABOUTME header updated.

Provider class name and file name **unchanged** to avoid churn during launch window.

## Reference
- Backend PRs: divine-funnelcake#305 (initial sort=watching), divine-funnelcake#307 (cdn_view_counts union)
- Web PR: divine-web#282 (Hot tab flip)
- Verified live: \`curl 'https://api.divine.video/api/v2/videos?sort=watching&limit=5'\` returns classic Vines (e.g. 2016 Naruto vine with 33M loops) above recent uploads.

## Test plan
- [x] \`flutter analyze\` clean for both edited files
- [x] funnelcake_api_client package: \`No issues found\`
- [ ] Manual: open PopularNow tab, confirm classic Vines appear among top results

Launching in 2 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)