### PR TITLE
fix(feed): hydrate home feed loop counts

### DIFF
--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -183,7 +183,8 @@ class VideosRepository {
         );
 
         final videos = _transformVideoStats(response.videos);
-        return (videos: videos, rawBody: response.rawBody);
+        final hydratedVideos = await _hydrateVideosWithBulkStats(videos);
+        return (videos: hydratedVideos, rawBody: response.rawBody);
       } on FunnelcakeException {
         // Fall through to Nostr
       }
@@ -202,7 +203,64 @@ class VideosRepository {
 
     final events = await _nostrClient.queryEvents([filter]);
 
-    return (videos: _transformAndFilter(events), rawBody: null);
+    final videos = _transformAndFilter(events);
+    final hydratedVideos = await _hydrateVideosWithBulkStats(videos);
+    return (videos: hydratedVideos, rawBody: null);
+  }
+
+  Future<List<VideoEvent>> _hydrateVideosWithBulkStats(
+    List<VideoEvent> videos,
+  ) async {
+    if (videos.isEmpty ||
+        _funnelcakeApiClient == null ||
+        !_funnelcakeApiClient.isAvailable) {
+      return videos;
+    }
+
+    final videosNeedingStats = videos
+        .where(
+          (video) =>
+              video.id.isNotEmpty &&
+              (video.originalLoops == null || video.rawTags['views'] == null),
+        )
+        .toList();
+    if (videosNeedingStats.isEmpty) return videos;
+
+    try {
+      final statsById = <String, BulkVideoStatsEntry>{};
+      for (var i = 0; i < videosNeedingStats.length; i += 100) {
+        final end = i + 100 > videosNeedingStats.length
+            ? videosNeedingStats.length
+            : i + 100;
+        final chunk = videosNeedingStats.sublist(i, end);
+        final response = await _funnelcakeApiClient.getBulkVideoStats(
+          chunk.map((video) => video.id).toList(),
+        );
+        statsById.addAll(response.stats);
+      }
+
+      if (statsById.isEmpty) return videos;
+
+      return videos.map((video) {
+        final stats = statsById[video.id];
+        if (stats == null) return video;
+
+        return video.copyWith(
+          originalLoops: stats.loops ?? video.originalLoops,
+          rawTags: video.rawTags['views'] == null && stats.views != null
+              ? {...video.rawTags, 'views': stats.views.toString()}
+              : video.rawTags,
+        );
+      }).toList();
+    } on Object catch (e, stackTrace) {
+      developer.log(
+        'Failed to hydrate home feed videos with bulk stats',
+        name: 'VideosRepository',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return videos;
+    }
   }
 
   /// Merges list videos with following videos and builds attribution.

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -682,6 +682,256 @@ void main() {
           verifyNever(() => mockNostrClient.queryEvents(any()));
         });
 
+        test(
+          'hydrates missing loops without replacing existing views',
+          () async {
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getHomeFeed(
+                pubkey: any(named: 'pubkey'),
+                limit: any(named: 'limit'),
+                before: any(named: 'before'),
+              ),
+            ).thenAnswer(
+              (_) async => HomeFeedResponse(
+                videos: [
+                  _createVideoStats(
+                    id: 'event-1',
+                    pubkey: 'followed-user',
+                    dTag: 'dtag-1',
+                    videoUrl: 'https://example.com/video.mp4',
+                    views: 7,
+                  ),
+                ],
+              ),
+            );
+            when(
+              () => mockFunnelcakeClient.getBulkVideoStats(['event-1']),
+            ).thenAnswer(
+              (_) async => const BulkVideoStatsResponse(
+                stats: {
+                  'event-1': BulkVideoStatsEntry(
+                    eventId: 'event-1',
+                    reactions: 0,
+                    comments: 0,
+                    reposts: 0,
+                    loops: 5,
+                    views: 42,
+                  ),
+                },
+              ),
+            );
+
+            final repositoryWithApi = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repositoryWithApi.getHomeFeedVideos(
+              authors: ['followed-user'],
+              userPubkey: 'my-pubkey',
+            );
+
+            expect(result.videos, hasLength(1));
+            expect(result.videos.first.rawTags['views'], equals('7'));
+            expect(result.videos.first.totalLoops, equals(12));
+            verify(
+              () => mockFunnelcakeClient.getBulkVideoStats(['event-1']),
+            ).called(1);
+            verifyNever(() => mockNostrClient.queryEvents(any()));
+          },
+        );
+
+        test('chunks bulk stat hydration for large API result sets', () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getHomeFeed(
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer(
+            (_) async => HomeFeedResponse(
+              videos: List.generate(
+                101,
+                (index) => _createVideoStats(
+                  id: 'event-$index',
+                  pubkey: 'followed-user',
+                  dTag: 'dtag-$index',
+                  videoUrl: 'https://example.com/video-$index.mp4',
+                  loops: 0,
+                ),
+              ),
+            ),
+          );
+          when(() => mockFunnelcakeClient.getBulkVideoStats(any())).thenAnswer((
+            invocation,
+          ) async {
+            final ids = invocation.positionalArguments.single as List<String>;
+            return BulkVideoStatsResponse(
+              stats: {
+                for (final id in ids)
+                  id: BulkVideoStatsEntry(
+                    eventId: id,
+                    reactions: 0,
+                    comments: 0,
+                    reposts: 0,
+                    views: int.parse(id.split('-').last) + 1,
+                  ),
+              },
+            );
+          });
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repositoryWithApi.getHomeFeedVideos(
+            authors: ['followed-user'],
+            userPubkey: 'my-pubkey',
+          );
+
+          expect(result.videos, hasLength(101));
+          final firstVideo = result.videos.firstWhere(
+            (video) => video.id == 'event-0',
+          );
+          final lastVideo = result.videos.firstWhere(
+            (video) => video.id == 'event-100',
+          );
+          expect(firstVideo.totalLoops, equals(1));
+          expect(lastVideo.totalLoops, equals(101));
+          final captured = verify(
+            () => mockFunnelcakeClient.getBulkVideoStats(captureAny()),
+          ).captured;
+          expect(captured, hasLength(2));
+          expect(captured.first as List<String>, hasLength(100));
+          expect(captured.last as List<String>, hasLength(1));
+          expect(
+            captured.expand((ids) => ids as List<String>),
+            containsAll(['event-0', 'event-100']),
+          );
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+        });
+
+        test(
+          'skips bulk stats when API results already include loops and views',
+          () async {
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getHomeFeed(
+                pubkey: any(named: 'pubkey'),
+                limit: any(named: 'limit'),
+                before: any(named: 'before'),
+              ),
+            ).thenAnswer(
+              (_) async => HomeFeedResponse(
+                videos: [
+                  _createVideoStats(
+                    id: 'event-1',
+                    pubkey: 'followed-user',
+                    dTag: 'dtag-1',
+                    videoUrl: 'https://example.com/video.mp4',
+                    loops: 5,
+                    views: 7,
+                  ),
+                ],
+              ),
+            );
+
+            final repositoryWithApi = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repositoryWithApi.getHomeFeedVideos(
+              authors: ['followed-user'],
+              userPubkey: 'my-pubkey',
+            );
+
+            expect(result.videos, hasLength(1));
+            expect(result.videos.first.rawTags['views'], equals('7'));
+            expect(result.videos.first.totalLoops, equals(12));
+            verifyNever(() => mockFunnelcakeClient.getBulkVideoStats(any()));
+            verifyNever(() => mockNostrClient.queryEvents(any()));
+          },
+        );
+
+        test(
+          'leaves videos unchanged when bulk stats omit their event id',
+          () async {
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getHomeFeed(
+                pubkey: any(named: 'pubkey'),
+                limit: any(named: 'limit'),
+                before: any(named: 'before'),
+              ),
+            ).thenAnswer(
+              (_) async => HomeFeedResponse(
+                videos: [
+                  _createVideoStats(
+                    id: 'event-1',
+                    pubkey: 'followed-user',
+                    dTag: 'dtag-1',
+                    videoUrl: 'https://example.com/video-1.mp4',
+                    loops: 0,
+                  ),
+                  _createVideoStats(
+                    id: 'event-2',
+                    pubkey: 'followed-user',
+                    dTag: 'dtag-2',
+                    videoUrl: 'https://example.com/video-2.mp4',
+                    loops: 0,
+                  ),
+                ],
+              ),
+            );
+            when(
+              () => mockFunnelcakeClient.getBulkVideoStats([
+                'event-1',
+                'event-2',
+              ]),
+            ).thenAnswer(
+              (_) async => const BulkVideoStatsResponse(
+                stats: {
+                  'event-1': BulkVideoStatsEntry(
+                    eventId: 'event-1',
+                    reactions: 0,
+                    comments: 0,
+                    reposts: 0,
+                    views: 42,
+                  ),
+                },
+              ),
+            );
+
+            final repositoryWithApi = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repositoryWithApi.getHomeFeedVideos(
+              authors: ['followed-user'],
+              userPubkey: 'my-pubkey',
+            );
+
+            expect(result.videos, hasLength(2));
+            expect(result.videos.first.rawTags['views'], equals('42'));
+            expect(result.videos.first.totalLoops, equals(42));
+            expect(result.videos.last.id, equals('event-2'));
+            expect(result.videos.last.rawTags['views'], isNull);
+            expect(result.videos.last.totalLoops, equals(0));
+            verify(
+              () => mockFunnelcakeClient.getBulkVideoStats([
+                'event-1',
+                'event-2',
+              ]),
+            ).called(1);
+            verifyNever(() => mockNostrClient.queryEvents(any()));
+          },
+        );
+
         test('maps REST moderation labels to moderationLabels '
             '(not contentWarningLabels) and does not apply warn', () async {
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
@@ -6357,6 +6607,7 @@ VideoStats _createVideoStats({
   String title = 'Test Video',
   String thumbnail = 'https://example.com/thumb.jpg',
   int? loops,
+  int? views,
   List<String> moderationLabels = const [],
   List<String> collaboratorPubkeys = const [],
 }) {
@@ -6374,6 +6625,7 @@ VideoStats _createVideoStats({
     reposts: 0,
     engagementScore: 0,
     loops: loops,
+    views: views,
     moderationLabels: moderationLabels,
     collaboratorPubkeys: collaboratorPubkeys,
   );

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -626,6 +626,62 @@ void main() {
           verifyNever(() => mockNostrClient.queryEvents(any()));
         });
 
+        test('hydrates sparse API results with bulk loop stats', () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getHomeFeed(
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer(
+            (_) async => HomeFeedResponse(
+              videos: [
+                _createVideoStats(
+                  id: 'event-1',
+                  pubkey: 'followed-user',
+                  dTag: 'dtag-1',
+                  videoUrl: 'https://example.com/video.mp4',
+                  loops: 0,
+                ),
+              ],
+            ),
+          );
+          when(
+            () => mockFunnelcakeClient.getBulkVideoStats(['event-1']),
+          ).thenAnswer(
+            (_) async => const BulkVideoStatsResponse(
+              stats: {
+                'event-1': BulkVideoStatsEntry(
+                  eventId: 'event-1',
+                  reactions: 0,
+                  comments: 0,
+                  reposts: 0,
+                  views: 42,
+                ),
+              },
+            ),
+          );
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repositoryWithApi.getHomeFeedVideos(
+            authors: ['followed-user'],
+            userPubkey: 'my-pubkey',
+          );
+
+          expect(result.videos, hasLength(1));
+          expect(result.videos.first.rawTags['views'], equals('42'));
+          expect(result.videos.first.totalLoops, equals(42));
+          verify(
+            () => mockFunnelcakeClient.getBulkVideoStats(['event-1']),
+          ).called(1);
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+        });
+
         test('maps REST moderation labels to moderationLabels '
             '(not contentWarningLabels) and does not apply warn', () async {
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);


### PR DESCRIPTION
Closes #3709

## Summary
- hydrate Home/For You feed videos with Funnelcake bulk stats after the home feed or relay fallback loads
- preserve feed resilience by returning the original videos if stats hydration fails
- add a regression test for home feed videos that arrive with zero loops but need views from bulk stats

## Verification
- flutter test test/src/videos_repository_test.dart --plain-name "hydrates sparse API results with bulk loop stats" (from mobile/packages/videos_repository)
- flutter analyze lib/src/videos_repository.dart test/src/videos_repository_test.dart (from mobile/packages/videos_repository)
- flutter test --coverage (from mobile/packages/videos_repository, 99.56% line coverage)
- pre-commit hook passed
- pre-push hook passed
