### PR TITLE
fix(social): bind feed-item BlocProvider to repo identity (#3503)

### DIFF
--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -947,13 +947,26 @@ class _PooledFullscreenItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final likesRepository = ref.read(likesRepositoryProvider);
-    final commentsRepository = ref.read(commentsRepositoryProvider);
-    final repostsRepository = ref.read(repostsRepositoryProvider);
+    // ref.watch + composite ValueKey: see video_feed_page.dart for rationale.
+    // Without this, a fullscreen entry that mounts during the auth-flip
+    // window (warm-up materialized providers pre-auth, then provider
+    // graph rebuilds) snapshots a stale LikesRepository whose underlying
+    // Nostr instance has an empty cached pubkey — every sendLike then
+    // throws StateError. See #3503.
+    final likesRepository = ref.watch(likesRepositoryProvider);
+    final commentsRepository = ref.watch(commentsRepositoryProvider);
+    final repostsRepository = ref.watch(repostsRepositoryProvider);
 
     final addressableId = video.addressableId;
 
     return BlocProvider<VideoInteractionsBloc>(
+      key: ValueKey(
+        Object.hash(
+          identityHashCode(likesRepository),
+          identityHashCode(commentsRepository),
+          identityHashCode(repostsRepository),
+        ),
+      ),
       create: (_) =>
           VideoInteractionsBloc(
               eventId: video.id,
@@ -1013,11 +1026,19 @@ class _WebFullscreenItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final likesRepository = ref.read(likesRepositoryProvider);
-    final commentsRepository = ref.read(commentsRepositoryProvider);
-    final repostsRepository = ref.read(repostsRepositoryProvider);
+    // See _PooledFullscreenItem.build for the rationale on watch + key. #3503.
+    final likesRepository = ref.watch(likesRepositoryProvider);
+    final commentsRepository = ref.watch(commentsRepositoryProvider);
+    final repostsRepository = ref.watch(repostsRepositoryProvider);
 
     return BlocProvider<VideoInteractionsBloc>(
+      key: ValueKey(
+        Object.hash(
+          identityHashCode(likesRepository),
+          identityHashCode(commentsRepository),
+          identityHashCode(repostsRepository),
+        ),
+      ),
       create: (_) =>
           VideoInteractionsBloc(
               eventId: video.id,

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -947,7 +947,7 @@ class _PooledFullscreenItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // ref.watch + composite ValueKey: see video_feed_page.dart for rationale.
+    // ref.watch + record key: see video_feed_page.dart for rationale.
     // Without this, a fullscreen entry that mounts during the auth-flip
     // window (warm-up materialized providers pre-auth, then provider
     // graph rebuilds) snapshots a stale LikesRepository whose underlying
@@ -960,13 +960,7 @@ class _PooledFullscreenItem extends ConsumerWidget {
     final addressableId = video.addressableId;
 
     return BlocProvider<VideoInteractionsBloc>(
-      key: ValueKey(
-        Object.hash(
-          identityHashCode(likesRepository),
-          identityHashCode(commentsRepository),
-          identityHashCode(repostsRepository),
-        ),
-      ),
+      key: ValueKey((likesRepository, commentsRepository, repostsRepository)),
       create: (_) =>
           VideoInteractionsBloc(
               eventId: video.id,
@@ -1032,13 +1026,7 @@ class _WebFullscreenItem extends ConsumerWidget {
     final repostsRepository = ref.watch(repostsRepositoryProvider);
 
     return BlocProvider<VideoInteractionsBloc>(
-      key: ValueKey(
-        Object.hash(
-          identityHashCode(likesRepository),
-          identityHashCode(commentsRepository),
-          identityHashCode(repostsRepository),
-        ),
-      ),
+      key: ValueKey((likesRepository, commentsRepository, repostsRepository)),
       create: (_) =>
           VideoInteractionsBloc(
               eventId: video.id,

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -895,10 +895,12 @@ class _PooledVideoFeedItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // ref.watch + composite ValueKey: when any of these provider instances
-    // is rebuilt (auth flip / sign-out / account switch) the BlocProvider's
+    // ref.watch + record key: when any of these provider instances is
+    // rebuilt (auth flip / sign-out / account switch) the BlocProvider's
     // key changes, the stale bloc is closed, and the new one's create:
-    // captures the fresh repository chain. See #3503.
+    // captures the fresh repository chain. Records compare structurally
+    // (per-field ==), and these classes don't override == — so equality
+    // falls through to identity, which is what we want. See #3503.
     final likesRepository = ref.watch(likesRepositoryProvider);
     final commentsRepository = ref.watch(commentsRepositoryProvider);
     final repostsRepository = ref.watch(repostsRepositoryProvider);
@@ -907,13 +909,7 @@ class _PooledVideoFeedItem extends ConsumerWidget {
     final addressableId = video.addressableId;
 
     return BlocProvider<VideoInteractionsBloc>(
-      key: ValueKey(
-        Object.hash(
-          identityHashCode(likesRepository),
-          identityHashCode(commentsRepository),
-          identityHashCode(repostsRepository),
-        ),
-      ),
+      key: ValueKey((likesRepository, commentsRepository, repostsRepository)),
       create: (_) =>
           VideoInteractionsBloc(
               eventId: video.id,
@@ -981,13 +977,7 @@ class _WebVideoFeedItem extends ConsumerWidget {
     final repostsRepository = ref.watch(repostsRepositoryProvider);
 
     return BlocProvider<VideoInteractionsBloc>(
-      key: ValueKey(
-        Object.hash(
-          identityHashCode(likesRepository),
-          identityHashCode(commentsRepository),
-          identityHashCode(repostsRepository),
-        ),
-      ),
+      key: ValueKey((likesRepository, commentsRepository, repostsRepository)),
       create: (_) =>
           VideoInteractionsBloc(
               eventId: video.id,

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -895,14 +895,25 @@ class _PooledVideoFeedItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final likesRepository = ref.read(likesRepositoryProvider);
-    final commentsRepository = ref.read(commentsRepositoryProvider);
-    final repostsRepository = ref.read(repostsRepositoryProvider);
+    // ref.watch + composite ValueKey: when any of these provider instances
+    // is rebuilt (auth flip / sign-out / account switch) the BlocProvider's
+    // key changes, the stale bloc is closed, and the new one's create:
+    // captures the fresh repository chain. See #3503.
+    final likesRepository = ref.watch(likesRepositoryProvider);
+    final commentsRepository = ref.watch(commentsRepositoryProvider);
+    final repostsRepository = ref.watch(repostsRepositoryProvider);
 
     // Build addressable ID for reposts if video has a d-tag (vineId)
     final addressableId = video.addressableId;
 
     return BlocProvider<VideoInteractionsBloc>(
+      key: ValueKey(
+        Object.hash(
+          identityHashCode(likesRepository),
+          identityHashCode(commentsRepository),
+          identityHashCode(repostsRepository),
+        ),
+      ),
       create: (_) =>
           VideoInteractionsBloc(
               eventId: video.id,
@@ -964,11 +975,19 @@ class _WebVideoFeedItem extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final likesRepository = ref.read(likesRepositoryProvider);
-    final commentsRepository = ref.read(commentsRepositoryProvider);
-    final repostsRepository = ref.read(repostsRepositoryProvider);
+    // See _PooledVideoFeedItem.build for the rationale on watch + key. #3503.
+    final likesRepository = ref.watch(likesRepositoryProvider);
+    final commentsRepository = ref.watch(commentsRepositoryProvider);
+    final repostsRepository = ref.watch(repostsRepositoryProvider);
 
     return BlocProvider<VideoInteractionsBloc>(
+      key: ValueKey(
+        Object.hash(
+          identityHashCode(likesRepository),
+          identityHashCode(commentsRepository),
+          identityHashCode(repostsRepository),
+        ),
+      ),
       create: (_) =>
           VideoInteractionsBloc(
               eventId: video.id,

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -629,6 +629,52 @@ void main() {
         ],
       );
 
+      // Regression for #3503: when the home feed mounts a feed item whose
+      // BlocProvider snapshotted a stale LikesRepository (one wrapping a
+      // Nostr instance with an empty cached public key), every sendLike
+      // surfaces as `StateError('No public key available …')` from
+      // `Nostr.ensurePublicKey`. The bloc must roll back the optimistic
+      // flip and surface `VideoInteractionsError.likeFailed` — not crash
+      // and not leave the heart filled. The fix in
+      // `_PooledVideoFeedItem.build` (video_feed_page.dart) prevents the
+      // stale snapshot in the first place; this test pins the bloc-side
+      // behaviour so a future change to `ensurePublicKey`'s error type
+      // doesn't silently drop the rollback.
+      blocTest<VideoInteractionsBloc, VideoInteractionsState>(
+        'rolls back when toggle throws StateError from ensurePublicKey',
+        setUp: () {
+          when(
+            () => mockLikesRepository.toggleLike(
+              eventId: testEventId,
+              authorPubkey: testAuthorPubkey,
+            ),
+          ).thenThrow(
+            StateError(
+              'No public key available — signer may not be configured',
+            ),
+          );
+        },
+        build: createBloc,
+        seed: () => const VideoInteractionsState(
+          status: VideoInteractionsStatus.success,
+          likeCount: 5,
+        ),
+        act: (bloc) => bloc.add(const VideoInteractionsLikeToggled()),
+        expect: () => [
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isLiked: true,
+            likeCount: 6,
+          ),
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            likeCount: 5,
+            error: VideoInteractionsError.likeFailed,
+          ),
+        ],
+        errors: () => [isA<StateError>()],
+      );
+
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
         'subscription stream tick during toggle does not double-emit',
         setUp: () {

--- a/mobile/test/screens/feed/pooled_video_feed_item_repo_swap_test.dart
+++ b/mobile/test/screens/feed/pooled_video_feed_item_repo_swap_test.dart
@@ -1,0 +1,236 @@
+// ABOUTME: Regression test for #3503 — verifies that the BlocProvider for
+// VideoInteractionsBloc on a pooled feed item recreates its bloc when any
+// of the three repository providers (likes, comments, reposts) is rebuilt.
+//
+// The production sites mirror this pattern at:
+//   - mobile/lib/screens/feed/video_feed_page.dart (_PooledVideoFeedItem,
+//     _WebVideoFeedItem)
+//   - mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+//     (_PooledFullscreenItem, _WebFullscreenItem)
+// Each does `ref.watch(...)` on the three repos and gates the BlocProvider
+// with a composite ValueKey of the three identity hashes. When any
+// provider rebuilds (auth flip / sign-out / account switch), the key
+// changes, the stale bloc is closed, and a fresh one wraps the new repos.
+
+@Tags(['skip_very_good_optimization'])
+import 'package:comments_repository/comments_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:likes_repository/likes_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:reposts_repository/reposts_repository.dart';
+
+class _MockLikesRepository extends Mock implements LikesRepository {}
+
+class _MockCommentsRepository extends Mock implements CommentsRepository {}
+
+class _MockRepostsRepository extends Mock implements RepostsRepository {}
+
+/// Mirror of the production BlocProvider pattern from `_PooledVideoFeedItem`
+/// in `mobile/lib/screens/feed/video_feed_page.dart`. Kept in this test
+/// file because the production widget is private; reviewers should verify
+/// this fixture stays in sync with the four production call sites.
+class _Fixture extends ConsumerWidget {
+  const _Fixture();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final likesRepository = ref.watch(likesRepositoryProvider);
+    final commentsRepository = ref.watch(commentsRepositoryProvider);
+    final repostsRepository = ref.watch(repostsRepositoryProvider);
+
+    return BlocProvider<VideoInteractionsBloc>(
+      key: ValueKey(
+        Object.hash(
+          identityHashCode(likesRepository),
+          identityHashCode(commentsRepository),
+          identityHashCode(repostsRepository),
+        ),
+      ),
+      create: (_) =>
+          VideoInteractionsBloc(
+              eventId: 'test-event',
+              authorPubkey: 'test-pubkey',
+              likesRepository: likesRepository,
+              commentsRepository: commentsRepository,
+              repostsRepository: repostsRepository,
+            )
+            ..add(const VideoInteractionsSubscriptionRequested())
+            ..add(const VideoInteractionsFetchRequested()),
+      child: const _Probe(),
+    );
+  }
+}
+
+class _Probe extends StatelessWidget {
+  const _Probe();
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+/// Toggle a `StateProvider<int>` to force `likesRepositoryProvider` to
+/// rebuild and return a different mock — mirrors what happens in
+/// production when auth flips (the real provider also rebuilds and
+/// returns a fresh repository instance).
+final _likesRepoSwap = StateProvider<int>((ref) => 0);
+
+void main() {
+  group('Pooled video feed item — BlocProvider repo-swap (#3503)', () {
+    late _MockLikesRepository mockLikesA;
+    late _MockLikesRepository mockLikesB;
+    late _MockCommentsRepository mockComments;
+    late _MockRepostsRepository mockReposts;
+
+    setUp(() {
+      mockLikesA = _MockLikesRepository();
+      mockLikesB = _MockLikesRepository();
+      mockComments = _MockCommentsRepository();
+      mockReposts = _MockRepostsRepository();
+
+      // VideoInteractionsBloc subscribes to these on construction
+      // (VideoInteractionsSubscriptionRequested) and fetches counts
+      // (VideoInteractionsFetchRequested). Stub them on both mocks so the
+      // bloc can run without throwing during the test.
+      when(
+        mockLikesA.watchLikedEventIds,
+      ).thenAnswer((_) => const Stream<List<String>>.empty());
+      when(
+        mockLikesB.watchLikedEventIds,
+      ).thenAnswer((_) => const Stream<List<String>>.empty());
+      when(() => mockLikesA.isLiked(any())).thenAnswer((_) async => false);
+      when(() => mockLikesB.isLiked(any())).thenAnswer((_) async => false);
+      when(
+        () => mockLikesA.getLikeCount(
+          any(),
+          addressableId: any(named: 'addressableId'),
+        ),
+      ).thenAnswer((_) async => 0);
+      when(
+        () => mockLikesB.getLikeCount(
+          any(),
+          addressableId: any(named: 'addressableId'),
+        ),
+      ).thenAnswer((_) async => 0);
+      when(
+        mockReposts.watchRepostedAddressableIds,
+      ).thenAnswer((_) => const Stream<Set<String>>.empty());
+      when(
+        () => mockReposts.getRepostCountByEventId(any()),
+      ).thenAnswer((_) async => 0);
+      when(
+        () => mockComments.getCommentsCount(
+          any(),
+          rootAddressableId: any(named: 'rootAddressableId'),
+        ),
+      ).thenAnswer((_) async => 0);
+    });
+
+    testWidgets(
+      'swaps VideoInteractionsBloc when likesRepositoryProvider rebuilds',
+      (tester) async {
+        final container = ProviderContainer(
+          overrides: [
+            likesRepositoryProvider.overrideWith((ref) {
+              final v = ref.watch(_likesRepoSwap);
+              return v == 0 ? mockLikesA : mockLikesB;
+            }),
+            commentsRepositoryProvider.overrideWith((_) => mockComments),
+            repostsRepositoryProvider.overrideWith((_) => mockReposts),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(home: _Fixture()),
+          ),
+        );
+
+        // Capture the bloc that was created when the fixture first built.
+        final probeContext = tester.element(find.byType(_Probe));
+        final blocA = BlocProvider.of<VideoInteractionsBloc>(probeContext);
+        expect(
+          blocA.isClosed,
+          isFalse,
+          reason: 'initial bloc should be alive',
+        );
+
+        // Flip the toggle. likesRepositoryProvider rebuilds, _Fixture's
+        // watch fires, the composite ValueKey changes, BlocProvider
+        // unmounts blocA and creates a new bloc wrapping mockLikesB.
+        container.read(_likesRepoSwap.notifier).state = 1;
+        await tester.pump();
+
+        final probeContextAfter = tester.element(find.byType(_Probe));
+        final blocB = BlocProvider.of<VideoInteractionsBloc>(probeContextAfter);
+
+        expect(
+          blocB,
+          isNot(same(blocA)),
+          reason:
+              'BlocProvider should create a new bloc when the composite '
+              'repo key changes — without this fix, the first feed items '
+              'snapshot a stale repository at cold launch and like '
+              'attempts throw `Bad state: No public key available`',
+        );
+        // (Cleanup of the old bloc is handled by BlocProvider.dispose →
+        // bloc.close(); not asserted here because the close future is not
+        // awaited in dispose and pumping it through reliably in widget
+        // tests adds fragility for no extra guarantee.)
+      },
+    );
+
+    testWidgets(
+      'preserves the same VideoInteractionsBloc when no repo identity changes',
+      (tester) async {
+        final container = ProviderContainer(
+          overrides: [
+            likesRepositoryProvider.overrideWith((ref) {
+              ref.watch(_likesRepoSwap);
+              return mockLikesA;
+            }),
+            commentsRepositoryProvider.overrideWith((_) => mockComments),
+            repostsRepositoryProvider.overrideWith((_) => mockReposts),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(home: _Fixture()),
+          ),
+        );
+
+        final blocA = BlocProvider.of<VideoInteractionsBloc>(
+          tester.element(find.byType(_Probe)),
+        );
+
+        // Force the override to re-run, but keep returning the same mock
+        // — the composite key (built from identity hashes) must stay the
+        // same, so BlocProvider keeps the same bloc.
+        container.read(_likesRepoSwap.notifier).state = 1;
+        await tester.pump();
+
+        final blocAfter = BlocProvider.of<VideoInteractionsBloc>(
+          tester.element(find.byType(_Probe)),
+        );
+
+        expect(
+          blocAfter,
+          same(blocA),
+          reason:
+              'identical repo identities should keep the same bloc — '
+              'the composite key prevents unnecessary churn on rebuilds',
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/screens/feed/pooled_video_feed_item_repo_swap_test.dart
+++ b/mobile/test/screens/feed/pooled_video_feed_item_repo_swap_test.dart
@@ -45,13 +45,7 @@ class _Fixture extends ConsumerWidget {
     final repostsRepository = ref.watch(repostsRepositoryProvider);
 
     return BlocProvider<VideoInteractionsBloc>(
-      key: ValueKey(
-        Object.hash(
-          identityHashCode(likesRepository),
-          identityHashCode(commentsRepository),
-          identityHashCode(repostsRepository),
-        ),
-      ),
+      key: ValueKey((likesRepository, commentsRepository, repostsRepository)),
       create: (_) =>
           VideoInteractionsBloc(
               eventId: 'test-event',
@@ -214,8 +208,9 @@ void main() {
         );
 
         // Force the override to re-run, but keep returning the same mock
-        // — the composite key (built from identity hashes) must stay the
-        // same, so BlocProvider keeps the same bloc.
+        // — the record key compares fields by `==` (identity for these
+        // classes), so identical instances yield equal keys and the
+        // BlocProvider keeps the same bloc.
         container.read(_likesRepoSwap.notifier).state = 1;
         await tester.pump();
 
@@ -228,7 +223,97 @@ void main() {
           same(blocA),
           reason:
               'identical repo identities should keep the same bloc — '
-              'the composite key prevents unnecessary churn on rebuilds',
+              'the record key prevents unnecessary churn on rebuilds',
+        );
+      },
+    );
+
+    // Documents an intentional trade-off raised in PR #3522 review: when
+    // the composite record key changes, the old bloc is closed and the
+    // new one starts from initial state. Optimistic flips and in-flight
+    // publishes against the previous repo are intentionally dropped —
+    // the new repo points at a different NostrClient (different signer,
+    // possibly different user) so replaying them would be unsafe.
+    //
+    // Today the only paths that flip this key are:
+    //   - auth state transitions (the cold-launch race this PR fixes),
+    //   - sign-in / sign-out / account switch.
+    // If a future change adds a non-auth invalidation of one of the
+    // three repository providers, this test will fail loudly so the
+    // state-loss can be re-evaluated in that context.
+    testWidgets(
+      'resets bloc state when likesRepositoryProvider rebuilds (intentional)',
+      (tester) async {
+        final container = ProviderContainer(
+          overrides: [
+            likesRepositoryProvider.overrideWith((ref) {
+              final v = ref.watch(_likesRepoSwap);
+              return v == 0 ? mockLikesA : mockLikesB;
+            }),
+            commentsRepositoryProvider.overrideWith((_) => mockComments),
+            repostsRepositoryProvider.overrideWith((_) => mockReposts),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(home: _Fixture()),
+          ),
+        );
+
+        final blocBefore = BlocProvider.of<VideoInteractionsBloc>(
+          tester.element(find.byType(_Probe)),
+        );
+
+        // Synthesise a non-initial state to prove it actually gets lost.
+        // Mirrors what an optimistic like emit would look like: heart
+        // flipped + count incremented, no error.
+        blocBefore.emit(
+          const VideoInteractionsState(
+            status: VideoInteractionsStatus.success,
+            isLiked: true,
+            likeCount: 7,
+          ),
+        );
+        await tester.pump();
+        expect(blocBefore.state.isLiked, isTrue);
+        expect(blocBefore.state.likeCount, equals(7));
+
+        // Flip the override → key changes → BlocProvider tears down
+        // blocBefore and creates a fresh bloc from initial state.
+        container.read(_likesRepoSwap.notifier).state = 1;
+        await tester.pump();
+
+        final blocAfter = BlocProvider.of<VideoInteractionsBloc>(
+          tester.element(find.byType(_Probe)),
+        );
+
+        expect(
+          blocAfter,
+          isNot(same(blocBefore)),
+          reason: 'precondition: a swap should have happened',
+        );
+        // The fresh bloc starts from initial state — the synthesised
+        // optimistic flip on blocBefore is gone. This is intentional:
+        // the optimistic state was bound to the previous repository
+        // (different NostrClient / signer), and replaying it against
+        // the new one is unsafe.
+        expect(
+          blocAfter.state.isLiked,
+          isFalse,
+          reason: 'new bloc should not inherit blocBefore.isLiked',
+        );
+        expect(
+          blocAfter.state.likeCount,
+          isNull,
+          reason: 'new bloc should not inherit blocBefore.likeCount',
+        );
+        expect(
+          blocAfter.state.error,
+          isNull,
+          reason: 'new bloc should not inherit blocBefore.error',
         );
       },
     );


### PR DESCRIPTION
## Description

Fixes the regression where users could not like the first two videos in the home feed at cold launch (`Bad state: No public key available — signer may not be configured`).

**Related Issue:** Closes #3503

## Root cause

`_PooledVideoFeedItem` and friends were calling `ref.read` on `likesRepositoryProvider` / `commentsRepositoryProvider` / `repostsRepositoryProvider` and capturing those instances permanently in the `BlocProvider.create:` callback.

At cold launch, the warmup chain
(`popularNowFeedProvider` → `videoEventServiceProvider` →
`likesRepositoryProvider` → `nostrServiceProvider`)
materialises the provider graph **before** `AuthService.initialize()` resolves. The resulting `Nostr` instance is built around the `LocalKeySigner(null)` placeholder, so `Nostr._cachedPublicKey` ends up as `''`.

When auth flips, `NostrService._onAuthStateChanged` swaps to a fresh `NostrClient`, but the first two `_PooledVideoFeedItem` slots — current + adjacent in the PageView cache — already snapshotted the stale chain. Every `sendLike` from those blocs hits `Nostr.ensurePublicKey()` (`packages/nostr_sdk/lib/nostr.dart:61`) on the *stale* `Nostr` and throws. Scrolling to video 3+ mounts a fresh feed item, which captures the post‑auth providers and works.

This matches @hm21's reproduction exactly: "I have to swipe to exactly the third video before I'm able to like anything." There are two `Nostr` instances live at the same time — the stale one (placeholder signer, empty cached pubkey) referenced by videos 1 & 2's blocs, and the fresh one referenced by video 3+'s bloc.

## The fix

Switch the four `BlocProvider<VideoInteractionsBloc>` creation sites to `ref.watch` and add a record `ValueKey((likesRepository, commentsRepository, repostsRepository))` on the `BlocProvider`:

- `_PooledVideoFeedItem.build` and `_WebVideoFeedItem.build` in `video_feed_page.dart`
- `_PooledFullscreenItem.build` and `_WebFullscreenItem.build` in `pooled_fullscreen_video_feed_screen.dart`

Records compare per-field with `==`; for these classes (no custom `==`) that falls through to identity. So the key changes iff *any* of the three repository instances changes identity. When any of the three provider values changes (auth flip, account switch, sign-out), the feed item rebuilds, the key changes, the stale bloc is closed, and a fresh bloc captures the new repository chain — including the cached PageView slots for videos 1 and 2.

This mirrors the existing identity-scoped subtree pattern already in this codebase at finer scope:
- `inbox_view.dart:86` — `KeyedSubtree(key: ValueKey('messages-$currentPubkey'))`
- `video_feed_page.dart:79` — `MultiBlocProvider(key: ValueKey('video-feed-$showDivineHostedOnly'))`
- `pooled_fullscreen_video_feed_screen.dart:1214` — `key: ValueKey('metrics-${video.id}')`

## Tradeoff: bloc state is reset on swap (intentional)

When the record key changes, the old `VideoInteractionsBloc` is closed and a new one is constructed at initial state. **In-flight optimistic state — heart flipped, count incremented, pending publish — is dropped.** This is intentional and correct:

- The optimistic state was bound to the *previous* repository, which wraps a different `NostrClient` (different signer, possibly different user). Replaying it against the new one is unsafe.
- The only paths that today flip this key are auth state transitions (the cold-launch race this PR fixes) and sign-in / sign-out / account switch — all cases where the user's previous interaction state is no longer meaningful.
- A grep confirms no code today calls `ref.invalidate(likesRepositoryProvider)` or its siblings outside the auth path.

The new test `resets bloc state when likesRepositoryProvider rebuilds (intentional)` in `pooled_video_feed_item_repo_swap_test.dart` pins this contract: it forces a non-auth invalidation, asserts the bloc is recreated, and asserts the synthesised optimistic state on the previous bloc does NOT carry over to the new one. If a future change introduces a manual invalidation of one of these providers without auth context, this test will fail loudly so the state-loss can be re-evaluated.

## Why not Pattern A (return null until `isNostrReady`)?

The codebase already gates `profileRepositoryProvider` and `pendingActionServiceProvider` on `isNostrReadyProvider` (return `null` until ready). Extending that to `likesRepositoryProvider` / `commentsRepositoryProvider` / `repostsRepositoryProvider` would require a UX decision on what the feed-item action buttons render during the unready window — a designer-involved change.

The current PR uses a Flutter idiom already present in this codebase, with no UX impact. Pattern A is filed as #3523 so it can move at its own pace.

## Why this isn't a #3409 revert

The race predates #3409 by weeks: PR #2777 (2026-04-06) introduced `Nostr.ensurePublicKey` which surfaces the empty cached pubkey as `StateError`. Before that, the same race produced an `ArgumentError("Invalid key")`. PR #3409 (2026-04-26) made the failure visible to users by switching likes to optimistic-first (heart fills then rolls back) — the underlying race is unchanged. Reverting #3409 would re-hide the race but not fix it.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] New widget test `pooled_video_feed_item_repo_swap_test.dart` (3 cases):
  - bloc swaps when `likesRepositoryProvider` is overridden mid-pump
  - bloc preserved when no repo identity changes (so we don't regress into "rebuild every frame")
  - bloc state resets on swap, intentionally — pins the state-loss contract
- [x] Extended `video_interactions_bloc_test.dart` — pins that `StateError("No public key available …")` from `LikesRepository.toggleLike` produces the rollback + `error: VideoInteractionsError.likeFailed`.
- [x] Existing `video_interactions_bloc_test.dart` (47 tests), `nostr_ensure_public_key_test.dart` — pass unchanged.
- [ ] **Manual**: cold-launch on a previously-authenticated session on Android (Galaxy preferred — @hm21's repro device); tap like on videos 1, 2, 3 in the home feed. All three should publish kind-7 successfully.

## Follow-ups (separate issues)

- #3523 — Apply Pattern A consistency across `likesRepository` / `commentsRepository` / `repostsRepository` (gate on `isNostrReady`, return `null` until ready) to match `profileRepository` precedent. Independent of this PR.
- #3524 — Atomic state swap in `NostrService._onAuthStateChanged` (commit `state = newClient` before disposing the old client). Defense-in-depth for any other consumer that captures `nostrServiceProvider` in a closure.
- #3525 — `VideoInteractionsState.error` is currently dead code (no widget reads it). Either wire it to a UI affordance or remove.
- #3526 — `addError(...)` in `VideoInteractionsBloc._publishLike` flows into nowhere (no `BlocObserver` registered). Forward Bloc errors to Crashlytics.
- #3527 — RFC tracker: migrate `nostrServiceProvider` to `AsyncValue<NostrClient>` and remove the `LocalKeySigner(null)` placeholder. Multi-PR migration.

cc @NotThatKindOfDrLiz — issue is assigned to you. Happy to drive review iterations or hand off; whichever you prefer.
