### PR TITLE
test(video-editor): cover sticker export round-trip

### DIFF
--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1060,15 +1060,8 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
             initStateHistory: editorStateHistory.isNotEmpty
                 ? .fromMap(
                     editorStateHistory,
-                    configs: ImportEditorConfigs(
-                      widgetLoader: (id, {meta}) {
-                        if (meta == null) return const SizedBox.shrink();
-
-                        return VideoEditorSticker(
-                          sticker: .fromJson(meta),
-                          enableLimitCacheSize: false,
-                        );
-                      },
+                    configs: const ImportEditorConfigs(
+                      widgetLoader: videoEditorStickerWidgetLoader,
                     ),
                   )
                 : null,

--- a/mobile/lib/widgets/video_editor/sticker_editor/video_editor_sticker.dart
+++ b/mobile/lib/widgets/video_editor/sticker_editor/video_editor_sticker.dart
@@ -7,6 +7,25 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:models/models.dart' show StickerData;
 import 'package:openvine/widgets/vine_cached_image.dart';
 
+/// Rehydrates a [VideoEditorSticker] from a serialized
+/// [StickerData] map produced during state-history export.
+///
+/// Used as the `widgetLoader` for `ImportStateHistory.fromMap` and
+/// `WidgetLayer.fromMap` so sticker layers survive the editor's
+/// export/reopen round-trip. Returns an empty box when [meta] is
+/// `null` (legacy widget layers without sticker metadata).
+Widget videoEditorStickerWidgetLoader(
+  String id, {
+  Map<String, dynamic>? meta,
+}) {
+  if (meta == null) return const SizedBox.shrink();
+
+  return VideoEditorSticker(
+    sticker: StickerData.fromJson(meta),
+    enableLimitCacheSize: false,
+  );
+}
+
 /// A sticker widget that displays an image from either an asset or URL.
 ///
 /// Local asset stickers are rendered as SVGs using [SvgPicture.asset].

--- a/mobile/test/widgets/video_editor/sticker_editor/video_editor_sticker_export_roundtrip_test.dart
+++ b/mobile/test/widgets/video_editor/sticker_editor/video_editor_sticker_export_roundtrip_test.dart
@@ -1,0 +1,205 @@
+// ABOUTME: Regression coverage for the sticker export round-trip
+// ABOUTME: shipped in PR #3666. Builds a [WidgetLayer] the way
+// ABOUTME: VideoEditorScreen._addStickers does, exports it through the same
+// ABOUTME: state-history map shape that pro_image_editor's ExportStateHistory
+// ABOUTME: produces, then re-imports it through ImportStateHistory.fromMap
+// ABOUTME: with the production widgetLoader — the exact path
+// ABOUTME: VideoEditorCanvas wires into ProImageEditorConfigs.stateHistory.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' show StickerData, StickerPackData;
+import 'package:openvine/widgets/video_editor/sticker_editor/video_editor_sticker.dart';
+import 'package:pro_image_editor/pro_image_editor.dart'
+    show
+        ImportEditorConfigs,
+        ImportStateHistory,
+        WidgetLayer,
+        WidgetLayerExportConfigs;
+
+void main() {
+  group('sticker export round-trip', () {
+    /// Mirrors how `VideoEditorScreen._addStickers` builds the layer that
+    /// the editor later serializes via `editor.exportStateHistory()`.
+    WidgetLayer buildAddedStickerLayer(
+      StickerData sticker, {
+      Offset offset = Offset.zero,
+      double rotation = 0,
+      double scale = 1,
+    }) {
+      return WidgetLayer(
+        width: 120,
+        widget: VideoEditorSticker(
+          sticker: sticker,
+          enableLimitCacheSize: false,
+        ),
+        meta: sticker.toJson(),
+        exportConfigs: WidgetLayerExportConfigs(
+          id: 'sticker-${sticker.description}',
+          meta: sticker.toJson(),
+        ),
+        offset: offset,
+        rotation: rotation,
+        scale: scale,
+      );
+    }
+
+    /// Wraps a layer map in the same shape `ExportStateHistory.toMap`
+    /// produces. This is the JSON we save into
+    /// `DivineVideoDraft.editorStateHistory` after the user adds a sticker
+    /// and the editor exports its history.
+    Map<String, dynamic> exportedHistoryFor(WidgetLayer layer) {
+      return {
+        'position': 0,
+        'history': [
+          {
+            'layers': [layer.toMap()],
+          },
+        ],
+      };
+    }
+
+    /// Re-imports the exported history through the same factory that
+    /// `VideoEditorCanvas` passes to
+    /// `ProImageEditorConfigs.stateHistory.initStateHistory`, using the
+    /// production sticker `widgetLoader`. Returns the rebuilt layers from
+    /// the first history entry.
+    List<Object?> reopenLayers(Map<String, dynamic> exportedHistory) {
+      final imported = ImportStateHistory.fromMap(
+        exportedHistory,
+        configs: const ImportEditorConfigs(
+          widgetLoader: videoEditorStickerWidgetLoader,
+        ),
+      );
+      expect(imported.stateHistory, hasLength(1));
+      return imported.stateHistory.first.layers;
+    }
+
+    test(
+      'network sticker added → exported → reopened as VideoEditorSticker',
+      () {
+        const sticker = StickerData.network(
+          'https://stickers.example.com/heart.png',
+          description: 'Red heart',
+          tags: ['heart', 'love'],
+          packData: StickerPackData(
+            packId: 'reactions',
+            packName: 'Reactions',
+          ),
+        );
+
+        final layers = reopenLayers(
+          exportedHistoryFor(buildAddedStickerLayer(sticker)),
+        );
+
+        expect(layers, hasLength(1));
+        final restored = layers.single;
+        expect(restored, isA<WidgetLayer>());
+        final widgetLayer = restored! as WidgetLayer;
+        expect(widgetLayer.exportConfigs.id, equals('sticker-Red heart'));
+        expect(widgetLayer.exportConfigs.meta, equals(sticker.toJson()));
+
+        expect(widgetLayer.widget, isA<VideoEditorSticker>());
+        expect(
+          (widgetLayer.widget as VideoEditorSticker).sticker.props,
+          equals(sticker.props),
+        );
+      },
+    );
+
+    test('asset sticker added → exported → reopened as VideoEditorSticker', () {
+      const sticker = StickerData.asset(
+        'assets/stickers/star.svg',
+        description: 'Gold star',
+        tags: ['star', 'rating'],
+        packData: StickerPackData.fallback,
+      );
+
+      final layers = reopenLayers(
+        exportedHistoryFor(buildAddedStickerLayer(sticker)),
+      );
+
+      expect(layers, hasLength(1));
+      final widgetLayer = layers.single! as WidgetLayer;
+      expect(widgetLayer.widget, isA<VideoEditorSticker>());
+      expect(
+        (widgetLayer.widget as VideoEditorSticker).sticker.props,
+        equals(sticker.props),
+      );
+    });
+
+    test(
+      'transform fields (offset, rotation, scale, width) survive the '
+      'round-trip',
+      () {
+        const sticker = StickerData.asset(
+          'assets/stickers/smile.svg',
+          description: 'Smile',
+          tags: ['smile'],
+          packData: StickerPackData.fallback,
+        );
+
+        final layers = reopenLayers(
+          exportedHistoryFor(
+            buildAddedStickerLayer(
+              sticker,
+              offset: const Offset(42, 84),
+              rotation: 1.25,
+              scale: 1.75,
+            ),
+          ),
+        );
+
+        final widgetLayer = layers.single! as WidgetLayer;
+        expect(widgetLayer.offset, equals(const Offset(42, 84)));
+        expect(widgetLayer.rotation, closeTo(1.25, 1e-6));
+        expect(widgetLayer.scale, closeTo(1.75, 1e-6));
+        expect(widgetLayer.width, equals(120));
+      },
+    );
+
+    test(
+      'legacy drafts that serialized stickers as type:"sticker" still '
+      'rehydrate via the production widgetLoader',
+      () {
+        const sticker = StickerData.asset(
+          'assets/stickers/legacy.svg',
+          description: 'Legacy sticker',
+          tags: ['legacy'],
+          packData: StickerPackData.fallback,
+        );
+
+        final layerMap = buildAddedStickerLayer(sticker).toMap()
+          ..['type'] = 'sticker';
+        final exported = {
+          'position': 0,
+          'history': [
+            {
+              'layers': [layerMap],
+            },
+          ],
+        };
+
+        final layers = reopenLayers(exported);
+
+        expect(layers.single, isA<WidgetLayer>());
+        expect(
+          ((layers.single! as WidgetLayer).widget as VideoEditorSticker)
+              .sticker
+              .props,
+          equals(sticker.props),
+        );
+      },
+    );
+
+    test(
+      'widgetLoader returns SizedBox.shrink when meta is missing '
+      '(legacy widget layers without sticker payload)',
+      () {
+        final widget = videoEditorStickerWidgetLoader('any-id');
+
+        expect(widget, isA<SizedBox>());
+      },
+    );
+  });
+}


### PR DESCRIPTION
 
## Description

Follow-up to #3666. Adds regression coverage for the full sticker export/import cycle that was shipped but not tested.

The main behaviour verified: a sticker added to the video editor survives the exportStateHistory → ImportStateHistory.fromMap round-trip and is correctly rehydrated as a VideoEditorSticker widget with the original StickerData intact.

**Related Issue:** Closes #3718

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore