### PR TITLE
chore(zapstore): point metadata at 1.0.9

### DIFF
--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,5 +1,5 @@
 repository: https://github.com/divinevideo/divine-mobile
-release_source: https://github.com/divinevideo/divine-mobile/releases/tag/1.0.8
+release_source: https://github.com/divinevideo/divine-mobile/releases/tag/1.0.9
 name: Divine
 description: |
   Divine is a new 6-second looping video app, inspired by Vine, with a


### PR DESCRIPTION
Closes #3671

## Summary\n- point Zapstore release_source at the existing 1.0.9 GitHub release\n\n## Verification\n- PATH="$HOME/go/bin:$PATH" GITHUB_TOKEN="$(gh auth token)" zsp publish --check zapstore.yaml -> {"package_id":"co.openvine.app"}\n\n## Publish status\n- The signed Zapstore publish command was attempted with browser signing, but blocked waiting for Nostr signer approval at http://127.0.0.1:17007.\n