### PR TITLE
fix: pass serverUrl to createGetAuthHeader in background cache queue

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -344,8 +344,14 @@ class FullscreenFeedBloc
       final blossomAuth = _blossomAuthService;
       final sha256 = request.sha256;
       if (blossomAuth != null && sha256 != null) {
+        // Extract the server origin from the video URL so the BUD-01 kind
+        // 24242 auth event includes the optional `server` tag.  Without it,
+        // media.divine.video returns 401 on bare-blob GET requests even when
+        // the hash and signature are otherwise valid.
+        final serverUrl = _serverOrigin(request.videoUrl);
         final header = await blossomAuth.createGetAuthHeader(
           sha256Hash: sha256,
+          serverUrl: serverUrl,
         );
         if (header != null) {
           authHeaders = {'Authorization': header};
@@ -499,6 +505,21 @@ class FullscreenFeedBloc
         removedVideoIds: updatedRemoved,
       ),
     );
+  }
+
+  /// Extracts the scheme+host origin from [url], e.g.
+  /// `https://media.divine.video/abc123` → `https://media.divine.video`.
+  ///
+  /// Returns `null` when the URL cannot be parsed, so callers can fall back
+  /// to omitting the `server` tag rather than sending a malformed value.
+  static String? _serverOrigin(String url) {
+    try {
+      final uri = Uri.parse(url);
+      if (!uri.hasScheme || uri.host.isEmpty) return null;
+      return '${uri.scheme}://${uri.host}${uri.hasPort ? ':${uri.port}' : ''}';
+    } on FormatException {
+      return null;
+    }
   }
 
   @override

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -773,6 +773,7 @@ void main() {
           when(
             () => mockBlossomAuth.createGetAuthHeader(
               sha256Hash: any(named: 'sha256Hash'),
+              serverUrl: any(named: 'serverUrl'),
             ),
           ).thenAnswer((_) async => 'Nostr test-token');
           when(
@@ -792,6 +793,14 @@ void main() {
             bloc.add(const FullscreenFeedVideoCacheStarted(index: 0)),
         wait: const Duration(milliseconds: 100),
         verify: (_) {
+          // Server origin extracted from videoUrl and forwarded so the
+          // BUD-01 kind 24242 event includes the `server` tag.
+          verify(
+            () => mockBlossomAuth.createGetAuthHeader(
+              sha256Hash: 'abc123',
+              serverUrl: 'https://example.com',
+            ),
+          ).called(1);
           verify(
             () => mockMediaCache.downloadFile(
               'https://example.com/video_video1.mp4',


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
`FullscreenFeedBloc._processCacheQueue` was calling `createGetAuthHeader` without a `serverUrl`, so the signed BUD-01 kind 24242 event omitted the optional `server` tag. `media.divine.video` requires that tag on bare-blob `GET /{hash}` requests and was returning 401, causing all background pre-cache attempts to fail silently.

The fix extracts the scheme+host origin from the video URL and passes it as `serverUrl`, matching the pattern already used in `MediaViewerAuthService` and `VideoErrorOverlay`.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #3692 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore