### PR TITLE
fix(profile): keep deleteCachedProfile in-memory indexes consistent

### DIFF
--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -175,9 +175,17 @@ class ProfileRepository {
 
   /// Deletes a cached profile from local storage.
   ///
-  /// Returns the number of rows deleted (0 or 1).
-  Future<int> deleteCachedProfile({required String pubkey}) {
-    return _userProfilesDao.deleteProfile(pubkey);
+  /// Returns the number of rows deleted (0 or 1). On a successful delete
+  /// (rows > 0), also removes the pubkey from the in-memory known-cached
+  /// set so [hasProfile] returns `false` for the rest of the session.
+  /// Does not add the pubkey to the confirmed-missing set — a local
+  /// eviction does not prove remote absence.
+  Future<int> deleteCachedProfile({required String pubkey}) async {
+    final rowsAffected = await _userProfilesDao.deleteProfile(pubkey);
+    if (rowsAffected > 0) {
+      _knownCached.remove(pubkey);
+    }
+    return rowsAffected;
   }
 
   /// Returns all cached profiles from local storage.

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -254,6 +254,49 @@ void main() {
 
         expect(result, equals(0));
       });
+
+      test(
+        'removes pubkey from known cached set on successful delete',
+        () async {
+          final profile = UserProfile.fromNostrEvent(mockProfileEvent);
+          await profileRepository.cacheProfile(profile);
+          expect(profileRepository.hasProfile(testPubkey), isTrue);
+
+          when(
+            () => mockUserProfilesDao.deleteProfile(any()),
+          ).thenAnswer((_) async => 1);
+
+          await profileRepository.deleteCachedProfile(pubkey: testPubkey);
+
+          expect(profileRepository.hasProfile(testPubkey), isFalse);
+        },
+      );
+
+      test('keeps pubkey in known cached set when delete is a no-op', () async {
+        final profile = UserProfile.fromNostrEvent(mockProfileEvent);
+        await profileRepository.cacheProfile(profile);
+        expect(profileRepository.hasProfile(testPubkey), isTrue);
+
+        when(
+          () => mockUserProfilesDao.deleteProfile(any()),
+        ).thenAnswer((_) async => 0);
+
+        await profileRepository.deleteCachedProfile(pubkey: testPubkey);
+
+        expect(profileRepository.hasProfile(testPubkey), isTrue);
+      });
+
+      test('does not mark pubkey as confirmed missing on delete', () async {
+        final profile = UserProfile.fromNostrEvent(mockProfileEvent);
+        await profileRepository.cacheProfile(profile);
+        when(
+          () => mockUserProfilesDao.deleteProfile(any()),
+        ).thenAnswer((_) async => 1);
+
+        await profileRepository.deleteCachedProfile(pubkey: testPubkey);
+
+        expect(profileRepository.isConfirmedMissing(testPubkey), isFalse);
+      });
     });
 
     group('getAllCachedProfiles', () {


### PR DESCRIPTION
## Description

`ProfileRepository.deleteCachedProfile` previously only delegated to the Drift
DAO. The session-scoped `_knownCached` set (populated by `cacheProfile`,
`fetchFreshProfile`, and `loadKnownCachedPubkeys`) was never updated on delete,
so after a successful eviction `hasProfile(pubkey)` kept returning `true` for
the rest of the session. Any caller that uses `hasProfile` as a "skip Kind 0
fetch" gate (`SubscriptionManager` and any future caller of the same shape)
would skip the relay refetch that the cache state actually requires, leaving
stale or missing profile UI until app restart.

This PR makes the delete path consistent with the cache path:

- Awaits `_userProfilesDao.deleteProfile(pubkey)` and removes the pubkey from
  `_knownCached` only when the DAO actually deleted a row (`rows > 0`).
- Leaves `_confirmedMissing` untouched — a local eviction does not prove
  remote absence (matches the issue's recommended fix).

**Related Issue:** Closes #3368

## Reproduction

Before this change:

```dart
await repo.cacheProfile(p);
expect(repo.hasProfile(p.pubkey), isTrue);   // OK

await repo.deleteCachedProfile(pubkey: p.pubkey); // returns 1
expect(repo.hasProfile(p.pubkey), isFalse);  // FAILS — still true
```

After this change `hasProfile` returns `false` once the DAO confirms the row
was deleted; on a no-op delete (`rows == 0`) the in-memory index is left
intact.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Testing

Three new unit tests added to `group('deleteCachedProfile', ...)`:

1. `removes pubkey from known cached set on successful delete` — caches a
   profile, deletes with `rows = 1`, asserts `hasProfile` is `false`.
2. `keeps pubkey in known cached set when delete is a no-op` — caches a
   profile, deletes with `rows = 0`, asserts `hasProfile` stays `true`.
3. `does not mark pubkey as confirmed missing on delete` — caches, deletes,
   asserts `isConfirmedMissing` is `false` (a local delete must not poison
   future `fetchFreshProfile` calls into skipping remote sources).

Local verification (from `mobile/packages/profile_repository`):

- `dart format --set-exit-if-changed`: clean.
- `flutter analyze lib test`: no issues.
- `flutter test test/src/profile_repository_test.dart`: 170 passed.

## Acceptance Criteria

- [x] Deleting an existing cached profile removes it from `_knownCached`.
- [x] `hasProfile(pubkey)` returns false after successful deletion.
- [x] Failed/no-op deletes do not incorrectly mark pubkeys missing.
- [x] Unit tests cover in-memory index behavior.

## Risk

Low. `deleteCachedProfile` has no current production callers (`grep -rn
deleteCachedProfile` outside test files returns zero hits), so this is a
pre-emptive fix that closes the trap before the next caller hits it. The
public signature (`Future<int>`) is unchanged; the behaviour change is
purely additive on the success path. The two existing tests
(`delegates to userProfilesDao.deleteProfile` and `returns 0 when profile
does not exist`) continue to pass.