### PR TITLE
fix(publish): cap relay-pool fan-out to unblock collab invites

### DIFF
--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -594,7 +594,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
     try {
       final hardBindingValue =
           await NativeProofModeService.generateSha256FileHash(filePath);
-      return await ref
+      final assertion = await ref
           .read(nostrCreatorBindingServiceProvider)
           .createAssertion(
             claims: _buildCreatorBindingClaims(
@@ -609,6 +609,20 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
               if (aiTrainingOptOut) 'cawg.training-mining',
             ],
           );
+
+      if (assertion == null) {
+        // Expected for OAuth-only identities while the Keycast backend
+        // does not yet expose `sign_canonical`, and for NIP-46 / NIP-55
+        // remote signers whose protocols don't include canonical signing.
+        // Logged at debug because it isn't an error condition.
+        Log.debug(
+          'Canonical signing not supported by current identity; '
+          'skipping creator-binding assertion.',
+          name: 'VideoPublishNotifier',
+          category: LogCategory.video,
+        );
+      }
+      return assertion;
     } catch (error, stackTrace) {
       Log.warning(
         'Failed to create creator-binding assertion: $error\n$stackTrace',

--- a/mobile/lib/services/nostr_creator_binding_service.dart
+++ b/mobile/lib/services/nostr_creator_binding_service.dart
@@ -85,7 +85,16 @@ class NostrCreatorBindingService {
   final NostrIdentity? _identity;
   final DateTime Function() _now;
 
-  Future<NostrCreatorBindingAssertion> createAssertion({
+  /// Builds a signed creator-binding assertion for the C2PA proof manifest.
+  ///
+  /// Returns `null` when the active identity does not support canonical
+  /// payload signing (e.g. Divine OAuth without a local key and without a
+  /// backend `sign_canonical` RPC method, NIP-46 bunker, NIP-55 amber).
+  /// Callers treat null as "skip the binding" and proceed without it.
+  ///
+  /// Throws [StateError] only when there is no authenticated identity at
+  /// all, which indicates a programmer error in the calling flow.
+  Future<NostrCreatorBindingAssertion?> createAssertion({
     required CreatorBindingClaims claims,
     required CreatorBindingHardBinding hardBinding,
     required List<String> referencedAssertions,
@@ -113,7 +122,10 @@ class NostrCreatorBindingService {
     final signature = await identity.signCanonicalPayload(payloadBytes);
 
     if (signature == null || signature.isEmpty) {
-      throw StateError('Failed to sign canonical creator-binding payload');
+      // Identity can't produce a canonical signature (RPC-only without
+      // backend support, or remote signers whose protocol lacks it).
+      // Caller skips the binding rather than aborting the publish.
+      return null;
     }
 
     final payloadJson = jsonEncode(<String, dynamic>{

--- a/mobile/lib/services/nostr_identity.dart
+++ b/mobile/lib/services/nostr_identity.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/services/local_key_signer.dart';
@@ -22,7 +23,10 @@ sealed class NostrIdentity implements NostrSigner {
   /// Signs an arbitrary canonical payload (SHA-256 + schnorr with fixed aux).
   ///
   /// Returns the signature hex string, or null if this identity does not
-  /// support deterministic local signing (remote-only signers).
+  /// support deterministic canonical signing. Local identities sign
+  /// directly; Keycast identities try local first and fall back to a
+  /// `sign_canonical` RPC. NIP-46 (bunker) and NIP-55 (amber) identities
+  /// always return null because their protocols only define event signing.
   Future<String?> signCanonicalPayload(Uint8List payload);
 }
 
@@ -125,8 +129,25 @@ class KeycastNostrIdentity extends NostrIdentity
 
   @override
   Future<String?> signCanonicalPayload(Uint8List payload) async {
-    // Canonical signing requires deterministic local keys.
-    return _localSigner?.signCanonicalPayload(payload);
+    // Local signing path (fast, deterministic) when a matching local key is
+    // available. This is the steady-state path for users who have completed
+    // BYOK setup or signed in with a recovery phrase.
+    final local = _localSigner;
+    if (local != null) {
+      final result = await local.signCanonicalPayload(payload);
+      if (result != null && result.isNotEmpty) return result;
+    }
+
+    // OAuth-only fallback: ask the Keycast backend to sign the canonical
+    // payload remotely. Returns null if the backend doesn't expose
+    // `sign_canonical` yet, in which case the caller skips creator-binding
+    // gracefully rather than blocking the publish.
+    final rpc = _rpcSigner;
+    if (rpc is KeycastRpc) {
+      return rpc.signCanonicalPayload(payload);
+    }
+
+    return null;
   }
 
   @override
@@ -204,6 +225,10 @@ class BunkerNostrIdentity extends NostrIdentity {
   @override
   Future<Event?> signEvent(Event event) => _remoteSigner.signEvent(event);
 
+  /// NIP-46 does not expose canonical-payload signing — the protocol
+  /// only defines event signing. C2PA creator-binding is therefore not
+  /// available for bunker-backed identities and the caller skips the
+  /// assertion gracefully.
   @override
   Future<String?> signCanonicalPayload(Uint8List payload) async => null;
 
@@ -248,6 +273,10 @@ class AmberNostrIdentity extends NostrIdentity {
   @override
   Future<Event?> signEvent(Event event) => _amberSigner.signEvent(event);
 
+  /// NIP-55 (Amber Android) does not expose canonical-payload signing —
+  /// only event signing. C2PA creator-binding is therefore not available
+  /// for amber-backed identities and the caller skips the assertion
+  /// gracefully.
   @override
   Future<String?> signCanonicalPayload(Uint8List payload) async => null;
 

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -204,8 +204,35 @@ class VideoEventPublisher {
         );
       }
 
-      // Use the existing Nostr service to publish
-      final sentEvent = await _nostrService.publishEvent(event);
+      // Use the existing Nostr service to publish.
+      //
+      // Defense-in-depth: hard 30s timeout so a misbehaving relay
+      // (e.g. stuck in connecting / reconnect backoff) cannot freeze the
+      // publish flow indefinitely. The retry loop in [publishDirectUpload]
+      // will pick up after each failed attempt.
+      //
+      // We use try/catch on [TimeoutException] rather than `.timeout(
+      // onTimeout: ...)`. The `onTimeout` closure has its return type
+      // runtime-checked against the source future's `T`, and mocktail-
+      // stubbed Futures (`thenAnswer((_) async => event)`) infer their
+      // runtime type as `Future<Event>` — non-nullable — even when the
+      // declared signature is `Future<Event?>`. That mismatch makes
+      // `onTimeout: () => null` throw at runtime in tests. The try/catch
+      // shape sidesteps the closure-cast entirely; behaviour against a
+      // real `NostrClient` is identical.
+      Event? sentEvent;
+      try {
+        sentEvent = await _nostrService
+            .publishEvent(event)
+            .timeout(const Duration(seconds: 30));
+      } on TimeoutException {
+        Log.error(
+          '⏱️ publishEvent timed out after 30s for event ${event.id}',
+          name: 'VideoEventPublisher',
+          category: LogCategory.video,
+        );
+        sentEvent = null;
+      }
 
       // Check if publish was successful
       if (sentEvent != null) {

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Provides remote signing via Keycast server for Nostr events
 
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 import 'package:keycast_flutter/src/models/exceptions.dart';
@@ -119,6 +120,38 @@ class KeycastRpc implements NostrSigner {
   @override
   Future<Map?> getRelays() async {
     return null;
+  }
+
+  /// Remote canonical-payload signing for C2PA creator-binding flows.
+  ///
+  /// Performs SHA-256 of [payload] and schnorr-signs the digest with the
+  /// account's private key, returning a hex-encoded signature. Server-side
+  /// MUST use deterministic auxiliary data (32 zero bytes) so repeated
+  /// signing of the same payload produces the same signature, matching the
+  /// local signer at `LocalKeySigner.signCanonicalPayload`.
+  ///
+  /// Returns `null` (rather than throwing) when:
+  ///   * the backend does not yet expose `sign_canonical` (method-not-found
+  ///     surfaces as [RpcException]),
+  ///   * the request errors at the HTTP level,
+  ///   * the response is malformed.
+  ///
+  /// Callers (e.g. [KeycastNostrIdentity]) treat null as "canonical signing
+  /// unsupported by this identity" and skip the assertion gracefully.
+  Future<String?> signCanonicalPayload(Uint8List payload) async {
+    try {
+      return await _call(
+        'sign_canonical',
+        [base64Encode(payload)],
+        (result) => result as String,
+      );
+    } on RpcException {
+      // Backend doesn't expose sign_canonical yet, or returned an error.
+      return null;
+    } catch (_) {
+      // Network/parse error: degrade gracefully.
+      return null;
+    }
   }
 
   @override

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies all RPC methods with mocked HTTP, error handling, auth headers
 
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -269,6 +270,98 @@ void main() {
         );
 
         expect(rpc.getPublicKey, throwsA(isA<RpcException>()));
+      });
+    });
+
+    group('signCanonicalPayload', () {
+      test(
+        'returns hex signature from RPC and base64-encodes payload',
+        () async {
+          final payload = Uint8List.fromList([0x01, 0x02, 0x03, 0xff]);
+          const expectedSig =
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+          mockClient = MockClient((request) async {
+            expect(request.headers['Authorization'], 'Bearer test_token');
+            expect(request.headers['Content-Type'], 'application/json');
+
+            final body = jsonDecode(request.body);
+            expect(body['method'], 'sign_canonical');
+            expect(body['params'], [base64Encode(payload)]);
+
+            return http.Response(
+              jsonEncode({'result': expectedSig}),
+              200,
+            );
+          });
+
+          final rpc = KeycastRpc(
+            nostrApi: 'https://login.divine.video/api/nostr',
+            accessToken: 'test_token',
+            httpClient: mockClient,
+          );
+
+          final result = await rpc.signCanonicalPayload(payload);
+          expect(result, equals(expectedSig));
+        },
+      );
+
+      test(
+        'returns null (not throw) when backend reports method-not-found',
+        () async {
+          mockClient = MockClient((request) async {
+            return http.Response(
+              jsonEncode({'error': 'method_not_found'}),
+              200,
+            );
+          });
+
+          final rpc = KeycastRpc(
+            nostrApi: 'https://login.divine.video/api/nostr',
+            accessToken: 'test_token',
+            httpClient: mockClient,
+          );
+
+          final result = await rpc.signCanonicalPayload(
+            Uint8List.fromList([1, 2, 3]),
+          );
+          expect(result, isNull);
+        },
+      );
+
+      test('returns null on HTTP 500 error response', () async {
+        mockClient = MockClient((request) async {
+          return http.Response('Server error', 500);
+        });
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+        );
+
+        final result = await rpc.signCanonicalPayload(
+          Uint8List.fromList([1, 2, 3]),
+        );
+        expect(result, isNull);
+      });
+
+      test('returns null on network exception', () async {
+        mockClient = MockClient((request) async {
+          throw Exception('connection refused');
+        });
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+        );
+
+        final result = await rpc.signCanonicalPayload(
+          Uint8List.fromList([1, 2, 3]),
+        );
+        expect(result, isNull);
       });
     });
   });

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -862,11 +862,27 @@ class RelayPool {
   /// frame (or it was queued for pending-auth delivery). It does NOT mean the
   /// relay accepted the event at the protocol level — use
   /// [sendEventAwaitOk] for that guarantee.
+  ///
+  /// Sends use `skipReconnect: true` so that a single disconnected relay
+  /// cannot block the sequential fan-out by triggering a multi-minute
+  /// exponential-backoff reconnect (mirrors the query fan-out paths above).
+  /// Reconnection is driven by the relay manager's heartbeat, not by
+  /// outbound publishes.
+  ///
+  /// Each individual `relay.send` is also wrapped in a 5-second timeout as a
+  /// belt-and-suspenders backstop. `skipReconnect: true` already short-
+  /// circuits the disconnected-state path inside `WebSocketConnectionManager`,
+  /// but it does not bypass the `connecting`-state wait nor protect against
+  /// a relay whose underlying socket is wedged after a successful handshake
+  /// (TCP backpressure, slow peer). The per-relay timeout caps any single
+  /// relay's contribution to the sequential fan-out at 5 seconds, so the
+  /// outer publish flow stays responsive even on degraded networks.
   Future<List<String>> _sendCollect(
     List<dynamic> message, {
     List<String>? tempRelays,
     List<String>? targetRelays,
   }) async {
+    const perRelayTimeout = Duration(seconds: 5);
     final sentTo = <String>[];
 
     for (final relay in _relaysSnapshot()) {
@@ -896,7 +912,13 @@ class RelayPool {
             log(
               '🔐 vine.hol.is detected - sending message to trigger AUTH challenge',
             );
-            var result = await relay.send(message, forceSend: true);
+            // Auth-trigger path intentionally does NOT pass skipReconnect:
+            // the AUTH handshake requires a real send. Per-relay timeout
+            // still applies so a stuck auth-trigger send cannot block the
+            // rest of the fan-out.
+            var result = await relay
+                .send(message, forceSend: true)
+                .timeout(perRelayTimeout, onTimeout: () => false);
             if (result) {
               sentTo.add(relay.url);
             }
@@ -913,7 +935,13 @@ class RelayPool {
           log(
             '🔐 Relay ${relay.url} sending immediately (alwaysAuth=${relay.relayStatus.alwaysAuth}, authed=${relay.relayStatus.authed})',
           );
-          var result = await relay.send(message);
+          // Skip reconnect during fan-out to avoid blocking other relays
+          // while one dead relay tries exponential backoff (can hang the
+          // publish for many minutes). Same convention as relayDoQuery /
+          // relayDoSubscribe above.
+          var result = await relay
+              .send(message, skipReconnect: true)
+              .timeout(perRelayTimeout, onTimeout: () => false);
           if (result) {
             sentTo.add(relay.url);
           }
@@ -927,7 +955,12 @@ class RelayPool {
     if (tempRelays != null) {
       for (var tempRelayAddr in tempRelays) {
         var tempRelay = checkAndGenTempRelay(tempRelayAddr);
-        var result = await tempRelay.send(message);
+        // Same skipReconnect rationale as the main loop above: a fresh
+        // tempRelay whose initial connection is still in-flight must not
+        // block the publish.
+        var result = await tempRelay
+            .send(message, skipReconnect: true)
+            .timeout(perRelayTimeout, onTimeout: () => false);
         if (result) {
           sentTo.add(tempRelay.url);
         }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
@@ -150,6 +150,91 @@ class _FailingSendRelay extends Relay {
   }
 }
 
+/// A relay that simulates the worst-case reconnect-backoff hang on the
+/// publish path. When `skipReconnect: true` is honoured, returns `false`
+/// in microseconds (the real `RelayBase.send` short-circuits the
+/// `_tryReconnect` loop). When `skipReconnect: false`, hangs for
+/// [stallDuration] to simulate the SDK's exponential-backoff reconnect
+/// dance that previously blocked the publish flow indefinitely.
+class _StallingReconnectRelay extends Relay {
+  _StallingReconnectRelay(
+    String url, {
+    this.stallDuration = const Duration(seconds: 30),
+  }) : super(url, RelayStatus(url));
+
+  final Duration stallDuration;
+  final List<List<dynamic>> sentMessages = [];
+  bool wasInvokedWithoutSkipReconnect = false;
+
+  @override
+  Future<bool> doConnect() async {
+    // Stay in disconnected state to force the reconnect path.
+    relayStatus.connected = ClientConnected.disconnect;
+    return false;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool? forceSend,
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+  }) async {
+    sentMessages.add(message);
+    if (skipReconnect) {
+      // Fast-fail path: this is what the publish loop must hit.
+      return false;
+    }
+    // Reconnect path: simulate the multi-minute exponential-backoff
+    // hang that motivated this regression test.
+    wasInvokedWithoutSkipReconnect = true;
+    await Future<void>.delayed(stallDuration);
+    return false;
+  }
+}
+
+/// A relay whose `send` hangs no matter what flags are passed — models
+/// pathological cases where `skipReconnect: true` is honoured but the
+/// underlying send still wedges (TCP backpressure, slow peer post-
+/// handshake, or a future SDK regression that drops the skipReconnect
+/// short-circuit). Used to verify the per-relay timeout backstop in
+/// `_sendCollect`.
+class _AlwaysHangingRelay extends Relay {
+  _AlwaysHangingRelay(String url) : super(url, RelayStatus(url));
+
+  final List<List<dynamic>> sentMessages = [];
+
+  @override
+  Future<bool> doConnect() async {
+    relayStatus.connected = ClientConnected.connected;
+    return true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool? forceSend,
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+  }) async {
+    sentMessages.add(message);
+    // Hang far longer than any reasonable per-relay timeout. The pool's
+    // `.timeout(...)` wrap must surface this as `false` and move on.
+    await Future<void>.delayed(const Duration(minutes: 1));
+    return true;
+  }
+}
+
 void main() {
   group('RelayPool concurrency', () {
     late Nostr nostr;
@@ -261,6 +346,84 @@ void main() {
       // onComplete should have been called immediately since no relay
       // accepted the query (saveQuery was never called)
       expect(completeCalled, isTrue);
+    });
+
+    test(
+      'pool.send does not block on a relay stuck in reconnect backoff',
+      () async {
+        // One healthy relay + one relay that would hang for 30s if
+        // _sendCollect forwarded the publish without `skipReconnect: true`.
+        // Regression test for the multi-minute publish hang where a
+        // single configured-but-disconnected relay (e.g. relay.ditto.pub)
+        // blocked the entire fan-out via WebSocketConnectionManager's
+        // exponential-backoff reconnect.
+        final healthy = _SucceedingRelay('wss://healthy.relay');
+        final stalling = _StallingReconnectRelay(
+          'wss://stalling.relay',
+          stallDuration: const Duration(seconds: 30),
+        );
+        await nostr.relayPool.add(healthy);
+        await nostr.relayPool.add(stalling);
+
+        final event = Event(await signer.getPublicKey() ?? '', 1, [], 'test');
+        await signer.signEvent(event);
+
+        final stopwatch = Stopwatch()..start();
+        final ok = await nostr.relayPool.send(['EVENT', event.toJson()]);
+        stopwatch.stop();
+
+        // If the bug regresses, this would take 30+ seconds.
+        expect(stopwatch.elapsedMilliseconds, lessThan(2000));
+        // At least one relay accepted the WebSocket frame.
+        expect(ok, isTrue);
+        // The healthy relay actually received the EVENT.
+        expect(
+          healthy.sentMessages
+              .where((m) => m.isNotEmpty && m.first == 'EVENT')
+              .length,
+          equals(1),
+        );
+        // The stalling relay's send was invoked with skipReconnect: true,
+        // so it short-circuited instead of hanging.
+        expect(stalling.wasInvokedWithoutSkipReconnect, isFalse);
+      },
+    );
+
+    test('pool.send respects the per-relay timeout when a relay hangs even '
+        'with skipReconnect honoured', () async {
+      // Belt-and-suspenders: skipReconnect: true short-circuits the
+      // disconnected-state reconnect dance, but does NOT bypass the
+      // `connecting` state's _waitForConnection() nor protect against
+      // a wedged-after-handshake socket. The 5s per-relay timeout in
+      // _sendCollect catches these residual cases so a single
+      // pathological relay cannot stall the sequential fan-out.
+      final healthy = _SucceedingRelay('wss://healthy.relay');
+      final hanging = _AlwaysHangingRelay('wss://hanging.relay');
+      await nostr.relayPool.add(healthy);
+      await nostr.relayPool.add(hanging);
+
+      final event = Event(await signer.getPublicKey() ?? '', 1, [], 'test');
+      await signer.signEvent(event);
+
+      final stopwatch = Stopwatch()..start();
+      final ok = await nostr.relayPool.send(['EVENT', event.toJson()]);
+      stopwatch.stop();
+
+      // Per-relay timeout is 5s. With one hanging relay, total elapsed
+      // should sit comfortably under 7s (5s timeout + setup overhead).
+      // If the timeout is removed, this test would hang for 60s+.
+      expect(stopwatch.elapsedMilliseconds, lessThan(7000));
+      // The healthy relay still accepted the EVENT.
+      expect(ok, isTrue);
+      expect(
+        healthy.sentMessages
+            .where((m) => m.isNotEmpty && m.first == 'EVENT')
+            .length,
+        equals(1),
+      );
+      // The hanging relay's send was invoked but did not contribute
+      // to sentTo because its future timed out.
+      expect(hanging.sentMessages, isNotEmpty);
     });
   });
 

--- a/mobile/test/diag/mocktail_timeout_diag_test.dart
+++ b/mobile/test/diag/mocktail_timeout_diag_test.dart
@@ -1,0 +1,136 @@
+// ABOUTME: Pinned regression tests for the mocktail + Future.timeout gotcha.
+// ABOUTME: When mocktail's thenAnswer((_) async => value) infers a non-nullable
+// ABOUTME: Future<T>, .timeout(onTimeout: () => null) throws a runtime TypeError
+// ABOUTME: because Null is not a subtype of FutureOr<T>. Production code in
+// ABOUTME: video_event_publisher.dart sidesteps this by using try/catch on
+// ABOUTME: TimeoutException; this file locks the gotcha so future contributors
+// ABOUTME: don't reach for onTimeout when stubbing publishEvent in tests.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _FakeEvent extends Fake implements Event {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+  });
+
+  group('mocktail + Future.timeout interaction', () {
+    late _MockNostrClient mock;
+    late Event event;
+
+    setUp(() {
+      mock = _MockNostrClient();
+      event = Event(
+        '385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd',
+        1,
+        const [],
+        'diag',
+      );
+    });
+
+    test(
+      'plain mocktail thenAnswer + await returns the stubbed event',
+      () async {
+        when(
+          () => mock.publishEvent(any()),
+        ).thenAnswer((_) async => event);
+
+        final result = await mock.publishEvent(event);
+
+        expect(result, equals(event));
+      },
+    );
+
+    test(
+      'GOTCHA: mocktail thenAnswer((_) async => event) + .timeout(onTimeout: '
+      '() => null) throws TypeError at runtime because the stubbed Future has '
+      'lost the ? nullability of the declared signature',
+      () async {
+        when(
+          () => mock.publishEvent(any()),
+        ).thenAnswer((_) async => event);
+
+        await expectLater(
+          () async => mock
+              .publishEvent(event)
+              .timeout(
+                const Duration(seconds: 30),
+                onTimeout: () => null,
+              ),
+          throwsA(
+            isA<TypeError>().having(
+              (e) => e.toString(),
+              'message',
+              contains("'() => Null' is not a subtype of"),
+            ),
+          ),
+          reason:
+              'If this assertion starts failing because no error was thrown, '
+              'mocktail or Dart fixed the inference and the try/catch '
+              'workaround in video_event_publisher.dart can be dropped.',
+        );
+      },
+    );
+
+    test(
+      'WORKAROUND A: try/catch on TimeoutException avoids the closure-cast '
+      'trap (this is the production-code shape)',
+      () async {
+        when(
+          () => mock.publishEvent(any()),
+        ).thenAnswer((_) async => event);
+
+        Event? result;
+        try {
+          result = await mock
+              .publishEvent(event)
+              .timeout(const Duration(seconds: 30));
+        } on TimeoutException {
+          result = null;
+        }
+
+        expect(result, equals(event));
+      },
+    );
+
+    test(
+      'WORKAROUND B: stubbing with Future<Event?>.value(event) preserves '
+      'nullability so onTimeout: () => null also works',
+      () async {
+        when(
+          () => mock.publishEvent(any()),
+        ).thenAnswer((_) => Future<Event?>.value(event));
+
+        final result = await mock
+            .publishEvent(event)
+            .timeout(
+              const Duration(seconds: 30),
+              onTimeout: () => null,
+            );
+
+        expect(result, equals(event));
+      },
+    );
+
+    test(
+      'sanity: plain Future.value with the right type + .timeout works',
+      () async {
+        // Confirms the gotcha is mocktail-specific, not a Dart stdlib issue.
+        final source = Future<Event?>.value(event);
+        final result = await source.timeout(
+          const Duration(seconds: 30),
+          onTimeout: () => null,
+        );
+        expect(result, equals(event));
+      },
+    );
+  });
+}

--- a/mobile/test/services/nostr_creator_binding_service_test.dart
+++ b/mobile/test/services/nostr_creator_binding_service_test.dart
@@ -5,10 +5,13 @@ import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/services/nostr_creator_binding_service.dart';
 import 'package:openvine/services/nostr_identity.dart';
 
 class _MockSecureKeyContainer extends Mock implements SecureKeyContainer {}
+
+class _MockNostrSigner extends Mock implements NostrSigner {}
 
 void main() {
   late _MockSecureKeyContainer mockKeyContainer;
@@ -85,7 +88,12 @@ void main() {
           ],
         );
 
-        final payload = jsonDecode(first.payloadJson) as Map<String, dynamic>;
+        expect(first, isNotNull);
+        expect(second, isNotNull);
+        final firstAssertion = first!;
+        final secondAssertion = second!;
+        final payload =
+            jsonDecode(firstAssertion.payloadJson) as Map<String, dynamic>;
         final claims = payload['claims'] as Map<String, dynamic>;
         final socialHandles = claims['social_handles'] as List<dynamic>;
         final unsignedPayload = Map<String, dynamic>.from(payload)
@@ -95,12 +103,12 @@ void main() {
             .toString();
 
         expect(
-          first.assertionLabel,
+          firstAssertion.assertionLabel,
           equals('video.divine.nostr.creator_binding'),
         );
-        expect(first.pubkey, equals(testPublicKey));
-        expect(first.payloadJson, equals(second.payloadJson));
-        expect(first.signature, equals(second.signature));
+        expect(firstAssertion.pubkey, equals(testPublicKey));
+        expect(firstAssertion.payloadJson, equals(secondAssertion.payloadJson));
+        expect(firstAssertion.signature, equals(secondAssertion.signature));
         expect(payload['version'], equals(1));
         expect(payload['pubkey'], equals(testPublicKey));
         expect(payload['sig_alg'], equals('nostr.secp256k1'));
@@ -155,5 +163,36 @@ void main() {
         throwsA(isA<StateError>()),
       );
     });
+
+    test(
+      'returns null (not throw) when identity does not support canonical '
+      'signing',
+      () async {
+        // BunkerNostrIdentity always returns null from signCanonicalPayload
+        // because NIP-46 has no canonical-sign primitive. The same fall-soft
+        // path applies to OAuth users until the Keycast backend exposes
+        // sign_canonical, and to Amber users.
+        final mockSigner = _MockNostrSigner();
+        final bunkerIdentity = BunkerNostrIdentity(
+          pubkey: testPublicKey,
+          remoteSigner: mockSigner,
+        );
+        final unsupportedService = NostrCreatorBindingService(
+          identity: bunkerIdentity,
+          now: () => DateTime.utc(2026, 3, 29, 8, 30),
+        );
+
+        final result = await unsupportedService.createAssertion(
+          claims: const CreatorBindingClaims(),
+          hardBinding: const CreatorBindingHardBinding(
+            alg: 'sha256',
+            value: 'deadbeef',
+          ),
+          referencedAssertions: const <String>['c2pa.hash.data'],
+        );
+
+        expect(result, isNull);
+      },
+    );
   });
 }

--- a/mobile/test/services/nostr_identity_test.dart
+++ b/mobile/test/services/nostr_identity_test.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
@@ -13,6 +14,8 @@ class _MockSecureKeyContainer extends Mock implements SecureKeyContainer {}
 class _MockNostrSigner extends Mock implements NostrSigner {}
 
 class _MockLocalKeySigner extends Mock implements LocalKeySigner {}
+
+class _MockKeycastRpc extends Mock implements KeycastRpc {}
 
 void main() {
   const testPrivateKey =
@@ -161,37 +164,128 @@ void main() {
       },
     );
 
-    test('signCanonicalPayload returns null without local signer', () async {
-      final identity = KeycastNostrIdentity(
-        pubkey: testPublicKey,
-        rpcSigner: mockRpc,
-      );
+    test(
+      'signCanonicalPayload returns null when no local signer and rpcSigner '
+      'is a generic NostrSigner (not KeycastRpc)',
+      () async {
+        // Generic NostrSigner doesn't implement signCanonicalPayload, so the
+        // identity must short-circuit to null rather than try to call it.
+        final identity = KeycastNostrIdentity(
+          pubkey: testPublicKey,
+          rpcSigner: mockRpc,
+        );
 
-      final result = await identity.signCanonicalPayload(
-        Uint8List.fromList([1, 2, 3]),
-      );
+        final result = await identity.signCanonicalPayload(
+          Uint8List.fromList([1, 2, 3]),
+        );
 
-      expect(result, isNull);
-    });
+        expect(result, isNull);
+      },
+    );
 
-    test('signCanonicalPayload delegates to local signer', () async {
-      final mockLocal = _MockLocalKeySigner();
-      when(
-        () => mockLocal.signCanonicalPayload(any()),
-      ).thenAnswer((_) async => 'sig_hex');
+    test(
+      'signCanonicalPayload falls back to KeycastRpc when no local signer',
+      () async {
+        // OAuth-only path: no local key, RPC backend supports sign_canonical.
+        final mockKeycastRpc = _MockKeycastRpc();
+        when(
+          () => mockKeycastRpc.signCanonicalPayload(any()),
+        ).thenAnswer((_) async => 'remote_sig_hex');
 
-      final identity = KeycastNostrIdentity(
-        pubkey: testPublicKey,
-        rpcSigner: mockRpc,
-        localSigner: mockLocal,
-      );
+        final identity = KeycastNostrIdentity(
+          pubkey: testPublicKey,
+          rpcSigner: mockKeycastRpc,
+        );
 
-      final result = await identity.signCanonicalPayload(
-        Uint8List.fromList([1, 2, 3]),
-      );
+        final result = await identity.signCanonicalPayload(
+          Uint8List.fromList([1, 2, 3]),
+        );
 
-      expect(result, equals('sig_hex'));
-    });
+        expect(result, equals('remote_sig_hex'));
+        verify(() => mockKeycastRpc.signCanonicalPayload(any())).called(1);
+      },
+    );
+
+    test(
+      'signCanonicalPayload returns null when KeycastRpc has no backend '
+      'support yet (graceful skip)',
+      () async {
+        // Backend doesn't expose sign_canonical → KeycastRpc returns null →
+        // identity returns null → caller skips creator-binding. Publish is
+        // not blocked.
+        final mockKeycastRpc = _MockKeycastRpc();
+        when(
+          () => mockKeycastRpc.signCanonicalPayload(any()),
+        ).thenAnswer((_) async => null);
+
+        final identity = KeycastNostrIdentity(
+          pubkey: testPublicKey,
+          rpcSigner: mockKeycastRpc,
+        );
+
+        final result = await identity.signCanonicalPayload(
+          Uint8List.fromList([1, 2, 3]),
+        );
+
+        expect(result, isNull);
+      },
+    );
+
+    test(
+      'signCanonicalPayload prefers local signer when available',
+      () async {
+        final mockLocal = _MockLocalKeySigner();
+        final mockKeycastRpc = _MockKeycastRpc();
+        when(
+          () => mockLocal.signCanonicalPayload(any()),
+        ).thenAnswer((_) async => 'local_sig_hex');
+
+        final identity = KeycastNostrIdentity(
+          pubkey: testPublicKey,
+          rpcSigner: mockKeycastRpc,
+          localSigner: mockLocal,
+        );
+
+        final result = await identity.signCanonicalPayload(
+          Uint8List.fromList([1, 2, 3]),
+        );
+
+        expect(result, equals('local_sig_hex'));
+        verify(() => mockLocal.signCanonicalPayload(any())).called(1);
+        // Local short-circuit means RPC must NOT be called for the perf
+        // optimisation to hold.
+        verifyNever(() => mockKeycastRpc.signCanonicalPayload(any()));
+      },
+    );
+
+    test(
+      'signCanonicalPayload falls back to KeycastRpc when local signer '
+      'returns null',
+      () async {
+        final mockLocal = _MockLocalKeySigner();
+        final mockKeycastRpc = _MockKeycastRpc();
+        when(
+          () => mockLocal.signCanonicalPayload(any()),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockKeycastRpc.signCanonicalPayload(any()),
+        ).thenAnswer((_) async => 'remote_sig_hex');
+
+        final identity = KeycastNostrIdentity(
+          pubkey: testPublicKey,
+          rpcSigner: mockKeycastRpc,
+          localSigner: mockLocal,
+        );
+
+        final result = await identity.signCanonicalPayload(
+          Uint8List.fromList([1, 2, 3]),
+        );
+
+        expect(result, equals('remote_sig_hex'));
+        verify(() => mockLocal.signCanonicalPayload(any())).called(1);
+        verify(() => mockKeycastRpc.signCanonicalPayload(any())).called(1);
+      },
+    );
   });
 
   group(BunkerNostrIdentity, () {

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -1,8 +1,11 @@
 // ABOUTME: Tests for VideoEventPublisher service ensuring complete imeta tag generation
 // ABOUTME: Verifies file metadata (size, SHA256), thumbnails, and NIP-71 kind 34236 compliance
 
+import 'dart:async';
 import 'dart:io';
+
 import 'package:crypto/crypto.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/models/pending_upload.dart';
 
@@ -445,5 +448,80 @@ void main() {
         reason: 'Should use original CDN URL',
       );
     });
+  });
+
+  group('publishEvent timeout guard', () {
+    // Locks the contract introduced in video_event_publisher.dart line 208:
+    // a 30s `Future.timeout` wrapped in try/catch (TimeoutException) so a
+    // stalled relay-pool send cannot freeze the publish flow. We use the
+    // try/catch shape (not `onTimeout: () => null`) because mocktail-stubbed
+    // Futures lose their declared `?` nullability at runtime, which would
+    // make the onTimeout closure-cast throw — see
+    // `test/diag/mocktail_timeout_diag_test.dart` for the full diagnosis.
+
+    test(
+      'a never-completing publishEvent future surfaces TimeoutException '
+      'after 30s and is mapped to null',
+      () {
+        fakeAsync((async) {
+          final never = Completer<String?>();
+          var completed = false;
+          String? result;
+
+          // Mirrors the exact wrapping at video_event_publisher.dart:208.
+          Future<void> wrapped() async {
+            try {
+              result = await never.future.timeout(
+                const Duration(seconds: 30),
+              );
+            } on TimeoutException {
+              result = null;
+            }
+            completed = true;
+          }
+
+          unawaited(wrapped());
+
+          // Just before the timeout — must still be pending.
+          async.elapse(const Duration(seconds: 29));
+          expect(completed, isFalse);
+
+          // Cross the timeout boundary.
+          async.elapse(const Duration(seconds: 2));
+          expect(completed, isTrue);
+          expect(result, isNull);
+        });
+      },
+    );
+
+    test(
+      'a publishEvent future that completes before the timeout returns its '
+      'value',
+      () {
+        fakeAsync((async) {
+          final completer = Completer<String?>();
+          var resolvedValue = 'unset';
+
+          Future<void> wrapped() async {
+            try {
+              final value = await completer.future.timeout(
+                const Duration(seconds: 30),
+              );
+              resolvedValue = value ?? 'null';
+            } on TimeoutException {
+              resolvedValue = 'timeout';
+            }
+          }
+
+          unawaited(wrapped());
+
+          async.elapse(const Duration(seconds: 5));
+          completer.complete('signed_event_id');
+          async.flushMicrotasks();
+
+          expect(resolvedValue, equals('signed_event_id'));
+        });
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description

Two related bugs surface on every Divine OAuth video publish.

### Bug 1: publish hang blocks NIP-17 collaborator invites

When a configured Nostr relay is disconnected, the in-app publish call never returns. The collaborator's NIP-17 (kind-1059) gift-wrap invite is therefore never sent, even though the underlying video event reaches healthy relays (visible echoing back through the existing subscription within ~300 ms).

Root cause: `_sendCollect` in `mobile/packages/nostr_sdk/lib/relay/relay_pool.dart` iterates relays sequentially with `await relay.send(message)`. For a disconnected relay, `RelayBase.send` falls into `WebSocketConnectionManager._tryReconnect`, which loops up to 10 times with exponential backoff capped at 5 minutes. A single dead relay can block the loop for 20+ minutes. Because collaborator invites are sent in `VideoPublishService` *after* `publishVideoEvent` returns, they never run while the loop is blocked.

The same file already uses `skipReconnect: true` for query fan-out at lines 221 and 653 with the comment *"Skip reconnect during query fan-out to avoid blocking other relays while one dead relay tries exponential backoff."* The publish path was never updated to match.

**Fix layers:**

1. `_sendCollect` now passes `skipReconnect: true` at all three send sites (main loop, vine.hol.is auth-trigger, tempRelays).
2. Each `relay.send(...)` is wrapped in a **5 s per-relay timeout** as a backstop — covers the `connecting`-state wait that `skipReconnect` does not bypass, the `forceSend: true` auth path, and tempRelays.
3. `_publishEventToNostr` wraps the publish call in a **30 s try/catch on `TimeoutException`** for defense in depth. Try/catch shape (not `onTimeout: () => null`) sidesteps a mocktail-stubbed-Future runtime-cast trap; see `test/diag/mocktail_timeout_diag_test.dart` for the full diagnosis.

After the fix, the worst-case bound for `_sendCollect` over 6 relays is **30 s** (5 s × 6), exactly matching the outer guard. In practice healthy relays return in microseconds and only wedged ones hit the 5 s cap.

### Bug 2: C2PA creator-binding silently missing on OAuth posts

Every Divine OAuth publish logs:

```
[WARNING] [VideoPublishNotifier] video: Failed to create creator-binding assertion: Bad state: Failed to sign canonical creator-binding payload
```

`KeycastNostrIdentity.signCanonicalPayload` (`mobile/lib/services/nostr_identity.dart`) returns null when no local signer is present, and `KeycastRpc` has no `sign_canonical` method, so OAuth users have no path to a signature. The C2PA creator-binding assertion is silently missing from every Divine OAuth post.

**Fix layers:**

1. `KeycastRpc` gains a `signCanonicalPayload` method that calls `sign_canonical` and returns `null` on `RpcException` — forward-compatible with the backend method when it ships, no-op until then.
2. `KeycastNostrIdentity.signCanonicalPayload` falls back to KeycastRpc when no local signer is available.
3. `NostrCreatorBindingService.createAssertion` returns `null` instead of throwing `StateError` when the identity cannot sign canonically; the caller skips the binding gracefully.
4. `video_publish_provider` demotes the warning to a debug log for the expected-skip path; real exceptions still warn.
5. NIP-46 (Bunker) and NIP-55 (Amber) identities documented as not supporting canonical signing per spec.

The C2PA assertion will be properly attached to every Divine OAuth post once a `sign_canonical` RPC method ships in the Keycast backend; no further mobile work needed.

**Related Issue:** Closes #2582

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Test coverage

| File | What it locks |
|------|---|
| `mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart` | `pool.send` returns ≤ 2 s when one relay would block on reconnect; per-relay timeout fires within ~5 s when a relay's send hangs even with `skipReconnect: true`. |
| `mobile/packages/keycast_flutter/test/rpc_client_test.dart` | `signCanonicalPayload` graceful degradation: success path, `RpcException` → null, HTTP 500 → null, network exception → null. |
| `mobile/test/services/nostr_identity_test.dart` | KeycastRpc fallback contract: local-preferred, local-null fallback to RPC, KeycastRpc-null graceful skip. |
| `mobile/test/services/nostr_creator_binding_service_test.dart` | Returns null (not throws) when identity does not support canonical signing. |
| `mobile/test/services/video_event_publisher_test.dart` | 30 s timeout guard via try/catch on `TimeoutException`, using `fake_async`. |
| `mobile/test/diag/mocktail_timeout_diag_test.dart` | Pins the mocktail / `Future.timeout` gotcha so future contributors do not reach for `onTimeout: () => null` when stubbing `publishEvent` in tests. |

**8 264** tests pass across `mobile/`, `nostr_sdk`, and `keycast_flutter` (0 failures, 400 skipped). `flutter analyze` clean. `dart format` clean.

## Reproducing the bug on a device (pre-fix behaviour)

1. Sign in to a Divine OAuth (Keycast) account.
2. Configure 6 Nostr relays with at least one currently unreachable. `wss://relay.ditto.pub` reproduces this when the relay is offline; `wss://nonexistent.divine.test` works as a deterministic substitute.
3. Force-quit and relaunch the app so the relay manager attempts the initial connection (and fails) before publishing.
4. Confirm in Settings → Relays that the bad relay is `disconnected`.
5. Record a 3 s clip, tag a collaborator pubkey as `Collaborator`, press **Post**.
6. Observe (pre-fix): the publish never resolves; the collaborator never receives an invite. Wait time before manual abort can exceed 20 minutes.

## Verifying the fix on a device

### Phase 1 — Baseline sanity (no regressions)

1. Sign in with all 6 relays healthy.
2. Record a 3 s clip, tag a collaborator, press **Post**.
3. **Pass:** publish completes within ~30 s, video appears on the profile grid, the collaborator receives the NIP-17 invite within ~10 s.
4. If Phase 1 fails, capture logs (Settings → Support → Export Logs) and stop. The regression is somewhere else.

### Phase 2 — The actual fix: configured-but-disconnected relay

1. Add an unreachable relay (e.g. `wss://nonexistent.divine.test`) to the relay list.
2. Force-quit and relaunch so the bad relay is in `disconnected` state.
3. Pre-test: Settings → Relays should show 5 of 6 connected.
4. Record a 3 s clip, tag a collaborator, press **Post**, start a stopwatch.
5. **Pass criteria (this is the actual fix):**
   - Stopwatch reads under **5 s** for the publish leg (after the upload completes).
   - Total time from tap-Post to video-on-profile is under ~30 s on a healthy connection.
   - Within ~10 s of publish completing, the collaborator receives the NIP-17 invite.
   - Logs show `📡 Event sent to relays, awaiting visibility confirmation: <id>` within a second of `🚀 Starting relay publication for event <id>` (this log line was missing for the entire 20+ minute hang on pre-fix builds).
6. **Fail signal:** if >60 s pass with no profile update / no collaborator invite, the fix did not take. Capture logs immediately and do not kill the app — the hang is part of the evidence.

### Phase 3 — Creator-binding log noise (Divine OAuth only)

1. Make sure you are signed in via Divine OAuth (not BYOK / local key).
2. Post any short clip.
3. Settings → Support → Export Logs. Open the file and search:

| Search string | Pre-fix | Post-fix |
|---|---|---|
| `Failed to sign canonical creator-binding payload` | present (warning) | **absent** |
| `Bad state: Failed to sign canonical` | present (warning) | **absent** |
| `Canonical signing not supported by current identity` | absent | **present (debug)** |

The publish itself still succeeds — the C2PA proof manifest just does not include the inline creator-binding assertion until the Keycast backend ships `sign_canonical`.

### Phase 4 — Collaborator side

On the collaborator's device:

1. Open Inbox.
2. **Pass:** within ~10 s of the publisher's post completing, a new DM invite from the publisher appears. Tapping it shows the video preview and a "you were added as a collaborator" affordance.

### Phase 5 — Optional smoke checks

1. **Mid-publish backgrounding:** start a Phase 2 publish, immediately background the app for 10 s, foreground. Publish should still complete; collab invite should still send.
2. **No collaborators:** post without tagging anyone. Should publish normally (validates we did not couple publish-success to invite-success).
3. **Multiple collaborators:** tag two pubkeys. Both should receive invites.
4. **Local-key account (BYOK):** if available, switch to a non-OAuth account. Publish should work, log should show local canonical signing without the new debug message (the local path takes precedence — this proves we did not regress the binding for users who *can* sign canonically).
5. **All relays healthy:** disconnect the bad test relay you added, repeat Phase 1. Confirms the happy path still works.

## Quick reference: log strings worth grepping during testing

```
# Phase 2 success markers
🚀 Starting relay publication for event
📡 Event sent to relays, awaiting visibility confirmation
Successfully published direct upload
Signing kind 13 via                    # NIP-17 seal
Signing kind 1059 via                  # NIP-17 gift wrap

# Phase 2 failure marker (timeout fired = SDK regression slipped through)
⏱️ publishEvent timed out after 30s for event

# Phase 3 success marker
Canonical signing not supported by current identity

# Phase 3 fail marker (old warning still firing)
Failed to sign canonical creator-binding payload
```

## Out-of-scope follow-ups

- **Keycast backend `sign_canonical` method** — tracked at [divinevideo/keycast#186](https://github.com/divinevideo/keycast/issues/186) with the determinism contract (SHA-256 + schnorr with 32-byte all-zero aux, matching `local_key_signer.dart:55-74`) and a concrete cross-implementation test vector inlined. The mobile side is already wired; once the backend ships the method, every Divine OAuth post gets the binding for free with no further mobile change.
- **Per-relay timeout coupling + telemetry** — tracked at #3688 and resolved by follow-up PR #3689, which exports `RelayPool.perRelaySendTimeout` from nostr_sdk, derives the outer publish timeout via `outerPublishTimeoutFor(relayCount)` (so the implicit `5s × 6 = 30s` coupling becomes an encoded contract), and enriches the per-relay + outer timeout log lines with relay url / count for production diagnostics. Stacked on this PR.
- **`WebSocketConnectionManager._waitForConnection` short-circuit when `skipReconnect: true`** — still a future low-priority ticket; the per-relay timeout already bounds the wait, but a clean short-circuit would skip the timeout entirely on the connecting-state path.
- NIP-46 (Bunker) and NIP-55 (Amber) canonical-signing discussion at the protocol level. Tracked via doc-comments in `nostr_identity.dart`.
