### PR TITLE
feat(time_formatter): add epoch-second DateTime extensions

### DIFF
--- a/mobile/packages/time_formatter/lib/src/epoch_seconds_extensions.dart
+++ b/mobile/packages/time_formatter/lib/src/epoch_seconds_extensions.dart
@@ -1,0 +1,23 @@
+// ABOUTME: DateTime extensions for Nostr-style epoch-second integers.
+// ABOUTME: Avoids the `* 1000` / `~/ 1000` magic numbers at every call site.
+
+/// Conversions from a Nostr-style epoch-seconds [int] to a [DateTime].
+extension EpochSecondsToDateTime on int {
+  /// Treats this int as Nostr-style epoch seconds and returns the
+  /// corresponding [DateTime] in UTC.
+  ///
+  /// Nostr `created_at` is conventionally UTC seconds, so the returned
+  /// value is always UTC. Call `.toLocal()` if the wall-clock value is
+  /// needed for display.
+  DateTime toDateTimeFromEpochSeconds() =>
+      DateTime.fromMillisecondsSinceEpoch(this * 1000, isUtc: true);
+}
+
+/// Conversions from a [DateTime] to Nostr-style epoch seconds.
+extension DateTimeToEpochSeconds on DateTime {
+  /// Returns this [DateTime] as Nostr-style epoch seconds.
+  ///
+  /// Sub-second precision is truncated (matches the dominant `~/ 1000`
+  /// idiom used across the codebase).
+  int toEpochSeconds() => millisecondsSinceEpoch ~/ 1000;
+}

--- a/mobile/packages/time_formatter/lib/time_formatter.dart
+++ b/mobile/packages/time_formatter/lib/time_formatter.dart
@@ -1,1 +1,2 @@
+export 'src/epoch_seconds_extensions.dart';
 export 'src/time_formatter.dart';

--- a/mobile/packages/time_formatter/test/src/epoch_seconds_extensions_test.dart
+++ b/mobile/packages/time_formatter/test/src/epoch_seconds_extensions_test.dart
@@ -1,0 +1,67 @@
+import 'package:test/test.dart';
+import 'package:time_formatter/time_formatter.dart';
+
+void main() {
+  group('EpochSecondsToDateTime', () {
+    test('zero seconds maps to the Unix epoch in UTC', () {
+      final dt = 0.toDateTimeFromEpochSeconds();
+      expect(dt, equals(DateTime.utc(1970)));
+    });
+
+    test('returned DateTime is UTC', () {
+      expect(0.toDateTimeFromEpochSeconds().isUtc, isTrue);
+      expect(1700000000.toDateTimeFromEpochSeconds().isUtc, isTrue);
+    });
+
+    test('known timestamp 1700000000 maps to expected UTC datetime', () {
+      // 2023-11-14T22:13:20Z
+      final dt = 1700000000.toDateTimeFromEpochSeconds();
+      expect(dt, equals(DateTime.utc(2023, 11, 14, 22, 13, 20)));
+    });
+
+    test('negative seconds return pre-epoch UTC datetime', () {
+      // -86400 seconds == one day before the epoch
+      final dt = (-86400).toDateTimeFromEpochSeconds();
+      expect(dt, equals(DateTime.utc(1969, 12, 31)));
+    });
+  });
+
+  group('DateTimeToEpochSeconds', () {
+    test('UTC epoch returns 0', () {
+      expect(DateTime.utc(1970).toEpochSeconds(), equals(0));
+    });
+
+    test('known UTC datetime returns expected epoch seconds', () {
+      expect(
+        DateTime.utc(2023, 11, 14, 22, 13, 20).toEpochSeconds(),
+        equals(1700000000),
+      );
+    });
+
+    test('truncates sub-second milliseconds', () {
+      // 1500ms past epoch -> 1 epoch second (not 2 — confirms `~/`, not round)
+      final dt = DateTime.fromMillisecondsSinceEpoch(1500, isUtc: true);
+      expect(dt.toEpochSeconds(), equals(1));
+    });
+
+    test('local datetime returns the same epoch seconds as its UTC value', () {
+      // millisecondsSinceEpoch is timezone-agnostic, so the extension
+      // must return the same int regardless of the DateTime's `isUtc`.
+      final utc = DateTime.utc(2023, 11, 14, 22, 13, 20);
+      expect(utc.toLocal().toEpochSeconds(), equals(utc.toEpochSeconds()));
+    });
+  });
+
+  group('round-trip', () {
+    test('epoch seconds -> DateTime -> epoch seconds is identity', () {
+      const samples = [0, 1, 1700000000, -86400, 2147483647];
+      for (final s in samples) {
+        expect(
+          s.toDateTimeFromEpochSeconds().toEpochSeconds(),
+          equals(s),
+          reason: 'round-trip failed for $s',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Description

Introduces two extensions in `time_formatter` so the `* 1000` / `~/ 1000` magic numbers don't have to be repeated at every Nostr-time call site:

```dart
extension EpochSecondsToDateTime on int {
  DateTime toDateTimeFromEpochSeconds() =>
      DateTime.fromMillisecondsSinceEpoch(this * 1000, isUtc: true);
}

extension DateTimeToEpochSeconds on DateTime {
  int toEpochSeconds() => millisecondsSinceEpoch ~/ 1000;
}
```

This PR adds the primitives only. Migrating the ~58 + ~28 existing call sites is explicitly out of scope and will be follow-up PR(s) split by package.

### Why `time_formatter` and not a new package

`time_formatter` already owns Nostr-time conversion logic — every one of its 8 formatter methods does `DateTime.fromMillisecondsSinceEpoch(unixSeconds * 1000, isUtc: true).toLocal()` internally. Adding the primitives that already underpin its formatters is cohesive, reuses the existing `min_coverage: 100` CI gate, and avoids spawning a new package.

### API decisions

- **`int`, not `int?`** — `Event.createdAt` is non-nullable `int` in `nostr_sdk/lib/event.dart:67` and `models/lib/src/video_event.dart:625`. Callers with nullable wrappers can keep their `?` check and call the extension on the unwrapped int.
- **UTC by default** — Nostr `created_at` is conventionally UTC seconds. Returning UTC is the only semantically correct choice. Callers needing a wall-clock value chain `.toLocal()` explicitly.
- **Single method per direction** — A `{bool isUtc = true}` parameter or a sibling `toDateTimeFromEpochSecondsLocal` would give callers a footgun. Force them through the correct primitive.
- **`~/ 1000` (truncating)** — matches 171 of 174 existing inverse call sites. The 3 `(/ 1000).round()` cases live in NIP-98 auth-header code where rounding-vs-truncating is operationally indistinguishable.

**Related Issue:** Closes #3504

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

---

## Manual test plan

This PR adds standalone extension methods with no UI surface; verification is via the package's own tests + CI coverage gate.

```
cd mobile/packages/time_formatter
flutter test --coverage
# verify 100% line coverage on lib/src/epoch_seconds_extensions.dart
```

## Automated tests

- `mobile/packages/time_formatter/test/src/epoch_seconds_extensions_test.dart`: 9 new tests across three groups (`EpochSecondsToDateTime`, `DateTimeToEpochSeconds`, `round-trip`). 42 total package tests pass. LCOV reports 3/3 lines hit on the new file (100%).
- `flutter analyze lib test`: clean.
- `dart format`: clean.

## Files changed

| File | Why |
|---|---|
| `mobile/packages/time_formatter/lib/src/epoch_seconds_extensions.dart` | New — the two extensions. |
| `mobile/packages/time_formatter/lib/time_formatter.dart` | Add `export 'src/epoch_seconds_extensions.dart';` to the barrel. |
| `mobile/packages/time_formatter/test/src/epoch_seconds_extensions_test.dart` | New — 9 unit tests covering zero / known timestamps / negative / UTC vs local / sub-second truncation / round-trip identity. |

## Out of scope (next PRs)

1. Migrate the 4 internal `time_formatter.dart` call sites that already match the new extension shape.
2. Migrate `mobile/packages/*` external call sites — split per package since each has its own CI workflow.
3. Migrate `mobile/lib/` call sites — likely 2–3 PRs grouped by feature area.