### PR TITLE
fix(download): save original video using file paths

### DIFF
--- a/mobile/lib/services/watermark_download_service.dart
+++ b/mobile/lib/services/watermark_download_service.dart
@@ -108,7 +108,7 @@ class WatermarkDownloadService {
       // which may be missing or wrong — e.g. a square video defaults to
       // 1080x1920 and causes black letterboxing).
       final metadata = await ProVideoEditor.instance.getMetadata(
-        EditorVideo.file(videoFile),
+        EditorVideo.file(videoFile.path),
       );
       final videoWidth = metadata.resolution.width.round();
       final videoHeight = metadata.resolution.height.round();
@@ -141,7 +141,7 @@ class WatermarkDownloadService {
       onProgress(WatermarkDownloadStage.saving);
 
       final saveResult = await _gallerySaveService.saveVideoToGallery(
-        EditorVideo.file(File(tempOutputPath)),
+        EditorVideo.file(tempOutputPath),
       );
 
       if (saveResult is GallerySavePermissionDenied) {
@@ -200,7 +200,7 @@ class WatermarkDownloadService {
       onProgress(OriginalSaveStage.saving);
 
       final saveResult = await _gallerySaveService.saveVideoToGallery(
-        EditorVideo.file(videoFile),
+        EditorVideo.file(videoFile.path),
       );
 
       if (saveResult is GallerySavePermissionDenied) {

--- a/mobile/test/services/watermark_download_service_test.dart
+++ b/mobile/test/services/watermark_download_service_test.dart
@@ -1,17 +1,35 @@
 // ABOUTME: Tests for WatermarkDownloadService result types and stage enums
 // ABOUTME: Validates the sealed class hierarchy and download flow contracts
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/services/watermark_download_service.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 
 class _MockMediaCacheManager extends Mock implements MediaCacheManager {}
 
 class _MockGallerySaveService extends Mock implements GallerySaveService {}
 
+VideoEvent _createTestVideo() => VideoEvent(
+  id: 'test-video-id-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+  pubkey:
+      'pubkey-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+  createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+  content: 'Test video',
+  timestamp: DateTime.now(),
+  videoUrl: 'https://example.com/video.mp4',
+);
+
 void main() {
+  setUpAll(() {
+    registerFallbackValue(EditorVideo.file('/tmp/fallback.mp4'));
+  });
+
   group('WatermarkDownloadStage', () {
     test('has all three stages', () {
       expect(WatermarkDownloadStage.values, hasLength(3));
@@ -101,6 +119,39 @@ void main() {
     });
 
     group('downloadOriginal', () {
+      test('saves a cached video file successfully', () async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'watermark-download-service-test',
+        );
+        final videoFile = File('${tempDir.path}/video.mp4');
+        await videoFile.writeAsBytes(const [1, 2, 3, 4]);
+
+        addTearDown(() async {
+          if (tempDir.existsSync()) {
+            await tempDir.delete(recursive: true);
+          }
+        });
+
+        final stages = <OriginalSaveStage>[];
+
+        when(() => mockCache.getCachedFileSync(any())).thenReturn(videoFile);
+        when(
+          () => mockGallerySave.saveVideoToGallery(any()),
+        ).thenAnswer((_) async => const GallerySaveSuccess());
+
+        final result = await service.downloadOriginal(
+          video: _createTestVideo(),
+          onProgress: stages.add,
+        );
+
+        expect(result, isA<WatermarkDownloadSuccess>());
+        expect(stages, [
+          OriginalSaveStage.downloading,
+          OriginalSaveStage.saving,
+        ]);
+        verify(() => mockGallerySave.saveVideoToGallery(any())).called(1);
+      });
+
       test('returns failure when video file cannot be downloaded', () async {
         when(() => mockCache.getCachedFileSync(any())).thenReturn(null);
 


### PR DESCRIPTION
## Summary
This fixes the user-visible save/download failure tracked in #3694.

The original save flow in WatermarkDownloadService was building editor inputs from File objects in this path. The failing user log showed that original-save flow throwing an invalid argument error before the gallery save completed.

This change normalizes those calls to pass file path strings instead, matching the working call sites used elsewhere in the app.

## Testing
- dart analyze lib/services/watermark_download_service.dart test/services/watermark_download_service_test.dart test/widgets/save_original_progress_sheet_test.dart
- flutter test --no-pub test/services/watermark_download_service_test.dart test/widgets/save_original_progress_sheet_test.dart

## Related Issue
Closes #3694