### PR TITLE
fix(profile): auto-lowercase username input to avoid case-only error

### DIFF
--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -893,10 +893,17 @@ class _ProfileSetupScreenViewState
                                           ),
                                           errorMaxLines: 2,
                                         ),
-                                        // Only allow valid subdomain characters
+                                        // Lowercase as the user types and
+                                        // restrict to canonical subdomain
+                                        // characters. The name server stores
+                                        // and resolves usernames as lowercase,
+                                        // so normalizing here avoids a
+                                        // confusing "invalid format" error
+                                        // for a typed capital letter.
                                         inputFormatters: [
+                                          const LowercaseTextInputFormatter(),
                                           FilteringTextInputFormatter.allow(
-                                            RegExp('[a-zA-Z0-9-]'),
+                                            RegExp('[a-z0-9-]'),
                                           ),
                                         ],
                                         textInputAction: TextInputAction.next,
@@ -1483,6 +1490,26 @@ class UsernameStatusIndicator extends StatelessWidget {
         message: errorText ?? 'Failed to check availability',
       ),
     };
+  }
+}
+
+/// Lowercases input text on every edit.
+///
+/// Composes with `FilteringTextInputFormatter` on the username field so that
+/// typed capital letters are normalized in place rather than triggering the
+/// lowercase-only validator. Lowercasing ASCII is a 1:1 character mapping so
+/// the existing selection offsets remain valid.
+class LowercaseTextInputFormatter extends TextInputFormatter {
+  const LowercaseTextInputFormatter();
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    final lowered = newValue.text.toLowerCase();
+    if (lowered == newValue.text) return newValue;
+    return newValue.copyWith(text: lowered);
   }
 }
 

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -4,6 +4,7 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -169,6 +170,89 @@ void main() {
       );
 
       expect(find.text('Username must be 3-20 characters'), findsOneWidget);
+    });
+  });
+
+  group('LowercaseTextInputFormatter', () {
+    const formatter = LowercaseTextInputFormatter();
+
+    TextEditingValue value(String text, {int? selection}) {
+      return TextEditingValue(
+        text: text,
+        selection: TextSelection.collapsed(offset: selection ?? text.length),
+      );
+    }
+
+    test('lowercases newly typed uppercase letters', () {
+      final result = formatter.formatEditUpdate(value(''), value('Alice'));
+
+      expect(result.text, 'alice');
+      expect(result.selection.baseOffset, 5);
+    });
+
+    test('preserves all-lowercase input unchanged (returns same instance)', () {
+      final next = value('alice');
+      final result = formatter.formatEditUpdate(value(''), next);
+
+      expect(identical(result, next), isTrue);
+    });
+
+    test('preserves caret position when editing in the middle', () {
+      // User has "abcde" with caret at offset 2, types capital "X" — newValue
+      // is "abXcde" with caret at 3.
+      final result = formatter.formatEditUpdate(
+        value('abcde', selection: 2),
+        value('abXcde', selection: 3),
+      );
+
+      expect(result.text, 'abxcde');
+      expect(result.selection.baseOffset, 3);
+    });
+
+    test('lowercases pasted mixed-case text', () {
+      final result = formatter.formatEditUpdate(value(''), value('MrBeast123'));
+
+      expect(result.text, 'mrbeast123');
+    });
+  });
+
+  group('username field input formatters', () {
+    Widget buildField(TextEditingController controller) {
+      return MaterialApp(
+        home: Scaffold(
+          body: TextField(
+            controller: controller,
+            inputFormatters: [
+              const LowercaseTextInputFormatter(),
+              FilteringTextInputFormatter.allow(RegExp('[a-z0-9-]')),
+            ],
+          ),
+        ),
+      );
+    }
+
+    testWidgets('uppercase typed by user is normalized to lowercase', (
+      tester,
+    ) async {
+      final controller = TextEditingController();
+      await tester.pumpWidget(buildField(controller));
+
+      await tester.enterText(find.byType(TextField), 'Alice');
+
+      expect(controller.text, 'alice');
+    });
+
+    testWidgets('disallowed characters are stripped, others lowercased', (
+      tester,
+    ) async {
+      final controller = TextEditingController();
+      await tester.pumpWidget(buildField(controller));
+
+      // Underscore, dot, and space are not in [a-z0-9-]; capitals get
+      // lowercased.
+      await tester.enterText(find.byType(TextField), 'Mr Beast.123_xyz');
+
+      expect(controller.text, 'mrbeast123xyz');
     });
   });
 


### PR DESCRIPTION
## Summary

- Compose a `LowercaseTextInputFormatter` ahead of the existing allow filter on the profile setup username field, so "Alice" becomes "alice" inline.
- Tighten the allow regex from `[a-zA-Z0-9-]` to `[a-z0-9-]` now that uppercase is normalized rather than passed through.
- Add unit tests for the formatter and widget tests confirming end-to-end normalization.

## Why

Typing a capital letter into the username field tripped `_usernamePattern = RegExp(r'^[a-z0-9._-]+$')` in `ProfileEditorBloc` and surfaced *"Only letters, numbers, and hyphens are allowed"* — a true statement that hides the actual rule (lowercase). The name server itself accepts mixed case and normalizes to lowercase (`divine-name-server/src/utils/validation.ts:88-90`), and the admin UI for the same name server already lowercases input on the way in (`admin-ui/src/pages/Reserve.tsx:144`). The mobile field was the outlier.

Auto-lowercasing at the formatter layer mirrors the server's canonical behavior and the admin UI's existing pattern. The error literally cannot fire for the case-only mistake the bug report describes.

## Scope

This intentionally does **not**:
- change ARB copy in 15 locales (per `.claude/rules/localization.md`'s Copy-alignment policy, copy changes are product-owned and ship as their own commit);
- touch the divergent BLoC vs repository regexes (tracked by #3364);
- remove the hardcoded English fallback in `UsernameStatusIndicator` (separate l10n-gap fix).

## Test plan

- [x] `flutter analyze lib/screens/profile_setup_screen.dart test/screens/profile_setup_screen_test.dart` — clean
- [x] `flutter test test/screens/profile_setup_screen_test.dart` — 27/27 pass (6 new + 21 existing)
- [x] `flutter test test/blocs/profile_editor/` — 71/71 pass
- [ ] Manual: type `Alice` in profile setup — field shows `alice`, no error appears

Closes divinevideo/divine-name-server#39