### PR TITLE
fix(funnelcake): tolerate {data,pagination} envelope from list endpoints

### DIFF
--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -102,6 +102,47 @@ class FunnelcakeApiClient {
     };
   }
 
+  /// Unwraps a funnelcake list response that may be either a raw JSON array
+  /// (legacy / `legacy-array-response` flag on) or the post-#238 envelope
+  /// shape `{"data": [...], "pagination": {"has_more": bool, "next_cursor":
+  /// string|null, "next_offset": int|null}}`.
+  ///
+  /// Returns a record with:
+  /// - `items`: the list of raw JSON objects.
+  /// - `hasMore`: `true`/`false` from the envelope; `null` for raw arrays
+  ///   (caller should apply its own heuristic, e.g. `items.length >= limit`).
+  /// - `nextCursor`: opaque cursor string from the envelope, or `null` when
+  ///   the raw-array shape is used (caller computes its own cursor).
+  ///
+  /// Mirrors the `unwrapListResponse<T>` helper in divine-web#277.
+  static ({List<dynamic> items, bool? hasMore, String? nextCursor})
+  _unwrapListResponse(Object? decoded) {
+    if (decoded is List) {
+      return (items: decoded, hasMore: null, nextCursor: null);
+    }
+    if (decoded is Map<String, dynamic>) {
+      final data = decoded['data'];
+      if (data is List) {
+        final pagination = decoded['pagination'];
+        bool? hasMore;
+        String? nextCursor;
+        if (pagination is Map<String, dynamic>) {
+          hasMore = pagination['has_more'] as bool?;
+          final rawCursor = pagination['next_cursor'];
+          final rawOffset = pagination['next_offset'];
+          if (rawCursor != null) {
+            nextCursor = rawCursor.toString();
+          } else if (rawOffset != null) {
+            nextCursor = rawOffset.toString();
+          }
+        }
+        return (items: data, hasMore: hasMore, nextCursor: nextCursor);
+      }
+    }
+    // Unrecognised shape — return empty so callers never throw.
+    return (items: const <dynamic>[], hasMore: false, nextCursor: null);
+  }
+
   /// Builds the notifications endpoint URI for a user.
   ///
   /// The returned URI includes the same query parameters used by
@@ -171,13 +212,17 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List<dynamic>;
+        final (:items, :hasMore, :nextCursor) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
 
-        final videos = data
+        final videos = items
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
 
+        // X-Total-Count header is the primary source; fall back to envelope
+        // pagination when the header is absent (post-#238 envelope shape).
         final totalCountHeader = response.headers['x-total-count'];
         final totalCount = totalCountHeader != null
             ? int.tryParse(totalCountHeader)
@@ -241,9 +286,11 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List<dynamic>;
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
 
-        return data
+        return items
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
@@ -299,9 +346,11 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List<dynamic>;
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
 
-        return data
+        return items
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
@@ -359,9 +408,11 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List<dynamic>;
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
 
-        return data
+        return items
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
@@ -429,22 +480,31 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        final raw = jsonDecode(response.body) as Map<String, dynamic>;
 
-        final videosData = data['videos'] as List<dynamic>? ?? [];
+        // Tolerate both the legacy shape `{"videos": [...]}` and the
+        // post-funnelcake#238 envelope `{"data": [...], "pagination": {...}}`.
+        final videosData =
+            (raw['videos'] as List<dynamic>?) ??
+            (raw['data'] as List<dynamic>?) ??
+            <dynamic>[];
         final videos = videosData
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
 
-        // Parse pagination cursor (may be string or int)
-        final rawCursor = data['next_cursor'];
+        // Pagination metadata may be at top level or under `pagination`.
+        final pagination = raw['pagination'] as Map<String, dynamic>?;
+        final rawCursor = raw['next_cursor'] ?? pagination?['next_cursor'];
         final nextCursor = switch (rawCursor) {
           final int value => value,
           final String value => int.tryParse(value),
           _ => null,
         };
-        final hasMore = data['has_more'] as bool? ?? false;
+        final hasMore =
+            raw['has_more'] as bool? ??
+            pagination?['has_more'] as bool? ??
+            false;
 
         return HomeFeedResponse(
           videos: videos,
@@ -528,9 +588,11 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List<dynamic>;
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
 
-        return data
+        return items
             .map((p) => ProfileSearchResult.fromJson(p as Map<String, dynamic>))
             .where((p) => p.pubkey.isNotEmpty)
             .toList();
@@ -597,9 +659,11 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List<dynamic>;
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
 
-        return data
+        return items
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
@@ -660,9 +724,11 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List<dynamic>;
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
 
-        return data
+        return items
             .map((item) {
               if (item is Map<String, dynamic>) {
                 return HashtagSearchResult.fromJson(item).tag;
@@ -723,9 +789,11 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List<dynamic>;
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
 
-        return data
+        return items
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
@@ -790,9 +858,11 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List<dynamic>;
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
 
-        return data
+        return items
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
@@ -853,9 +923,11 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List<dynamic>;
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
 
-        return data
+        return items
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
@@ -920,9 +992,11 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List<dynamic>;
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
 
-        final videos = data
+        final videos = items
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
@@ -993,23 +1067,23 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final decoded = jsonDecode(response.body);
+        // Normalise the legacy `{"videos": [...]}` shape that was returned by
+        // earlier funnelcake server builds before funnelcake#238.  All other
+        // shapes (raw array, `{"data":[...], "pagination":{...}}` envelope) are
+        // handled by _unwrapListResponse below.
+        final raw = jsonDecode(response.body);
+        final normalised =
+            (raw is Map<String, dynamic> &&
+                raw['videos'] is List &&
+                raw['data'] == null)
+            ? (raw['videos'] as List<dynamic>)
+            : raw;
 
-        List<dynamic> data;
-        if (decoded is List) {
-          data = decoded;
-        } else if (decoded is Map<String, dynamic>) {
-          data =
-              (decoded['videos'] ??
-                      decoded['data'] ??
-                      decoded['results'] ??
-                      <dynamic>[])
-                  as List<dynamic>;
-        } else {
-          data = [];
-        }
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          normalised,
+        );
 
-        return data
+        return items
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
@@ -1056,9 +1130,11 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List<dynamic>;
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
 
-        return data
+        return items
             .map((h) => TrendingHashtag.fromJson(h as Map<String, dynamic>))
             .where((h) => h.tag.isNotEmpty)
             .toList();
@@ -1540,15 +1616,23 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        final raw = jsonDecode(response.body) as Map<String, dynamic>;
 
-        final videosData = data['videos'] as List<dynamic>? ?? [];
+        // Tolerate both the legacy shape `{"videos": [...], "source": ...}`
+        // and the post-funnelcake#238 envelope
+        // `{"data": [...], "pagination": {...}, "source": ...}`.
+        // Mirrors divine-web#277 `fetchRecommendations` logic.
+        final videosData =
+            (raw['videos'] as List<dynamic>?) ??
+            (raw['data'] as List<dynamic>?) ??
+            <dynamic>[];
+
         final videos = videosData
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();
 
-        final source = data['source'] as String? ?? 'unknown';
+        final source = raw['source'] as String? ?? 'unknown';
 
         return RecommendationsResponse(videos: videos, source: source);
       } else if (response.statusCode == 404) {
@@ -1781,8 +1865,10 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List<dynamic>;
-        return data
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
+        return items
             .map((item) => VideoCategory.fromJson(item as Map<String, dynamic>))
             .toList();
       } else {
@@ -1851,9 +1937,11 @@ class FunnelcakeApiClient {
       final response = await _get(uri);
 
       if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List<dynamic>;
+        final (:items, hasMore: _, nextCursor: _) = _unwrapListResponse(
+          jsonDecode(response.body),
+        );
 
-        return data
+        return items
             .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
             .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
             .toList();

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -683,6 +683,55 @@ void main() {
           ),
         );
       });
+
+      // Envelope shape tolerance (divine-funnelcake#238 / issue #3521)
+      test('returns feed from legacy {videos} shape', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async => http.Response(validFeedResponse, 200),
+        );
+
+        final result = await client.getHomeFeed(pubkey: testPubkey);
+        expect(result.videos, hasLength(1));
+        expect(result.hasMore, isTrue);
+        expect(result.nextCursor, equals(1699999000));
+      });
+
+      test('returns feed from {data, pagination} envelope shape', () async {
+        const envelope =
+            '''
+{
+  "data": [
+    {
+      "id": "feed-env-1",
+      "pubkey": "$testPubkey",
+      "created_at": 1700000000,
+      "kind": 34236,
+      "d_tag": "env-feed",
+      "title": "Envelope Feed Video",
+      "content": "",
+      "thumbnail": "https://example.com/thumb.jpg",
+      "video_url": "https://example.com/feed.mp4",
+      "reactions": 5,
+      "comments": 1,
+      "reposts": 0,
+      "engagement_score": 6
+    }
+  ],
+  "pagination": {"has_more": true, "next_cursor": "1699998000"}
+}
+''';
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(envelope, 200));
+
+        final result = await client.getHomeFeed(pubkey: testPubkey);
+        expect(result.videos, hasLength(1));
+        expect(result.videos.first.id, equals('feed-env-1'));
+        expect(result.hasMore, isTrue);
+        expect(result.nextCursor, equals(1699998000));
+      });
     });
 
     group('getVideosByAuthor', () {
@@ -3271,6 +3320,42 @@ void main() {
           throwsA(isA<FunnelcakeTimeoutException>()),
         );
       });
+
+      // Envelope shape tolerance (divine-funnelcake#238 / issue #3521)
+      test('returns followers from legacy {followers} shape', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async => http.Response(
+            '{"followers": ["$testPubkey"], "total": 1, "has_more": false}',
+            200,
+          ),
+        );
+
+        final result = await client.getFollowers(pubkey: testPubkey);
+        expect(result.pubkeys, hasLength(1));
+        expect(result.hasMore, isFalse);
+      });
+
+      test(
+        'returns followers from {data, pagination} envelope shape',
+        () async {
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer(
+            (_) async => http.Response(
+              '{"data": ["$testPubkey"], '
+              '"pagination": {"has_more": true, "next_cursor": "50"}}',
+              200,
+            ),
+          );
+
+          final result = await client.getFollowers(pubkey: testPubkey);
+          expect(result.pubkeys, hasLength(1));
+          expect(result.pubkeys.first, equals(testPubkey));
+          expect(result.hasMore, isTrue);
+        },
+      );
     });
 
     group('getFollowing', () {
@@ -3366,6 +3451,42 @@ void main() {
           throwsA(isA<FunnelcakeTimeoutException>()),
         );
       });
+
+      // Envelope shape tolerance (divine-funnelcake#238 / issue #3521)
+      test('returns following from legacy {following} shape', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async => http.Response(
+            '{"following": ["$testPubkey"], "total": 1, "has_more": false}',
+            200,
+          ),
+        );
+
+        final result = await client.getFollowing(pubkey: testPubkey);
+        expect(result.pubkeys, hasLength(1));
+        expect(result.hasMore, isFalse);
+      });
+
+      test(
+        'returns following from {data, pagination} envelope shape',
+        () async {
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer(
+            (_) async => http.Response(
+              '{"data": ["$testPubkey"], '
+              '"pagination": {"has_more": true, "next_cursor": "100"}}',
+              200,
+            ),
+          );
+
+          final result = await client.getFollowing(pubkey: testPubkey);
+          expect(result.pubkeys, hasLength(1));
+          expect(result.pubkeys.first, equals(testPubkey));
+          expect(result.hasMore, isTrue);
+        },
+      );
     });
 
     group('getRecommendations', () {
@@ -3542,7 +3663,62 @@ void main() {
           ),
         );
       });
-    });
+
+      // Envelope shape tolerance (divine-funnelcake#238 / issue #3521)
+      test(
+        'returns videos from legacy {videos} shape (pre-#238)',
+        () async {
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer(
+            (_) async => http.Response(validResponse, 200),
+          );
+
+          final result = await client.getRecommendations(pubkey: testPubkey);
+          expect(result.videos, hasLength(1));
+          expect(result.videos.first.id, equals('rec123'));
+          expect(result.source, equals('personalized'));
+        },
+      );
+
+      test(
+        'returns videos from post-#238 {data, pagination} envelope shape',
+        () async {
+          const envelopeResponse =
+              '''
+{
+  "data": [
+    {
+      "id": "rec-env-1",
+      "pubkey": "$testPubkey",
+      "created_at": 1700000000,
+      "kind": 34236,
+      "d_tag": "rec-env",
+      "title": "Envelope Rec",
+      "content": "",
+      "thumbnail": "https://example.com/thumb.jpg",
+      "video_url": "https://example.com/env.mp4",
+      "reactions": 100,
+      "comments": 10,
+      "reposts": 5,
+      "engagement_score": 115
+    }
+  ],
+  "pagination": {"has_more": true, "next_cursor": "opaque-1"},
+  "source": "personalized"
+}
+''';
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer((_) async => http.Response(envelopeResponse, 200));
+
+          final result = await client.getRecommendations(pubkey: testPubkey);
+          expect(result.videos, hasLength(1));
+          expect(result.videos.first.id, equals('rec-env-1'));
+          expect(result.source, equals('personalized'));
+        },
+      );
+    }); // end group('getRecommendations')
 
     group('getBulkProfiles', () {
       test('returns profiles on success', () async {
@@ -4165,7 +4341,264 @@ void main() {
         );
       });
     });
-  });
+    // -------------------------------------------------------------------------
+    // Envelope shape tolerance tests (divine-funnelcake#238 / issue #3521)
+    //
+    // Each representative parser must handle BOTH the legacy raw-array shape
+    // (current production) AND the new {data, pagination} envelope shape
+    // (post-flag-flip) without throwing or returning empty.
+    // -------------------------------------------------------------------------
+
+    group('envelope shape tolerance', () {
+      const videoJson =
+          '''
+{
+  "id": "envvideo01",
+  "pubkey": "$testPubkey",
+  "created_at": 1700000000,
+  "kind": 34236,
+  "d_tag": "env-video",
+  "title": "Envelope Video",
+  "content": "Test",
+  "thumbnail": "https://example.com/thumb.jpg",
+  "video_url": "https://example.com/video.mp4",
+  "reactions": 10,
+  "comments": 2,
+  "reposts": 1,
+  "engagement_score": 13
+}
+''';
+
+      group('_unwrapListResponse via getTrendingVideos', () {
+        test('raw-array shape returns items correctly', () async {
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer(
+            (_) async => http.Response('[$videoJson]', 200),
+          );
+
+          final videos = await client.getTrendingVideos();
+          expect(videos, hasLength(1));
+          expect(
+            videos.first.id,
+            equals(
+              'envvideo01',
+            ),
+          );
+        });
+
+        test(
+          '{data, pagination} envelope shape returns items correctly',
+          () async {
+            const envelope =
+                '''
+{
+  "data": [$videoJson],
+  "pagination": {
+    "has_more": true,
+    "next_cursor": "1699999999"
+  }
+}
+''';
+            when(
+              () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+            ).thenAnswer((_) async => http.Response(envelope, 200));
+
+            final videos = await client.getTrendingVideos();
+            expect(videos, hasLength(1));
+            expect(
+              videos.first.id,
+              equals(
+                'envvideo01',
+              ),
+            );
+          },
+        );
+
+        test(
+          'envelope with next_offset instead of next_cursor returns items',
+          () async {
+            const envelope =
+                '''
+{
+  "data": [$videoJson],
+  "pagination": {
+    "has_more": true,
+    "next_offset": 50
+  }
+}
+''';
+            when(
+              () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+            ).thenAnswer((_) async => http.Response(envelope, 200));
+
+            final videos = await client.getTrendingVideos();
+            expect(videos, hasLength(1));
+          },
+        );
+
+        test(
+          'unrecognised shape returns empty list without throwing',
+          () async {
+            when(
+              () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+            ).thenAnswer(
+              (_) async => http.Response('{"unexpected": "shape"}', 200),
+            );
+
+            final videos = await client.getTrendingVideos();
+            expect(videos, isEmpty);
+          },
+        );
+      });
+
+      group('searchVideos envelope shape', () {
+        test(
+          'envelope returns videos, uses length for totalCount',
+          () async {
+            const envelope =
+                '''
+{
+  "data": [$videoJson],
+  "pagination": {
+    "has_more": false,
+    "next_cursor": null
+  }
+}
+''';
+            when(
+              () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+            ).thenAnswer((_) async => http.Response(envelope, 200));
+
+            final result = await client.searchVideos(query: 'test');
+            expect(result.videos, hasLength(1));
+            // X-Total-Count header is absent; fallback to videos.length.
+            expect(result.totalCount, equals(1));
+          },
+        );
+
+        test('raw-array shape still returns videos', () async {
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer(
+            (_) async => http.Response('[$videoJson]', 200),
+          );
+
+          final result = await client.searchVideos(query: 'test');
+          expect(result.videos, hasLength(1));
+        });
+      });
+
+      group('fetchTrendingHashtags envelope shape', () {
+        const hashtagJson = '''{"tag": "funny", "count": 42}''';
+
+        test('{data, pagination} envelope returns hashtags', () async {
+          const envelope =
+              '''
+{
+  "data": [$hashtagJson],
+  "pagination": {"has_more": false, "next_cursor": null}
+}
+''';
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer((_) async => http.Response(envelope, 200));
+
+          final hashtags = await client.fetchTrendingHashtags();
+          expect(hashtags, hasLength(1));
+          expect(hashtags.first.tag, equals('funny'));
+        });
+
+        test('raw-array shape returns hashtags', () async {
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer(
+            (_) async => http.Response('[$hashtagJson]', 200),
+          );
+
+          final hashtags = await client.fetchTrendingHashtags();
+          expect(hashtags, hasLength(1));
+          expect(hashtags.first.tag, equals('funny'));
+        });
+      });
+
+      group('searchProfiles envelope shape', () {
+        const profileJson =
+            '''
+{
+  "pubkey": "$testPubkey",
+  "name": "Alice",
+  "display_name": "Alice",
+  "about": "",
+  "picture": "",
+  "nip05": "",
+  "follower_count": 0,
+  "following_count": 0,
+  "video_count": 1
+}
+''';
+
+        test('{data, pagination} envelope returns profiles', () async {
+          const envelope =
+              '''
+{
+  "data": [$profileJson],
+  "pagination": {"has_more": false, "next_cursor": null}
+}
+''';
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer((_) async => http.Response(envelope, 200));
+
+          final profiles = await client.searchProfiles(query: 'alice');
+          expect(profiles, hasLength(1));
+          expect(profiles.first.pubkey, equals(testPubkey));
+        });
+
+        test('raw-array shape returns profiles', () async {
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer((_) async => http.Response('[$profileJson]', 200));
+
+          final profiles = await client.searchProfiles(query: 'alice');
+          expect(profiles, hasLength(1));
+        });
+      });
+
+      group('getCategories envelope shape', () {
+        const categoryJson =
+            '{"name": "comedy", "display_name": "Comedy", "video_count": 100}';
+
+        test('{data, pagination} envelope returns categories', () async {
+          const envelope =
+              '''
+{
+  "data": [$categoryJson],
+  "pagination": {"has_more": false, "next_cursor": null}
+}
+''';
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer((_) async => http.Response(envelope, 200));
+
+          final categories = await client.getCategories();
+          expect(categories, hasLength(1));
+          expect(categories.first.name, equals('comedy'));
+        });
+
+        test('raw-array shape returns categories', () async {
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer(
+            (_) async => http.Response('[$categoryJson]', 200),
+          );
+
+          final categories = await client.getCategories();
+          expect(categories, hasLength(1));
+        });
+      }); // end group('getCategories envelope shape')
+    }); // end group('envelope shape tolerance')
+  }); // end group('FunnelcakeApiClient')
 
   group('Exceptions', () {
     test('FunnelcakeException has correct toString', () {
@@ -4213,5 +4646,5 @@ void main() {
       const exceptionWithoutUrl = FunnelcakeTimeoutException();
       expect(exceptionWithoutUrl.message, equals('Request timed out'));
     });
-  });
-}
+  }); // end group('Exceptions')
+} // end main

--- a/mobile/packages/models/lib/src/paginated_pubkeys.dart
+++ b/mobile/packages/models/lib/src/paginated_pubkeys.dart
@@ -14,20 +14,29 @@ class PaginatedPubkeys {
 
   /// Creates a [PaginatedPubkeys] from JSON response.
   ///
-  /// The Funnelcake API uses context-specific keys:
-  /// - `/following` returns `{"following": [...]}`
-  /// - `/followers` returns `{"followers": [...]}`
-  /// - Falls back to `"pubkeys"` for generic responses
+  /// Tolerates both the legacy shape and the post-funnelcake#238 envelope:
+  /// - Legacy: `{"following": [...], "total": int, "has_more": bool}`
+  ///   (key varies: `following`, `followers`, or `pubkeys`)
+  /// - Envelope: `{"data": [...], "pagination": {"has_more": bool,
+  ///   "next_cursor": string}}`
   factory PaginatedPubkeys.fromJson(Map<String, dynamic> json) {
+    final pagination = json['pagination'] as Map<String, dynamic>?;
+
+    // Prefer the envelope `data` key; fall back to endpoint-specific keys.
     final pubkeysData =
+        json['data'] as List<dynamic>? ??
         json['following'] as List<dynamic>? ??
         json['followers'] as List<dynamic>? ??
         json['pubkeys'] as List<dynamic>? ??
         <dynamic>[];
+
+    final hasMore =
+        json['has_more'] as bool? ?? pagination?['has_more'] as bool? ?? false;
+
     return PaginatedPubkeys(
       pubkeys: pubkeysData.map((e) => e.toString()).toList(),
       total: json['total'] as int? ?? pubkeysData.length,
-      hasMore: json['has_more'] as bool? ?? false,
+      hasMore: hasMore,
     );
   }
 

--- a/mobile/packages/models/test/src/paginated_pubkeys_test.dart
+++ b/mobile/packages/models/test/src/paginated_pubkeys_test.dart
@@ -95,6 +95,38 @@ void main() {
 
         expect(result.pubkeys, equals(['a']));
       });
+
+      // Envelope shape tolerance (divine-funnelcake#238 / issue #3521)
+      test('parses post-#238 {data, pagination} envelope', () {
+        final result = PaginatedPubkeys.fromJson(const {
+          'data': ['pub1', 'pub2'],
+          'pagination': {'has_more': true, 'next_cursor': '50'},
+        });
+
+        expect(result.pubkeys, equals(['pub1', 'pub2']));
+        expect(result.hasMore, isTrue);
+        expect(result.total, equals(2));
+      });
+
+      test('data key takes precedence over following in envelope', () {
+        final result = PaginatedPubkeys.fromJson(const {
+          'data': ['env1'],
+          'following': ['old1'],
+          'pagination': {'has_more': false},
+        });
+
+        expect(result.pubkeys, equals(['env1']));
+        expect(result.hasMore, isFalse);
+      });
+
+      test('has_more from pagination sub-object', () {
+        final result = PaginatedPubkeys.fromJson(const {
+          'data': ['x'],
+          'pagination': {'has_more': true},
+        });
+
+        expect(result.hasMore, isTrue);
+      });
     });
 
     group('equality', () {


### PR DESCRIPTION



<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Add _unwrapListResponse helper that handles both the legacy raw-array shape (current production, legacy-array-response flag ON) and the post-funnelcake {data:[...], pagination {has_more, next_cursor}} envelope shape.

Update all 14 bare-array list-parsing call sites in FunnelcakeApiClient to use the helper: getTrendingVideos, getRecentVideos, getWatchingVideos, getVideosByLoops, getVideosByHashtag, getClassicVideosByHashtag, getVideosByCategory, getVideosByAuthor, getCollabVideos, searchVideos, searchProfiles, searchHashtags, fetchTrendingHashtags, getCategories.

getClassicVines retains its pre-existing 'videos' key fallback for the older server-side shape, then delegates to the new helper.

Adds 27 new unit tests covering both shapes for representative parsers: videos, search, hashtags, profiles, categories, and recommendations.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #3521

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore