### PR TITLE
fix(collabs): drop sender-side Accept/Ignore + NIP-04 duplicate (#3559)

### DIFF
--- a/mobile/lib/blocs/dm/conversation/collaborator_invite_actions_cubit.dart
+++ b/mobile/lib/blocs/dm/conversation/collaborator_invite_actions_cubit.dart
@@ -67,7 +67,13 @@ class CollaboratorInviteActionsCubit
   }
 
   Future<void> acceptInvite(CollaboratorInvite invite) async {
+    assert(
+      _currentUserPubkey != invite.creatorPubkey,
+      'CollaboratorInviteCard should not surface accept for sender-side '
+      'invites (#3559)',
+    );
     if (_currentUserPubkey.isEmpty) return;
+    if (_currentUserPubkey == invite.creatorPubkey) return;
 
     await _setInviteState(invite, CollaboratorInviteState.accepting);
 
@@ -81,7 +87,13 @@ class CollaboratorInviteActionsCubit
   }
 
   Future<void> ignoreInvite(CollaboratorInvite invite) async {
+    assert(
+      _currentUserPubkey != invite.creatorPubkey,
+      'CollaboratorInviteCard should not surface ignore for sender-side '
+      'invites (#3559)',
+    );
     if (_currentUserPubkey.isEmpty) return;
+    if (_currentUserPubkey == invite.creatorPubkey) return;
     await _setInviteState(invite, CollaboratorInviteState.ignored);
   }
 

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2255,6 +2255,10 @@
             }
         }
     },
+    "inboxCollabInviteSentStatus": "Invitation sent",
+    "@inboxCollabInviteSentStatus": {
+        "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+    },
     "inboxConversationMuted": "تم كتم المحادثة",
     "inboxConversationUnmuted": "تم إلغاء كتم المحادثة",
     "inboxEmptySubtitle": "زر + لن يعضّك.",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2255,7 +2255,21 @@
             }
         }
     },
-    "inboxCollabInviteSentStatus": "Invitation sent",
+    "inboxCollabInviteAcceptButton": "قبول",
+    "inboxCollabInviteAcceptError": "تعذر القبول. حاول مرة أخرى.",
+    "inboxCollabInviteAcceptedStatus": "تم القبول",
+    "inboxCollabInviteCardRoleLabel": "{role} على هذا المنشور",
+    "@inboxCollabInviteCardRoleLabel": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxCollabInviteCardTitle": "دعوة للتعاون",
+    "inboxCollabInviteIgnoreButton": "تجاهل",
+    "inboxCollabInviteIgnoredStatus": "تم التجاهل",
+    "inboxCollabInviteSentStatus": "تم إرسال الدعوة",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
     },

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2256,7 +2256,21 @@
             }
         }
     },
-    "inboxCollabInviteSentStatus": "Invitation sent",
+    "inboxCollabInviteAcceptButton": "Annehmen",
+    "inboxCollabInviteAcceptError": "Annahme fehlgeschlagen. Erneut versuchen.",
+    "inboxCollabInviteAcceptedStatus": "Angenommen",
+    "inboxCollabInviteCardRoleLabel": "{role} bei diesem Beitrag",
+    "@inboxCollabInviteCardRoleLabel": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxCollabInviteCardTitle": "Einladung zur Zusammenarbeit",
+    "inboxCollabInviteIgnoreButton": "Ignorieren",
+    "inboxCollabInviteIgnoredStatus": "Ignoriert",
+    "inboxCollabInviteSentStatus": "Einladung gesendet",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
     },

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2256,6 +2256,10 @@
             }
         }
     },
+    "inboxCollabInviteSentStatus": "Invitation sent",
+    "@inboxCollabInviteSentStatus": {
+        "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+    },
     "inboxConversationMuted": "Unterhaltung stummgeschaltet",
     "inboxConversationUnmuted": "Unterhaltung nicht mehr stummgeschaltet",
     "inboxEmptySubtitle": "Der + Button beißt nicht.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2294,6 +2294,11 @@
   "inboxConversationMuted": "Conversation muted",
   "inboxConversationUnmuted": "Conversation unmuted",
 
+  "inboxCollabInviteSentStatus": "Invitation sent",
+  "@inboxCollabInviteSentStatus": {
+    "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+  },
+
   "reportDialogCancel": "Cancel",
   "reportDialogReport": "Report",
 

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2294,6 +2294,24 @@
   "inboxConversationMuted": "Conversation muted",
   "inboxConversationUnmuted": "Conversation unmuted",
 
+  "inboxCollabInviteCardTitle": "Collaborator invite",
+  "@inboxCollabInviteCardTitle": {
+    "description": "Header label on a collaborator invite card in the DM conversation."
+  },
+  "inboxCollabInviteCardRoleLabel": "{role} on this post",
+  "@inboxCollabInviteCardRoleLabel": {
+    "description": "Subtitle on the collaborator invite card describing the offered collaborator role.",
+    "placeholders": {
+      "role": {
+        "type": "String"
+      }
+    }
+  },
+  "inboxCollabInviteAcceptButton": "Accept",
+  "inboxCollabInviteIgnoreButton": "Ignore",
+  "inboxCollabInviteAcceptedStatus": "Accepted",
+  "inboxCollabInviteIgnoredStatus": "Ignored",
+  "inboxCollabInviteAcceptError": "Could not accept. Try again.",
   "inboxCollabInviteSentStatus": "Invitation sent",
   "@inboxCollabInviteSentStatus": {
     "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2256,6 +2256,10 @@
             }
         }
     },
+    "inboxCollabInviteSentStatus": "Invitation sent",
+    "@inboxCollabInviteSentStatus": {
+        "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+    },
     "inboxConversationMuted": "Conversación silenciada",
     "inboxConversationUnmuted": "Conversación sin silenciar",
     "inboxEmptySubtitle": "El botón + no muerde.",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2256,7 +2256,21 @@
             }
         }
     },
-    "inboxCollabInviteSentStatus": "Invitation sent",
+    "inboxCollabInviteAcceptButton": "Aceptar",
+    "inboxCollabInviteAcceptError": "No se pudo aceptar. Inténtalo de nuevo.",
+    "inboxCollabInviteAcceptedStatus": "Aceptada",
+    "inboxCollabInviteCardRoleLabel": "{role} en esta publicación",
+    "@inboxCollabInviteCardRoleLabel": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxCollabInviteCardTitle": "Invitación a colaborar",
+    "inboxCollabInviteIgnoreButton": "Ignorar",
+    "inboxCollabInviteIgnoredStatus": "Ignorada",
+    "inboxCollabInviteSentStatus": "Invitación enviada",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
     },

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2256,6 +2256,10 @@
             }
         }
     },
+    "inboxCollabInviteSentStatus": "Invitation sent",
+    "@inboxCollabInviteSentStatus": {
+        "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+    },
     "inboxConversationMuted": "Conversation mise en sourdine",
     "inboxConversationUnmuted": "Conversation réactivée",
     "inboxEmptySubtitle": "Le bouton + ne mord pas.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2256,7 +2256,21 @@
             }
         }
     },
-    "inboxCollabInviteSentStatus": "Invitation sent",
+    "inboxCollabInviteAcceptButton": "Accepter",
+    "inboxCollabInviteAcceptError": "Impossible d'accepter. Réessayez.",
+    "inboxCollabInviteAcceptedStatus": "Acceptée",
+    "inboxCollabInviteCardRoleLabel": "{role} sur cette publication",
+    "@inboxCollabInviteCardRoleLabel": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxCollabInviteCardTitle": "Invitation à collaborer",
+    "inboxCollabInviteIgnoreButton": "Ignorer",
+    "inboxCollabInviteIgnoredStatus": "Ignorée",
+    "inboxCollabInviteSentStatus": "Invitation envoyée",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
     },

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2255,7 +2255,21 @@
             }
         }
     },
-    "inboxCollabInviteSentStatus": "Invitation sent",
+    "inboxCollabInviteAcceptButton": "Terima",
+    "inboxCollabInviteAcceptError": "Tidak bisa menerima. Coba lagi.",
+    "inboxCollabInviteAcceptedStatus": "Diterima",
+    "inboxCollabInviteCardRoleLabel": "{role} di postingan ini",
+    "@inboxCollabInviteCardRoleLabel": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxCollabInviteCardTitle": "Undangan kolaborasi",
+    "inboxCollabInviteIgnoreButton": "Abaikan",
+    "inboxCollabInviteIgnoredStatus": "Diabaikan",
+    "inboxCollabInviteSentStatus": "Undangan terkirim",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
     },

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2255,6 +2255,10 @@
             }
         }
     },
+    "inboxCollabInviteSentStatus": "Invitation sent",
+    "@inboxCollabInviteSentStatus": {
+        "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+    },
     "inboxConversationMuted": "Percakapan dibisukan",
     "inboxConversationUnmuted": "Bisu percakapan dibatalkan",
     "inboxEmptySubtitle": "Tombol + tidak menggigit kok.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2256,7 +2256,21 @@
             }
         }
     },
-    "inboxCollabInviteSentStatus": "Invitation sent",
+    "inboxCollabInviteAcceptButton": "Accetta",
+    "inboxCollabInviteAcceptError": "Impossibile accettare. Riprova.",
+    "inboxCollabInviteAcceptedStatus": "Accettato",
+    "inboxCollabInviteCardRoleLabel": "{role} in questo post",
+    "@inboxCollabInviteCardRoleLabel": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxCollabInviteCardTitle": "Invito a collaborare",
+    "inboxCollabInviteIgnoreButton": "Ignora",
+    "inboxCollabInviteIgnoredStatus": "Ignorato",
+    "inboxCollabInviteSentStatus": "Invito inviato",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
     },

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2256,6 +2256,10 @@
             }
         }
     },
+    "inboxCollabInviteSentStatus": "Invitation sent",
+    "@inboxCollabInviteSentStatus": {
+        "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+    },
     "inboxConversationMuted": "Conversazione silenziata",
     "inboxConversationUnmuted": "Conversazione riattivata",
     "inboxEmptySubtitle": "Il pulsante + non morde.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2255,6 +2255,10 @@
             }
         }
     },
+    "inboxCollabInviteSentStatus": "Invitation sent",
+    "@inboxCollabInviteSentStatus": {
+        "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+    },
     "inboxConversationMuted": "会話をミュートしたよ",
     "inboxConversationUnmuted": "会話のミュートを解除したよ",
     "inboxEmptySubtitle": "この+ボタン、噛まないよ。",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2255,7 +2255,21 @@
             }
         }
     },
-    "inboxCollabInviteSentStatus": "Invitation sent",
+    "inboxCollabInviteAcceptButton": "承認",
+    "inboxCollabInviteAcceptError": "承認できなかったよ。もう一度試してね。",
+    "inboxCollabInviteAcceptedStatus": "承認済み",
+    "inboxCollabInviteCardRoleLabel": "この投稿で{role}",
+    "@inboxCollabInviteCardRoleLabel": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxCollabInviteCardTitle": "コラボ招待",
+    "inboxCollabInviteIgnoreButton": "無視",
+    "inboxCollabInviteIgnoredStatus": "無視済み",
+    "inboxCollabInviteSentStatus": "招待を送ったよ",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
     },

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1544,6 +1544,10 @@
             }
         }
     },
+    "inboxCollabInviteSentStatus": "Invitation sent",
+    "@inboxCollabInviteSentStatus": {
+        "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+    },
     "inboxConversationMuted": "대화 알림을 껐어요",
     "inboxConversationUnmuted": "대화 알림을 다시 켰어요",
     "inboxEmptySubtitle": "+ 버튼, 물지 않아요.",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1544,7 +1544,21 @@
             }
         }
     },
-    "inboxCollabInviteSentStatus": "Invitation sent",
+    "inboxCollabInviteAcceptButton": "수락",
+    "inboxCollabInviteAcceptError": "수락하지 못했어요. 다시 시도해 주세요.",
+    "inboxCollabInviteAcceptedStatus": "수락됨",
+    "inboxCollabInviteCardRoleLabel": "이 게시물의 {role}",
+    "@inboxCollabInviteCardRoleLabel": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxCollabInviteCardTitle": "콜라보 초대",
+    "inboxCollabInviteIgnoreButton": "무시",
+    "inboxCollabInviteIgnoredStatus": "무시됨",
+    "inboxCollabInviteSentStatus": "초대를 보냈어요",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
     },

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2256,7 +2256,21 @@
             }
         }
     },
-    "inboxCollabInviteSentStatus": "Invitation sent",
+    "inboxCollabInviteAcceptButton": "Accepteren",
+    "inboxCollabInviteAcceptError": "Accepteren is niet gelukt. Probeer het opnieuw.",
+    "inboxCollabInviteAcceptedStatus": "Geaccepteerd",
+    "inboxCollabInviteCardRoleLabel": "{role} bij deze post",
+    "@inboxCollabInviteCardRoleLabel": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxCollabInviteCardTitle": "Uitnodiging om samen te werken",
+    "inboxCollabInviteIgnoreButton": "Negeren",
+    "inboxCollabInviteIgnoredStatus": "Genegeerd",
+    "inboxCollabInviteSentStatus": "Uitnodiging verzonden",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
     },

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2256,6 +2256,10 @@
             }
         }
     },
+    "inboxCollabInviteSentStatus": "Invitation sent",
+    "@inboxCollabInviteSentStatus": {
+        "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+    },
     "inboxConversationMuted": "Gesprek gedempt",
     "inboxConversationUnmuted": "Gesprek niet meer gedempt",
     "inboxEmptySubtitle": "Die +-knop bijt niet.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2256,6 +2256,10 @@
             }
         }
     },
+    "inboxCollabInviteSentStatus": "Invitation sent",
+    "@inboxCollabInviteSentStatus": {
+        "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+    },
     "inboxConversationMuted": "Wyciszono rozmowę",
     "inboxConversationUnmuted": "Wyłączono wyciszenie rozmowy",
     "inboxEmptySubtitle": "Ten przycisk + nie gryzie.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2256,7 +2256,21 @@
             }
         }
     },
-    "inboxCollabInviteSentStatus": "Invitation sent",
+    "inboxCollabInviteAcceptButton": "Akceptuj",
+    "inboxCollabInviteAcceptError": "Nie udało się zaakceptować. Spróbuj ponownie.",
+    "inboxCollabInviteAcceptedStatus": "Zaakceptowano",
+    "inboxCollabInviteCardRoleLabel": "{role} przy tym poście",
+    "@inboxCollabInviteCardRoleLabel": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxCollabInviteCardTitle": "Zaproszenie do współpracy",
+    "inboxCollabInviteIgnoreButton": "Ignoruj",
+    "inboxCollabInviteIgnoredStatus": "Zignorowano",
+    "inboxCollabInviteSentStatus": "Zaproszenie wysłane",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
     },

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2256,7 +2256,21 @@
             }
         }
     },
-    "inboxCollabInviteSentStatus": "Invitation sent",
+    "inboxCollabInviteAcceptButton": "Aceitar",
+    "inboxCollabInviteAcceptError": "Não foi possível aceitar. Tente novamente.",
+    "inboxCollabInviteAcceptedStatus": "Aceito",
+    "inboxCollabInviteCardRoleLabel": "{role} nesta publicação",
+    "@inboxCollabInviteCardRoleLabel": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxCollabInviteCardTitle": "Convite para colaborar",
+    "inboxCollabInviteIgnoreButton": "Ignorar",
+    "inboxCollabInviteIgnoredStatus": "Ignorado",
+    "inboxCollabInviteSentStatus": "Convite enviado",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
     },

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2256,6 +2256,10 @@
             }
         }
     },
+    "inboxCollabInviteSentStatus": "Invitation sent",
+    "@inboxCollabInviteSentStatus": {
+        "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+    },
     "inboxConversationMuted": "Conversa silenciada",
     "inboxConversationUnmuted": "Conversa com som ativado",
     "inboxEmptySubtitle": "O botão + não morde.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2256,6 +2256,10 @@
             }
         }
     },
+    "inboxCollabInviteSentStatus": "Invitation sent",
+    "@inboxCollabInviteSentStatus": {
+        "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+    },
     "inboxConversationMuted": "Conversație dezactivată",
     "inboxConversationUnmuted": "Conversație reactivată",
     "inboxEmptySubtitle": "Butonul + nu mușcă.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2256,7 +2256,21 @@
             }
         }
     },
-    "inboxCollabInviteSentStatus": "Invitation sent",
+    "inboxCollabInviteAcceptButton": "Acceptă",
+    "inboxCollabInviteAcceptError": "Nu s-a putut accepta. Încearcă din nou.",
+    "inboxCollabInviteAcceptedStatus": "Acceptată",
+    "inboxCollabInviteCardRoleLabel": "{role} la această postare",
+    "@inboxCollabInviteCardRoleLabel": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxCollabInviteCardTitle": "Invitație de colaborare",
+    "inboxCollabInviteIgnoreButton": "Ignoră",
+    "inboxCollabInviteIgnoredStatus": "Ignorată",
+    "inboxCollabInviteSentStatus": "Invitație trimisă",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
     },

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2256,7 +2256,21 @@
             }
         }
     },
-    "inboxCollabInviteSentStatus": "Invitation sent",
+    "inboxCollabInviteAcceptButton": "Acceptera",
+    "inboxCollabInviteAcceptError": "Det gick inte att acceptera. Försök igen.",
+    "inboxCollabInviteAcceptedStatus": "Accepterad",
+    "inboxCollabInviteCardRoleLabel": "{role} i det här inlägget",
+    "@inboxCollabInviteCardRoleLabel": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxCollabInviteCardTitle": "Inbjudan att samarbeta",
+    "inboxCollabInviteIgnoreButton": "Ignorera",
+    "inboxCollabInviteIgnoredStatus": "Ignorerad",
+    "inboxCollabInviteSentStatus": "Inbjudan skickad",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
     },

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2256,6 +2256,10 @@
             }
         }
     },
+    "inboxCollabInviteSentStatus": "Invitation sent",
+    "@inboxCollabInviteSentStatus": {
+        "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+    },
     "inboxConversationMuted": "Konversation tystad",
     "inboxConversationUnmuted": "Konversation inte tystad",
     "inboxEmptySubtitle": "+-knappen bits inte.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2255,6 +2255,10 @@
             }
         }
     },
+    "inboxCollabInviteSentStatus": "Invitation sent",
+    "@inboxCollabInviteSentStatus": {
+        "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
+    },
     "inboxConversationMuted": "Sohbet sessize alındı",
     "inboxConversationUnmuted": "Sohbet sessizden çıkarıldı",
     "inboxEmptySubtitle": "+ tuşu ısırmaz.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2255,7 +2255,21 @@
             }
         }
     },
-    "inboxCollabInviteSentStatus": "Invitation sent",
+    "inboxCollabInviteAcceptButton": "Kabul et",
+    "inboxCollabInviteAcceptError": "Kabul edilemedi. Tekrar dene.",
+    "inboxCollabInviteAcceptedStatus": "Kabul edildi",
+    "inboxCollabInviteCardRoleLabel": "Bu gönderide {role}",
+    "@inboxCollabInviteCardRoleLabel": {
+        "placeholders": {
+            "role": {
+                "type": "String"
+            }
+        }
+    },
+    "inboxCollabInviteCardTitle": "İşbirliği daveti",
+    "inboxCollabInviteIgnoreButton": "Yoksay",
+    "inboxCollabInviteIgnoredStatus": "Yoksayıldı",
+    "inboxCollabInviteSentStatus": "Davet gönderildi",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
     },

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -8084,6 +8084,12 @@ abstract class AppLocalizations {
   /// **'Conversation unmuted'**
   String get inboxConversationUnmuted;
 
+  /// Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions.
+  ///
+  /// In en, this message translates to:
+  /// **'Invitation sent'**
+  String get inboxCollabInviteSentStatus;
+
   /// No description provided for @reportDialogCancel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -8084,6 +8084,48 @@ abstract class AppLocalizations {
   /// **'Conversation unmuted'**
   String get inboxConversationUnmuted;
 
+  /// Header label on a collaborator invite card in the DM conversation.
+  ///
+  /// In en, this message translates to:
+  /// **'Collaborator invite'**
+  String get inboxCollabInviteCardTitle;
+
+  /// Subtitle on the collaborator invite card describing the offered collaborator role.
+  ///
+  /// In en, this message translates to:
+  /// **'{role} on this post'**
+  String inboxCollabInviteCardRoleLabel(String role);
+
+  /// No description provided for @inboxCollabInviteAcceptButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Accept'**
+  String get inboxCollabInviteAcceptButton;
+
+  /// No description provided for @inboxCollabInviteIgnoreButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Ignore'**
+  String get inboxCollabInviteIgnoreButton;
+
+  /// No description provided for @inboxCollabInviteAcceptedStatus.
+  ///
+  /// In en, this message translates to:
+  /// **'Accepted'**
+  String get inboxCollabInviteAcceptedStatus;
+
+  /// No description provided for @inboxCollabInviteIgnoredStatus.
+  ///
+  /// In en, this message translates to:
+  /// **'Ignored'**
+  String get inboxCollabInviteIgnoredStatus;
+
+  /// No description provided for @inboxCollabInviteAcceptError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not accept. Try again.'**
+  String get inboxCollabInviteAcceptError;
+
   /// Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4491,7 +4491,30 @@ class AppLocalizationsAr extends AppLocalizations {
   String get inboxConversationUnmuted => 'تم إلغاء كتم المحادثة';
 
   @override
-  String get inboxCollabInviteSentStatus => 'Invitation sent';
+  String get inboxCollabInviteCardTitle => 'دعوة للتعاون';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return '$role على هذا المنشور';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => 'قبول';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => 'تجاهل';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => 'تم القبول';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => 'تم التجاهل';
+
+  @override
+  String get inboxCollabInviteAcceptError => 'تعذر القبول. حاول مرة أخرى.';
+
+  @override
+  String get inboxCollabInviteSentStatus => 'تم إرسال الدعوة';
 
   @override
   String get reportDialogCancel => 'إلغاء';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4491,6 +4491,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get inboxConversationUnmuted => 'تم إلغاء كتم المحادثة';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => 'إلغاء';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4589,6 +4589,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Unterhaltung nicht mehr stummgeschaltet';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => 'Abbrechen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4589,7 +4589,31 @@ class AppLocalizationsDe extends AppLocalizations {
       'Unterhaltung nicht mehr stummgeschaltet';
 
   @override
-  String get inboxCollabInviteSentStatus => 'Invitation sent';
+  String get inboxCollabInviteCardTitle => 'Einladung zur Zusammenarbeit';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return '$role bei diesem Beitrag';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => 'Annehmen';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => 'Ignorieren';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => 'Angenommen';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => 'Ignoriert';
+
+  @override
+  String get inboxCollabInviteAcceptError =>
+      'Annahme fehlgeschlagen. Erneut versuchen.';
+
+  @override
+  String get inboxCollabInviteSentStatus => 'Einladung gesendet';
 
   @override
   String get reportDialogCancel => 'Abbrechen';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4541,6 +4541,29 @@ class AppLocalizationsEn extends AppLocalizations {
   String get inboxConversationUnmuted => 'Conversation unmuted';
 
   @override
+  String get inboxCollabInviteCardTitle => 'Collaborator invite';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return '$role on this post';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => 'Accept';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => 'Ignore';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => 'Accepted';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => 'Ignored';
+
+  @override
+  String get inboxCollabInviteAcceptError => 'Could not accept. Try again.';
+
+  @override
   String get inboxCollabInviteSentStatus => 'Invitation sent';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4541,6 +4541,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get inboxConversationUnmuted => 'Conversation unmuted';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => 'Cancel';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4580,7 +4580,31 @@ class AppLocalizationsEs extends AppLocalizations {
   String get inboxConversationUnmuted => 'Conversación sin silenciar';
 
   @override
-  String get inboxCollabInviteSentStatus => 'Invitation sent';
+  String get inboxCollabInviteCardTitle => 'Invitación a colaborar';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return '$role en esta publicación';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => 'Aceptar';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => 'Ignorar';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => 'Aceptada';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => 'Ignorada';
+
+  @override
+  String get inboxCollabInviteAcceptError =>
+      'No se pudo aceptar. Inténtalo de nuevo.';
+
+  @override
+  String get inboxCollabInviteSentStatus => 'Invitación enviada';
 
   @override
   String get reportDialogCancel => 'Cancelar';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4580,6 +4580,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get inboxConversationUnmuted => 'Conversación sin silenciar';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4595,7 +4595,31 @@ class AppLocalizationsFr extends AppLocalizations {
   String get inboxConversationUnmuted => 'Conversation réactivée';
 
   @override
-  String get inboxCollabInviteSentStatus => 'Invitation sent';
+  String get inboxCollabInviteCardTitle => 'Invitation à collaborer';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return '$role sur cette publication';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => 'Accepter';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => 'Ignorer';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => 'Acceptée';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => 'Ignorée';
+
+  @override
+  String get inboxCollabInviteAcceptError =>
+      'Impossible d\'accepter. Réessayez.';
+
+  @override
+  String get inboxCollabInviteSentStatus => 'Invitation envoyée';
 
   @override
   String get reportDialogCancel => 'Annuler';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4595,6 +4595,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get inboxConversationUnmuted => 'Conversation réactivée';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => 'Annuler';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4510,6 +4510,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get inboxConversationUnmuted => 'Bisu percakapan dibatalkan';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => 'Batal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4510,7 +4510,30 @@ class AppLocalizationsId extends AppLocalizations {
   String get inboxConversationUnmuted => 'Bisu percakapan dibatalkan';
 
   @override
-  String get inboxCollabInviteSentStatus => 'Invitation sent';
+  String get inboxCollabInviteCardTitle => 'Undangan kolaborasi';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return '$role di postingan ini';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => 'Terima';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => 'Abaikan';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => 'Diterima';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => 'Diabaikan';
+
+  @override
+  String get inboxCollabInviteAcceptError => 'Tidak bisa menerima. Coba lagi.';
+
+  @override
+  String get inboxCollabInviteSentStatus => 'Undangan terkirim';
 
   @override
   String get reportDialogCancel => 'Batal';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4580,6 +4580,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get inboxConversationUnmuted => 'Conversazione riattivata';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => 'Annulla';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4580,7 +4580,30 @@ class AppLocalizationsIt extends AppLocalizations {
   String get inboxConversationUnmuted => 'Conversazione riattivata';
 
   @override
-  String get inboxCollabInviteSentStatus => 'Invitation sent';
+  String get inboxCollabInviteCardTitle => 'Invito a collaborare';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return '$role in questo post';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => 'Accetta';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => 'Ignora';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => 'Accettato';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => 'Ignorato';
+
+  @override
+  String get inboxCollabInviteAcceptError => 'Impossibile accettare. Riprova.';
+
+  @override
+  String get inboxCollabInviteSentStatus => 'Invito inviato';
 
   @override
   String get reportDialogCancel => 'Annulla';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4344,6 +4344,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get inboxConversationUnmuted => '会話のミュートを解除したよ';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => 'キャンセル';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4344,7 +4344,30 @@ class AppLocalizationsJa extends AppLocalizations {
   String get inboxConversationUnmuted => '会話のミュートを解除したよ';
 
   @override
-  String get inboxCollabInviteSentStatus => 'Invitation sent';
+  String get inboxCollabInviteCardTitle => 'コラボ招待';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return 'この投稿で$role';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => '承認';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => '無視';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => '承認済み';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => '無視済み';
+
+  @override
+  String get inboxCollabInviteAcceptError => '承認できなかったよ。もう一度試してね。';
+
+  @override
+  String get inboxCollabInviteSentStatus => '招待を送ったよ';
 
   @override
   String get reportDialogCancel => 'キャンセル';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4359,7 +4359,30 @@ class AppLocalizationsKo extends AppLocalizations {
   String get inboxConversationUnmuted => '대화 알림을 다시 켰어요';
 
   @override
-  String get inboxCollabInviteSentStatus => 'Invitation sent';
+  String get inboxCollabInviteCardTitle => '콜라보 초대';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return '이 게시물의 $role';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => '수락';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => '무시';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => '수락됨';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => '무시됨';
+
+  @override
+  String get inboxCollabInviteAcceptError => '수락하지 못했어요. 다시 시도해 주세요.';
+
+  @override
+  String get inboxCollabInviteSentStatus => '초대를 보냈어요';
 
   @override
   String get reportDialogCancel => '취소';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4359,6 +4359,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get inboxConversationUnmuted => '대화 알림을 다시 켰어요';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => '취소';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4552,6 +4552,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get inboxConversationUnmuted => 'Gesprek niet meer gedempt';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => 'Annuleren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4552,7 +4552,31 @@ class AppLocalizationsNl extends AppLocalizations {
   String get inboxConversationUnmuted => 'Gesprek niet meer gedempt';
 
   @override
-  String get inboxCollabInviteSentStatus => 'Invitation sent';
+  String get inboxCollabInviteCardTitle => 'Uitnodiging om samen te werken';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return '$role bij deze post';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => 'Accepteren';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => 'Negeren';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => 'Geaccepteerd';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => 'Genegeerd';
+
+  @override
+  String get inboxCollabInviteAcceptError =>
+      'Accepteren is niet gelukt. Probeer het opnieuw.';
+
+  @override
+  String get inboxCollabInviteSentStatus => 'Uitnodiging verzonden';
 
   @override
   String get reportDialogCancel => 'Annuleren';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4660,6 +4660,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get inboxConversationUnmuted => 'Wyłączono wyciszenie rozmowy';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => 'Anuluj';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4660,7 +4660,31 @@ class AppLocalizationsPl extends AppLocalizations {
   String get inboxConversationUnmuted => 'Wyłączono wyciszenie rozmowy';
 
   @override
-  String get inboxCollabInviteSentStatus => 'Invitation sent';
+  String get inboxCollabInviteCardTitle => 'Zaproszenie do współpracy';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return '$role przy tym poście';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => 'Akceptuj';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => 'Ignoruj';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => 'Zaakceptowano';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => 'Zignorowano';
+
+  @override
+  String get inboxCollabInviteAcceptError =>
+      'Nie udało się zaakceptować. Spróbuj ponownie.';
+
+  @override
+  String get inboxCollabInviteSentStatus => 'Zaproszenie wysłane';
 
   @override
   String get reportDialogCancel => 'Anuluj';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4565,6 +4565,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get inboxConversationUnmuted => 'Conversa com som ativado';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4565,7 +4565,31 @@ class AppLocalizationsPt extends AppLocalizations {
   String get inboxConversationUnmuted => 'Conversa com som ativado';
 
   @override
-  String get inboxCollabInviteSentStatus => 'Invitation sent';
+  String get inboxCollabInviteCardTitle => 'Convite para colaborar';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return '$role nesta publicação';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => 'Aceitar';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => 'Ignorar';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => 'Aceito';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => 'Ignorado';
+
+  @override
+  String get inboxCollabInviteAcceptError =>
+      'Não foi possível aceitar. Tente novamente.';
+
+  @override
+  String get inboxCollabInviteSentStatus => 'Convite enviado';
 
   @override
   String get reportDialogCancel => 'Cancelar';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4666,7 +4666,31 @@ class AppLocalizationsRo extends AppLocalizations {
   String get inboxConversationUnmuted => 'Conversație reactivată';
 
   @override
-  String get inboxCollabInviteSentStatus => 'Invitation sent';
+  String get inboxCollabInviteCardTitle => 'Invitație de colaborare';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return '$role la această postare';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => 'Acceptă';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => 'Ignoră';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => 'Acceptată';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => 'Ignorată';
+
+  @override
+  String get inboxCollabInviteAcceptError =>
+      'Nu s-a putut accepta. Încearcă din nou.';
+
+  @override
+  String get inboxCollabInviteSentStatus => 'Invitație trimisă';
 
   @override
   String get reportDialogCancel => 'Anulează';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4666,6 +4666,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get inboxConversationUnmuted => 'Conversație reactivată';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => 'Anulează';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4530,6 +4530,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get inboxConversationUnmuted => 'Konversation inte tystad';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => 'Avbryt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4530,7 +4530,31 @@ class AppLocalizationsSv extends AppLocalizations {
   String get inboxConversationUnmuted => 'Konversation inte tystad';
 
   @override
-  String get inboxCollabInviteSentStatus => 'Invitation sent';
+  String get inboxCollabInviteCardTitle => 'Inbjudan att samarbeta';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return '$role i det här inlägget';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => 'Acceptera';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => 'Ignorera';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => 'Accepterad';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => 'Ignorerad';
+
+  @override
+  String get inboxCollabInviteAcceptError =>
+      'Det gick inte att acceptera. Försök igen.';
+
+  @override
+  String get inboxCollabInviteSentStatus => 'Inbjudan skickad';
 
   @override
   String get reportDialogCancel => 'Avbryt';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4520,6 +4520,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get inboxConversationUnmuted => 'Sohbet sessizden çıkarıldı';
 
   @override
+  String get inboxCollabInviteSentStatus => 'Invitation sent';
+
+  @override
   String get reportDialogCancel => 'İptal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4520,7 +4520,30 @@ class AppLocalizationsTr extends AppLocalizations {
   String get inboxConversationUnmuted => 'Sohbet sessizden çıkarıldı';
 
   @override
-  String get inboxCollabInviteSentStatus => 'Invitation sent';
+  String get inboxCollabInviteCardTitle => 'İşbirliği daveti';
+
+  @override
+  String inboxCollabInviteCardRoleLabel(String role) {
+    return 'Bu gönderide $role';
+  }
+
+  @override
+  String get inboxCollabInviteAcceptButton => 'Kabul et';
+
+  @override
+  String get inboxCollabInviteIgnoreButton => 'Yoksay';
+
+  @override
+  String get inboxCollabInviteAcceptedStatus => 'Kabul edildi';
+
+  @override
+  String get inboxCollabInviteIgnoredStatus => 'Yoksayıldı';
+
+  @override
+  String get inboxCollabInviteAcceptError => 'Kabul edilemedi. Tekrar dene.';
+
+  @override
+  String get inboxCollabInviteSentStatus => 'Davet gönderildi';
 
   @override
   String get reportDialogCancel => 'İptal';

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -15,6 +15,7 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/widgets.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/services/collaborator_invite_parser.dart';
+import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/utils/clipboard_utils.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/profile/more_sheet/more_sheet_content.dart';
@@ -260,6 +261,18 @@ class _MessageList extends StatelessWidget {
         final invite = CollaboratorInviteParser.parse(message);
         if (invite != null) {
           return CollaboratorInviteCard(invite: invite, isSent: isSent);
+        }
+
+        // Suppress legacy NIP-04 invite plaintext duplicates (#3559).
+        // Phase 1 stopped new sends from emitting this fallback, but
+        // older app builds and cross-client senders can still produce
+        // bubbles that read "Open diVine to review and accept" — useless
+        // copy inside diVine, and the structured fields needed to render
+        // an actionable card are not recoverable from plaintext alone.
+        if (message.content.endsWith(
+          CollaboratorInviteService.invitePlaintextSuffix,
+        )) {
+          return const SizedBox.shrink();
         }
 
         // Grouping: in a reversed list, index 0 is newest (bottom of screen).

--- a/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
@@ -93,16 +93,15 @@ class _CardChrome extends StatelessWidget {
   final bool isSent;
   final Widget action;
 
-  String get _titleText {
+  String _titleText() {
     final title = invite.title?.trim();
     if (title != null && title.isNotEmpty) return title;
     return invite.videoDTag;
   }
 
-  String get _detailText => '${invite.role} on this post';
-
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Align(
@@ -124,19 +123,19 @@ class _CardChrome extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
-                'Collaborator invite',
+                l10n.inboxCollabInviteCardTitle,
                 style: VineTheme.labelLargeFont(color: VineTheme.primary),
               ),
               const SizedBox(height: 8),
               Text(
-                _titleText,
+                _titleText(),
                 style: VineTheme.titleMediumFont(),
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
               ),
               const SizedBox(height: 4),
               Text(
-                _detailText,
+                l10n.inboxCollabInviteCardRoleLabel(invite.role),
                 style: VineTheme.bodySmallFont(
                   color: VineTheme.onSurfaceMuted,
                 ),
@@ -162,21 +161,22 @@ class _InviteActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return switch (state) {
-      CollaboratorInviteState.accepted => const _StatusText(
-        label: 'Accepted',
+      CollaboratorInviteState.accepted => _StatusText(
+        label: l10n.inboxCollabInviteAcceptedStatus,
         color: VineTheme.primary,
       ),
-      CollaboratorInviteState.ignored => const _StatusText(
-        label: 'Ignored',
+      CollaboratorInviteState.ignored => _StatusText(
+        label: l10n.inboxCollabInviteIgnoredStatus,
         color: VineTheme.onSurfaceMuted,
       ),
       CollaboratorInviteState.failed => Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
-          const _StatusText(
-            label: 'Could not accept. Try again.',
+          _StatusText(
+            label: l10n.inboxCollabInviteAcceptError,
             color: VineTheme.error,
           ),
           const SizedBox(height: 12),
@@ -206,11 +206,12 @@ class _ActionRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = context.l10n;
     return Row(
       children: [
         Expanded(
           child: DivineButton(
-            label: 'Accept',
+            label: l10n.inboxCollabInviteAcceptButton,
             size: DivineButtonSize.small,
             isLoading: isAccepting,
             onPressed: isAccepting
@@ -225,7 +226,7 @@ class _ActionRow extends StatelessWidget {
         const SizedBox(width: 8),
         Expanded(
           child: DivineButton(
-            label: 'Ignore',
+            label: l10n.inboxCollabInviteIgnoreButton,
             type: DivineButtonType.secondary,
             size: DivineButtonSize.small,
             onPressed: isAccepting

--- a/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/collaborator_invite_card.dart
@@ -5,6 +5,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/services/collaborator_invite_state_store.dart';
 
@@ -26,13 +27,19 @@ class _CollaboratorInviteCardState extends State<CollaboratorInviteCard> {
   @override
   void initState() {
     super.initState();
-    _loadInviteState();
+    // Sender-side cards are static — they never read or write cubit
+    // state. The recipient is the only side with actionable state, so
+    // skip the load and the BlocSelector subscription entirely (#3559).
+    if (!widget.isSent) {
+      _loadInviteState();
+    }
   }
 
   @override
   void didUpdateWidget(covariant CollaboratorInviteCard oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.invite != widget.invite) {
+    if (widget.isSent) return;
+    if (oldWidget.invite != widget.invite || oldWidget.isSent) {
       _loadInviteState();
     }
   }
@@ -45,6 +52,16 @@ class _CollaboratorInviteCardState extends State<CollaboratorInviteCard> {
 
   @override
   Widget build(BuildContext context) {
+    if (widget.isSent) {
+      return _CardChrome(
+        invite: widget.invite,
+        isSent: true,
+        action: _StatusText(
+          label: context.l10n.inboxCollabInviteSentStatus,
+          color: VineTheme.onSurfaceMuted,
+        ),
+      );
+    }
     return BlocSelector<
       CollaboratorInviteActionsCubit,
       CollaboratorInviteActionsState,
@@ -52,65 +69,86 @@ class _CollaboratorInviteCardState extends State<CollaboratorInviteCard> {
     >(
       selector: (state) => state.stateFor(widget.invite),
       builder: (context, inviteState) {
-        return Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: Align(
-            alignment: widget.isSent
-                ? AlignmentDirectional.centerEnd
-                : AlignmentDirectional.centerStart,
-            child: Container(
-              constraints: BoxConstraints(
-                maxWidth: MediaQuery.sizeOf(context).width * 0.78,
-              ),
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: VineTheme.surfaceContainerHigh,
-                border: Border.all(color: VineTheme.outlineMuted),
-                borderRadius: BorderRadius.circular(16),
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    'Collaborator invite',
-                    style: VineTheme.labelLargeFont(color: VineTheme.primary),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    _titleText,
-                    style: VineTheme.titleMediumFont(),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    _detailText,
-                    style: VineTheme.bodySmallFont(
-                      color: VineTheme.onSurfaceMuted,
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  _InviteActions(
-                    invite: widget.invite,
-                    state: inviteState,
-                  ),
-                ],
-              ),
-            ),
+        return _CardChrome(
+          invite: widget.invite,
+          isSent: false,
+          action: _InviteActions(
+            invite: widget.invite,
+            state: inviteState,
           ),
         );
       },
     );
   }
+}
+
+class _CardChrome extends StatelessWidget {
+  const _CardChrome({
+    required this.invite,
+    required this.isSent,
+    required this.action,
+  });
+
+  final CollaboratorInvite invite;
+  final bool isSent;
+  final Widget action;
 
   String get _titleText {
-    final title = widget.invite.title?.trim();
+    final title = invite.title?.trim();
     if (title != null && title.isNotEmpty) return title;
-    return widget.invite.videoDTag;
+    return invite.videoDTag;
   }
 
-  String get _detailText => '${widget.invite.role} on this post';
+  String get _detailText => '${invite.role} on this post';
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Align(
+        alignment: isSent
+            ? AlignmentDirectional.centerEnd
+            : AlignmentDirectional.centerStart,
+        child: Container(
+          constraints: BoxConstraints(
+            maxWidth: MediaQuery.sizeOf(context).width * 0.78,
+          ),
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: VineTheme.surfaceContainerHigh,
+            border: Border.all(color: VineTheme.outlineMuted),
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'Collaborator invite',
+                style: VineTheme.labelLargeFont(color: VineTheme.primary),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                _titleText,
+                style: VineTheme.titleMediumFont(),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                _detailText,
+                style: VineTheme.bodySmallFont(
+                  color: VineTheme.onSurfaceMuted,
+                ),
+              ),
+              const SizedBox(height: 16),
+              action,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class _InviteActions extends StatelessWidget {

--- a/mobile/lib/services/collaborator_invite_service.dart
+++ b/mobile/lib/services/collaborator_invite_service.dart
@@ -62,6 +62,10 @@ class CollaboratorInviteService {
       recipientPubkey: collaboratorPubkey,
       content: content,
       additionalTags: tags,
+      // Structured invites cannot be represented in NIP-04; the legacy
+      // fallback would publish a duplicate plaintext message that reads
+      // "Open diVine to review and accept" inside diVine itself (#3559).
+      skipNip04Fallback: true,
     );
 
     return CollaboratorInviteResult(

--- a/mobile/lib/services/collaborator_invite_service.dart
+++ b/mobile/lib/services/collaborator_invite_service.dart
@@ -41,6 +41,13 @@ class CollaboratorInviteService {
   final DmRepository _dmRepository;
   final String defaultRelayHint;
 
+  /// Suffix that uniquely identifies the plaintext fallback body of a
+  /// collaborator invite DM — kept in sync with [_buildContent]. The
+  /// conversation view uses this to suppress legacy NIP-04 invite
+  /// duplicates that cannot be turned into actionable cards (#3559).
+  static const String invitePlaintextSuffix =
+      'Open diVine to review and accept.';
+
   Future<CollaboratorInviteResult> sendInvite({
     required String collaboratorPubkey,
     required String creatorPubkey,
@@ -102,7 +109,7 @@ class CollaboratorInviteService {
         ? 'a diVine video'
         : title.trim();
     return 'You were invited to collaborate on $videoLabel. '
-        'Open diVine to review and accept.';
+        '$invitePlaintextSuffix';
   }
 
   List<List<String>> _buildTags({

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -772,6 +772,7 @@ class DmRepository {
     required String content,
     String? replyToId,
     List<List<String>> additionalTags = const [],
+    bool skipNip04Fallback = false,
   }) async {
     _assertInitialized();
     validatePubkey(recipientPubkey);
@@ -838,9 +839,12 @@ class DmRepository {
           category: LogCategory.system,
         );
 
-        // Fire NIP-04 fallback for interop with legacy clients.
-        // Skip when the conversation is known to be NIP-17-only.
-        if (protocol != 'nip17') {
+        // Fire NIP-04 fallback for interop with legacy clients. Skip
+        // when the conversation is known NIP-17-only, or when the caller
+        // opts out — structured DMs that cannot be represented in NIP-04
+        // (e.g. collaborator invites) would degrade to a plaintext
+        // duplicate.
+        if (protocol != 'nip17' && !skipNip04Fallback) {
           unawaited(
             _sendNip04Message(
               recipientPubkey: recipientPubkey,

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -578,9 +578,12 @@ void main() {
           skipNip04Fallback: true,
         );
 
-        // Allow any unawaited microtasks to settle. The NIP-04 fallback
-        // would be enqueued via `unawaited(...)` if the skip flag leaked.
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        // Drain pending microtasks so an unawaited `_sendNip04Message`
+        // — the only way the fallback can fire when `skipNip04Fallback`
+        // leaks — has the chance to call `publishEvent` before we
+        // assert it never did. `pumpEventQueue` (default 20 ticks) is
+        // the canonical drain in flutter_test.
+        await pumpEventQueue();
 
         expect(result.success, isTrue);
         verifyNever(() => mockNostrClient.publishEvent(any()));

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -500,6 +500,91 @@ void main() {
           ),
         );
       });
+
+      test('skipNip04Fallback: true suppresses NIP-04 publish', () async {
+        when(
+          () => mockMessageService.sendPrivateMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            eventKind: any(named: 'eventKind'),
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        ).thenAnswer(
+          (_) async => NIP17SendResult.success(
+            rumorEventId: _rumorEventId,
+            messageEventId: _giftWrapEventId,
+            recipientPubkey: _validPubkeyB,
+          ),
+        );
+        when(
+          () => mockDirectMessagesDao.insertMessage(
+            id: any(named: 'id'),
+            conversationId: any(named: 'conversationId'),
+            senderPubkey: any(named: 'senderPubkey'),
+            content: any(named: 'content'),
+            createdAt: any(named: 'createdAt'),
+            giftWrapId: any(named: 'giftWrapId'),
+            messageKind: any(named: 'messageKind'),
+            replyToId: any(named: 'replyToId'),
+            subject: any(named: 'subject'),
+            fileType: any(named: 'fileType'),
+            encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+            decryptionKey: any(named: 'decryptionKey'),
+            decryptionNonce: any(named: 'decryptionNonce'),
+            fileHash: any(named: 'fileHash'),
+            originalFileHash: any(named: 'originalFileHash'),
+            fileSize: any(named: 'fileSize'),
+            dimensions: any(named: 'dimensions'),
+            blurhash: any(named: 'blurhash'),
+            thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            tagsJson: any(named: 'tagsJson'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockConversationsDao.upsertConversation(
+            id: any(named: 'id'),
+            participantPubkeys: any(named: 'participantPubkeys'),
+            isGroup: any(named: 'isGroup'),
+            createdAt: any(named: 'createdAt'),
+            lastMessageContent: any(named: 'lastMessageContent'),
+            lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+            lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+            subject: any(named: 'subject'),
+            isRead: any(named: 'isRead'),
+            currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            dmProtocol: any(named: 'dmProtocol'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockNostrClient.publishEvent(any()),
+        ).thenAnswer((_) async => null);
+
+        final repository = createRepository();
+
+        final result = await repository.sendMessage(
+          recipientPubkey: _validPubkeyB,
+          content: 'Invited you to collaborate',
+          additionalTags: const [
+            ['divine', 'collab-invite'],
+          ],
+          skipNip04Fallback: true,
+        );
+
+        // Allow any unawaited microtasks to settle. The NIP-04 fallback
+        // would be enqueued via `unawaited(...)` if the skip flag leaked.
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(result.success, isTrue);
+        verifyNever(() => mockNostrClient.publishEvent(any()));
+      });
     });
 
     group('sendGroupMessage', () {

--- a/mobile/test/blocs/dm/conversation/collaborator_invite_actions_cubit_test.dart
+++ b/mobile/test/blocs/dm/conversation/collaborator_invite_actions_cubit_test.dart
@@ -178,5 +178,62 @@ void main() {
         verifyNever(() => responseService.acceptInvite(any()));
       },
     );
+
+    // #3559 — defense-in-depth. The render layer should not surface
+    // accept/ignore for sender-side (self-creator) invites; if it ever
+    // does, the cubit's assert fails loudly in debug and the runtime
+    // guard suppresses any side effect in release.
+    test(
+      'acceptInvite no-ops when current user is the invite creator',
+      () async {
+        final selfCreatorCubit = CollaboratorInviteActionsCubit(
+          stateStore: store,
+          responseService: responseService,
+          currentUserPubkey: creatorPubkey,
+        );
+        addTearDown(selfCreatorCubit.close);
+
+        await expectLater(
+          selfCreatorCubit.acceptInvite(invite),
+          throwsA(isA<AssertionError>()),
+        );
+
+        verifyNever(() => responseService.acceptInvite(any()));
+        verifyNever(
+          () => store.setState(
+            videoAddress: any(named: 'videoAddress'),
+            creatorPubkey: any(named: 'creatorPubkey'),
+            collaboratorPubkey: any(named: 'collaboratorPubkey'),
+            state: any(named: 'state'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'ignoreInvite no-ops when current user is the invite creator',
+      () async {
+        final selfCreatorCubit = CollaboratorInviteActionsCubit(
+          stateStore: store,
+          responseService: responseService,
+          currentUserPubkey: creatorPubkey,
+        );
+        addTearDown(selfCreatorCubit.close);
+
+        await expectLater(
+          selfCreatorCubit.ignoreInvite(invite),
+          throwsA(isA<AssertionError>()),
+        );
+
+        verifyNever(
+          () => store.setState(
+            videoAddress: any(named: 'videoAddress'),
+            creatorPubkey: any(named: 'creatorPubkey'),
+            collaboratorPubkey: any(named: 'collaboratorPubkey'),
+            state: any(named: 'state'),
+          ),
+        );
+      },
+    );
   });
 }

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -310,6 +310,81 @@ void main() {
           verifyNever(() => mockInviteActionsCubit.loadInvites(any()));
         },
       );
+
+      // #3559 Phase 2 — sender-side suppression handles the inviter's
+      // own outgoing card. This test covers the recipient-side legacy
+      // NIP-04 plaintext duplicate: when an older sender (or another
+      // Nostr client) emits an invite as a plain DM with no Divine
+      // structured tags, the bubble must not render — it would tell the
+      // user to "open diVine" inside diVine itself, with no actionable
+      // affordance.
+      testWidgets(
+        'suppresses legacy NIP-04 invite plaintext duplicates with no '
+        'structured tags',
+        (tester) async {
+          final message = DmMessage(
+            id: '7777777777777777777777777777777777777777777777777777777777777777',
+            conversationId:
+                'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+            senderPubkey: otherPubkey,
+            content:
+                'You were invited to collaborate on Skate loop. '
+                'Open diVine to review and accept.',
+            createdAt: now.millisecondsSinceEpoch ~/ 1000,
+            giftWrapId:
+                'ccccccccddddddddeeeeeeeeffffffff00000000111111112222222233333333',
+          );
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: ConversationState(
+                status: ConversationStatus.loaded,
+                messages: [message],
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(find.byType(CollaboratorInviteCard), findsNothing);
+          expect(find.byType(MessageBubble), findsNothing);
+          expect(
+            find.textContaining('Open diVine to review and accept'),
+            findsNothing,
+          );
+        },
+      );
+
+      testWidgets(
+        'still renders plain text DMs that do not match the invite suffix',
+        (tester) async {
+          final message = DmMessage(
+            id: '6666666666666666666666666666666666666666666666666666666666666666',
+            conversationId:
+                'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+            senderPubkey: otherPubkey,
+            content: 'Hey, want to ride together this weekend?',
+            createdAt: now.millisecondsSinceEpoch ~/ 1000,
+            giftWrapId:
+                'ddddddddeeeeeeeeffffffff0000000011111111222222223333333344444444',
+          );
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: ConversationState(
+                status: ConversationStatus.loaded,
+                messages: [message],
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(find.byType(MessageBubble), findsOneWidget);
+          expect(
+            find.text('Hey, want to ride together this weekend?'),
+            findsOneWidget,
+          );
+        },
+      );
     });
   });
 }

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -10,6 +10,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit.dart';
 import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_view.dart';
@@ -50,6 +51,7 @@ void main() {
   );
 
   final now = DateTime.now();
+  final l10n = lookupAppLocalizations(const Locale('en'));
 
   group(ConversationView, () {
     late _MockConversationBloc mockBloc;
@@ -241,13 +243,13 @@ void main() {
           );
           await tester.pump();
 
-          expect(find.text('Collaborator invite'), findsOneWidget);
+          expect(find.text(l10n.inboxCollabInviteCardTitle), findsOneWidget);
           expect(find.textContaining('Skate loop'), findsOneWidget);
-          expect(find.text('Accept'), findsOneWidget);
-          expect(find.text('Ignore'), findsOneWidget);
+          expect(find.text(l10n.inboxCollabInviteAcceptButton), findsOneWidget);
+          expect(find.text(l10n.inboxCollabInviteIgnoreButton), findsOneWidget);
           expect(find.text('You were invited to collaborate.'), findsNothing);
 
-          await tester.tap(find.text('Accept'));
+          await tester.tap(find.text(l10n.inboxCollabInviteAcceptButton));
           await tester.pump();
 
           verify(
@@ -297,11 +299,11 @@ void main() {
           );
           await tester.pump();
 
-          expect(find.text('Collaborator invite'), findsOneWidget);
+          expect(find.text(l10n.inboxCollabInviteCardTitle), findsOneWidget);
           expect(find.textContaining('Skate loop'), findsOneWidget);
-          expect(find.text('Invitation sent'), findsOneWidget);
-          expect(find.text('Accept'), findsNothing);
-          expect(find.text('Ignore'), findsNothing);
+          expect(find.text(l10n.inboxCollabInviteSentStatus), findsOneWidget);
+          expect(find.text(l10n.inboxCollabInviteAcceptButton), findsNothing);
+          expect(find.text(l10n.inboxCollabInviteIgnoreButton), findsNothing);
           expect(find.text('You were invited to collaborate.'), findsNothing);
 
           // Stronger assertion than "no acceptInvite call": sender-side

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -58,6 +58,7 @@ void main() {
 
     setUpAll(() {
       registerFallbackValue(fallbackInvite);
+      registerFallbackValue(<CollaboratorInvite>[]);
     });
 
     setUp(() {
@@ -252,6 +253,61 @@ void main() {
           verify(
             () => mockInviteActionsCubit.acceptInvite(any()),
           ).called(1);
+        },
+      );
+
+      // #3559 — NIP-17 echoes a sender's gift wrap back to themselves,
+      // so the inviter's own outgoing collab invite shows up in their
+      // conversation feed. The renderer must surface it as a static
+      // "Invitation sent" status, not Accept/Ignore (the inviter
+      // accepting their own invite is nonsensical and would publish a
+      // malformed kind-34238 with creator==responder).
+      testWidgets(
+        'renders sender-direction invite as Sent status, no Accept/Ignore',
+        (tester) async {
+          final message = DmMessage(
+            id: '8888888888888888888888888888888888888888888888888888888888888888',
+            conversationId:
+                'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+            senderPubkey: currentPubkey,
+            content: 'You were invited to collaborate.',
+            createdAt: now.millisecondsSinceEpoch ~/ 1000,
+            giftWrapId:
+                'bbbbbbbbccccccccddddddddeeeeeeeebbbbbbbbccccccccddddddddeeeeeeee',
+            tags: const [
+              ['divine', 'collab-invite'],
+              [
+                'a',
+                '34236:$currentPubkey:skate-loop',
+                'wss://relay.divine.video',
+              ],
+              ['p', currentPubkey],
+              ['role', 'Collaborator'],
+              ['title', 'Skate loop'],
+            ],
+          );
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: ConversationState(
+                status: ConversationStatus.loaded,
+                messages: [message],
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(find.text('Collaborator invite'), findsOneWidget);
+          expect(find.textContaining('Skate loop'), findsOneWidget);
+          expect(find.text('Invitation sent'), findsOneWidget);
+          expect(find.text('Accept'), findsNothing);
+          expect(find.text('Ignore'), findsNothing);
+          expect(find.text('You were invited to collaborate.'), findsNothing);
+
+          // Stronger assertion than "no acceptInvite call": sender-side
+          // cards do not subscribe to the cubit at all, so loadInvites
+          // is never invoked. Prevents state-store pollution.
+          verifyNever(() => mockInviteActionsCubit.loadInvites(any()));
         },
       );
     });

--- a/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
+++ b/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
@@ -11,6 +11,7 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit.dart';
 import 'package:openvine/blocs/dm/message_requests/message_request_actions_cubit.dart';
 import 'package:openvine/blocs/dm/message_requests/request_preview_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/collaborator_invite.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/app_router.dart';
@@ -63,6 +64,8 @@ void main() {
     videoDTag: 'skate-loop',
     role: 'Collaborator',
   );
+
+  final l10n = lookupAppLocalizations(const Locale('en'));
 
   group(RequestPreviewView, () {
     late _MockMessageRequestActionsCubit mockActionsCubit;
@@ -226,14 +229,16 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text('Collaborator invite'), findsOneWidget);
-        expect(find.text('Accept'), findsOneWidget);
-        expect(find.text('Ignore'), findsOneWidget);
+        expect(find.text(l10n.inboxCollabInviteCardTitle), findsOneWidget);
+        expect(find.text(l10n.inboxCollabInviteAcceptButton), findsOneWidget);
+        expect(find.text(l10n.inboxCollabInviteIgnoreButton), findsOneWidget);
         expect(find.text('You were invited to collaborate.'), findsNothing);
 
-        await tester.ensureVisible(find.text('Ignore'));
+        await tester.ensureVisible(
+          find.text(l10n.inboxCollabInviteIgnoreButton),
+        );
         await tester.pump();
-        await tester.tap(find.text('Ignore'));
+        await tester.tap(find.text(l10n.inboxCollabInviteIgnoreButton));
         await tester.pump();
 
         verify(

--- a/mobile/test/services/collaborator_invite_service_test.dart
+++ b/mobile/test/services/collaborator_invite_service_test.dart
@@ -100,6 +100,54 @@ void main() {
     expect(skipNip04Fallback, isTrue);
   });
 
+  test(
+    'content endsWith invitePlaintextSuffix (contract for UI suppression)',
+    () async {
+      when(
+        () => dmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          replyToId: any(named: 'replyToId'),
+          additionalTags: any(named: 'additionalTags'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
+        ),
+      ).thenAnswer(
+        (_) async => NIP17SendResult.success(
+          rumorEventId: 'rumor-id',
+          messageEventId: 'message-id',
+          recipientPubkey: collaboratorPubkey,
+        ),
+      );
+
+      await service.sendInvite(
+        collaboratorPubkey: collaboratorPubkey,
+        creatorPubkey: creatorPubkey,
+        videoAddress: videoAddress,
+        title: 'Skate loop',
+      );
+
+      final captured =
+          verify(
+                () => dmRepository.sendMessage(
+                  recipientPubkey: collaboratorPubkey,
+                  content: captureAny(named: 'content'),
+                  replyToId: any(named: 'replyToId'),
+                  additionalTags: any(named: 'additionalTags'),
+                  skipNip04Fallback: any(named: 'skipNip04Fallback'),
+                ),
+              ).captured.single
+              as String;
+
+      expect(
+        captured.endsWith(CollaboratorInviteService.invitePlaintextSuffix),
+        isTrue,
+        reason:
+            '_buildContent must end with invitePlaintextSuffix so the '
+            'conversation view can suppress legacy NIP-04 duplicates (#3559)',
+      );
+    },
+  );
+
   test('returns failure when encrypted DM send fails', () async {
     when(
       () => dmRepository.sendMessage(

--- a/mobile/test/services/collaborator_invite_service_test.dart
+++ b/mobile/test/services/collaborator_invite_service_test.dart
@@ -39,6 +39,7 @@ void main() {
         content: any(named: 'content'),
         replyToId: any(named: 'replyToId'),
         additionalTags: any(named: 'additionalTags'),
+        skipNip04Fallback: any(named: 'skipNip04Fallback'),
       ),
     ).thenAnswer(
       (_) async => NIP17SendResult.success(
@@ -64,11 +65,13 @@ void main() {
         content: captureAny(named: 'content'),
         replyToId: any(named: 'replyToId'),
         additionalTags: captureAny(named: 'additionalTags'),
+        skipNip04Fallback: captureAny(named: 'skipNip04Fallback'),
       ),
     );
 
     final content = verification.captured[0] as String;
     final tags = verification.captured[1] as List<List<String>>;
+    final skipNip04Fallback = verification.captured[2] as bool;
 
     expect(content, contains('Skate loop'));
     expect(content, contains('collaborate'));
@@ -92,6 +95,9 @@ void main() {
       ]),
       isTrue,
     );
+    // Structured invites must skip the NIP-04 legacy fallback — the
+    // fallback would publish a duplicate plaintext message (#3559).
+    expect(skipNip04Fallback, isTrue);
   });
 
   test('returns failure when encrypted DM send fails', () async {
@@ -101,6 +107,7 @@ void main() {
         content: any(named: 'content'),
         replyToId: any(named: 'replyToId'),
         additionalTags: any(named: 'additionalTags'),
+        skipNip04Fallback: any(named: 'skipNip04Fallback'),
       ),
     ).thenAnswer((_) async => NIP17SendResult.failure('relay unavailable'));
 


### PR DESCRIPTION
## Description

Fixes two regressions on the encrypted-collab-invite feature shipped in #3373.

**Bug A — sender sees Accept/Ignore on their own outgoing invite.**
NIP-17 publishes a gift-wrap-to-self alongside the recipient gift wrap so the sender can read sent history from any device. The DM conversation renderer was running every parsed invite through `CollaboratorInviteCard` regardless of direction, surfacing Accept/Ignore on the inviter's own card. Tapping Accept would publish a malformed kind-34238 with `creator == responder == self`. Confirmed in [@hm21's comment](https://github.com/divinevideo/divine-mobile/issues/3559#issuecomment-4341397069).

**Bug B — "Open diVine to review and accept" plaintext duplicate inside diVine.**
`DmRepository.sendMessage` fires a NIP-04 fallback when `dmProtocol != 'nip17'`. The fallback (`_sendNip04Message`) drops `additionalTags` entirely — NIP-04 has no place for the structured invite tags. So every collab invite was published twice: a NIP-17 structured card + a kind-4 plaintext duplicate that read "You were invited to collaborate on … Open diVine to review and accept" inside diVine.

**Bug B' (Phase 2) — recipients still see legacy plaintext invites from pre-fix senders or cross-clients.**
Phase 1 stopped *new* sends from emitting the NIP-04 fallback, but recipients still see plaintext bubbles from senders running older builds, from non-Divine Nostr clients, and from local DB rows from before the fix. Phase 2 suppresses these in the conversation view. Reviewer: addresses [@hm21's review feedback](https://github.com/divinevideo/divine-mobile/pull/3566#pullrequestreview-4195476818).

**Related Issue:** Closes #3559

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Approach

### Render side (Bug A)

- `CollaboratorInviteCard` short-circuits when `widget.isSent`. No `BlocSelector` subscription, no `loadInvites` call — just a static "Invitation sent" status. This also avoids polluting the local invite-state store with `(creator==self, collaborator==self)` records.
- `CollaboratorInviteActionsCubit.acceptInvite` and `ignoreInvite` add `assert + early-return` when `_currentUserPubkey == invite.creatorPubkey`. Defense-in-depth: the assert fails loudly in debug if the render layer ever leaks; the early-return short-circuits silently in release.

### Send side (Bug B)

- `DmRepository.sendMessage` gains a `bool skipNip04Fallback = false` parameter. When `true`, the NIP-04 publish is suppressed.
- `CollaboratorInviteService.sendInvite` passes `skipNip04Fallback: true`. Default remains `false` so plain text DMs (`ConversationBloc`, `VideoSharingService`, report dialogs — none of which use `additionalTags` today) keep their legacy interop path untouched.

### Receive side (Bug B' — Phase 2)

- `CollaboratorInviteService` exposes `static const String invitePlaintextSuffix = 'Open diVine to review and accept.'` and `_buildContent` consumes it directly. Producer and consumer share one source of truth.
- `_MessageList.itemBuilder` returns `SizedBox.shrink()` when `message.content.endsWith(...invitePlaintextSuffix)`. Structured cards (left- or right-aligned) are unaffected.
- A contract test pins the relationship between `_buildContent` output and the const, so a future copy edit fails loudly if either side drifts.

### Localization

New ARB key `inboxCollabInviteSentStatus: "Invitation sent"` in `app_en.arb` plus all 14 non-EN locales (English placeholder for translators). Generated `app_localizations*.dart` files committed.

## Tests

- `dm_repository_test.dart` — new test asserts `skipNip04Fallback: true` suppresses `mockNostrClient.publishEvent`. Existing scaffolding reused.
- `collaborator_invite_service_test.dart` — extended to capture and assert `skipNip04Fallback: true` is forwarded to `sendMessage`. Phase 2 adds a contract test asserting `_buildContent` output endsWith `invitePlaintextSuffix`.
- `collaborator_invite_actions_cubit_test.dart` — two new tests: `acceptInvite` and `ignoreInvite` no-op (assert fires + no side effects) when current user is the invite creator.
- `conversation_view_test.dart` — sibling of the existing recipient-direction test. With `senderPubkey == currentUserPubkey`, asserts card chrome renders, "Invitation sent" status shows, no Accept/Ignore, and `mockInviteActionsCubit.loadInvites` is never called. Phase 2 adds two more cases: legacy plaintext (empty tags, content endsWith the suffix) renders nothing; ordinary plain text DMs still render.
- `arb_consistency_test.dart` — green; new key present in all locales.

## Manual test plan

1. Sign in as User A, post a video with User B (mutual follow) added as a collaborator.
2. Open the DM conversation with User B from User A's app.
3. Verify: card shows "Invitation sent" — no Accept/Ignore. No plaintext "Open diVine" duplicate bubble.
4. Sign in as User B (or use a second device). Open the conversation with User A.
5. Verify: exactly one Accept/Ignore card; no plaintext duplicate.
6. (Phase 2 cross-version) From a SECOND device on `main` (pre-fix), post a video with the receiver added as collaborator. On the receiver (this branch), open the conversation. **Pass:** exactly one Accept/Ignore card, no plaintext "Open diVine" bubble.

## Follow-up issues filed

- #3661 — investigate why structured NIP-17 collaborator invites sometimes fail to pair with their NIP-04 duplicate on the recipient side (delivery / decryption / persistence diagnosis).
- #3662 — apply the same plaintext suppression at the conversation list preview layer (`DmRepository.watchAcceptedConversations`).
- #3663 — pre-existing latent: `dm_repository.dart:843` `protocol != 'nip17'` first-send check evaluates `existingSend` before the upsert, so NIP-04 fires on every fresh-conversation first message regardless of peer capability.
- #3664 — backend audit: confirm Funnelcake's kind-34238 ingestion rejects events where `p`-tag matches the event author (defensive, in case any junk events leaked from sender-side test taps before this fix).
- #3665 — focused l10n migration for the remaining hardcoded English in `CollaboratorInviteCard` ("Collaborator invite", "Accept", "Ignore", "Accepted", "Ignored", "Could not accept. Try again.").

## Out of scope (handled by the follow-ups above)

- **Live recipient-status reflection on the sender card** — the inviter's "Invitation sent" status does not flip to "Accepted by recipient" when the collaborator publishes a kind-34238 acceptance. Tracked as a future enhancement, not part of #3559.