### PR TITLE
fix(router): stop double-decoding hashtag/search path params (#3413)

### DIFF
--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -408,6 +408,11 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         name: HashtagScreenRouter.routeName,
         parentNavigatorKey: NavigatorKeys.root,
         builder: (ctx, st) {
+          // go_router already decodes path parameters once during route
+          // matching (see go_router/src/match.dart). Decoding again here
+          // would crash on legitimate inputs containing literal `%`
+          // (e.g. `100%fun`) because the second decode sees a malformed
+          // sequence. Pass the value through as-is.
           final tag = st.pathParameters['tag'];
           if (tag == null || tag.isEmpty) {
             return Scaffold(
@@ -415,8 +420,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
               body: Center(child: Text(ctx.l10n.routeInvalidHashtag)),
             );
           }
-          final decoded = Uri.decodeComponent(tag);
-          return HashtagFeedScreen(hashtag: decoded);
+          return HashtagFeedScreen(hashtag: tag);
         },
       ),
       // SEARCH RESULTS - unified search screen (no bottom nav)
@@ -424,9 +428,9 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         path: SearchResultsPage.path,
         parentNavigatorKey: NavigatorKeys.root,
         builder: (ctx, st) {
-          final query = st.pathParameters['query'];
-          final decoded = query != null ? Uri.decodeComponent(query) : '';
-          return SearchResultsPage(initialQuery: decoded);
+          // See note above: do not double-decode path parameters.
+          final query = st.pathParameters['query'] ?? '';
+          return SearchResultsPage(initialQuery: query);
         },
       ),
 

--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -133,6 +133,22 @@ class RouteContext {
   final String? conversationId;
 }
 
