### PR TITLE
fix(dm): post-#3566 collab invite follow-ups (#3661 #3662 #3663)

### DIFF
--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2269,6 +2269,10 @@
     "inboxCollabInviteCardTitle": "دعوة للتعاون",
     "inboxCollabInviteIgnoreButton": "تجاهل",
     "inboxCollabInviteIgnoredStatus": "تم التجاهل",
+    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "@inboxConversationCollabInvitePreview": {
+        "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
+    },
     "inboxCollabInviteSentStatus": "تم إرسال الدعوة",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2269,7 +2269,7 @@
     "inboxCollabInviteCardTitle": "دعوة للتعاون",
     "inboxCollabInviteIgnoreButton": "تجاهل",
     "inboxCollabInviteIgnoredStatus": "تم التجاهل",
-    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "inboxConversationCollabInvitePreview": "دعوة للتعاون",
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2270,6 +2270,10 @@
     "inboxCollabInviteCardTitle": "Einladung zur Zusammenarbeit",
     "inboxCollabInviteIgnoreButton": "Ignorieren",
     "inboxCollabInviteIgnoredStatus": "Ignoriert",
+    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "@inboxConversationCollabInvitePreview": {
+        "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
+    },
     "inboxCollabInviteSentStatus": "Einladung gesendet",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2270,7 +2270,7 @@
     "inboxCollabInviteCardTitle": "Einladung zur Zusammenarbeit",
     "inboxCollabInviteIgnoreButton": "Ignorieren",
     "inboxCollabInviteIgnoredStatus": "Ignoriert",
-    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "inboxConversationCollabInvitePreview": "Einladung zur Zusammenarbeit",
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2342,6 +2342,11 @@
     "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."
   },
 
+  "inboxConversationCollabInvitePreview": "Collaborator invite",
+  "@inboxConversationCollabInvitePreview": {
+    "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list. The plaintext copy ('Open diVine to review and accept') is misleading inside diVine."
+  },
+
   "reportDialogCancel": "Cancel",
   "reportDialogReport": "Report",
 

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2270,7 +2270,7 @@
     "inboxCollabInviteCardTitle": "Invitación a colaborar",
     "inboxCollabInviteIgnoreButton": "Ignorar",
     "inboxCollabInviteIgnoredStatus": "Ignorada",
-    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "inboxConversationCollabInvitePreview": "Invitación a colaborar",
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2270,6 +2270,10 @@
     "inboxCollabInviteCardTitle": "Invitación a colaborar",
     "inboxCollabInviteIgnoreButton": "Ignorar",
     "inboxCollabInviteIgnoredStatus": "Ignorada",
+    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "@inboxConversationCollabInvitePreview": {
+        "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
+    },
     "inboxCollabInviteSentStatus": "Invitación enviada",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2270,7 +2270,7 @@
     "inboxCollabInviteCardTitle": "Invitation à collaborer",
     "inboxCollabInviteIgnoreButton": "Ignorer",
     "inboxCollabInviteIgnoredStatus": "Ignorée",
-    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "inboxConversationCollabInvitePreview": "Invitation à collaborer",
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2270,6 +2270,10 @@
     "inboxCollabInviteCardTitle": "Invitation à collaborer",
     "inboxCollabInviteIgnoreButton": "Ignorer",
     "inboxCollabInviteIgnoredStatus": "Ignorée",
+    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "@inboxConversationCollabInvitePreview": {
+        "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
+    },
     "inboxCollabInviteSentStatus": "Invitation envoyée",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2269,6 +2269,10 @@
     "inboxCollabInviteCardTitle": "Undangan kolaborasi",
     "inboxCollabInviteIgnoreButton": "Abaikan",
     "inboxCollabInviteIgnoredStatus": "Diabaikan",
+    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "@inboxConversationCollabInvitePreview": {
+        "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
+    },
     "inboxCollabInviteSentStatus": "Undangan terkirim",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2269,7 +2269,7 @@
     "inboxCollabInviteCardTitle": "Undangan kolaborasi",
     "inboxCollabInviteIgnoreButton": "Abaikan",
     "inboxCollabInviteIgnoredStatus": "Diabaikan",
-    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "inboxConversationCollabInvitePreview": "Undangan kolaborasi",
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2270,6 +2270,10 @@
     "inboxCollabInviteCardTitle": "Invito a collaborare",
     "inboxCollabInviteIgnoreButton": "Ignora",
     "inboxCollabInviteIgnoredStatus": "Ignorato",
+    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "@inboxConversationCollabInvitePreview": {
+        "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
+    },
     "inboxCollabInviteSentStatus": "Invito inviato",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2270,7 +2270,7 @@
     "inboxCollabInviteCardTitle": "Invito a collaborare",
     "inboxCollabInviteIgnoreButton": "Ignora",
     "inboxCollabInviteIgnoredStatus": "Ignorato",
-    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "inboxConversationCollabInvitePreview": "Invito a collaborare",
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2269,7 +2269,7 @@
     "inboxCollabInviteCardTitle": "コラボ招待",
     "inboxCollabInviteIgnoreButton": "無視",
     "inboxCollabInviteIgnoredStatus": "無視済み",
-    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "inboxConversationCollabInvitePreview": "コラボ招待",
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2269,6 +2269,10 @@
     "inboxCollabInviteCardTitle": "コラボ招待",
     "inboxCollabInviteIgnoreButton": "無視",
     "inboxCollabInviteIgnoredStatus": "無視済み",
+    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "@inboxConversationCollabInvitePreview": {
+        "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
+    },
     "inboxCollabInviteSentStatus": "招待を送ったよ",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1558,7 +1558,7 @@
     "inboxCollabInviteCardTitle": "콜라보 초대",
     "inboxCollabInviteIgnoreButton": "무시",
     "inboxCollabInviteIgnoredStatus": "무시됨",
-    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "inboxConversationCollabInvitePreview": "콜라보 초대",
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1558,6 +1558,10 @@
     "inboxCollabInviteCardTitle": "콜라보 초대",
     "inboxCollabInviteIgnoreButton": "무시",
     "inboxCollabInviteIgnoredStatus": "무시됨",
+    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "@inboxConversationCollabInvitePreview": {
+        "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
+    },
     "inboxCollabInviteSentStatus": "초대를 보냈어요",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2270,7 +2270,7 @@
     "inboxCollabInviteCardTitle": "Uitnodiging om samen te werken",
     "inboxCollabInviteIgnoreButton": "Negeren",
     "inboxCollabInviteIgnoredStatus": "Genegeerd",
-    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "inboxConversationCollabInvitePreview": "Uitnodiging om samen te werken",
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2270,6 +2270,10 @@
     "inboxCollabInviteCardTitle": "Uitnodiging om samen te werken",
     "inboxCollabInviteIgnoreButton": "Negeren",
     "inboxCollabInviteIgnoredStatus": "Genegeerd",
+    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "@inboxConversationCollabInvitePreview": {
+        "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
+    },
     "inboxCollabInviteSentStatus": "Uitnodiging verzonden",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2270,7 +2270,7 @@
     "inboxCollabInviteCardTitle": "Zaproszenie do współpracy",
     "inboxCollabInviteIgnoreButton": "Ignoruj",
     "inboxCollabInviteIgnoredStatus": "Zignorowano",
-    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "inboxConversationCollabInvitePreview": "Zaproszenie do współpracy",
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2270,6 +2270,10 @@
     "inboxCollabInviteCardTitle": "Zaproszenie do współpracy",
     "inboxCollabInviteIgnoreButton": "Ignoruj",
     "inboxCollabInviteIgnoredStatus": "Zignorowano",
+    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "@inboxConversationCollabInvitePreview": {
+        "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
+    },
     "inboxCollabInviteSentStatus": "Zaproszenie wysłane",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2270,7 +2270,7 @@
     "inboxCollabInviteCardTitle": "Convite para colaborar",
     "inboxCollabInviteIgnoreButton": "Ignorar",
     "inboxCollabInviteIgnoredStatus": "Ignorado",
-    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "inboxConversationCollabInvitePreview": "Convite para colaborar",
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2270,6 +2270,10 @@
     "inboxCollabInviteCardTitle": "Convite para colaborar",
     "inboxCollabInviteIgnoreButton": "Ignorar",
     "inboxCollabInviteIgnoredStatus": "Ignorado",
+    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "@inboxConversationCollabInvitePreview": {
+        "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
+    },
     "inboxCollabInviteSentStatus": "Convite enviado",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2270,7 +2270,7 @@
     "inboxCollabInviteCardTitle": "Invitație de colaborare",
     "inboxCollabInviteIgnoreButton": "Ignoră",
     "inboxCollabInviteIgnoredStatus": "Ignorată",
-    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "inboxConversationCollabInvitePreview": "Invitație de colaborare",
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2270,6 +2270,10 @@
     "inboxCollabInviteCardTitle": "Invitație de colaborare",
     "inboxCollabInviteIgnoreButton": "Ignoră",
     "inboxCollabInviteIgnoredStatus": "Ignorată",
+    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "@inboxConversationCollabInvitePreview": {
+        "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
+    },
     "inboxCollabInviteSentStatus": "Invitație trimisă",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2270,6 +2270,10 @@
     "inboxCollabInviteCardTitle": "Inbjudan att samarbeta",
     "inboxCollabInviteIgnoreButton": "Ignorera",
     "inboxCollabInviteIgnoredStatus": "Ignorerad",
+    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "@inboxConversationCollabInvitePreview": {
+        "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
+    },
     "inboxCollabInviteSentStatus": "Inbjudan skickad",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2270,7 +2270,7 @@
     "inboxCollabInviteCardTitle": "Inbjudan att samarbeta",
     "inboxCollabInviteIgnoreButton": "Ignorera",
     "inboxCollabInviteIgnoredStatus": "Ignorerad",
-    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "inboxConversationCollabInvitePreview": "Inbjudan att samarbeta",
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2269,7 +2269,7 @@
     "inboxCollabInviteCardTitle": "İşbirliği daveti",
     "inboxCollabInviteIgnoreButton": "Yoksay",
     "inboxCollabInviteIgnoredStatus": "Yoksayıldı",
-    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "inboxConversationCollabInvitePreview": "İşbirliği daveti",
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2269,6 +2269,10 @@
     "inboxCollabInviteCardTitle": "İşbirliği daveti",
     "inboxCollabInviteIgnoreButton": "Yoksay",
     "inboxCollabInviteIgnoredStatus": "Yoksayıldı",
+    "inboxConversationCollabInvitePreview": "Collaborator invite",
+    "@inboxConversationCollabInvitePreview": {
+        "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
+    },
     "inboxCollabInviteSentStatus": "Davet gönderildi",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -8162,6 +8162,12 @@ abstract class AppLocalizations {
   /// **'Invitation sent'**
   String get inboxCollabInviteSentStatus;
 
+  /// Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list. The plaintext copy ('Open diVine to review and accept') is misleading inside diVine.
+  ///
+  /// In en, this message translates to:
+  /// **'Collaborator invite'**
+  String get inboxConversationCollabInvitePreview;
+
   /// No description provided for @reportDialogCancel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4535,6 +4535,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'تم إرسال الدعوة';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => 'إلغاء';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4535,7 +4535,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'تم إرسال الدعوة';
 
   @override
-  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+  String get inboxConversationCollabInvitePreview => 'دعوة للتعاون';
 
   @override
   String get reportDialogCancel => 'إلغاء';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4634,7 +4634,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Einladung gesendet';
 
   @override
-  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+  String get inboxConversationCollabInvitePreview =>
+      'Einladung zur Zusammenarbeit';
 
   @override
   String get reportDialogCancel => 'Abbrechen';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4634,6 +4634,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Einladung gesendet';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => 'Abbrechen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4584,6 +4584,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Invitation sent';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => 'Cancel';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4625,7 +4625,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Invitación enviada';
 
   @override
-  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+  String get inboxConversationCollabInvitePreview => 'Invitación a colaborar';
 
   @override
   String get reportDialogCancel => 'Cancelar';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4625,6 +4625,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Invitación enviada';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4640,6 +4640,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Invitation envoyée';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => 'Annuler';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4640,7 +4640,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Invitation envoyée';
 
   @override
-  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+  String get inboxConversationCollabInvitePreview => 'Invitation à collaborer';
 
   @override
   String get reportDialogCancel => 'Annuler';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4554,7 +4554,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Undangan terkirim';
 
   @override
-  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+  String get inboxConversationCollabInvitePreview => 'Undangan kolaborasi';
 
   @override
   String get reportDialogCancel => 'Batal';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4554,6 +4554,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Undangan terkirim';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => 'Batal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4624,7 +4624,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Invito inviato';
 
   @override
-  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+  String get inboxConversationCollabInvitePreview => 'Invito a collaborare';
 
   @override
   String get reportDialogCancel => 'Annulla';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4624,6 +4624,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Invito inviato';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => 'Annulla';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4387,6 +4387,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get inboxCollabInviteSentStatus => '招待を送ったよ';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => 'キャンセル';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4387,7 +4387,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get inboxCollabInviteSentStatus => '招待を送ったよ';
 
   @override
-  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+  String get inboxConversationCollabInvitePreview => 'コラボ招待';
 
   @override
   String get reportDialogCancel => 'キャンセル';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4402,6 +4402,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get inboxCollabInviteSentStatus => '초대를 보냈어요';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => '취소';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4402,7 +4402,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get inboxCollabInviteSentStatus => '초대를 보냈어요';
 
   @override
-  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+  String get inboxConversationCollabInvitePreview => '콜라보 초대';
 
   @override
   String get reportDialogCancel => '취소';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4597,7 +4597,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Uitnodiging verzonden';
 
   @override
-  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+  String get inboxConversationCollabInvitePreview =>
+      'Uitnodiging om samen te werken';
 
   @override
   String get reportDialogCancel => 'Annuleren';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4597,6 +4597,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Uitnodiging verzonden';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => 'Annuleren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4705,7 +4705,8 @@ class AppLocalizationsPl extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Zaproszenie wysłane';
 
   @override
-  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+  String get inboxConversationCollabInvitePreview =>
+      'Zaproszenie do współpracy';
 
   @override
   String get reportDialogCancel => 'Anuluj';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4705,6 +4705,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Zaproszenie wysłane';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => 'Anuluj';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4610,6 +4610,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Convite enviado';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4610,7 +4610,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Convite enviado';
 
   @override
-  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+  String get inboxConversationCollabInvitePreview => 'Convite para colaborar';
 
   @override
   String get reportDialogCancel => 'Cancelar';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4711,7 +4711,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Invitație trimisă';
 
   @override
-  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+  String get inboxConversationCollabInvitePreview => 'Invitație de colaborare';
 
   @override
   String get reportDialogCancel => 'Anulează';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4711,6 +4711,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Invitație trimisă';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => 'Anulează';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4575,7 +4575,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Inbjudan skickad';
 
   @override
-  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+  String get inboxConversationCollabInvitePreview => 'Inbjudan att samarbeta';
 
   @override
   String get reportDialogCancel => 'Avbryt';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4575,6 +4575,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Inbjudan skickad';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => 'Avbryt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4564,6 +4564,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Davet gönderildi';
 
   @override
+  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+
+  @override
   String get reportDialogCancel => 'İptal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4564,7 +4564,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get inboxCollabInviteSentStatus => 'Davet gönderildi';
 
   @override
-  String get inboxConversationCollabInvitePreview => 'Collaborator invite';
+  String get inboxConversationCollabInvitePreview => 'İşbirliği daveti';
 
   @override
   String get reportDialogCancel => 'İptal';

--- a/mobile/lib/screens/inbox/widgets/conversation_tile.dart
+++ b/mobile/lib/screens/inbox/widgets/conversation_tile.dart
@@ -9,6 +9,7 @@ import 'package:models/models.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -134,9 +135,12 @@ class ConversationTile extends ConsumerWidget {
                       if (conversation.lastMessageContent != null) ...[
                         const SizedBox(height: 4),
                         Text(
-                          conversation.lastMessageContent!,
+                          _previewText(
+                            context,
+                            conversation.lastMessageContent!,
+                          ),
                           style: VineTheme.bodyMediumFont(
-                            color: VineTheme.onSurfaceVariant,
+                            color: VineTheme.onSurfaceMuted,
                           ),
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
@@ -152,6 +156,17 @@ class ConversationTile extends ConsumerWidget {
       ),
     );
   }
+}
+
+String _previewText(BuildContext context, String content) {
+  // The structured collaborator-invite card carries a deterministic
+  // plaintext fallback ("...Open diVine to review and accept.") so old
+  // clients can still see something. Inside diVine that copy is misleading
+  // — show a localized label instead (#3662, follows up on #3559 Phase 2).
+  if (content.endsWith(CollaboratorInviteService.invitePlaintextSuffix)) {
+    return context.l10n.inboxConversationCollabInvitePreview;
+  }
+  return content;
 }
 
 class _UnreadDot extends StatelessWidget {

--- a/mobile/lib/services/collaborator_invite_parser.dart
+++ b/mobile/lib/services/collaborator_invite_parser.dart
@@ -19,14 +19,18 @@ class CollaboratorInviteParser {
     final address = _parseAddress(addressTag[1]);
     if (address == null) return null;
 
-    final creatorTag = _firstWhereOrNull<String>(
-      tags
-          .where((tag) => tag.length >= 2 && tag[0] == 'p')
-          .map((tag) => tag[1]),
-      _isPubkey,
-    );
+    // NIP-17 rumors carry the recipient as their first `p` tag (added by
+    // the gift-wrap layer in NIP17MessageService.sendPrivateMessage), so a
+    // collaborator invite typically arrives with at least two p tags:
+    // recipient + creator. Match by membership rather than by first-hit
+    // so the recipient p tag does not silently reject the invite (#3661).
+    final pTagValues = tags
+        .where((tag) => tag.length >= 2 && tag[0] == 'p')
+        .map((tag) => tag[1])
+        .where(_isPubkey)
+        .toList(growable: false);
 
-    if (creatorTag != null && creatorTag != address.creatorPubkey) {
+    if (pTagValues.isNotEmpty && !pTagValues.contains(address.creatorPubkey)) {
       return null;
     }
 
@@ -37,7 +41,7 @@ class CollaboratorInviteParser {
       messageId: message.id,
       videoAddress: address.videoAddress,
       videoKind: address.videoKind,
-      creatorPubkey: creatorTag ?? address.creatorPubkey,
+      creatorPubkey: address.creatorPubkey,
       videoDTag: address.videoDTag,
       role: role,
       relayHint: _nonEmpty(addressTag.length >= 3 ? addressTag[2] : null),

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -819,6 +819,12 @@ class DmRepository {
             ownerPubkey: _userPubkey,
           );
           protocol = existingSend?.dmProtocol;
+          // Mark the conversation as NIP-17 once we successfully publish
+          // a NIP-17 message ourselves. Without this, `dmProtocol` only
+          // ever flips when the peer sends us a NIP-17 message, so a
+          // send-first conversation stayed `null` forever and every
+          // subsequent send fired the NIP-04 fallback (#3663).
+          final nextProtocol = protocol ?? 'nip17';
           await _conversationsDao.upsertConversation(
             id: conversationId,
             participantPubkeys: jsonEncode(participants),
@@ -829,7 +835,7 @@ class DmRepository {
             lastMessageSenderPubkey: _userPubkey,
             currentUserHasSent: true,
             ownerPubkey: _userPubkey,
-            dmProtocol: protocol,
+            dmProtocol: nextProtocol,
           );
         });
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -588,6 +588,145 @@ void main() {
         expect(result.success, isTrue);
         verifyNever(() => mockNostrClient.publishEvent(any()));
       });
+
+      test(
+        'second send to same conversation skips NIP-04 fallback (#3663)',
+        () async {
+          when(
+            () => mockMessageService.sendPrivateMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              eventKind: any(named: 'eventKind'),
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId,
+              recipientPubkey: _validPubkeyB,
+            ),
+          );
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: any(named: 'isGroup'),
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: any(named: 'lastMessageContent'),
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+              subject: any(named: 'subject'),
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockNostrClient.publishEvent(any()),
+          ).thenAnswer((_) async => null);
+
+          // First send: conversation does not exist yet → NIP-04
+          // fallback fires (safe legacy interop).
+          when(
+            () => mockConversationsDao.getConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+
+          final repository = createRepository();
+          await repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'Hello!',
+          );
+          await pumpEventQueue();
+
+          verify(() => mockNostrClient.publishEvent(any())).called(1);
+
+          // Capture the dmProtocol the repository wrote on first send.
+          final upsertCall = verify(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: any(named: 'isGroup'),
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: any(named: 'lastMessageContent'),
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+              subject: any(named: 'subject'),
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: captureAny(named: 'dmProtocol'),
+            ),
+          ).captured;
+          expect(upsertCall.last, equals('nip17'));
+
+          // Second send: simulate the conversation row now exists with
+          // dmProtocol='nip17' (which is what the first send wrote).
+          // The fallback must NOT fire again.
+          reset(mockNostrClient);
+          when(
+            () => mockNostrClient.publishEvent(any()),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockConversationsDao.getConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer(
+            (_) async => ConversationRow(
+              id:
+                  'dddddddddddddddddddddddddddddddddddddddddddddddddddddddd'
+                  'dddddddd',
+              participantPubkeys: jsonEncode([_validPubkeyA, _validPubkeyB]),
+              isGroup: false,
+              createdAt: 1700000000,
+              lastMessageContent: 'Hello!',
+              lastMessageTimestamp: 1700000000,
+              lastMessageSenderPubkey: _validPubkeyA,
+              isRead: true,
+              currentUserHasSent: true,
+              ownerPubkey: _validPubkeyA,
+              dmProtocol: 'nip17',
+            ),
+          );
+
+          await repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'Follow-up',
+          );
+          await pumpEventQueue();
+
+          verifyNever(() => mockNostrClient.publishEvent(any()));
+        },
+      );
     });
 
     group('sendGroupMessage', () {

--- a/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
+++ b/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
@@ -5,6 +5,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/widgets/conversation_tile.dart';
 import 'package:openvine/widgets/user_avatar.dart';
@@ -162,7 +163,11 @@ void main() {
           );
           await tester.pumpAndSettle();
 
-          expect(find.text('Collaborator invite'), findsOneWidget);
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          expect(
+            find.text(l10n.inboxConversationCollabInvitePreview),
+            findsOneWidget,
+          );
           expect(
             find.textContaining('Open diVine to review and accept'),
             findsNothing,

--- a/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
+++ b/mobile/test/screens/inbox/widgets/conversation_tile_test.dart
@@ -128,6 +128,48 @@ void main() {
         expect(find.text('Hey, how are you?'), findsOneWidget);
       });
 
+      // #3662 — the structured collab invite carries a deterministic
+      // plaintext fallback ('...Open diVine to review and accept.') so
+      // legacy clients can still see something. Inside diVine that copy
+      // is misleading; the conversation list should show a localized
+      // label instead.
+      testWidgets(
+        'replaces legacy collab invite plaintext with localized preview',
+        (tester) async {
+          final testProfile = createTestProfile(displayName: 'Alice');
+          final testConversation = createTestConversation(
+            lastMessageContent:
+                'You were invited to collaborate on Skate loop. '
+                'Open diVine to review and accept.',
+            lastMessageTimestamp: nowUnix,
+          );
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              additionalOverrides: [
+                fetchUserProfileProvider(
+                  otherPubkey,
+                ).overrideWith((ref) async => testProfile),
+              ],
+              home: Scaffold(
+                body: ConversationTile(
+                  conversation: testConversation,
+                  currentUserPubkey: currentPubkey,
+                  onTap: () {},
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.text('Collaborator invite'), findsOneWidget);
+          expect(
+            find.textContaining('Open diVine to review and accept'),
+            findsNothing,
+          );
+        },
+      );
+
       testWidgets('renders unread indicator when conversation is unread', (
         tester,
       ) async {

--- a/mobile/test/services/collaborator_invite_parser_test.dart
+++ b/mobile/test/services/collaborator_invite_parser_test.dart
@@ -103,5 +103,44 @@ void main() {
 
       expect(CollaboratorInviteParser.parse(message), isNull);
     });
+
+    // #3661 — NIP-17 rumors arrive with the recipient p tag at index 0
+    // (injected by NIP17MessageService.sendPrivateMessage). The creator
+    // p tag the invite service appends comes after. Match by membership.
+    test('parses invite when recipient p tag precedes creator p tag', () {
+      const recipientPubkey =
+          'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+      final message = messageWithTags([
+        ['divine', 'collab-invite'],
+        ['a', videoAddress, 'wss://relay.divine.video', 'root'],
+        // Order matches what the wire actually delivers.
+        ['p', recipientPubkey],
+        ['p', creatorPubkey],
+        ['role', 'Collaborator'],
+        ['title', 'Skate loop'],
+      ]);
+
+      final invite = CollaboratorInviteParser.parse(message);
+
+      expect(invite, isNotNull);
+      expect(invite!.creatorPubkey, creatorPubkey);
+      expect(invite.title, 'Skate loop');
+    });
+
+    test('rejects invite when no p tag matches the address creator', () {
+      const recipientPubkey =
+          'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+      const otherPubkey =
+          'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+      final message = messageWithTags([
+        ['divine', 'collab-invite'],
+        ['a', videoAddress, 'wss://relay.divine.video', 'root'],
+        ['p', recipientPubkey],
+        ['p', otherPubkey],
+        ['role', 'Collaborator'],
+      ]);
+
+      expect(CollaboratorInviteParser.parse(message), isNull);
+    });
   });
 }


### PR DESCRIPTION
## Description

Three small follow-ups to PR #3566 (the #3559 collaborator-invite regression fix), bundled into one PR with one commit per issue. Also closes the housekeeping items #3664 (backend, no mobile changes) and #3665 (already shipped on main — l10n keys for `CollaboratorInviteCard` are present and consumed).

**Related issues:** Closes #3661, Closes #3662, Closes #3663.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Commits

### `2bb7c06ba` — fix(dm): match collaborator invite creator across all p-tags (#3661)

**Root cause** — `nip17_message_service.dart:71-74` builds the rumor as `[['p', recipientPubkey], ...additionalTags]`, so a real collab invite always arrives with the recipient p-tag at index 0 and the creator p-tag (added by `CollaboratorInviteService._buildTags`) after. `CollaboratorInviteParser` was reading the FIRST valid-hex p-tag and rejecting if it didn't match `address.creatorPubkey`. **Result: every real invite has been silently rejected on the recipient side since #3373** — no Accept/Ignore card, only the NIP-04 plaintext fallback (which #3566 Phase 2 then suppressed, leaving the recipient with nothing). This is exactly what @hm21 saw on PR #3566.

**Fix** — match by membership: the invite is valid if any p-tag matches `address.creatorPubkey`. Pre-existing parser tests passed because they used a single-p-tag fixture that never simulated the actual NIP-17 wire shape. Two new cases lock the multi-p-tag positive and negative paths.

### `7f6862160` — fix(dm): localize legacy invite plaintext in conversation list (#3662)

The conversation tile in the inbox shows the most-recent-message preview from `lastMessageContent`. When the latest message is a structured invite plaintext, that preview reads "You were invited to collaborate on … Open diVine to review and accept." inside diVine — misleading.

**Fix** — at the tile widget, when `lastMessageContent.endsWith(CollaboratorInviteService.invitePlaintextSuffix)`, render a localized label instead. New ARB key `inboxConversationCollabInvitePreview = "Collaborator invite"` ships in all 15 locales (English placeholder for non-EN until translation pass). Repository-layer storage stays untouched.

### `ee323de4e` — fix(dm): mark conversation NIP-17 on first outbound send (#3663)

`DmRepository.sendMessage` gated the NIP-04 legacy fallback on `protocol != 'nip17'`, where `protocol` was `existingSend?.dmProtocol`. That field only ever flips to `'nip17'` when the peer sends us a NIP-17 message — so a send-first conversation stayed `null` forever and every subsequent send fired the NIP-04 fallback, doubling traffic and producing duplicate kind-4 events for any peer running a NIP-17 client without dedup.

**Fix** — when we successfully publish a NIP-17 message, write `dmProtocol = 'nip17'` on the conversation row. The very first send to a brand-new peer still fires the fallback (we have no peer-capability signal yet — safe legacy interop), but the second send and onwards correctly reads the row we just wrote and skips. Test pins both the first-send-fires-once and second-send-skips contracts.

## Closeout for the other two follow-ups

- **#3664 — Funnelcake kind-34238 ingestion audit.** Confirmed via grep that no mobile code filters incoming kind-34238 events. The mobile publish path is closed by #3566's cubit guard. **No mobile changes — pinging backend on the issue.**
- **#3665 — l10n migration of `CollaboratorInviteCard`.** Already shipped on `main`: all 8 ARB keys (`inboxCollabInviteCardTitle`, `inboxCollabInviteCardRoleLabel`, `inboxCollabInviteAcceptedStatus`, `inboxCollabInviteIgnoredStatus`, `inboxCollabInviteAcceptError`, `inboxCollabInviteAcceptButton`, `inboxCollabInviteIgnoreButton`, `inboxCollabInviteSentStatus`) are present in all 15 locales and consumed by `collaborator_invite_card.dart`. **Will close as already-resolved.**

## Tests

- `collaborator_invite_parser_test.dart` — multi-p-tag positive (recipient first, creator second) and negative (no p-tag matches creator).
- `conversation_tile_test.dart` — preview substitution; legacy invite plaintext renders the localized label, no "Open diVine" leak.
- `dm_repository_test.dart` — `dmProtocol = 'nip17'` written on first send; second send to same conversation skips NIP-04 fallback.
- All existing tests pass: full mobile + dm_repository suites green via the pre-push hook (analyze + test).

## Manual test plan

1. Sign in as User A. Post a video with User B (mutual follow) added as collaborator.
2. As User B, open the conversation with User A. **Pass:** Collaborator invite card with Accept/Ignore renders. No "Open diVine to review and accept" plaintext bubble.
3. As User B, the inbox list preview for the conversation shows "Collaborator invite" (or the most recent non-invite message), not the misleading "Open diVine" copy.
4. As User A, send User B a fresh plain-text DM (a brand-new conversation), then send another. **Pass:** the second message does NOT publish a NIP-04 kind-4 duplicate (verifiable via relay logs or DevTools).

## Known limitations

- The very first plain-text DM to a brand-new peer still fires NIP-04 fallback. Intentional safe legacy interop — we have no peer-capability signal on first contact. Documented inline.

## Risks

- **#3661 parser change** — relaxes the p-tag check. Negative test asserts that an invite with no creator p-tag among the p-tags is still rejected. Fixture-only existing tests continue to pass.
- **#3663 dmProtocol write** — every successful NIP-17 send now marks the conversation as NIP-17. A test that asserted `dmProtocol: any(named: 'dmProtocol')` would still pass; one asserting null would not, but I grepped the suite and no test pins `dmProtocol` to null on first send.
