### PR TITLE
docs(rules): extend Riverpod-into-bloc bridge rule to stateful widgets (#3533 follow-up)

### DIFF
--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -95,6 +95,14 @@ State management:
   `ValueKey` over the dependency tuple. `ref.read` here silently
   captures stale state on the next dep rebuild — see
   [`state_management.md`](state_management.md#bridging-riverpod-provided-dependencies-into-blocprovider).
+- [ ] No `ConsumerStatefulWidget` constructs a bloc with
+  `late final SomeBloc _bloc = SomeBloc(repo: ref.read(...Provider))`
+  in `initState` capturing an identity-flippable Riverpod
+  dependency. The preferred fix is the Page/View split — push bloc
+  construction into a `ConsumerWidget` parent that wraps a stateful
+  child via `BlocProvider`-keyed-on-identity (the existing rule
+  then covers the parent). See
+  [`state_management.md`](state_management.md#stateful-widgets-that-hold-the-captured-dep-bloc-directly).
 - [ ] No error strings / exception objects in BLoC `state`. Use status
   enums + `addError`. See [`state_management.md`](state_management.md).
 - [ ] No mutable instance variables on a BLoC class. All state lives in

--- a/.claude/rules/state_management.md
+++ b/.claude/rules/state_management.md
@@ -421,6 +421,184 @@ If the surrounding widget is a `ConsumerWidget` /
 
 ---
 
+## Stateful widgets that hold the captured-dep bloc directly
+
+The same capture trap reproduces in a different shape:
+`ConsumerStatefulWidget` whose `State` constructs a bloc in
+`initState` and holds it via `late final`. The `ref.read` calls
+inside `initState` capture whichever instance each provider
+returned at that moment, and the `late final` field can never be
+reassigned — so the captured chain is permanent for the widget's
+lifetime, even across auth flips and account switches. Greppable
+shape:
+
+```dart
+class _MyState extends ConsumerState<MyWidget> {
+  late final SomeBloc _bloc;
+
+  @override
+  void initState() {
+    super.initState();
+    _bloc = SomeBloc(
+      repository: ref.read(someRepositoryProvider), // WRONG
+    );
+  }
+}
+```
+
+The `BlocProvider`-keyed-on-identity rule above doesn't apply
+directly — there is no `BlocProvider` at the construction site to
+attach a `ValueKey` to.
+
+### Preferred fix: Page/View split
+
+Push the bloc construction up into a `ConsumerWidget` parent that
+wraps a `StatefulWidget` child via `BlocProvider`, and have the
+stateful child consume the bloc through `context.read<Bloc>()`.
+The parent then uses the existing rule (record-typed `ValueKey`
+over the captured provider tuple) — no new shape introduced. This
+matches the four canonical existing examples in this codebase:
+`_PooledVideoFeedItem` / `_PooledVideoFeedItemContent` in
+`video_feed_page.dart`, and `_PooledFullscreenItem` /
+`_PooledFullscreenItemContent` in
+`pooled_fullscreen_video_feed_screen.dart`. It also follows the
+Page/View pattern in [`ui_theming.md`](ui_theming.md) and the
+constructor-injection guidance in
+[`architecture.md`](architecture.md) — the stateful child stops
+reaching into Riverpod for its dependencies.
+
+**Skeleton:**
+
+```dart
+class _MyParent extends ConsumerWidget {
+  const _MyParent({required this.input});
+
+  final InputType input;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final repo1 = ref.watch(repo1Provider);
+    final repo2 = ref.watch(repo2Provider);
+    return BlocProvider<MyBloc>(
+      key: ValueKey((repo1, repo2)),
+      create: (_) => MyBloc(repo1: repo1, repo2: repo2)
+        ..add(const MyInitialEvent()),
+      child: _MyChild(input: input),
+    );
+  }
+}
+
+class _MyChild extends StatefulWidget {
+  const _MyChild({required this.input});
+
+  final InputType input;
+
+  @override
+  State<_MyChild> createState() => _MyChildState();
+}
+
+class _MyChildState extends State<_MyChild> {
+  // animation controllers, ValueNotifiers, scroll listeners, …
+
+  @override
+  Widget build(BuildContext context) {
+    final bloc = context.read<MyBloc>();
+    // …
+  }
+}
+```
+
+The split lets the parent own dependency lifecycle and the child
+own local UI state, which is the same separation the existing four
+sites already use.
+
+### Workaround when refactor is blocked
+
+When splitting the widget isn't feasible in scope (e.g. the
+stateful logic tangles with the bloc lifecycle in a way the
+refactor would balloon), snapshot the captured deps in `initState`
+and use `ref.listen` in `build` to detect identity changes and
+rebuild the bloc. The codebase already uses `ref.listen`-in-`build`
+for forwarding Riverpod signals to a Bloc (see
+`my_followers_screen.dart`'s blocklist invalidation handler) — this
+extends the same idiom to "rebuild the bloc itself when its
+captured deps change identity":
+
+```dart
+late MyBloc _bloc;
+late (Repo1, Repo2) _captured;
+
+@override
+void initState() {
+  super.initState();
+  _captured = (
+    ref.read(repo1Provider),
+    ref.read(repo2Provider),
+  );
+  _bloc = _createBloc(_captured)..add(const MyInitialEvent());
+}
+
+@override
+Widget build(BuildContext context) {
+  ref.listen<Repo1>(repo1Provider, (_, _) => _maybeRecreate());
+  ref.listen<Repo2>(repo2Provider, (_, _) => _maybeRecreate());
+  return BlocProvider<MyBloc>.value(
+    value: _bloc,
+    child: const _MyChild(),
+  );
+}
+
+void _maybeRecreate() {
+  if (!mounted) return;
+  final fresh = (
+    ref.read(repo1Provider),
+    ref.read(repo2Provider),
+  );
+  if (fresh == _captured) return;
+  _bloc.close();
+  _captured = fresh;
+  setState(() {
+    _bloc = _createBloc(fresh)..add(const MyInitialEvent());
+  });
+}
+
+@override
+void dispose() {
+  _bloc.close();
+  super.dispose();
+}
+
+MyBloc _createBloc((Repo1, Repo2) deps) {
+  final (repo1, repo2) = deps;
+  return MyBloc(repo1: repo1, repo2: repo2);
+}
+```
+
+This is a fallback, not the primary recommendation. It introduces
+a shape that doesn't currently appear elsewhere in the codebase
+and bypasses the established Page/View precedent. Prefer the
+refactor when reasonable.
+
+The same state-loss tradeoff applies as the `BlocProvider` case:
+each recreate drops in-flight optimistic state and pending
+publishes, which is the correct behaviour when the underlying
+repository is bound to a different signer / `NostrClient` / user.
+
+### Detection
+
+```
+grep -rn "late\s\+\(final\s\+\)\?[A-Z][A-Za-z]*\(Bloc\|Cubit\)\b" mobile/lib --include="*.dart"
+```
+
+For each hit, check `initState` for `ref.read(...Provider)` calls
+that capture providers whose identity can flip (auth flip, account
+switch, sign-out, explicit `ref.invalidate`). Apply the same
+identity-flip judgment as the `BlocProvider.create:` case — if the
+captured provider rebuilds in response to runtime events, the
+`late final` field will go stale.
+
+---
+
 ## Persisting state across shell-route transitions
 
 Screens inside a `ShellRoute` whose content is gated on the current URL


### PR DESCRIPTION
Closes #3537

## Description

Extends the Riverpod-into-bloc bridge rule from PR #3533 to a second shape of the same trap: a `ConsumerStatefulWidget` whose `State` constructs a bloc in `initState` and holds it via `late final`. The `ref.read` calls inside `initState` capture whichever instance each provider returned at that moment, and the `late final` field can never be reassigned — so the captured chain is permanent for the widget's lifetime, even across auth flips and account switches.

PR #3533 (the parent of this stack) covered the `BlocProvider.create:` shape via record-typed `ValueKey` over the dependency tuple. This PR codifies the answer for the stateful-widget shape, which the parent rule explicitly does not address.

**Related:**
- Base PR: #3533 (sharpening of the parent rule per @hm21's review).
- Original incident: #3503 / #3522 (cold-launch race causing first feed-item likes to throw).

## What this adds

- **`.claude/rules/state_management.md`** — new top-level section "Stateful widgets that hold the captured-dep bloc directly", inserted immediately after the existing "Bridging Riverpod-provided dependencies into BlocProvider" section. The parent rule's anchor is unchanged. Covers:
  - The trap restated for the stateful shape (`late final` field captures permanently, no `BlocProvider` to attach a `ValueKey` to)
  - **Preferred fix: Page/View split.** Move bloc construction up into a `ConsumerWidget` parent wrapping a `StatefulWidget` child via `BlocProvider`, with the stateful child consuming via `context.read<Bloc>()`. Mirrors the four canonical existing examples (`_PooledVideoFeedItem` / `_PooledVideoFeedItemContent` in `video_feed_page.dart`; `_PooledFullscreenItem` / `_PooledFullscreenItemContent` in `pooled_fullscreen_video_feed_screen.dart`) and aligns with `ui_theming.md`'s Page/View pattern + `architecture.md`'s constructor-injection guidance.
  - **Fallback when refactor is blocked: `ref.listen`-in-`build` snapshot+recreate.** Documented explicitly as a workaround that introduces a new shape the codebase doesn't otherwise use — primary recommendation stays the refactor. Extends the existing `ref.listen`-in-`build` idiom (used in `my_followers_screen.dart` for forwarding Riverpod signals to a Bloc) to "rebuild the bloc itself when its captured deps change identity."
  - **Detection grep** for `late\s+(final\s+)?[A-Z][A-Za-z]*(Bloc|Cubit)` inside `ConsumerStatefulWidget` files.

- **`.claude/rules/self_review_checklist.md`** — one bullet added under "While implementing → State management", below the existing Riverpod-into-BlocProvider bullet, anchor-linked to the new section.

## Why prefer the Page/View split (vs `didChangeDependencies` snapshot+recreate)

The `BlocProvider`-keyed-on-identity pattern is already established at four sites in this codebase. The Page/View split lets a stateful widget reuse it unchanged: the parent (`ConsumerWidget`) handles dependency lifecycle and identity-flip; the child (`StatefulWidget`) holds local UI state with no Riverpod awareness. The existing rule then covers the parent without introducing anything new.

The alternative — snapshot in `initState` + compare in `didChangeDependencies` + `bloc.close()` + recreate — is functionally correct, but it adds a shape that doesn't currently appear in the codebase, requires per-site boilerplate, and bypasses the established pattern. It's documented as a fallback, not the primary recommendation, with `ref.listen`-in-`build` as the snapshot-trigger mechanism (consistent with how the codebase already drives Riverpod→Bloc signals).

## Greppable sites in `mobile/lib`

The detection grep currently surfaces five sites — listed here for reference, not committed-to as production fixes in this PR (per-site triage is out of scope; per-site PRs can land independently of this rule):

| Site | Bloc/Cubit | Captured providers |
|---|---|---|
| `widgets/video_feed_item/video_feed_item.dart` | `VideoInteractionsBloc` | likes / comments / repostsRepository — same three as #3503 |
| `widgets/video_feed_item/actions/share_action_button.dart` (`_UnifiedShareSheet`) | `ShareSheetBloc` | followRepository, bookmarkService, videoSharingService, currentEnvironment — production-relevant |
| `screens/settings/settings_screen.dart` | `SettingsAccountCubit` | authService (stable), draftStorageService (rebuilds on auth) |
| `screens/auth/email_verification_screen.dart` | `EmailVerificationCubit` | likely safe (auth screen unmounts on auth flip) |
| `screens/video_editor/video_editor_screen.dart` | `VideoEditorStickerBloc` / `ClipEditorBloc` / `TimelineOverlayBloc` | editor-local providers |

Each site needs its own triage to decide between Page/View refactor, `ref.listen` workaround, or "captured deps don't actually flip identity, leave as-is."

## Type of Change

- [x] 📝 Documentation

## Test plan

Documentation-only. No Dart files staged; pre-commit hook is Dart-only and skips cleanly.

Manual verification:

- [x] Pre-commit / pre-push hooks skip Dart checks (`No Dart files staged, skipping checks` confirmed on commit).
- [ ] Anchor link from the new self-review bullet (`state_management.md#stateful-widgets-that-hold-the-captured-dep-bloc-directly`) renders correctly on GitHub.
- [ ] Section reads end-to-end as self-contained.
- [ ] Existing PR #3533 anchor (`#bridging-riverpod-provided-dependencies-into-blocprovider`) still resolves — heading text is unchanged on the base branch.
- [ ] No CI gates relevant: changes are outside `mobile/`, so `Analyze` / `Tests` / `Format` / `Generated Files` / `build` workflows are not exercised by this diff.

## Stack

Base of this PR is **`docs/rules-riverpod-bloc-bridge`** (PR #3533), not `main`. When #3533 merges, GitHub will retarget this PR to `main` automatically. If #3533 is force-pushed during review, this branch needs a rebase onto the new tip — both branches are doc-only and textually-additive, so rebase is mechanical.
