### PR TITLE
fix(lifecycle): release video pool from app-root on background

### DIFF
--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -16,6 +16,7 @@ import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:openvine/services/screen_analytics_service.dart';
 import 'package:openvine/utils/log_message_batcher.dart';
+import 'package:pooled_video_player/pooled_video_player.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Handles app lifecycle events for video playback
@@ -140,6 +141,17 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
 
         if (_tickersEnabled) {
           setState(() => _tickersEnabled = false);
+        }
+
+        // Release pooled native video players eagerly so iOS can suspend.
+        // media_kit (mpv) keeps native dispatch loops, audio session and
+        // decoder sessions alive even when paused; iOS responds with
+        // RUNNINGBOARD 0xdead10cc (watchdog SIGKILL) if those resources
+        // are still held when the suspend window closes. The reactive
+        // pause-on-foreground-false chain only calls Player.pause(), which
+        // is not enough on its own — players must be disposed.
+        if (PlayerPool.isInitialized) {
+          unawaited(PlayerPool.instance.releaseAll());
         }
 
         // Active video pause is now handled by derived provider:

--- a/mobile/test/widgets/app_lifecycle_handler_release_pool_test.dart
+++ b/mobile/test/widgets/app_lifecycle_handler_release_pool_test.dart
@@ -1,0 +1,151 @@
+// ABOUTME: Verifies AppLifecycleHandler releases the PlayerPool on background.
+// ABOUTME: Prevents the iOS RUNNINGBOARD 0xdead10cc watchdog SIGKILL where
+// ABOUTME: media_kit (mpv) keeps native dispatch loops alive past suspension.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/background_activity_manager.dart';
+import 'package:openvine/services/video_visibility_manager.dart';
+import 'package:openvine/widgets/app_lifecycle_handler.dart';
+import 'package:pooled_video_player/pooled_video_player.dart';
+
+class _MockPlayerPool extends Mock implements PlayerPool {}
+
+class _FakeAuthService extends Fake implements AuthService {
+  // Broadcast stream that never emits — keeps the lifecycle handler's
+  // postFrameCallback awaiting an authenticated state for the lifetime
+  // of the test, so it never proceeds to read other providers we have
+  // not overridden. We deliberately do NOT close the controller in
+  // tearDown: a closed stream completes `firstWhere` with a StateError
+  // that surfaces as a post-test failure.
+  final _controller = StreamController<AuthState>.broadcast();
+
+  @override
+  bool get isAuthenticated => false;
+
+  @override
+  Stream<AuthState> get authStateStream => _controller.stream;
+}
+
+void main() {
+  late _MockPlayerPool mockPool;
+  late _FakeAuthService fakeAuthService;
+  late VideoVisibilityManager visibilityManager;
+
+  setUp(() {
+    mockPool = _MockPlayerPool();
+    fakeAuthService = _FakeAuthService();
+    visibilityManager = VideoVisibilityManager();
+
+    when(() => mockPool.releaseAll()).thenAnswer((_) async {});
+
+    PlayerPool.instanceForTesting = mockPool;
+    // BackgroundActivityManager is a process-wide singleton. Tests in this
+    // file share the same instance — reset it to foreground before each
+    // test so the next backgrounding triggers a fresh _onAppBackgrounded.
+    BackgroundActivityManager().onAppLifecycleStateChanged(
+      AppLifecycleState.resumed,
+    );
+  });
+
+  tearDown(() {
+    PlayerPool.instanceForTesting = null;
+    // Cancel the 30s _backgroundSuspensionTimer that _onAppBackgrounded
+    // schedules; otherwise flutter_test's _verifyInvariants asserts on
+    // pending timers and the test fails after passing assertions.
+    BackgroundActivityManager().onAppLifecycleStateChanged(
+      AppLifecycleState.resumed,
+    );
+  });
+
+  Future<void> pumpHandler(WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authServiceProvider.overrideWithValue(fakeAuthService),
+          videoVisibilityManagerProvider.overrideWithValue(visibilityManager),
+        ],
+        child: const MaterialApp(
+          home: AppLifecycleHandler(
+            child: SizedBox(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // Each test that transitions to paused/hidden must transition back to
+  // resumed before returning. _onAppBackgrounded schedules a 30s timer,
+  // and flutter_test's _verifyInvariants asserts no pending timers when
+  // the test body ends. _onAppResumed cancels the timer.
+  Future<void> drainBackgroundTimer(WidgetTester tester) async {
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+  }
+
+  testWidgets(
+    'releases PlayerPool when app transitions to paused',
+    (tester) async {
+      await pumpHandler(tester);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+
+      verify(() => mockPool.releaseAll()).called(1);
+
+      await drainBackgroundTimer(tester);
+    },
+  );
+
+  testWidgets(
+    'releases PlayerPool when app transitions to hidden',
+    (tester) async {
+      await pumpHandler(tester);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      await tester.pump();
+
+      verify(() => mockPool.releaseAll()).called(1);
+
+      await drainBackgroundTimer(tester);
+    },
+  );
+
+  testWidgets(
+    'does not release PlayerPool on inactive (desktop transient state)',
+    (tester) async {
+      await pumpHandler(tester);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+      await tester.pump();
+
+      verifyNever(() => mockPool.releaseAll());
+    },
+  );
+
+  testWidgets(
+    'does not crash when PlayerPool is not initialized',
+    (tester) async {
+      // Simulate uninitialized pool (e.g. on web where PlayerPool.init is
+      // skipped). The lifecycle handler must guard on isInitialized.
+      PlayerPool.instanceForTesting = null;
+
+      await pumpHandler(tester);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
+
+      // No assertion on the mock — it was never registered. Reaching this
+      // line means the guarded call did not throw.
+      verifyZeroInteractions(mockPool);
+
+      await drainBackgroundTimer(tester);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Adds an app-root `PlayerPool.releaseAll()` call in `AppLifecycleHandler.didChangeAppLifecycleState` on `paused` / `hidden`, guarded on `PlayerPool.isInitialized`.
- Defense-in-depth on top of #3442 — covers the gap where the user backgrounds from a non-feed screen (profile, DM, settings, single-video detail) while the pool still holds players from earlier viewing. `PooledVideoFeed`'s per-widget observer cannot fire when the widget is not mounted.
- `releaseAll()` keeps the pool reusable; new players are allocated lazily on resume. Existing post-`releaseAll` recreate path is exercised by the `PooledVideoFeed` lifecycle and `_FullscreenFeedContent` resume hook.

## Why

iOS RUNNINGBOARD sends `0xdead10cc` (watchdog SIGKILL) when the app fails to release native media resources before the background suspend window closes. mpv keeps its `core_thread` / `vo_thread` / `demux_thread` / dispatch queue alive even when the player is paused — disposal is required, not just pause. #3442 disposes via `PooledVideoFeed`'s own observer; this PR plugs the gap when no such widget is mounted.

See linked issue #3539 for the full crash analysis, references (djangocas.dev, inessential.com / Marco Arment) and reproduction steps.

## Diff scope

- `mobile/lib/widgets/app_lifecycle_handler.dart` — 1 import + 6 lines guarded on `PlayerPool.isInitialized`.
- `mobile/test/widgets/app_lifecycle_handler_release_pool_test.dart` — new file, 4 widget tests covering `paused`, `hidden`, `inactive` (must NOT release on desktop transient state), and uninitialized-pool guard.

## Test plan

- [x] `flutter analyze lib test integration_test` — clean.
- [x] `flutter test test/widgets/app_lifecycle_handler_release_pool_test.dart` — 4/4 pass.
- [x] `flutter test test/services/background_activity_manager_test.dart test/providers/app_lifecycle_provider_test.dart` — green (no regression in adjacent lifecycle tests).
- [x] `flutter test packages/pooled_video_player/test/controllers/player_pool_test.dart` — 66/66 pass (PlayerPool primitive untouched).
- [ ] **Manual on real iPhone 15 Pro / iOS 26.x TestFlight build** following the repro in #3539:
  - Open feed, scroll 3–5 videos to fill the pool, navigate to a profile screen, press home, wait 30–60 s, reopen.
  - Pre-PR build: app cold-relaunches with new `Runner-…ips` crash log under Analytics Data, `Termination Reason: RUNNINGBOARD 0xdead10cc`.
  - Post-PR build: app resumes cleanly. Console.app shows `📱 App backgrounded - clearing active video and pausing all videos` followed by clean resume.

## Notes for reviewers

- Order inside the `paused` / `hidden` branch: `setForeground(false)` runs first (existing CRITICAL invariant — disables visibility detection before anything else can re-enable a player). `releaseAll()` follows. `Future.microtask(visibilityManager.pauseAllVideos)` last (existing).
- `unawaited(...)` is intentional. The lifecycle method is `void`; we want disposal to start immediately rather than block the scene update.
- The web build path is covered by `PlayerPool.isInitialized` returning `false` (web skips `PlayerPool.init()`), so this is a no-op there.
- The fourth test (uninitialized pool) verifies the guard so that any future test setup that leaves the pool uninitialized does not crash this lifecycle path.

Closes #3539

Refs #3427, #3442