### PR TITLE
feat(observability): forward Bloc errors to Crashlytics via BlocObserver

### DIFF
--- a/.claude/rules/error_handling.md
+++ b/.claude/rules/error_handling.md
@@ -155,6 +155,11 @@ If the matrix says YES, wrap the inner error at the `addError` call site:
 }
 ```
 
+Important: anything that reaches the generic `catch (e, stackTrace)` block is
+being implicitly classified as reportable. If you add a new expected/domain
+failure path that should stay out of Crashlytics, add a specific
+`on FooException catch` handler above the generic catch and handle it there.
+
 `Reportable<T>` is an `Exception` (via the `ReportableError` marker), so
 existing `errors: () => [isA<Exception>()]` `blocTest` assertions stay
 green. Tests that pin a specific inner type — e.g. `isA<StateError>()` —

--- a/.claude/rules/error_handling.md
+++ b/.claude/rules/error_handling.md
@@ -176,6 +176,42 @@ errors: () => [
 `T`, so Crashlytics still groups by the actual inner type even when
 `T == Object`.
 
+### Naming `context` identifiers
+
+The `context` parameter is a free-form `String?` — same shape as
+`Log.error(name: 'XxxBloc')` used elsewhere in the codebase. For a single
+migrated site in a feature, a string literal at the call site is fine:
+
+```dart
+addError(Reportable(e, context: '_publishLike'), stackTrace);
+```
+
+Once a feature accumulates **2+ migrated sites**, lift the identifiers
+into a per-feature constants class colocated with the bloc:
+
+```dart
+abstract class VideoInteractionsReportableSites {
+  static const publishLike = '_publishLike';
+  static const publishRepost = '_publishRepost';
+}
+
+addError(
+  Reportable(e, context: VideoInteractionsReportableSites.publishLike),
+  stackTrace,
+);
+```
+
+Class naming: `<FeatureNoun>ReportableSites`. Members are
+`static const String`.
+
+Per-feature constants (rather than a global enum) keep PR-stack
+parallelism — each feature-area migration PR edits only its own constants
+file, not a shared hot-spot. Crashlytics groups by `error.runtimeType`
+and the observer's `Bloc.addError $runtimeType` reason; `context` is
+supplementary triage text, not a dashboard branching key, so the
+typed-vs-string choice is a call-site discoverability decision rather
+than a dashboard-taxonomy decision.
+
 ### PII
 
 `Reportable.toString()` strips Nostr `npub1…` and `nsec1…` identifiers

--- a/.claude/rules/error_handling.md
+++ b/.claude/rules/error_handling.md
@@ -119,6 +119,79 @@ void main() {
 
 ---
 
+## Reportable errors and Crashlytics
+
+A project-wide `BlocObserver` (`DivineBlocObserver`) writes every Bloc/Cubit
+error to the unified log. Forwarding to **Crashlytics** is gated on the
+error implementing `ReportableError` — without that gate, expected domain
+errors (network timeouts, "no public key yet" during cold start, 4xx
+responses, validation failures) flood the dashboard and drown the real
+bugs.
+
+**Default**: an error is NOT reportable. Wrap with `Reportable(e, context:
+'<callsite>')` only when the matrix below says YES.
+
+### Decision matrix
+
+| Category | Reportable? | Why |
+|---|---|---|
+| Network / IO (timeout, dropped connection, DNS) | NO | Expected on flaky networks. Surface via UI status enum. |
+| API / domain (4xx, server validation) | NO | Expected, often user-input-driven. |
+| Auth / session (token expired, signed out) | NO | Expected during cold start and after logout. |
+| Form / business-rule validation | NO | Surface in UI. |
+| `StateError`, `TypeError`, `RangeError` | YES | Programming-invariant violation. |
+| Project-owned `*InvariantException` types | YES | Domain code intentionally signaling impossibility. |
+| When in doubt | NO | Better to under-report and migrate later than flood. |
+
+### Migration recipe
+
+If the matrix says YES, wrap the inner error at the `addError` call site:
+
+```dart
+} catch (e, stackTrace) {
+  Log.error('Foo failed', name: 'FooBloc', error: e, stackTrace: stackTrace);
+  addError(Reportable(e, context: '_onFooSubmitted'), stackTrace);
+  emit(state.copyWith(status: FooStatus.failure));
+}
+```
+
+`Reportable<T>` is an `Exception` (via the `ReportableError` marker), so
+existing `errors: () => [isA<Exception>()]` `blocTest` assertions stay
+green. Tests that pin a specific inner type — e.g. `isA<StateError>()` —
+need to update after migration. Note that inside a `catch (e, st)` block
+`e` is statically `Object`, so `Reportable(e, ...)` infers
+`Reportable<Object>`. Assert on the unwrap rather than the generic:
+
+```dart
+errors: () => [
+  isA<Reportable<Object>>().having(
+    (r) => r.unwrap(),
+    'unwrap',
+    isA<StateError>(),
+  ),
+],
+```
+
+`Reportable.toString()` uses `error.runtimeType` rather than the static
+`T`, so Crashlytics still groups by the actual inner type even when
+`T == Object`.
+
+### PII
+
+`Reportable.toString()` strips Nostr `npub1…` and `nsec1…` identifiers
+before they reach Crashlytics. Other Nostr-format references (`note1`,
+`nevent1`, `nprofile1`) encode pointers, not secrets, and are
+intentionally left intact for triage value — call sites that need to
+redact those should do so explicitly before constructing the error
+message.
+
+If you opt a project-owned exception in by `implements ReportableError`
+directly (skipping the `Reportable` wrapper), the marker bypasses the
+sanitizer. Make sure your `toString()` does not embed `npub` / `nsec`
+strings, or wrap the throw with `Reportable` at the boundary instead.
+
+---
+
 ## Error Handling Patterns
 
 ### Try-Catch Best Practices

--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -8,6 +8,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:models/models.dart' show NIP71VideoKinds;
+import 'package:openvine/observability/reportable_error.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -272,7 +273,7 @@ class VideoInteractionsBloc
         name: 'VideoInteractionsBloc',
         category: LogCategory.system,
       );
-      addError(e, stackTrace);
+      addError(Reportable(e, context: '_publishLike'), stackTrace);
       outcome = _LikeSettleFailed(wasLiked: wasLiked);
     }
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -43,6 +43,7 @@ import 'package:openvine/l10n/resolve_app_ui_locale.dart';
 import 'package:openvine/network/vine_cdn_http_overrides.dart'
     if (dart.library.html) 'package:openvine/utils/platform_io_web.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
+import 'package:openvine/observability/divine_bloc_observer.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/deep_link_provider.dart';
@@ -764,6 +765,11 @@ Future<void> _startOpenVineApp() async {
   StartupPerformanceService.instance.checkpoint('pre_app_launch');
 
   await initializeDateFormatting();
+
+  // Forward Bloc/Cubit errors (addError, uncaught handler throws, emit
+  // failures) to Crashlytics + UnifiedLogger. Surfaced during the #3503
+  // investigation as a missing observability hook. See #3526.
+  Bloc.observer = DivineBlocObserver();
 
   runApp(
     UncontrolledProviderScope(

--- a/mobile/lib/observability/divine_bloc_observer.dart
+++ b/mobile/lib/observability/divine_bloc_observer.dart
@@ -1,0 +1,55 @@
+// ABOUTME: BlocObserver that forwards Bloc errors to Crashlytics + UnifiedLogger
+// ABOUTME: Wired once in main.dart before runApp; covers addError, handler throws, emit failures
+
+import 'dart:async';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/observability/reportable_error.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Forwards Bloc/Cubit errors to the project's crash reporter and the unified
+/// log.
+///
+/// Bloc's [BlocObserver.onError] fires for three things:
+/// 1. An explicit `bloc.addError(error, stackTrace)` from a handler.
+/// 2. An uncaught exception thrown inside an event handler.
+/// 3. A failure inside `emit(...)` (e.g. emitting from a closed bloc).
+///
+/// All three are written to the unified log (so the in-memory bug-report
+/// capture flow stays complete). Forwarding to Crashlytics is **gated** on
+/// the error implementing [ReportableError] — without that gate, expected
+/// domain errors (network timeouts, "no public key yet" during cold start,
+/// 4xx responses, validation failures) flood the dashboard and drown the
+/// real bugs. See the decision matrix in `.claude/rules/error_handling.md`.
+///
+/// Wire once at app start, before `runApp`:
+///
+/// ```dart
+/// Bloc.observer = DivineBlocObserver();
+/// runApp(...);
+/// ```
+class DivineBlocObserver extends BlocObserver {
+  DivineBlocObserver({CrashReportingService? crashReporting})
+    : _crashReporting = crashReporting ?? CrashReportingService.instance;
+
+  final CrashReportingService _crashReporting;
+
+  @override
+  void onError(BlocBase<dynamic> bloc, Object error, StackTrace stackTrace) {
+    super.onError(bloc, error, stackTrace);
+    final runtimeType = bloc.runtimeType;
+    Log.error(
+      'Bloc error: $runtimeType',
+      name: 'BlocObserver',
+      error: error,
+      stackTrace: stackTrace,
+    );
+    if (error is! ReportableError) return;
+    final reason = sanitizeForCrashReport('Bloc.addError $runtimeType');
+    // CrashReportingService.recordError swallows its own failures (returns
+    // early when uninitialized, wraps the FirebaseCrashlytics call in
+    // try/catch); see crash_reporting_service.dart for the contract.
+    unawaited(_crashReporting.recordError(error, stackTrace, reason: reason));
+  }
+}

--- a/mobile/lib/observability/reportable_error.dart
+++ b/mobile/lib/observability/reportable_error.dart
@@ -1,0 +1,72 @@
+// ABOUTME: Marker interface + wrapper + PII sanitizer used to gate Bloc errors
+// ABOUTME: forwarded to Crashlytics. See .claude/rules/error_handling.md.
+
+/// Marker interface signalling that an error is worth reporting to Crashlytics.
+///
+/// Errors that flow through `addError(error, st)` only reach the crash reporter
+/// when they implement [ReportableError]. Default for an unmarked error is
+/// "log locally, do not forward" — see the decision matrix in
+/// `.claude/rules/error_handling.md`.
+///
+/// To opt an existing exception type in, declare
+/// `class FooInvariantException implements ReportableError { … }`. To wrap a
+/// foreign exception (e.g. a `StateError` raised by a third-party library) at
+/// a specific call site, use [Reportable].
+abstract interface class ReportableError implements Exception {}
+
+/// Wraps a foreign error so it can be forwarded to Crashlytics through a
+/// `BlocObserver` filter without modifying the underlying exception type.
+///
+/// Use at the `addError` call site:
+///
+/// ```dart
+/// } catch (e, stackTrace) {
+///   addError(Reportable(e, context: '_publishLike'), stackTrace);
+/// }
+/// ```
+///
+/// [context] is a short identifier — usually the method name — that becomes
+/// part of the Crashlytics report annotation so dashboards can distinguish
+/// multiple call sites in the same bloc.
+///
+/// [toString] runs [sanitizeForCrashReport] over the inner error's
+/// stringification so `npub1…` / `nsec1…` identifiers never reach the crash
+/// reporter, regardless of which call site produced the error.
+final class Reportable<T extends Object> implements ReportableError {
+  const Reportable(this.error, {this.context});
+
+  final T error;
+  final String? context;
+
+  T unwrap() => error;
+
+  @override
+  String toString() {
+    final sanitized = sanitizeForCrashReport(error.toString());
+    final ctx = context;
+    // Use the inner error's runtime type rather than the generic [T] —
+    // most call sites live inside `catch (e, st)` blocks where `e` is
+    // statically `Object`, so `T` would erase the actual inner type.
+    final innerType = error.runtimeType;
+    return ctx == null
+        ? 'Reportable<$innerType>: $sanitized'
+        : 'Reportable<$innerType>($ctx): $sanitized';
+  }
+}
+
+final RegExp _npubPattern = RegExp('npub1[a-z0-9]+');
+final RegExp _nsecPattern = RegExp('nsec1[a-z0-9]+');
+
+/// Strips Nostr `npub1…` and `nsec1…` identifiers from [input] before it is
+/// forwarded to a third-party crash reporter.
+///
+/// Scope is intentionally narrow: only `npub` (public-key bech32) and `nsec`
+/// (private-key bech32). Other Nostr-format references (`note1`, `nevent1`,
+/// `nprofile1`) encode event/profile pointers, not secrets, and removing them
+/// removes triage value. Call sites that need to redact those should do so
+/// explicitly before constructing the error message.
+String sanitizeForCrashReport(String input) {
+  return input
+      .replaceAll(_npubPattern, 'npub1<redacted>')
+      .replaceAll(_nsecPattern, 'nsec1<redacted>');
+}

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
+import 'package:openvine/observability/reportable_error.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 
 class _MockLikesRepository extends Mock implements LikesRepository {}
@@ -672,7 +673,13 @@ void main() {
             error: VideoInteractionsError.likeFailed,
           ),
         ],
-        errors: () => [isA<StateError>()],
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(

--- a/mobile/test/observability/divine_bloc_observer_test.dart
+++ b/mobile/test/observability/divine_bloc_observer_test.dart
@@ -1,0 +1,148 @@
+// ABOUTME: Tests for DivineBlocObserver — gates Crashlytics forwarding on
+// ABOUTME: ReportableError, sanitizes the reason annotation, and preserves
+// ABOUTME: Log.error coverage for every Bloc onError trigger.
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/observability/divine_bloc_observer.dart';
+import 'package:openvine/observability/reportable_error.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
+
+class _MockCrashReportingService extends Mock
+    implements CrashReportingService {}
+
+class _CountCubit extends Cubit<int> {
+  _CountCubit() : super(0);
+
+  void boom(Object error, StackTrace stackTrace) => addError(error, stackTrace);
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(StackTrace.current);
+  });
+
+  group(DivineBlocObserver, () {
+    late _MockCrashReportingService mockCrash;
+    late DivineBlocObserver observer;
+
+    setUp(() {
+      mockCrash = _MockCrashReportingService();
+      when(
+        () => mockCrash.recordError(
+          any<dynamic>(),
+          any<StackTrace?>(),
+          reason: any(named: 'reason'),
+        ),
+      ).thenAnswer((_) async {});
+      observer = DivineBlocObserver(crashReporting: mockCrash);
+    });
+
+    test('forwards Reportable errors to CrashReportingService.recordError', () {
+      final cubit = _CountCubit();
+      addTearDown(cubit.close);
+
+      final stack = StackTrace.current;
+      final error = Reportable(StateError('boom'), context: 'test');
+
+      observer.onError(cubit, error, stack);
+
+      verify(
+        () => mockCrash.recordError(
+          error,
+          stack,
+          reason: 'Bloc.addError _CountCubit',
+        ),
+      ).called(1);
+    });
+
+    test('annotates the report with the bloc runtime type', () {
+      final cubit = _CountCubit();
+      addTearDown(cubit.close);
+
+      observer.onError(
+        cubit,
+        Reportable(StateError('x')),
+        StackTrace.current,
+      );
+
+      verify(
+        () => mockCrash.recordError(
+          any<dynamic>(),
+          any<StackTrace?>(),
+          reason: any(named: 'reason', that: contains('_CountCubit')),
+        ),
+      ).called(1);
+    });
+
+    test('does not forward non-Reportable errors to Crashlytics', () {
+      final cubit = _CountCubit();
+      addTearDown(cubit.close);
+
+      observer.onError(cubit, Exception('domain failure'), StackTrace.current);
+
+      verifyNever(
+        () => mockCrash.recordError(
+          any<dynamic>(),
+          any<StackTrace?>(),
+          reason: any(named: 'reason'),
+        ),
+      );
+    });
+
+    test('records a Reportable whose toString sanitizes npub identifiers', () {
+      final cubit = _CountCubit();
+      addTearDown(cubit.close);
+
+      const npub =
+          'npub1abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvw';
+      final error = Reportable(
+        StateError('No public key for $npub during cold start'),
+        context: '_publishLike',
+      );
+
+      observer.onError(cubit, error, StackTrace.current);
+
+      final captured = verify(
+        () => mockCrash.recordError(
+          captureAny<dynamic>(),
+          any<StackTrace?>(),
+          reason: any(named: 'reason'),
+        ),
+      ).captured;
+      expect(captured, hasLength(1));
+      expect(captured.single.toString(), contains('npub1<redacted>'));
+      expect(captured.single.toString(), isNot(contains(npub)));
+    });
+
+    test(
+      'integration: addError(Reportable) on a Cubit triggers recordError once',
+      () async {
+        final previousObserver = Bloc.observer;
+        Bloc.observer = observer;
+        addTearDown(() => Bloc.observer = previousObserver);
+
+        final cubit = _CountCubit();
+        addTearDown(cubit.close);
+
+        cubit.boom(
+          Reportable(Exception('e2e'), context: 'integration'),
+          StackTrace.current,
+        );
+
+        // addError dispatches to the bloc error stream via a microtask;
+        // drain it before verifying the synchronous expectation.
+        await Future<void>.delayed(Duration.zero);
+
+        verify(
+          () => mockCrash.recordError(
+            any<dynamic>(that: isA<ReportableError>()),
+            any<StackTrace?>(),
+            reason: 'Bloc.addError _CountCubit',
+          ),
+        ).called(1);
+      },
+    );
+  });
+}

