### PR TITLE
fix(video-info-sheet): guard VideoRepostersCubit emit after close

### DIFF
--- a/mobile/lib/widgets/video_feed_item/metadata/video_reposters_cubit.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/video_reposters_cubit.dart
@@ -39,13 +39,16 @@ class VideoRepostersCubit extends Cubit<VideoRepostersState> {
 
   Future<void> _fetch() async {
     if (_videoId.isEmpty) {
+      if (isClosed) return;
       emit(const VideoRepostersState(isLoading: false));
       return;
     }
     try {
       final pubkeys = await _videoEventService.getRepostersForVideo(_videoId);
+      if (isClosed) return;
       emit(VideoRepostersState(pubkeys: pubkeys, isLoading: false));
     } catch (e, stackTrace) {
+      if (isClosed) return;
       addError(e, stackTrace);
       emit(const VideoRepostersState(isLoading: false));
     }

--- a/mobile/test/widgets/video_feed_item/metadata/video_reposters_cubit_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/video_reposters_cubit_test.dart
@@ -1,0 +1,121 @@
+// ABOUTME: Unit tests for VideoRepostersCubit.
+// ABOUTME: Pins the success/error paths and the close-during-fetch race
+// ABOUTME: that previously surfaced as a Crashlytics 'emit after close'.
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/widgets/video_feed_item/metadata/video_reposters_cubit.dart';
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+void main() {
+  group(VideoRepostersCubit, () {
+    late _MockVideoEventService service;
+
+    setUp(() {
+      service = _MockVideoEventService();
+    });
+
+    blocTest<VideoRepostersCubit, VideoRepostersState>(
+      'emits success state when fetch resolves before close',
+      setUp: () {
+        when(
+          () => service.getRepostersForVideo('video-id'),
+        ).thenAnswer((_) async => ['pubkey-a', 'pubkey-b']);
+      },
+      build: () => VideoRepostersCubit(
+        videoEventService: service,
+        videoId: 'video-id',
+      ),
+      expect: () => const [
+        VideoRepostersState(
+          pubkeys: ['pubkey-a', 'pubkey-b'],
+          isLoading: false,
+        ),
+      ],
+    );
+
+    test('moves to loading=false when videoId is empty', () async {
+      final cubit = VideoRepostersCubit(
+        videoEventService: service,
+        videoId: '',
+      );
+      // The empty-id branch emits synchronously inside the constructor,
+      // so a direct state check is the right shape — blocTest's stream
+      // listener attaches too late to observe it.
+      expect(cubit.state, equals(const VideoRepostersState(isLoading: false)));
+      verifyNever(() => service.getRepostersForVideo(any()));
+      await cubit.close();
+    });
+
+    blocTest<VideoRepostersCubit, VideoRepostersState>(
+      'emits loading=false and reports addError on relay failure',
+      setUp: () {
+        when(
+          () => service.getRepostersForVideo('video-id'),
+        ).thenAnswer((_) async => throw StateError('relay unavailable'));
+      },
+      build: () => VideoRepostersCubit(
+        videoEventService: service,
+        videoId: 'video-id',
+      ),
+      expect: () => const [VideoRepostersState(isLoading: false)],
+      errors: () => [isA<StateError>()],
+    );
+
+    test(
+      'does not emit (or throw) when closed before in-flight fetch resolves '
+      '— regression for #3734 emit-after-close race',
+      () async {
+        final completer = Completer<List<String>>();
+        when(
+          () => service.getRepostersForVideo('video-id'),
+        ).thenAnswer((_) => completer.future);
+
+        final cubit = VideoRepostersCubit(
+          videoEventService: service,
+          videoId: 'video-id',
+        );
+
+        final emissions = <VideoRepostersState>[];
+        final subscription = cubit.stream.listen(emissions.add);
+
+        await cubit.close();
+        completer.complete(['pubkey-late']);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emissions, isEmpty);
+        await subscription.cancel();
+      },
+    );
+
+    test(
+      'does not emit (or addError) when closed before in-flight fetch errors',
+      () async {
+        final completer = Completer<List<String>>();
+        when(
+          () => service.getRepostersForVideo('video-id'),
+        ).thenAnswer((_) => completer.future);
+
+        final cubit = VideoRepostersCubit(
+          videoEventService: service,
+          videoId: 'video-id',
+        );
+
+        final emissions = <VideoRepostersState>[];
+        final subscription = cubit.stream.listen(emissions.add);
+
+        await cubit.close();
+        completer.completeError(StateError('relay timeout'));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emissions, isEmpty);
+        await subscription.cancel();
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

`VideoRepostersCubit._fetch` awaits a 5-second relay query from its constructor, then emits unconditionally. If the user dismisses the metadata sheet before the relay returns, the cubit is closed and the late `emit(...)` throws `Bad state: Cannot emit new states after calling close` — a non-fatal Crashlytics event that polluted telemetry without affecting users.

This adds `if (isClosed) return;` guards before each emit (and before `addError`), so a dismissed sheet's pending fetch becomes a silent no-op rather than an exception.

The shape matches established precedent in this repo:
- `mobile/lib/blocs/video_interactions/video_interactions_bloc.dart:273, 389`
- `mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart:322`
- `mobile/lib/blocs/others_followers/others_followers_bloc.dart:116`

## Trace this fixes

```
flutter: ----------------FIREBASE CRASHLYTICS----------------
flutter: The following exception was thrown runZonedGuarded:
flutter: Bad state: Cannot emit new states after calling close

#0      BlocBase.emit (package:bloc/src/bloc_base.dart:100:9)
#1      VideoRepostersCubit._fetch (package:openvine/widgets/video_feed_item/metadata/video_reposters_cubit.dart:50:7)
<asynchronous suspension>
```

The preceding log line — `Reposters query timeout for video aa76ba96... - found 2 reposters` — confirms the relay returned **after** the cubit was disposed.

## Test plan

- [x] New `mobile/test/widgets/video_feed_item/metadata/video_reposters_cubit_test.dart` covers:
  - emits success state when fetch resolves before close
  - moves to loading=false synchronously when videoId is empty
  - emits loading=false and reports addError on relay failure
  - **does not emit (or throw) when closed before in-flight fetch resolves** — regression for #3734
  - **does not emit (or addError) when closed before in-flight fetch errors** — also regression
- [x] `flutter analyze lib test integration_test` — 0 issues
- [x] `flutter test test/widgets/video_feed_item/metadata/video_reposters_cubit_test.dart` — 5/5 pass

## Out of scope

The same emit-after-close shape may exist elsewhere in the codebase. A repo-wide audit can be a follow-up.

Closes #3734