### PR TITLE
docs: add README for blurhash_service 

### DIFF
--- a/mobile/packages/blurhash_service/README.md
+++ b/mobile/packages/blurhash_service/README.md
@@ -1,0 +1,25 @@
+# blurhash_service
+
+Status: Current
+Validated against: `pubspec.yaml` on 2026-04-30.
+
+Purpose: blurhash generation and decoding for video thumbnail placeholders. Provides `BlurhashService`, `BlurhashData`, and `BlurhashCache`.
+
+Used by: the Flutter app to display progressive loading placeholders while video thumbnails are fetched.
+
+## Behaviour
+
+- Encoding runs in a background isolate via `compute` to keep the UI thread free.
+- Component counts are chosen by aspect ratio: `4×7` for 9:16 portrait, `4×4` for 1:1 square.
+- Decoding returns a `BlurhashData` object with pixel data, representative colours, and a gradient fallback.
+
+## Legacy hash compatibility
+
+Blurhashes stored in Nostr events published before PR #3684 were encoded with a 4:3 component ratio. They still render acceptably — colours are representative — but fine detail will not align with 9:16 content. This is an expected tradeoff for pre-existing events; no backfill was performed. New uploads generate hashes at the correct 9:16 dimensions.
+
+## Test locally
+
+```bash
+cd mobile/packages/blurhash_service
+flutter test
+```

--- a/mobile/packages/blurhash_service/README.md
+++ b/mobile/packages/blurhash_service/README.md
@@ -3,19 +3,20 @@
 Status: Current
 Validated against: `pubspec.yaml` on 2026-04-30.
 
-Purpose: blurhash generation and decoding for video thumbnail placeholders. Provides `BlurhashService`, `BlurhashData`, and `BlurhashCache`.
+Purpose: blurhash generation and decoding for video thumbnail placeholders. Provides `BlurhashService`, `BlurhashData`, `BlurhashCache`, `BlurhashException`, and the `VineContentType` enum consumed by `getBlurhashForContentType`.
 
 Used by: the Flutter app to display progressive loading placeholders while video thumbnails are fetched.
 
 ## Behaviour
 
-- Encoding runs in a background isolate via `compute` to keep the UI thread free.
-- Component counts are chosen by aspect ratio: `4×7` for 9:16 portrait, `4×4` for 1:1 square.
+- Encoding runs in a background isolate via `compute` to keep the UI thread free. (`generateBlurhashFromImage` performs the PNG conversion on the caller's thread before delegating — keep it off the UI path for large images.)
+- Component counts are chosen by aspect ratio: `4×7` for portrait (ratio < 0.9), `4×4` for square or landscape (ratio ≥ 0.9).
 - Decoding returns a `BlurhashData` object with pixel data, representative colours, and a gradient fallback.
+- `BlurhashCache` provides a bounded in-memory cache of decoded blurhash data with expiry-based eviction.
 
 ## Legacy hash compatibility
 
-Blurhashes stored in Nostr events published before PR #3684 were encoded with a 4:3 component ratio. They still render acceptably — colours are representative — but fine detail will not align with 9:16 content. This is an expected tradeoff for pre-existing events; no backfill was performed. New uploads generate hashes at the correct 9:16 dimensions.
+Blurhashes stored in Nostr events published before PR #3684 were encoded with `4×3` components (the previous defaults), regardless of the source aspect ratio. They still render acceptably — colours are representative — but fine detail will not align with 9:16 content. This is an expected tradeoff for pre-existing events; no backfill was performed. New uploads generate hashes at the correct 9:16 dimensions.
 
 ## Test locally
 


### PR DESCRIPTION

## Description

Adds a README for `blurhash_service` and documents the legacy 4:3 blurhash compatibility caveat introduced by #3684.


**Related Issue:** Closes #3717

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore