### PR TITLE
chore(video_interactions): remove dead VideoInteractionsState.error field

### DIFF
--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -183,24 +183,19 @@ class VideoInteractionsBloc
               ? repostCount
               : null,
           commentCount: commentCount,
-          clearError: true,
         ),
       );
-    } catch (e) {
+    } catch (e, stackTrace) {
       Log.error(
         'VideoInteractionsBloc: Failed to fetch for $_eventId - $e',
         name: 'VideoInteractionsBloc',
         category: LogCategory.system,
       );
+      addError(e, stackTrace);
 
       // Still mark as success if we have partial data
       // The UI can handle null counts gracefully
-      emit(
-        state.copyWith(
-          status: VideoInteractionsStatus.success,
-          error: VideoInteractionsError.fetchFailed,
-        ),
-      );
+      emit(state.copyWith(status: VideoInteractionsStatus.success));
     }
   }
 
@@ -230,7 +225,6 @@ class VideoInteractionsBloc
         // copyWith treats null as "no change", so when the count hasn't
         // been fetched yet we leave it null (don't synthesize a 0).
         likeCount: _adjustCount(wasCount, increment: optimisticLiked),
-        clearError: true,
       ),
     );
 
@@ -303,11 +297,7 @@ class VideoInteractionsBloc
         emit(state.copyWith(isLiked: false, likeCount: event.wasCount));
       case _LikeSettleFailed(:final wasLiked):
         emit(
-          state.copyWith(
-            isLiked: wasLiked,
-            likeCount: event.wasCount,
-            error: VideoInteractionsError.likeFailed,
-          ),
+          state.copyWith(isLiked: wasLiked, likeCount: event.wasCount),
         );
     }
   }
@@ -342,7 +332,6 @@ class VideoInteractionsBloc
         name: 'VideoInteractionsBloc',
         category: LogCategory.system,
       );
-      emit(state.copyWith(error: VideoInteractionsError.repostFailed));
       return;
     }
 
@@ -354,7 +343,6 @@ class VideoInteractionsBloc
       state.copyWith(
         isReposted: optimisticReposted,
         repostCount: _adjustCount(wasCount, increment: optimisticReposted),
-        clearError: true,
       ),
     );
 
@@ -425,11 +413,7 @@ class VideoInteractionsBloc
         emit(state.copyWith(isReposted: false, repostCount: event.wasCount));
       case _RepostSettleFailed(:final wasReposted):
         emit(
-          state.copyWith(
-            isReposted: wasReposted,
-            repostCount: event.wasCount,
-            error: VideoInteractionsError.repostFailed,
-          ),
+          state.copyWith(isReposted: wasReposted, repostCount: event.wasCount),
         );
     }
   }

--- a/mobile/lib/blocs/video_interactions/video_interactions_state.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_state.dart
@@ -42,7 +42,6 @@ class VideoInteractionsState extends Equatable {
     this.repostCount,
     this.commentCount,
     this.isCommentsInProgress = false,
-    this.error,
   });
 
   /// Current status of the bloc.
@@ -69,9 +68,6 @@ class VideoInteractionsState extends Equatable {
   /// Whether a comments operation is currently in progress.
   final bool isCommentsInProgress;
 
-  /// Error that occurred, if any.
-  final VideoInteractionsError? error;
-
   /// Whether interaction counts are still loading.
   bool get isLoading =>
       status == VideoInteractionsStatus.initial ||
@@ -89,8 +85,6 @@ class VideoInteractionsState extends Equatable {
     int? repostCount,
     int? commentCount,
     bool? isCommentsInProgress,
-    VideoInteractionsError? error,
-    bool clearError = false,
   }) {
     return VideoInteractionsState(
       status: status ?? this.status,
@@ -100,7 +94,6 @@ class VideoInteractionsState extends Equatable {
       repostCount: repostCount ?? this.repostCount,
       commentCount: commentCount ?? this.commentCount,
       isCommentsInProgress: isCommentsInProgress ?? this.isCommentsInProgress,
-      error: clearError ? null : (error ?? this.error),
     );
   }
 
@@ -113,18 +106,5 @@ class VideoInteractionsState extends Equatable {
     repostCount,
     commentCount,
     isCommentsInProgress,
-    error,
   ];
-}
-
-/// Errors that can occur in video interactions.
-enum VideoInteractionsError {
-  /// Failed to fetch counts.
-  fetchFailed,
-
-  /// Failed to toggle like.
-  likeFailed,
-
-  /// Failed to toggle repost.
-  repostFailed,
 }

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -78,7 +78,6 @@ void main() {
       expect(bloc.state.isReposted, isFalse);
       expect(bloc.state.repostCount, isNull);
       expect(bloc.state.commentCount, isNull);
-      expect(bloc.state.error, isNull);
       bloc.close();
     });
 
@@ -281,7 +280,7 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'emits [loading, success] with error when fetch fails',
+        'emits [loading, success] and reports addError when fetch fails',
         setUp: () {
           when(
             () => mockLikesRepository.isLiked(testEventId),
@@ -291,11 +290,9 @@ void main() {
         act: (bloc) => bloc.add(const VideoInteractionsFetchRequested()),
         expect: () => [
           const VideoInteractionsState(status: VideoInteractionsStatus.loading),
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
-            error: VideoInteractionsError.fetchFailed,
-          ),
+          const VideoInteractionsState(status: VideoInteractionsStatus.success),
         ],
+        errors: () => [isA<Exception>()],
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
@@ -591,12 +588,11 @@ void main() {
             isLiked: true,
           ),
           // Rollback after the publish failure restores the pre-tap heart
-          // state and surfaces the error.
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
-            error: VideoInteractionsError.likeFailed,
-          ),
+          // state. The failure itself is surfaced via addError, asserted
+          // below.
+          const VideoInteractionsState(status: VideoInteractionsStatus.success),
         ],
+        errors: () => [isA<Exception>()],
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
@@ -624,9 +620,9 @@ void main() {
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
             likeCount: 10,
-            error: VideoInteractionsError.likeFailed,
           ),
         ],
+        errors: () => [isA<Exception>()],
       );
 
       // Regression for #3503: when the home feed mounts a feed item whose
@@ -634,8 +630,8 @@ void main() {
       // Nostr instance with an empty cached public key), every sendLike
       // surfaces as `StateError('No public key available …')` from
       // `Nostr.ensurePublicKey`. The bloc must roll back the optimistic
-      // flip and surface `VideoInteractionsError.likeFailed` — not crash
-      // and not leave the heart filled. The fix in
+      // flip and surface the StateError via `addError` — not crash and
+      // not leave the heart filled. The fix in
       // `_PooledVideoFeedItem.build` (video_feed_page.dart) prevents the
       // stale snapshot in the first place; this test pins the bloc-side
       // behaviour so a future change to `ensurePublicKey`'s error type
@@ -669,7 +665,6 @@ void main() {
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
             likeCount: 5,
-            error: VideoInteractionsError.likeFailed,
           ),
         ],
         errors: () => [isA<StateError>()],
@@ -1018,18 +1013,16 @@ void main() {
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
-        'emits error when no addressable ID is present',
+        'no-ops when no addressable ID is present',
         build: createBloc, // No addressable ID
         seed: () => const VideoInteractionsState(
           status: VideoInteractionsStatus.success,
         ),
         act: (bloc) => bloc.add(const VideoInteractionsRepostToggled()),
-        expect: () => [
-          const VideoInteractionsState(
-            status: VideoInteractionsStatus.success,
-            error: VideoInteractionsError.repostFailed,
-          ),
-        ],
+        // The handler logs a warning and returns early — no state emit, no
+        // addError. Reposting a non-addressable video is a precondition
+        // failure, not an exceptional error worth Crashlytics noise.
+        expect: () => const <VideoInteractionsState>[],
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
@@ -1106,9 +1099,9 @@ void main() {
           const VideoInteractionsState(
             status: VideoInteractionsStatus.success,
             repostCount: 5,
-            error: VideoInteractionsError.repostFailed,
           ),
         ],
+        errors: () => [isA<Exception>()],
       );
 
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
@@ -1388,16 +1381,6 @@ void main() {
       expect(updated.isLiked, isTrue);
       expect(updated.likeCount, 42);
       expect(updated.commentCount, 10);
-    });
-
-    test('copyWith clearError clears error', () {
-      const state = VideoInteractionsState(
-        error: VideoInteractionsError.likeFailed,
-      );
-
-      final updated = state.copyWith(clearError: true);
-
-      expect(updated.error, isNull);
     });
   });
 }

--- a/mobile/test/screens/feed/pooled_video_feed_item_repo_swap_test.dart
+++ b/mobile/test/screens/feed/pooled_video_feed_item_repo_swap_test.dart
@@ -310,11 +310,6 @@ void main() {
           isNull,
           reason: 'new bloc should not inherit blocBefore.likeCount',
         );
-        expect(
-          blocAfter.state.error,
-          isNull,
-          reason: 'new bloc should not inherit blocBefore.error',
-        );
       },
     );
   });


### PR DESCRIPTION
## Description

`VideoInteractionsState.error` was set by the bloc on four paths but read by no widget — the user's perception of "like failed" is the optimistic-flip-then-rollback animation, not a snackbar or icon driven by this field. Surfaced during the #3503 investigation.

**Related Issue:** Closes #3525.

## What this removes

- `VideoInteractionsError? error` field on the state
- `VideoInteractionsError` enum (`fetchFailed | likeFailed | repostFailed`)
- `clearError` parameter on `copyWith`
- All four bloc-side set sites and three `clearError: true` resets

## Behavior changes (intentional)

1. **`_onFetchRequested` catch block.** Previously `Log.error(...)` + `emit(state.copyWith(status: success, error: fetchFailed))`. Now `Log.error(...)` + `addError(e, stackTrace)` + `emit(state.copyWith(status: success))`. The `addError` brings the fetch path into the same `Log.error + addError` pattern already used by `_publishLike` and `_publishRepost`, so failures route through `DivineBlocObserver` (#3534) into Crashlytics.

2. **`_onRepostToggled` no-addressable-id guard.** Previously `Log.warning(...)` + `emit(state.copyWith(error: repostFailed))`. The emit was a no-op via the dead field; now just `Log.warning(...) + return`. Reposting a non-addressable video is a precondition failure (the video has no d-tag), not an exceptional error worth Crashlytics noise — `Log.warning` is the right signal level.

3. **`_LikeSettleFailed` / `_RepostSettleFailed` reconcile branches.** Drop `error: ...` from the rollback emit. Failure is still surfaced via `addError(e, stackTrace)` inside `_publishLike` / `_publishRepost`, which already runs before the settle event is dispatched. The state transition (count + isLiked/isReposted return to baseline) is the user-visible part.

## Test rewrites

- 9 sites in `video_interactions_bloc_test.dart` drop `error: VideoInteractionsError.xxx` from `expect:` state literals.
- Tests where the bloc now `addError`s gain `errors: () => [isA<Exception>()]` (or `isA<StateError>()` for the #3503 regression).
- `'emits error when no addressable ID is present'` renamed to `'no-ops when no addressable ID is present'`, expects no state emit.
- `expect(bloc.state.error, isNull)` in the initial-state test removed.
- `'copyWith clearError clears error'` test deleted (`clearError` no longer exists).
- `pooled_video_feed_item_repo_swap_test.dart`: drop the stale `expect(blocAfter.state.error, isNull, ...)` assertion. The two remaining assertions (`isLiked`, `likeCount`) still pin the state-loss-on-swap contract introduced in PR #3522.

## Type of Change

- [x] 🧹 Code refactor

## Test plan

- [x] Format: `dart format --output=none --set-exit-if-changed lib/blocs/video_interactions/ test/blocs/video_interactions/ test/screens/feed/pooled_video_feed_item_repo_swap_test.dart` — 0 changed.
- [x] Analyze: `flutter analyze lib/blocs/video_interactions/ test/blocs/video_interactions/ test/screens/feed/pooled_video_feed_item_repo_swap_test.dart` — no issues.
- [x] Pre-commit hook (full `flutter analyze lib test integration_test` over 2000 files) passed locally.
- [x] Tests: `flutter test test/blocs/video_interactions/video_interactions_bloc_test.dart test/screens/feed/pooled_video_feed_item_repo_swap_test.dart` — 49 / 49 pass.
- [ ] CI: `Analyze`, `Tests`, `Format`, `Generated Files`, `build` all green.

## Relationship to the #3503 follow-ups

This is step 6 of the #3503 brainstorm punch list. The four predecessors:

| # | Status | What |
|---|--------|------|
| #3522 | merged (in main) | Point fix: four feed-item `BlocProvider` sites bound to repo identity via `ref.watch` + record `ValueKey` |
| #3533 | open | Codifies the Riverpod-into-`BlocProvider` bridge rule + self-review checklist bullet |
| #3534 | open | `DivineBlocObserver` forwards `addError` to Crashlytics (the observability replacement that makes this PR's removal safe) |
| #3523 | deferred | Pattern A consistency — see [comment](https://github.com/divinevideo/divine-mobile/issues/3523#issuecomment-4338247037) |

Files in this PR are disjoint from #3533 and #3534, so it can land in any order. The `_onFetchRequested` `addError` addition only becomes user-visible (Crashlytics signal) once #3534 lands; until then it's a no-op (no observer registered).

## Out of scope

- Other states with their own `error` field + `clearError` flag (`ProfileLikedVideosState`, `ProfileSavedVideosState`, `ProfileRepostedVideosState`, `VideoFeedState`, `ClipManagerState`) are untouched. Each is a separate decision — some of those `error` fields are read by widgets (e.g. `comments_screen.dart:204` reads `state.error`, `video_feed_page.dart:569` reads `_FeedErrorWidget(error: state.error)`). #3525 was scoped to `VideoInteractionsState` specifically.
- Migrating the `Log.error + addError` pairs to a single `addError` (the observer makes the explicit `Log.error` redundant) — out of scope per #3526's note.
