### PR TITLE
fix(profile): kind 0 publish on no-relays fails fast with generic error

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -407,7 +407,8 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         name: 'ProfileEditorBloc',
       );
       await _profileRepository.cacheProfile(savedProfile);
-    } catch (error) {
+    } catch (error, stackTrace) {
+      addError(error, stackTrace);
       Log.error('Failed to publish profile: $error', name: 'ProfileEditorBloc');
       final profileError = error is NoRelaysConnectedException
           ? ProfileEditorError.noRelaysConnected

--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -409,10 +409,13 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       await _profileRepository.cacheProfile(savedProfile);
     } catch (error) {
       Log.error('Failed to publish profile: $error', name: 'ProfileEditorBloc');
+      final profileError = error is NoRelaysConnectedException
+          ? ProfileEditorError.noRelaysConnected
+          : ProfileEditorError.publishFailed;
       emit(
         state.copyWith(
           status: ProfileEditorStatus.failure,
-          error: ProfileEditorError.publishFailed,
+          error: profileError,
         ),
       );
       return;

--- a/mobile/lib/blocs/profile_editor/profile_editor_state.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_state.dart
@@ -25,8 +25,15 @@ enum ProfileEditorStatus {
 ///
 /// The UI layer should map these to localized strings.
 enum ProfileEditorError {
-  /// Failed to publish profile to Nostr relays.
+  /// Failed to publish profile to Nostr relays (relay rejected or send error).
   publishFailed,
+
+  /// Failed to publish profile because no relays are currently connected.
+  ///
+  /// This is distinct from [publishFailed]: the device has no active relay
+  /// connections at all, rather than a relay actively rejecting the event.
+  /// The UI should show a connectivity-specific message and offer a retry.
+  noRelaysConnected,
 
   /// Failed to claim username (network error or other issue).
   claimFailed,

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -316,6 +316,7 @@
     "profileSetupUsernameTaken": "تم أخذ اسم المستخدم للتو. يرجى اختيار اسم آخر.",
     "profileSetupClaimFailed": "تعذّرت المطالبة باسم المستخدم. حاول مرّة أخرى.",
     "profileSetupPublishFailed": "تعذّر نشر الملف الشخصي. حاول مرّة أخرى.",
+    "profileSetupNoRelaysConnected": "لا يمكن الوصول إلى الشبكة. تحقق من اتصالك وحاول مرة أخرى.",
     "profileSetupDisplayNameLabel": "الاسم المعروض",
     "profileSetupDisplayNameHint": "كيف يجب أن يعرفك الناس؟",
     "profileSetupDisplayNameHelper": "أي اسم أو لقب تريد. لا يلزم أن يكون فريدًا.",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -317,6 +317,7 @@
     "profileSetupClaimFailed": "تعذّرت المطالبة باسم المستخدم. حاول مرّة أخرى.",
     "profileSetupPublishFailed": "تعذّر نشر الملف الشخصي. حاول مرّة أخرى.",
     "profileSetupNoRelaysConnected": "لا يمكن الوصول إلى الشبكة. تحقق من اتصالك وحاول مرة أخرى.",
+    "profileSetupRetryLabel": "إعادة المحاولة",
     "profileSetupDisplayNameLabel": "الاسم المعروض",
     "profileSetupDisplayNameHint": "كيف يجب أن يعرفك الناس؟",
     "profileSetupDisplayNameHelper": "أي اسم أو لقب تريد. لا يلزم أن يكون فريدًا.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -316,6 +316,7 @@
     "profileSetupUsernameTaken": "Der Benutzername wurde gerade vergeben. Bitte wähl einen anderen.",
     "profileSetupClaimFailed": "Benutzername konnte nicht reserviert werden. Bitte versuch es nochmal.",
     "profileSetupPublishFailed": "Profil konnte nicht veröffentlicht werden. Bitte versuch es nochmal.",
+    "profileSetupNoRelaysConnected": "Netzwerk nicht erreichbar. Überprüfe deine Verbindung und versuch es nochmal.",
     "profileSetupDisplayNameLabel": "Anzeigename",
     "profileSetupDisplayNameHint": "Wie sollen dich die Leute kennen?",
     "profileSetupDisplayNameHelper": "Beliebiger Name oder Label. Muss nicht einzigartig sein.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -317,6 +317,7 @@
     "profileSetupClaimFailed": "Benutzername konnte nicht reserviert werden. Bitte versuch es nochmal.",
     "profileSetupPublishFailed": "Profil konnte nicht veröffentlicht werden. Bitte versuch es nochmal.",
     "profileSetupNoRelaysConnected": "Netzwerk nicht erreichbar. Überprüfe deine Verbindung und versuch es nochmal.",
+    "profileSetupRetryLabel": "Wiederholen",
     "profileSetupDisplayNameLabel": "Anzeigename",
     "profileSetupDisplayNameHint": "Wie sollen dich die Leute kennen?",
     "profileSetupDisplayNameHelper": "Beliebiger Name oder Label. Muss nicht einzigartig sein.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -330,6 +330,7 @@
   "profileSetupUsernameTaken": "Username was just taken. Please choose another.",
   "profileSetupClaimFailed": "Failed to claim username. Please try again.",
   "profileSetupPublishFailed": "Failed to publish profile. Please try again.",
+  "profileSetupNoRelaysConnected": "Couldn't reach the network. Check your connection and try again.",
   "profileSetupDisplayNameLabel": "Display Name",
   "profileSetupDisplayNameHint": "How should people know you?",
   "profileSetupDisplayNameHelper": "Any name or label you want. Doesn't have to be unique.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -331,6 +331,7 @@
   "profileSetupClaimFailed": "Failed to claim username. Please try again.",
   "profileSetupPublishFailed": "Failed to publish profile. Please try again.",
   "profileSetupNoRelaysConnected": "Couldn't reach the network. Check your connection and try again.",
+  "profileSetupRetryLabel": "Retry",
   "profileSetupDisplayNameLabel": "Display Name",
   "profileSetupDisplayNameHint": "How should people know you?",
   "profileSetupDisplayNameHelper": "Any name or label you want. Doesn't have to be unique.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -317,6 +317,7 @@
     "profileSetupClaimFailed": "No se pudo reservar el nombre de usuario. Probá de nuevo.",
     "profileSetupPublishFailed": "No se pudo publicar el perfil. Probá de nuevo.",
     "profileSetupNoRelaysConnected": "No se pudo conectar a la red. Verificá tu conexión e intentá de nuevo.",
+    "profileSetupRetryLabel": "Reintentar",
     "profileSetupDisplayNameLabel": "Nombre a mostrar",
     "profileSetupDisplayNameHint": "¿Cómo querés que te conozcan?",
     "profileSetupDisplayNameHelper": "Cualquier nombre o apodo que quieras. No tiene que ser único.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -316,6 +316,7 @@
     "profileSetupUsernameTaken": "Ese nombre de usuario se acaba de ocupar. Elegí otro.",
     "profileSetupClaimFailed": "No se pudo reservar el nombre de usuario. Probá de nuevo.",
     "profileSetupPublishFailed": "No se pudo publicar el perfil. Probá de nuevo.",
+    "profileSetupNoRelaysConnected": "No se pudo conectar a la red. Verificá tu conexión e intentá de nuevo.",
     "profileSetupDisplayNameLabel": "Nombre a mostrar",
     "profileSetupDisplayNameHint": "¿Cómo querés que te conozcan?",
     "profileSetupDisplayNameHelper": "Cualquier nombre o apodo que quieras. No tiene que ser único.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -317,6 +317,7 @@
     "profileSetupClaimFailed": "Échec de la réservation du nom d'utilisateur. Réessaie.",
     "profileSetupPublishFailed": "Échec de la publication du profil. Réessaie.",
     "profileSetupNoRelaysConnected": "Impossible d'accéder au réseau. Vérifie ta connexion et réessaie.",
+    "profileSetupRetryLabel": "Réessayer",
     "profileSetupDisplayNameLabel": "Nom affiché",
     "profileSetupDisplayNameHint": "Comment veux-tu qu'on te reconnaisse ?",
     "profileSetupDisplayNameHelper": "N'importe quel nom ou pseudo. Pas besoin qu'il soit unique.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -316,6 +316,7 @@
     "profileSetupUsernameTaken": "Ce nom d'utilisateur vient d'être pris. Choisis-en un autre.",
     "profileSetupClaimFailed": "Échec de la réservation du nom d'utilisateur. Réessaie.",
     "profileSetupPublishFailed": "Échec de la publication du profil. Réessaie.",
+    "profileSetupNoRelaysConnected": "Impossible d'accéder au réseau. Vérifie ta connexion et réessaie.",
     "profileSetupDisplayNameLabel": "Nom affiché",
     "profileSetupDisplayNameHint": "Comment veux-tu qu'on te reconnaisse ?",
     "profileSetupDisplayNameHelper": "N'importe quel nom ou pseudo. Pas besoin qu'il soit unique.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -317,6 +317,7 @@
     "profileSetupClaimFailed": "Gagal mengklaim username. Silakan coba lagi.",
     "profileSetupPublishFailed": "Gagal mempublikasikan profil. Silakan coba lagi.",
     "profileSetupNoRelaysConnected": "Tidak dapat menjangkau jaringan. Periksa koneksimu dan coba lagi.",
+    "profileSetupRetryLabel": "Coba lagi",
     "profileSetupDisplayNameLabel": "Nama Tampilan",
     "profileSetupDisplayNameHint": "Bagaimana orang harus mengenalmu?",
     "profileSetupDisplayNameHelper": "Nama atau label apa pun yang kamu mau. Tidak harus unik.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -316,6 +316,7 @@
     "profileSetupUsernameTaken": "Username baru saja diambil. Pilih yang lain.",
     "profileSetupClaimFailed": "Gagal mengklaim username. Silakan coba lagi.",
     "profileSetupPublishFailed": "Gagal mempublikasikan profil. Silakan coba lagi.",
+    "profileSetupNoRelaysConnected": "Tidak dapat menjangkau jaringan. Periksa koneksimu dan coba lagi.",
     "profileSetupDisplayNameLabel": "Nama Tampilan",
     "profileSetupDisplayNameHint": "Bagaimana orang harus mengenalmu?",
     "profileSetupDisplayNameHelper": "Nama atau label apa pun yang kamu mau. Tidak harus unik.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -316,6 +316,7 @@
     "profileSetupUsernameTaken": "Il nome utente è appena stato preso. Scegline un altro.",
     "profileSetupClaimFailed": "Impossibile rivendicare il nome utente. Riprova.",
     "profileSetupPublishFailed": "Impossibile pubblicare il profilo. Riprova.",
+    "profileSetupNoRelaysConnected": "Impossibile raggiungere la rete. Controlla la connessione e riprova.",
     "profileSetupDisplayNameLabel": "Nome visualizzato",
     "profileSetupDisplayNameHint": "Come ti devono conoscere?",
     "profileSetupDisplayNameHelper": "Qualsiasi nome o etichetta. Non deve essere univoco.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -317,6 +317,7 @@
     "profileSetupClaimFailed": "Impossibile rivendicare il nome utente. Riprova.",
     "profileSetupPublishFailed": "Impossibile pubblicare il profilo. Riprova.",
     "profileSetupNoRelaysConnected": "Impossibile raggiungere la rete. Controlla la connessione e riprova.",
+    "profileSetupRetryLabel": "Riprova",
     "profileSetupDisplayNameLabel": "Nome visualizzato",
     "profileSetupDisplayNameHint": "Come ti devono conoscere?",
     "profileSetupDisplayNameHelper": "Qualsiasi nome o etichetta. Non deve essere univoco.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -317,6 +317,7 @@
     "profileSetupClaimFailed": "ユーザー名の取得がうまくいかなかった。もう一回試してみて。",
     "profileSetupPublishFailed": "プロフィールの公開がうまくいかなかった。もう一回試してみて。",
     "profileSetupNoRelaysConnected": "ネットワークに接続できなかった。接続を確認してもう一回試してみて。",
+    "profileSetupRetryLabel": "再試行",
     "profileSetupDisplayNameLabel": "表示名",
     "profileSetupDisplayNameHint": "みんなに何て呼ばれたい?",
     "profileSetupDisplayNameHelper": "好きな名前やラベルを使ってOK。一意じゃなくて大丈夫。",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -316,6 +316,7 @@
     "profileSetupUsernameTaken": "そのユーザー名はたった今取られちゃった。別の名前にしてみて。",
     "profileSetupClaimFailed": "ユーザー名の取得がうまくいかなかった。もう一回試してみて。",
     "profileSetupPublishFailed": "プロフィールの公開がうまくいかなかった。もう一回試してみて。",
+    "profileSetupNoRelaysConnected": "ネットワークに接続できなかった。接続を確認してもう一回試してみて。",
     "profileSetupDisplayNameLabel": "表示名",
     "profileSetupDisplayNameHint": "みんなに何て呼ばれたい?",
     "profileSetupDisplayNameHelper": "好きな名前やラベルを使ってOK。一意じゃなくて大丈夫。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -164,6 +164,7 @@
     "profileSetupClaimFailed": "사용자명을 가져오지 못했어요. 다시 시도해보세요.",
     "profileSetupPublishFailed": "프로필을 게시하지 못했어요. 다시 시도해보세요.",
     "profileSetupNoRelaysConnected": "네트워크에 연결할 수 없어요. 연결 상태를 확인하고 다시 시도해보세요.",
+    "profileSetupRetryLabel": "다시 시도",
     "profileSetupDisplayNameLabel": "표시 이름",
     "profileSetupDisplayNameHint": "사람들에게 어떻게 불리고 싶으세요?",
     "profileSetupDisplayNameHelper": "원하는 아무 이름이나 라벨이요. 고유하지 않아도 돼요.",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -163,6 +163,7 @@
     "profileSetupUsernameTaken": "이 사용자명은 방금 선점됐어요. 다른 이름을 고르세요.",
     "profileSetupClaimFailed": "사용자명을 가져오지 못했어요. 다시 시도해보세요.",
     "profileSetupPublishFailed": "프로필을 게시하지 못했어요. 다시 시도해보세요.",
+    "profileSetupNoRelaysConnected": "네트워크에 연결할 수 없어요. 연결 상태를 확인하고 다시 시도해보세요.",
     "profileSetupDisplayNameLabel": "표시 이름",
     "profileSetupDisplayNameHint": "사람들에게 어떻게 불리고 싶으세요?",
     "profileSetupDisplayNameHelper": "원하는 아무 이름이나 라벨이요. 고유하지 않아도 돼요.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -317,6 +317,7 @@
     "profileSetupClaimFailed": "Gebruikersnaam claimen mislukt. Probeer het opnieuw.",
     "profileSetupPublishFailed": "Profiel publiceren mislukt. Probeer het opnieuw.",
     "profileSetupNoRelaysConnected": "Kan het netwerk niet bereiken. Controleer je verbinding en probeer het opnieuw.",
+    "profileSetupRetryLabel": "Opnieuw",
     "profileSetupDisplayNameLabel": "Weergavenaam",
     "profileSetupDisplayNameHint": "Hoe moeten mensen je kennen?",
     "profileSetupDisplayNameHelper": "Elke naam of label die je wilt. Hoeft niet uniek te zijn.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -316,6 +316,7 @@
     "profileSetupUsernameTaken": "Deze gebruikersnaam is net bezet. Kies een andere.",
     "profileSetupClaimFailed": "Gebruikersnaam claimen mislukt. Probeer het opnieuw.",
     "profileSetupPublishFailed": "Profiel publiceren mislukt. Probeer het opnieuw.",
+    "profileSetupNoRelaysConnected": "Kan het netwerk niet bereiken. Controleer je verbinding en probeer het opnieuw.",
     "profileSetupDisplayNameLabel": "Weergavenaam",
     "profileSetupDisplayNameHint": "Hoe moeten mensen je kennen?",
     "profileSetupDisplayNameHelper": "Elke naam of label die je wilt. Hoeft niet uniek te zijn.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -316,6 +316,7 @@
     "profileSetupUsernameTaken": "Nazwa użytkownika została właśnie zajęta. Wybierz inną.",
     "profileSetupClaimFailed": "Nie udało się zarezerwować nazwy użytkownika. Spróbuj ponownie.",
     "profileSetupPublishFailed": "Nie udało się opublikować profilu. Spróbuj ponownie.",
+    "profileSetupNoRelaysConnected": "Nie można połączyć się z siecią. Sprawdź połączenie i spróbuj ponownie.",
     "profileSetupDisplayNameLabel": "Nazwa wyświetlana",
     "profileSetupDisplayNameHint": "Jak ludzie mają cię rozpoznawać?",
     "profileSetupDisplayNameHelper": "Dowolna nazwa lub etykieta. Nie musi być unikalna.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -317,6 +317,7 @@
     "profileSetupClaimFailed": "Nie udało się zarezerwować nazwy użytkownika. Spróbuj ponownie.",
     "profileSetupPublishFailed": "Nie udało się opublikować profilu. Spróbuj ponownie.",
     "profileSetupNoRelaysConnected": "Nie można połączyć się z siecią. Sprawdź połączenie i spróbuj ponownie.",
+    "profileSetupRetryLabel": "Spróbuj ponownie",
     "profileSetupDisplayNameLabel": "Nazwa wyświetlana",
     "profileSetupDisplayNameHint": "Jak ludzie mają cię rozpoznawać?",
     "profileSetupDisplayNameHelper": "Dowolna nazwa lub etykieta. Nie musi być unikalna.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -317,6 +317,7 @@
     "profileSetupClaimFailed": "Falha ao reivindicar o nome de usuário. Tente novamente.",
     "profileSetupPublishFailed": "Falha ao publicar perfil. Tente novamente.",
     "profileSetupNoRelaysConnected": "Não foi possível acessar a rede. Verifique sua conexão e tente novamente.",
+    "profileSetupRetryLabel": "Tentar novamente",
     "profileSetupDisplayNameLabel": "Nome de exibição",
     "profileSetupDisplayNameHint": "Como as pessoas devem te conhecer?",
     "profileSetupDisplayNameHelper": "Qualquer nome ou rótulo que você queira. Não precisa ser único.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -316,6 +316,7 @@
     "profileSetupUsernameTaken": "Esse nome de usuário acabou de ser pego. Escolha outro.",
     "profileSetupClaimFailed": "Falha ao reivindicar o nome de usuário. Tente novamente.",
     "profileSetupPublishFailed": "Falha ao publicar perfil. Tente novamente.",
+    "profileSetupNoRelaysConnected": "Não foi possível acessar a rede. Verifique sua conexão e tente novamente.",
     "profileSetupDisplayNameLabel": "Nome de exibição",
     "profileSetupDisplayNameHint": "Como as pessoas devem te conhecer?",
     "profileSetupDisplayNameHelper": "Qualquer nome ou rótulo que você queira. Não precisa ser único.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -316,6 +316,7 @@
     "profileSetupUsernameTaken": "Numele tocmai a fost luat. Alege altul.",
     "profileSetupClaimFailed": "N-am putut revendica numele. Încearcă din nou.",
     "profileSetupPublishFailed": "N-am putut publica profilul. Încearcă din nou.",
+    "profileSetupNoRelaysConnected": "Nu s-a putut accesa rețeaua. Verifică conexiunea și încearcă din nou.",
     "profileSetupDisplayNameLabel": "Nume afișat",
     "profileSetupDisplayNameHint": "Cum să te știe oamenii?",
     "profileSetupDisplayNameHelper": "Orice nume sau etichetă vrei. Nu trebuie să fie unic.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -317,6 +317,7 @@
     "profileSetupClaimFailed": "N-am putut revendica numele. Încearcă din nou.",
     "profileSetupPublishFailed": "N-am putut publica profilul. Încearcă din nou.",
     "profileSetupNoRelaysConnected": "Nu s-a putut accesa rețeaua. Verifică conexiunea și încearcă din nou.",
+    "profileSetupRetryLabel": "Încearcă din nou",
     "profileSetupDisplayNameLabel": "Nume afișat",
     "profileSetupDisplayNameHint": "Cum să te știe oamenii?",
     "profileSetupDisplayNameHelper": "Orice nume sau etichetă vrei. Nu trebuie să fie unic.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -317,6 +317,7 @@
     "profileSetupClaimFailed": "Kunde inte claima användarnamnet. Försök igen.",
     "profileSetupPublishFailed": "Kunde inte publicera profilen. Försök igen.",
     "profileSetupNoRelaysConnected": "Kunde inte nå nätverket. Kontrollera din anslutning och försök igen.",
+    "profileSetupRetryLabel": "Försök igen",
     "profileSetupDisplayNameLabel": "Visningsnamn",
     "profileSetupDisplayNameHint": "Hur ska folk känna dig?",
     "profileSetupDisplayNameHelper": "Vilket namn eller etikett du vill. Behöver inte vara unikt.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -316,6 +316,7 @@
     "profileSetupUsernameTaken": "Användarnamnet togs precis. Välj ett annat.",
     "profileSetupClaimFailed": "Kunde inte claima användarnamnet. Försök igen.",
     "profileSetupPublishFailed": "Kunde inte publicera profilen. Försök igen.",
+    "profileSetupNoRelaysConnected": "Kunde inte nå nätverket. Kontrollera din anslutning och försök igen.",
     "profileSetupDisplayNameLabel": "Visningsnamn",
     "profileSetupDisplayNameHint": "Hur ska folk känna dig?",
     "profileSetupDisplayNameHelper": "Vilket namn eller etikett du vill. Behöver inte vara unikt.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -316,6 +316,7 @@
     "profileSetupUsernameTaken": "Kullanıcı adı az önce alındı. Lütfen başka birini seç.",
     "profileSetupClaimFailed": "Kullanıcı adı alınamadı. Lütfen tekrar dene.",
     "profileSetupPublishFailed": "Profil yayınlanamadı. Lütfen tekrar dene.",
+    "profileSetupNoRelaysConnected": "Ağa ulaşılamadı. Bağlantını kontrol et ve tekrar dene.",
     "profileSetupDisplayNameLabel": "Görünen Ad",
     "profileSetupDisplayNameHint": "Seni nasıl tanısınlar?",
     "profileSetupDisplayNameHelper": "İstediğin herhangi bir ad veya etiket. Benzersiz olması gerekmez.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -317,6 +317,7 @@
     "profileSetupClaimFailed": "Kullanıcı adı alınamadı. Lütfen tekrar dene.",
     "profileSetupPublishFailed": "Profil yayınlanamadı. Lütfen tekrar dene.",
     "profileSetupNoRelaysConnected": "Ağa ulaşılamadı. Bağlantını kontrol et ve tekrar dene.",
+    "profileSetupRetryLabel": "Tekrar dene",
     "profileSetupDisplayNameLabel": "Görünen Ad",
     "profileSetupDisplayNameHint": "Seni nasıl tanısınlar?",
     "profileSetupDisplayNameHelper": "İstediğin herhangi bir ad veya etiket. Benzersiz olması gerekmez.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -1174,6 +1174,12 @@ abstract class AppLocalizations {
   /// **'Couldn\'t reach the network. Check your connection and try again.'**
   String get profileSetupNoRelaysConnected;
 
+  /// No description provided for @profileSetupRetryLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get profileSetupRetryLabel;
+
   /// No description provided for @profileSetupDisplayNameLabel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -1168,6 +1168,12 @@ abstract class AppLocalizations {
   /// **'Failed to publish profile. Please try again.'**
   String get profileSetupPublishFailed;
 
+  /// No description provided for @profileSetupNoRelaysConnected.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t reach the network. Check your connection and try again.'**
+  String get profileSetupNoRelaysConnected;
+
   /// No description provided for @profileSetupDisplayNameLabel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -605,6 +605,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'تعذّر نشر الملف الشخصي. حاول مرّة أخرى.';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      'لا يمكن الوصول إلى الشبكة. تحقق من اتصالك وحاول مرة أخرى.';
+
+  @override
   String get profileSetupDisplayNameLabel => 'الاسم المعروض';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -609,6 +609,9 @@ class AppLocalizationsAr extends AppLocalizations {
       'لا يمكن الوصول إلى الشبكة. تحقق من اتصالك وحاول مرة أخرى.';
 
   @override
+  String get profileSetupRetryLabel => 'إعادة المحاولة';
+
+  @override
   String get profileSetupDisplayNameLabel => 'الاسم المعروض';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -633,6 +633,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Profil konnte nicht veröffentlicht werden. Bitte versuch es nochmal.';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      'Netzwerk nicht erreichbar. Überprüfe deine Verbindung und versuch es nochmal.';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Anzeigename';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -637,6 +637,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Netzwerk nicht erreichbar. Überprüfe deine Verbindung und versuch es nochmal.';
 
   @override
+  String get profileSetupRetryLabel => 'Wiederholen';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Anzeigename';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -628,6 +628,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Failed to publish profile. Please try again.';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      'Couldn\'t reach the network. Check your connection and try again.';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Display Name';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -632,6 +632,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Couldn\'t reach the network. Check your connection and try again.';
 
   @override
+  String get profileSetupRetryLabel => 'Retry';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Display Name';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -640,6 +640,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se pudo conectar a la red. Verificá tu conexión e intentá de nuevo.';
 
   @override
+  String get profileSetupRetryLabel => 'Reintentar';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Nombre a mostrar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -636,6 +636,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'No se pudo publicar el perfil. Probá de nuevo.';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      'No se pudo conectar a la red. Verificá tu conexión e intentá de nuevo.';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Nombre a mostrar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -647,6 +647,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Impossible d\'accéder au réseau. Vérifie ta connexion et réessaie.';
 
   @override
+  String get profileSetupRetryLabel => 'Réessayer';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Nom affiché';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -643,6 +643,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Échec de la publication du profil. Réessaie.';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      'Impossible d\'accéder au réseau. Vérifie ta connexion et réessaie.';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Nom affiché';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -616,6 +616,9 @@ class AppLocalizationsId extends AppLocalizations {
       'Tidak dapat menjangkau jaringan. Periksa koneksimu dan coba lagi.';
 
   @override
+  String get profileSetupRetryLabel => 'Coba lagi';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Nama Tampilan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -612,6 +612,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Gagal mempublikasikan profil. Silakan coba lagi.';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      'Tidak dapat menjangkau jaringan. Periksa koneksimu dan coba lagi.';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Nama Tampilan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -636,6 +636,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Impossibile pubblicare il profilo. Riprova.';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      'Impossibile raggiungere la rete. Controlla la connessione e riprova.';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Nome visualizzato';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -640,6 +640,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Impossibile raggiungere la rete. Controlla la connessione e riprova.';
 
   @override
+  String get profileSetupRetryLabel => 'Riprova';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Nome visualizzato';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -576,6 +576,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get profileSetupPublishFailed => 'プロフィールの公開がうまくいかなかった。もう一回試してみて。';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      'ネットワークに接続できなかった。接続を確認してもう一回試してみて。';
+
+  @override
   String get profileSetupDisplayNameLabel => '表示名';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -580,6 +580,9 @@ class AppLocalizationsJa extends AppLocalizations {
       'ネットワークに接続できなかった。接続を確認してもう一回試してみて。';
 
   @override
+  String get profileSetupRetryLabel => '再試行';
+
+  @override
   String get profileSetupDisplayNameLabel => '表示名';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -577,6 +577,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get profileSetupPublishFailed => '프로필을 게시하지 못했어요. 다시 시도해보세요.';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      '네트워크에 연결할 수 없어요. 연결 상태를 확인하고 다시 시도해보세요.';
+
+  @override
   String get profileSetupDisplayNameLabel => '표시 이름';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -581,6 +581,9 @@ class AppLocalizationsKo extends AppLocalizations {
       '네트워크에 연결할 수 없어요. 연결 상태를 확인하고 다시 시도해보세요.';
 
   @override
+  String get profileSetupRetryLabel => '다시 시도';
+
+  @override
   String get profileSetupDisplayNameLabel => '표시 이름';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -629,6 +629,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Profiel publiceren mislukt. Probeer het opnieuw.';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      'Kan het netwerk niet bereiken. Controleer je verbinding en probeer het opnieuw.';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Weergavenaam';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -633,6 +633,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'Kan het netwerk niet bereiken. Controleer je verbinding en probeer het opnieuw.';
 
   @override
+  String get profileSetupRetryLabel => 'Opnieuw';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Weergavenaam';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -638,6 +638,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Nie udało się opublikować profilu. Spróbuj ponownie.';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      'Nie można połączyć się z siecią. Sprawdź połączenie i spróbuj ponownie.';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Nazwa wyświetlana';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -642,6 +642,9 @@ class AppLocalizationsPl extends AppLocalizations {
       'Nie można połączyć się z siecią. Sprawdź połączenie i spróbuj ponownie.';
 
   @override
+  String get profileSetupRetryLabel => 'Spróbuj ponownie';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Nazwa wyświetlana';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -637,6 +637,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Falha ao publicar perfil. Tente novamente.';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      'Não foi possível acessar a rede. Verifique sua conexão e tente novamente.';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Nome de exibição';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -641,6 +641,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Não foi possível acessar a rede. Verifique sua conexão e tente novamente.';
 
   @override
+  String get profileSetupRetryLabel => 'Tentar novamente';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Nome de exibição';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -656,6 +656,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'N-am putut publica profilul. Încearcă din nou.';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      'Nu s-a putut accesa rețeaua. Verifică conexiunea și încearcă din nou.';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Nume afișat';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -660,6 +660,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Nu s-a putut accesa rețeaua. Verifică conexiunea și încearcă din nou.';
 
   @override
+  String get profileSetupRetryLabel => 'Încearcă din nou';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Nume afișat';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -613,6 +613,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Kunde inte publicera profilen. Försök igen.';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      'Kunde inte nå nätverket. Kontrollera din anslutning och försök igen.';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Visningsnamn';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -617,6 +617,9 @@ class AppLocalizationsSv extends AppLocalizations {
       'Kunde inte nå nätverket. Kontrollera din anslutning och försök igen.';
 
   @override
+  String get profileSetupRetryLabel => 'Försök igen';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Visningsnamn';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -615,6 +615,9 @@ class AppLocalizationsTr extends AppLocalizations {
       'Ağa ulaşılamadı. Bağlantını kontrol et ve tekrar dene.';
 
   @override
+  String get profileSetupRetryLabel => 'Tekrar dene';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Görünen Ad';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -611,6 +611,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Profil yayınlanamadı. Lütfen tekrar dene.';
 
   @override
+  String get profileSetupNoRelaysConnected =>
+      'Ağa ulaşılamadı. Bağlantını kontrol et ve tekrar dene.';
+
+  @override
   String get profileSetupDisplayNameLabel => 'Görünen Ad';
 
   @override

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -312,6 +312,15 @@ class _ProfileSetupScreenViewState
                       backgroundColor: VineTheme.error,
                     ),
                   );
+                case ProfileEditorError.noRelaysConnected:
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(
+                        context.l10n.profileSetupNoRelaysConnected,
+                      ),
+                      backgroundColor: VineTheme.error,
+                    ),
+                  );
                 case null:
                   break;
               }

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -19,6 +19,7 @@ import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:openvine/utils/user_profile_utils.dart';
@@ -319,6 +320,17 @@ class _ProfileSetupScreenViewState
                         context.l10n.profileSetupNoRelaysConnected,
                       ),
                       backgroundColor: VineTheme.error,
+                      duration: const Duration(seconds: 6),
+                      action: pubkey == null
+                          ? null
+                          : SnackBarAction(
+                              label: context.l10n.profileSetupRetryLabel,
+                              textColor: VineTheme.whiteText,
+                              onPressed: () => _retryAfterRelayReconnect(
+                                context,
+                                pubkey,
+                              ),
+                            ),
                     ),
                   );
                 case null:
@@ -1038,6 +1050,32 @@ class _ProfileSetupScreenViewState
             ),
           );
         },
+      ),
+    );
+  }
+
+  /// Attempts to reconnect relays and re-dispatches [ProfileSaved].
+  ///
+  /// Called from the retry CTA on the no-relays-connected SnackBar. Triggers
+  /// [NostrClient.retryDisconnectedRelays] before re-submitting so the relay
+  /// pool has a chance to reconnect before the publish is attempted again.
+  Future<void> _retryAfterRelayReconnect(
+    BuildContext context,
+    String pubkey,
+  ) async {
+    await ref.read(nostrServiceProvider).retryDisconnectedRelays();
+    if (!context.mounted) return;
+    context.read<ProfileEditorBloc>().add(
+      ProfileSaved(
+        pubkey: pubkey,
+        displayName: _nameController.text,
+        about: _bioController.text,
+        username: _nip05Controller.text,
+        externalNip05: _externalNip05Controller.text,
+        picture: _pictureController.text,
+        banner: _selectedProfileColor != null
+            ? '0x${_selectedProfileColor!.toARGB32().toRadixString(16).substring(2)}'
+            : null,
       ),
     );
   }

--- a/mobile/packages/profile_repository/lib/src/exceptions.dart
+++ b/mobile/packages/profile_repository/lib/src/exceptions.dart
@@ -21,10 +21,11 @@ class ProfilePublishFailedException extends ProfileRepositoryException {
 
 /// Thrown when profile publish fails because no relays are connected.
 ///
-/// This is a distinct subcase of [ProfilePublishFailedException] — it means
-/// the device has no active Nostr relay connections rather than a relay
-/// actively rejecting the event. The caller can show a connectivity-specific
-/// error and offer a reconnect/retry action.
+/// A sibling of [ProfilePublishFailedException] — both extend
+/// [ProfileRepositoryException] directly. This exception signals that the
+/// device has no active Nostr relay connections rather than a relay actively
+/// rejecting the event. The caller can show a connectivity-specific error and
+/// offer a reconnect/retry action.
 class NoRelaysConnectedException extends ProfileRepositoryException {
   /// Creates a no-relays-connected exception with an optional [message].
   const NoRelaysConnectedException([super.message]);

--- a/mobile/packages/profile_repository/lib/src/exceptions.dart
+++ b/mobile/packages/profile_repository/lib/src/exceptions.dart
@@ -18,3 +18,17 @@ class ProfilePublishFailedException extends ProfileRepositoryException {
   @override
   String toString() => 'ProfilePublishFailedException: $message';
 }
+
+/// Thrown when profile publish fails because no relays are connected.
+///
+/// This is a distinct subcase of [ProfilePublishFailedException] — it means
+/// the device has no active Nostr relay connections rather than a relay
+/// actively rejecting the event. The caller can show a connectivity-specific
+/// error and offer a reconnect/retry action.
+class NoRelaysConnectedException extends ProfileRepositoryException {
+  /// Creates a no-relays-connected exception with an optional [message].
+  const NoRelaysConnectedException([super.message]);
+
+  @override
+  String toString() => 'NoRelaysConnectedException: $message';
+}

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -536,9 +536,22 @@ class ProfileRepository {
     );
 
     if (profileEvent == null) {
+      // Distinguish "no relays at all" from "relay rejected / send error".
+      // publishEvent already called retryDisconnectedRelays() internally, so
+      // if connectedRelays is still empty the device has no relay connections.
+      if (_nostrClient.connectedRelays.isEmpty) {
+        Log.error(
+          'sendProfile returned null — no connected relays after retry',
+          name: 'ProfileRepository.saveProfileEvent',
+          category: LogCategory.relay,
+        );
+        throw const NoRelaysConnectedException(
+          'No relays connected. Check your connection and try again.',
+        );
+      }
       Log.error(
         'sendProfile returned null '
-        '(no relays connected or relay rejected the event)',
+        '(relay rejected the event or send failed)',
         name: 'ProfileRepository.saveProfileEvent',
         category: LogCategory.relay,
       );

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -3086,6 +3086,13 @@ void main() {
         expect(e.message, isNull);
         expect(e.toString(), contains('ProfileRepositoryException'));
       });
+
+      test('NoRelaysConnectedException has message and toString', () {
+        const e = NoRelaysConnectedException('no relays');
+
+        expect(e.message, equals('no relays'));
+        expect(e.toString(), equals('NoRelaysConnectedException: no relays'));
+      });
     });
 
     group('claimUsername', () {

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -1427,10 +1427,33 @@ void main() {
               profileContent: any(named: 'profileContent'),
             ),
           ).thenAnswer((_) async => null);
+          when(
+            () => mockNostrClient.connectedRelays,
+          ).thenReturn(['wss://relay.example.com']);
 
           await expectLater(
             profileRepository.saveProfileEvent(displayName: 'Test'),
             throwsA(isA<ProfilePublishFailedException>()),
+          );
+          verifyNever(() => mockUserProfilesDao.upsertProfile(any()));
+        },
+      );
+
+      test(
+        'throws NoRelaysConnectedException when no relays are connected',
+        () async {
+          when(
+            () => mockNostrClient.sendProfile(
+              profileContent: any(named: 'profileContent'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockNostrClient.connectedRelays,
+          ).thenReturn([]);
+
+          await expectLater(
+            profileRepository.saveProfileEvent(displayName: 'Test'),
+            throwsA(isA<NoRelaysConnectedException>()),
           );
           verifyNever(() => mockUserProfilesDao.upsertProfile(any()));
         },

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -512,6 +512,7 @@ void main() {
                   ProfileEditorError.noRelaysConnected,
                 ),
           ],
+          errors: () => [isA<NoRelaysConnectedException>()],
         );
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -473,6 +473,82 @@ void main() {
         );
       });
 
+      group('no relays connected', () {
+        blocTest<ProfileEditorBloc, ProfileEditorState>(
+          'emits [loading, failure] with noRelaysConnected error',
+          setUp: () {
+            when(
+              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+            ).thenAnswer((_) async => null);
+            when(
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: testAbout,
+                picture: testPicture,
+                clearNip05: any(named: 'clearNip05'),
+              ),
+            ).thenThrow(const NoRelaysConnectedException('No relays'));
+          },
+          build: createBloc,
+          act: (bloc) => bloc.add(
+            const ProfileSaved(
+              pubkey: testPubkey,
+              displayName: testDisplayName,
+              about: testAbout,
+              picture: testPicture,
+            ),
+          ),
+          expect: () => [
+            isA<ProfileEditorState>().having(
+              (s) => s.status,
+              'status',
+              ProfileEditorStatus.loading,
+            ),
+            isA<ProfileEditorState>()
+                .having((s) => s.status, 'status', ProfileEditorStatus.failure)
+                .having(
+                  (s) => s.error,
+                  'error',
+                  ProfileEditorError.noRelaysConnected,
+                ),
+          ],
+        );
+
+        blocTest<ProfileEditorBloc, ProfileEditorState>(
+          'does not attempt username claim when no relays are connected',
+          setUp: () {
+            when(
+              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+            ).thenAnswer((_) async => null);
+            when(
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: testAbout,
+                username: testUsername,
+                picture: testPicture,
+              ),
+            ).thenThrow(const NoRelaysConnectedException('No relays'));
+          },
+          build: createBloc,
+          act: (bloc) => bloc.add(
+            const ProfileSaved(
+              pubkey: testPubkey,
+              displayName: testDisplayName,
+              about: testAbout,
+              picture: testPicture,
+              username: testUsername,
+            ),
+          ),
+          verify: (_) {
+            verifyNever(
+              () => mockProfileRepository.claimUsername(
+                username: any(named: 'username'),
+              ),
+            );
+          },
+        );
+      });
+
       group('username taken', () {
         blocTest<ProfileEditorBloc, ProfileEditorState>(
           'emits [loading, failure] with usernameTaken error',

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,3 @@
+# Lessons
+
+- When a user-reported timing symptom (e.g. 20 seconds) is plausible but unverified, search for duplicate tickets with overlapping log buffers before designing a fix; the first ticket may truncate past the smoking gun.

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,3 +1,0 @@
-# Lessons
-
-- When a user-reported timing symptom (e.g. 20 seconds) is plausible but unverified, search for duplicate tickets with overlapping log buffers before designing a fix; the first ticket may truncate past the smoking gun.


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
When a user had no Nostr relays connected, the kind 0 publish step in `_saveProfile` failed silently with a generic "Failed to publish profile" error, giving the user no indication that connectivity was the cause. This fix distinguishes the no-relays case at every layer — a new `NoRelaysConnectedException` is thrown by the repository when `connectedRelays` is empty after the publish attempt, a new `ProfileEditorError.noRelaysConnected` enum value is emitted by the BLoC, and the UI surfaces a specific "Couldn't reach the network. Check your connection and try again." message in all 14 supported languages.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #3469, Closes #3152

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
