### PR TITLE
fix(explore): restore refresh recovery for empty feeds

### DIFF
--- a/mobile/lib/providers/classic_vines_provider.dart
+++ b/mobile/lib/providers/classic_vines_provider.dart
@@ -287,8 +287,7 @@ int classicVinesFeedCount(Ref ref) {
 /// Classic vines require Funnelcake REST API to be available.
 @riverpod
 Future<bool> classicVinesAvailable(Ref ref) async {
-  final funnelcakeAsync = ref.watch(funnelcakeAvailableProvider);
-  return funnelcakeAsync.asData?.value ?? false;
+  return ref.watch(funnelcakeAvailableProvider.future);
 }
 
 /// Data model for a top classic Viner

--- a/mobile/lib/providers/classic_vines_provider.dart
+++ b/mobile/lib/providers/classic_vines_provider.dart
@@ -8,6 +8,7 @@ import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/curation_providers.dart';
+import 'package:openvine/providers/feed_refresh_helpers.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
 import 'package:openvine/state/video_feed_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -66,15 +67,24 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
       return const VideoFeedState(videos: [], hasMoreContent: false);
     }
 
-    final client = ref.read(funnelcakeApiClientProvider);
-    final videoEventService = ref.read(videoEventServiceProvider);
-    final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
     final funnelcakeAvailable =
         ref.watch(funnelcakeAvailableProvider).asData?.value ?? false;
 
     // Pick a random offset within the top 500 most-looped vines
     _randomOffset = _random.nextInt(_maxRandomOffset + 1);
     _loadMorePages = 0;
+
+    return _loadFirstPage(funnelcakeAvailable: funnelcakeAvailable);
+  }
+
+  Future<VideoFeedState> _loadFirstPage({
+    required bool funnelcakeAvailable,
+    bool preserveCurrentOnEmptyFallback = false,
+  }) async {
+    final client = ref.read(funnelcakeApiClientProvider);
+    final videoEventService = ref.read(videoEventServiceProvider);
+    final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
+    Object? restError;
 
     // Try REST API first (Funnelcake has comprehensive classic Vine data)
     if (funnelcakeAvailable) {
@@ -96,20 +106,31 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
               .toList(),
         )..shuffle(_random);
 
-        Log.info(
-          '🎬 ClassicVinesFeed: Loaded ${filteredVideos.length} videos '
-          '(offset: $_randomOffset, shuffled)',
-          name: 'ClassicVinesFeedProvider',
-          category: LogCategory.video,
-        );
+        if (filteredVideos.isEmpty) {
+          restError = StateError('Classics API returned no videos');
+          Log.warning(
+            '🎬 ClassicVinesFeed: REST API returned no videos, falling back to Nostr',
+            name: 'ClassicVinesFeedProvider',
+            category: LogCategory.video,
+          );
+          // Fall through to Nostr fallback.
+        } else {
+          Log.info(
+            '🎬 ClassicVinesFeed: Loaded ${filteredVideos.length} videos '
+            '(offset: $_randomOffset, shuffled)',
+            name: 'ClassicVinesFeedProvider',
+            category: LogCategory.video,
+          );
 
-        final nextOffset = _randomOffset + _pageSize;
-        return VideoFeedState(
-          videos: filteredVideos,
-          hasMoreContent: nextOffset < _totalClassicVines,
-          lastUpdated: DateTime.now(),
-        );
+          final nextOffset = _randomOffset + _pageSize;
+          return VideoFeedState(
+            videos: filteredVideos,
+            hasMoreContent: nextOffset < _totalClassicVines,
+            lastUpdated: DateTime.now(),
+          );
+        }
       } catch (e) {
+        restError = e;
         Log.warning(
           '🎬 ClassicVinesFeed: REST API error, falling back to Nostr: $e',
           name: 'ClassicVinesFeedProvider',
@@ -139,24 +160,22 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
     final topClassics = classicVideos.take(_pageSize).toList()
       ..shuffle(_random);
 
+    if (topClassics.isEmpty && preserveCurrentOnEmptyFallback) {
+      throw restError ?? StateError('Classics API unavailable');
+    }
+
     return VideoFeedState(
       videos: topClassics,
       hasMoreContent: classicVideos.length > _pageSize,
+      error: restError?.toString(),
       lastUpdated: DateTime.now(),
     );
   }
 
   /// Refresh with a new random slice of classic vines
   Future<void> refresh() async {
-    final client = ref.read(funnelcakeApiClientProvider);
     final funnelcakeAvailable =
         ref.read(funnelcakeAvailableProvider).asData?.value ?? false;
-
-    if (!funnelcakeAvailable) {
-      // Can't paginate without API — invalidate to re-run build()
-      ref.invalidateSelf();
-      return;
-    }
 
     // Pick a new random offset for a fresh slice
     _randomOffset = _random.nextInt(_maxRandomOffset + 1);
@@ -168,40 +187,15 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
       category: LogCategory.video,
     );
 
-    state = const AsyncLoading();
-
-    try {
-      final stats = await client.getClassicVines(
-        limit: _pageSize,
-        offset: _randomOffset,
-      );
-      final videos = stats.toVideoEvents();
-
-      final videoEventService = ref.read(videoEventServiceProvider);
-      final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
-      final filteredVideos = videoEventService.filterVideoList(
-        videos
-            .where((v) => v.isSupportedOnCurrentPlatform)
-            .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
-            .toList(),
-      )..shuffle(_random);
-
-      final nextOffset = _randomOffset + _pageSize;
-      state = AsyncData(
-        VideoFeedState(
-          videos: filteredVideos,
-          hasMoreContent: nextOffset < _totalClassicVines,
-          lastUpdated: DateTime.now(),
-        ),
-      );
-    } catch (e) {
-      Log.error(
-        '🎬 ClassicVinesFeed: Error refreshing (offset $_randomOffset): $e',
-        name: 'ClassicVinesFeedProvider',
-        category: LogCategory.video,
-      );
-      state = AsyncError(e, StackTrace.current);
-    }
+    await staleWhileRevalidate(
+      getCurrentState: () => state,
+      isMounted: () => ref.mounted,
+      setState: (s) => state = s,
+      fetchFresh: () => _loadFirstPage(
+        funnelcakeAvailable: funnelcakeAvailable,
+        preserveCurrentOnEmptyFallback: true,
+      ),
+    );
   }
 
   /// Load more videos (append next sequential page from current offset)

--- a/mobile/lib/providers/classic_vines_provider.g.dart
+++ b/mobile/lib/providers/classic_vines_provider.g.dart
@@ -219,7 +219,7 @@ final class ClassicVinesAvailableProvider
 }
 
 String _$classicVinesAvailableHash() =>
-    r'39ee4ffc7ab9d5494577f0ef017908bc6103f394';
+    r'617a64b91dcb7896bcc986e4a7af0f0db6544825';
 
 /// Provider for top classic Viners derived from classic videos
 ///

--- a/mobile/lib/providers/classic_vines_provider.g.dart
+++ b/mobile/lib/providers/classic_vines_provider.g.dart
@@ -51,7 +51,7 @@ final class ClassicVinesFeedProvider
   ClassicVinesFeed create() => ClassicVinesFeed();
 }
 
-String _$classicVinesFeedHash() => r'dae0e59fd5c1d737a96b612fbae7e0fe532027aa';
+String _$classicVinesFeedHash() => r'31af899ba468acb15c63498bf119caf3426fa295';
 
 /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
 ///

--- a/mobile/lib/widgets/classic_vines_tab.dart
+++ b/mobile/lib/widgets/classic_vines_tab.dart
@@ -12,12 +12,14 @@ import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/classic_vines_provider.dart';
+import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/state/video_feed_state.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/classic_viners_slider.dart';
+import 'package:openvine/widgets/feed_refresh_control.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
 import 'package:rxdart/rxdart.dart';
@@ -64,7 +66,11 @@ class _ClassicVinesTabState extends ConsumerState<ClassicVinesTab> {
 
     // If REST API not available (or still checking), show unavailable state
     if (!isAvailable) {
-      return const _ClassicVinesUnavailableState();
+      return RefreshableFeedStateView(
+        autoRefresh: true,
+        onRefresh: _refreshClassics,
+        child: const _ClassicVinesUnavailableState(),
+      );
     }
 
     // Track feed loading start
@@ -85,7 +91,12 @@ class _ClassicVinesTabState extends ConsumerState<ClassicVinesTab> {
         errorMessage: classicVinesAsync.error.toString(),
       );
       _feedLoadStartTime = null;
-      return _ClassicVinesErrorState(error: classicVinesAsync.error.toString());
+      return RefreshableFeedStateView(
+        onRefresh: _refreshClassics,
+        child: _ClassicVinesErrorState(
+          error: classicVinesAsync.error.toString(),
+        ),
+      );
     }
 
     // Show loading state
@@ -110,7 +121,11 @@ class _ClassicVinesTabState extends ConsumerState<ClassicVinesTab> {
 
     if (videos.isEmpty) {
       _feedTracker?.trackEmptyFeed('classics');
-      return const _ClassicVinesEmptyState();
+      return RefreshableFeedStateView(
+        autoRefresh: true,
+        onRefresh: _refreshClassics,
+        child: const _ClassicVinesEmptyState(),
+      );
     }
 
     return _ClassicVinesContent(
@@ -118,6 +133,14 @@ class _ClassicVinesTabState extends ConsumerState<ClassicVinesTab> {
       isLoadingMore: feedState.isLoadingMore,
       hasMoreContent: feedState.hasMoreContent,
     );
+  }
+
+  Future<void> _refreshClassics() async {
+    ref.read(funnelcakeAvailableProvider.notifier).refresh();
+    await ref.read(funnelcakeAvailableProvider.future);
+    ref.invalidate(classicVinesAvailableProvider);
+    await ref.read(classicVinesAvailableProvider.future);
+    await ref.read(classicVinesFeedProvider.notifier).refresh();
   }
 }
 
@@ -194,20 +217,21 @@ class _ClassicVinesContentState extends ConsumerState<_ClassicVinesContent>
       classicVinesFeedProvider.notifier,
     );
 
-    return RefreshIndicator(
-      color: VineTheme.onPrimary,
-      backgroundColor: VineTheme.vineGreen,
+    return FeedRefreshControl(
+      scrollController: _scrollController,
       onRefresh: () async {
         Log.info(
           '🔄 ClassicVinesTab: Spinning to next batch of classics',
           name: 'ClassicVinesTab',
           category: LogCategory.video,
         );
-        // Only refresh classics feed (roulette to next page)
+        ref.read(funnelcakeAvailableProvider.notifier).refresh();
+        await ref.read(funnelcakeAvailableProvider.future);
         await classicVinesFeedNotifier.refresh();
       },
       child: CustomScrollView(
         controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
         slivers: [
           // Viners slider at top
           const SliverToBoxAdapter(child: ClassicVinersSlider()),

--- a/mobile/lib/widgets/classic_vines_tab.dart
+++ b/mobile/lib/widgets/classic_vines_tab.dart
@@ -55,7 +55,7 @@ class _ClassicVinesTabState extends ConsumerState<ClassicVinesTab> {
   Widget build(BuildContext context) {
     final classicVinesAsync = ref.watch(classicVinesFeedProvider);
     final isAvailableAsync = ref.watch(classicVinesAvailableProvider);
-    final isAvailable = isAvailableAsync.asData?.value ?? false;
+    final isAvailable = isAvailableAsync.asData?.value;
 
     Log.debug(
       '🎬 ClassicVinesTab: AsyncValue state - isLoading: ${classicVinesAsync.isLoading}, '
@@ -64,8 +64,12 @@ class _ClassicVinesTabState extends ConsumerState<ClassicVinesTab> {
       category: LogCategory.video,
     );
 
-    // If REST API not available (or still checking), show unavailable state
-    if (!isAvailable) {
+    if (isAvailableAsync.isLoading) {
+      return const _ClassicVinesLoadingState();
+    }
+
+    // If REST API not available, show unavailable state
+    if (isAvailable != true) {
       return RefreshableFeedStateView(
         autoRefresh: true,
         onRefresh: _refreshClassics,

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -4,7 +4,6 @@
 import 'dart:async';
 
 import 'package:divine_ui/divine_ui.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
@@ -16,6 +15,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/services/content_deletion_service.dart';
 import 'package:openvine/utils/delete_failure_localization.dart';
+import 'package:openvine/widgets/feed_refresh_control.dart';
 import 'package:openvine/widgets/share_video_menu.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
@@ -72,13 +72,7 @@ class ComposableVideoGrid extends ConsumerStatefulWidget {
 
 class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
     with ScrollPaginationMixin {
-  static const double _pointerRefreshTriggerDistance = 80;
-
-  final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey =
-      GlobalKey<RefreshIndicatorState>();
   final ScrollController _scrollController = ScrollController();
-  double _pointerRefreshPullDistance = 0;
-  bool _isPointerRefreshRunning = false;
 
   @override
   ScrollController get paginationScrollController => _scrollController;
@@ -221,61 +215,11 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
       return child;
     }
 
-    return Listener(
-      onPointerSignal: _handlePointerSignal,
-      child: RefreshIndicator(
-        key: _refreshIndicatorKey,
-        semanticsLabel: context.l10n.videoGridRefreshLabel,
-        onRefresh: widget.onRefresh!,
-        displacement: 70,
-        color: VineTheme.onPrimary,
-        backgroundColor: VineTheme.vineGreen,
-        child: child,
-      ),
+    return FeedRefreshControl(
+      onRefresh: widget.onRefresh!,
+      scrollController: _scrollController,
+      child: child,
     );
-  }
-
-  void _handlePointerSignal(PointerSignalEvent event) {
-    if (event is! PointerScrollEvent ||
-        !_scrollController.hasClients ||
-        widget.onRefresh == null) {
-      return;
-    }
-
-    final position = _scrollController.position;
-    final isAtTop = position.pixels <= position.minScrollExtent + 0.5;
-    final isPullingDown = event.scrollDelta.dy < 0;
-
-    if (!isAtTop || !isPullingDown) {
-      _pointerRefreshPullDistance = 0;
-      return;
-    }
-
-    _pointerRefreshPullDistance += -event.scrollDelta.dy;
-    if (_pointerRefreshPullDistance < _pointerRefreshTriggerDistance) {
-      return;
-    }
-
-    _pointerRefreshPullDistance = 0;
-    unawaited(_showRefreshFromPointerSignal());
-  }
-
-  Future<void> _showRefreshFromPointerSignal() async {
-    if (_isPointerRefreshRunning) {
-      return;
-    }
-
-    final refreshIndicator = _refreshIndicatorKey.currentState;
-    if (refreshIndicator == null) {
-      return;
-    }
-
-    _isPointerRefreshRunning = true;
-    try {
-      await refreshIndicator.show();
-    } finally {
-      _isPointerRefreshRunning = false;
-    }
   }
 
   /// Show context menu for long press on video tiles

--- a/mobile/lib/widgets/feed_refresh_control.dart
+++ b/mobile/lib/widgets/feed_refresh_control.dart
@@ -88,6 +88,10 @@ class _FeedRefreshControlState extends State<FeedRefreshControl> {
   }
 
   Future<void> _showRefreshFromPointerSignal() async {
+    await showRefreshIndicator();
+  }
+
+  Future<void> showRefreshIndicator() async {
     if (_isPointerRefreshRunning) {
       return;
     }
@@ -174,6 +178,12 @@ class _RefreshableFeedStateViewState extends State<RefreshableFeedStateView> {
     _autoRefreshStarted = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
+      final refreshControlState = context
+          .findAncestorStateOfType<_FeedRefreshControlState>();
+      if (refreshControlState != null) {
+        unawaited(refreshControlState.showRefreshIndicator());
+        return;
+      }
       unawaited(widget.onRefresh());
     });
   }

--- a/mobile/lib/widgets/feed_refresh_control.dart
+++ b/mobile/lib/widgets/feed_refresh_control.dart
@@ -1,0 +1,180 @@
+// ABOUTME: Shared pull-to-refresh wrappers for feed scroll views and states
+// ABOUTME: Keeps empty/error feed screens refreshable across touch and trackpad
+
+import 'dart:async';
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// Shared refresh wrapper for feed scrollables.
+///
+/// Flutter's [RefreshIndicator] does not handle trackpad pull gestures on
+/// desktop, so this also watches top-edge pointer scroll signals and shows the
+/// same indicator when the user pulls down far enough.
+class FeedRefreshControl extends StatefulWidget {
+  const FeedRefreshControl({
+    required this.child,
+    required this.onRefresh,
+    super.key,
+    this.scrollController,
+    this.semanticsLabel,
+    this.displacement = 70,
+  });
+
+  final Widget child;
+  final Future<void> Function() onRefresh;
+  final ScrollController? scrollController;
+  final String? semanticsLabel;
+  final double displacement;
+
+  @override
+  State<FeedRefreshControl> createState() => _FeedRefreshControlState();
+}
+
+class _FeedRefreshControlState extends State<FeedRefreshControl> {
+  static const double _pointerRefreshTriggerDistance = 80;
+
+  final GlobalKey<RefreshIndicatorState> _refreshIndicatorKey =
+      GlobalKey<RefreshIndicatorState>();
+  double _pointerRefreshPullDistance = 0;
+  bool _isPointerRefreshRunning = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerSignal: _handlePointerSignal,
+      child: RefreshIndicator(
+        key: _refreshIndicatorKey,
+        semanticsLabel:
+            widget.semanticsLabel ?? context.l10n.videoGridRefreshLabel,
+        onRefresh: widget.onRefresh,
+        displacement: widget.displacement,
+        color: VineTheme.onPrimary,
+        backgroundColor: VineTheme.vineGreen,
+        child: widget.child,
+      ),
+    );
+  }
+
+  void _handlePointerSignal(PointerSignalEvent event) {
+    if (event is! PointerScrollEvent) {
+      return;
+    }
+
+    final position = widget.scrollController?.hasClients == true
+        ? widget.scrollController!.position
+        : Scrollable.maybeOf(context)?.position;
+    if (position == null) {
+      return;
+    }
+
+    final isAtTop = position.pixels <= position.minScrollExtent + 0.5;
+    final isPullingDown = event.scrollDelta.dy < 0;
+
+    if (!isAtTop || !isPullingDown) {
+      _pointerRefreshPullDistance = 0;
+      return;
+    }
+
+    _pointerRefreshPullDistance += -event.scrollDelta.dy;
+    if (_pointerRefreshPullDistance < _pointerRefreshTriggerDistance) {
+      return;
+    }
+
+    _pointerRefreshPullDistance = 0;
+    unawaited(_showRefreshFromPointerSignal());
+  }
+
+  Future<void> _showRefreshFromPointerSignal() async {
+    if (_isPointerRefreshRunning) {
+      return;
+    }
+
+    final refreshIndicator = _refreshIndicatorKey.currentState;
+    if (refreshIndicator == null) {
+      return;
+    }
+
+    _isPointerRefreshRunning = true;
+    try {
+      await refreshIndicator.show();
+    } finally {
+      _isPointerRefreshRunning = false;
+    }
+  }
+}
+
+/// Refreshable full-height state view for feed empty/error/unavailable states.
+class RefreshableFeedStateView extends StatefulWidget {
+  const RefreshableFeedStateView({
+    required this.child,
+    required this.onRefresh,
+    super.key,
+    this.autoRefresh = false,
+  });
+
+  final Widget child;
+  final Future<void> Function() onRefresh;
+
+  /// Runs [onRefresh] once after the state first appears.
+  ///
+  /// This is useful for feeds where an empty state often means a transient
+  /// network/server miss rather than a truly terminal result.
+  final bool autoRefresh;
+
+  @override
+  State<RefreshableFeedStateView> createState() =>
+      _RefreshableFeedStateViewState();
+}
+
+class _RefreshableFeedStateViewState extends State<RefreshableFeedStateView> {
+  final ScrollController _scrollController = ScrollController();
+  bool _autoRefreshStarted = false;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _scheduleAutoRefreshIfNeeded();
+  }
+
+  @override
+  void didUpdateWidget(covariant RefreshableFeedStateView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _scheduleAutoRefreshIfNeeded();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FeedRefreshControl(
+      onRefresh: widget.onRefresh,
+      scrollController: _scrollController,
+      child: CustomScrollView(
+        controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          SliverFillRemaining(hasScrollBody: false, child: widget.child),
+        ],
+      ),
+    );
+  }
+
+  void _scheduleAutoRefreshIfNeeded() {
+    if (!widget.autoRefresh || _autoRefreshStarted) {
+      return;
+    }
+
+    _autoRefreshStarted = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(widget.onRefresh());
+    });
+  }
+}

--- a/mobile/lib/widgets/for_you_tab.dart
+++ b/mobile/lib/widgets/for_you_tab.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/for_you_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
@@ -16,6 +17,7 @@ import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/state/video_feed_state.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
+import 'package:openvine/widgets/feed_refresh_control.dart';
 import 'package:openvine/widgets/scroll_to_hide_mixin.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -61,7 +63,11 @@ class _ForYouTabState extends ConsumerState<ForYouTab> {
 
     // If not available, show unavailable state
     if (!isAvailable) {
-      return const _ForYouUnavailableState();
+      return RefreshableFeedStateView(
+        autoRefresh: true,
+        onRefresh: _refreshForYou,
+        child: const _ForYouUnavailableState(),
+      );
     }
 
     // Track feed loading start
@@ -82,7 +88,10 @@ class _ForYouTabState extends ConsumerState<ForYouTab> {
         errorMessage: forYouAsync.error.toString(),
       );
       _feedLoadStartTime = null;
-      return _ForYouErrorState(error: forYouAsync.error.toString());
+      return RefreshableFeedStateView(
+        onRefresh: _refreshForYou,
+        child: _ForYouErrorState(error: forYouAsync.error.toString()),
+      );
     }
 
     // Show loading state
@@ -107,7 +116,6 @@ class _ForYouTabState extends ConsumerState<ForYouTab> {
 
     if (videos.isEmpty) {
       _feedTracker?.trackEmptyFeed('for_you');
-      return const _ForYouEmptyState();
     }
 
     return _ForYouContent(
@@ -115,6 +123,12 @@ class _ForYouTabState extends ConsumerState<ForYouTab> {
       isLoadingMore: feedState.isLoadingMore,
       hasMoreContent: feedState.hasMoreContent,
     );
+  }
+
+  Future<void> _refreshForYou() async {
+    ref.read(funnelcakeAvailableProvider.notifier).refresh();
+    await ref.read(funnelcakeAvailableProvider.future);
+    await ref.read(forYouFeedProvider.notifier).refresh();
   }
 }
 

--- a/mobile/lib/widgets/new_videos_tab.dart
+++ b/mobile/lib/widgets/new_videos_tab.dart
@@ -18,6 +18,7 @@ import 'package:openvine/services/screen_analytics_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
+import 'package:openvine/widgets/feed_refresh_control.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -120,12 +121,20 @@ class _NewVideosTabState extends ConsumerState<NewVideosTab> {
 
     if (newVideosAsync.hasError) {
       _trackErrorState(newVideosAsync.error);
-      return _NewVideosErrorState(error: newVideosAsync.error);
+      return RefreshableFeedStateView(
+        onRefresh: _refreshNewVideos,
+        child: _NewVideosErrorState(error: newVideosAsync.error),
+      );
     }
 
     // Only show loading if we truly have no data yet
     _trackLoadingState();
     return const _NewVideosLoadingState();
+  }
+
+  Future<void> _refreshNewVideos() async {
+    ref.invalidate(newVideosFeedProvider);
+    await ref.read(newVideosFeedProvider.future);
   }
 
   void _trackLoadingState() {

--- a/mobile/lib/widgets/popular_videos_tab.dart
+++ b/mobile/lib/widgets/popular_videos_tab.dart
@@ -18,6 +18,7 @@ import 'package:openvine/services/top_hashtags_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
+import 'package:openvine/widgets/feed_refresh_control.dart';
 import 'package:openvine/widgets/scroll_to_hide_mixin.dart';
 import 'package:openvine/widgets/trending_hashtags_section.dart';
 import 'package:rxdart/rxdart.dart';
@@ -89,12 +90,19 @@ class _PopularVideosTabState extends ConsumerState<PopularVideosTab> {
 
     if (feedAsync.hasError) {
       _trackErrorState(feedAsync.error);
-      return const _PopularVideosErrorState();
+      return RefreshableFeedStateView(
+        onRefresh: _refreshPopularVideos,
+        child: const _PopularVideosErrorState(),
+      );
     }
 
     // Only show loading if we truly have no data yet
     _trackLoadingState();
     return const _PopularVideosLoadingState();
+  }
+
+  Future<void> _refreshPopularVideos() async {
+    await ref.read(popularVideosFeedProvider.notifier).refresh();
   }
 
   Widget _buildDataState(List<VideoEvent> videos) {

--- a/mobile/test/providers/classic_vines_refresh_test.dart
+++ b/mobile/test/providers/classic_vines_refresh_test.dart
@@ -1,0 +1,173 @@
+// ABOUTME: Tests ClassicVines refresh recovery after transient API failures
+// ABOUTME: Verifies refresh does not strand the feed without existing data
+
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/classic_vines_provider.dart';
+import 'package:openvine/providers/curation_providers.dart';
+import 'package:openvine/providers/readiness_gate_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:riverpod/riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
+
+class _TestFunnelcakeAvailable extends FunnelcakeAvailable {
+  @override
+  Future<bool> build() async => true;
+}
+
+void main() {
+  group(ClassicVinesFeed, () {
+    late _MockFunnelcakeApiClient mockFunnelcakeClient;
+    late _MockVideoEventService mockVideoEventService;
+    late _MockContentBlocklistRepository mockBlocklistRepository;
+    late SharedPreferences sharedPreferences;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      sharedPreferences = await SharedPreferences.getInstance();
+
+      mockFunnelcakeClient = _MockFunnelcakeApiClient();
+      mockVideoEventService = _MockVideoEventService();
+      mockBlocklistRepository = _MockContentBlocklistRepository();
+
+      when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+      when(() => mockVideoEventService.discoveryVideos).thenReturn(const []);
+      when(
+        () => mockVideoEventService.filterVideoList(any()),
+      ).thenAnswer((invocation) {
+        return invocation.positionalArguments.first as List<VideoEvent>;
+      });
+      when(
+        () => mockBlocklistRepository.shouldFilterFromFeeds(any()),
+      ).thenReturn(false);
+    });
+
+    ProviderContainer createContainer() {
+      return ProviderContainer(
+        overrides: [
+          appReadyProvider.overrideWithValue(true),
+          sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+          funnelcakeApiClientProvider.overrideWithValue(mockFunnelcakeClient),
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          contentBlocklistRepositoryProvider.overrideWithValue(
+            mockBlocklistRepository,
+          ),
+          funnelcakeAvailableProvider.overrideWith(
+            _TestFunnelcakeAvailable.new,
+          ),
+        ],
+      );
+    }
+
+    test(
+      'preserves existing videos with an error when refresh API fails',
+      () async {
+        var calls = 0;
+        when(
+          () => mockFunnelcakeClient.getClassicVines(
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+          ),
+        ).thenAnswer((_) async {
+          calls++;
+          if (calls == 1) {
+            return [_videoStats('classic-initial')];
+          }
+          throw Exception('server unavailable');
+        });
+
+        final container = createContainer();
+        addTearDown(container.dispose);
+
+        await container.read(funnelcakeAvailableProvider.future);
+        final initialState = await container.read(
+          classicVinesFeedProvider.future,
+        );
+        expect(initialState.videos.map((video) => video.id), [
+          'classic-initial',
+        ]);
+
+        await container.read(classicVinesFeedProvider.notifier).refresh();
+
+        final asyncState = container.read(classicVinesFeedProvider);
+        expect(asyncState.hasError, isFalse);
+
+        final refreshedState = asyncState.value!;
+        expect(refreshedState.videos.map((video) => video.id), [
+          'classic-initial',
+        ]);
+        expect(refreshedState.isRefreshing, isFalse);
+        expect(refreshedState.error, contains('server unavailable'));
+      },
+    );
+
+    test(
+      'preserves existing videos when refresh API returns an empty page',
+      () async {
+        var calls = 0;
+        when(
+          () => mockFunnelcakeClient.getClassicVines(
+            limit: any(named: 'limit'),
+            offset: any(named: 'offset'),
+          ),
+        ).thenAnswer((_) async {
+          calls++;
+          if (calls == 1) {
+            return [_videoStats('classic-initial')];
+          }
+          return const [];
+        });
+
+        final container = createContainer();
+        addTearDown(container.dispose);
+
+        await container.read(funnelcakeAvailableProvider.future);
+        final initialState = await container.read(
+          classicVinesFeedProvider.future,
+        );
+        expect(initialState.videos.map((video) => video.id), [
+          'classic-initial',
+        ]);
+
+        await container.read(classicVinesFeedProvider.notifier).refresh();
+
+        final refreshedState = container.read(classicVinesFeedProvider).value!;
+        expect(refreshedState.videos.map((video) => video.id), [
+          'classic-initial',
+        ]);
+        expect(refreshedState.isRefreshing, isFalse);
+        expect(refreshedState.error, contains('returned no videos'));
+      },
+    );
+  });
+}
+
+VideoStats _videoStats(String id) {
+  return VideoStats(
+    id: id,
+    pubkey: 'author-$id',
+    createdAt: DateTime(2026, 3, 17),
+    kind: 34236,
+    dTag: id,
+    title: id,
+    thumbnail: 'https://example.com/$id.jpg',
+    videoUrl: 'https://example.com/$id.mp4',
+    reactions: 0,
+    comments: 0,
+    reposts: 0,
+    engagementScore: 0,
+    loops: 100,
+  );
+}

--- a/mobile/test/providers/classic_vines_refresh_test.dart
+++ b/mobile/test/providers/classic_vines_refresh_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests ClassicVines refresh recovery after transient API failures
 // ABOUTME: Verifies refresh does not strand the feed without existing data
 
+import 'dart:async';
+
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
@@ -25,6 +27,13 @@ class _MockContentBlocklistRepository extends Mock
 class _TestFunnelcakeAvailable extends FunnelcakeAvailable {
   @override
   Future<bool> build() async => true;
+}
+
+Completer<bool>? _loadingAvailabilityCompleter;
+
+class _LoadingFunnelcakeAvailable extends FunnelcakeAvailable {
+  @override
+  Future<bool> build() async => _loadingAvailabilityCompleter!.future;
 }
 
 void main() {
@@ -151,6 +160,24 @@ void main() {
         expect(refreshedState.error, contains('returned no videos'));
       },
     );
+
+    test('stays loading while funnelcake availability is still resolving', () {
+      _loadingAvailabilityCompleter = Completer<bool>();
+
+      final container = ProviderContainer(
+        overrides: [
+          funnelcakeAvailableProvider.overrideWith(
+            _LoadingFunnelcakeAvailable.new,
+          ),
+        ],
+      );
+      addTearDown(() {
+        _loadingAvailabilityCompleter = null;
+        container.dispose();
+      });
+
+      expect(container.read(classicVinesAvailableProvider).isLoading, isTrue);
+    });
   });
 }
 

