### PR TITLE
feat(lists): Implement create user list flow

### DIFF
--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -47,9 +47,9 @@ enum FeatureFlag {
     'Route web video playback through hls.js with NIP-98 auth headers so '
         'age-gated and other 401-protected media can be viewed on web',
   ),
-  peopleListSearch(
-    'People List Search',
-    'Show people list (kind 30000) results alongside video lists in search',
+  profileListFeatures(
+    'Profile List Features',
+    'Enable people list creation from profiles and people list results in search (NIP-51 kind 30000)',
   ),
   contentPolicyV2(
     'Content Policy v2',

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -41,8 +41,8 @@ class BuildConfiguration {
         return const bool.fromEnvironment('FF_ACCOUNT_SWITCHING');
       case FeatureFlag.hlsAuthWebPlayer:
         return const bool.fromEnvironment('FF_HLS_AUTH_WEB_PLAYER');
-      case FeatureFlag.peopleListSearch:
-        return const bool.fromEnvironment('FF_PEOPLE_LIST_SEARCH');
+      case FeatureFlag.profileListFeatures:
+        return const bool.fromEnvironment('FF_PROFILE_LIST_FEATURES');
       case FeatureFlag.contentPolicyV2:
         return const bool.fromEnvironment('FF_CONTENT_POLICY_V2');
       case FeatureFlag.advancedRelaySettings:
@@ -87,8 +87,8 @@ class BuildConfiguration {
         return 'FF_ACCOUNT_SWITCHING';
       case FeatureFlag.hlsAuthWebPlayer:
         return 'FF_HLS_AUTH_WEB_PLAYER';
-      case FeatureFlag.peopleListSearch:
-        return 'FF_PEOPLE_LIST_SEARCH';
+      case FeatureFlag.profileListFeatures:
+        return 'FF_PROFILE_LIST_FEATURES';
       case FeatureFlag.contentPolicyV2:
         return 'FF_CONTENT_POLICY_V2';
       case FeatureFlag.advancedRelaySettings:

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -241,6 +241,14 @@
             }
         }
     },
+    "profileAddToListDisplayName": "إضافة {displayName} إلى قائمة",
+    "@profileAddToListDisplayName": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "profileUserBlockedTitle": "تم حظر المستخدم",
     "profileUserBlockedContent": "لن ترى محتوى من هذا المستخدم في تغذياتك.",
     "profileUserBlockedUnblockHint": "يمكنك إلغاء حظره في أي وقت من ملفه الشخصي أو من الإعدادات > الأمان.",
@@ -1942,6 +1950,10 @@
         }
     },
     "listCreateNewList": "إنشاء قائمة جديدة",
+    "listNewPeopleList": "قائمة أشخاص جديدة",
+    "listCollaboratorsNone": "لا أحد",
+    "listAddCollaboratorTitle": "إضافة متعاون",
+    "listCollaboratorSearchHint": "ابحث في diVine...",
     "listNameLabel": "اسم القائمة",
     "listDescriptionLabel": "الوصف (اختياري)",
     "listPublicList": "قائمة عامة",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -241,6 +241,14 @@
             }
         }
     },
+    "profileAddToListDisplayName": "{displayName} zu einer Liste hinzufügen",
+    "@profileAddToListDisplayName": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "profileUserBlockedTitle": "Nutzer blockiert",
     "profileUserBlockedContent": "Du siehst keine Inhalte von diesem Nutzer mehr in deinen Feeds.",
     "profileUserBlockedUnblockHint": "Du kannst ihn jederzeit über sein Profil oder unter Einstellungen > Sicherheit entsperren.",
@@ -1943,6 +1951,10 @@
         }
     },
     "listCreateNewList": "Neue Liste erstellen",
+    "listNewPeopleList": "Neue Personenliste",
+    "listCollaboratorsNone": "Keine",
+    "listAddCollaboratorTitle": "Mitarbeiter hinzufügen",
+    "listCollaboratorSearchHint": "diVine durchsuchen...",
     "listNameLabel": "Listenname",
     "listDescriptionLabel": "Beschreibung (optional)",
     "listPublicList": "Öffentliche Liste",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -241,6 +241,14 @@
       }
     }
   },
+  "profileAddToListDisplayName": "Add {displayName} to a list",
+  "@profileAddToListDisplayName": {
+    "placeholders": {
+      "displayName": {
+        "type": "String"
+      }
+    }
+  },
   "profileUserBlockedTitle": "User Blocked",
   "profileUserBlockedContent": "You won't see content from this user in your feeds.",
   "profileUserBlockedUnblockHint": "You can unblock them anytime from their profile or in Settings > Safety.",
@@ -1996,6 +2004,10 @@
     }
   },
   "listCreateNewList": "Create New List",
+  "listNewPeopleList": "New people list",
+  "listCollaboratorsNone": "None",
+  "listAddCollaboratorTitle": "Add a collaborator",
+  "listCollaboratorSearchHint": "Search diVine...",
   "listNameLabel": "List Name",
   "listDescriptionLabel": "Description (optional)",
   "listPublicList": "Public List",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -241,6 +241,14 @@
             }
         }
     },
+    "profileAddToListDisplayName": "Añadir {displayName} a una lista",
+    "@profileAddToListDisplayName": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "profileUserBlockedTitle": "Usuario bloqueado",
     "profileUserBlockedContent": "No vas a ver contenido de esta persona en tus feeds.",
     "profileUserBlockedUnblockHint": "Podés desbloquearla cuando quieras desde su perfil o en Ajustes > Seguridad.",
@@ -1943,6 +1951,10 @@
         }
     },
     "listCreateNewList": "Crear lista nueva",
+    "listNewPeopleList": "Nueva lista de personas",
+    "listCollaboratorsNone": "Ninguno",
+    "listAddCollaboratorTitle": "Añadir colaborador",
+    "listCollaboratorSearchHint": "Buscar en diVine...",
     "listNameLabel": "Nombre de la lista",
     "listDescriptionLabel": "Descripción (opcional)",
     "listPublicList": "Lista pública",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -241,6 +241,14 @@
             }
         }
     },
+    "profileAddToListDisplayName": "Ajouter {displayName} à une liste",
+    "@profileAddToListDisplayName": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "profileUserBlockedTitle": "Utilisateur bloqué",
     "profileUserBlockedContent": "Tu ne verras plus son contenu dans tes fils.",
     "profileUserBlockedUnblockHint": "Tu peux le débloquer n'importe quand depuis son profil ou dans Réglages > Sécurité.",
@@ -1943,6 +1951,10 @@
         }
     },
     "listCreateNewList": "Créer une nouvelle liste",
+    "listNewPeopleList": "Nouvelle liste de personnes",
+    "listCollaboratorsNone": "Aucun",
+    "listAddCollaboratorTitle": "Ajouter un collaborateur",
+    "listCollaboratorSearchHint": "Rechercher sur diVine...",
     "listNameLabel": "Nom de la liste",
     "listDescriptionLabel": "Description (facultatif)",
     "listPublicList": "Liste publique",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -241,6 +241,14 @@
             }
         }
     },
+    "profileAddToListDisplayName": "Tambahkan {displayName} ke daftar",
+    "@profileAddToListDisplayName": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "profileUserBlockedTitle": "Pengguna Diblokir",
     "profileUserBlockedContent": "Kamu tidak akan melihat konten dari pengguna ini di feed-mu.",
     "profileUserBlockedUnblockHint": "Kamu bisa membuka blokir mereka kapan saja dari profilnya atau di Pengaturan > Keamanan.",
@@ -1942,6 +1950,10 @@
         }
     },
     "listCreateNewList": "Buat Daftar Baru",
+    "listNewPeopleList": "Daftar orang baru",
+    "listCollaboratorsNone": "Tidak ada",
+    "listAddCollaboratorTitle": "Tambahkan kolaborator",
+    "listCollaboratorSearchHint": "Cari diVine...",
     "listNameLabel": "Nama Daftar",
     "listDescriptionLabel": "Deskripsi (opsional)",
     "listPublicList": "Daftar Publik",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -241,6 +241,14 @@
             }
         }
     },
+    "profileAddToListDisplayName": "Aggiungi {displayName} a una lista",
+    "@profileAddToListDisplayName": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "profileUserBlockedTitle": "Utente bloccato",
     "profileUserBlockedContent": "Non vedrai più contenuti di questo utente nei tuoi feed.",
     "profileUserBlockedUnblockHint": "Puoi sbloccarlo in qualsiasi momento dal suo profilo o in Impostazioni > Sicurezza.",
@@ -1943,6 +1951,10 @@
         }
     },
     "listCreateNewList": "Crea nuova lista",
+    "listNewPeopleList": "Nuova lista persone",
+    "listCollaboratorsNone": "Nessuno",
+    "listAddCollaboratorTitle": "Aggiungi collaboratore",
+    "listCollaboratorSearchHint": "Cerca su diVine...",
     "listNameLabel": "Nome lista",
     "listDescriptionLabel": "Descrizione (opzionale)",
     "listPublicList": "Lista pubblica",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -241,6 +241,14 @@
             }
         }
     },
+    "profileAddToListDisplayName": "{displayName}をリストに追加",
+    "@profileAddToListDisplayName": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "profileUserBlockedTitle": "ブロックしたよ",
     "profileUserBlockedContent": "このユーザーのコンテンツはフィードに出なくなるよ。",
     "profileUserBlockedUnblockHint": "いつでもプロフィールか [設定] > [安全] からブロック解除できるよ。",
@@ -1942,6 +1950,10 @@
         }
     },
     "listCreateNewList": "新しいリストを作る",
+    "listNewPeopleList": "新しい人リスト",
+    "listCollaboratorsNone": "なし",
+    "listAddCollaboratorTitle": "コラボレーターを追加",
+    "listCollaboratorSearchHint": "diVineを検索...",
     "listNameLabel": "リスト名",
     "listDescriptionLabel": "説明 (任意)",
     "listPublicList": "公開リスト",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -102,6 +102,7 @@
     "profileUnfollowDisplayName": "{displayName}님 언팔로우",
     "profileBlockDisplayName": "{displayName}님 차단",
     "profileUnblockDisplayName": "{displayName}님 차단 해제",
+    "profileAddToListDisplayName": "{displayName}님을 목록에 추가",
     "profileUserBlockedTitle": "사용자를 차단했어요",
     "profileUserBlockedContent": "이 사용자의 콘텐츠는 피드에서 보이지 않아요.",
     "profileUserBlockedUnblockHint": "언제든 프로필이나 설정 > 안전에서 차단을 해제할 수 있어요.",
@@ -1231,6 +1232,10 @@
         }
     },
     "listCreateNewList": "새 목록 만들기",
+    "listNewPeopleList": "새 사람 목록",
+    "listCollaboratorsNone": "없음",
+    "listAddCollaboratorTitle": "협업자 추가",
+    "listCollaboratorSearchHint": "diVine 검색...",
     "listNameLabel": "목록 이름",
     "listDescriptionLabel": "설명 (선택)",
     "listPublicList": "공개 목록",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -241,6 +241,14 @@
             }
         }
     },
+    "profileAddToListDisplayName": "{displayName} aan een lijst toevoegen",
+    "@profileAddToListDisplayName": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "profileUserBlockedTitle": "Gebruiker geblokkeerd",
     "profileUserBlockedContent": "Je ziet geen inhoud meer van deze gebruiker in je feeds.",
     "profileUserBlockedUnblockHint": "Je kunt ze altijd deblokkeren via hun profiel of bij Instellingen > Veiligheid.",
@@ -1943,6 +1951,10 @@
         }
     },
     "listCreateNewList": "Nieuwe lijst maken",
+    "listNewPeopleList": "Nieuwe personenlijst",
+    "listCollaboratorsNone": "Geen",
+    "listAddCollaboratorTitle": "Medewerker toevoegen",
+    "listCollaboratorSearchHint": "Zoek in diVine...",
     "listNameLabel": "Lijstnaam",
     "listDescriptionLabel": "Beschrijving (optioneel)",
     "listPublicList": "Openbare lijst",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -241,6 +241,14 @@
             }
         }
     },
+    "profileAddToListDisplayName": "Dodaj {displayName} do listy",
+    "@profileAddToListDisplayName": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "profileUserBlockedTitle": "Użytkownik zablokowany",
     "profileUserBlockedContent": "Nie będziesz widzieć treści tego użytkownika w swoich kanałach.",
     "profileUserBlockedUnblockHint": "Możesz go odblokować w dowolnej chwili z jego profilu lub w Ustawienia > Bezpieczeństwo.",
@@ -1943,6 +1951,10 @@
         }
     },
     "listCreateNewList": "Utwórz nową listę",
+    "listNewPeopleList": "Nowa lista osób",
+    "listCollaboratorsNone": "Brak",
+    "listAddCollaboratorTitle": "Dodaj współpracownika",
+    "listCollaboratorSearchHint": "Szukaj w diVine...",
     "listNameLabel": "Nazwa listy",
     "listDescriptionLabel": "Opis (opcjonalnie)",
     "listPublicList": "Publiczna lista",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -241,6 +241,14 @@
             }
         }
     },
+    "profileAddToListDisplayName": "Adicionar {displayName} a uma lista",
+    "@profileAddToListDisplayName": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "profileUserBlockedTitle": "Usuário bloqueado",
     "profileUserBlockedContent": "Você não vai mais ver conteúdo desse usuário no seu feed.",
     "profileUserBlockedUnblockHint": "Você pode desbloqueá-lo a qualquer momento no perfil dele ou em Configurações > Segurança.",
@@ -1943,6 +1951,10 @@
         }
     },
     "listCreateNewList": "Criar nova lista",
+    "listNewPeopleList": "Nova lista de pessoas",
+    "listCollaboratorsNone": "Nenhum",
+    "listAddCollaboratorTitle": "Adicionar colaborador",
+    "listCollaboratorSearchHint": "Pesquisar no diVine...",
     "listNameLabel": "Nome da lista",
     "listDescriptionLabel": "Descrição (opcional)",
     "listPublicList": "Lista pública",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -241,6 +241,14 @@
             }
         }
     },