+/// Decodes a URL path segment, returning the raw input on malformed
+/// percent-encoding instead of throwing. See #3413.
+///
+/// `Uri.decodeComponent` throws `ArgumentError` on malformed input
+/// (e.g. a dangling `%` from a hand-crafted deep link). Treating that
+/// as a recoverable boundary error rather than a programmer bug is
+/// intentional here, so the lint is suppressed locally.
+String _safeDecode(String segment) {
+  try {
+    return Uri.decodeComponent(segment);
+    // ignore: avoid_catching_errors
+  } on ArgumentError {
+    return segment;
+  }
+}
+
 /// Parse a URL path into a structured RouteContext
 /// Normalizes negative indices to 0 and decodes URL-encoded parameters
 RouteContext parseRoute(String path) {
@@ -162,7 +178,7 @@ RouteContext parseRoute(String path) {
       if (segments.length < 2) {
         return const RouteContext(type: RouteType.home);
       }
-      final npub = Uri.decodeComponent(segments[1]); // Decode URL encoding
+      final npub = _safeDecode(segments[1]); // Decode URL encoding
       // Grid mode (no index) vs feed mode (with index)
       if (segments.length > 2) {
         final rawIndex = int.tryParse(segments[2]) ?? 0;
@@ -187,7 +203,7 @@ RouteContext parseRoute(String path) {
       // /inbox/message-requests - message requests inbox
       // /inbox/message-requests/:id - request preview
       if (segments.length > 2 && segments[1] == 'conversation') {
-        final conversationId = Uri.decodeComponent(segments[2]);
+        final conversationId = _safeDecode(segments[2]);
         return RouteContext(
           type: RouteType.conversation,
           conversationId: conversationId,
@@ -195,7 +211,7 @@ RouteContext parseRoute(String path) {
       }
       if (segments.length > 1 && segments[1] == 'message-requests') {
         if (segments.length > 2) {
-          final conversationId = Uri.decodeComponent(segments[2]);
+          final conversationId = _safeDecode(segments[2]);
           return RouteContext(
             type: RouteType.requestPreview,
             conversationId: conversationId,
@@ -219,7 +235,7 @@ RouteContext parseRoute(String path) {
       if (segments.length < 2) {
         return const RouteContext(type: RouteType.home);
       }
-      final tag = Uri.decodeComponent(segments[1]); // Decode URL encoding
+      final tag = _safeDecode(segments[1]); // Decode URL encoding
       final rawIndex = segments.length > 2 ? int.tryParse(segments[2]) : null;
       final index = rawIndex != null && rawIndex < 0 ? 0 : rawIndex;
       return RouteContext(
@@ -232,7 +248,7 @@ RouteContext parseRoute(String path) {
       if (segments.length < 2) {
         return const RouteContext(type: RouteType.home);
       }
-      final categoryName = Uri.decodeComponent(segments[1]);
+      final categoryName = _safeDecode(segments[1]);
       return RouteContext(
         type: RouteType.categoryGallery,
         categoryName: categoryName,
@@ -243,7 +259,7 @@ RouteContext parseRoute(String path) {
 
     case 'video-editor':
       if (segments.length > 1) {
-        final draftId = Uri.decodeComponent(segments[1]);
+        final draftId = _safeDecode(segments[1]);
         return RouteContext(type: RouteType.videoEditor, draftId: draftId);
       }
       return const RouteContext(type: RouteType.videoEditor);
@@ -258,7 +274,7 @@ RouteContext parseRoute(String path) {
       if (segments.length > 1) {
         return RouteContext(
           type: RouteType.settings,
-          appSlug: Uri.decodeComponent(segments[1]),
+          appSlug: _safeDecode(segments[1]),
         );
       }
       return const RouteContext(type: RouteType.settings, appSlug: '');
@@ -341,11 +357,11 @@ RouteContext parseRoute(String path) {
     case 'developer-options':
       return const RouteContext(type: RouteType.developerOptions);
     case 'following':
-      final followingPubkey = Uri.decodeComponent(segments[1]);
+      final followingPubkey = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.following, npub: followingPubkey);
 
     case 'followers':
-      final followersPubkey = Uri.decodeComponent(segments[1]);
+      final followersPubkey = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.followers, npub: followersPubkey);
 
     case 'video-feed':
@@ -354,7 +370,7 @@ RouteContext parseRoute(String path) {
       if (segments.length < 2) {
         return const RouteContext(type: RouteType.explore);
       }
-      final listId = Uri.decodeComponent(segments[1]);
+      final listId = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.curatedList, listId: listId);
 
     case 'discover-lists':
@@ -364,14 +380,14 @@ RouteContext parseRoute(String path) {
       if (segments.length < 2) {
         return const RouteContext(type: RouteType.home);
       }
-      final soundId = Uri.decodeComponent(segments[1]);
+      final soundId = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.sound, soundId: soundId);
 
     case 'original-sound':
       if (segments.length < 2) {
         return const RouteContext(type: RouteType.home);
       }
-      final originalSoundPubkey = Uri.decodeComponent(segments[1]);
+      final originalSoundPubkey = _safeDecode(segments[1]);
       return RouteContext(
         type: RouteType.originalSound,
         npub: originalSoundPubkey,
@@ -381,7 +397,7 @@ RouteContext parseRoute(String path) {
       if (segments.length < 2) {
         return const RouteContext(type: RouteType.home);
       }
-      final profileViewNpub = Uri.decodeComponent(segments[1]);
+      final profileViewNpub = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.profileView, npub: profileViewNpub);
 
     case 'secure-account':
@@ -394,7 +410,7 @@ RouteContext parseRoute(String path) {
       if (segments.length < 2) {
         return const RouteContext(type: RouteType.home);
       }
-      final videoId = Uri.decodeComponent(segments[1]);
+      final videoId = _safeDecode(segments[1]);
       return RouteContext(type: RouteType.videoDetail, videoId: videoId);
 
     default:

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies stale auth refreshes do not reach a disposed container
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -145,7 +146,7 @@ void main() {
     );
 
     testWidgets(
-      'pathForTag with literal # round-trips through go_router decode',
+      'pathForTag with literal `#` (encoded as `%23`) round-trips correctly',
       (tester) async {
         const original = 'c#dev';
         final result = await navigateAndCapture(
@@ -185,5 +186,71 @@ void main() {
         expect(result.capturedQuery, equals(original));
       },
     );
+  });
+
+  // Static-source regression guard for #3413 — Crashlytics issue
+  // 489d5ebc7bd571dfd29e4701e92abdf6. The round-trip tests above assert
+  // the encode/decode contract holds when callers use pathForTag /
+  // pathForQuery, but they use a synthetic GoRoute builder and so do not
+  // exercise the production builders in lib/router/app_router.dart. This
+  // guard reads the production source and fails if the hashtag or search
+  // builder regions reintroduce Uri.decodeComponent — the exact regression
+  // that originally caused the crash.
+  group('Builder regression guard (#3413)', () {
+    test('hashtag and search builders do not call Uri.decodeComponent', () {
+      final source = File('lib/router/app_router.dart').readAsStringSync();
+
+      final hashtagPathOffset = source.indexOf(
+        'path: HashtagScreenRouter.path',
+      );
+      final searchPathOffset = source.indexOf(
+        'path: SearchResultsPage.path',
+      );
+      expect(
+        hashtagPathOffset,
+        isNonNegative,
+        reason:
+            'Hashtag GoRoute marker not found in app_router.dart. '
+            'Update this regression test to match the new marker.',
+      );
+      expect(
+        searchPathOffset,
+        greaterThan(hashtagPathOffset),
+        reason:
+            'Search-results GoRoute marker not found after hashtag '
+            'GoRoute. Update this regression test to match the new layout.',
+      );
+
+      final hashtagRegion = source.substring(
+        hashtagPathOffset,
+        searchPathOffset,
+      );
+      final nextGoRouteAfterSearch = source.indexOf(
+        'GoRoute(',
+        searchPathOffset,
+      );
+      final searchRegion = source.substring(
+        searchPathOffset,
+        nextGoRouteAfterSearch == -1 ? source.length : nextGoRouteAfterSearch,
+      );
+
+      const guard =
+          'go_router 16.x already decodes path parameters once during '
+          'route matching. Calling Uri.decodeComponent again here '
+          'crashes on legitimate inputs containing a literal `%` '
+          '(e.g. searching for "100%") — the original Crashlytics '
+          'issue. Pass state.pathParameters[...] through unchanged.';
+
+      expect(
+        hashtagRegion.contains('Uri.decodeComponent'),
+        isFalse,
+        reason: 'Hashtag builder must not double-decode. $guard',
+      );
+      expect(
+        searchRegion.contains('Uri.decodeComponent'),
+        isFalse,
+        reason: 'Search-results builder must not double-decode. $guard',
+      );
+    });
   });
 }

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -10,6 +11,8 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
+import 'package:openvine/screens/hashtag_screen_router.dart';
+import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -75,4 +78,112 @@ void main() {
       expect(routerB, isA<GoRouter>());
     },
   );
+
+  // Regression tests for #3413 — Crashlytics issue
+  // 489d5ebc7bd571dfd29e4701e92abdf6 ("Illegal percent encoding in URI"). The
+  // hashtag/search route builders used to call Uri.decodeComponent on values
+  // that go_router had already decoded once, which crashed on any input
+  // containing a literal `%` after the first decode (e.g. a search for
+  // "100%"). The fix is to pass state.pathParameters through unchanged.
+  //
+  // These tests use a minimal GoRouter so that the production builder's
+  // contract — "the value reaching state.pathParameters equals the original
+  // string passed to pathForTag/pathForQuery" — can be exercised without
+  // pulling in the full app provider graph.
+  group('Path-parameter round-trip (#3413)', () {
+    Future<({String? capturedTag, String? capturedQuery})> navigateAndCapture(
+      WidgetTester tester,
+      String location,
+    ) async {
+      String? capturedTag;
+      String? capturedQuery;
+
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (_, _) => const SizedBox.shrink(),
+          ),
+          GoRoute(
+            path: HashtagScreenRouter.path,
+            builder: (ctx, st) {
+              capturedTag = st.pathParameters['tag'];
+              return const SizedBox.shrink();
+            },
+          ),
+          GoRoute(
+            path: SearchResultsPage.path,
+            builder: (ctx, st) {
+              capturedQuery = st.pathParameters['query'];
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      router.go(location);
+      await tester.pumpAndSettle();
+
+      return (capturedTag: capturedTag, capturedQuery: capturedQuery);
+    }
+
+    testWidgets(
+      'pathForTag with literal % round-trips through go_router decode',
+      (tester) async {
+        const original = '100%fun';
+        final result = await navigateAndCapture(
+          tester,
+          HashtagScreenRouter.pathForTag(original),
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(result.capturedTag, equals(original));
+      },
+    );
+
+    testWidgets(
+      'pathForTag with literal # round-trips through go_router decode',
+      (tester) async {
+        const original = 'c#dev';
+        final result = await navigateAndCapture(
+          tester,
+          HashtagScreenRouter.pathForTag(original),
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(result.capturedTag, equals(original));
+      },
+    );
+
+    testWidgets(
+      'pathForQuery with literal % round-trips through go_router decode',
+      (tester) async {
+        const original = '100%';
+        final result = await navigateAndCapture(
+          tester,
+          SearchResultsPage.pathForQuery(original),
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(result.capturedQuery, equals(original));
+      },
+    );
+
+    testWidgets(
+      'pathForQuery with literal % and spaces round-trips correctly',
+      (tester) async {
+        const original = '50% off deals';
+        final result = await navigateAndCapture(
+          tester,
+          SearchResultsPage.pathForQuery(original),
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(result.capturedQuery, equals(original));
+      },
+    );
+  });
 }

--- a/mobile/test/router/route_coverage_test.dart
+++ b/mobile/test/router/route_coverage_test.dart
@@ -436,5 +436,45 @@ void main() {
         );
       }
     });
+
+    // Regression tests for #3413: malformed percent-encoded deep links
+    // (e.g. dangling `%`, `%2`, `%ZZ`) used to crash parseRoute when it
+    // called Uri.decodeComponent unguarded. parseRoute now routes every
+    // segment decode through a safe helper that returns the raw input on
+    // ArgumentError. The route type and raw segment are preserved.
+    group('Malformed percent-encoded segments do not throw', () {
+      const malformedSegments = ['foo%', 'foo%2', 'foo%ZZ', '%'];
+
+      for (final segment in malformedSegments) {
+        test('parseRoute(/hashtag/$segment) does not throw', () {
+          expect(() => parseRoute('/hashtag/$segment'), returnsNormally);
+          final context = parseRoute('/hashtag/$segment');
+          expect(context.type, RouteType.hashtag);
+          expect(context.hashtag, segment);
+        });
+
+        test('parseRoute(/profile/$segment) does not throw', () {
+          expect(() => parseRoute('/profile/$segment'), returnsNormally);
+          final context = parseRoute('/profile/$segment');
+          expect(context.type, RouteType.profile);
+          expect(context.npub, segment);
+        });
+
+        test('parseRoute(/video/$segment) does not throw', () {
+          expect(() => parseRoute('/video/$segment'), returnsNormally);
+          final context = parseRoute('/video/$segment');
+          expect(context.type, RouteType.videoDetail);
+          expect(context.videoId, segment);
+        });
+      }
+
+      test('parseRoute still decodes well-formed segments correctly', () {
+        // Sanity: the safe helper must remain a no-op for valid input.
+        final encoded = Uri.encodeComponent('hello world');
+        final context = parseRoute('/hashtag/$encoded');
+        expect(context.type, RouteType.hashtag);
+        expect(context.hashtag, 'hello world');
+      });
+    });
   });
 }


### PR DESCRIPTION
## Description

Fixes the iOS Crashlytics crash `489d5ebc7bd571dfd29e4701e92abdf6` (*"Invalid argument(s): Illegal percent encoding in URI"*) raised from `app_router.dart` whenever a hashtag or search-results route receives a path parameter that contains a literal `%` after one URL decode (e.g. searching for `100%`).

`go_router` 16.3.0 already calls `Uri.decodeComponent` on path parameters during route matching ([`go_router/src/match.dart:223`](https://github.com/flutter/packages/blob/main/packages/go_router/lib/src/match.dart#L223)). The two GoRoute builders for `/hashtag/:tag` and `/search-results/:query` were decoding a second time, so any value whose raw URL form contained `%25` round-tripped to a single `%`, which then crashed the second decode.

The primary commit removes the redundant decode in those two builders. The secondary commit hardens `parseRoute` in `page_context_provider.dart` (which still parses raw URL strings and therefore still needs to decode segments) by routing every segment decode **in `parseRoute`** through a `_safeDecode` helper that returns the raw input on `ArgumentError` instead of throwing.

Other decode sites in the codebase are intentionally untouched. In particular `deep_link_service.dart:206` still calls `Uri.decodeComponent` directly on the invite-code segment — the entire `parseDeepLink` body is wrapped in a top-level `try/catch` (see `deep_link_service.dart:227-234`) that converts any decode error into `DeepLinkType.unknown`, which is a different but functional crash-prevention mechanism. Routing it through `_safeDecode` would change the user-visible failure (raw segment forwarded to redemption vs. "unknown deep link"), which is a scoped behavior decision, not a drive-by hardening.

**Related Issue:** Closes #3413

## Reproduction (pre-fix)

1. Run the app on iOS in release mode (or debug — the crash is the same).
2. Open the search bar and submit any query containing a literal `%`, such as `100%` or `50% off`.
   - Equivalent deep link: `divine://search-results/100%25` (or `https://divine.video/search/100%25`).
3. Observe `FlutterError: Invalid argument(s): Illegal percent encoding in URI. Error thrown.` from `Uri.decodeComponent` at `app_router.dart` (line 418/428 pre-fix).

The same crash reproduces for hashtags via `divine://hashtag/100%25fun` (a hashtag like `100%fun`).

## Root cause

```
'100%' → Uri.encodeComponent('100%') = '100%25'             // SearchResultsPage.pathForQuery / HashtagScreenRouter.pathForTag
       → URL '/search-results/100%25'
       → go_router extractPathParams: 'query' = '100%25'    // raw regex capture
       → match.dart:223  Uri.decodeComponent('100%25') = '100%'
       → state.pathParameters['query'] == '100%'
       → app_router.dart  Uri.decodeComponent('100%') ❌ throws  // double-decode
```

## Fix

- **`app_router.dart`** — pass `state.pathParameters['tag']` / `['query']` directly to `HashtagFeedScreen` / `SearchResultsPage`. `go_router` already gives a fully-decoded value.
- **`page_context_provider.dart`** — add a private `_safeDecode(segment)` helper and route all 14 `Uri.decodeComponent(segments[...])` callsites in `parseRoute` through it so a hand-crafted deep link (e.g. `/hashtag/foo%`) cannot crash the location stream.

The split is intentional: the first commit closes the Crashlytics issue; the second commit is defensive hardening for any other malformed URL that reaches the parse path.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Test plan

New tests, all passing locally:

- `test/router/app_router_test.dart` — round-trip tests covering `pathForTag('100%fun')`, `pathForTag('c#dev')`, `pathForQuery('100%')`, `pathForQuery('50% off deals')`. Each pumps a minimal `GoRouter` mirroring the production builders, navigates via the canonical helper, and verifies that the captured `state.pathParameters` value equals the original input with no thrown exceptions. A second group adds a static-source guard that reads `lib/router/app_router.dart` and fails if either the hashtag or search-results builder region reintroduces `Uri.decodeComponent` (the exact regression that caused the crash) — closes the gap that the round-trip tests' synthetic builder doesn't cover.
- `test/router/route_coverage_test.dart` — `parseRoute` malformed-input regressions for `foo%`, `foo%2`, `foo%ZZ`, `%` against `/hashtag`, `/profile`, and `/video` routes, plus a sanity test that valid `Uri.encodeComponent` input still decodes correctly.

Verification commands run from `mobile/`:

```sh
dart format <changed files>           # 0 changes
flutter analyze lib test               # No issues found
flutter test test/router/              # 134 passed, 65 pre-existing skips
flutter test test/services/deep_link_service_test.dart \
             test/providers/deep_link_provider_test.dart   # All passed
```

## Risk

- **Behavior change for legitimate inputs**: none. `pathForTag` / `pathForQuery` always encode once via `Uri.encodeComponent` and `go_router` decodes once on the way back, so the post-fix path is the symmetric counterpart of how URLs are constructed. Inputs without `%` are unaffected.
- **External callers**: `grep` shows no call site that bypasses `pathForTag` / `pathForQuery` to construct these URLs by hand inside `mobile/lib`.
- **Universal links / share sheets**: handled upstream by `universal_link_resolver.dart` before reaching the GoRoute builder; that layer already passes through encoded paths.

## Post-release verification

After this lands in a release build, confirm Crashlytics issue [`489d5ebc7bd571dfd29e4701e92abdf6`](https://console.firebase.google.com/project/openvine-co/crashlytics/app/ios:co.openvine.app/issues/489d5ebc7bd571dfd29e4701e92abdf6) stops receiving new events.
