### PR TITLE
fix(video-thumbnail): add blurhash support for loading placeholders

### DIFF
--- a/mobile/lib/widgets/profile/profile_collabs_grid.dart
+++ b/mobile/lib/widgets/profile/profile_collabs_grid.dart
@@ -183,7 +183,10 @@ class _CollabGridTile extends StatelessWidget {
       borderRadius: BorderRadius.circular(4),
       child: DecoratedBox(
         decoration: const BoxDecoration(color: VineTheme.cardBackground),
-        child: ProfileTabThumbnail(thumbnailUrl: videoEvent.thumbnailUrl),
+        child: ProfileTabThumbnail(
+          thumbnailUrl: videoEvent.thumbnailUrl,
+          blurhash: videoEvent.blurhash,
+        ),
       ),
     ),
   );

--- a/mobile/lib/widgets/profile/profile_comments_grid.dart
+++ b/mobile/lib/widgets/profile/profile_comments_grid.dart
@@ -189,7 +189,10 @@ class _VideoReplyTile extends StatelessWidget {
           child: Stack(
             fit: StackFit.expand,
             children: [
-              ProfileTabThumbnail(thumbnailUrl: comment.thumbnailUrl),
+              ProfileTabThumbnail(
+                thumbnailUrl: comment.thumbnailUrl,
+                blurhash: comment.videoBlurhash,
+              ),
               // Play icon overlay
               const Center(
                 child: Icon(

--- a/mobile/lib/widgets/profile/profile_liked_grid.dart
+++ b/mobile/lib/widgets/profile/profile_liked_grid.dart
@@ -173,7 +173,10 @@ class _LikedGridTile extends ConsumerWidget {
         borderRadius: BorderRadius.circular(4),
         child: DecoratedBox(
           decoration: const BoxDecoration(color: VineTheme.cardBackground),
-          child: ProfileTabThumbnail(thumbnailUrl: videoEvent.thumbnailUrl),
+          child: ProfileTabThumbnail(
+            thumbnailUrl: videoEvent.thumbnailUrl,
+            blurhash: videoEvent.blurhash,
+          ),
         ),
       ),
     ),

--- a/mobile/lib/widgets/profile/profile_reposts_grid.dart
+++ b/mobile/lib/widgets/profile/profile_reposts_grid.dart
@@ -171,7 +171,10 @@ class _RepostGridTile extends ConsumerWidget {
       borderRadius: BorderRadius.circular(4),
       child: DecoratedBox(
         decoration: const BoxDecoration(color: VineTheme.cardBackground),
-        child: ProfileTabThumbnail(thumbnailUrl: videoEvent.thumbnailUrl),
+        child: ProfileTabThumbnail(
+          thumbnailUrl: videoEvent.thumbnailUrl,
+          blurhash: videoEvent.blurhash,
+        ),
       ),
     ),
   );

--- a/mobile/lib/widgets/profile/profile_saved_grid.dart
+++ b/mobile/lib/widgets/profile/profile_saved_grid.dart
@@ -165,7 +165,10 @@ class _SavedGridTile extends ConsumerWidget {
         borderRadius: BorderRadius.circular(4),
         child: DecoratedBox(
           decoration: const BoxDecoration(color: VineTheme.cardBackground),
-          child: ProfileTabThumbnail(thumbnailUrl: videoEvent.thumbnailUrl),
+          child: ProfileTabThumbnail(
+            thumbnailUrl: videoEvent.thumbnailUrl,
+            blurhash: videoEvent.blurhash,
+          ),
         ),
       ),
     ),

--- a/mobile/lib/widgets/profile/profile_tab_thumbnail.dart
+++ b/mobile/lib/widgets/profile/profile_tab_thumbnail.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Shared cached thumbnail widget for profile tab grids
-// ABOUTME: Wraps VineCachedImage with placeholder and error fallbacks
+// ABOUTME: Wraps VineCachedImage with blurhash and placeholder fallbacks
 
 import 'package:flutter/material.dart';
 import 'package:openvine/widgets/blurhash_display.dart';
@@ -37,7 +37,6 @@ class ProfileTabThumbnail extends StatelessWidget {
         fadeOutDuration: isPrecached
             ? Duration.zero
             : const Duration(milliseconds: 1000),
-
         placeholder: (context, url) => _Fallback(blurhash: blurhash),
         errorWidget: (context, url, error) => _Fallback(blurhash: blurhash),
       );

--- a/mobile/lib/widgets/profile/profile_tab_thumbnail.dart
+++ b/mobile/lib/widgets/profile/profile_tab_thumbnail.dart
@@ -2,24 +2,28 @@
 // ABOUTME: Wraps VineCachedImage with placeholder and error fallbacks
 
 import 'package:flutter/material.dart';
+import 'package:openvine/widgets/blurhash_display.dart';
 import 'package:openvine/widgets/profile/profile_tab_thumbnail_placeholder.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
 /// Cached thumbnail for profile grid tiles.
 ///
 /// Shows a [VineCachedImage] when [thumbnailUrl] is non-empty, falling back
-/// to [ProfileTabThumbnailPlaceholder] for loading, error, and null states.
+/// to a [BlurhashDisplay] (when [blurhash] is provided) or
+/// [ProfileTabThumbnailPlaceholder] for loading, error, and null states.
 ///
 /// Set [isPrecached] to `true` to skip fade animations (used when the image
 /// was already resolved before the widget mounted).
 class ProfileTabThumbnail extends StatelessWidget {
   const ProfileTabThumbnail({
     required this.thumbnailUrl,
+    this.blurhash,
     this.isPrecached = false,
     super.key,
   });
 
   final String? thumbnailUrl;
+  final String? blurhash;
   final bool isPrecached;
 
   @override
@@ -33,10 +37,24 @@ class ProfileTabThumbnail extends StatelessWidget {
         fadeOutDuration: isPrecached
             ? Duration.zero
             : const Duration(milliseconds: 1000),
-        placeholder: (context, url) => const ProfileTabThumbnailPlaceholder(),
-        errorWidget: (context, url, error) =>
-            const ProfileTabThumbnailPlaceholder(),
+
+        placeholder: (context, url) => _Fallback(blurhash: blurhash),
+        errorWidget: (context, url, error) => _Fallback(blurhash: blurhash),
       );
+    }
+    return _Fallback(blurhash: blurhash);
+  }
+}
+
+class _Fallback extends StatelessWidget {
+  const _Fallback({required this.blurhash});
+
+  final String? blurhash;
+
+  @override
+  Widget build(BuildContext context) {
+    if (blurhash != null && blurhash!.isNotEmpty) {
+      return BlurhashDisplay(blurhash: blurhash!);
     }
     return const ProfileTabThumbnailPlaceholder();
   }

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -388,6 +388,7 @@ class _VideoGridTile extends StatelessWidget {
           decoration: const BoxDecoration(color: VineTheme.cardBackground),
           child: ProfileTabThumbnail(
             thumbnailUrl: videoEvent.thumbnailUrl,
+            blurhash: videoEvent.blurhash,
             isPrecached: isPrecached,
           ),
         ),

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart'
     show HttpExceptionWithStatus;
 import 'package:models/models.dart' hide AspectRatio, LogCategory;
+import 'package:openvine/widgets/blurhash_display.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -93,12 +94,20 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
       return Stack(
         fit: StackFit.expand,
         children: [
-          // Show flat color as background while image loads
-          Container(
-            width: widget.width,
-            height: widget.height,
-            color: VineTheme.surfaceContainer,
-          ),
+          // Show blurhash or flat color as background while image loads
+          if (widget.video.blurhash != null)
+            BlurhashDisplay(
+              blurhash: widget.video.blurhash!,
+              width: widget.width,
+              height: widget.height,
+              fit: fit,
+            )
+          else
+            Container(
+              width: widget.width,
+              height: widget.height,
+              color: VineTheme.surfaceContainer,
+            ),
           // Actual thumbnail image with error boundary
           _SafeNetworkImage(
             url: _thumbnailUrl!,
@@ -130,15 +139,24 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
       );
     }
 
-    // No thumbnail URL - show flat placeholder color with optional play icon
+    // No thumbnail URL - show blurhash or flat placeholder color with
+    // optional play icon
     return Stack(
       fit: StackFit.expand,
       children: [
-        Container(
-          width: widget.width,
-          height: widget.height,
-          color: VineTheme.surfaceContainer,
-        ),
+        if (widget.video.blurhash != null && !widget.showPlayIcon)
+          BlurhashDisplay(
+            blurhash: widget.video.blurhash!,
+            width: widget.width,
+            height: widget.height,
+            fit: fit,
+          )
+        else
+          Container(
+            width: widget.width,
+            height: widget.height,
+            color: VineTheme.surfaceContainer,
+          ),
         if (widget.showPlayIcon)
           Center(
             child: Container(

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -144,7 +144,7 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
     return Stack(
       fit: StackFit.expand,
       children: [
-        if (widget.video.blurhash != null && !widget.showPlayIcon)
+        if (widget.video.blurhash != null)
           BlurhashDisplay(
             blurhash: widget.video.blurhash!,
             width: widget.width,

--- a/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
+++ b/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
@@ -104,7 +104,7 @@ class BlurhashService {
 
       final bytes = byteData.buffer.asUint8List();
       return generateBlurhash(bytes);
-    } on Exception catch (e) {
+    } on Object catch (e) {
       Log.error(
         'Failed to generate blurhash from image: $e',
         name: 'BlurhashService',

--- a/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
+++ b/mobile/packages/blurhash_service/lib/src/blurhash_service.dart
@@ -3,7 +3,6 @@
 // ABOUTME: Creates compact representations of images
 // for better UX during vine loading
 
-import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:blurhash_dart/blurhash_dart.dart' as blurhash_dart;
@@ -11,60 +10,72 @@ import 'package:flutter/foundation.dart';
 import 'package:image/image.dart' as img;
 import 'package:unified_logger/unified_logger.dart';
 
+/// Isolate worker for [BlurhashService.generateBlurhash].
+///
+/// Top-level so [compute] can pass it to a background isolate.
+String? _generateBlurhashSync(Uint8List imageBytes) {
+  final image = img.decodeImage(imageBytes);
+  if (image == null) return null;
+
+  final (componentX, componentY) = BlurhashService._componentsForAspectRatio(
+    image.width,
+    image.height,
+  );
+
+  final resized = image.width > BlurhashService._encodeMaxWidth
+      ? img.copyResize(image, width: BlurhashService._encodeMaxWidth)
+      : image;
+
+  return blurhash_dart.BlurHash.encode(
+    resized,
+    numCompX: componentX,
+    numCompY: componentY,
+  ).hash;
+}
+
 /// Service for generating and decoding Blurhash
 /// placeholders.
 class BlurhashService {
-  /// Default horizontal component count.
-  static const int defaultComponentX = 4;
+  /// Components for 9:16 portrait videos (4:7 ≈ 0.57, matches 9:16 ≈ 0.5625).
+  static const int _portraitComponentX = 4;
+  static const int _portraitComponentY = 7;
 
-  /// Default vertical component count.
-  static const int defaultComponentY = 3;
+  /// Components for 1:1 square videos (balanced).
+  static const int _squareComponentX = 4;
+  static const int _squareComponentY = 4;
+
+  /// Max width used when downscaling before encoding.
+  static const int _encodeMaxWidth = 128;
 
   /// Default punch (contrast) value.
   static const double defaultPunch = 1;
 
-  /// Generate blurhash from image bytes using
-  /// blurhash_dart.
+  /// Returns component counts suited to the image's aspect ratio.
+  /// Supports 9:16 portrait and 1:1 square; falls back to portrait.
+  static (int compX, int compY) _componentsForAspectRatio(
+    int width,
+    int height,
+  ) {
+    if (width == 0 || height == 0) {
+      return (_portraitComponentX, _portraitComponentY);
+    }
+    final ratio = width / height;
+    // Square: ratio ≥ 0.9 (covers 1:1 with rounding tolerance)
+    if (ratio >= 0.9) return (_squareComponentX, _squareComponentY);
+    // Portrait 9:16 (and any other tall format)
+    return (_portraitComponentX, _portraitComponentY);
+  }
+
+  /// Generate blurhash from image bytes.
+  ///
+  /// Encoding runs in a background isolate via [compute] to avoid
+  /// blocking the UI thread.
   static Future<String?> generateBlurhash(
-    Uint8List imageBytes, {
-    int componentX = defaultComponentX,
-    int componentY = defaultComponentY,
-  }) async {
+    Uint8List imageBytes,
+  ) async {
     try {
-      // Decode image to get dimensions and pixel data
-      final image = img.decodeImage(imageBytes);
-      if (image == null) {
-        // coverage:ignore-start
-        Log.error(
-          'Failed to decode image for blurhash '
-          'generation',
-          name: 'BlurhashService',
-          category: LogCategory.system,
-        );
-        return null;
-        // coverage:ignore-end
-      }
-
-      // Encode blurhash using blurhash_dart library
-      final blurhash = blurhash_dart.BlurHash.encode(
-        image,
-        numCompX: componentX,
-        numCompY: componentY,
-      );
-
-      final hashString = blurhash.hash;
-
-      Log.verbose(
-        'Generated blurhash: $hashString '
-        '(${image.width}x${image.height}, '
-        '${componentX}x$componentY components)',
-        name: 'BlurhashService',
-        category: LogCategory.system,
-      );
-
-      return hashString;
-      // coverage:ignore-start
-    } on Exception catch (e, stackTrace) {
+      return await compute(_generateBlurhashSync, imageBytes);
+    } on Object catch (e, stackTrace) {
       Log.error(
         'Failed to generate blurhash: $e',
         name: 'BlurhashService',
@@ -77,16 +88,13 @@ class BlurhashService {
       );
       return null;
     }
-    // coverage:ignore-end
   }
 
   /// Generate blurhash from a [ui.Image] instance.
   // coverage:ignore-start
   static Future<String?> generateBlurhashFromImage(
-    ui.Image image, {
-    int componentX = defaultComponentX,
-    int componentY = defaultComponentY,
-  }) async {
+    ui.Image image,
+  ) async {
     try {
       // Convert image to bytes
       final byteData = await image.toByteData(
@@ -95,11 +103,7 @@ class BlurhashService {
       if (byteData == null) return null;
 
       final bytes = byteData.buffer.asUint8List();
-      return generateBlurhash(
-        bytes,
-        componentX: componentX,
-        componentY: componentY,
-      );
+      return generateBlurhash(bytes);
     } on Exception catch (e) {
       Log.error(
         'Failed to generate blurhash from image: $e',

--- a/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
+++ b/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
@@ -1,8 +1,17 @@
 import 'dart:io';
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:blurhash_service/blurhash_service.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+
+/// Creates a solid-colour JPEG with the given [width] and [height].
+Uint8List _makeJpeg({required int width, required int height}) {
+  final image = img.Image(width: width, height: height);
+  img.fill(image, color: img.ColorRgb8(100, 149, 237));
+  return Uint8List.fromList(img.encodeJpg(image));
+}
 
 void main() {
   group('BlurhashService', () {
@@ -21,7 +30,6 @@ void main() {
 
       expect(blurhash1, isNotNull);
       expect(blurhash1, equals(blurhash2)); // Should be deterministic
-      expect(blurhash1!.startsWith('L'), isTrue);
     });
 
     test('decodes blurhash to color data', () {
@@ -75,6 +83,54 @@ void main() {
 
       expect(data, isNotNull);
       expect(data!.isValid, isTrue);
+    });
+
+    group('generateBlurhash aspect-ratio component selection', () {
+      // Blurhash length = 6 + 2 * (compX * compY - 1)
+      // Portrait 4×7 → 6 + 2*27 = 60 chars
+      // Square   4×4 → 6 + 2*15 = 36 chars
+
+      test('uses 4×7 components for 9:16 portrait image', () async {
+        final bytes = _makeJpeg(width: 90, height: 160);
+        final hash = await BlurhashService.generateBlurhash(bytes);
+        expect(hash, isNotNull);
+        expect(hash!.length, equals(60));
+      });
+
+      test('uses 4×4 components for 1:1 square image', () async {
+        final bytes = _makeJpeg(width: 100, height: 100);
+        final hash = await BlurhashService.generateBlurhash(bytes);
+        expect(hash, isNotNull);
+        expect(hash!.length, equals(36));
+      });
+
+      test('real fixture (720×1280) uses portrait components', () async {
+        final thumbnailFile = File('test/fixtures/test_thumbnail.jpg');
+        if (!thumbnailFile.existsSync()) {
+          fail('Test thumbnail not found at test/fixtures/test_thumbnail.jpg.');
+        }
+        final hash = await BlurhashService.generateBlurhash(
+          await thumbnailFile.readAsBytes(),
+        );
+        expect(hash, isNotNull);
+        expect(hash!.length, equals(60));
+      });
+
+      test('runs encoding in a background isolate '
+          '(result is still deterministic)', () async {
+        final bytes = _makeJpeg(width: 90, height: 160);
+        final hash1 = await BlurhashService.generateBlurhash(bytes);
+        final hash2 = await BlurhashService.generateBlurhash(bytes);
+        expect(hash1, isNotNull);
+        expect(hash1, equals(hash2));
+      });
+
+      test('returns null for invalid image bytes', () async {
+        final hash = await BlurhashService.generateBlurhash(
+          Uint8List.fromList([0, 1, 2, 3]),
+        );
+        expect(hash, isNull);
+      });
     });
 
     group('getBlurhashForContentType', () {

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -219,16 +219,24 @@ class VideoStats {
             blurhashFromTag = tagValue;
           }
           if (tagName == 'imeta') {
-            // Parse space-separated imeta components to extract blurhash
-            // (publisher embeds blurhash inside imeta, not as a standalone tag)
+            // Extract blurhash from imeta. Two formats are seen in the wild:
+            //   - space-separated: ['imeta', 'blurhash <hash>', ...]
+            //   - positional:      ['imeta', 'blurhash', '<hash>', ...]
             for (var i = 1; i < tag.length; i++) {
               final element = tag[i].toString();
               final spaceIndex = element.indexOf(' ');
-              if (spaceIndex <= 0) continue;
-              final key = element.substring(0, spaceIndex);
-              final value = element.substring(spaceIndex + 1);
+              String? key;
+              String? value;
+              if (spaceIndex > 0) {
+                key = element.substring(0, spaceIndex);
+                value = element.substring(spaceIndex + 1);
+              } else if (element == 'blurhash' && i + 1 < tag.length) {
+                key = element;
+                value = tag[i + 1].toString();
+              }
               if (key == 'blurhash' &&
                   blurhashFromTag == null &&
+                  value != null &&
                   value.isNotEmpty) {
                 blurhashFromTag = value;
               }

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -218,6 +218,22 @@ class VideoStats {
           if (tagName == 'blurhash' && blurhashFromTag == null) {
             blurhashFromTag = tagValue;
           }
+          if (tagName == 'imeta') {
+            // Parse space-separated imeta components to extract blurhash
+            // (publisher embeds blurhash inside imeta, not as a standalone tag)
+            for (var i = 1; i < tag.length; i++) {
+              final element = tag[i].toString();
+              final spaceIndex = element.indexOf(' ');
+              if (spaceIndex <= 0) continue;
+              final key = element.substring(0, spaceIndex);
+              final value = element.substring(spaceIndex + 1);
+              if (key == 'blurhash' &&
+                  blurhashFromTag == null &&
+                  value.isNotEmpty) {
+                blurhashFromTag = value;
+              }
+            }
+          }
           if ((tagName == 'dim' || tagName == 'size') && dimensions == null) {
             dimensions = tagValue;
           }
@@ -280,12 +296,14 @@ class VideoStats {
         json['author_avatar']?.toString();
     if (authorAvatar != null && authorAvatar.isEmpty) authorAvatar = null;
 
-    // Parse blurhash for thumbnail placeholders
-    var blurhash =
-        eventData['blurhash']?.toString() ??
-        json['blurhash']?.toString() ??
-        blurhashFromTag;
-    if (blurhash != null && blurhash.isEmpty) blurhash = null;
+    // Parse blurhash for thumbnail placeholders.
+    // Use firstWhere so that empty strings from the API don't shadow the
+    // blurhashFromTag value extracted from the Nostr imeta/blurhash tags.
+    final blurhash = [
+      eventData['blurhash']?.toString(),
+      json['blurhash']?.toString(),
+      blurhashFromTag,
+    ].firstWhere((s) => s != null && s.isNotEmpty, orElse: () => null);
 
     // Parse reactions/likes - check multiple field names
     final reactions =

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -705,6 +705,88 @@ void main() {
       });
     });
 
+    group('blurhash from imeta tag', () {
+      Map<String, dynamic> jsonWithImetaTag(List<dynamic> imetaTag) => {
+        'event': {
+          'id': 'event-id',
+          'pubkey': 'event-pubkey',
+          'created_at': 1700000000,
+          'kind': 34236,
+          'd_tag': 'video-1',
+          'title': 'Test',
+          'thumbnail': 'https://example.com/thumb.jpg',
+          'video_url': 'https://example.com/video.mp4',
+          'tags': [imetaTag],
+        },
+        'reactions': 0,
+        'comments': 0,
+        'reposts': 0,
+        'engagement_score': 0,
+      };
+
+      test('extracts blurhash from space-separated imeta format', () {
+        final stats = VideoStats.fromJson(
+          jsonWithImetaTag([
+            'imeta',
+            'url https://example.com/video.mp4',
+            'blurhash LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+          ]),
+        );
+
+        expect(stats.blurhash, equals('LEHV6nWB2yk8pyo0adR*.7kCMdnj'));
+      });
+
+      test('extracts blurhash from positional imeta format', () {
+        final stats = VideoStats.fromJson(
+          jsonWithImetaTag([
+            'imeta',
+            'url',
+            'https://example.com/video.mp4',
+            'blurhash',
+            'LEHV6nWB2yk8pyo0adR*.7kCMdnj',
+          ]),
+        );
+
+        expect(stats.blurhash, equals('LEHV6nWB2yk8pyo0adR*.7kCMdnj'));
+      });
+
+      test('ignores empty blurhash value in imeta', () {
+        final stats = VideoStats.fromJson(
+          jsonWithImetaTag([
+            'imeta',
+            'blurhash ',
+          ]),
+        );
+
+        expect(stats.blurhash, isNull);
+      });
+
+      test('standalone blurhash tag wins over imeta when both present', () {
+        final stats = VideoStats.fromJson(const {
+          'event': {
+            'id': 'event-id',
+            'pubkey': 'event-pubkey',
+            'created_at': 1700000000,
+            'kind': 34236,
+            'd_tag': 'video-1',
+            'title': 'Test',
+            'thumbnail': 'https://example.com/thumb.jpg',
+            'video_url': 'https://example.com/video.mp4',
+            'tags': [
+              ['blurhash', 'STANDALONE_HASH'],
+              ['imeta', 'blurhash IMETA_HASH'],
+            ],
+          },
+          'reactions': 0,
+          'comments': 0,
+          'reposts': 0,
+          'engagement_score': 0,
+        });
+
+        expect(stats.blurhash, equals('STANDALONE_HASH'));
+      });
+    });
+
     group('text-track fields', () {
       test('parses text_track_ref from top-level JSON', () {
         final json = {

--- a/mobile/test/widgets/profile/profile_tab_thumbnail_test.dart
+++ b/mobile/test/widgets/profile/profile_tab_thumbnail_test.dart
@@ -2,13 +2,18 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/blurhash_display.dart';
 import 'package:openvine/widgets/profile/profile_tab_thumbnail.dart';
 import 'package:openvine/widgets/profile/profile_tab_thumbnail_placeholder.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
 void main() {
   group(ProfileTabThumbnail, () {
-    Widget buildSubject({String? thumbnailUrl, bool isPrecached = false}) {
+    Widget buildSubject({
+      String? thumbnailUrl,
+      String? blurhash,
+      bool isPrecached = false,
+    }) {
       return MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -19,6 +24,7 @@ void main() {
             height: 100,
             child: ProfileTabThumbnail(
               thumbnailUrl: thumbnailUrl,
+              blurhash: blurhash,
               isPrecached: isPrecached,
             ),
           ),
@@ -93,6 +99,41 @@ void main() {
         expect(image.fadeInDuration, equals(Duration.zero));
         expect(image.fadeOutDuration, equals(Duration.zero));
       });
+    });
+
+    group('blurhash fallback', () {
+      const validBlurhash = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
+
+      testWidgets(
+        '$BlurhashDisplay when thumbnailUrl is null and blurhash is provided',
+        (tester) async {
+          await tester.pumpWidget(buildSubject(blurhash: validBlurhash));
+
+          expect(find.byType(BlurhashDisplay), findsOneWidget);
+          expect(find.byType(ProfileTabThumbnailPlaceholder), findsNothing);
+        },
+      );
+
+      testWidgets(
+        '$ProfileTabThumbnailPlaceholder when thumbnailUrl and blurhash are '
+        'both null',
+        (tester) async {
+          await tester.pumpWidget(buildSubject());
+
+          expect(find.byType(ProfileTabThumbnailPlaceholder), findsOneWidget);
+          expect(find.byType(BlurhashDisplay), findsNothing);
+        },
+      );
+
+      testWidgets(
+        '$ProfileTabThumbnailPlaceholder when blurhash is empty string',
+        (tester) async {
+          await tester.pumpWidget(buildSubject(blurhash: ''));
+
+          expect(find.byType(ProfileTabThumbnailPlaceholder), findsOneWidget);
+          expect(find.byType(BlurhashDisplay), findsNothing);
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #3685

## Description

Currently, we only showed a plain color when the thumbnail wasn’t loaded. However, when a video is uploaded, we already extract the blurhash and store it in Nostr. This PR now uses that blurhash to display a preview until the thumbnail has loaded.

Note that the previous blurhash logic wasn’t fully correct, so existing blurhashes may not look perfect for 9:16 videos because they was generated for 4:3 videos. The new logic adjusts the blurhash to the video size and also uses isolates to prevent the main thread from freezing on low-end devices during video uploads.



| Before | After | When thumbnail is loaded |
| ------ | ----- | ------------------------ |
|     <img width="333"  alt="Bildschirmfoto 2026-04-29 um 21 05 57" src="https://github.com/user-attachments/assets/effc79f4-255a-4951-b631-6ad48bf584e7" />       |   <img width="333"  alt="Bildschirmfoto 2026-04-29 um 21 05 35" src="https://github.com/user-attachments/assets/5b643f6c-e009-4c8c-91d6-486969945705" />    |      <img width="333"  alt="Bildschirmfoto 2026-04-29 um 21 06 31" src="https://github.com/user-attachments/assets/426d1305-75d2-4637-bdcc-429275dcfd5e" />           |

**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore