### PR TITLE
fix(likes,reposts): queue on publish failure when callback wired

### DIFF
--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -5,6 +5,7 @@
 // ABOUTME: Supports offline queuing via callback injection.
 
 import 'dart:async';
+import 'dart:developer' as developer;
 import 'dart:math';
 
 import 'package:likes_repository/src/exceptions.dart';
@@ -324,8 +325,14 @@ class LikesRepository {
       await _localStorage?.saveLikeRecord(confirmed);
 
       return reactionEvent.id;
-    } catch (_) {
+    } catch (e, stackTrace) {
       if (_queueOfflineAction != null) {
+        developer.log(
+          'Like publish failed; queuing optimistic action for retry',
+          name: 'LikesRepository',
+          error: e,
+          stackTrace: stackTrace,
+        );
         await _queueOfflineAction(
           isLike: true,
           eventId: eventId,
@@ -444,8 +451,14 @@ class LikesRepository {
       if (deletionEvent == null) {
         throw const UnlikeFailedException('Failed to publish unlike deletion');
       }
-    } catch (_) {
+    } catch (e, stackTrace) {
       if (_queueOfflineAction != null) {
+        developer.log(
+          'Unlike publish failed; queuing optimistic action for retry',
+          name: 'LikesRepository',
+          error: e,
+          stackTrace: stackTrace,
+        );
         await _queueOfflineAction(
           isLike: false,
           eventId: eventId,

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -294,8 +294,14 @@ class LikesRepository {
       return placeholderId;
     }
 
-    // 3. Online → publish kind 7; on success swap placeholder for real id,
-    // on failure roll back memory + DB + count + stream.
+    // 3. Online → publish kind 7; on success swap placeholder for real id.
+    // On failure, prefer queuing via [_queueOfflineAction] when wired so the
+    // optimistic state survives transient relay-pool problems (e.g. all
+    // configured relays in `disconnected` state at publish time but
+    // [ConnectionStatusService] still reports online because at least one
+    // relay is technically connected). Without a wired callback, fall back
+    // to rollback + rethrow to preserve the original contract for tests
+    // and non-app embedders.
     try {
       final reactionEvent = await _nostrClient.sendLike(
         eventId,
@@ -319,6 +325,16 @@ class LikesRepository {
 
       return reactionEvent.id;
     } catch (_) {
+      if (_queueOfflineAction != null) {
+        await _queueOfflineAction(
+          isLike: true,
+          eventId: eventId,
+          authorPubkey: authorPubkey,
+          addressableId: addressableId,
+          targetKind: targetKind,
+        );
+        return placeholderId;
+      }
       _likeRecords.remove(eventId);
       await _localStorage?.deleteLikeRecord(eventId);
       if (previousCount != null) _likeCountCache[eventId] = previousCount;
@@ -411,8 +427,11 @@ class LikesRepository {
       return;
     }
 
-    // 3. Online → publish kind 5 (skipped for never-synced placeholders);
-    // on failure roll back memory + DB + count + stream.
+    // 3. Online → publish kind 5 (skipped for never-synced placeholders).
+    // On failure, prefer queuing via [_queueOfflineAction] when wired so the
+    // optimistic unlike survives transient relay-pool problems (mirror of
+    // [likeEvent]). Without a wired callback, fall back to rollback +
+    // rethrow to preserve the original contract.
     if (snapshotRecord.reactionEventId.startsWith('pending_')) {
       // Pending like never reached the relay; nothing to delete on the wire.
       return;
@@ -426,6 +445,14 @@ class LikesRepository {
         throw const UnlikeFailedException('Failed to publish unlike deletion');
       }
     } catch (_) {
+      if (_queueOfflineAction != null) {
+        await _queueOfflineAction(
+          isLike: false,
+          eventId: eventId,
+          authorPubkey: '', // Not needed for unlike
+        );
+        return;
+      }
       _likeRecords[eventId] = snapshotRecord;
       await _localStorage?.saveLikeRecord(snapshotRecord);
       if (previousCount != null) _likeCountCache[eventId] = previousCount;

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -71,10 +71,16 @@ void main() {
     }
 
     // Helper to create repository with standard setup
-    LikesRepository createRepository({bool withLocalStorage = true}) {
+    LikesRepository createRepository({
+      bool withLocalStorage = true,
+      IsOnlineCallback? isOnline,
+      QueueOfflineActionCallback? queueOfflineAction,
+    }) {
       return LikesRepository(
         nostrClient: mockNostrClient,
         localStorage: withLocalStorage ? mockLocalStorage : null,
+        isOnline: isOnline,
+        queueOfflineAction: queueOfflineAction,
       );
     }
 
@@ -455,6 +461,114 @@ void main() {
         verify(() => mockLocalStorage.deleteLikeRecord(testEventId)).called(1);
         expect(await repository.isLiked(testEventId), isFalse);
       });
+
+      // Defense-in-depth: when the publish fails but the offline-action
+      // callback is wired, the optimistic state must be preserved and the
+      // action queued for retry. This covers the "device says online but
+      // relays are unhealthy" case where the existing `if (!_isOnline())`
+      // guard at the top of likeEvent does not fire.
+      test(
+        'queues offline action and preserves optimistic state when '
+        'sendLike returns null and queueOfflineAction is wired',
+        () async {
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockLocalStorage.saveLikeRecord(any()),
+          ).thenAnswer((_) async {});
+
+          var queueCalls = 0;
+          String? queuedEventId;
+          bool? queuedIsLike;
+          repository = createRepository(
+            isOnline: () => true,
+            queueOfflineAction:
+                ({
+                  required isLike,
+                  required eventId,
+                  required authorPubkey,
+                  addressableId,
+                  targetKind,
+                }) async {
+                  queueCalls++;
+                  queuedEventId = eventId;
+                  queuedIsLike = isLike;
+                },
+          );
+
+          final result = await repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          expect(
+            result,
+            equals('pending_like_$testEventId'),
+            reason: 'must return placeholder ID, not throw',
+          );
+          expect(queueCalls, equals(1));
+          expect(queuedEventId, equals(testEventId));
+          expect(queuedIsLike, isTrue);
+          expect(
+            await repository.isLiked(testEventId),
+            isTrue,
+            reason: 'optimistic state must be preserved across the failure',
+          );
+          verifyNever(
+            () => mockLocalStorage.deleteLikeRecord(any()),
+          );
+        },
+      );
+
+      test(
+        'queues offline action when sendLike throws and '
+        'queueOfflineAction is wired',
+        () async {
+          when(
+            () => mockNostrClient.sendLike(
+              any(),
+              content: any(named: 'content'),
+              addressableId: any(named: 'addressableId'),
+              targetAuthorPubkey: any(named: 'targetAuthorPubkey'),
+              targetKind: any(named: 'targetKind'),
+            ),
+          ).thenThrow(Exception('relay closed'));
+          when(
+            () => mockLocalStorage.saveLikeRecord(any()),
+          ).thenAnswer((_) async {});
+
+          var queueCalls = 0;
+          repository = createRepository(
+            isOnline: () => true,
+            queueOfflineAction:
+                ({
+                  required isLike,
+                  required eventId,
+                  required authorPubkey,
+                  addressableId,
+                  targetKind,
+                }) async {
+                  queueCalls++;
+                },
+          );
+
+          final result = await repository.likeEvent(
+            eventId: testEventId,
+            authorPubkey: testAuthorPubkey,
+          );
+
+          expect(result, equals('pending_like_$testEventId'));
+          expect(queueCalls, equals(1));
+          expect(await repository.isLiked(testEventId), isTrue);
+        },
+      );
     });
 
     group('unlikeEvent', () {
@@ -625,6 +739,91 @@ void main() {
         verify(() => mockLocalStorage.saveLikeRecord(any())).called(1);
         expect(await repository.isLiked(testEventId), isTrue);
       });
+
+      // Defense-in-depth (mirror of likeEvent): when the kind-5 deletion
+      // fails but the offline-action callback is wired, the optimistic
+      // removal must be preserved and the unlike queued for retry.
+      test(
+        'queues offline action and preserves optimistic removal when '
+        'deleteEvent returns null and queueOfflineAction is wired',
+        () async {
+          when(
+            () => mockLocalStorage.getAllLikeRecords(),
+          ).thenAnswer((_) async => [createLikeRecord()]);
+          when(
+            () => mockNostrClient.deleteEvent(testReactionEventId),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockLocalStorage.deleteLikeRecord(testEventId),
+          ).thenAnswer((_) async => true);
+
+          var queueCalls = 0;
+          bool? queuedIsLike;
+          repository = createRepository(
+            isOnline: () => true,
+            queueOfflineAction:
+                ({
+                  required isLike,
+                  required eventId,
+                  required authorPubkey,
+                  addressableId,
+                  targetKind,
+                }) async {
+                  queueCalls++;
+                  queuedIsLike = isLike;
+                },
+          );
+          await repository.isLiked(testEventId); // Initialize cache
+
+          await repository.unlikeEvent(testEventId);
+
+          expect(queueCalls, equals(1));
+          expect(queuedIsLike, isFalse);
+          expect(
+            await repository.isLiked(testEventId),
+            isFalse,
+            reason: 'optimistic removal must be preserved',
+          );
+          verifyNever(() => mockLocalStorage.saveLikeRecord(any()));
+        },
+      );
+
+      test(
+        'queues offline action when deleteEvent throws and '
+        'queueOfflineAction is wired',
+        () async {
+          when(
+            () => mockLocalStorage.getAllLikeRecords(),
+          ).thenAnswer((_) async => [createLikeRecord()]);
+          when(
+            () => mockNostrClient.deleteEvent(testReactionEventId),
+          ).thenThrow(Exception('relay closed'));
+          when(
+            () => mockLocalStorage.deleteLikeRecord(testEventId),
+          ).thenAnswer((_) async => true);
+
+          var queueCalls = 0;
+          repository = createRepository(
+            isOnline: () => true,
+            queueOfflineAction:
+                ({
+                  required isLike,
+                  required eventId,
+                  required authorPubkey,
+                  addressableId,
+                  targetKind,
+                }) async {
+                  queueCalls++;
+                },
+          );
+          await repository.isLiked(testEventId); // Initialize cache
+
+          await repository.unlikeEvent(testEventId);
+
+          expect(queueCalls, equals(1));
+          expect(await repository.isLiked(testEventId), isFalse);
+        },
+      );
     });
 
     group('toggleLike', () {

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -293,8 +293,12 @@ class RepostsRepository {
       return placeholderId;
     }
 
-    // 3. Online → publish kind 16; on success swap placeholder for real id,
-    // on failure roll back memory + DB + count + stream.
+    // 3. Online → publish kind 16; on success swap placeholder for real id.
+    // On failure, prefer queuing via [_queueOfflineAction] when wired so the
+    // optimistic state survives transient relay-pool problems (mirror of
+    // [LikesRepository.likeEvent]). Without a wired callback, fall back to
+    // rollback + rethrow to preserve the original contract for tests and
+    // non-app embedders.
     try {
       final sentEvent = await _nostrClient.sendGenericRepost(
         addressableId: addressableId,
@@ -320,6 +324,15 @@ class RepostsRepository {
 
       return sentEvent.id;
     } catch (_) {
+      if (_queueOfflineAction != null) {
+        await _queueOfflineAction(
+          isRepost: true,
+          addressableId: addressableId,
+          originalAuthorPubkey: originalAuthorPubkey,
+          eventId: eventId,
+        );
+        return placeholderId;
+      }
       _repostRecords.remove(addressableId);
       await _localStorage?.deleteRepostRecord(addressableId);
       if (previousCount != null) {
@@ -416,8 +429,11 @@ class RepostsRepository {
       return;
     }
 
-    // 3. Online → publish kind 5 (skipped for never-synced placeholders);
-    // on failure roll back memory + DB + count + stream.
+    // 3. Online → publish kind 5 (skipped for never-synced placeholders).
+    // On failure, prefer queuing via [_queueOfflineAction] when wired so the
+    // optimistic unrepost survives transient relay-pool problems (mirror of
+    // [repostVideo]). Without a wired callback, fall back to rollback +
+    // rethrow to preserve the original contract.
     if (snapshotRecord.repostEventId.startsWith('pending_')) {
       // Pending repost never reached the relay; nothing to delete on the wire.
       return;
@@ -433,6 +449,14 @@ class RepostsRepository {
         );
       }
     } catch (_) {
+      if (_queueOfflineAction != null) {
+        await _queueOfflineAction(
+          isRepost: false,
+          addressableId: addressableId,
+          originalAuthorPubkey: snapshotRecord.originalAuthorPubkey,
+        );
+        return;
+      }
       _repostRecords[addressableId] = snapshotRecord;
       await _localStorage?.saveRepostRecord(snapshotRecord);
       if (previousCount != null) {

--- a/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
+++ b/mobile/packages/reposts_repository/lib/src/reposts_repository.dart
@@ -5,6 +5,7 @@
 // ABOUTME: Supports offline queuing via callback injection.
 
 import 'dart:async';
+import 'dart:developer' as developer;
 import 'dart:math';
 
 import 'package:nostr_client/nostr_client.dart';
@@ -323,8 +324,14 @@ class RepostsRepository {
       await _localStorage?.saveRepostRecord(confirmed);
 
       return sentEvent.id;
-    } catch (_) {
+    } catch (e, stackTrace) {
       if (_queueOfflineAction != null) {
+        developer.log(
+          'Repost publish failed; queuing optimistic action for retry',
+          name: 'RepostsRepository',
+          error: e,
+          stackTrace: stackTrace,
+        );
         await _queueOfflineAction(
           isRepost: true,
           addressableId: addressableId,
@@ -448,8 +455,14 @@ class RepostsRepository {
           'Failed to publish unrepost deletion',
         );
       }
-    } catch (_) {
+    } catch (e, stackTrace) {
       if (_queueOfflineAction != null) {
+        developer.log(
+          'Unrepost publish failed; queuing optimistic action for retry',
+          name: 'RepostsRepository',
+          error: e,
+          stackTrace: stackTrace,
+        );
         await _queueOfflineAction(
           isRepost: false,
           addressableId: addressableId,

--- a/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
+++ b/mobile/packages/reposts_repository/test/src/reposts_repository_test.dart
@@ -516,6 +516,110 @@ void main() {
           expect(count, equals(4));
         },
       );
+
+      // Defense-in-depth: when the publish fails but the offline-action
+      // callback is wired, the optimistic repost must be preserved and
+      // the action queued for retry. Mirror of the LikesRepository test.
+      test(
+        'queues offline action and preserves optimistic state when '
+        'sendGenericRepost returns null and queueOfflineAction is wired',
+        () async {
+          when(
+            () => mockNostrClient.sendGenericRepost(
+              addressableId: any(named: 'addressableId'),
+              targetKind: any(named: 'targetKind'),
+              authorPubkey: any(named: 'authorPubkey'),
+              content: any(named: 'content'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async => null);
+
+          var queueCalls = 0;
+          String? queuedAddressableId;
+          bool? queuedIsRepost;
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+            isOnline: () => true,
+            queueOfflineAction:
+                ({
+                  required isRepost,
+                  required addressableId,
+                  required originalAuthorPubkey,
+                  eventId,
+                }) async {
+                  queueCalls++;
+                  queuedAddressableId = addressableId;
+                  queuedIsRepost = isRepost;
+                },
+          );
+
+          final result = await repository.repostVideo(
+            addressableId: testAddressableId,
+            originalAuthorPubkey: testAuthorPubkey,
+          );
+
+          expect(
+            result,
+            equals('pending_repost_$testAddressableId'),
+            reason: 'must return placeholder ID, not throw',
+          );
+          expect(queueCalls, equals(1));
+          expect(queuedAddressableId, equals(testAddressableId));
+          expect(queuedIsRepost, isTrue);
+          expect(
+            repository.isRepostedSync(testAddressableId),
+            isTrue,
+            reason: 'optimistic state must be preserved across the failure',
+          );
+          verifyNever(
+            () => mockLocalStorage.deleteRepostRecord(any()),
+          );
+        },
+      );
+
+      test(
+        'queues offline action when sendGenericRepost throws and '
+        'queueOfflineAction is wired',
+        () async {
+          when(
+            () => mockNostrClient.sendGenericRepost(
+              addressableId: any(named: 'addressableId'),
+              targetKind: any(named: 'targetKind'),
+              authorPubkey: any(named: 'authorPubkey'),
+              content: any(named: 'content'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenThrow(Exception('relay closed'));
+
+          var queueCalls = 0;
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+            isOnline: () => true,
+            queueOfflineAction:
+                ({
+                  required isRepost,
+                  required addressableId,
+                  required originalAuthorPubkey,
+                  eventId,
+                }) async {
+                  queueCalls++;
+                },
+          );
+
+          final result = await repository.repostVideo(
+            addressableId: testAddressableId,
+            originalAuthorPubkey: testAuthorPubkey,
+          );
+
+          expect(result, equals('pending_repost_$testAddressableId'));
+          expect(queueCalls, equals(1));
+          expect(repository.isRepostedSync(testAddressableId), isTrue);
+        },
+      );
     });
 
     group('unrepostVideo', () {
@@ -725,6 +829,87 @@ void main() {
           expect(repository.isRepostedSync(testAddressableId), isTrue);
           final count = await repository.getRepostCount(testAddressableId);
           expect(count, equals(8));
+        },
+      );
+
+      // Defense-in-depth (mirror of repostVideo): when the kind-5 deletion
+      // fails but the offline-action callback is wired, the optimistic
+      // unrepost must be preserved and the action queued for retry.
+      test(
+        'queues offline action and preserves optimistic removal when '
+        'deleteEvent returns null and queueOfflineAction is wired',
+        () async {
+          when(
+            () => mockNostrClient.deleteEvent(any()),
+          ).thenAnswer((_) async => null);
+
+          var queueCalls = 0;
+          bool? queuedIsRepost;
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+            isOnline: () => true,
+            queueOfflineAction:
+                ({
+                  required isRepost,
+                  required addressableId,
+                  required originalAuthorPubkey,
+                  eventId,
+                }) async {
+                  queueCalls++;
+                  queuedIsRepost = isRepost;
+                },
+          );
+          // Establish a real (non-pending) repost record to delete.
+          await repository.repostVideo(
+            addressableId: testAddressableId,
+            originalAuthorPubkey: testAuthorPubkey,
+          );
+
+          await repository.unrepostVideo(testAddressableId);
+
+          expect(queueCalls, equals(1));
+          expect(queuedIsRepost, isFalse);
+          expect(
+            repository.isRepostedSync(testAddressableId),
+            isFalse,
+            reason: 'optimistic removal must be preserved',
+          );
+        },
+      );
+
+      test(
+        'queues offline action when deleteEvent throws and '
+        'queueOfflineAction is wired',
+        () async {
+          when(
+            () => mockNostrClient.deleteEvent(any()),
+          ).thenThrow(Exception('relay closed'));
+
+          var queueCalls = 0;
+          final repository = RepostsRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+            isOnline: () => true,
+            queueOfflineAction:
+                ({
+                  required isRepost,
+                  required addressableId,
+                  required originalAuthorPubkey,
+                  eventId,
+                }) async {
+                  queueCalls++;
+                },
+          );
+          await repository.repostVideo(
+            addressableId: testAddressableId,
+            originalAuthorPubkey: testAuthorPubkey,
+          );
+
+          await repository.unrepostVideo(testAddressableId);
+
+          expect(queueCalls, equals(1));
+          expect(repository.isRepostedSync(testAddressableId), isFalse);
         },
       );
     });


### PR DESCRIPTION
## Description

Defense-in-depth fix for the visible "tap → optimistic flip → revert ~150 ms later" bug on likes / reposts. When the underlying publish fails (`sendLike` / `sendGenericRepost` / `deleteEvent` returns `null` or throws) and `_queueOfflineAction` is wired by the app layer, the repository now queues the action and preserves optimistic state — instead of rolling back and rethrowing.

This does **not** fix the upstream SDK regression that is the root cause (see #3741 for the full trace). It converts a UX-visible silent-revert into eventual consistency through the existing `PendingActionService` retry mechanism.

**Related Issue:** Closes #3741

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Why this fix sits at the repository layer, not the SDK

Root cause is in `mobile/packages/nostr_sdk/lib/relay/relay_pool.dart`'s `_sendCollect`, where #3683 added `skipReconnect: true` to every `relay.send(...)` call without a companion path to drive reconnects when the heartbeat-induced or cold-launch `disconnected` state isn't lifted by something else. Fixing that properly is its own PR (likely either drop `skipReconnect: true` from the publish path keeping only the 5 s timeout, or wire `RelayPool` to drive proactive reconnection from `WebSocketConnectionManager.stateStream`).

This PR is intentionally narrow:
- Stops the user-visible flicker today.
- Makes the publish-result the gate, not the (currently misleading) `_isOnline()` flag.
- Behavior is unchanged for callers without `queueOfflineAction` wired (tests, non-app embedders) — the catch falls through to the original rollback + rethrow.

## What changed

| File | What |
|------|------|
| `mobile/packages/likes_repository/lib/src/likes_repository.dart` | `likeEvent` (kind-7) catch block: if `_queueOfflineAction != null`, log a warning, queue, and return placeholder; else rollback as before. Same for `unlikeEvent` (kind-5 deletion). |
| `mobile/packages/reposts_repository/lib/src/reposts_repository.dart` | Same shape for `repostVideo` (kind-16) and `unrepostVideo` (kind-5 deletion). |
| `mobile/packages/likes_repository/test/src/likes_repository_test.dart` | Extended `createRepository` helper. Added 4 new tests covering queue-on-null and queue-on-throw with the wired callback (likeEvent + unlikeEvent). Existing rollback-and-rethrow tests retained for the no-callback case. |
| `mobile/packages/reposts_repository/test/src/reposts_repository_test.dart` | Mirror of the likes test additions (4 new tests). |

No changes to BLoC, UI, providers, router, or the Nostr SDK itself. Wiring at `mobile/lib/providers/app_providers.dart:2432-2454` was already correct — the new path activates automatically in production.

## Verification

Local sweep on the changed packages:

```
dart format --set-exit-if-changed                         # 4 files, 0 changed
dart analyze (in packages/likes_repository)              # No issues found!
dart analyze (in packages/reposts_repository)            # No issues found!
flutter test (likes_repository)                          # 157/157 passed
flutter test (reposts_repository)                        # 114/114 passed
flutter analyze lib/blocs/video_interactions \
    test/blocs/video_interactions \
    lib/providers/app_providers.dart                     # No issues found!
flutter test test/blocs/video_interactions/              # 46/46 passed
```

## Test plan

Manual on simulator (cold-launch repro from #3741):

- [ ] Cold launch → tap heart on first For You video immediately. Heart stays red, count stays incremented.
- [ ] Background app for ~30 s → foreground → tap like. Heart stays red.
- [ ] Tap like after scrolling 5–10 s (relays connected). Indistinguishable from current happy-path behavior.
- [ ] Genuine offline path (Wi-Fi off → tap → Wi-Fi on). Existing offline branch still queues and drains.
- [ ] Repost / unrepost: same matrix.
- [ ] Like → unlike sequence: optimistic flips both directions; if both queue while online, `PendingActionService.queueAction` cancels the conflicting pair (existing logic at `pending_action_service.dart:168-188`).

## Risks and known follow-ups

1. **Eventual-consistency gap.** `PendingActionService.syncPendingActions()` only fires on `ConnectionStatusService` flip from `false → true`, on init, or on explicit external trigger. In the bug scenario the device is reported "online" the whole time, so a queued-while-online action waits for the next connectivity flap or app restart to drain. The cushion still meaningfully improves UX (no flicker; the like persists in the user's own grid; lands at the next genuine connectivity event), but does not guarantee timely server-side propagation. **Recommended follow-up:** trigger `syncPendingActions()` when any relay transitions disconnected→connected (cleanest place: a state-change stream on `RelayPool` that `PendingActionService` subscribes to). Out of scope for this PR — happy to open a tracking issue once this lands.

2. **Queued publish failures are now logged locally rather than surfaced through the BLoC error path.** When `_queueOfflineAction` is wired, the repository no longer rethrows the original publish failure, so `VideoInteractionsBloc.addError(...)` does not fire for that path. This PR now logs those handled failures with `developer.log(...)` before queueing so they remain visible in local diagnostics and exported logs without polluting Crashlytics with expected transient relay-pool noise.

3. **The upstream SDK regression remains.** This is the root cause and should be fixed in a separate PR. Two reasonable shapes:
   - Drop `skipReconnect: true` from the publish path in `_sendCollect`, keep only the 5 s `.timeout(...)`. The 5 s cap was always the real backstop — `skipReconnect: true` is over-broad and broke the "reconnect on send" contract that `WebSocketConnectionManager` documents.
   - Or have `RelayPool` listen to `stateStream` and call `relay.connect()` on `connected → disconnected` transitions. Fixes the broken contract regardless of `skipReconnect`.

4. **CHANGELOG.md not added.** Neither package has an existing CHANGELOG; the contract change is captured inline on the catch block and in this PR description. Happy to add CHANGELOGs if reviewers prefer that convention going forward.
