### PR TITLE
test(blurhash): cover thrown-exception fallback path in BlurhashService

### DIFF
--- a/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
+++ b/mobile/packages/blurhash_service/test/src/blurhash_service_test.dart
@@ -133,6 +133,16 @@ void main() {
       });
     });
 
+    group('generateBlurhash fallback behavior', () {
+      test('returns null when encoding throws an exception', () async {
+        // Empty bytes cause `img.decodeImage` to throw a RangeError rather
+        // than return null, which exercises the broad `on Object catch`
+        // branch in `BlurhashService.generateBlurhash`.
+        final hash = await BlurhashService.generateBlurhash(Uint8List(0));
+        expect(hash, isNull);
+      });
+    });
+
     group('getBlurhashForContentType', () {
       test('returns unique blurhash for each content type', () {
         final results = <VineContentType, String>{};


### PR DESCRIPTION


## Description

Adds a regression test that exercises the broad `on Object catch` branch in `BlurhashService.generateBlurhash`. Previously the only failure-path test (`'returns null for invalid image bytes'` with `[0, 1, 2, 3]`) hit the `if (image == null) return null` early-return inside the isolate worker, leaving the outer try/catch uncovered.

The new test passes `Uint8List(0)`, which causes `img.decodeImage` to throw a `RangeError` instead of returning `null`. This propagates out of the `compute()` call and is caught by `generateBlurhash`'s catch block — verified via lcov (lines 79/80/84/85 went from `0` to `1`).


**Related Issue:** Closes #3716

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore