### PR TITLE
docs(rules): codify Riverpod-into-BlocProvider bridge rule

### DIFF
--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -88,6 +88,13 @@ State management:
   `BlocListener<X,`, `BlocConsumer<X,`, or `BlocSelector<X,`. If not,
   either add `lazy: false` with a justification or delete the wrapper
   entirely — side effects in `create:` never fire without a consumer.
+- [ ] Inside every `BlocProvider<X>(create: ...)` factory, any
+  Riverpod-provided dependency whose identity can change at runtime
+  (auth flip, account switch, sign-out, explicit `ref.invalidate`) is
+  read via `ref.watch` *and* the surrounding `BlocProvider` carries a
+  `ValueKey` over the dependency tuple. `ref.read` here silently
+  captures stale state on the next dep rebuild — see
+  [`state_management.md`](state_management.md#bridging-riverpod-provided-dependencies-into-blocprovider).
 - [ ] No error strings / exception objects in BLoC `state`. Use status
   enums + `addError`. See [`state_management.md`](state_management.md).
 - [ ] No mutable instance variables on a BLoC class. All state lives in

--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -95,6 +95,14 @@ State management:
   `ValueKey` over the dependency tuple. `ref.read` here silently
   captures stale state on the next dep rebuild — see
   [`state_management.md`](state_management.md#bridging-riverpod-provided-dependencies-into-blocprovider).
+- [ ] No `ConsumerStatefulWidget` constructs a bloc with
+  `late final SomeBloc _bloc = SomeBloc(repo: ref.read(...Provider))`
+  in `initState` capturing an identity-flippable Riverpod
+  dependency. The preferred fix is the Page/View split — push bloc
+  construction into a `ConsumerWidget` parent that wraps a stateful
+  child via `BlocProvider`-keyed-on-identity (the existing rule
+  then covers the parent). See
+  [`state_management.md`](state_management.md#stateful-widgets-that-hold-the-captured-dep-bloc-directly).
 - [ ] No error strings / exception objects in BLoC `state`. Use status
   enums + `addError`. See [`state_management.md`](state_management.md).
 - [ ] No mutable instance variables on a BLoC class. All state lives in

--- a/.claude/rules/state_management.md
+++ b/.claude/rules/state_management.md
@@ -260,6 +260,22 @@ provider emits a fresh instance, but the bloc stays wired to the
 stale one and silently operates on the previous state of the
 world.
 
+**Before applying this rule, check whether Pattern A is available.**
+Some Riverpod-provided dependencies are *already* gated on a
+readiness signal — `profileRepositoryProvider` and
+`pendingActionServiceProvider` return `null` until
+`isNostrReadyProvider` resolves. When that's the case, the consumer
+reads the nullable value and renders a loading / disabled
+affordance until it's non-null; the bloc never gets a chance to
+capture a stale instance, and there's nothing for this rule to
+guard. #3523 tracks the in-flight migration of `likes` / `comments`
+/ `reposts` to the same shape — once it ships, the four canonical
+sites this rule cites won't need this rule at all.
+
+The rule below is the answer when Pattern A isn't available — when
+the provider has no clean "not ready" signal, or when restructuring
+the provider isn't in scope.
+
 **Rule.** When a `BlocProvider.create:` consumes a Riverpod
 dependency whose identity can change at runtime, the surrounding
 `ConsumerWidget.build` must (a) read each such dependency with
@@ -270,6 +286,28 @@ changes identity, the key changes, the old bloc is closed, and
 per-field with `==`; for classes that don't override `==` (most
 repositories and clients in this codebase) equality falls through
 to identity — exactly the semantics this pattern needs.
+
+**If any captured type ever overrides `==`** (e.g. content-based
+equality on a repository for testing) the record key silently stops
+detecting identity swaps — two distinct instances with equal
+content compare equal, the key doesn't change on rebuild, and the
+bloc keeps the stale capture. In that case, switch to an explicit
+identity-hash key:
+
+```dart
+key: ValueKey(
+  Object.hash(
+    identityHashCode(likesRepository),
+    identityHashCode(commentsRepository),
+    identityHashCode(repostsRepository),
+  ),
+),
+```
+
+This was the original form shipped in #3503 before #3522 simplified
+to records once the captured classes were confirmed not to override
+`==`. The hash form stays correct under any `==` override, at the
+cost of a vanishingly small (~2⁻³²) collision risk on a swap.
 
 **Bad — captures the dep at first build, never recovers:**
 ```dart
@@ -359,11 +397,22 @@ that test fails loudly so the state loss can be re-evaluated.
 ### Detection
 
 A reviewer's quickest first filter is to grep for `ref.read` of a
-repository provider, then check whether each hit sits inside a
-`BlocProvider.create:` callback:
+provider whose backing object can flip identity, then check whether
+each hit sits inside a `BlocProvider.create:` callback:
 
 ```
-grep -rn "ref\.read(.*RepositoryProvider)" mobile/lib --include="*.dart"
+grep -rn "ref\.read(.*\(Repository\|Service\|Client\|Manager\)Provider)" mobile/lib --include="*.dart"
+```
+
+The type-suffix filter is a starting point, not exhaustive — the
+codebase has ~40 `*ServiceProvider` / `*ClientProvider` /
+`*ManagerProvider` instances on top of the `*RepositoryProvider`
+ones, and naming isn't enforced. To catch every case at the cost of
+more false positives (e.g. unchanging `StateProvider`s, `.notifier`
+/ `.future` modifiers), widen to:
+
+```
+grep -rn "ref\.read\(.*Provider\)" mobile/lib --include="*.dart"
 ```
 
 If the surrounding widget is a `ConsumerWidget` /

--- a/.claude/rules/state_management.md
+++ b/.claude/rules/state_management.md
@@ -421,6 +421,184 @@ If the surrounding widget is a `ConsumerWidget` /
 
 ---
 
+## Stateful widgets that hold the captured-dep bloc directly
+
+The same capture trap reproduces in a different shape:
+`ConsumerStatefulWidget` whose `State` constructs a bloc in
+`initState` and holds it via `late final`. The `ref.read` calls
+inside `initState` capture whichever instance each provider
+returned at that moment, and the `late final` field can never be
+reassigned — so the captured chain is permanent for the widget's
+lifetime, even across auth flips and account switches. Greppable
+shape:
+
+```dart
+class _MyState extends ConsumerState<MyWidget> {
+  late final SomeBloc _bloc;
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = SomeBloc(
+      repository: ref.read(someRepositoryProvider), // WRONG
+    );
+  }
+}
+```
+
+The `BlocProvider`-keyed-on-identity rule above doesn't apply
+directly — there is no `BlocProvider` at the construction site to
+attach a `ValueKey` to.
+
+### Preferred fix: Page/View split
+
+Push the bloc construction up into a `ConsumerWidget` parent that
+wraps a `StatefulWidget` child via `BlocProvider`, and have the
+stateful child consume the bloc through `context.read<Bloc>()`.
+The parent then uses the existing rule (record-typed `ValueKey`
+over the captured provider tuple) — no new shape introduced. This
+matches the four canonical existing examples in this codebase:
+`_PooledVideoFeedItem` / `_PooledVideoFeedItemContent` in
+`video_feed_page.dart`, and `_PooledFullscreenItem` /
+`_PooledFullscreenItemContent` in
+`pooled_fullscreen_video_feed_screen.dart`. It also follows the
+Page/View pattern in [`ui_theming.md`](ui_theming.md) and the
+constructor-injection guidance in
+[`architecture.md`](architecture.md) — the stateful child stops
+reaching into Riverpod for its dependencies.
+
+**Skeleton:**
+
+```dart
+class _MyParent extends ConsumerWidget {
+  const _MyParent({required this.input});
+
+  final InputType input;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final repo1 = ref.watch(repo1Provider);
+    final repo2 = ref.watch(repo2Provider);
+    return BlocProvider<MyBloc>(
+      key: ValueKey((repo1, repo2)),
+      create: (_) => MyBloc(repo1: repo1, repo2: repo2)
+        ..add(const MyInitialEvent()),
+      child: _MyChild(input: input),
+    );
+  }
+}
+
+class _MyChild extends StatefulWidget {
+  const _MyChild({required this.input});
+
+  final InputType input;
+
+  @override
+  State<_MyChild> createState() => _MyChildState();
+}
+
+class _MyChildState extends State<_MyChild> {
+  // animation controllers, ValueNotifiers, scroll listeners, …
+
+  @override
+  Widget build(BuildContext context) {
+    final bloc = context.read<MyBloc>();
+    // …
+  }
+}
+```
+
+The split lets the parent own dependency lifecycle and the child
+own local UI state, which is the same separation the existing four
+sites already use.
+
+### Workaround when refactor is blocked
+
+When splitting the widget isn't feasible in scope (e.g. the
+stateful logic tangles with the bloc lifecycle in a way the
+refactor would balloon), snapshot the captured deps in `initState`
+and use `ref.listen` in `build` to detect identity changes and
+rebuild the bloc. The codebase already uses `ref.listen`-in-`build`
+for forwarding Riverpod signals to a Bloc (see
+`my_followers_screen.dart`'s blocklist invalidation handler) — this
+extends the same idiom to "rebuild the bloc itself when its
+captured deps change identity":
+
+```dart
+late MyBloc _bloc;
+late (Repo1, Repo2) _captured;
+
+@override
+void initState() {
+  super.initState();
+  _captured = (
+    ref.read(repo1Provider),
+    ref.read(repo2Provider),
+  );
+  _bloc = _createBloc(_captured)..add(const MyInitialEvent());
+}
+
+@override
+Widget build(BuildContext context) {
+  ref.listen<Repo1>(repo1Provider, (_, _) => _maybeRecreate());
+  ref.listen<Repo2>(repo2Provider, (_, _) => _maybeRecreate());
+  return BlocProvider<MyBloc>.value(
+    value: _bloc,
+    child: const _MyChild(),
+  );
+}
+
+void _maybeRecreate() {
+  if (!mounted) return;
+  final fresh = (
+    ref.read(repo1Provider),
+    ref.read(repo2Provider),
+  );
+  if (fresh == _captured) return;
+  _bloc.close();
+  _captured = fresh;
+  setState(() {
+    _bloc = _createBloc(fresh)..add(const MyInitialEvent());
+  });
+}
+
+@override
+void dispose() {
+  _bloc.close();
+  super.dispose();
+}
+
+MyBloc _createBloc((Repo1, Repo2) deps) {
+  final (repo1, repo2) = deps;
+  return MyBloc(repo1: repo1, repo2: repo2);
+}
+```
+
+This is a fallback, not the primary recommendation. It introduces
+a shape that doesn't currently appear elsewhere in the codebase
+and bypasses the established Page/View precedent. Prefer the
+refactor when reasonable.
+
+The same state-loss tradeoff applies as the `BlocProvider` case:
+each recreate drops in-flight optimistic state and pending
+publishes, which is the correct behaviour when the underlying
+repository is bound to a different signer / `NostrClient` / user.
+
+### Detection
+
+```
+grep -rn "late\s\+\(final\s\+\)\?[A-Z][A-Za-z]*\(Bloc\|Cubit\)\b" mobile/lib --include="*.dart"
+```
+
+For each hit, check `initState` for `ref.read(...Provider)` calls
+that capture providers whose identity can flip (auth flip, account
+switch, sign-out, explicit `ref.invalidate`). Apply the same
+identity-flip judgment as the `BlocProvider.create:` case — if the
+captured provider rebuilds in response to runtime events, the
+`late final` field will go stale.
+
+---
+
 ## Persisting state across shell-route transitions
 
 Screens inside a `ShellRoute` whose content is gated on the current URL

--- a/.claude/rules/state_management.md
+++ b/.claude/rules/state_management.md
@@ -248,6 +248,130 @@ bloc needs its own consumer; one consumer does not wake the others.
 
 ---
 
+## Bridging Riverpod-provided dependencies into BlocProvider
+
+`BlocProvider(create: ...)` runs its factory **once per subtree
+mount**. If the factory reads a Riverpod-provided dependency via
+`ref.read`, the bloc captures whatever instance the provider
+returned at that moment and keeps it for the lifetime of the
+surrounding widget. When that dependency is later rebuilt — auth
+flip, account switch, sign-out, explicit `ref.invalidate` — the
+provider emits a fresh instance, but the bloc stays wired to the
+stale one and silently operates on the previous state of the
+world.
+
+**Rule.** When a `BlocProvider.create:` consumes a Riverpod
+dependency whose identity can change at runtime, the surrounding
+`ConsumerWidget.build` must (a) read each such dependency with
+`ref.watch`, and (b) compose those watched values into a
+record-typed `ValueKey` on the `BlocProvider`. When any dependency
+changes identity, the key changes, the old bloc is closed, and
+`create:` runs again with the fresh dependencies. Records compare
+per-field with `==`; for classes that don't override `==` (most
+repositories and clients in this codebase) equality falls through
+to identity — exactly the semantics this pattern needs.
+
+**Bad — captures the dep at first build, never recovers:**
+```dart
+class _FeedItem extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final likesRepository = ref.read(likesRepositoryProvider); // WRONG
+    return BlocProvider<VideoInteractionsBloc>(
+      create: (_) => VideoInteractionsBloc(
+        likesRepository: likesRepository,
+        // ...
+      ),
+      child: ...,
+    );
+  }
+}
+```
+
+**Good — bloc lifecycle tracks the dep's identity:**
+```dart
+class _FeedItem extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final likesRepository = ref.watch(likesRepositoryProvider);
+    final commentsRepository = ref.watch(commentsRepositoryProvider);
+    final repostsRepository = ref.watch(repostsRepositoryProvider);
+    return BlocProvider<VideoInteractionsBloc>(
+      key: ValueKey(
+        (likesRepository, commentsRepository, repostsRepository),
+      ),
+      create: (_) => VideoInteractionsBloc(
+        likesRepository: likesRepository,
+        commentsRepository: commentsRepository,
+        repostsRepository: repostsRepository,
+        // ...
+      ),
+      child: ...,
+    );
+  }
+}
+```
+
+The canonical implementation lives at four sites — see
+`video_feed_page.dart` (`_PooledVideoFeedItem.build`,
+`_WebVideoFeedItem.build`) and
+`pooled_fullscreen_video_feed_screen.dart`
+(`_PooledFullscreenItem.build`, `_WebFullscreenItem.build`). The
+failure they cure (#3503): a cold-launch race where the warm-up
+chain materialised `likesRepository` before
+`AuthService.initialize()` resolved, the underlying `Nostr` wrapped
+a `LocalKeySigner(null)` placeholder, and every `sendLike` from the
+captured bloc threw `StateError("No public key available …")`.
+
+### Tradeoff: bloc state resets on swap
+
+When the record key flips, the old bloc is closed and a new one is
+constructed at initial state. **In-flight optimistic state — half-
+flipped UI, pending publishes — is dropped.** This is intentional:
+the optimistic state was bound to the *previous* dependency (a
+different signer / `NostrClient` / user), and replaying it against
+the new one is unsafe. The state-loss contract is pinned by
+`pooled_video_feed_item_repo_swap_test.dart` ("resets bloc state
+when likesRepositoryProvider rebuilds (intentional)"). If a future
+change introduces a non-auth invalidation of one of these providers,
+that test fails loudly so the state loss can be re-evaluated.
+
+### When the rule does NOT apply
+
+1. **The Riverpod dependency is genuinely stable for the bloc's
+   lifetime.** A `StateProvider<int>` that is never invalidated is
+   fine to read with `ref.read` — document the assumption inline.
+2. **The bloc lives at a higher scope than the dependency change.**
+   An app-shell-level bloc that needs to *react* to auth flips
+   internally must subscribe to the change (e.g. via `ref.listen`
+   from a parent `ConsumerWidget` or a stream subscription inside
+   the bloc) — the `BlocProvider` key trick does not apply, because
+   the bloc is supposed to outlive the change.
+3. **Pattern A (gate the provider on readiness) is available.**
+   When the dependency can be in a "not ready" state, the cleaner
+   option is to gate the *provider itself* on a readiness flag —
+   `profileRepositoryProvider` and `pendingActionServiceProvider`
+   already gate on `isNostrReadyProvider` and return `null` until
+   the real instance is available. The widget renders a loading /
+   disabled affordance until the provider hands over a non-null
+   dependency, and the bloc never gets to capture a stale one.
+
+### Detection
+
+A reviewer's quickest first filter is to grep for `ref.read` of a
+repository provider, then check whether each hit sits inside a
+`BlocProvider.create:` callback:
+
+```
+grep -rn "ref\.read(.*RepositoryProvider)" mobile/lib --include="*.dart"
+```
+
+If the surrounding widget is a `ConsumerWidget` /
+`ConsumerStatefulWidget` that wraps the value in a
+`BlocProvider<...>` without a `ValueKey`, this rule applies.
+
+---
+
 ## Persisting state across shell-route transitions
 
 Screens inside a `ShellRoute` whose content is gated on the current URL


### PR DESCRIPTION
## Description

Adds a project rule capturing the pattern PR #3522 established at four feed-item sites, so future `BlocProvider` factories that consume Riverpod-provided dependencies don't reintroduce the cold-launch "first two likes throw `StateError`" race.

**Related Issue:** Relates to #3503 (#3522 fixed the bug; this PR codifies the rule so the next reviewer has something to grep against).

## What this adds

- **`.claude/rules/state_management.md`** — new section "Bridging Riverpod-provided dependencies into BlocProvider", inserted between the existing "BlocProvider is lazy by default" and "Persisting state across shell-route transitions" sections. Covers:
  - The trap (factory runs once, `ref.read` snapshots a stale instance forever)
  - The rule (`ref.watch` + record-typed `ValueKey` over the dependency tuple)
  - Bad / Good code blocks
  - Worked #3503 example, citing the four canonical sites in `video_feed_page.dart` and `pooled_fullscreen_video_feed_screen.dart`
  - Intentional state-loss-on-swap tradeoff (and the test that pins the contract)
  - Three "does NOT apply" cases (stable deps, app-shell-scope blocs, Pattern A providers gated on `isNostrReady`)
  - A grep that reviewers can run as a first-pass filter

- **`.claude/rules/self_review_checklist.md`** — one bullet added under "While implementing → State management", linking to the new section anchor. Sits next to the existing "every BlocProvider has a consumer" bullet — same area of concern, different surface (factory body vs. consumer existence).

## Why now

The shipped fix in #3522 is correct but localized — four sites switched from `ref.read` to `ref.watch` + a record `ValueKey`. Without the rule documented, the next time someone wires a `BlocProvider` over a Riverpod-provided repository (or pulls in a new Riverpod dep on an existing bloc) we have to re-derive the trap from #3503's postmortem. The rule + checklist bullet make that a 30-second reviewer check instead.

## Type of Change

- [x] 📝 Documentation

## Test plan

Documentation-only — no Dart changes, no tests.

Manual verification:

- [x] Pre-commit hook is Dart-only (`No Dart files staged, skipping checks`) — confirmed on commit.
- [ ] Anchor link from the new self-review bullet (`state_management.md#bridging-riverpod-provided-dependencies-into-blocprovider`) renders correctly on GitHub.
- [ ] Section reads end-to-end as a self-contained rule (no implicit "see the previous section" references).
- [ ] No CI gates relevant: changes are outside `mobile/`, so `Analyze` / `Tests` / `Format` / `Generated Files` / `build` workflows are not exercised by this diff.

## Out of scope (filed separately, not bundled)

The four follow-ups #3522 already filed remain follow-ups. This PR codifies the rule only:

- #3523 — Pattern A consistency: gate `likes`/`comments`/`reposts` repos on `isNostrReady`.
- #3524 — Atomic state swap in `NostrService._onAuthStateChanged`.
- #3525 — Dead `VideoInteractionsState.error` field.
- #3526 — Register a `BlocObserver` to forward Bloc errors to Crashlytics.
- #3527 — RFC: migrate `nostrServiceProvider` to `AsyncValue<NostrClient>`.

The rule's "When does NOT apply" section explicitly references #3523's `isNostrReady` precedent, so if/when that PR ships the rule still reads correctly.