### PR TITLE
fix(profile): preserve loop metrics when merging profile videos

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
@@ -73,6 +73,21 @@ final class FullscreenFeedState extends Equatable {
   /// [VideoFeedController].
   List<VideoItem> get pooledVideos => videos.toPooledVideoItems();
 
+  /// Metadata-sensitive signature for detecting updates to videos that keep
+  /// the same IDs and order but change user-visible fields like loop counts.
+  List<String> get videoUpdateSignature => videos
+      .map(
+        (video) => [
+          video.id,
+          video.stableId,
+          video.videoUrl ?? '',
+          video.thumbnailUrl ?? '',
+          '${video.originalLoops ?? ''}',
+          video.rawTags['views'] ?? '',
+        ].join('|'),
+      )
+      .toList(growable: false);
+
   /// Whether we have pooled videos ready for playback.
   bool get hasPooledVideos => pooledVideos.isNotEmpty;
 
@@ -106,6 +121,7 @@ final class FullscreenFeedState extends Equatable {
   List<Object?> get props => [
     status,
     videos,
+    videoUpdateSignature,
     currentIndex,
     isLoadingMore,
     canLoadMore,

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -172,6 +172,16 @@ class ProfileFeed extends _$ProfileFeed {
     );
   }
 
+  @visibleForTesting
+  static Map<String, String> mergeRawTagsForVideoMerge(
+    Map<String, String> primary,
+    Map<String, String> secondary,
+  ) {
+    // Preserve REST-only analytics tags like `views` while still letting the
+    // primary video win on collisions for actual event metadata.
+    return {...secondary, ...primary};
+  }
+
   /// Refresh state - uses REST API when available, otherwise Nostr with metadata preservation
   /// Call this after a video is updated to sync the provider's state
   void refreshFromService() {
@@ -785,7 +795,7 @@ class ProfileFeed extends _$ProfileFeed {
       publishedAt: primaryHasPublishedAt
           ? primary.publishedAt
           : secondary.publishedAt,
-      rawTags: primary.rawTags.isNotEmpty ? primary.rawTags : secondary.rawTags,
+      rawTags: mergeRawTagsForVideoMerge(primary.rawTags, secondary.rawTags),
       contentWarningLabels: primary.contentWarningLabels.isNotEmpty
           ? primary.contentWarningLabels
           : secondary.contentWarningLabels,

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -571,11 +571,13 @@ class ProfileFeed extends _$ProfileFeed {
   void _cacheVideoMetadata(List<VideoEvent> videos) {
     for (final video in videos) {
       if (video.originalLoops != null ||
+          video.rawTags['views'] != null ||
           video.originalLikes != null ||
           video.originalComments != null ||
           video.originalReposts != null) {
         _metadataCache[video.id.toLowerCase()] = _VideoMetadataCache(
           originalLoops: video.originalLoops,
+          views: video.rawTags['views'],
           originalLikes: video.originalLikes,
           originalComments: video.originalComments,
           originalReposts: video.originalReposts,
@@ -589,21 +591,45 @@ class ProfileFeed extends _$ProfileFeed {
     return videos.map((video) {
       final cached = _metadataCache[video.id.toLowerCase()];
       if (cached == null) return video;
-
-      // Only apply if video is missing metadata but cache has it
-      if (video.originalLoops == null && cached.originalLoops != null ||
-          video.originalLikes == null && cached.originalLikes != null ||
-          video.originalComments == null && cached.originalComments != null ||
-          video.originalReposts == null && cached.originalReposts != null) {
-        return video.copyWith(
-          originalLoops: video.originalLoops ?? cached.originalLoops,
-          originalLikes: video.originalLikes ?? cached.originalLikes,
-          originalComments: video.originalComments ?? cached.originalComments,
-          originalReposts: video.originalReposts ?? cached.originalReposts,
-        );
-      }
-      return video;
+      return applyCachedMetadataForVideo(
+        video,
+        originalLoops: cached.originalLoops,
+        views: cached.views,
+        originalLikes: cached.originalLikes,
+        originalComments: cached.originalComments,
+        originalReposts: cached.originalReposts,
+      );
     }).toList();
+  }
+
+  @visibleForTesting
+  static VideoEvent applyCachedMetadataForVideo(
+    VideoEvent video, {
+    int? originalLoops,
+    String? views,
+    int? originalLikes,
+    int? originalComments,
+    int? originalReposts,
+  }) {
+    final currentViews = video.rawTags['views'];
+    final shouldApply =
+        (video.originalLoops == null && originalLoops != null) ||
+        (currentViews == null && views != null) ||
+        (video.originalLikes == null && originalLikes != null) ||
+        (video.originalComments == null && originalComments != null) ||
+        (video.originalReposts == null && originalReposts != null);
+
+    if (!shouldApply) return video;
+
+    return video.copyWith(
+      originalLoops: video.originalLoops ?? originalLoops,
+      rawTags: currentViews == null && views != null
+          ? {...video.rawTags, 'views': views}
+          : video.rawTags,
+      originalLikes: video.originalLikes ?? originalLikes,
+      originalComments: video.originalComments ?? originalComments,
+      originalReposts: video.originalReposts ?? originalReposts,
+    );
   }
 
   void _registerRetainedRealtimeListeners() {
@@ -905,12 +931,14 @@ class ProfileFeed extends _$ProfileFeed {
 class _VideoMetadataCache {
   const _VideoMetadataCache({
     this.originalLoops,
+    this.views,
     this.originalLikes,
     this.originalComments,
     this.originalReposts,
   });
 
   final int? originalLoops;
+  final String? views;
   final int? originalLikes;
   final int? originalComments;
   final int? originalReposts;

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -182,6 +182,24 @@ class ProfileFeed extends _$ProfileFeed {
     return {...secondary, ...primary};
   }
 
+  @visibleForTesting
+  static bool sameVideoSequenceForMerge(
+    List<VideoEvent> left,
+    List<VideoEvent> right,
+  ) {
+    if (left.length != right.length) return false;
+    for (var i = 0; i < left.length; i++) {
+      final leftVideo = left[i];
+      final rightVideo = right[i];
+      if (leftVideo.id != rightVideo.id) return false;
+      if (leftVideo.originalLoops != rightVideo.originalLoops) return false;
+      if (leftVideo.rawTags['views'] != rightVideo.rawTags['views']) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /// Refresh state - uses REST API when available, otherwise Nostr with metadata preservation
   /// Call this after a video is updated to sync the provider's state
   void refreshFromService() {
@@ -857,11 +875,7 @@ class ProfileFeed extends _$ProfileFeed {
   }
 
   bool _sameVideoSequence(List<VideoEvent> left, List<VideoEvent> right) {
-    if (left.length != right.length) return false;
-    for (var i = 0; i < left.length; i++) {
-      if (left[i].id != right[i].id) return false;
-    }
-    return true;
+    return sameVideoSequenceForMerge(left, right);
   }
 
   void _emitState(VideoFeedState nextState) {

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -53,13 +53,6 @@ class ProfileFeed extends _$ProfileFeed {
   /// Guard against duplicate listener registration from retained-state path.
   bool _listenersRegistered = false;
 
-  /// Guard against duplicate Funnelcake availability listener registration.
-  bool _availabilityListenerRegistered = false;
-
-  /// Tracks a late availability flip that happened before the notifier had
-  /// published its first state.
-  bool _pendingAvailabilityRefresh = false;
-
   /// Cached [VideoEventService] captured at build() time.
   ///
   /// Both [videoEventServiceProvider] and this notifier are keepAlive, so
@@ -86,7 +79,6 @@ class ProfileFeed extends _$ProfileFeed {
     );
 
     _videoEventService = ref.watch(videoEventServiceProvider);
-    _registerFunnelcakeAvailabilityListener();
     List<VideoEvent> authorVideos = [];
 
     // Try REST API first if available (use centralized availability check)
@@ -119,7 +111,7 @@ class ProfileFeed extends _$ProfileFeed {
     unawaited(
       Future(() async {
         await _refreshFromNostrSource();
-        if (funnelcakeAvailable) {
+        if (funnelcakeAvailable || await _awaitFunnelcakeAvailability()) {
           await _refreshFromRestApi(clientOverride: funnelcakeClient);
         }
       }),
@@ -146,14 +138,6 @@ class ProfileFeed extends _$ProfileFeed {
       totalVideoCount: _totalVideoCount,
     );
     _cacheSnapshot(initialState);
-    if (_pendingAvailabilityRefresh) {
-      _pendingAvailabilityRefresh = false;
-      unawaited(refresh(retainedState: initialState));
-      return initialState.copyWith(
-        isRefreshing: true,
-        isFetchingTotalCount: true,
-      );
-    }
     return initialState;
   }
 
@@ -220,31 +204,6 @@ class ProfileFeed extends _$ProfileFeed {
   /// Call this after a video is updated to sync the provider's state
   void refreshFromService() {
     unawaited(refresh());
-  }
-
-  void _registerFunnelcakeAvailabilityListener() {
-    if (_availabilityListenerRegistered) return;
-    _availabilityListenerRegistered = true;
-
-    ref.listen<AsyncValue<bool>>(funnelcakeAvailableProvider, (previous, next) {
-      final wasAvailable = previous?.asData?.value ?? false;
-      final isAvailable = next.asData?.value ?? false;
-      if (wasAvailable || !isAvailable || !ref.mounted) return;
-
-      final currentState = state.asData?.value;
-      if (currentState == null) {
-        _pendingAvailabilityRefresh = true;
-        return;
-      }
-
-      if (_usingRestApi || _isRefreshing) return;
-      unawaited(refresh(retainedState: currentState));
-    });
-
-    ref.onDispose(() {
-      _availabilityListenerRegistered = false;
-      _pendingAvailabilityRefresh = false;
-    });
   }
 
   /// Optimistically add a newly published video to the profile feed state.
@@ -385,6 +344,16 @@ class ProfileFeed extends _$ProfileFeed {
       if (currentState != null && currentState.isFetchingTotalCount) {
         _emitState(currentState.copyWith(isFetchingTotalCount: false));
       }
+    }
+  }
+
+  Future<bool> _awaitFunnelcakeAvailability() async {
+    try {
+      return await ref
+          .read(funnelcakeAvailableProvider.future)
+          .timeout(const Duration(seconds: 4));
+    } catch (_) {
+      return false;
     }
   }
 
@@ -608,7 +577,22 @@ class ProfileFeed extends _$ProfileFeed {
 
     final refreshFutures = <Future<void>>[
       _refreshFromNostrSource(),
-      if (funnelcakeAvailable) _refreshFromRestApi(),
+      if (funnelcakeAvailable)
+        _refreshFromRestApi()
+      else
+        () async {
+          final becameAvailable = await _awaitFunnelcakeAvailability();
+          if (becameAvailable && ref.mounted) {
+            await _refreshFromRestApi();
+          } else if (currentState != null && ref.mounted) {
+            final latestState = state.asData?.value;
+            if (latestState != null && latestState.isFetchingTotalCount) {
+              state = AsyncData(
+                latestState.copyWith(isFetchingTotalCount: false),
+              );
+            }
+          }
+        }(),
     ];
 
     await Future.wait(refreshFutures);

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -53,6 +53,13 @@ class ProfileFeed extends _$ProfileFeed {
   /// Guard against duplicate listener registration from retained-state path.
   bool _listenersRegistered = false;
 
+  /// Guard against duplicate Funnelcake availability listener registration.
+  bool _availabilityListenerRegistered = false;
+
+  /// Tracks a late availability flip that happened before the notifier had
+  /// published its first state.
+  bool _pendingAvailabilityRefresh = false;
+
   /// Cached [VideoEventService] captured at build() time.
   ///
   /// Both [videoEventServiceProvider] and this notifier are keepAlive, so
@@ -60,26 +67,6 @@ class ProfileFeed extends _$ProfileFeed {
   /// the merge/tombstone hot path was unnecessary friction. Reassigned on
   /// each build() so a test-time provider override still wins.
   late VideoEventService _videoEventService;
-
-  void _logLoopSnapshot(String stage, List<VideoEvent> videos) {
-    final withViews = videos.where((v) => v.rawTags['views'] != null).length;
-    final withLoops = videos.where((v) => v.originalLoops != null).length;
-    final sample = videos
-        .take(3)
-        .map((video) {
-          return '${video.id}'
-              '[loops=${video.originalLoops ?? 'null'},'
-              'views=${video.rawTags['views'] ?? 'null'},'
-              'total=${video.totalLoops}]';
-        })
-        .join(', ');
-    Log.info(
-      'ProfileFeed LOOP_DEBUG $stage user=$userId count=${videos.length} '
-      'withViews=$withViews withOriginalLoops=$withLoops sample=[$sample]',
-      name: 'ProfileFeedProvider',
-      category: LogCategory.video,
-    );
-  }
 
   @override
   Future<VideoFeedState> build(String userId) async {
@@ -99,6 +86,7 @@ class ProfileFeed extends _$ProfileFeed {
     );
 
     _videoEventService = ref.watch(videoEventServiceProvider);
+    _registerFunnelcakeAvailabilityListener();
     List<VideoEvent> authorVideos = [];
 
     // Try REST API first if available (use centralized availability check)
@@ -107,13 +95,6 @@ class ProfileFeed extends _$ProfileFeed {
     // cascade rebuilds create new instances and lose state.
     final funnelcakeAsync = ref.read(funnelcakeAvailableProvider);
     final funnelcakeAvailable = funnelcakeAsync.asData?.value ?? false;
-    Log.info(
-      'ProfileFeed LOOP_DEBUG build availability user=$userId '
-      'funnelcakeResolved=${funnelcakeAsync.hasValue} '
-      'funnelcakeAvailable=$funnelcakeAvailable',
-      name: 'ProfileFeedProvider',
-      category: LogCategory.video,
-    );
     final funnelcakeClient = ref.read(funnelcakeApiClientProvider);
     final sessionCache = ref.read(profileFeedSessionCacheProvider);
     final retainedState = sessionCache.read(userId);
@@ -165,6 +146,14 @@ class ProfileFeed extends _$ProfileFeed {
       totalVideoCount: _totalVideoCount,
     );
     _cacheSnapshot(initialState);
+    if (_pendingAvailabilityRefresh) {
+      _pendingAvailabilityRefresh = false;
+      unawaited(refresh(retainedState: initialState));
+      return initialState.copyWith(
+        isRefreshing: true,
+        isFetchingTotalCount: true,
+      );
+    }
     return initialState;
   }
 
@@ -233,6 +222,31 @@ class ProfileFeed extends _$ProfileFeed {
     unawaited(refresh());
   }
 
+  void _registerFunnelcakeAvailabilityListener() {
+    if (_availabilityListenerRegistered) return;
+    _availabilityListenerRegistered = true;
+
+    ref.listen<AsyncValue<bool>>(funnelcakeAvailableProvider, (previous, next) {
+      final wasAvailable = previous?.asData?.value ?? false;
+      final isAvailable = next.asData?.value ?? false;
+      if (wasAvailable || !isAvailable || !ref.mounted) return;
+
+      final currentState = state.asData?.value;
+      if (currentState == null) {
+        _pendingAvailabilityRefresh = true;
+        return;
+      }
+
+      if (_usingRestApi || _isRefreshing) return;
+      unawaited(refresh(retainedState: currentState));
+    });
+
+    ref.onDispose(() {
+      _availabilityListenerRegistered = false;
+      _pendingAvailabilityRefresh = false;
+    });
+  }
+
   /// Optimistically add a newly published video to the profile feed state.
   /// This is called when the user publishes a new video to ensure instant feedback
   /// without waiting for Funnelcake REST API to index the event.
@@ -292,7 +306,6 @@ class ProfileFeed extends _$ProfileFeed {
         result.videos.toVideoEvents(),
         client: client,
       );
-      _logLoopSnapshot('afterAuthorRestHydration', apiVideos);
 
       if (!ref.mounted) return;
 
@@ -305,11 +318,9 @@ class ProfileFeed extends _$ProfileFeed {
           relayVideos,
           apiVideos.where((v) => !v.isRepost).toList(),
         );
-        _logLoopSnapshot('afterAuthorMerge', authorVideos);
         _cacheVideoMetadata(authorVideos);
 
         final filteredVideos = _videoEventService.filterVideoList(authorVideos);
-        _logLoopSnapshot('afterAuthorFilter', filteredVideos);
 
         _usingRestApi = true;
         _mergeSourceVideos(
@@ -429,7 +440,6 @@ class ProfileFeed extends _$ProfileFeed {
           result.videos.toVideoEvents(),
           client: client,
         );
-        _logLoopSnapshot('afterLoadMoreRestHydration', apiVideos);
 
         if (!ref.mounted) return;
         _totalVideoCount = result.totalCount ?? _totalVideoCount;
@@ -450,7 +460,6 @@ class ProfileFeed extends _$ProfileFeed {
 
           // Apply content filter preferences
           newVideos = _videoEventService.filterVideoList(newVideos);
-          _logLoopSnapshot('afterLoadMoreFilter', newVideos);
 
           if (newVideos.isNotEmpty) {
             final allVideos = _mergeVideoLists(currentState.videos, newVideos);
@@ -653,7 +662,6 @@ class ProfileFeed extends _$ProfileFeed {
         originalLoops: stats.loops ?? video.originalLoops,
       );
     }).toList();
-    _logLoopSnapshot('afterBulkStats', hydrated);
     return hydrated;
   }
 
@@ -687,7 +695,6 @@ class ProfileFeed extends _$ProfileFeed {
         rawTags: <String, String>{...video.rawTags, 'views': '$count'},
       );
     }).toList();
-    _logLoopSnapshot('afterViewsEndpoint', hydrated);
     return hydrated;
   }
 
@@ -899,7 +906,6 @@ class ProfileFeed extends _$ProfileFeed {
         ? currentState?.videos ?? const <VideoEvent>[]
         : const <VideoEvent>[];
     final mergedVideos = _mergeVideoLists(currentVideos, incoming);
-    _logLoopSnapshot('mergeSourceVideos', mergedVideos);
 
     final nextState =
         (currentState ??

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -61,6 +61,26 @@ class ProfileFeed extends _$ProfileFeed {
   /// each build() so a test-time provider override still wins.
   late VideoEventService _videoEventService;
 
+  void _logLoopSnapshot(String stage, List<VideoEvent> videos) {
+    final withViews = videos.where((v) => v.rawTags['views'] != null).length;
+    final withLoops = videos.where((v) => v.originalLoops != null).length;
+    final sample = videos
+        .take(3)
+        .map((video) {
+          return '${video.id}'
+              '[loops=${video.originalLoops ?? 'null'},'
+              'views=${video.rawTags['views'] ?? 'null'},'
+              'total=${video.totalLoops}]';
+        })
+        .join(', ');
+    Log.info(
+      'ProfileFeed LOOP_DEBUG $stage user=$userId count=${videos.length} '
+      'withViews=$withViews withOriginalLoops=$withLoops sample=[$sample]',
+      name: 'ProfileFeedProvider',
+      category: LogCategory.video,
+    );
+  }
+
   @override
   Future<VideoFeedState> build(String userId) async {
     // Reset REST pagination state at start of build to ensure clean state.
@@ -87,6 +107,13 @@ class ProfileFeed extends _$ProfileFeed {
     // cascade rebuilds create new instances and lose state.
     final funnelcakeAsync = ref.read(funnelcakeAvailableProvider);
     final funnelcakeAvailable = funnelcakeAsync.asData?.value ?? false;
+    Log.info(
+      'ProfileFeed LOOP_DEBUG build availability user=$userId '
+      'funnelcakeResolved=${funnelcakeAsync.hasValue} '
+      'funnelcakeAvailable=$funnelcakeAvailable',
+      name: 'ProfileFeedProvider',
+      category: LogCategory.video,
+    );
     final funnelcakeClient = ref.read(funnelcakeApiClientProvider);
     final sessionCache = ref.read(profileFeedSessionCacheProvider);
     final retainedState = sessionCache.read(userId);
@@ -265,6 +292,7 @@ class ProfileFeed extends _$ProfileFeed {
         result.videos.toVideoEvents(),
         client: client,
       );
+      _logLoopSnapshot('afterAuthorRestHydration', apiVideos);
 
       if (!ref.mounted) return;
 
@@ -277,9 +305,11 @@ class ProfileFeed extends _$ProfileFeed {
           relayVideos,
           apiVideos.where((v) => !v.isRepost).toList(),
         );
+        _logLoopSnapshot('afterAuthorMerge', authorVideos);
         _cacheVideoMetadata(authorVideos);
 
         final filteredVideos = _videoEventService.filterVideoList(authorVideos);
+        _logLoopSnapshot('afterAuthorFilter', filteredVideos);
 
         _usingRestApi = true;
         _mergeSourceVideos(
@@ -399,6 +429,7 @@ class ProfileFeed extends _$ProfileFeed {
           result.videos.toVideoEvents(),
           client: client,
         );
+        _logLoopSnapshot('afterLoadMoreRestHydration', apiVideos);
 
         if (!ref.mounted) return;
         _totalVideoCount = result.totalCount ?? _totalVideoCount;
@@ -419,6 +450,7 @@ class ProfileFeed extends _$ProfileFeed {
 
           // Apply content filter preferences
           newVideos = _videoEventService.filterVideoList(newVideos);
+          _logLoopSnapshot('afterLoadMoreFilter', newVideos);
 
           if (newVideos.isNotEmpty) {
             final allVideos = _mergeVideoLists(currentState.videos, newVideos);
@@ -604,7 +636,7 @@ class ProfileFeed extends _$ProfileFeed {
 
     if (statsById.isEmpty) return videos;
 
-    return videos.map((video) {
+    final hydrated = videos.map((video) {
       final stats = statsById[video.id];
       if (stats == null) return video;
 
@@ -621,6 +653,8 @@ class ProfileFeed extends _$ProfileFeed {
         originalLoops: stats.loops ?? video.originalLoops,
       );
     }).toList();
+    _logLoopSnapshot('afterBulkStats', hydrated);
+    return hydrated;
   }
 
   Future<List<VideoEvent>> _hydrateVideosWithViewsEndpoint(
@@ -646,13 +680,15 @@ class ProfileFeed extends _$ProfileFeed {
 
     if (fetchedViews.isEmpty) return videos;
 
-    return videos.map((video) {
+    final hydrated = videos.map((video) {
       final count = fetchedViews[video.id];
       if (count == null) return video;
       return video.copyWith(
         rawTags: <String, String>{...video.rawTags, 'views': '$count'},
       );
     }).toList();
+    _logLoopSnapshot('afterViewsEndpoint', hydrated);
+    return hydrated;
   }
 
   bool _hasViewLikeCount(VideoEvent video) {
@@ -863,6 +899,7 @@ class ProfileFeed extends _$ProfileFeed {
         ? currentState?.videos ?? const <VideoEvent>[]
         : const <VideoEvent>[];
     final mergedVideos = _mergeVideoLists(currentVideos, incoming);
+    _logLoopSnapshot('mergeSourceVideos', mergedVideos);
 
     final nextState =
         (currentState ??

--- a/mobile/lib/providers/profile_feed_provider.dart
+++ b/mobile/lib/providers/profile_feed_provider.dart
@@ -261,7 +261,10 @@ class ProfileFeed extends _$ProfileFeed {
       final result = await client
           .getVideosByAuthor(pubkey: userId)
           .timeout(_restApiTimeout);
-      final apiVideos = result.videos.toVideoEvents();
+      final apiVideos = await _hydrateRestVideosFromStats(
+        result.videos.toVideoEvents(),
+        client: client,
+      );
 
       if (!ref.mounted) return;
 
@@ -392,7 +395,10 @@ class ProfileFeed extends _$ProfileFeed {
         final result = await client
             .getVideosByAuthor(pubkey: userId, offset: offset)
             .timeout(_restApiTimeout);
-        final apiVideos = result.videos.toVideoEvents();
+        final apiVideos = await _hydrateRestVideosFromStats(
+          result.videos.toVideoEvents(),
+          client: client,
+        );
 
         if (!ref.mounted) return;
         _totalVideoCount = result.totalCount ?? _totalVideoCount;
@@ -565,6 +571,106 @@ class ProfileFeed extends _$ProfileFeed {
     ];
 
     await Future.wait(refreshFutures);
+  }
+
+  Future<List<VideoEvent>> _hydrateRestVideosFromStats(
+    List<VideoEvent> videos, {
+    required FunnelcakeApiClient client,
+  }) async {
+    if (videos.isEmpty) return videos;
+
+    final withBulkStats = await _hydrateVideosWithBulkStats(
+      videos,
+      client: client,
+    );
+    return _hydrateVideosWithViewsEndpoint(withBulkStats, client: client);
+  }
+
+  Future<List<VideoEvent>> _hydrateVideosWithBulkStats(
+    List<VideoEvent> videos, {
+    required FunnelcakeApiClient client,
+  }) async {
+    final ids = videos.map((video) => video.id).where((id) => id.isNotEmpty);
+    final idList = ids.toList();
+    if (idList.isEmpty) return videos;
+
+    final statsById = <String, BulkVideoStatsEntry>{};
+    for (var i = 0; i < idList.length; i += 100) {
+      final end = math.min(i + 100, idList.length);
+      final chunk = idList.sublist(i, end);
+      final response = await client.getBulkVideoStats(chunk);
+      statsById.addAll(response.stats);
+    }
+
+    if (statsById.isEmpty) return videos;
+
+    return videos.map((video) {
+      final stats = statsById[video.id];
+      if (stats == null) return video;
+
+      final mergedTags = <String, String>{...video.rawTags};
+      if (stats.loops != null) {
+        mergedTags['loops'] = stats.loops!.toString();
+      }
+      if (stats.views != null) {
+        mergedTags['views'] = stats.views!.toString();
+      }
+
+      return video.copyWith(
+        rawTags: mergedTags,
+        originalLoops: stats.loops ?? video.originalLoops,
+      );
+    }).toList();
+  }
+
+  Future<List<VideoEvent>> _hydrateVideosWithViewsEndpoint(
+    List<VideoEvent> videos, {
+    required FunnelcakeApiClient client,
+  }) async {
+    final missingViews = videos
+        .where((video) => !_hasViewLikeCount(video) && video.id.isNotEmpty)
+        .toList();
+    if (missingViews.isEmpty) return videos;
+
+    final fetchedViews = <String, int>{};
+    for (var i = 0; i < missingViews.length; i += 12) {
+      final end = math.min(i + 12, missingViews.length);
+      final chunk = missingViews.sublist(i, end);
+      final counts = await Future.wait(
+        chunk.map((video) => client.getVideoViews(video.id)),
+      );
+      for (var j = 0; j < chunk.length; j++) {
+        fetchedViews[chunk[j].id] = counts[j];
+      }
+    }
+
+    if (fetchedViews.isEmpty) return videos;
+
+    return videos.map((video) {
+      final count = fetchedViews[video.id];
+      if (count == null) return video;
+      return video.copyWith(
+        rawTags: <String, String>{...video.rawTags, 'views': '$count'},
+      );
+    }).toList();
+  }
+
+  bool _hasViewLikeCount(VideoEvent video) {
+    final viewTags = [
+      video.rawTags['views'],
+      video.rawTags['view_count'],
+      video.rawTags['total_views'],
+      video.rawTags['unique_views'],
+      video.rawTags['unique_viewers'],
+    ];
+    for (final value in viewTags) {
+      if (value == null) continue;
+      final normalized = value.replaceAll(',', '').trim();
+      if (normalized.isEmpty) continue;
+      if (int.tryParse(normalized) != null) return true;
+      if (double.tryParse(normalized) != null) return true;
+    }
+    return false;
   }
 
   /// Cache metadata from REST API videos for later merging with Nostr data

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -89,7 +89,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'94255ddcc8905e2716b7e47275ec3ff9d6c38ab5';
+String _$profileFeedHash() => r'c7a0e4b4bd219d7f1ca9e59c5bac692ac9bd72b2';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -89,7 +89,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'f5b4860ce46b3c95df7f036d8aee49566479b530';
+String _$profileFeedHash() => r'aab274df3a3e0d41b01e160fffa3418d21b0d109';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -89,7 +89,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'c7a0e4b4bd219d7f1ca9e59c5bac692ac9bd72b2';
+String _$profileFeedHash() => r'f5b4860ce46b3c95df7f036d8aee49566479b530';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///

--- a/mobile/lib/providers/profile_feed_provider.g.dart
+++ b/mobile/lib/providers/profile_feed_provider.g.dart
@@ -89,7 +89,7 @@ final class ProfileFeedProvider
   }
 }
 
-String _$profileFeedHash() => r'aab274df3a3e0d41b01e160fffa3418d21b0d109';
+String _$profileFeedHash() => r'1a00da4dd770a87aafe5f762e4c8cddb8dd89e45';
 
 /// Profile feed provider - shows videos for a specific user with pagination
 ///

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -76,6 +76,7 @@ import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/page_load_observer.dart';
 import 'package:openvine/services/video_stop_navigator_observer.dart';
 import 'package:openvine/widgets/camera_permission_gate.dart';
+import 'package:openvine/widgets/profile/profile_video_feed_view.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Global route observer for [RouteAware] subscribers (e.g. pausing video
@@ -977,24 +978,35 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         path: PooledFullscreenVideoFeedScreen.path,
         name: PooledFullscreenVideoFeedScreen.routeName,
         builder: (ctx, st) {
-          final args = st.extra as PooledFullscreenVideoFeedArgs?;
-          if (args == null) {
-            return Scaffold(
-              appBar: DiVineAppBar(title: ctx.l10n.routeErrorTitle),
-              body: Center(child: Text(ctx.l10n.routeNoVideosToDisplay)),
+          final extra = st.extra;
+          if (extra is PooledFullscreenVideoFeedArgs) {
+            return PooledFullscreenVideoFeedScreen(
+              videosStream: extra.videosStream,
+              initialIndex: extra.initialIndex,
+              onLoadMore: extra.onLoadMore,
+              hasMoreStream: extra.hasMoreStream,
+              removedIdsStream: extra.removedIdsStream,
+              contextTitle: extra.contextTitle,
+              trafficSource: extra.trafficSource,
+              sourceDetail: extra.sourceDetail,
+              autoOpenComments: extra.autoOpenComments,
+              onPageChanged: extra.onPageChanged,
             );
           }
-          return PooledFullscreenVideoFeedScreen(
-            videosStream: args.videosStream,
-            initialIndex: args.initialIndex,
-            onLoadMore: args.onLoadMore,
-            hasMoreStream: args.hasMoreStream,
-            removedIdsStream: args.removedIdsStream,
-            contextTitle: args.contextTitle,
-            trafficSource: args.trafficSource,
-            sourceDetail: args.sourceDetail,
-            autoOpenComments: args.autoOpenComments,
-            onPageChanged: args.onPageChanged,
+          if (extra is ProfilePooledFullscreenVideoFeedArgs) {
+            return ProfileVideoFeedView(
+              npub: '',
+              userIdHex: extra.userIdHex,
+              videoIndex: extra.initialIndex,
+              initialVideoId: extra.initialVideoId,
+              initialStableId: extra.initialStableId,
+              contextTitleOverride: extra.contextTitle,
+              onPageChanged: extra.onPageChanged ?? (_) {},
+            );
+          }
+          return Scaffold(
+            appBar: DiVineAppBar(title: ctx.l10n.routeErrorTitle),
+            body: Center(child: Text(ctx.l10n.routeNoVideosToDisplay)),
           );
         },
       ),

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -877,55 +877,64 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                       onScrollOffsetChanged: (page) =>
                           _pagePosition.value = page,
                       maxLoopDuration: VideoEditorConstants.maxDuration,
-                      itemBuilder:
-                          (context, video, index, {required isActive}) {
-                            if (state.videos.isEmpty) {
-                              debugPrint(
-                                'FullscreenFeed: itemBuilder called with empty '
-                                'state.videos! index=$index, '
-                                'video.id=${video.id}',
-                              );
-                              return const ColoredBox(
-                                color: VineTheme.backgroundColor,
-                              );
-                            }
-                            final originalEvent = state.videos.firstWhere(
-                              (v) => v.id == video.id,
-                              orElse: () {
-                                final clamped = index.clamp(
-                                  0,
-                                  state.videos.length - 1,
-                                );
-                                debugPrint(
-                                  'FullscreenFeed: video ID lookup miss! '
-                                  'video.id=${video.id}, index=$index, '
-                                  'clamped=$clamped, '
-                                  'state.videos.length='
-                                  '${state.videos.length}, '
-                                  'pooledVideos.length='
-                                  '${state.pooledVideos.length}',
-                                );
-                                return state.videos[clamped];
-                              },
+                      itemBuilder: (context, video, index, {required isActive}) {
+                        if (state.videos.isEmpty) {
+                          debugPrint(
+                            'FullscreenFeed: itemBuilder called with empty '
+                            'state.videos! index=$index, '
+                            'video.id=${video.id}',
+                          );
+                          return const ColoredBox(
+                            color: VineTheme.backgroundColor,
+                          );
+                        }
+                        final originalEvent = state.videos.firstWhere(
+                          (v) => v.id == video.id,
+                          orElse: () {
+                            final clamped = index.clamp(
+                              0,
+                              state.videos.length - 1,
                             );
-                            return _PooledFullscreenItem(
-                              video: originalEvent,
-                              index: index,
-                              isActive: isActive,
-                              pagePosition: _pagePosition,
-                              contextTitle: widget.contextTitle,
-                              trafficSource: widget.trafficSource,
-                              sourceDetail: widget.sourceDetail,
-                              isOwnVideo: isOwnVideo,
-                              showAutoButton: autoAdvanceAvailable,
-                              isAutoEnabled: effectiveAutoEnabled,
-                              isAutoAdvanceActive: effectiveAutoActive,
-                              onAutoPressed: _toggleAutoAdvance,
-                              onInteracted: _suppressAutoAdvance,
-                              onAutoAdvanceCompleted:
-                                  _handleAutoAdvanceCompleted,
+                            debugPrint(
+                              'FullscreenFeed: video ID lookup miss! '
+                              'video.id=${video.id}, index=$index, '
+                              'clamped=$clamped, '
+                              'state.videos.length='
+                              '${state.videos.length}, '
+                              'pooledVideos.length='
+                              '${state.pooledVideos.length}',
                             );
+                            return state.videos[clamped];
                           },
+                        );
+                        if (index == state.currentIndex) {
+                          Log.info(
+                            'PooledFullscreen LOOP_DEBUG '
+                            'index=$index videoId=${originalEvent.id} '
+                            'loops=${originalEvent.originalLoops ?? 'null'} '
+                            "views=${originalEvent.rawTags['views'] ?? 'null'} "
+                            'total=${originalEvent.totalLoops}',
+                            name: 'PooledFullscreenVideoFeedScreen',
+                            category: LogCategory.video,
+                          );
+                        }
+                        return _PooledFullscreenItem(
+                          video: originalEvent,
+                          index: index,
+                          isActive: isActive,
+                          pagePosition: _pagePosition,
+                          contextTitle: widget.contextTitle,
+                          trafficSource: widget.trafficSource,
+                          sourceDetail: widget.sourceDetail,
+                          isOwnVideo: isOwnVideo,
+                          showAutoButton: autoAdvanceAvailable,
+                          isAutoEnabled: effectiveAutoEnabled,
+                          isAutoAdvanceActive: effectiveAutoActive,
+                          onAutoPressed: _toggleAutoAdvance,
+                          onInteracted: _suppressAutoAdvance,
+                          onAutoAdvanceCompleted: _handleAutoAdvanceCompleted,
+                        );
+                      },
                     ),
             );
           },

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -148,6 +148,29 @@ class PooledFullscreenVideoFeedArgs {
   final void Function(int index)? onPageChanged;
 }
 
+/// Profile-backed arguments for fullscreen playback.
+///
+/// Unlike [PooledFullscreenVideoFeedArgs], this keeps the fullscreen route
+/// subscribed directly to [profileFeedProvider] so profile-specific metadata
+/// updates (like loop counts) are not lost when the launching grid unmounts.
+class ProfilePooledFullscreenVideoFeedArgs {
+  const ProfilePooledFullscreenVideoFeedArgs({
+    required this.userIdHex,
+    required this.initialIndex,
+    this.initialVideoId,
+    this.initialStableId,
+    this.contextTitle,
+    this.onPageChanged,
+  });
+
+  final String userIdHex;
+  final int initialIndex;
+  final String? initialVideoId;
+  final String? initialStableId;
+  final String? contextTitle;
+  final void Function(int index)? onPageChanged;
+}
+
 /// Fullscreen video feed screen using pooled_video_player.
 ///
 /// This screen is pushed outside the shell route so it doesn't show

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -606,7 +606,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
           // Handle new videos from pagination
           BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
             listenWhen: (prev, curr) =>
-                prev.videos.length != curr.videos.length,
+                prev.videoUpdateSignature != curr.videoUpdateSignature,
             listener: (context, state) => _handleVideosChanged(state),
           ),
           BlocListener<FullscreenFeedBloc, FullscreenFeedState>(

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -877,64 +877,55 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                       onScrollOffsetChanged: (page) =>
                           _pagePosition.value = page,
                       maxLoopDuration: VideoEditorConstants.maxDuration,
-                      itemBuilder: (context, video, index, {required isActive}) {
-                        if (state.videos.isEmpty) {
-                          debugPrint(
-                            'FullscreenFeed: itemBuilder called with empty '
-                            'state.videos! index=$index, '
-                            'video.id=${video.id}',
-                          );
-                          return const ColoredBox(
-                            color: VineTheme.backgroundColor,
-                          );
-                        }
-                        final originalEvent = state.videos.firstWhere(
-                          (v) => v.id == video.id,
-                          orElse: () {
-                            final clamped = index.clamp(
-                              0,
-                              state.videos.length - 1,
+                      itemBuilder:
+                          (context, video, index, {required isActive}) {
+                            if (state.videos.isEmpty) {
+                              debugPrint(
+                                'FullscreenFeed: itemBuilder called with empty '
+                                'state.videos! index=$index, '
+                                'video.id=${video.id}',
+                              );
+                              return const ColoredBox(
+                                color: VineTheme.backgroundColor,
+                              );
+                            }
+                            final originalEvent = state.videos.firstWhere(
+                              (v) => v.id == video.id,
+                              orElse: () {
+                                final clamped = index.clamp(
+                                  0,
+                                  state.videos.length - 1,
+                                );
+                                debugPrint(
+                                  'FullscreenFeed: video ID lookup miss! '
+                                  'video.id=${video.id}, index=$index, '
+                                  'clamped=$clamped, '
+                                  'state.videos.length='
+                                  '${state.videos.length}, '
+                                  'pooledVideos.length='
+                                  '${state.pooledVideos.length}',
+                                );
+                                return state.videos[clamped];
+                              },
                             );
-                            debugPrint(
-                              'FullscreenFeed: video ID lookup miss! '
-                              'video.id=${video.id}, index=$index, '
-                              'clamped=$clamped, '
-                              'state.videos.length='
-                              '${state.videos.length}, '
-                              'pooledVideos.length='
-                              '${state.pooledVideos.length}',
+                            return _PooledFullscreenItem(
+                              video: originalEvent,
+                              index: index,
+                              isActive: isActive,
+                              pagePosition: _pagePosition,
+                              contextTitle: widget.contextTitle,
+                              trafficSource: widget.trafficSource,
+                              sourceDetail: widget.sourceDetail,
+                              isOwnVideo: isOwnVideo,
+                              showAutoButton: autoAdvanceAvailable,
+                              isAutoEnabled: effectiveAutoEnabled,
+                              isAutoAdvanceActive: effectiveAutoActive,
+                              onAutoPressed: _toggleAutoAdvance,
+                              onInteracted: _suppressAutoAdvance,
+                              onAutoAdvanceCompleted:
+                                  _handleAutoAdvanceCompleted,
                             );
-                            return state.videos[clamped];
                           },
-                        );
-                        if (index == state.currentIndex) {
-                          Log.info(
-                            'PooledFullscreen LOOP_DEBUG '
-                            'index=$index videoId=${originalEvent.id} '
-                            'loops=${originalEvent.originalLoops ?? 'null'} '
-                            "views=${originalEvent.rawTags['views'] ?? 'null'} "
-                            'total=${originalEvent.totalLoops}',
-                            name: 'PooledFullscreenVideoFeedScreen',
-                            category: LogCategory.video,
-                          );
-                        }
-                        return _PooledFullscreenItem(
-                          video: originalEvent,
-                          index: index,
-                          isActive: isActive,
-                          pagePosition: _pagePosition,
-                          contextTitle: widget.contextTitle,
-                          trafficSource: widget.trafficSource,
-                          sourceDetail: widget.sourceDetail,
-                          isOwnVideo: isOwnVideo,
-                          showAutoButton: autoAdvanceAvailable,
-                          isAutoEnabled: effectiveAutoEnabled,
-                          isAutoAdvanceActive: effectiveAutoActive,
-                          onAutoPressed: _toggleAutoAdvance,
-                          onInteracted: _suppressAutoAdvance,
-                          onAutoAdvanceCompleted: _handleAutoAdvanceCompleted,
-                        );
-                      },
                     ),
             );
           },

--- a/mobile/lib/widgets/profile/profile_video_feed_view.dart
+++ b/mobile/lib/widgets/profile/profile_video_feed_view.dart
@@ -24,9 +24,12 @@ class ProfileVideoFeedView extends ConsumerStatefulWidget {
   const ProfileVideoFeedView({
     required this.npub,
     required this.userIdHex,
-    required this.videos,
     required this.videoIndex,
     required this.onPageChanged,
+    this.videos = const [],
+    this.initialVideoId,
+    this.initialStableId,
+    this.contextTitleOverride,
     super.key,
   });
 
@@ -36,11 +39,19 @@ class ProfileVideoFeedView extends ConsumerStatefulWidget {
   /// The hex public key of the profile.
   final String userIdHex;
 
-  /// Initial list of videos to seed the feed with.
+  /// Initial list of videos to seed the feed with before the provider resolves.
   final List<VideoEvent> videos;
 
   /// Current video index from the URL.
   final int videoIndex;
+
+  /// Optional specific tapped video identity for resolving the initial index
+  /// against the live provider-backed feed.
+  final String? initialVideoId;
+  final String? initialStableId;
+
+  /// Optional title override when the caller already has context.
+  final String? contextTitleOverride;
 
   /// Callback when the page changes (for URL updates).
   final void Function(int newIndex) onPageChanged;
@@ -95,29 +106,29 @@ class _ProfileVideoFeedViewState extends ConsumerState<ProfileVideoFeedView> {
 
   @override
   Widget build(BuildContext context) {
-    // Watch feed state only for the hasMoreContent flag; pushing videos into
-    // the stream is handled in initState / didUpdateWidget so each rebuild
-    // doesn't trigger a redundant stream event.
     final feedState = ref
         .watch(profileFeedProvider(widget.userIdHex))
         .asData
         ?.value;
+    final liveVideos = feedState?.videos ?? const <VideoEvent>[];
+    final effectiveVideos = liveVideos.isNotEmpty ? liveVideos : widget.videos;
+    _pushVideos(effectiveVideos);
     final hasMoreContent = feedState?.hasMoreContent ?? false;
     _pushHasMore(hasMoreContent);
 
-    final safeIndex = widget.videos.isEmpty
-        ? 0
-        : widget.videoIndex.clamp(0, widget.videos.length - 1);
+    final resolvedIndex = _resolveInitialIndex(effectiveVideos);
 
-    final contextTitle = ref
-        .watch(fetchUserProfileProvider(widget.userIdHex))
-        .value
-        ?.betterDisplayName(context.l10n.profileTitle);
+    final contextTitle =
+        widget.contextTitleOverride ??
+        ref
+            .watch(fetchUserProfileProvider(widget.userIdHex))
+            .value
+            ?.betterDisplayName(context.l10n.profileTitle);
 
     return PooledFullscreenVideoFeedScreen(
       // Pass the raw broadcast stream — seeding happened in initState.
       videosStream: _videosController.stream,
-      initialIndex: safeIndex,
+      initialIndex: resolvedIndex,
       trafficSource: ViewTrafficSource.profile,
       contextTitle: contextTitle,
       onLoadMore: hasMoreContent
@@ -129,5 +140,22 @@ class _ProfileVideoFeedViewState extends ConsumerState<ProfileVideoFeedView> {
       removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
       onPageChanged: widget.onPageChanged,
     );
+  }
+
+  int _resolveInitialIndex(List<VideoEvent> videos) {
+    if (videos.isEmpty) return 0;
+
+    final initialVideoId = widget.initialVideoId;
+    final initialStableId = widget.initialStableId;
+    if (initialVideoId != null || initialStableId != null) {
+      final resolved = videos.indexWhere(
+        (video) =>
+            (initialVideoId != null && video.id == initialVideoId) ||
+            (initialStableId != null && video.stableId == initialStableId),
+      );
+      if (resolved >= 0) return resolved;
+    }
+
+    return widget.videoIndex.clamp(0, videos.length - 1);
   }
 }

--- a/mobile/lib/widgets/profile/profile_video_feed_view.dart
+++ b/mobile/lib/widgets/profile/profile_video_feed_view.dart
@@ -13,6 +13,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 /// Fullscreen video feed view for profile screens.
 ///
@@ -117,6 +118,19 @@ class _ProfileVideoFeedViewState extends ConsumerState<ProfileVideoFeedView> {
     _pushHasMore(hasMoreContent);
 
     final resolvedIndex = _resolveInitialIndex(effectiveVideos);
+    final selectedVideo = effectiveVideos.isEmpty
+        ? null
+        : effectiveVideos[resolvedIndex];
+    Log.info(
+      'ProfileVideoFeedView LOOP_DEBUG user=${widget.userIdHex} '
+      'resolvedIndex=$resolvedIndex initialVideoId=${widget.initialVideoId} '
+      'selectedId=${selectedVideo?.id ?? 'none'} '
+      'loops=${selectedVideo?.originalLoops ?? 'null'} '
+      'views=${selectedVideo?.rawTags['views'] ?? 'null'} '
+      'total=${selectedVideo?.totalLoops ?? 'null'}',
+      name: 'ProfileVideoFeedView',
+      category: LogCategory.video,
+    );
 
     final contextTitle =
         widget.contextTitleOverride ??

--- a/mobile/lib/widgets/profile/profile_video_feed_view.dart
+++ b/mobile/lib/widgets/profile/profile_video_feed_view.dart
@@ -5,7 +5,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:models/models.dart' hide LogCategory;
+import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/profile_feed_provider.dart';
@@ -13,7 +13,6 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:rxdart/rxdart.dart';
-import 'package:unified_logger/unified_logger.dart';
 
 /// Fullscreen video feed view for profile screens.
 ///
@@ -118,19 +117,6 @@ class _ProfileVideoFeedViewState extends ConsumerState<ProfileVideoFeedView> {
     _pushHasMore(hasMoreContent);
 
     final resolvedIndex = _resolveInitialIndex(effectiveVideos);
-    final selectedVideo = effectiveVideos.isEmpty
-        ? null
-        : effectiveVideos[resolvedIndex];
-    Log.info(
-      'ProfileVideoFeedView LOOP_DEBUG user=${widget.userIdHex} '
-      'resolvedIndex=$resolvedIndex initialVideoId=${widget.initialVideoId} '
-      'selectedId=${selectedVideo?.id ?? 'none'} '
-      'loops=${selectedVideo?.originalLoops ?? 'null'} '
-      'views=${selectedVideo?.rawTags['views'] ?? 'null'} '
-      'total=${selectedVideo?.totalLoops ?? 'null'}',
-      name: 'ProfileVideoFeedView',
-      category: LogCategory.video,
-    );
 
     final contextTitle =
         widget.contextTitleOverride ??

--- a/mobile/lib/widgets/profile/profile_video_feed_view.dart
+++ b/mobile/lib/widgets/profile/profile_video_feed_view.dart
@@ -126,8 +126,10 @@ class _ProfileVideoFeedViewState extends ConsumerState<ProfileVideoFeedView> {
             ?.betterDisplayName(context.l10n.profileTitle);
 
     return PooledFullscreenVideoFeedScreen(
-      // Pass the raw broadcast stream — seeding happened in initState.
-      videosStream: _videosController.stream,
+      // Seed the fullscreen route with the latest effective videos at
+      // subscription time so the first list can't be lost on a broadcast
+      // stream before FullscreenFeedBloc attaches.
+      videosStream: _videosController.stream.startWith(effectiveVideos),
       initialIndex: resolvedIndex,
       trafficSource: ViewTrafficSource.profile,
       contextTitle: contextTitle,

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -1,7 +1,7 @@
 // ABOUTME: Grid widget displaying user's videos on profile page
 // ABOUTME: Shows 3-column grid with thumbnails, handles empty state and navigation
 
-import 'dart:async';
+import 'dart:async' show FutureOr;
 import 'dart:io';
 
 import 'package:divine_ui/divine_ui.dart';
@@ -17,7 +17,6 @@ import 'package:openvine/mixins/scroll_pagination_mixin.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/profile_feed_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
-import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/profile/profile_tab_empty_state.dart';
 import 'package:openvine/widgets/profile/profile_tab_error_state.dart';
 import 'package:openvine/widgets/profile/profile_tab_loading_more_sliver.dart';
@@ -25,7 +24,6 @@ import 'package:openvine/widgets/profile/profile_tab_loading_state.dart';
 import 'package:openvine/widgets/profile/profile_tab_thumbnail.dart';
 import 'package:openvine/widgets/profile/profile_tab_thumbnail_placeholder.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
-import 'package:rxdart/rxdart.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Internal class that represents a video entry in the grid
@@ -70,9 +68,6 @@ class ProfileVideosGrid extends ConsumerStatefulWidget {
 class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
     with GridPrefetchMixin, ScrollPaginationMixin {
   List<VideoEvent>? _lastPrefetchedVideos;
-  final _videosStreamController =
-      StreamController<List<VideoEvent>>.broadcast();
-  final _hasMoreStreamController = StreamController<bool>.broadcast();
   final _precachedThumbnailUrls = <String>{};
 
   /// Resolved from [PrimaryScrollController] provided by [NestedScrollView].
@@ -120,8 +115,6 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
   @override
   void dispose() {
     disposePagination();
-    _videosStreamController.close();
-    _hasMoreStreamController.close();
     super.dispose();
   }
 
@@ -149,7 +142,6 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
     VideoEvent tappedVideo, {
     required int fallbackIndex,
     required List<VideoEvent> displayedVideos,
-    required VoidCallback onLoadMore,
   }) {
     final currentFeedVideos = ref
         .read(profileFeedProvider(widget.userIdHex))
@@ -166,13 +158,6 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
               video.stableId == tappedVideo.stableId),
     );
     final resolvedIndex = index >= 0 ? index : fallbackIndex;
-    final hasMoreContent =
-        ref
-            .read(profileFeedProvider(widget.userIdHex))
-            .asData
-            ?.value
-            .hasMoreContent ??
-        false;
     Log.info(
       '🎯 ProfileVideosGrid TAP: gridIndex=$resolvedIndex, '
       'videoId=${tappedVideo.id}',
@@ -184,38 +169,18 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
 
     context.push(
       PooledFullscreenVideoFeedScreen.path,
-      extra: PooledFullscreenVideoFeedArgs(
-        videosStream: _videosStreamController.stream.startWith(videos),
+      extra: ProfilePooledFullscreenVideoFeedArgs(
+        userIdHex: widget.userIdHex,
         initialIndex: resolvedIndex,
-        onLoadMore: onLoadMore,
-        hasMoreStream: _hasMoreStreamController.stream.startWith(
-          hasMoreContent,
-        ),
-        removedIdsStream: ref.read(videoEventServiceProvider).removedVideoIds,
-        trafficSource: ViewTrafficSource.profile,
+        initialVideoId: tappedVideo.id,
+        initialStableId: tappedVideo.stableId,
       ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    // Push provider updates to stream for fullscreen feed
-    ref.listen(profileFeedProvider(widget.userIdHex), (_, next) {
-      next.whenData((feedState) {
-        if (!_videosStreamController.isClosed) {
-          _videosStreamController.add(feedState.videos);
-        }
-        if (!_hasMoreStreamController.isClosed) {
-          _hasMoreStreamController.add(feedState.hasMoreContent);
-        }
-      });
-    });
-
     final authService = ref.read(authServiceProvider);
-    final profileFeedNotifier = ref.read(
-      profileFeedProvider(widget.userIdHex).notifier,
-    );
-    Future<void> loadMoreProfileVideos() => profileFeedNotifier.loadMore();
     final backgroundPublish = context.watch<BackgroundPublishBloc>();
     final isOwnProfile = authService.currentPublicKeyHex == widget.userIdHex;
 
@@ -353,7 +318,6 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
                         eventEntry.videoEvent,
                         fallbackIndex: publishedIndex,
                         displayedVideos: displayedVideos,
-                        onLoadMore: loadMoreProfileVideos,
                       );
                     }
                   },

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:models/models.dart' hide LogCategory;
+import 'package:models/models.dart';
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/grid_prefetch_mixin.dart';
@@ -24,7 +24,6 @@ import 'package:openvine/widgets/profile/profile_tab_loading_state.dart';
 import 'package:openvine/widgets/profile/profile_tab_thumbnail.dart';
 import 'package:openvine/widgets/profile/profile_tab_thumbnail_placeholder.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
-import 'package:unified_logger/unified_logger.dart';
 
 /// Internal class that represents a video entry in the grid
 /// It can be a video event or an uploading video
@@ -158,18 +157,6 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
               video.stableId == tappedVideo.stableId),
     );
     final resolvedIndex = index >= 0 ? index : fallbackIndex;
-    final matchedVideo = index >= 0 ? videos[index] : null;
-    Log.info(
-      '🎯 ProfileVideosGrid TAP: gridIndex=$resolvedIndex, '
-      'videoId=${tappedVideo.id} '
-      'tappedLoops=${tappedVideo.originalLoops ?? 'null'} '
-      'tappedViews=${tappedVideo.rawTags['views'] ?? 'null'} '
-      'tappedTotal=${tappedVideo.totalLoops} '
-      'matchedLoops=${matchedVideo?.originalLoops ?? 'null'} '
-      'matchedViews=${matchedVideo?.rawTags['views'] ?? 'null'} '
-      'matchedTotal=${matchedVideo?.totalLoops ?? 'null'}',
-      category: LogCategory.video,
-    );
 
     // Pre-warm adjacent videos before navigation
     prefetchAroundIndex(resolvedIndex, videos);

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -158,9 +158,16 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
               video.stableId == tappedVideo.stableId),
     );
     final resolvedIndex = index >= 0 ? index : fallbackIndex;
+    final matchedVideo = index >= 0 ? videos[index] : null;
     Log.info(
       '🎯 ProfileVideosGrid TAP: gridIndex=$resolvedIndex, '
-      'videoId=${tappedVideo.id}',
+      'videoId=${tappedVideo.id} '
+      'tappedLoops=${tappedVideo.originalLoops ?? 'null'} '
+      'tappedViews=${tappedVideo.rawTags['views'] ?? 'null'} '
+      'tappedTotal=${tappedVideo.totalLoops} '
+      'matchedLoops=${matchedVideo?.originalLoops ?? 'null'} '
+      'matchedViews=${matchedVideo?.rawTags['views'] ?? 'null'} '
+      'matchedTotal=${matchedVideo?.totalLoops ?? 'null'}',
       category: LogCategory.video,
     );
 

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -145,8 +145,27 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
     await ref.read(profileFeedProvider(widget.userIdHex).notifier).loadMore();
   }
 
-  void _onVideoTapped(int index, {required VoidCallback onLoadMore}) {
-    final videos = widget.videos;
+  void _onVideoTapped(
+    VideoEvent tappedVideo, {
+    required int fallbackIndex,
+    required List<VideoEvent> displayedVideos,
+    required VoidCallback onLoadMore,
+  }) {
+    final currentFeedVideos = ref
+        .read(profileFeedProvider(widget.userIdHex))
+        .asData
+        ?.value
+        .videos;
+    final videos = currentFeedVideos != null && currentFeedVideos.isNotEmpty
+        ? currentFeedVideos
+        : displayedVideos;
+    final index = videos.indexWhere(
+      (video) =>
+          video.id == tappedVideo.id ||
+          (video.pubkey == tappedVideo.pubkey &&
+              video.stableId == tappedVideo.stableId),
+    );
+    final resolvedIndex = index >= 0 ? index : fallbackIndex;
     final hasMoreContent =
         ref
             .read(profileFeedProvider(widget.userIdHex))
@@ -155,19 +174,19 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
             .hasMoreContent ??
         false;
     Log.info(
-      '🎯 ProfileVideosGrid TAP: gridIndex=$index, '
-      'videoId=${videos[index].id}',
+      '🎯 ProfileVideosGrid TAP: gridIndex=$resolvedIndex, '
+      'videoId=${tappedVideo.id}',
       category: LogCategory.video,
     );
 
     // Pre-warm adjacent videos before navigation
-    prefetchAroundIndex(index, videos);
+    prefetchAroundIndex(resolvedIndex, videos);
 
     context.push(
       PooledFullscreenVideoFeedScreen.path,
       extra: PooledFullscreenVideoFeedArgs(
         videosStream: _videosStreamController.stream.startWith(videos),
-        initialIndex: index,
+        initialIndex: resolvedIndex,
         onLoadMore: onLoadMore,
         hasMoreStream: _hasMoreStreamController.stream.startWith(
           hasMoreContent,
@@ -329,8 +348,11 @@ class _ProfileVideosGridState extends ConsumerState<ProfileVideosGrid>
                     // Adjust index to account for uploading videos at the top
                     final publishedIndex = index - uploadingCount;
                     if (publishedIndex >= 0) {
+                      final displayedVideos = filteredVideos;
                       _onVideoTapped(
-                        publishedIndex,
+                        eventEntry.videoEvent,
+                        fallbackIndex: publishedIndex,
+                        displayedVideos: displayedVideos,
                         onLoadMore: loadMoreProfileVideos,
                       );
                     }

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -777,6 +777,50 @@ void main() {
         expect(result.totalCount, equals(42));
       });
 
+      test(
+        'parses total_loops and total_views from author videos response',
+        () async {
+          const responseWithLoopMetrics =
+              '''
+[
+  {
+    "id": "abc123def456",
+    "pubkey": "$testPubkey",
+    "created_at": 1700000000,
+    "kind": 34236,
+    "d_tag": "test-video-1",
+    "title": "Test Video",
+    "content": "A test video description",
+    "thumbnail": "https://example.com/thumb.jpg",
+    "video_url": "https://example.com/video.mp4",
+    "total_loops": 42.0,
+    "total_views": 100.0,
+    "reactions": 100,
+    "comments": 10,
+    "reposts": 5,
+    "engagement_score": 115
+  }
+]
+''';
+          when(
+            () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+          ).thenAnswer(
+            (_) async => http.Response(
+              responseWithLoopMetrics,
+              200,
+              headers: {'x-total-count': '42'},
+            ),
+          );
+
+          final result = await client.getVideosByAuthor(pubkey: testPubkey);
+          final video = result.videos.single.toVideoEvent();
+
+          expect(video.originalLoops, equals(42));
+          expect(video.rawTags['views'], equals('100'));
+          expect(video.totalLoops, equals(142));
+        },
+      );
+
       test('constructs correct URL with default limit', () async {
         when(
           () => mockHttpClient.get(any(), headers: any(named: 'headers')),

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -100,7 +100,15 @@ class VideoStats {
     // Parse loops from multiple possible sources
     int? loops;
     final directLoops =
-        statsData['loops'] ?? json['loops'] ?? json['original_loops'];
+        statsData['loops'] ??
+        statsData['total_loops'] ??
+        statsData['computed_loops'] ??
+        statsData['embedded_loops'] ??
+        json['loops'] ??
+        json['original_loops'] ??
+        json['total_loops'] ??
+        json['computed_loops'] ??
+        json['embedded_loops'];
     if (directLoops is int) {
       loops = directLoops;
     } else if (directLoops is double) {
@@ -134,7 +142,12 @@ class VideoStats {
     // Parse view counts from multiple possible sources
     int? views;
     final directViews =
-        statsData['views'] ?? json['views'] ?? json['view_count'];
+        statsData['views'] ??
+        statsData['view_count'] ??
+        statsData['total_views'] ??
+        json['views'] ??
+        json['view_count'] ??
+        json['total_views'];
     if (directViews is int) {
       views = directViews;
     } else if (directViews is double) {

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -557,6 +557,29 @@ void main() {
         expect(stats.views, equals(100));
       });
 
+      test('parses total_loops and total_views field variants', () {
+        final json = {
+          'id': 'test-id',
+          'pubkey': 'test-pubkey',
+          'created_at': 1700000000,
+          'kind': 34236,
+          'd_tag': 'video-1',
+          'title': 'Test',
+          'thumbnail': 'https://example.com/thumb.jpg',
+          'video_url': 'https://example.com/video.mp4',
+          'reactions': 10,
+          'comments': 5,
+          'reposts': 2,
+          'engagement_score': 125,
+          'total_loops': 42.0,
+          'total_views': 100.0,
+        };
+
+        final stats = VideoStats.fromJson(json);
+        expect(stats.loops, equals(42));
+        expect(stats.views, equals(100));
+      });
+
       test('normalizes empty values to null', () {
         final json = {
           'id': 'test-id',

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -216,12 +216,46 @@ void main() {
         expect(state.props, [
           FullscreenFeedStatus.ready,
           [video],
+          [
+            '${video.id}|${video.stableId}|${video.videoUrl ?? ''}|${video.thumbnailUrl ?? ''}|${video.originalLoops ?? ''}|${video.rawTags['views'] ?? ''}',
+          ],
           2,
           true,
           false,
           <String>{},
           null,
         ]);
+      });
+
+      test('videoUpdateSignature changes when loop metadata changes', () {
+        final now = DateTime.now();
+        final baseVideo = VideoEvent(
+          id: 'video1',
+          pubkey: '0' * 64,
+          createdAt: now.millisecondsSinceEpoch ~/ 1000,
+          content: '',
+          timestamp: now,
+          videoUrl: 'https://example.com/video1.mp4',
+          rawTags: const {'views': '0'},
+        );
+        final updatedVideo = baseVideo.copyWith(
+          rawTags: const {'views': '42'},
+        );
+
+        final baseState = FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [baseVideo],
+        );
+        final updatedState = FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [updatedVideo],
+        );
+
+        expect(
+          baseState.videoUpdateSignature,
+          isNot(updatedState.videoUpdateSignature),
+        );
+        expect(baseState, isNot(updatedState));
       });
     });
 

--- a/mobile/test/providers/profile_feed_pagination_contract_test.dart
+++ b/mobile/test/providers/profile_feed_pagination_contract_test.dart
@@ -31,6 +31,18 @@ class _NeverAvailableFunnelcake extends FunnelcakeAvailable {
   Future<bool> build() async => false;
 }
 
+bool _controlledFunnelcakeAvailability = false;
+final _controlledFunnelcakeAvailabilityProvider = Provider<bool>(
+  (ref) => _controlledFunnelcakeAvailability,
+);
+
+class _ControlledFunnelcake extends FunnelcakeAvailable {
+  @override
+  Future<bool> build() async {
+    return ref.watch(_controlledFunnelcakeAvailabilityProvider);
+  }
+}
+
 void main() {
   const userId =
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -124,6 +136,7 @@ void main() {
     late _MockNostrClient mockNostrClient;
 
     setUp(() {
+      _controlledFunnelcakeAvailability = false;
       mockFunnelcakeApiClient = _MockFunnelcakeApiClient();
       mockVideoEventService = _MockVideoEventService();
       mockNostrClient = _MockNostrClient();
@@ -159,14 +172,19 @@ void main() {
       ).thenReturn(false);
     });
 
-    ProviderContainer createContainer({bool funnelcakeAvailable = true}) {
+    ProviderContainer createContainer({
+      bool funnelcakeAvailable = true,
+      bool useControlledAvailability = false,
+    }) {
       final container = ProviderContainer(
         overrides: [
           funnelcakeApiClientProvider.overrideWithValue(
             mockFunnelcakeApiClient,
           ),
           funnelcakeAvailableProvider.overrideWith(
-            funnelcakeAvailable
+            useControlledAvailability
+                ? _ControlledFunnelcake.new
+                : funnelcakeAvailable
                 ? _AlwaysAvailableFunnelcake.new
                 : _NeverAvailableFunnelcake.new,
           ),
@@ -257,6 +275,79 @@ void main() {
 
         expect(state.videos.map((v) => v.id), ['relay-head']);
         expect(state.isInitialLoad, isFalse);
+      },
+    );
+
+    test(
+      'late Funnelcake availability refreshes relay-only profile videos with REST stats',
+      () async {
+        when(() => mockVideoEventService.authorVideos(userId)).thenReturn([
+          _relayVideo(
+            id: 'video-0',
+            pubkey: userId,
+            stableId: 'video-0',
+            createdAt: DateTime(2026, 3, 30, 12),
+          ),
+        ]);
+        when(
+          () => mockFunnelcakeApiClient.getVideosByAuthor(pubkey: userId),
+        ).thenAnswer(
+          (_) async => VideosByAuthorResponse(
+            videos: [
+              VideoStats(
+                id: 'video-0',
+                pubkey: userId,
+                createdAt: DateTime(2026, 3, 30, 12),
+                kind: 22,
+                dTag: 'video-0',
+                title: 'Video 0',
+                thumbnail: 'https://example.com/thumb-0.jpg',
+                videoUrl: 'https://example.com/video-0.mp4',
+                reactions: 0,
+                comments: 0,
+                reposts: 0,
+                engagementScore: 0,
+              ),
+            ],
+          ),
+        );
+        when(
+          () => mockFunnelcakeApiClient.getVideoViews('video-0'),
+        ).thenAnswer((_) async => 42);
+
+        final container = createContainer(useControlledAvailability: true);
+
+        final initialState = await container.read(
+          profileFeedProvider(userId).future,
+        );
+        expect(initialState.videos, hasLength(1));
+        expect(initialState.videos.single.totalLoops, 0);
+        expect(initialState.isFetchingTotalCount, isFalse);
+
+        final hydrated = Completer<VideoFeedState>();
+        final subscription = container.listen<AsyncValue<VideoFeedState>>(
+          profileFeedProvider(userId),
+          (previous, next) {
+            final value = next.asData?.value;
+            if (value != null &&
+                value.videos.length == 1 &&
+                value.videos.single.totalLoops == 42 &&
+                !hydrated.isCompleted) {
+              hydrated.complete(value);
+            }
+          },
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+
+        _controlledFunnelcakeAvailability = true;
+        container.invalidate(_controlledFunnelcakeAvailabilityProvider);
+
+        final hydratedState = await hydrated.future.timeout(
+          const Duration(milliseconds: 300),
+        );
+        expect(hydratedState.videos.single.rawTags['views'], '42');
+        expect(hydratedState.videos.single.totalLoops, 42);
       },
     );
 

--- a/mobile/test/providers/profile_feed_pagination_contract_test.dart
+++ b/mobile/test/providers/profile_feed_pagination_contract_test.dart
@@ -129,6 +129,12 @@ void main() {
       mockNostrClient = _MockNostrClient();
 
       when(
+        () => mockFunnelcakeApiClient.getBulkVideoStats(any()),
+      ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+      when(
+        () => mockFunnelcakeApiClient.getVideoViews(any()),
+      ).thenAnswer((_) async => 0);
+      when(
         () => mockNostrClient.queryEvents(any()),
       ).thenAnswer((_) async => []);
       when(

--- a/mobile/test/providers/profile_feed_provider_test.dart
+++ b/mobile/test/providers/profile_feed_provider_test.dart
@@ -163,6 +163,45 @@ void main() {
         expect(key2, equals('pubkey1:stableid'));
       });
     });
+
+    group('rawTags merge behavior', () {
+      test('preserves REST views when relay copy wins merge precedence', () {
+        final merged = ProfileFeed.mergeRawTagsForVideoMerge(
+          {'d': 'stable1', 'title': 'Relay title'},
+          {'views': '42'},
+        );
+
+        expect(merged['d'], equals('stable1'));
+        expect(merged['title'], equals('Relay title'));
+        expect(merged['views'], equals('42'));
+      });
+
+      test('merged tags keep loop totals available on profile videos', () {
+        final relayVideo = createTestVideo(
+          'id1',
+          'pubkey1',
+          'stable1',
+          baseTime,
+        );
+        final restVideo = createTestVideo(
+          'id2',
+          'pubkey1',
+          'stable1',
+          baseTime.subtract(const Duration(seconds: 1)),
+        ).copyWith(rawTags: {'views': '42'});
+
+        final mergedVideo = relayVideo.copyWith(
+          rawTags: ProfileFeed.mergeRawTagsForVideoMerge(
+            relayVideo.rawTags,
+            restVideo.rawTags,
+          ),
+          originalLoops: relayVideo.originalLoops ?? restVideo.originalLoops,
+        );
+
+        expect(mergedVideo.rawTags['views'], equals('42'));
+        expect(mergedVideo.totalLoops, equals(42));
+      });
+    });
   });
 }
 

--- a/mobile/test/providers/profile_feed_provider_test.dart
+++ b/mobile/test/providers/profile_feed_provider_test.dart
@@ -201,6 +201,57 @@ void main() {
         expect(mergedVideo.rawTags['views'], equals('42'));
         expect(mergedVideo.totalLoops, equals(42));
       });
+
+      test('sequence comparison treats views-only metadata changes as updates', () {
+        final stale = [
+          createTestVideo(
+            'id1',
+            'pubkey1',
+            'stable1',
+            baseTime,
+          ),
+        ];
+        final enriched = [
+          createTestVideo(
+            'id1',
+            'pubkey1',
+            'stable1',
+            baseTime,
+          ).copyWith(rawTags: {'d': 'stable1', 'views': '42'}),
+        ];
+
+        expect(
+          ProfileFeed.sameVideoSequenceForMerge(stale, enriched),
+          isFalse,
+        );
+      });
+
+      test(
+        'sequence comparison treats originalLoops changes as updates',
+        () {
+          final stale = [
+            createTestVideo(
+              'id1',
+              'pubkey1',
+              'stable1',
+              baseTime,
+            ),
+          ];
+          final enriched = [
+            createTestVideo(
+              'id1',
+              'pubkey1',
+              'stable1',
+              baseTime,
+            ).copyWith(originalLoops: 100),
+          ];
+
+          expect(
+            ProfileFeed.sameVideoSequenceForMerge(stale, enriched),
+            isFalse,
+          );
+        },
+      );
     });
   });
 }

--- a/mobile/test/providers/profile_feed_provider_test.dart
+++ b/mobile/test/providers/profile_feed_provider_test.dart
@@ -202,29 +202,32 @@ void main() {
         expect(mergedVideo.totalLoops, equals(42));
       });
 
-      test('sequence comparison treats views-only metadata changes as updates', () {
-        final stale = [
-          createTestVideo(
-            'id1',
-            'pubkey1',
-            'stable1',
-            baseTime,
-          ),
-        ];
-        final enriched = [
-          createTestVideo(
-            'id1',
-            'pubkey1',
-            'stable1',
-            baseTime,
-          ).copyWith(rawTags: {'d': 'stable1', 'views': '42'}),
-        ];
+      test(
+        'sequence comparison treats views-only metadata changes as updates',
+        () {
+          final stale = [
+            createTestVideo(
+              'id1',
+              'pubkey1',
+              'stable1',
+              baseTime,
+            ),
+          ];
+          final enriched = [
+            createTestVideo(
+              'id1',
+              'pubkey1',
+              'stable1',
+              baseTime,
+            ).copyWith(rawTags: {'d': 'stable1', 'views': '42'}),
+          ];
 
-        expect(
-          ProfileFeed.sameVideoSequenceForMerge(stale, enriched),
-          isFalse,
-        );
-      });
+          expect(
+            ProfileFeed.sameVideoSequenceForMerge(stale, enriched),
+            isFalse,
+          );
+        },
+      );
 
       test(
         'sequence comparison treats originalLoops changes as updates',

--- a/mobile/test/providers/profile_feed_provider_test.dart
+++ b/mobile/test/providers/profile_feed_provider_test.dart
@@ -202,6 +202,23 @@ void main() {
         expect(mergedVideo.totalLoops, equals(42));
       });
 
+      test('cached metadata rehydrates views onto relay profile videos', () {
+        final relayVideo = createTestVideo(
+          'id1',
+          'pubkey1',
+          'stable1',
+          baseTime,
+        );
+
+        final hydrated = ProfileFeed.applyCachedMetadataForVideo(
+          relayVideo,
+          views: '42',
+        );
+
+        expect(hydrated.rawTags['views'], equals('42'));
+        expect(hydrated.totalLoops, equals(42));
+      });
+
       test(
         'sequence comparison treats views-only metadata changes as updates',
         () {

--- a/mobile/test/screens/profile_grid_tap_navigation_test.dart
+++ b/mobile/test/screens/profile_grid_tap_navigation_test.dart
@@ -570,10 +570,10 @@ void main() {
       );
     });
 
-    testWidgets('passes a live hasMoreStream to fullscreen navigation', (
+    testWidgets('passes provider-backed fullscreen args to navigation', (
       tester,
     ) async {
-      PooledFullscreenVideoFeedArgs? capturedArgs;
+      ProfilePooledFullscreenVideoFeedArgs? capturedArgs;
 
       final router = GoRouter(
         initialLocation: '/',
@@ -590,7 +590,8 @@ void main() {
           GoRoute(
             path: PooledFullscreenVideoFeedScreen.path,
             builder: (context, state) {
-              capturedArgs = state.extra! as PooledFullscreenVideoFeedArgs;
+              capturedArgs =
+                  state.extra! as ProfilePooledFullscreenVideoFeedArgs;
               return const Scaffold(body: SizedBox.shrink());
             },
           ),
@@ -629,8 +630,9 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(capturedArgs, isNotNull);
-      expect(capturedArgs!.hasMoreStream, isNotNull);
-      expect(capturedArgs!.removedIdsStream, isNotNull);
+      expect(capturedArgs!.userIdHex, testUserHex);
+      expect(capturedArgs!.initialVideoId, mockVideos[0].id);
+      expect(capturedArgs!.initialStableId, mockVideos[0].stableId);
     });
   });
 }


### PR DESCRIPTION
Closes #3547

## Summary
- preserve REST analytics tags like views when profile videos are merged with relay copies
- keep profile-page loop counts consistent with home and explore feeds
- add a regression test covering the profile merge path that previously dropped loop totals

## Testing
- dart analyze lib/providers/profile_feed_provider.dart test/providers/profile_feed_provider_test.dart
- flutter test test/providers/profile_feed_provider_test.dart