+    "profileAddToListDisplayName": "Adaugă {displayName} la o listă",
+    "@profileAddToListDisplayName": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "profileUserBlockedTitle": "Utilizator blocat",
     "profileUserBlockedContent": "Nu vei mai vedea conținut de la acest utilizator în feedurile tale.",
     "profileUserBlockedUnblockHint": "Îl poți debloca oricând din profilul lui sau din Setări > Siguranță.",
@@ -1943,6 +1951,10 @@
         }
     },
     "listCreateNewList": "Creează o listă nouă",
+    "listNewPeopleList": "Listă de persoane nouă",
+    "listCollaboratorsNone": "Niciunul",
+    "listAddCollaboratorTitle": "Adaugă colaborator",
+    "listCollaboratorSearchHint": "Caută în diVine...",
     "listNameLabel": "Numele listei",
     "listDescriptionLabel": "Descriere (opțional)",
     "listPublicList": "Listă publică",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -241,6 +241,14 @@
             }
         }
     },
+    "profileAddToListDisplayName": "Lägg till {displayName} i en lista",
+    "@profileAddToListDisplayName": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "profileUserBlockedTitle": "Användare blockerad",
     "profileUserBlockedContent": "Du kommer inte se innehåll från den här användaren i dina flöden.",
     "profileUserBlockedUnblockHint": "Du kan avblockera när som helst från deras profil eller under Inställningar > Säkerhet.",
@@ -1943,6 +1951,10 @@
         }
     },
     "listCreateNewList": "Skapa ny lista",
+    "listNewPeopleList": "Ny personlista",
+    "listCollaboratorsNone": "Ingen",
+    "listAddCollaboratorTitle": "Lägg till en samarbetspartner",
+    "listCollaboratorSearchHint": "Sök diVine...",
     "listNameLabel": "Listnamn",
     "listDescriptionLabel": "Beskrivning (valfritt)",
     "listPublicList": "Publik lista",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -241,6 +241,14 @@
             }
         }
     },
+    "profileAddToListDisplayName": "{displayName} kişisini bir listeye ekle",
+    "@profileAddToListDisplayName": {
+        "placeholders": {
+            "displayName": {
+                "type": "String"
+            }
+        }
+    },
     "profileUserBlockedTitle": "Kullanıcı Engellendi",
     "profileUserBlockedContent": "Bu kullanıcının içeriğini artık akışında görmeyeceksin.",
     "profileUserBlockedUnblockHint": "Profilinden veya Ayarlar > Güvenlik'ten istediğin zaman engelini kaldırabilirsin.",
@@ -1942,6 +1950,10 @@
         }
     },
     "listCreateNewList": "Yeni Liste Oluştur",
+    "listNewPeopleList": "Yeni kişi listesi",
+    "listCollaboratorsNone": "Yok",
+    "listAddCollaboratorTitle": "İşbirlikçi ekle",
+    "listCollaboratorSearchHint": "diVine'da ara...",
     "listNameLabel": "Liste Adı",
     "listDescriptionLabel": "Açıklama (opsiyonel)",
     "listPublicList": "Herkese Açık Liste",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -736,6 +736,12 @@ abstract class AppLocalizations {
   /// **'Unblock {displayName}'**
   String profileUnblockDisplayName(String displayName);
 
+  /// No description provided for @profileAddToListDisplayName.
+  ///
+  /// In en, this message translates to:
+  /// **'Add {displayName} to a list'**
+  String profileAddToListDisplayName(String displayName);
+
   /// No description provided for @profileUserBlockedTitle.
   ///
   /// In en, this message translates to:
@@ -6907,6 +6913,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Create New List'**
   String get listCreateNewList;
+
+  /// No description provided for @listNewPeopleList.
+  ///
+  /// In en, this message translates to:
+  /// **'New people list'**
+  String get listNewPeopleList;
+
+  /// No description provided for @listCollaboratorsNone.
+  ///
+  /// In en, this message translates to:
+  /// **'None'**
+  String get listCollaboratorsNone;
+
+  /// No description provided for @listAddCollaboratorTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add a collaborator'**
+  String get listAddCollaboratorTitle;
+
+  /// No description provided for @listCollaboratorSearchHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search diVine...'**
+  String get listCollaboratorSearchHint;
 
   /// No description provided for @listNameLabel.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -373,6 +373,11 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return 'إضافة $displayName إلى قائمة';
+  }
+
+  @override
   String get profileUserBlockedTitle => 'تم حظر المستخدم';
 
   @override
@@ -3865,6 +3870,18 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get listCreateNewList => 'إنشاء قائمة جديدة';
+
+  @override
+  String get listNewPeopleList => 'قائمة أشخاص جديدة';
+
+  @override
+  String get listCollaboratorsNone => 'لا أحد';
+
+  @override
+  String get listAddCollaboratorTitle => 'إضافة متعاون';
+
+  @override
+  String get listCollaboratorSearchHint => 'ابحث في diVine...';
 
   @override
   String get listNameLabel => 'اسم القائمة';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -392,6 +392,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return '$displayName zu einer Liste hinzufügen';
+  }
+
+  @override
   String get profileUserBlockedTitle => 'Nutzer blockiert';
 
   @override
@@ -3954,6 +3959,18 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get listCreateNewList => 'Neue Liste erstellen';
+
+  @override
+  String get listNewPeopleList => 'Neue Personenliste';
+
+  @override
+  String get listCollaboratorsNone => 'Keine';
+
+  @override
+  String get listAddCollaboratorTitle => 'Mitarbeiter hinzufügen';
+
+  @override
+  String get listCollaboratorSearchHint => 'diVine durchsuchen...';
 
   @override
   String get listNameLabel => 'Listenname';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -389,6 +389,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return 'Add $displayName to a list';
+  }
+
+  @override
   String get profileUserBlockedTitle => 'User Blocked';
 
   @override
@@ -3911,6 +3916,18 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get listCreateNewList => 'Create New List';
+
+  @override
+  String get listNewPeopleList => 'New people list';
+
+  @override
+  String get listCollaboratorsNone => 'None';
+
+  @override
+  String get listAddCollaboratorTitle => 'Add a collaborator';
+
+  @override
+  String get listCollaboratorSearchHint => 'Search diVine...';
 
   @override
   String get listNameLabel => 'List Name';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -392,6 +392,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return 'Añadir $displayName a una lista';
+  }
+
+  @override
   String get profileUserBlockedTitle => 'Usuario bloqueado';
 
   @override
@@ -3950,6 +3955,18 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get listCreateNewList => 'Crear lista nueva';
+
+  @override
+  String get listNewPeopleList => 'Nueva lista de personas';
+
+  @override
+  String get listCollaboratorsNone => 'Ninguno';
+
+  @override
+  String get listAddCollaboratorTitle => 'Añadir colaborador';
+
+  @override
+  String get listCollaboratorSearchHint => 'Buscar en diVine...';
 
   @override
   String get listNameLabel => 'Nombre de la lista';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -400,6 +400,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return 'Ajouter $displayName à une liste';
+  }
+
+  @override
   String get profileUserBlockedTitle => 'Utilisateur bloqué';
 
   @override
@@ -3960,6 +3965,18 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get listCreateNewList => 'Créer une nouvelle liste';
+
+  @override
+  String get listNewPeopleList => 'Nouvelle liste de personnes';
+
+  @override
+  String get listCollaboratorsNone => 'Aucun';
+
+  @override
+  String get listAddCollaboratorTitle => 'Ajouter un collaborateur';
+
+  @override
+  String get listCollaboratorSearchHint => 'Rechercher sur diVine...';
 
   @override
   String get listNameLabel => 'Nom de la liste';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -372,6 +372,11 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return 'Tambahkan $displayName ke daftar';
+  }
+
+  @override
   String get profileUserBlockedTitle => 'Pengguna Diblokir';
 
   @override
@@ -3881,6 +3886,18 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get listCreateNewList => 'Buat Daftar Baru';
+
+  @override
+  String get listNewPeopleList => 'Daftar orang baru';
+
+  @override
+  String get listCollaboratorsNone => 'Tidak ada';
+
+  @override
+  String get listAddCollaboratorTitle => 'Tambahkan kolaborator';
+
+  @override
+  String get listCollaboratorSearchHint => 'Cari diVine...';
 
   @override
   String get listNameLabel => 'Nama Daftar';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -393,6 +393,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return 'Aggiungi $displayName a una lista';
+  }
+
+  @override
   String get profileUserBlockedTitle => 'Utente bloccato';
 
   @override
@@ -3948,6 +3953,18 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get listCreateNewList => 'Crea nuova lista';
+
+  @override
+  String get listNewPeopleList => 'Nuova lista persone';
+
+  @override
+  String get listCollaboratorsNone => 'Nessuno';
+
+  @override
+  String get listAddCollaboratorTitle => 'Aggiungi collaboratore';
+
+  @override
+  String get listCollaboratorSearchHint => 'Cerca su diVine...';
 
   @override
   String get listNameLabel => 'Nome lista';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -353,6 +353,11 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return '$displayNameをリストに追加';
+  }
+
+  @override
   String get profileUserBlockedTitle => 'ブロックしたよ';
 
   @override
@@ -3723,6 +3728,18 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get listCreateNewList => '新しいリストを作る';
+
+  @override
+  String get listNewPeopleList => '新しい人リスト';
+
+  @override
+  String get listCollaboratorsNone => 'なし';
+
+  @override
+  String get listAddCollaboratorTitle => 'コラボレーターを追加';
+
+  @override
+  String get listCollaboratorSearchHint => 'diVineを検索...';
 
   @override
   String get listNameLabel => 'リスト名';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -354,6 +354,11 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return '$displayName님을 목록에 추가';
+  }
+
+  @override
   String get profileUserBlockedTitle => '사용자를 차단했어요';
 
   @override
@@ -3736,6 +3741,18 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get listCreateNewList => '새 목록 만들기';
+
+  @override
+  String get listNewPeopleList => '새 사람 목록';
+
+  @override
+  String get listCollaboratorsNone => '없음';
+
+  @override
+  String get listAddCollaboratorTitle => '협업자 추가';
+
+  @override
+  String get listCollaboratorSearchHint => 'diVine 검색...';
 
   @override
   String get listNameLabel => '목록 이름';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -389,6 +389,11 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return '$displayName aan een lijst toevoegen';
+  }
+
+  @override
   String get profileUserBlockedTitle => 'Gebruiker geblokkeerd';
 
   @override
@@ -3923,6 +3928,18 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get listCreateNewList => 'Nieuwe lijst maken';
+
+  @override
+  String get listNewPeopleList => 'Nieuwe personenlijst';
+
+  @override
+  String get listCollaboratorsNone => 'Geen';
+
+  @override
+  String get listAddCollaboratorTitle => 'Medewerker toevoegen';
+
+  @override
+  String get listCollaboratorSearchHint => 'Zoek in diVine...';
 
   @override
   String get listNameLabel => 'Lijstnaam';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -398,6 +398,11 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return 'Dodaj $displayName do listy';
+  }
+
+  @override
   String get profileUserBlockedTitle => 'Użytkownik zablokowany';
 
   @override
@@ -4021,6 +4026,18 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get listCreateNewList => 'Utwórz nową listę';
+
+  @override
+  String get listNewPeopleList => 'Nowa lista osób';
+
+  @override
+  String get listCollaboratorsNone => 'Brak';
+
+  @override
+  String get listAddCollaboratorTitle => 'Dodaj współpracownika';
+
+  @override
+  String get listCollaboratorSearchHint => 'Szukaj w diVine...';
 
   @override
   String get listNameLabel => 'Nazwa listy';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -397,6 +397,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return 'Adicionar $displayName a uma lista';
+  }
+
+  @override
   String get profileUserBlockedTitle => 'Usuário bloqueado';
 
   @override
@@ -3933,6 +3938,18 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get listCreateNewList => 'Criar nova lista';
+
+  @override
+  String get listNewPeopleList => 'Nova lista de pessoas';
+
+  @override
+  String get listCollaboratorsNone => 'Nenhum';
+
+  @override
+  String get listAddCollaboratorTitle => 'Adicionar colaborador';
+
+  @override
+  String get listCollaboratorSearchHint => 'Pesquisar no diVine...';
 
   @override
   String get listNameLabel => 'Nome da lista';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -412,6 +412,11 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return 'Adaugă $displayName la o listă';
+  }
+
+  @override
   String get profileUserBlockedTitle => 'Utilizator blocat';
 
   @override
@@ -4026,6 +4031,18 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get listCreateNewList => 'Creează o listă nouă';
+
+  @override
+  String get listNewPeopleList => 'Listă de persoane nouă';
+
+  @override
+  String get listCollaboratorsNone => 'Niciunul';
+
+  @override
+  String get listAddCollaboratorTitle => 'Adaugă colaborator';
+
+  @override
+  String get listCollaboratorSearchHint => 'Caută în diVine...';
 
   @override
   String get listNameLabel => 'Numele listei';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -378,6 +378,11 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return 'Lägg till $displayName i en lista';
+  }
+
+  @override
   String get profileUserBlockedTitle => 'Användare blockerad';
 
   @override
@@ -3902,6 +3907,18 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get listCreateNewList => 'Skapa ny lista';
+
+  @override
+  String get listNewPeopleList => 'Ny personlista';
+
+  @override
+  String get listCollaboratorsNone => 'Ingen';
+
+  @override
+  String get listAddCollaboratorTitle => 'Lägg till en samarbetspartner';
+
+  @override
+  String get listCollaboratorSearchHint => 'Sök diVine...';
 
   @override
   String get listNameLabel => 'Listnamn';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -371,6 +371,11 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String profileAddToListDisplayName(String displayName) {
+    return '$displayName kişisini bir listeye ekle';
+  }
+
+  @override
   String get profileUserBlockedTitle => 'Kullanıcı Engellendi';
 
   @override
@@ -3893,6 +3898,18 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get listCreateNewList => 'Yeni Liste Oluştur';
+
+  @override
+  String get listNewPeopleList => 'Yeni kişi listesi';
+
+  @override
+  String get listCollaboratorsNone => 'Yok';
+
+  @override
+  String get listAddCollaboratorTitle => 'İşbirlikçi ekle';
+
+  @override
+  String get listCollaboratorSearchHint => 'diVine\'da ara...';
 
   @override
   String get listNameLabel => 'Liste Adı';

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -76,6 +76,9 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
         if (mounted) context.pop();
       case MoreSheetResult.unblockConfirmed:
         await blocklistRepository.unblockUser(otherPubkey);
+      case MoreSheetResult.addToList:
+        // TODO: Handle this case.
+        throw UnimplementedError();
     }
   }
 

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -7,6 +7,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/other_profile/other_profile_bloc.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -21,6 +23,7 @@ import 'package:openvine/utils/npub_hex.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_content.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_result.dart';
+import 'package:openvine/widgets/profile/new_people_list_sheet.dart';
 import 'package:openvine/widgets/profile/profile_grid.dart';
 import 'package:openvine/widgets/profile/profile_loading_view.dart';
 import 'package:share_plus/share_plus.dart';
@@ -199,6 +202,10 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
     final displayName =
         profile?.bestDisplayName ?? widget.displayNameHint ?? fallbackName;
 
+    final userListsEnabled = ref.read(
+      isFeatureEnabledProvider(FeatureFlag.profileListFeatures),
+    );
+
     final result = await VineBottomSheet.show<MoreSheetResult>(
       context: context,
       scrollable: false,
@@ -209,6 +216,7 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
             displayName: displayName,
             isFollowing: isFollowing,
             isBlocked: isBlocked,
+            showAddToList: userListsEnabled,
           );
         },
       ),
@@ -258,6 +266,14 @@ class _OtherProfileViewState extends ConsumerState<OtherProfileView> {
             SnackBar(content: Text(l10n.profileUnblockedUser(name))),
           );
         }
+      case MoreSheetResult.addToList:
+        final profile = ref
+            .read(userProfileReactiveProvider(widget.pubkey))
+            .value;
+        await showNewPeopleListSheet(
+          context,
+          initialCollaborator: profile,
+        );
     }
   }
 

--- a/mobile/lib/screens/search_results/view/search_results_page.dart
+++ b/mobile/lib/screens/search_results/view/search_results_page.dart
@@ -56,7 +56,7 @@ class SearchResultsPage extends ConsumerWidget {
           create: (_) => ListSearchBloc(
             curatedListRepository: ref.read(curatedListRepositoryProvider),
             peopleListSearchEnabled: ref.read(
-              isFeatureEnabledProvider(FeatureFlag.peopleListSearch),
+              isFeatureEnabledProvider(FeatureFlag.profileListFeatures),
             ),
           ),
         ),

--- a/mobile/lib/services/social_service.dart
+++ b/mobile/lib/services/social_service.dart
@@ -380,11 +380,13 @@ class SocialService {
       );
 
       if (event != null) {
-        // Cache the follow set event immediately after creation
-        _personalEventCache?.cacheUserEvent(event);
-
         final sentEvent = await _nostrService.publishEvent(event);
         if (sentEvent != null) {
+          // Cache only after confirmed publish — kind 30000 is parameterized
+          // replaceable so NostrClient intentionally skips optimistic caching.
+          // Caching here mirrors the relay's acceptance of the event.
+          _personalEventCache?.cacheUserEvent(sentEvent);
+
           // Update local set with Nostr event ID
           final setIndex = _followSets.indexWhere((s) => s.id == set.id);
           if (setIndex != -1) {

--- a/mobile/lib/widgets/profile/more_sheet/more_sheet_content.dart
+++ b/mobile/lib/widgets/profile/more_sheet/more_sheet_content.dart
@@ -30,6 +30,7 @@ class MoreSheetContent extends StatefulWidget {
     required this.displayName,
     required this.isFollowing,
     required this.isBlocked,
+    this.showAddToList = false,
     this.initialMode = MoreSheetMode.menu,
     super.key,
   });
@@ -45,6 +46,9 @@ class MoreSheetContent extends StatefulWidget {
 
   /// Whether this user is blocked.
   final bool isBlocked;
+
+  /// Whether to show the "Add to list" option (gated by feature flag).
+  final bool showAddToList;
 
   /// The initial mode to display.
   final MoreSheetMode initialMode;
@@ -156,7 +160,10 @@ class _MoreSheetContentState extends State<MoreSheetContent>
       displayName: widget.displayName,
       isFollowing: widget.isFollowing,
       isBlocked: widget.isBlocked,
+      showAddToList: widget.showAddToList,
       onCopy: () => Navigator.of(context).pop(MoreSheetResult.copy),
+      onAddToList: () =>
+          Navigator.of(context).pop(MoreSheetResult.addToList),
       onUnfollow: () => Navigator.of(context).pop(MoreSheetResult.unfollow),
       onBlockTap: () {
         if (widget.isBlocked) {

--- a/mobile/lib/widgets/profile/more_sheet/more_sheet_menu.dart
+++ b/mobile/lib/widgets/profile/more_sheet/more_sheet_menu.dart
@@ -14,8 +14,10 @@ class MoreSheetMenu extends StatelessWidget {
     required this.isFollowing,
     required this.isBlocked,
     required this.onCopy,
+    required this.onAddToList,
     required this.onUnfollow,
     required this.onBlockTap,
+    this.showAddToList = false,
     super.key,
   });
 
@@ -31,6 +33,12 @@ class MoreSheetMenu extends StatelessWidget {
   /// Called when copy public key is tapped.
   final VoidCallback onCopy;
 
+  /// Called when add to list is tapped.
+  final VoidCallback onAddToList;
+
+  /// Whether to show the "Add to list" option.
+  final bool showAddToList;
+
   /// Called when unfollow is tapped.
   final VoidCallback onUnfollow;
 
@@ -43,6 +51,32 @@ class MoreSheetMenu extends StatelessWidget {
       key: const ValueKey('menu'),
       mainAxisSize: MainAxisSize.min,
       children: [
+        // Add to list action (gated by userLists feature flag)
+        if (showAddToList)
+          InkWell(
+          onTap: onAddToList,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
+            child: Row(
+              children: [
+                SvgPicture.asset(
+                  DivineIconName.listPlus.assetPath,
+                  width: 24,
+                  height: 24,
+                  colorFilter: const ColorFilter.mode(
+                    VineTheme.whiteText,
+                    BlendMode.srcIn,
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Text(
+                  context.l10n.profileAddToListDisplayName(displayName),
+                  style: VineTheme.titleMediumFont(),
+                ),
+              ],
+            ),
+          ),
+        ),
         // Copy public key action
         InkWell(
           onTap: onCopy,

--- a/mobile/lib/widgets/profile/more_sheet/more_sheet_result.dart
+++ b/mobile/lib/widgets/profile/more_sheet/more_sheet_result.dart
@@ -16,4 +16,7 @@ enum MoreSheetResult {
 
   /// User confirmed unblock action.
   unblockConfirmed,
+
+  /// User tapped add to list.
+  addToList,
 }

--- a/mobile/lib/widgets/profile/new_people_list_sheet.dart
+++ b/mobile/lib/widgets/profile/new_people_list_sheet.dart
@@ -1,0 +1,227 @@
+// ABOUTME: Bottom sheet for creating a new people list from a profile
+// ABOUTME: Shows list name and description inputs with close and done buttons
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:models/models.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/widgets/user_picker_sheet.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Shows the "New people list" bottom sheet.
+///
+/// Creates the list locally via [UserListService] and publishes it to Nostr
+/// via [SocialService] when the check button is tapped.
+///
+/// [initialCollaborator] is pre-added as the first collaborator — useful when
+/// opening the sheet directly from a profile.
+Future<void> showNewPeopleListSheet(
+  BuildContext context, {
+  UserProfile? initialCollaborator,
+}) {
+  final bodyKey = GlobalKey<_NewPeopleListSheetBodyState>();
+
+  return VineBottomSheet.show<void>(
+    context: context,
+    scrollable: false,
+    title: Builder(
+      builder: (context) => Text(context.l10n.listNewPeopleList),
+    ),
+    onComplete: () async {
+      await bodyKey.currentState?._createList();
+    },
+    body: _NewPeopleListSheetBody(
+      key: bodyKey,
+      initialCollaborator: initialCollaborator,
+    ),
+  );
+}
+
+class _NewPeopleListSheetBody extends ConsumerStatefulWidget {
+  const _NewPeopleListSheetBody({
+    this.initialCollaborator,
+    super.key,
+  });
+
+  final UserProfile? initialCollaborator;
+
+  @override
+  ConsumerState<_NewPeopleListSheetBody> createState() =>
+      _NewPeopleListSheetBodyState();
+}
+
+class _NewPeopleListSheetBodyState
+    extends ConsumerState<_NewPeopleListSheetBody> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
+
+  late final List<UserProfile> _collaborators;
+
+  @override
+  void initState() {
+    super.initState();
+    _collaborators = [
+      if (widget.initialCollaborator != null) widget.initialCollaborator!,
+    ];
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  /// Creates the list locally and publishes it to Nostr.
+  Future<void> _createList() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) return;
+
+    final description = _descriptionController.text.trim().isEmpty
+        ? null
+        : _descriptionController.text.trim();
+    final pubkeys = _collaborators.map((p) => p.pubkey).toList();
+
+    // 1. Persist locally so the list appears in the Lists tab immediately.
+    final userListService =
+        await ref.read(userListServiceProvider.future);
+    await userListService.createList(
+      name: name,
+      description: description,
+      pubkeys: pubkeys,
+    );
+
+    // 2. Publish to Nostr as a NIP-51 kind 30000 follow set.
+    final socialService = ref.read(socialServiceProvider);
+    await socialService.createFollowSet(
+      name: name,
+      description: description,
+      initialPubkeys: pubkeys,
+    );
+
+    Log.info(
+      'Created people list "$name" with ${pubkeys.length} members',
+      name: 'NewPeopleListSheet',
+      category: LogCategory.ui,
+    );
+
+    // Invalidate the provider so the Lists tab refreshes.
+    ref.invalidate(userListServiceProvider);
+  }
+
+  Future<void> _pickCollaborator() async {
+    await showUserPickerSheet(
+      context,
+      filterMode: UserPickerFilterMode.mutualFollowsOnly,
+      title: context.l10n.listAddCollaboratorTitle,
+      searchText: context.l10n.videoMetadataMutualFollowersSearchText,
+      searchHint: context.l10n.listCollaboratorSearchHint,
+      excludePubkeys: _collaborators.map((p) => p.pubkey).toSet(),
+      onUserToggled: (profile) {
+        setState(() {
+          final already = _collaborators.any((p) => p.pubkey == profile.pubkey);
+          if (already) {
+            _collaborators.removeWhere((p) => p.pubkey == profile.pubkey);
+          } else {
+            _collaborators.add(profile);
+          }
+        });
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    final l10n = context.l10n;
+
+    return SingleChildScrollView(
+      padding: EdgeInsets.fromLTRB(16, 24, 16, 16 + bottomInset),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          DivineAuthTextField(
+            label: l10n.listNameLabel,
+            controller: _nameController,
+            textCapitalization: TextCapitalization.sentences,
+            textInputAction: TextInputAction.next,
+          ),
+          const SizedBox(height: 16),
+          DivineAuthTextField(
+            label: l10n.listDescriptionLabel,
+            controller: _descriptionController,
+            textCapitalization: TextCapitalization.sentences,
+            textInputAction: TextInputAction.done,
+          ),
+          const SizedBox(height: 24),
+          _CollaboratorsRow(
+            collaborators: _collaborators,
+            onTap: _pickCollaborator,
+            l10n: l10n,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CollaboratorsRow extends StatelessWidget {
+  const _CollaboratorsRow({
+    required this.collaborators,
+    required this.onTap,
+    required this.l10n,
+  });
+
+  final List<UserProfile> collaborators;
+  final VoidCallback onTap;
+  final AppLocalizations l10n;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasCollaborators = collaborators.isNotEmpty;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n.metadataCollaboratorsLabel,
+          style: VineTheme.titleSmallFont(color: VineTheme.onSurfaceVariant),
+        ),
+        const SizedBox(height: 8),
+        InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: Row(
+              children: [
+                Expanded(
+                  child: hasCollaborators
+                      ? Text(
+                          collaborators
+                              .map((p) => p.bestDisplayName)
+                              .join(', '),
+                          style: VineTheme.titleMediumFont(),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        )
+                      : Text(
+                          l10n.listCollaboratorsNone,
+                          style: VineTheme.titleMediumFont(),
+                        ),
+                ),
+                const DivineIcon(
+                  icon: DivineIconName.caretRight,
+                  color: VineTheme.primary,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -31,7 +31,9 @@ Future<UserProfile?> showUserPickerSheet(
   required String title,
   bool autoFocus = false,
   String? searchText,
+  String? searchHint,
   Set<String> excludePubkeys = const {},
+  ValueChanged<UserProfile>? onUserToggled,
 }) {
   final resolvedSearchText = searchText ?? context.l10n.userPickerSearchByName;
 
@@ -52,6 +54,8 @@ Future<UserProfile?> showUserPickerSheet(
       scrollController: scrollController,
       autoFocus: autoFocus,
       excludePubkeys: excludePubkeys,
+      searchHint: searchHint,
+      onUserToggled: onUserToggled,
     ),
   );
 }
@@ -64,6 +68,8 @@ class UserPickerSheet extends ConsumerStatefulWidget {
     this.scrollController,
     this.autoFocus = false,
     this.excludePubkeys = const {},
+    this.searchHint,
+    this.onUserToggled,
     super.key,
   });
 
@@ -77,6 +83,15 @@ class UserPickerSheet extends ConsumerStatefulWidget {
 
   /// Pubkeys to exclude from search results (already selected users).
   final Set<String> excludePubkeys;
+
+  /// Optional override for the search field hint text.
+  final String? searchHint;
+
+  /// When provided, tapping a user calls this callback instead of popping
+  /// the sheet. Use this for multi-select flows where the sheet should stay
+  /// open. Selected users should be tracked by the caller and reflected via
+  /// [excludePubkeys] (they will appear in the checked/disabled state).
+  final ValueChanged<UserProfile>? onUserToggled;
 
   @override
   ConsumerState<UserPickerSheet> createState() => _UserPickerSheetState();
@@ -94,12 +109,18 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   /// Whether the profile repository was unavailable at init time.
   bool _profileRepoMissing = false;
 
+  /// Tracks selected pubkeys locally so toggling is reflected immediately.
+  /// Initialised from [widget.excludePubkeys] so pre-selected users show
+  /// as checked from the start.
+  late Set<String> _selectedPubkeys;
+
   bool get _useLocalSearch =>
       widget.filterMode == UserPickerFilterMode.mutualFollowsOnly;
 
   @override
   void initState() {
     super.initState();
+    _selectedPubkeys = Set.of(widget.excludePubkeys);
     final profileRepo = ref.read(profileRepositoryProvider);
     if (profileRepo == null) {
       _profileRepoMissing = true;
@@ -188,7 +209,18 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   }
 
   void _onUserSelected(UserProfile profile) {
-    Navigator.of(context).pop(profile);
+    if (widget.onUserToggled != null) {
+      setState(() {
+        if (_selectedPubkeys.contains(profile.pubkey)) {
+          _selectedPubkeys.remove(profile.pubkey);
+        } else {
+          _selectedPubkeys.add(profile.pubkey);
+        }
+      });
+      widget.onUserToggled!(profile);
+    } else {
+      Navigator.of(context).pop(profile);
+    }
   }
 
   @override
@@ -197,9 +229,10 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
       return const _ProfileRepoUnavailable();
     }
 
-    final hintText = _useLocalSearch
-        ? context.l10n.userPickerFilterByNameHint
-        : context.l10n.userPickerSearchByNameHint;
+    final hintText = widget.searchHint ??
+        (_useLocalSearch
+            ? context.l10n.userPickerFilterByNameHint
+            : context.l10n.userPickerSearchByNameHint);
 
     return Column(
       children: [
@@ -259,13 +292,13 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
                   followProfiles: _followProfiles,
                   filteredFollowProfiles: _filteredFollowProfiles,
                   onUserSelected: _onUserSelected,
-                  excludePubkeys: widget.excludePubkeys,
+                  excludePubkeys: _selectedPubkeys,
                 )
               : _NetworkResults(
                   searchBloc: _searchBloc!,
                   scrollController: widget.scrollController,
                   onUserSelected: _onUserSelected,
-                  excludePubkeys: widget.excludePubkeys,
+                  excludePubkeys: _selectedPubkeys,
                 ),
         ),
 
@@ -281,6 +314,7 @@ class _UserSearchTile extends StatelessWidget {
     required this.profile,
     required this.onTap,
     this.isDisabled = false,
+    super.key,
   });
 
   final UserProfile profile;
@@ -339,7 +373,7 @@ class _UserSearchTile extends StatelessWidget {
                     profile.bestDisplayName,
                   ),
             child: InkWell(
-              onTap: isDisabled ? null : onTap,
+              onTap: onTap,
               child: Container(
                 padding: const .all(8),
                 decoration: ShapeDecoration(
@@ -519,6 +553,7 @@ class _ResultsList extends StatelessWidget {
         final profile = results[index];
         final isDisabled = excludePubkeys.contains(profile.pubkey);
         return _UserSearchTile(
+          key: ValueKey('${profile.pubkey}_$isDisabled'),
           profile: profile,
           onTap: () => onUserSelected(profile),
           isDisabled: isDisabled,
@@ -627,6 +662,7 @@ class _LocalResults extends StatelessWidget {
         final profile = filteredFollowProfiles[index];
         final isDisabled = excludePubkeys.contains(profile.pubkey);
         return _UserSearchTile(
+          key: ValueKey('${profile.pubkey}_$isDisabled'),
           profile: profile,
           onTap: () => onUserSelected(profile),
           isDisabled: isDisabled,

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Supports both scrollable (draggable) and fixed modes
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// A reusable bottom sheet component following Vine's design system.
@@ -30,6 +31,7 @@ class VineBottomSheet extends StatelessWidget {
     this.body,
     this.buildScrollBody,
     this.trailing,
+    this.onComplete,
     this.bottomInput,
     this.expanded = true,
     this.showHeaderDivider = true,
@@ -83,6 +85,14 @@ class VineBottomSheet extends StatelessWidget {
   /// Optional trailing widget in header (e.g., badge, button)
   final Widget? trailing;
 
+  /// Optional callback invoked when the complete/check button is tapped.
+  ///
+  /// When provided, the header automatically shows a close (X) button on the
+  /// left and a check button on the right. The close button dismisses the
+  /// sheet; the check button awaits [onComplete] then dismisses the sheet.
+  /// The check button shows a loading indicator while [onComplete] is running.
+  final AsyncCallback? onComplete;
+
   /// Optional bottom input section (e.g., comment input)
   final Widget? bottomInput;
 
@@ -134,6 +144,7 @@ class VineBottomSheet extends StatelessWidget {
     Widget? body,
     Widget Function(ScrollController scrollController)? buildScrollBody,
     Widget? trailing,
+    AsyncCallback? onComplete,
     Widget? bottomInput,
     bool expanded = true,
     bool showHeaderDivider = true,
@@ -196,6 +207,7 @@ class VineBottomSheet extends StatelessWidget {
               scrollController: scrollController,
               buildScrollBody: buildScrollBody,
               trailing: trailing,
+              onComplete: onComplete,
               bottomInput: bottomInput,
               expanded: expanded,
               showHeaderDivider: showHeaderDivider,
@@ -280,6 +292,7 @@ class VineBottomSheet extends StatelessWidget {
             title: title,
             contentTitle: contentTitle,
             trailing: trailing,
+            onComplete: onComplete,
             bottomInput: bottomInput,
             expanded: expanded,
             showHeaderDivider: showHeaderDivider,
@@ -306,6 +319,7 @@ class VineBottomSheet extends StatelessWidget {
                 showHeader: showHeader,
                 title: title,
                 trailing: trailing,
+                onComplete: onComplete,
                 body: body,
                 buildScrollBody: buildScrollBody,
                 scrollController: scrollController,
@@ -319,6 +333,7 @@ class VineBottomSheet extends StatelessWidget {
                 showHeader: showHeader,
                 title: title,
                 trailing: trailing,
+                onComplete: onComplete,
                 body: body,
                 contentTitle: contentTitle,
                 bottomInput: bottomInput,
@@ -349,6 +364,7 @@ class _ScrollableContent extends StatelessWidget {
     required this.showHeader,
     required this.title,
     required this.trailing,
+    required this.onComplete,
     required this.body,
     required this.buildScrollBody,
     required this.scrollController,
@@ -362,6 +378,7 @@ class _ScrollableContent extends StatelessWidget {
   final bool showHeader;
   final Widget? title;
   final Widget? trailing;
+  final AsyncCallback? onComplete;
   final Widget? body;
   final Widget Function(ScrollController scrollController)? buildScrollBody;
   final ScrollController? scrollController;
@@ -379,7 +396,15 @@ class _ScrollableContent extends StatelessWidget {
           // Header with drag handle, title, trailing actions, and divider
           VineBottomSheetHeader(
             title: title,
-            trailing: trailing,
+            leading: onComplete != null
+                ? _CloseButton(onClose: () => Navigator.of(context).pop())
+                : null,
+            trailing: onComplete != null
+                ? _CompleteButton(
+                    onComplete: onComplete!,
+                    onDismiss: () => Navigator.of(context).pop(),
+                  )
+                : trailing,
             showDivider: showHeaderDivider,
             padding: headerPadding,
           )
@@ -432,6 +457,7 @@ class _FixedContent extends StatelessWidget {
     required this.showHeader,
     required this.title,
     required this.trailing,
+    required this.onComplete,
     required this.body,
     required this.contentTitle,
     required this.children,
@@ -443,6 +469,7 @@ class _FixedContent extends StatelessWidget {
   final bool showHeader;
   final Widget? title;
   final Widget? trailing;
+  final AsyncCallback? onComplete;
   final Widget? body;
   final String? contentTitle;
   final List<Widget>? children;
@@ -461,7 +488,15 @@ class _FixedContent extends StatelessWidget {
             // Header with drag handle and divider
             VineBottomSheetHeader(
               title: title,
-              trailing: trailing,
+              leading: onComplete != null
+                  ? _CloseButton(onClose: () => Navigator.of(context).pop())
+                  : null,
+              trailing: onComplete != null
+                  ? _CompleteButton(
+                      onComplete: onComplete!,
+                      onDismiss: () => Navigator.of(context).pop(),
+                    )
+                  : trailing,
               showDivider: showHeaderDivider,
               padding:
                   headerPadding ??
@@ -510,6 +545,84 @@ class _FixedContent extends StatelessWidget {
           ?bottomInput,
         ],
       ),
+    );
+  }
+}
+
+/// Close (X) button used in the header when [VineBottomSheet.onComplete]
+/// is set.
+class _CloseButton extends StatelessWidget {
+  const _CloseButton({required this.onClose});
+
+  final VoidCallback onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    return DivineIconButton(
+      icon: DivineIconName.x,
+      type: DivineIconButtonType.secondary,
+      size: DivineIconButtonSize.small,
+      onPressed: onClose,
+    );
+  }
+}
+
+/// Check button used in the header when [VineBottomSheet.onComplete] is set.
+///
+/// Shows a loading indicator while the async [onComplete] callback runs,
+/// then calls [onDismiss] to close the sheet.
+class _CompleteButton extends StatefulWidget {
+  const _CompleteButton({
+    required this.onComplete,
+    required this.onDismiss,
+  });
+
+  final AsyncCallback onComplete;
+  final VoidCallback onDismiss;
+
+  @override
+  State<_CompleteButton> createState() => _CompleteButtonState();
+}
+
+class _CompleteButtonState extends State<_CompleteButton> {
+  bool _loading = false;
+
+  Future<void> _handleTap() async {
+    if (_loading) return;
+    setState(() => _loading = true);
+    try {
+      await widget.onComplete();
+    } finally {
+      if (mounted) {
+        setState(() => _loading = false);
+        widget.onDismiss();
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const SizedBox(
+        width: 40,
+        height: 40,
+        child: Center(
+          child: SizedBox(
+            width: 20,
+            height: 20,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              color: VineTheme.primary,
+            ),
+          ),
+        ),
+      );
+    }
+
+    return DivineIconButton(
+      icon: DivineIconName.check,
+      size: DivineIconButtonSize.small,
+      onPressed: _handleTap,
     );
   }
 }

--- a/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_header.dart
+++ b/mobile/packages/divine_ui/lib/src/bottom_sheet/vine_bottom_sheet_header.dart
@@ -10,9 +10,10 @@ import 'package:flutter/material.dart';
 /// Uses Bricolage Grotesque bold font at 24px for title.
 class VineBottomSheetHeader extends StatelessWidget {
   /// Creates a [VineBottomSheetHeader] with the given title and optional
-  /// trailing widget.
+  /// leading and trailing widgets.
   const VineBottomSheetHeader({
     this.title,
+    this.leading,
     this.trailing,
     this.showDivider = true,
     this.padding,
@@ -21,6 +22,9 @@ class VineBottomSheetHeader extends StatelessWidget {
 
   /// Optional title widget displayed in the center
   final Widget? title;
+
+  /// Optional leading widget on the left (e.g., close button)
+  final Widget? leading;
 
   /// Optional trailing widget on the right (e.g., badge, button)
   final Widget? trailing;
@@ -61,24 +65,37 @@ class VineBottomSheetHeader extends StatelessWidget {
               const SizedBox(height: 20),
 
               if (hasTitle)
-                // Title (centered) + optional trailing actions
+                // Title (centered) + optional leading/trailing actions
                 Padding(
                   padding: const EdgeInsets.only(bottom: 14),
-                  child: Stack(
-                    alignment: Alignment.center,
-                    children: [
-                      // Centered title
-                      Center(
-                        child: DefaultTextStyle(
-                          style: VineTheme.titleMediumFont(),
-                          child: title!,
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(minHeight: 40),
+                    child: Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        // Centered title
+                        Center(
+                          child: DefaultTextStyle(
+                            style: VineTheme.titleMediumFont(),
+                            child: title!,
+                          ),
                         ),
-                      ),
 
-                      // Trailing widget positioned on the right
-                      if (trailing != null)
-                        Positioned(right: 0, child: trailing!),
-                    ],
+                        // Leading widget aligned to the center-left
+                        if (leading != null)
+                          Align(
+                            alignment: Alignment.centerLeft,
+                            child: leading,
+                          ),
+
+                        // Trailing widget aligned to the center-right
+                        if (trailing != null)
+                          Align(
+                            alignment: Alignment.centerRight,
+                            child: trailing,
+                          ),
+                      ],
+                    ),
                   ),
                 ),
             ],


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Adds a "New people list" flow accessible from a user's profile three-dots menu. Tapping "Add {name} to a list" opens a bottom sheet where the tapped user is pre-selected as a collaborator. The user can name the list, add a description, and pick additional collaborators from mutual followers. On confirm, the list is persisted locally via `UserListService` and published to Nostr as a NIP-51 kind 30000 parameterized-replaceable event via `SocialService`.

The feature is gated behind a new **Profile List Features** experiment flag (`FF_PROFILE_LIST_FEATURES`) which also replaces the previous `peopleListSearch` flag - both people list creation and people list search in results are now controlled by the single toggle.
<p align="center">
  <img src="https://github.com/user-attachments/assets/68f7ddc3-29c3-495f-b2de-82333a401cd8" width="48%" />
  <img src="https://github.com/user-attachments/assets/73ee9845-bd94-4572-b2d4-3736280bd2c3" width="48%" />
</p>

<!--- Describe your changes in detail -->

**Related Issue:** Closes #3205

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore