### PR TITLE
fix(clip-library): update border-radius in masonry grid for video clips

### DIFF
--- a/mobile/lib/widgets/library/clips_tab.dart
+++ b/mobile/lib/widgets/library/clips_tab.dart
@@ -261,7 +261,6 @@ class _MasonryLayout extends StatelessWidget {
         borderRadius: clips.length >= _columnCount
             ? const .vertical(top: _radius)
             : .zero,
-        clipBehavior: .hardEdge,
         child: MasonryGridView.count(
           controller: scrollController,
           padding: .only(bottom: MediaQuery.viewPaddingOf(context).bottom),

--- a/mobile/lib/widgets/library/clips_tab.dart
+++ b/mobile/lib/widgets/library/clips_tab.dart
@@ -247,7 +247,7 @@ class _MasonryLayout extends StatelessWidget {
   final double? targetAspectRatio;
 
   static const _columnCount = 3;
-  static const _radius = Radius.circular(32);
+  static const _radius = Radius.circular(VineTheme.shellInnerCornerRadius);
 
   @override
   Widget build(BuildContext context) {
@@ -255,39 +255,38 @@ class _MasonryLayout extends StatelessWidget {
       for (var i = 0; i < selectedClipIds.length; i++)
         selectedClipIds.elementAt(i): i + 1,
     };
-    return MasonryGridView.count(
-      controller: scrollController,
-      padding: .fromSTEB(8, 0, 8, MediaQuery.viewPaddingOf(context).bottom),
-      crossAxisCount: _columnCount,
-      mainAxisSpacing: 4,
-      crossAxisSpacing: 4,
-      cacheExtent: MediaQuery.sizeOf(context).height * 2,
-      itemCount: clips.length,
-      itemBuilder: (context, index) {
-        final clip = clips[index];
-        final selectionIndex = selectionIndexById[clip.id] ?? -1;
-        final firstRowLastIndex = clips.length < _columnCount
-            ? clips.length - 1
-            : _columnCount - 1;
-        final isLastInFirstRow = index == firstRowLastIndex;
-        final borderRadius = BorderRadius.only(
-          topLeft: index == 0 ? _radius : Radius.zero,
-          topRight: isLastInFirstRow ? _radius : Radius.zero,
-        );
-        return ClipRRect(
-          borderRadius: borderRadius,
-          child: VideoClipThumbnailCard(
-            clip: clip,
-            selectionIndex: selectionIndex,
-            disabled:
-                disabledClipIds.contains(clip.id) ||
-                (targetAspectRatio != null &&
-                    targetAspectRatio != clip.targetAspectRatio.value),
-            onTap: () => onTapClip(clip),
-            onLongPress: () => onLongPressClip(clip),
-          ),
-        );
-      },
+    return Padding(
+      padding: const .symmetric(horizontal: 8),
+      child: ClipRRect(
+        borderRadius: clips.length >= _columnCount
+            ? const .vertical(top: _radius)
+            : .zero,
+        clipBehavior: .hardEdge,
+        child: MasonryGridView.count(
+          controller: scrollController,
+          padding: .only(bottom: MediaQuery.viewPaddingOf(context).bottom),
+          crossAxisCount: _columnCount,
+          mainAxisSpacing: 4,
+          crossAxisSpacing: 4,
+          cacheExtent: MediaQuery.sizeOf(context).height * 2,
+          itemCount: clips.length,
+          itemBuilder: (context, index) {
+            final clip = clips[index];
+            final selectionIndex = selectionIndexById[clip.id] ?? -1;
+
+            return VideoClipThumbnailCard(
+              clip: clip,
+              selectionIndex: selectionIndex,
+              disabled:
+                  disabledClipIds.contains(clip.id) ||
+                  (targetAspectRatio != null &&
+                      targetAspectRatio != clip.targetAspectRatio.value),
+              onTap: () => onTapClip(clip),
+              onLongPress: () => onLongPressClip(clip),
+            );
+          },
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
Closes #3669

## Description

Previously, the border radius in the clip library was inconsistent compared to the other tabs. In the other tabs, the border radius stays visible while scrolling, but in the clip library it disappeared because it was only applied to the first clip. The radius is now applied consistently and only when there are at least three clips in the library.


**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore