### PR TITLE
fix(perf): close profile feed traces from cache

### DIFF
--- a/mobile/lib/services/performance_monitoring_service.dart
+++ b/mobile/lib/services/performance_monitoring_service.dart
@@ -4,8 +4,21 @@
 import 'package:firebase_performance/firebase_performance.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Minimal trace API used by services that need testable performance spans.
+abstract class PerformanceTraceMonitor {
+  Future<void> startTrace(String traceName);
+
+  Future<void> stopTrace(String traceName);
+
+  void incrementMetric(String traceName, String metricName, int value);
+
+  void setMetric(String traceName, String metricName, int value);
+
+  void putAttribute(String traceName, String attribute, String value);
+}
+
 /// Performance monitoring service for tracking app performance
-class PerformanceMonitoringService {
+class PerformanceMonitoringService implements PerformanceTraceMonitor {
   static PerformanceMonitoringService? _instance;
   static PerformanceMonitoringService get instance =>
       _instance ??= PerformanceMonitoringService._();
@@ -43,6 +56,7 @@ class PerformanceMonitoringService {
   }
 
   /// Start a custom trace for tracking operation performance
+  @override
   Future<void> startTrace(String traceName) async {
     if (!_initialized) return;
 
@@ -67,6 +81,7 @@ class PerformanceMonitoringService {
   }
 
   /// Stop a custom trace and record the duration
+  @override
   Future<void> stopTrace(String traceName) async {
     if (!_initialized) return;
 
@@ -88,6 +103,7 @@ class PerformanceMonitoringService {
   }
 
   /// Add a metric to an active trace
+  @override
   void incrementMetric(String traceName, String metricName, int value) {
     if (!_initialized) return;
 
@@ -114,6 +130,7 @@ class PerformanceMonitoringService {
   }
 
   /// Set a metric value on an active trace
+  @override
   void setMetric(String traceName, String metricName, int value) {
     if (!_initialized) return;
 
@@ -140,6 +157,7 @@ class PerformanceMonitoringService {
   }
 
   /// Add an attribute to an active trace for filtering in Firebase Console
+  @override
   void putAttribute(String traceName, String attribute, String value) {
     if (!_initialized) return;
 

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -129,10 +129,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     ProfileRepository? profileRepository,
     EventRouter? eventRouter,
     VideoFilterBuilder? videoFilterBuilder,
+    PerformanceTraceMonitor? performanceMonitor,
   }) : _subscriptionManager = subscriptionManager,
        _profileRepository = profileRepository,
        _eventRouter = eventRouter,
-       _videoFilterBuilder = videoFilterBuilder {
+       _videoFilterBuilder = videoFilterBuilder,
+       _performanceMonitor =
+           performanceMonitor ?? PerformanceMonitoringService.instance {
     _initializePaginationStates();
     _initializeRepostResolver();
   }
@@ -141,6 +144,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   final ProfileRepository? _profileRepository;
   final EventRouter? _eventRouter;
   final VideoFilterBuilder? _videoFilterBuilder;
+  final PerformanceTraceMonitor _performanceMonitor;
   final ConnectionStatusService _connectionService = ConnectionStatusService();
 
   // REFACTORED: Separate event lists per subscription type
@@ -1679,7 +1683,24 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
         // Start performance trace for feed loading
         final traceName = 'feed_load_${subscriptionType.name}';
-        await PerformanceMonitoringService.instance.startTrace(traceName);
+        var traceCompleted = false;
+        void completeFeedLoadTrace(String completion, {int? eventTotal}) {
+          if (traceCompleted) return;
+          traceCompleted = true;
+          _performanceMonitor.setMetric(
+            traceName,
+            'event_count',
+            eventTotal ?? eventCount,
+          );
+          _performanceMonitor.putAttribute(
+            traceName,
+            'completion',
+            completion,
+          );
+          unawaited(_performanceMonitor.stopTrace(traceName));
+        }
+
+        await _performanceMonitor.startTrace(traceName);
 
         Log.info(
           '📡 Creating subscription for $subscriptionType at ${subscriptionStartTime.toIso8601String()}',
@@ -1724,6 +1745,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
               relayConnected: _nostrService.connectedRelayCount > 0,
               isOnline: _connectionService.isOnline,
             );
+
+            completeFeedLoadTrace('timeout');
           }
         });
 
@@ -1780,6 +1803,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             name: 'VideoEventService',
             category: LogCategory.video,
           );
+          completeFeedLoadTrace('cache', eventTotal: cachedEvents.length);
         }
 
         // 🎯 RELAY DEBUG: Track loop counts from relay
@@ -1858,6 +1882,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
                 relayConnected: _nostrService.connectedRelayCount > 0,
                 isOnline: _connectionService.isOnline,
               );
+              completeFeedLoadTrace('eose_empty');
+            } else {
+              completeFeedLoadTrace('eose');
             }
 
             // Complete per-subscription loading state — historical data
@@ -1898,13 +1925,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
               );
 
               // Stop performance trace on first event arrival
-              final traceName = 'feed_load_${subscriptionType.name}';
-              PerformanceMonitoringService.instance.setMetric(
-                traceName,
-                'event_count',
-                eventCount,
-              );
-              PerformanceMonitoringService.instance.stopTrace(traceName);
+              completeFeedLoadTrace('first_relay_event');
             }
 
             if (subscriptionType == SubscriptionType.homeFeed) {
@@ -1939,6 +1960,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
               name: 'VideoEventService',
               category: LogCategory.video,
             );
+            completeFeedLoadTrace('error');
             _handleSubscriptionError(error, subscriptionType);
           },
           onDone: () {
@@ -1953,6 +1975,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
             // PERSISTENT SUBSCRIPTION: onDone means relay closed connection
             // For main feeds, this should trigger reconnection attempt
+            completeFeedLoadTrace('done');
             _handleSubscriptionComplete(subscriptionType);
             if (_shouldMaintainSubscription(subscriptionType)) {
               _scheduleReconnection(subscriptionType);

--- a/mobile/test/services/video_event_service_startup_contract_test.dart
+++ b/mobile/test/services/video_event_service_startup_contract_test.dart
@@ -8,6 +8,7 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/services/event_router.dart';
+import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/subscription_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:profile_repository/profile_repository.dart';
@@ -23,6 +24,39 @@ class _MockAppDatabase extends Mock implements AppDatabase {}
 class _MockNostrEventsDao extends Mock implements NostrEventsDao {}
 
 class _FakeFilter extends Fake implements Filter {}
+
+class _RecordingPerformanceMonitor implements PerformanceTraceMonitor {
+  final startedTraces = <String>[];
+  final stoppedTraces = <String>[];
+  final metrics = <String, Map<String, int>>{};
+  final attributes = <String, Map<String, String>>{};
+
+  @override
+  void incrementMetric(String traceName, String metricName, int value) {
+    metrics.putIfAbsent(traceName, () => {})[metricName] =
+        (metrics[traceName]?[metricName] ?? 0) + value;
+  }
+
+  @override
+  void putAttribute(String traceName, String attribute, String value) {
+    attributes.putIfAbsent(traceName, () => {})[attribute] = value;
+  }
+
+  @override
+  void setMetric(String traceName, String metricName, int value) {
+    metrics.putIfAbsent(traceName, () => {})[metricName] = value;
+  }
+
+  @override
+  Future<void> startTrace(String traceName) async {
+    startedTraces.add(traceName);
+  }
+
+  @override
+  Future<void> stopTrace(String traceName) async {
+    stoppedTraces.add(traceName);
+  }
+}
 
 void main() {
   setUpAll(() {
@@ -40,6 +74,8 @@ void main() {
     late StreamController<Event> relayController;
     late VideoEventService videoEventService;
     late Completer<Map<String, UserProfile>> batchFetchCompleter;
+    late _RecordingPerformanceMonitor performanceMonitor;
+    late void Function()? relayEose;
 
     setUp(() {
       mockNostrService = _MockNostrClient();
@@ -49,12 +85,17 @@ void main() {
       mockNostrEventsDao = _MockNostrEventsDao();
       relayController = StreamController<Event>.broadcast();
       batchFetchCompleter = Completer<Map<String, UserProfile>>();
+      performanceMonitor = _RecordingPerformanceMonitor();
+      relayEose = null;
 
       when(() => mockNostrService.isInitialized).thenReturn(true);
       when(() => mockNostrService.connectedRelayCount).thenReturn(1);
       when(
         () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
-      ).thenAnswer((_) => relayController.stream);
+      ).thenAnswer((invocation) {
+        relayEose = invocation.namedArguments[#onEose] as void Function()?;
+        return relayController.stream;
+      });
 
       when(() => mockDatabase.nostrEventsDao).thenReturn(mockNostrEventsDao);
       when(
@@ -81,6 +122,7 @@ void main() {
         subscriptionManager: mockSubscriptionManager,
         profileRepository: mockProfileRepository,
         eventRouter: EventRouter(mockDatabase),
+        performanceMonitor: performanceMonitor,
       );
     });
 
@@ -107,6 +149,58 @@ void main() {
         ).called(1);
       },
     );
+
+    test(
+      'stops profile feed trace when cached events populate the feed',
+      () async {
+        await videoEventService
+            .subscribeToVideoFeed(
+              subscriptionType: SubscriptionType.profile,
+              authors: ['a' * 64],
+            )
+            .timeout(const Duration(milliseconds: 100));
+
+        expect(performanceMonitor.startedTraces, contains('feed_load_profile'));
+        expect(performanceMonitor.stoppedTraces, contains('feed_load_profile'));
+        expect(
+          performanceMonitor.metrics['feed_load_profile']?['event_count'],
+          1,
+        );
+        expect(
+          performanceMonitor.attributes['feed_load_profile']?['completion'],
+          'cache',
+        );
+      },
+    );
+
+    test('stops profile feed trace when relay completes empty', () async {
+      when(
+        () => mockNostrEventsDao.getEventsByFilter(
+          any(),
+          sortBy: any(named: 'sortBy'),
+        ),
+      ).thenAnswer((_) async => const <Event>[]);
+
+      await videoEventService
+          .subscribeToVideoFeed(
+            subscriptionType: SubscriptionType.profile,
+            authors: ['a' * 64],
+          )
+          .timeout(const Duration(milliseconds: 100));
+
+      relayEose!();
+
+      expect(performanceMonitor.startedTraces, contains('feed_load_profile'));
+      expect(performanceMonitor.stoppedTraces, contains('feed_load_profile'));
+      expect(
+        performanceMonitor.metrics['feed_load_profile']?['event_count'],
+        0,
+      );
+      expect(
+        performanceMonitor.attributes['feed_load_profile']?['completion'],
+        'eose_empty',
+      );
+    });
   });
 }
 


### PR DESCRIPTION
Relates to #3708

## Summary
- close `feed_load_profile` when cache-first results already populate the feed
- close feed-load traces on empty EOSE, timeout, stream error, and stream completion
- add regression coverage with an injectable performance trace monitor

## Test Plan
- [x] `flutter analyze lib/services/performance_monitoring_service.dart lib/services/video_event_service.dart test/services/video_event_service_startup_contract_test.dart`
- [x] `flutter test test/services/video_event_service_startup_contract_test.dart test/services/performance_monitoring_service_test.dart test/services/video_event_service_eose_empty_test.dart test/services/video_event_service_timeout_test.dart`
- [x] `flutter test test/services/video_event_service_*.dart`
- [x] pre-commit checks: format and full mobile analysis
- [x] pre-push checks: changed-file tests

## Notes
- Pre-commit full analysis still reports the existing dependency-sort info in `packages/content_blocklist_repository/pubspec.yaml`; the hook treats it as non-blocking and completed successfully.
