### PR TITLE
fix(settings): drop progress snackbar blocking dev-mode tap unlock

### DIFF
--- a/mobile/lib/providers/developer_mode_tap_provider.dart
+++ b/mobile/lib/providers/developer_mode_tap_provider.dart
@@ -19,6 +19,7 @@ class DeveloperModeTapCounter extends _$DeveloperModeTapCounter {
     return 0;
   }
 
+  /// Increments the counter and returns the updated tap count.
   int tap() {
     _resetTimer?.cancel();
     _resetTimer = Timer(const Duration(seconds: 2), () {

--- a/mobile/lib/providers/developer_mode_tap_provider.dart
+++ b/mobile/lib/providers/developer_mode_tap_provider.dart
@@ -19,12 +19,13 @@ class DeveloperModeTapCounter extends _$DeveloperModeTapCounter {
     return 0;
   }
 
-  void tap() {
+  int tap() {
     _resetTimer?.cancel();
     _resetTimer = Timer(const Duration(seconds: 2), () {
       state = 0;
     });
     state++;
+    return state;
   }
 
   void reset() {

--- a/mobile/lib/providers/developer_mode_tap_provider.g.dart
+++ b/mobile/lib/providers/developer_mode_tap_provider.g.dart
@@ -42,7 +42,7 @@ final class DeveloperModeTapCounterProvider
 }
 
 String _$developerModeTapCounterHash() =>
-    r'e1ec2bae8ee07c4cae51ff611316063cd2cda3ec';
+    r'024a1056be2a82a13b9c355e428bbbb266d3a013';
 
 abstract class _$DeveloperModeTapCounter extends $Notifier<int> {
   int build();

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -487,7 +487,6 @@ class _VersionTile extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final isDeveloperMode = ref.watch(isDeveloperModeEnabledProvider);
     final environmentService = ref.watch(environmentServiceProvider);
-    final newCount = ref.watch(developerModeTapCounterProvider);
 
     return Semantics(
       button: true,
@@ -504,15 +503,17 @@ class _VersionTile extends ConsumerWidget {
             return;
           }
 
-          ref.read(developerModeTapCounterProvider.notifier).tap();
+          final tapCount = ref
+              .read(developerModeTapCounterProvider.notifier)
+              .tap();
 
           Log.debug(
-            'Dev mode count: $newCount',
+            'Dev mode count: $tapCount',
             name: 'SettingsScreen',
             category: LogCategory.ui,
           );
 
-          if (newCount >= 7) {
+          if (tapCount >= 7) {
             await environmentService.enableDeveloperMode();
             ref.read(developerModeTapCounterProvider.notifier).reset();
 
@@ -522,21 +523,6 @@ class _VersionTile extends ConsumerWidget {
                   content: Text(context.l10n.settingsDeveloperModeEnabled),
                   backgroundColor: VineTheme.vineGreen,
                   duration: const Duration(seconds: 2),
-                ),
-              );
-            }
-            return;
-          }
-
-          if (newCount >= 4) {
-            final remaining = 7 - newCount;
-            if (context.mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text(
-                    context.l10n.settingsDeveloperModeTapsRemaining(remaining),
-                  ),
-                  duration: const Duration(milliseconds: 500),
                 ),
               );
             }


### PR DESCRIPTION
Closes #3520

## Summary

You couldn't enable developer mode by tapping the version 7 times because the **\"N more taps to enable developer mode\"** SnackBar showed up at tap 5 and rendered at the bottom of the settings list — exactly where the version tile lives. Subsequent taps hit the SnackBar instead of the tile and the counter never advanced.

Also fixed an off-by-one that made it actually take **8** taps: the threshold check read the *pre-tap* value via \`ref.watch\`. \`tap()\` now returns the new count and the gate uses that, so 7 taps unlocks as documented.

## Changes

- \`lib/screens/settings/settings_screen.dart\`: remove the \"N more taps\" SnackBar branch; capture the post-tap count from \`tap()\` and gate on it.
- \`lib/providers/developer_mode_tap_provider.dart\`: \`tap()\` returns the new state value instead of \`void\`.
- \`lib/providers/developer_mode_tap_provider.g.dart\`: regenerated codegen hash.

The orphaned \`settingsDeveloperModeTapsRemaining\` ARB key is left in place to keep this diff focused; can be cleaned up in a follow-up if desired.

## Test plan

- [x] \`flutter analyze\` clean
- [x] \`flutter test test/screens/settings/ test/l10n/l10n_test.dart\` — 32 tests pass
- [x] Pre-commit hooks pass (format, analyze, generated-files verification)
- [ ] Manual: open Settings, tap \"Version …\" 7 times, see \"Developer mode enabled!\" snackbar; no progress snackbars cover the tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)