### PR TITLE
fix(collabs): emit lowercase collaborator marker on video p-tags

### DIFF
--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -650,7 +650,7 @@ class VideoEventPublisher {
 
       // Add collaborator p-tags (standard NIP-71 format)
       for (final pubkey in collaboratorPubkeys) {
-        tags.add(['p', pubkey, 'wss://relay.divine.video', 'Collaborator']);
+        tags.add(['p', pubkey, 'wss://relay.divine.video', 'collaborator']);
       }
 
       // Add Inspired By a-tag (specific video reference)

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -1740,7 +1740,7 @@ class _EditVideoDialogState extends ConsumerState<_EditVideoDialog> {
 
       // Add collaborator p-tags
       for (final pubkey in _collaboratorPubkeys) {
-        tags.add(['p', pubkey, 'wss://relay.divine.video', 'Collaborator']);
+        tags.add(['p', pubkey, 'wss://relay.divine.video', 'collaborator']);
       }
 
       // Add inspired-by a-tag (video reference)

--- a/mobile/test/services/video_event_publisher_collaborator_tags_test.dart
+++ b/mobile/test/services/video_event_publisher_collaborator_tags_test.dart
@@ -138,7 +138,7 @@ void main() {
   }
 
   test(
-    'publishes collaborator p-tags with explicit Collaborator role',
+    'publishes collaborator p-tags with lowercase collaborator marker',
     () async {
       stubSignAndPublish();
 
@@ -153,9 +153,19 @@ void main() {
           'p',
           collaboratorPubkey,
           'wss://relay.divine.video',
-          'Collaborator',
+          'collaborator',
         ]),
         isTrue,
+      );
+      // Verify no capitalized form is emitted
+      expect(
+        _containsTag(capturedTags, const [
+          'p',
+          collaboratorPubkey,
+          'wss://relay.divine.video',
+          'Collaborator',
+        ]),
+        isFalse,
       );
     },
   );


### PR DESCRIPTION
## Summary

- Normalizes outbound Kind 34236 p-tag marker from `"Collaborator"` to canonical lowercase `"collaborator"` in both emitter locations (direct upload publish and post-publish edit)
- Updates regression test to assert lowercase and reject capitalized form
- DM role tags (`collaborator_invite_service.dart`) intentionally unchanged -- separate NIP-17 protocol surface, closed loop within mobile

Closes #3682

## Test plan

- [x] Existing collaborator tag test passes with lowercase assertion
- [x] `flutter analyze` clean on changed files
- [ ] Publish a video with a collaborator tagged, verify the relay event carries lowercase `"collaborator"` marker