### PR TITLE
refactor(publish): derive outer publish timeout from per-relay fan-out (#3688)

### DIFF
--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -64,7 +64,7 @@ const Duration _outerPublishTimeoutCeiling = Duration(seconds: 60);
 /// `perRelay × N` budget at default-config sizes (≈14% of the 35s outer
 /// at N=6) but large enough to absorb realistic dispatch overhead on
 /// cold-start without erosion as the relay count grows.
-const Duration _outerPublishTimeoutBuffer = Duration(seconds: 5);
+const Duration _outerPublishTimeoutBuffer = RelayPool.perRelaySendTimeout;
 
 /// Computes the outer timeout that bounds the call into
 /// [NostrClient.publishEvent] inside `_publishEventToNostr`.

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -14,6 +14,7 @@ import 'package:models/models.dart'
     hide LogCategory, NIP71VideoKinds, PendingUpload, UploadStatus;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/relay/relay_pool.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/audio_extraction_service.dart';
@@ -26,6 +27,77 @@ import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/utils/proofmode_publishing_helpers.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
+
+/// Floor for the derived outer publish timeout. Covers empty-config /
+/// pre-init races where `configuredRelayCount` reads as `0` but the
+/// publish would still queue against a tempRelay or wait on
+/// initialisation. Also keeps the timeout from collapsing to the buffer
+/// alone for `relayCount == 1`, which would leave no slack for normal
+/// network latency.
+const Duration _outerPublishTimeoutFloor = Duration(seconds: 10);
+
+/// Ceiling for the derived outer publish timeout. Bounds worst-case
+/// user-visible publish latency on misconfigured huge relay lists so a
+/// user with 50 wedged relays does not wait several minutes for the
+/// publish to give up.
+///
+/// **Trade-off**: clamping to the ceiling means the strict invariant
+/// `outer >= inner_worst_case + buffer` only holds while
+/// `derived <= ceiling`. Beyond that boundary (currently
+/// `relayCount >= 12` with `perRelaySendTimeout = 5s` and `buffer = 5s`)
+/// the buffer evaporates; from `relayCount == 13` upward the outer
+/// guard can fire before the inner sequential fan-out completes,
+/// re-introducing the original false-negative-publish failure mode for
+/// that edge case. We accept this because the field worst case is
+/// driven by `connecting`-state waits and post-handshake socket
+/// wedges — not all configured relays — so practical fan-out times for
+/// any reasonable config stay well under the ceiling. The retry loop in
+/// [VideoEventPublisher.publishDirectUpload] absorbs the rare
+/// false-negative when it does happen.
+const Duration _outerPublishTimeoutCeiling = Duration(seconds: 60);
+
+/// Buffer added on top of the per-relay × count derivation. Covers the
+/// microtask queue drains between sequential `relay.send` calls inside
+/// [RelayPool._sendCollect], plus a small allowance for log formatting
+/// and other in-process scheduling jitter. Picked at one
+/// `perRelaySendTimeout` worth of slack — small relative to the total
+/// `perRelay × N` budget at default-config sizes (≈14% of the 35s outer
+/// at N=6) but large enough to absorb realistic dispatch overhead on
+/// cold-start without erosion as the relay count grows.
+const Duration _outerPublishTimeoutBuffer = Duration(seconds: 5);
+
+/// Computes the outer timeout that bounds the call into
+/// [NostrClient.publishEvent] inside `_publishEventToNostr`.
+///
+/// Derivation: `RelayPool.perRelaySendTimeout * relayCount + buffer`,
+/// clamped to `[floor, ceiling]`. Encoding the relationship in code
+/// keeps the outer guard from silently firing before the inner
+/// sequential fan-out inside [RelayPool._sendCollect] can complete on
+/// degraded networks, regardless of how many relays the user has
+/// configured — up to the ceiling boundary documented on
+/// [_outerPublishTimeoutCeiling].
+///
+/// **Caveats on `relayCount`**: the value passed in is treated as an
+/// upper bound on the actual sequential fan-out width. Two factors
+/// make the real fan-out narrower:
+///   * `_sendCollect` skips relays without `writeAccess` for `EVENT`
+///     messages, so read-only relays in the configured set don't
+///     consume a per-relay slot.
+///   * Callers passing `tempRelays` to `RelayPool.send` add fan-out
+///     width that this helper cannot see; the canonical
+///     [VideoEventPublisher] path does not, but a future caller might.
+/// Both factors err on the conservative side — the derived bound is
+/// never tighter than the real worst case.
+///
+/// Exposed at file scope so unit tests can assert the math directly
+/// without spinning up a [NostrClient].
+Duration outerPublishTimeoutFor(int relayCount) {
+  final derived =
+      RelayPool.perRelaySendTimeout * relayCount + _outerPublishTimeoutBuffer;
+  if (derived < _outerPublishTimeoutFloor) return _outerPublishTimeoutFloor;
+  if (derived > _outerPublishTimeoutCeiling) return _outerPublishTimeoutCeiling;
+  return derived;
+}
 
 /// Service for publishing processed videos to Nostr relays
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
@@ -63,6 +135,17 @@ class VideoEventPublisher {
   int _totalEventsPublished = 0;
   int _totalEventsFailed = 0;
   DateTime? _lastPublishTime;
+
+  /// The outer timeout that will bound the next call into
+  /// [NostrClient.publishEvent] inside [_publishEventToNostr], computed
+  /// live from [outerPublishTimeoutFor] and the current
+  /// [NostrClient.configuredRelayCount].
+  ///
+  /// Exposed so tests can pin the production wiring between the helper
+  /// and the call site without instrumenting `Future.timeout`. Reading
+  /// this getter has no side effects.
+  Duration get currentOuterPublishTimeout =>
+      outerPublishTimeoutFor(_nostrService.configuredRelayCount);
 
   /// Initialize the publisher
   Future<void> initialize() async {
@@ -206,10 +289,17 @@ class VideoEventPublisher {
 
       // Use the existing Nostr service to publish.
       //
-      // Defense-in-depth: hard 30s timeout so a misbehaving relay
-      // (e.g. stuck in connecting / reconnect backoff) cannot freeze the
-      // publish flow indefinitely. The retry loop in [publishDirectUpload]
-      // will pick up after each failed attempt.
+      // Defense-in-depth: outer timeout so a misbehaving relay (e.g. stuck
+      // in connecting / reconnect backoff) cannot freeze the publish flow
+      // indefinitely. The retry loop in [publishDirectUpload] picks up
+      // after each failed attempt.
+      //
+      // The bound is derived from [RelayPool.perRelaySendTimeout] and the
+      // configured relay count (see [outerPublishTimeoutFor]) so it stays
+      // strictly above the worst-case sequential fan-out inside
+      // [_sendCollect]. Hard-coding the outer timeout would silently break
+      // the moment a user adds a relay or the SDK retunes the per-relay
+      // cap; the derivation encodes the invariant in code.
       //
       // We use try/catch on [TimeoutException] rather than `.timeout(
       // onTimeout: ...)`. The `onTimeout` closure has its return type
@@ -220,14 +310,19 @@ class VideoEventPublisher {
       // `onTimeout: () => null` throw at runtime in tests. The try/catch
       // shape sidesteps the closure-cast entirely; behaviour against a
       // real `NostrClient` is identical.
+      final outerTimeout = currentOuterPublishTimeout;
       Event? sentEvent;
       try {
         sentEvent = await _nostrService
             .publishEvent(event)
-            .timeout(const Duration(seconds: 30));
+            .timeout(
+              outerTimeout,
+            );
       } on TimeoutException {
         Log.error(
-          '⏱️ publishEvent timed out after 30s for event ${event.id}',
+          '⏱️ publishEvent timed out after ${outerTimeout.inSeconds}s for '
+          'event ${event.id} '
+          '(relayCount=${_nostrService.configuredRelayCount})',
           name: 'VideoEventPublisher',
           category: LogCategory.video,
         );

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -31,6 +31,16 @@ class RelayPool {
     EventKind.comment,
   ];
 
+  /// Per-relay cap inside [_sendCollect]'s sequential fan-out.
+  ///
+  /// Exposed as part of the public API so callers that wrap publish calls
+  /// in their own outer guard can size that guard against the worst-case
+  /// fan-out duration (`perRelaySendTimeout * configuredRelays.length`)
+  /// rather than duplicating the literal. See
+  /// `mobile/lib/services/video_event_publisher.dart` for the canonical
+  /// caller-side derivation.
+  static const Duration perRelaySendTimeout = Duration(seconds: 5);
+
   Nostr localNostr;
 
   final Map<String, Relay> _tempRelays = {};
@@ -869,20 +879,22 @@ class RelayPool {
   /// Reconnection is driven by the relay manager's heartbeat, not by
   /// outbound publishes.
   ///
-  /// Each individual `relay.send` is also wrapped in a 5-second timeout as a
-  /// belt-and-suspenders backstop. `skipReconnect: true` already short-
+  /// Each individual `relay.send` is also wrapped in [perRelaySendTimeout]
+  /// as a belt-and-suspenders backstop. `skipReconnect: true` already short-
   /// circuits the disconnected-state path inside `WebSocketConnectionManager`,
   /// but it does not bypass the `connecting`-state wait nor protect against
   /// a relay whose underlying socket is wedged after a successful handshake
   /// (TCP backpressure, slow peer). The per-relay timeout caps any single
-  /// relay's contribution to the sequential fan-out at 5 seconds, so the
-  /// outer publish flow stays responsive even on degraded networks.
+  /// relay's contribution to the sequential fan-out, so the outer publish
+  /// flow stays responsive even on degraded networks. Callers that wrap
+  /// the publish call in their own outer guard should size that guard
+  /// against `perRelaySendTimeout * configuredRelays.length` plus a small
+  /// scheduling buffer.
   Future<List<String>> _sendCollect(
     List<dynamic> message, {
     List<String>? tempRelays,
     List<String>? targetRelays,
   }) async {
-    const perRelayTimeout = Duration(seconds: 5);
     final sentTo = <String>[];
 
     for (final relay in _relaysSnapshot()) {
@@ -918,7 +930,17 @@ class RelayPool {
             // rest of the fan-out.
             var result = await relay
                 .send(message, forceSend: true)
-                .timeout(perRelayTimeout, onTimeout: () => false);
+                .timeout(
+                  perRelaySendTimeout,
+                  onTimeout: () {
+                    log(
+                      '⏱️ Per-relay auth-trigger send timeout for ${relay.url} '
+                      '(connected=${relay.relayStatus.connected}, '
+                      'authed=${relay.relayStatus.authed})',
+                    );
+                    return false;
+                  },
+                );
             if (result) {
               sentTo.add(relay.url);
             }
@@ -941,7 +963,17 @@ class RelayPool {
           // relayDoSubscribe above.
           var result = await relay
               .send(message, skipReconnect: true)
-              .timeout(perRelayTimeout, onTimeout: () => false);
+              .timeout(
+                perRelaySendTimeout,
+                onTimeout: () {
+                  log(
+                    '⏱️ Per-relay send timeout for ${relay.url} '
+                    '(connected=${relay.relayStatus.connected}, '
+                    'authed=${relay.relayStatus.authed})',
+                  );
+                  return false;
+                },
+              );
           if (result) {
             sentTo.add(relay.url);
           }
@@ -960,7 +992,16 @@ class RelayPool {
         // block the publish.
         var result = await tempRelay
             .send(message, skipReconnect: true)
-            .timeout(perRelayTimeout, onTimeout: () => false);
+            .timeout(
+              perRelaySendTimeout,
+              onTimeout: () {
+                log(
+                  '⏱️ Per-relay send timeout for tempRelay ${tempRelay.url} '
+                  '(connected=${tempRelay.relayStatus.connected})',
+                );
+                return false;
+              },
+            );
         if (result) {
           sentTo.add(tempRelay.url);
         }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
@@ -394,8 +394,8 @@ void main() {
       // Belt-and-suspenders: skipReconnect: true short-circuits the
       // disconnected-state reconnect dance, but does NOT bypass the
       // `connecting` state's _waitForConnection() nor protect against
-      // a wedged-after-handshake socket. The 5s per-relay timeout in
-      // _sendCollect catches these residual cases so a single
+      // a wedged-after-handshake socket. The [RelayPool.perRelaySendTimeout]
+      // backstop in _sendCollect catches these residual cases so a single
       // pathological relay cannot stall the sequential fan-out.
       final healthy = _SucceedingRelay('wss://healthy.relay');
       final hanging = _AlwaysHangingRelay('wss://hanging.relay');
@@ -409,10 +409,15 @@ void main() {
       final ok = await nostr.relayPool.send(['EVENT', event.toJson()]);
       stopwatch.stop();
 
-      // Per-relay timeout is 5s. With one hanging relay, total elapsed
-      // should sit comfortably under 7s (5s timeout + setup overhead).
-      // If the timeout is removed, this test would hang for 60s+.
-      expect(stopwatch.elapsedMilliseconds, lessThan(7000));
+      // With one hanging relay, total elapsed should sit comfortably
+      // under perRelaySendTimeout + 2s of setup overhead. If the
+      // timeout is removed, this test would hang for 60s+.
+      final expectedCeiling =
+          RelayPool.perRelaySendTimeout + const Duration(seconds: 2);
+      expect(
+        stopwatch.elapsedMilliseconds,
+        lessThan(expectedCeiling.inMilliseconds),
+      );
       // The healthy relay still accepted the EVENT.
       expect(ok, isTrue);
       expect(
@@ -425,6 +430,22 @@ void main() {
       // to sentTo because its future timed out.
       expect(hanging.sentMessages, isNotEmpty);
     });
+
+    test(
+      'RelayPool.perRelaySendTimeout is exposed as a stable public contract',
+      () {
+        // Pin: the public constant is the SDK's contract with callers
+        // that need to size their own outer guards (e.g.
+        // `outerPublishTimeoutFor` in mobile/lib/services/
+        // video_event_publisher.dart). Bumping this value is a SDK-
+        // public-API change — callers depending on the worst-case
+        // sequential fan-out math need to be revisited.
+        expect(
+          RelayPool.perRelaySendTimeout,
+          equals(const Duration(seconds: 5)),
+        );
+      },
+    );
   });
 
   group('RelayPool COUNT concurrency', () {

--- a/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
+++ b/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
@@ -194,4 +194,63 @@ void main() {
       verify(() => mockNostrClient.publishEvent(signedEvent)).called(1);
     });
   });
+
+  group('VideoEventPublisher.currentOuterPublishTimeout wiring', () {
+    // Pins the production wiring between [outerPublishTimeoutFor] and
+    // the actual `Future.timeout` inside _publishEventToNostr. The math
+    // is covered exhaustively in video_event_publisher_test.dart; this
+    // group only verifies the call site reads from the helper rather
+    // than re-introducing a hard-coded literal.
+
+    test(
+      'reflects outerPublishTimeoutFor for the current configuredRelayCount',
+      () {
+        when(() => mockNostrClient.configuredRelayCount).thenReturn(6);
+        expect(
+          publisher.currentOuterPublishTimeout,
+          equals(outerPublishTimeoutFor(6)),
+        );
+      },
+    );
+
+    test('updates live as configuredRelayCount changes', () {
+      when(() => mockNostrClient.configuredRelayCount).thenReturn(0);
+      expect(
+        publisher.currentOuterPublishTimeout,
+        equals(outerPublishTimeoutFor(0)),
+      );
+
+      when(() => mockNostrClient.configuredRelayCount).thenReturn(50);
+      expect(
+        publisher.currentOuterPublishTimeout,
+        equals(outerPublishTimeoutFor(50)),
+      );
+    });
+
+    test(
+      'never collapses to a single hard-coded literal across relay counts',
+      () {
+        // Regression guard against reverting the call site to e.g.
+        // `Duration(seconds: 30)`. With three different stubbed counts
+        // straddling the floor / mid-range / ceiling, the getter must
+        // produce three distinct values.
+        when(() => mockNostrClient.configuredRelayCount).thenReturn(0);
+        final atFloor = publisher.currentOuterPublishTimeout;
+
+        when(() => mockNostrClient.configuredRelayCount).thenReturn(6);
+        final atDefault = publisher.currentOuterPublishTimeout;
+
+        when(() => mockNostrClient.configuredRelayCount).thenReturn(50);
+        final atCeiling = publisher.currentOuterPublishTimeout;
+
+        expect(
+          {atFloor, atDefault, atCeiling},
+          hasLength(3),
+          reason:
+              'getter must vary with configuredRelayCount; '
+              'a single literal would collapse all three to one value',
+        );
+      },
+    );
+  });
 }

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -7,7 +7,9 @@ import 'dart:io';
 import 'package:crypto/crypto.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/relay/relay_pool.dart';
 import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/video_event_publisher.dart';
 
 /// Helper class to test imeta tag generation logic
 class ImetaTagGenerator {
@@ -451,29 +453,33 @@ void main() {
   });
 
   group('publishEvent timeout guard', () {
-    // Locks the contract introduced in video_event_publisher.dart line 208:
-    // a 30s `Future.timeout` wrapped in try/catch (TimeoutException) so a
-    // stalled relay-pool send cannot freeze the publish flow. We use the
-    // try/catch shape (not `onTimeout: () => null`) because mocktail-stubbed
-    // Futures lose their declared `?` nullability at runtime, which would
-    // make the onTimeout closure-cast throw — see
+    // Locks the contract introduced in video_event_publisher.dart's
+    // `_publishEventToNostr`: a derived `Future.timeout` wrapped in
+    // try/catch (TimeoutException) so a stalled relay-pool send cannot
+    // freeze the publish flow. We use the try/catch shape (not
+    // `onTimeout: () => null`) because mocktail-stubbed Futures lose
+    // their declared `?` nullability at runtime, which would make the
+    // onTimeout closure-cast throw — see
     // `test/diag/mocktail_timeout_diag_test.dart` for the full diagnosis.
+    //
+    // The duration used here is incidental to the pattern under test;
+    // production sizes the timeout via `outerPublishTimeoutFor`, covered
+    // by the dedicated group below.
+    const patternTimeout = Duration(seconds: 30);
 
     test(
       'a never-completing publishEvent future surfaces TimeoutException '
-      'after 30s and is mapped to null',
+      'and is mapped to null',
       () {
         fakeAsync((async) {
           final never = Completer<String?>();
           var completed = false;
           String? result;
 
-          // Mirrors the exact wrapping at video_event_publisher.dart:208.
+          // Mirrors the exact wrapping inside _publishEventToNostr.
           Future<void> wrapped() async {
             try {
-              result = await never.future.timeout(
-                const Duration(seconds: 30),
-              );
+              result = await never.future.timeout(patternTimeout);
             } on TimeoutException {
               result = null;
             }
@@ -504,9 +510,7 @@ void main() {
 
           Future<void> wrapped() async {
             try {
-              final value = await completer.future.timeout(
-                const Duration(seconds: 30),
-              );
+              final value = await completer.future.timeout(patternTimeout);
               resolvedValue = value ?? 'null';
             } on TimeoutException {
               resolvedValue = 'timeout';
@@ -521,6 +525,127 @@ void main() {
 
           expect(resolvedValue, equals('signed_event_id'));
         });
+      },
+    );
+  });
+
+  group('outerPublishTimeoutFor', () {
+    // Pins the derivation introduced as the follow-up to PR #3683 / issue
+    // #3688: the outer publish timeout is `RelayPool.perRelaySendTimeout *
+    // relayCount + buffer`, clamped to `[floor, ceiling]`. Encoding the
+    // relationship in code keeps the outer guard from silently firing
+    // before the inner sequential fan-out can complete on degraded
+    // networks, regardless of how many relays the user configures.
+
+    test('clamps to the floor when the relay count is zero', () {
+      // 0 * 5s + 5s = 5s, which is below the 10s floor.
+      expect(
+        outerPublishTimeoutFor(0),
+        equals(const Duration(seconds: 10)),
+      );
+    });
+
+    test('still clamps to the floor for a single relay', () {
+      // 1 * 5s + 5s = 10s, exactly at the floor — never below it.
+      expect(
+        outerPublishTimeoutFor(1),
+        equals(const Duration(seconds: 10)),
+      );
+    });
+
+    test('scales linearly between the floor and ceiling', () {
+      // 2 * 5s + 5s = 15s
+      expect(
+        outerPublishTimeoutFor(2),
+        equals(const Duration(seconds: 15)),
+      );
+      // 6 * 5s + 5s = 35s — the current default-config worst case.
+      expect(
+        outerPublishTimeoutFor(6),
+        equals(const Duration(seconds: 35)),
+      );
+      // 11 * 5s + 5s = 60s, exactly at the ceiling.
+      expect(
+        outerPublishTimeoutFor(11),
+        equals(const Duration(seconds: 60)),
+      );
+    });
+
+    test('clamps to the ceiling for misconfigured huge relay lists', () {
+      // 12 * 5s + 5s = 65s → clamped to 60s ceiling. Bounds worst-case
+      // publish latency so the user never stares at a spinner for
+      // several minutes.
+      expect(
+        outerPublishTimeoutFor(12),
+        equals(const Duration(seconds: 60)),
+      );
+      expect(
+        outerPublishTimeoutFor(50),
+        equals(const Duration(seconds: 60)),
+      );
+    });
+
+    test(
+      'strictly exceeds the inner worst-case fan-out up to the ceiling '
+      'boundary',
+      () {
+        // The whole point of the derivation: the outer guard must never
+        // fire before the inner sequential fan-out inside
+        // `RelayPool._sendCollect` can complete. Asserts the invariant
+        // strictly (with the buffer present) for the full range up to
+        // the ceiling boundary.
+        for (final relayCount in [0, 1, 2, 6, 7, 11]) {
+          final innerWorstCase = RelayPool.perRelaySendTimeout * relayCount;
+          final outer = outerPublishTimeoutFor(relayCount);
+          expect(
+            outer > innerWorstCase,
+            isTrue,
+            reason:
+                'outer ($outer) must strictly exceed inner worst case '
+                '($innerWorstCase) for relayCount=$relayCount '
+                '(buffer must be present)',
+          );
+        }
+      },
+    );
+
+    test(
+      'invariant degrades at the ceiling boundary (relayCount >= 12)',
+      () {
+        // Pinned trade-off: clamping to the 60s ceiling means the
+        // strict `outer > inner_worst_case` invariant evaporates at the
+        // boundary and inverts beyond it. This test locks the documented
+        // edge so any change to the ceiling, the per-relay timeout, or
+        // the buffer surfaces here loudly. See the
+        // `_outerPublishTimeoutCeiling` doc comment for the rationale.
+
+        // At relayCount == 12: derived = 12 * 5s + 5s = 65s, clamped to
+        // 60s. Inner worst case = 12 * 5s = 60s. Outer == inner; buffer
+        // is gone but the invariant is not yet violated.
+        final innerAt12 = RelayPool.perRelaySendTimeout * 12;
+        final outerAt12 = outerPublishTimeoutFor(12);
+        expect(outerAt12, equals(const Duration(seconds: 60)));
+        expect(outerAt12, equals(innerAt12));
+        expect(
+          outerAt12 > innerAt12,
+          isFalse,
+          reason: 'buffer is exhausted at relayCount == 12',
+        );
+
+        // At relayCount == 13: derived = 70s, clamped to 60s. Inner
+        // worst case = 65s. Outer < inner — the original false-negative
+        // failure mode is back for this edge. The retry loop in
+        // VideoEventPublisher.publishDirectUpload absorbs it.
+        final innerAt13 = RelayPool.perRelaySendTimeout * 13;
+        final outerAt13 = outerPublishTimeoutFor(13);
+        expect(outerAt13, equals(const Duration(seconds: 60)));
+        expect(
+          outerAt13 < innerAt13,
+          isTrue,
+          reason:
+              'invariant breaks at relayCount == 13: '
+              'outer ($outerAt13) < inner ($innerAt13)',
+        );
       },
     );
   });


### PR DESCRIPTION
## Description

Replaces the implicit `5s × 6 relay = 30s` coupling left in #3683 with an
encoded contract:

- **`nostr_sdk`** exports `RelayPool.perRelaySendTimeout` (new public
  `static const Duration`) so callers wrapping publish calls in their
  own outer guard can size that guard against the worst-case sequential
  fan-out instead of duplicating the literal.
- **`VideoEventPublisher`** now derives the outer `Future.timeout` via a
  top-level `outerPublishTimeoutFor(int relayCount)` helper —
  `perRelay × configuredRelayCount + buffer`, clamped to a `[10s, 60s]`
  range. Hard-coding the outer 30s would silently break the moment a
  user adds a relay or the SDK retunes the per-relay cap; the
  derivation encodes the invariant in code.
- **Log enrichment** (sub-item 3 of #3688): per-relay timeouts inside
  `_sendCollect` now log `relay.url`, `connected` state, and `authed`
  state. The existing outer timeout log gains `configuredRelayCount` so
  a coupling-violation incident is visible from logs alone.

**Decision on telemetry** (sub-item 3 of #3688): logging only, no new
analytics SDK. The repo's existing `Log.error` flows to the production
sink already in place; a histogram pipeline would require an analytics
seam this codebase doesn't currently have. Reconsider if the per-relay
timeout starts firing in the field.

**Related Issue:** Relates to #3688 (closes sub-items 1 and 3; sub-item
2 — Keycast `sign_canonical` cross-repo tracking — opened at
[divinevideo/keycast#186](https://github.com/divinevideo/keycast/issues/186)
with the determinism contract and a concrete cross-implementation test
vector).

**Stacked on:** #3683 — base branch is `fix/publish-hang-disconnected-relay`.

## Type of Change

- [x] 🧹 Code refactor

## Trade-off worth surfacing

The 60s ceiling means the strict `outer > inner_worst_case + buffer`
invariant evaporates at `relayCount == 12` (zero buffer) and inverts at
`relayCount >= 13` (outer < inner). This re-introduces the original
false-negative-publish failure mode for the unlikely edge case of 13+
relays all simultaneously wedged-after-handshake. Documented loudly on
`_outerPublishTimeoutCeiling` and pinned by a dedicated test
(`'invariant degrades at the ceiling boundary (relayCount >= 12)'`).
The retry loop in `publishDirectUpload` absorbs the rare
false-negative when it does happen. Alternatives considered (no
ceiling = 4-minute spinner on misconfigured 50-relay sets; parallel
fan-out = separate ticket already noted in #3683 out-of-scope).

## Test coverage

| File | What it locks |
|---|---|
| `mobile/test/services/video_event_publisher_test.dart` | `outerPublishTimeoutFor` math: floor / linear scaling / ceiling clamp / strict-exceed-up-to-boundary / boundary degradation at relayCount=12 and 13. |
| `mobile/test/services/video_event_publisher_publish_confirmation_test.dart` | `currentOuterPublishTimeout` getter wiring: reflects helper, updates live with relay count, never collapses to a single literal (regression guard against reverting to a hard-coded `Duration(seconds: 30)`). |
| `mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart` | `RelayPool.perRelaySendTimeout` exposed as a stable public contract; existing per-relay timeout test now references the constant instead of the 5s literal. |

89 tests pass on push; `flutter analyze` clean on `mobile/lib test integration_test` and `mobile/packages/nostr_sdk`; `dart format` clean.

## Out of scope (tracked elsewhere)

- Backend implementation of `sign_canonical` — tracked at [divinevideo/keycast#186](https://github.com/divinevideo/keycast/issues/186) (#3688 sub-item 2; mobile is already wired and forward-compatible).
- Parallel fan-out inside `_sendCollect` — eliminates the coupling
  entirely. Listed as a future follow-up in #3683's out-of-scope
  section; explicitly not bundled here.

## Test plan

- [ ] CI: `Tests`, `Analyze`, `Format`, `Generated Files`, `build / build` (divine_ui coverage) green.
- [ ] Stacked PR base shows correctly as `fix/publish-hang-disconnected-relay`.
- [ ] `git diff main..HEAD -- mobile/lib/services/video_event_publisher.dart` shows the helper extraction and getter, not just isolated literal swaps.
- [ ] Manual smoke (after #3683 merges and this rebases on main): publish a clip with all 6 relays healthy → completes within ~35s. Add 2 unreachable relays (8 total) → publish still completes under ~45s thanks to `skipReconnect`; outer guard does not fire.