--- a/mobile/test/widgets/feed_refresh_control_test.dart
+++ b/mobile/test/widgets/feed_refresh_control_test.dart
@@ -1,0 +1,108 @@
+// ABOUTME: Tests reusable feed pull-to-refresh wrappers for empty/error states
+// ABOUTME: Verifies feed refresh remains available without scrollable content
+
+import 'dart:ui' show PointerDeviceKind;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/feed_refresh_control.dart';
+
+void main() {
+  Widget buildSubject(Widget child) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(body: child),
+    );
+  }
+
+  group(RefreshableFeedStateView, () {
+    testWidgets('keeps standalone feed state refreshable', (tester) async {
+      var refreshCount = 0;
+
+      await tester.pumpWidget(
+        buildSubject(
+          RefreshableFeedStateView(
+            onRefresh: () async {
+              refreshCount++;
+            },
+            child: const Text('No videos available'),
+          ),
+        ),
+      );
+
+      expect(find.text('No videos available'), findsOneWidget);
+      expect(find.byType(RefreshIndicator), findsOneWidget);
+      expect(find.byType(Scrollable), findsOneWidget);
+
+      final refreshIndicator = tester.widget<RefreshIndicator>(
+        find.byType(RefreshIndicator),
+      );
+      await refreshIndicator.onRefresh();
+
+      expect(refreshCount, 1);
+    });
+
+    testWidgets('refreshes from top-edge pointer scroll down', (tester) async {
+      var refreshCount = 0;
+
+      await tester.pumpWidget(
+        buildSubject(
+          RefreshableFeedStateView(
+            onRefresh: () async {
+              refreshCount++;
+            },
+            child: const Text('No videos available'),
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      final pointer = TestPointer(1, PointerDeviceKind.trackpad);
+      pointer.hover(tester.getCenter(find.byType(Scrollable)));
+
+      await tester.sendEventToBinding(pointer.scroll(const Offset(0, -120)));
+      await tester.pumpAndSettle();
+
+      expect(refreshCount, 1);
+    });
+
+    testWidgets('can run one automatic empty-state refresh', (tester) async {
+      var refreshCount = 0;
+
+      await tester.pumpWidget(
+        buildSubject(
+          RefreshableFeedStateView(
+            autoRefresh: true,
+            onRefresh: () async {
+              refreshCount++;
+            },
+            child: const Text('No videos available'),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump();
+
+      expect(refreshCount, 1);
+
+      await tester.pumpWidget(
+        buildSubject(
+          RefreshableFeedStateView(
+            autoRefresh: true,
+            onRefresh: () async {
+              refreshCount++;
+            },
+            child: const Text('No videos available'),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(refreshCount, 1);
+    });
+  });
+}


### PR DESCRIPTION
Closes #3702

## Summary
- add a shared feed refresh wrapper for scrollable feeds and standalone empty/error states
- make Classics empty/unavailable/error states pull-refreshable and auto-recheck once when empty
- keep existing Classics videos when refresh fails or the API returns an empty page
- wire stranded error/unavailable states for New, Popular, and For You through the shared refresh view

## Verification
- flutter test test/widgets/feed_refresh_control_test.dart test/widgets/composable_video_grid_test.dart test/providers/feed_refresh_helpers_test.dart test/providers/classic_vines_refresh_test.dart test/providers/feed_background_preservation_test.dart test/providers/explore_feed_refresh_retention_test.dart
- flutter analyze lib/widgets/feed_refresh_control.dart lib/widgets/composable_video_grid.dart lib/widgets/classic_vines_tab.dart lib/widgets/new_videos_tab.dart lib/widgets/popular_videos_tab.dart lib/widgets/for_you_tab.dart lib/providers/classic_vines_provider.dart test/widgets/feed_refresh_control_test.dart test/providers/classic_vines_refresh_test.dart
- pre-commit hook: format, analyze, generated-file verification
- pre-push hook: generated-file verification and changed-file tests