### PR TITLE
chore(release): bump app version to 1.0.10

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.9+498
+version: 1.0.10+499
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
## Summary
- bump app version from  to 
- unblock App Store Connect uploads after the  train was closed for new submissions

## Context
App Store Connect rejected the previous upload because:
- pre-release train  is closed for new build submissions
-  must be higher than the previously approved 

This PR exists only to move the build to a new version train on  so the next iOS upload can succeed.