### PR TITLE
refactor(providers): de-dup userRelaysDiscoveredCallback closures

### DIFF
--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -74,27 +74,9 @@ class NostrService extends _$NostrService {
 
     // Register callback so when NIP-65 discovery completes later, we add those
     // relays to this client (fixes race where discovery finishes after client build)
-    authService.registerUserRelaysDiscoveredCallback((relayUrls) {
-      if (relayUrls.isEmpty) return;
-      Future.microtask(() async {
-        try {
-          final added = await client.addRelays(relayUrls);
-          if (added > 0) {
-            Log.info(
-              '[NostrService] Added $added discovered relay(s) after NIP-65 discovery',
-              name: 'NostrService',
-              category: LogCategory.system,
-            );
-          }
-        } catch (e) {
-          Log.warning(
-            '[NostrService] Failed to add discovered relays: $e',
-            name: 'NostrService',
-            category: LogCategory.system,
-          );
-        }
-      });
-    });
+    authService.registerUserRelaysDiscoveredCallback(
+      _userRelaysDiscoveredCallbackFor(client),
+    );
 
     // Register bootstrap kind:10002 callback — AuthService calls this when
     // indexer discovery returns empty, so we self-publish a minimal relay
@@ -189,27 +171,9 @@ class NostrService extends _$NostrService {
       );
 
       // Register callback for new client so later discovery adds relays to it
-      authService.registerUserRelaysDiscoveredCallback((relayUrls) {
-        if (relayUrls.isEmpty) return;
-        Future.microtask(() async {
-          try {
-            final added = await newClient.addRelays(relayUrls);
-            if (added > 0) {
-              Log.info(
-                '[NostrService] Added $added discovered relay(s) after NIP-65 discovery',
-                name: 'NostrService',
-                category: LogCategory.system,
-              );
-            }
-          } catch (e) {
-            Log.warning(
-              '[NostrService] Failed to add discovered relays: $e',
-              name: 'NostrService',
-              category: LogCategory.system,
-            );
-          }
-        });
-      });
+      authService.registerUserRelaysDiscoveredCallback(
+        _userRelaysDiscoveredCallbackFor(newClient),
+      );
 
       // Register bootstrap kind:10002 callback for the new client. See
       // divine-mobile#3174 / keycast#94.
@@ -227,6 +191,35 @@ class NostrService extends _$NostrService {
       await newClient.initialize();
       state = newClient;
     }
+  }
+
+  /// Builds the NIP-65 discovered-relays callback bound to [client].
+  /// Used at both initial-build and account-switch sites so the
+  /// add-relays-on-discovery flow stays in one place.
+  UserRelaysDiscoveredCallback _userRelaysDiscoveredCallbackFor(
+    NostrClient client,
+  ) {
+    return (relayUrls) {
+      if (relayUrls.isEmpty) return;
+      Future.microtask(() async {
+        try {
+          final added = await client.addRelays(relayUrls);
+          if (added > 0) {
+            Log.info(
+              '[NostrService] Added $added discovered relay(s) after NIP-65 discovery',
+              name: 'NostrService',
+              category: LogCategory.system,
+            );
+          }
+        } catch (e) {
+          Log.warning(
+            '[NostrService] Failed to add discovered relays: $e',
+            name: 'NostrService',
+            category: LogCategory.system,
+          );
+        }
+      });
+    };
   }
 
   /// Builds the bootstrap kind:10002 publisher closure bound to [client].

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -72,8 +72,7 @@ class NostrService extends _$NostrService {
       dbClient: dbClient,
     );
 
-    // Register callback so when NIP-65 discovery completes later, we add those
-    // relays to this client (fixes race where discovery finishes after client build)
+    // NIP-65 discovered-relays callback — see _userRelaysDiscoveredCallbackFor.
     authService.registerUserRelaysDiscoveredCallback(
       _userRelaysDiscoveredCallbackFor(client),
     );
@@ -168,7 +167,7 @@ class NostrService extends _$NostrService {
         dbClient: dbClient,
       );
 
-      // Register callback for new client so later discovery adds relays to it
+      // NIP-65 discovered-relays callback — see _userRelaysDiscoveredCallbackFor.
       authService.registerUserRelaysDiscoveredCallback(
         _userRelaysDiscoveredCallbackFor(newClient),
       );
@@ -191,9 +190,13 @@ class NostrService extends _$NostrService {
   }
 
   /// Builds the NIP-65 discovered-relays callback bound to [client].
-  /// Used at both initial-build and account-switch sites so the
+  ///
+  /// Registered with AuthService so when NIP-65 discovery completes later,
+  /// the discovered relays are added to [client] — this fixes the race
+  /// where discovery finishes after the client has been built. Used at
+  /// both initial-build and account-switch sites so the
   /// add-relays-on-discovery flow stays in one place.
-  UserRelaysDiscoveredCallback _userRelaysDiscoveredCallbackFor(
+  static UserRelaysDiscoveredCallback _userRelaysDiscoveredCallbackFor(
     NostrClient client,
   ) {
     return (relayUrls) {


### PR DESCRIPTION
## Summary

- Extracts `_userRelaysDiscoveredCallbackFor(NostrClient)` on `NostrService`, used at both registration sites (initial `build()` and `_onAuthStateChanged` account-switch path).
- Two structurally identical 21-line closures collapse to one line per call site.
- Mirrors the bootstrap kind:10002 dedup in #3511 (same file, same pattern, helper sits next to `_bootstrapCallbackFor`).
- Pure cleanup. No behavior change.

**Stacked on #3511** — base is `refactor/3182-dedup-bootstrap-callback` so the two helpers don't fight over the same end-of-class region. GitHub will retarget this PR to `main` automatically when #3511 merges.

Closes #3512.

## Test plan

- [x] `flutter analyze lib/providers/nostr_client_provider.dart` — clean.
- [x] `flutter test test/providers/nostr_service_identity_source_test.dart` — 3/3 pass (covers initial build + full account-switch A → unauth → B path that hits both registration sites).
- [x] `flutter test test/services/auth_service_relay_fallback_test.dart` — 3/3 pass (AuthService side that invokes the callback after NIP-65 discovery).
- [x] Pre-commit hook (format + analyze) green.

> Note: stacked PRs see only policy gates (mergeability, semantic-pull-request, ensure-linked-issue) until the base merges to main. Full Mobile CI (Analyze / Tests / Format / Generated Files) runs once the base merges and this PR auto-retargets.