--- a/mobile/test/observability/reportable_error_test.dart
+++ b/mobile/test/observability/reportable_error_test.dart
@@ -1,0 +1,115 @@
+// ABOUTME: Tests for ReportableError marker, Reportable<T> wrapper, and the
+// ABOUTME: npub/nsec sanitizer that runs on Reportable.toString().
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/observability/reportable_error.dart';
+
+void main() {
+  group(Reportable, () {
+    test('is an Exception', () {
+      final wrapped = Reportable(StateError('boom'));
+
+      expect(wrapped, isA<Exception>());
+    });
+
+    test('is a ReportableError', () {
+      final wrapped = Reportable(StateError('boom'));
+
+      expect(wrapped, isA<ReportableError>());
+    });
+
+    test('unwrap returns the inner error identity', () {
+      final inner = StateError('boom');
+      final wrapped = Reportable(inner);
+
+      expect(identical(wrapped.unwrap(), inner), isTrue);
+    });
+
+    test('toString includes the inner type and the inner message', () {
+      final wrapped = Reportable(StateError('something broke'));
+
+      expect(wrapped.toString(), contains('StateError'));
+      expect(wrapped.toString(), contains('something broke'));
+    });
+
+    test('toString includes the context annotation when provided', () {
+      final wrapped = Reportable(
+        StateError('boom'),
+        context: '_publishLike',
+      );
+
+      expect(wrapped.toString(), contains('_publishLike'));
+    });
+
+    test('toString omits the context annotation when null', () {
+      final wrapped = Reportable(StateError('boom'));
+
+      expect(wrapped.toString(), isNot(contains('()')));
+    });
+
+    test('toString sanitizes npub identifiers in the inner message', () {
+      const npub =
+          'npub1abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvw';
+      final wrapped = Reportable(
+        StateError('No public key for $npub during cold start'),
+      );
+
+      expect(wrapped.toString(), contains('npub1<redacted>'));
+      expect(wrapped.toString(), isNot(contains(npub)));
+    });
+
+    test('toString sanitizes nsec identifiers in the inner message', () {
+      const nsec =
+          'nsec1abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvw';
+      final wrapped = Reportable(
+        StateError('Signer leaked $nsec to logs'),
+      );
+
+      expect(wrapped.toString(), contains('nsec1<redacted>'));
+      expect(wrapped.toString(), isNot(contains(nsec)));
+    });
+  });
+
+  group('sanitizeForCrashReport', () {
+    test('replaces a single npub with the redaction marker', () {
+      const input =
+          'No public key for npub1abcdefghijklmnopqrstuvwxyz0123456789abcdefg';
+
+      expect(
+        sanitizeForCrashReport(input),
+        'No public key for npub1<redacted>',
+      );
+    });
+
+    test('replaces a single nsec with the redaction marker', () {
+      const input = 'leaked nsec1qwertyuiopasdfghjklzxcvbnm0123456789abcdef';
+
+      expect(sanitizeForCrashReport(input), 'leaked nsec1<redacted>');
+    });
+
+    test('replaces multiple identifiers in the same string', () {
+      const input =
+          'npub1aaaaaaaaaaaaaaaaaaaaaaaa shared nsec1bbbbbbbbbbbbbbbbbbbbbbbb';
+      final out = sanitizeForCrashReport(input);
+
+      expect(out, contains('npub1<redacted>'));
+      expect(out, contains('nsec1<redacted>'));
+      expect(out, isNot(contains('npub1aaa')));
+      expect(out, isNot(contains('nsec1bbb')));
+    });
+
+    test('is a no-op for strings without nostr identifiers', () {
+      const input = 'plain old failure with no nostr keys here';
+
+      expect(sanitizeForCrashReport(input), equals(input));
+    });
+
+    test('does not redact note1 / nevent1 / nprofile1 references', () {
+      // These encode pointers, not secrets — explicitly out of scope.
+      const input =
+          'failed to fetch note1abcdefghijklmnopqrstuvwxyz0123456789abcdef';
+
+      expect(sanitizeForCrashReport(input), equals(input));
+    });
+  });
+}


### PR DESCRIPTION
## Description

`addError(error, stackTrace)` calls inside BLoCs/Cubits had no registered observer — they flowed into the bloc error stream and were swallowed. Surfaced during the #3503 cold-launch race investigation: `VideoInteractionsBloc._publishLike`'s `addError` was the only signal of the `StateError`, with no production telemetry on it.

The original commit on this branch wired a project-wide `BlocObserver` that forwarded **every** `onError` to Crashlytics. Per @hm21's review, that design floods the dashboard with expected domain errors (network timeouts, "no public key yet" during cold start, 4xx responses, validation failures) — exactly the noise that motivated the original investigation. This push pivots to a **classification-first** design and re-scopes the work as **PR1 of a 7-PR stack**.

**Related Issue:** Closes #3526.

## What this adds (PR1)

1. **`mobile/lib/observability/reportable_error.dart`** — empty marker interface `ReportableError implements Exception` plus a `Reportable<T extends Object>` wrapper for foreign exception types whose source can't be modified. The wrapper exposes `unwrap()` and a sanitized `toString()` that uses `error.runtimeType` (rather than the generic `T`), so the inner exception class survives Dart's `catch (e)` `Object`-erasure and Crashlytics still groups by the actual type.
2. **`sanitizeForCrashReport(String)`** — strips `npub1…` / `nsec1…` from any string before it leaves the device. `note1` / `nevent1` / `nprofile1` are intentionally left intact (pointers, not secrets — removing them removes triage value).
3. **`mobile/lib/observability/divine_bloc_observer.dart`** — `Log.error` runs for **every** `onError` (so the in-memory bug-report capture flow stays complete). Crashlytics forwarding is gated:
   ```dart
   if (error is! ReportableError) return;
   final reason = sanitizeForCrashReport('Bloc.addError $runtimeType');
   unawaited(_crashReporting.recordError(error, stackTrace, reason: reason));
   ```
4. **`mobile/lib/blocs/video_interactions/video_interactions_bloc.dart`** — `_publishLike` migrated to `addError(Reportable(e, context: '_publishLike'), st)` so the `StateError` path that motivated #3503 stays covered from PR1 forward. Other ~60 `addError` sites are intentionally un-marked; they migrate by feature area in PR2–PR7.
5. **`.claude/rules/error_handling.md`** — new "Reportable errors and Crashlytics" section: decision matrix, migration recipe, PII note, test pattern.
6. **Tests** — new `test/observability/reportable_error_test.dart` (13 cases covering marker conformance, sanitizer, context, runtime-type fidelity) and a pivoted `divine_bloc_observer_test.dart` (5 cases: forwards `Reportable`, annotates with bloc runtime type, **skips non-Reportable**, sanitizes npub in the recorded payload, integration test with `await Future<void>.delayed(Duration.zero)` to drain the bloc-error microtask). Updated one assertion in `video_interactions_bloc_test.dart` to match the migrated call site.

`main.dart` wiring (`Bloc.observer = DivineBlocObserver()` between `initializeDateFormatting()` and `runApp`) was already in place from the previous commit and is unchanged.

## Decision matrix (lives in `error_handling.md`)

| Category | Reportable? |
|---|---|
| Network / IO (timeout, dropped connection, DNS) | NO |
| API / domain (4xx, server validation) | NO |
| Auth / session (token expired, signed out) | NO |
| Form / business-rule validation | NO |
| `StateError`, `TypeError`, `RangeError` | YES |
| Project-owned `*InvariantException` types | YES |
| When in doubt | NO |

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Test plan

- [x] Format: `dart format --output=none --set-exit-if-changed lib/observability lib/blocs/video_interactions/video_interactions_bloc.dart test/observability test/blocs/video_interactions/video_interactions_bloc_test.dart` — 0 changed.
- [x] Analyze: `flutter analyze lib/observability lib/blocs/video_interactions test/observability test/blocs/video_interactions` — no issues.
- [x] Tests: `flutter test test/observability/ test/blocs/video_interactions/video_interactions_bloc_test.dart` — 65 / 65 pass.
- [ ] Manual smoke (post-merge): trigger a synthetic `Reportable(StateError(...))` in release-flavor debug build and confirm it lands in Crashlytics with `reason: Bloc.addError <BlocType>` and a sanitized message; trigger a non-Reportable `Exception(...)` and confirm it does **not**.
- [ ] CI: `Analyze`, `Tests`, `Format`, `Generated Files`, `build` all green on the PR.

## Out of scope (filed separately or follow-ups)

- **Migration sweep — PR2 through PR7.** Each follow-up PR migrates one feature area to `addError(Reportable(e, context: '<callsite>'), st)` and ships a per-site classification table citing the matrix row, so the review is "validate the matrix application" rather than "re-derive each call." Coverage widens monotonically — `_publishLike` is covered from PR1, no multi-week observability vacuum.

  | PR | Area | Sites |
  |---|---|---|
  | PR2 | search / discovery | ~10 |
  | PR3 | DM / messaging | ~12 |
  | PR4 | profile | ~6 |
  | PR5 | video editor / clips | ~10 |
  | PR6 | welcome / settings / publish | ~9 |
  | PR7 | notifications | ~5 |

- **#3525 (dead `VideoInteractionsState.error` field).** Not folded in. The dead-field assertion is referenced by 9 existing bloc tests including the #3503 regression test added in PR #3522, so removing the field is non-trivial test churn that belongs in its own PR. With this observer in place, the field's *observability* function is fully replaced by Crashlytics, so a follow-up removal is now safe.
- **Migrating `Log.error + addError` pairs to a single `addError`.** Out of scope per #3526's "Out of scope" note. Sweep filed for after PR7.
- **Enriched Crashlytics context (event name, state snapshot, build tag).** Separate observability layer (custom keys via `BlocObserver.onTransition` / `onChange`); happy to file as a follow-up issue if reviewers want it tracked.

Stacked-plan parents: #3522 (originating investigation), #3503 (motivating bug), #3525 (dead-field follow-up), #3527 (Riverpod-into-AsyncValue RFC), #3533 (parallel Riverpod-into-BlocProvider docs PR).