### PR TITLE
fix(profile): include reservedUsernames in ProfileEditorState equality

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_state.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_state.dart
@@ -233,6 +233,7 @@ final class ProfileEditorState extends Equatable {
     usernameStatus,
     usernameError,
     usernameFormatMessage,
+    reservedUsernames,
     nip05Mode,
     externalNip05,
     initialExternalNip05,

--- a/mobile/test/blocs/profile_editor/profile_editor_state_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_state_test.dart
@@ -79,5 +79,22 @@ void main() {
 
       expect(state1, isNot(equals(state2)));
     });
+
+    test('different reservedUsernames are not equal', () {
+      const state1 = ProfileEditorState();
+      const state2 = ProfileEditorState(reservedUsernames: {'admin'});
+
+      expect(state1, isNot(equals(state2)));
+    });
+
+    test(
+      'reservedUsernames with same elements are equal regardless of order',
+      () {
+        const state1 = ProfileEditorState(reservedUsernames: {'admin', 'root'});
+        const state2 = ProfileEditorState(reservedUsernames: {'root', 'admin'});
+
+        expect(state1, equals(state2));
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description

`ProfileEditorState` declares, defaults, and `copyWith`-copies the `reservedUsernames` field but omits it from `Equatable.props`. Two states differing only in the reserved-username cache therefore compare equal, which (a) violates the equality contract and (b) makes any `emit()` whose only delta is the cache get suppressed by `bloc`'s built-in distinct-state short-circuit.

This is currently a **latent** bug: every emit in the bloc that mutates `reservedUsernames` (`profile_editor_bloc.dart:196, 307, 325, 346, 489`) also mutates `usernameStatus` or `status`, both already in props, so the status delta carries the emit through. Any future cache-only emit — preload-from-cache, dedup, etc. — would silently drop today.

The fix is a one-line addition to `props` plus a regression test.

**Related Issue:** Closes #3370

## Reproduction (unit-test level)

Without the fix, the following test passes when it should fail — proving the equality contract is broken:

```dart
test('reservedUsernames participates in equality', () {
  const a = ProfileEditorState();
  const b = ProfileEditorState(reservedUsernames: {'admin'});
  expect(a, equals(b)); // PASSES on main — bug
});
```

After the fix, two states differing only by `reservedUsernames` are correctly unequal, and two states with the same elements in different insertion order are correctly equal (Equatable 2.0.8 implements `Set` equality natively via `setEquals` and order-independent hashing — confirmed in `pub-cache/equatable-2.0.8/lib/src/equatable_utils.dart:38-45,95-97`).

## Changes

- `mobile/lib/blocs/profile_editor/profile_editor_state.dart` — add `reservedUsernames` to `props` between `usernameFormatMessage` and `nip05Mode` to mirror constructor / field declaration order.
- `mobile/test/blocs/profile_editor/profile_editor_state_test.dart` — add two tests:
  - inequality when only `reservedUsernames` differs (the AC test from the issue),
  - order-independence sanity check confirming Set semantics.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `flutter test test/blocs/profile_editor/profile_editor_state_test.dart test/blocs/profile_editor/profile_editor_bloc_test.dart` — 69/69 pass (8 original state + 2 new + 59 bloc).
- [x] `flutter analyze lib/blocs/profile_editor test/blocs/profile_editor` — no issues.
- [x] Pre-commit hook (format + analyze) green.

## Notes for reviewer

- The audit issue #3370 speculates a link to #3161 / #3152 ("can't save username"). Those user logs show `ProfilePublishFailedException` (publish-side), not state suppression — this PR fixes the equality bug on its own merits and should **not** be expected to close those Zendesk tickets.
- No sorting / List-wrapping is needed for the `Set<String>` prop — Equatable handles it natively. Verified against the installed equatable 2.0.8 sources.
- Regression risk is very low: the change makes states more discriminating, not less; all existing tests stay green and grep confirms no code path depends on cache-only collapses.