### PR TITLE
fix(profile): prevent that the layout shift when stats loading

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -702,7 +702,7 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
 
   @override
   Widget build(BuildContext context) {
-    final isLoading = widget.profileStats == null && !_timeoutExpired;
+    final isLoading = widget.profileStats == null;
 
     final hasFollowers = widget.profileStats?.followers != null;
     final hasFollowing = widget.profileStats?.following != null;
@@ -717,7 +717,7 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
               ? _skeletonPlaceholderCount
               : widget.profileStats!.totalViews,
           label: l10n.profileLoopsLabel,
-          isLoading: isLoading,
+          isLoading: isLoading && _timeoutExpired,
         ),
       if (hasLikes || isLoading)
         ProfileStatColumn(
@@ -725,7 +725,7 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
               ? _skeletonPlaceholderCount
               : widget.profileStats!.totalLikes,
           label: l10n.profileLikesLabel,
-          isLoading: isLoading,
+          isLoading: isLoading && _timeoutExpired,
         ),
       if (hasFollowing || isLoading)
         ProfileStatColumn(
@@ -733,7 +733,7 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
               ? _skeletonPlaceholderCount
               : widget.profileStats!.following,
           label: l10n.profileFollowingLabel,
-          isLoading: isLoading,
+          isLoading: isLoading && _timeoutExpired,
           onTap: () => context.push(
             FollowingScreenRouter.pathForPubkey(widget.userIdHex),
           ),
@@ -744,7 +744,7 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
               ? _skeletonPlaceholderCount
               : widget.profileStats!.followers,
           label: l10n.profileFollowersLabel,
-          isLoading: isLoading,
+          isLoading: isLoading && _timeoutExpired,
           onTap: () => context.push(
             FollowersScreenRouter.pathForPubkey(widget.userIdHex),
           ),
@@ -752,7 +752,7 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
     ];
 
     return Skeletonizer(
-      enabled: isLoading,
+      enabled: isLoading && !_timeoutExpired,
       enableSwitchAnimation: true,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -657,9 +657,11 @@ class _BannerImage extends StatelessWidget {
 
 /// Stats row displaying Followers, Following, Likes, and Loops with dividers.
 ///
-/// Shows a skeleton for up to [_skeletonTimeout] while stats are being fetched.
-/// After the timeout the row collapses to nothing if stats still haven't arrived,
-/// rather than showing a skeleton indefinitely.
+/// Shows a skeleton for up to [_ProfileStatsRowState._skeletonTimeout] while
+/// stats are being fetched. After the timeout the row keeps all four columns
+/// visible but renders a `—` placeholder for each count, rather than
+/// shimmering indefinitely or collapsing the row (which would shift the
+/// surrounding profile layout).
 class _ProfileStatsRow extends StatefulWidget {
   const _ProfileStatsRow({
     required this.userIdHex,

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -676,6 +676,11 @@ class _ProfileStatsRow extends StatefulWidget {
 class _ProfileStatsRowState extends State<_ProfileStatsRow> {
   static const _skeletonTimeout = Duration(seconds: 7);
 
+  /// Two-digit placeholder painted behind the Skeletonizer shimmer while the
+  /// real stats load. The number itself is never visible — it only sets the
+  /// width of the skeleton bar.
+  static const _skeletonPlaceholderCount = 99;
+
   Timer? _timer;
   bool _timeoutExpired = false;
 
@@ -708,19 +713,25 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
     final columns = <Widget>[
       if (hasLoops || isLoading)
         ProfileStatColumn(
-          count: isLoading ? 99 : widget.profileStats!.totalViews,
+          count: isLoading
+              ? _skeletonPlaceholderCount
+              : widget.profileStats!.totalViews,
           label: l10n.profileLoopsLabel,
           isLoading: isLoading,
         ),
       if (hasLikes || isLoading)
         ProfileStatColumn(
-          count: isLoading ? 99 : widget.profileStats!.totalLikes,
+          count: isLoading
+              ? _skeletonPlaceholderCount
+              : widget.profileStats!.totalLikes,
           label: l10n.profileLikesLabel,
           isLoading: isLoading,
         ),
       if (hasFollowing || isLoading)
         ProfileStatColumn(
-          count: isLoading ? 99 : widget.profileStats!.following,
+          count: isLoading
+              ? _skeletonPlaceholderCount
+              : widget.profileStats!.following,
           label: l10n.profileFollowingLabel,
           isLoading: isLoading,
           onTap: () => context.push(
@@ -729,7 +740,9 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
         ),
       if (hasFollowers || isLoading)
         ProfileStatColumn(
-          count: isLoading ? 99 : widget.profileStats!.followers,
+          count: isLoading
+              ? _skeletonPlaceholderCount
+              : widget.profileStats!.followers,
           label: l10n.profileFollowersLabel,
           isLoading: isLoading,
           onTap: () => context.push(

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -756,6 +756,7 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
     return Skeletonizer(
       enabled: isLoading && !_timeoutExpired,
       enableSwitchAnimation: true,
+      effect: vineSkeletonEffect,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Profile header widget showing avatar, stats, name, and bio
 // ABOUTME: Reusable between own profile and others' profile screens
 
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:divine_ui/divine_ui.dart';
@@ -30,6 +31,7 @@ import 'package:openvine/widgets/profile/profile_stats_row_widget.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 /// Profile header widget displaying avatar, stats, name, and bio.
 class ProfileHeaderWidget extends ConsumerStatefulWidget {
@@ -654,59 +656,100 @@ class _BannerImage extends StatelessWidget {
 }
 
 /// Stats row displaying Followers, Following, Likes, and Loops with dividers.
-class _ProfileStatsRow extends StatelessWidget {
-  const _ProfileStatsRow({required this.userIdHex, this.profileStats});
+///
+/// Shows a skeleton for up to [_skeletonTimeout] while stats are being fetched.
+/// After the timeout the row collapses to nothing if stats still haven't arrived,
+/// rather than showing a skeleton indefinitely.
+class _ProfileStatsRow extends StatefulWidget {
+  const _ProfileStatsRow({
+    required this.userIdHex,
+    this.profileStats,
+  });
 
   final String userIdHex;
   final ProfileStats? profileStats;
 
   @override
+  State<_ProfileStatsRow> createState() => _ProfileStatsRowState();
+}
+
+class _ProfileStatsRowState extends State<_ProfileStatsRow> {
+  static const _skeletonTimeout = Duration(seconds: 7);
+
+  Timer? _timer;
+  bool _timeoutExpired = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.profileStats == null) {
+      _timer = Timer(_skeletonTimeout, () {
+        if (mounted) setState(() => _timeoutExpired = true);
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final hasFollowers = profileStats?.followers != null;
-    final hasFollowing = profileStats?.following != null;
-    final hasLikes = profileStats?.totalLikes != null;
-    final hasLoops = profileStats?.totalViews != null;
+    final isLoading = widget.profileStats == null && !_timeoutExpired;
+
+    final hasFollowers = widget.profileStats?.followers != null;
+    final hasFollowing = widget.profileStats?.following != null;
+    final hasLikes = widget.profileStats?.totalLikes != null;
+    final hasLoops = widget.profileStats?.totalViews != null;
 
     final l10n = context.l10n;
     final columns = <Widget>[
-      if (hasLoops)
+      if (hasLoops || isLoading)
         ProfileStatColumn(
-          count: profileStats!.totalViews,
+          count: isLoading ? 99 : widget.profileStats!.totalViews,
           label: l10n.profileLoopsLabel,
-          isLoading: false,
+          isLoading: isLoading,
         ),
-      if (hasLikes)
+      if (hasLikes || isLoading)
         ProfileStatColumn(
-          count: profileStats!.totalLikes,
+          count: isLoading ? 99 : widget.profileStats!.totalLikes,
           label: l10n.profileLikesLabel,
-          isLoading: false,
+          isLoading: isLoading,
         ),
-      if (hasFollowing)
+      if (hasFollowing || isLoading)
         ProfileStatColumn(
-          count: profileStats!.following,
+          count: isLoading ? 99 : widget.profileStats!.following,
           label: l10n.profileFollowingLabel,
-          isLoading: false,
-          onTap: () =>
-              context.push(FollowingScreenRouter.pathForPubkey(userIdHex)),
+          isLoading: isLoading,
+          onTap: () => context.push(
+            FollowingScreenRouter.pathForPubkey(widget.userIdHex),
+          ),
         ),
-      if (hasFollowers)
+      if (hasFollowers || isLoading)
         ProfileStatColumn(
-          count: profileStats!.followers,
+          count: isLoading ? 99 : widget.profileStats!.followers,
           label: l10n.profileFollowersLabel,
-          isLoading: false,
-          onTap: () =>
-              context.push(FollowersScreenRouter.pathForPubkey(userIdHex)),
+          isLoading: isLoading,
+          onTap: () => context.push(
+            FollowersScreenRouter.pathForPubkey(widget.userIdHex),
+          ),
         ),
     ];
 
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        for (int i = 0; i < columns.length; i++) ...[
-          if (i > 0) const _StatDivider(),
-          columns[i],
+    return Skeletonizer(
+      enabled: isLoading,
+      enableSwitchAnimation: true,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          for (int i = 0; i < columns.length; i++) ...[
+            if (i > 0) const _StatDivider(),
+            columns[i],
+          ],
         ],
-      ],
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/profile/profile_stats_row_widget.dart
+++ b/mobile/lib/widgets/profile/profile_stats_row_widget.dart
@@ -4,6 +4,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/utils/string_utils.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 /// Individual stat column widget for followers/following/likes/loops counts.
 ///
@@ -42,9 +43,11 @@ class ProfileStatColumn extends StatelessWidget {
             ),
           ),
         ),
-        Text(
-          label,
-          style: VineTheme.bodySmallFont(color: VineTheme.onSurfaceVariant),
+        Skeleton.keep(
+          child: Text(
+            label,
+            style: VineTheme.bodySmallFont(color: VineTheme.onSurfaceVariant),
+          ),
         ),
       ],
     );

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -363,24 +363,79 @@ void main() {
       expect(find.text('Loops'), findsOneWidget);
     });
 
-    testWidgets('hides all stat columns when profileStats is null', (
-      tester,
-    ) async {
-      final testProfile = createTestProfile(displayName: 'Test User');
+    testWidgets(
+      'hides all stat columns once the skeleton timeout expires and profileStats is still null',
+      (tester) async {
+        final testProfile = createTestProfile(displayName: 'Test User');
 
-      await tester.pumpWidget(
-        buildTestWidget(
-          userIdHex: testUserHex,
-          isOwnProfile: true,
-          profile: testProfile,
-        ),
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: testProfile,
+          ),
+        );
+        // Advance past the 4-second skeleton timeout, then settle any
+        // remaining switch animations.
+        await tester.pump(const Duration(seconds: 5));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Followers'), findsNothing);
+        expect(find.text('Following'), findsNothing);
+        expect(find.text('Likes'), findsNothing);
+        expect(find.text('Loops'), findsNothing);
+      },
+    );
+
+    group('Stats row skeleton timeout', () {
+      testWidgets(
+        'shows placeholder columns as skeleton while profileStats is null before timeout',
+        (tester) async {
+          final testProfile = createTestProfile(displayName: 'Test User');
+
+          await tester.pumpWidget(
+            buildTestWidget(
+              userIdHex: testUserHex,
+              isOwnProfile: true,
+              profile: testProfile,
+              // profileStats deliberately omitted (null)
+            ),
+          );
+          // One frame only — the 4-second skeleton timer has not fired yet.
+          await tester.pump();
+
+          // All four column labels are in the tree, rendered as skeletons.
+          expect(find.text('Followers'), findsOneWidget);
+          expect(find.text('Following'), findsOneWidget);
+          expect(find.text('Likes'), findsOneWidget);
+          expect(find.text('Loops'), findsOneWidget);
+        },
       );
-      await tester.pumpAndSettle();
 
-      expect(find.text('Followers'), findsNothing);
-      expect(find.text('Following'), findsNothing);
-      expect(find.text('Likes'), findsNothing);
-      expect(find.text('Loops'), findsNothing);
+      testWidgets(
+        'stat columns remain visible once profileStats arrives before timeout',
+        (tester) async {
+          const stats = ProfileStats(
+            pubkey: testUserHex,
+            totalLikes: 10,
+            totalViews: 20,
+          );
+
+          await tester.pumpWidget(
+            buildTestWidget(
+              userIdHex: testUserHex,
+              isOwnProfile: true,
+              profile: createTestProfile(displayName: 'Test User'),
+              profileStats: stats,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // Actual data shown — no timeout was needed.
+          expect(find.text('Loops'), findsOneWidget);
+          expect(find.text('Likes'), findsOneWidget);
+        },
+      );
     });
 
     testWidgets('displays user bio when present', (tester) async {

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -21,6 +21,7 @@ import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/widgets/profile/profile_header_widget.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 
 import '../../helpers/test_provider_overrides.dart';
 
@@ -387,6 +388,14 @@ void main() {
         expect(find.text('Likes'), findsOneWidget);
         expect(find.text('Loops'), findsOneWidget);
         expect(find.text('—'), findsNWidgets(4));
+
+        // Skeleton must be disabled after timeout — data is shown as-is.
+        // bySubtype is required because Skeletonizer is abstract; the
+        // concrete widget in the tree is the private _Skeletonizer subclass.
+        final s = tester.widget<Skeletonizer>(
+          find.bySubtype<Skeletonizer>(),
+        );
+        expect(s.enabled, isFalse);
       },
     );
 
@@ -412,6 +421,14 @@ void main() {
           expect(find.text('Following'), findsOneWidget);
           expect(find.text('Likes'), findsOneWidget);
           expect(find.text('Loops'), findsOneWidget);
+
+          // Skeleton must be active — not just present in the tree.
+          // bySubtype is required because Skeletonizer is abstract; the
+          // concrete widget in the tree is the private _Skeletonizer subclass.
+          final s = tester.widget<Skeletonizer>(
+            find.bySubtype<Skeletonizer>(),
+          );
+          expect(s.enabled, isTrue);
         },
       );
 

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -364,7 +364,8 @@ void main() {
     });
 
     testWidgets(
-      'hides all stat columns once the skeleton timeout expires and profileStats is still null',
+      'keeps all stat columns visible with em-dash placeholders once the '
+      'skeleton timeout expires and profileStats is still null',
       (tester) async {
         final testProfile = createTestProfile(displayName: 'Test User');
 
@@ -380,10 +381,12 @@ void main() {
         await tester.pump(const Duration(seconds: 8));
         await tester.pumpAndSettle();
 
-        expect(find.text('Followers'), findsNothing);
-        expect(find.text('Following'), findsNothing);
-        expect(find.text('Likes'), findsNothing);
-        expect(find.text('Loops'), findsNothing);
+        // All four labels stay in the tree; counts fall back to '—'.
+        expect(find.text('Followers'), findsOneWidget);
+        expect(find.text('Following'), findsOneWidget);
+        expect(find.text('Likes'), findsOneWidget);
+        expect(find.text('Loops'), findsOneWidget);
+        expect(find.text('—'), findsNWidgets(4));
       },
     );
 

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -375,9 +375,9 @@ void main() {
             profile: testProfile,
           ),
         );
-        // Advance past the 4-second skeleton timeout, then settle any
+        // Advance past the 7-second skeleton timeout, then settle any
         // remaining switch animations.
-        await tester.pump(const Duration(seconds: 5));
+        await tester.pump(const Duration(seconds: 8));
         await tester.pumpAndSettle();
 
         expect(find.text('Followers'), findsNothing);
@@ -401,7 +401,7 @@ void main() {
               // profileStats deliberately omitted (null)
             ),
           );
-          // One frame only — the 4-second skeleton timer has not fired yet.
+          // One frame only — the 7-second skeleton timer has not fired yet.
           await tester.pump();
 
           // All four column labels are in the tree, rendered as skeletons.


### PR DESCRIPTION
Closes #3674

## Description

Until now, when a user opened their own or another profile for the first time and the data wasn’t cached, the profile stats were completely hidden until the data finished loading, which caused the entire layout to shift. This PR changes that behavior by introducing a skeleton loader.

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/61d6011d-1a0d-4544-aec1-765712645a78" controls width="300"></video> | <video src="https://github.com/user-attachments/assets/be670e28-1755-41ac-b5da-828a84f26da7" controls width="300"></video> |


**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore