### PR TITLE
fix(audio-sharing): ensure audio sharing permission works as expected

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -644,9 +644,8 @@ ModerationLabelService moderationLabelService(Ref ref) {
 /// for reuse by default. keepAlive ensures setting persists across widget rebuilds.
 @Riverpod(keepAlive: true)
 AudioSharingPreferenceService audioSharingPreferenceService(Ref ref) {
-  final service = AudioSharingPreferenceService();
-  service.initialize(); // Initialize asynchronously
-  return service;
+  final prefs = ref.watch(sharedPreferencesProvider);
+  return AudioSharingPreferenceService(prefs);
 }
 
 /// AI training opt-out preference service. Controls whether the

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -990,7 +990,7 @@ final class AudioSharingPreferenceServiceProvider
 }
 
 String _$audioSharingPreferenceServiceHash() =>
-    r'6d09af615c19937bc2842079c368161b513dd323';
+    r'e63c48c60864949925db6eeed76f7e8a67e5444a';
 
 /// AI training opt-out preference service. Controls whether the
 /// CAWG training-mining assertion is embedded in C2PA manifests.

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -81,7 +81,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         category: LogCategory.video,
       );
     });
-    return VideoEditorProviderState();
+    final audioSharingEnabled = ref
+        .read(audioSharingPreferenceServiceProvider)
+        .isAudioSharingEnabled;
+    return VideoEditorProviderState(allowAudioReuse: audioSharingEnabled);
   }
 
   /// Invalidate the final rendered clip when content changes.
@@ -121,7 +124,14 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// and metadata.
   Future<void> initialize({String? draftId}) async {
     // Reset old editing states but keep metadata
-    state = state.copyWith(isProcessing: false, isSavingDraft: false);
+    final audioSharingEnabled = ref
+        .read(audioSharingPreferenceServiceProvider)
+        .isAudioSharingEnabled;
+    state = state.copyWith(
+      isProcessing: false,
+      isSavingDraft: false,
+      allowAudioReuse: audioSharingEnabled,
+    );
 
     // If the editor screen is opened from a draft, we initialize it here.
     if (draftId != null && draftId.isNotEmpty) {
@@ -161,7 +171,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       name: 'VideoEditorNotifier',
       category: .video,
     );
-    state = VideoEditorProviderState();
+    final audioSharingEnabled = ref
+        .read(audioSharingPreferenceServiceProvider)
+        .isAudioSharingEnabled;
+    state = VideoEditorProviderState(allowAudioReuse: audioSharingEnabled);
     _autosaveTimer?.cancel();
     draftId = null;
     if (!keepAutosavedDraft) {

--- a/mobile/lib/services/audio_sharing_preference_service.dart
+++ b/mobile/lib/services/audio_sharing_preference_service.dart
@@ -8,37 +8,22 @@ import 'package:unified_logger/unified_logger.dart';
 /// for reuse by other users. This is a global setting that can be overridden
 /// on a per-video basis during publishing.
 class AudioSharingPreferenceService {
+  AudioSharingPreferenceService(this._prefs)
+    : _isAudioSharingEnabled = _prefs.getBool(prefsKey) ?? false;
+
   /// SharedPreferences key for the audio sharing preference
   static const String prefsKey = 'audio_sharing_enabled';
 
-  bool _isAudioSharingEnabled = false;
+  final SharedPreferences _prefs;
+  bool _isAudioSharingEnabled;
 
   /// Whether the user has enabled audio sharing by default
   bool get isAudioSharingEnabled => _isAudioSharingEnabled;
 
-  /// Initialize the service by loading the saved preference
-  Future<void> initialize() async {
-    await _loadPreference();
-  }
-
-  Future<void> _loadPreference() async {
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      _isAudioSharingEnabled = prefs.getBool(prefsKey) ?? false;
-    } catch (e) {
-      Log.error(
-        'Error loading audio sharing preference: $e',
-        name: 'AudioSharingPreferenceService',
-        category: LogCategory.system,
-      );
-    }
-  }
-
   /// Set the audio sharing preference
   Future<void> setAudioSharingEnabled(bool enabled) async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setBool(prefsKey, enabled);
+      await _prefs.setBool(prefsKey, enabled);
       _isAudioSharingEnabled = enabled;
 
       Log.debug(

--- a/mobile/lib/services/audio_sharing_preference_service.dart
+++ b/mobile/lib/services/audio_sharing_preference_service.dart
@@ -9,7 +9,7 @@ import 'package:unified_logger/unified_logger.dart';
 /// on a per-video basis during publishing.
 class AudioSharingPreferenceService {
   AudioSharingPreferenceService(this._prefs)
-    : _isAudioSharingEnabled = _prefs.getBool(prefsKey) ?? false;
+    : _isAudioSharingEnabled = _prefs.getBool(prefsKey) ?? true;
 
   /// SharedPreferences key for the audio sharing preference
   static const String prefsKey = 'audio_sharing_enabled';

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -9,9 +9,11 @@ import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/clip_library_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
@@ -23,7 +25,9 @@ void main() {
     late _MockDraftStorageService mockDraftStorageService;
     late _MockClipLibraryService mockClipLibraryService;
 
-    setUp(() {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
       mockDraftStorageService = _MockDraftStorageService();
       mockClipLibraryService = _MockClipLibraryService();
       when(
@@ -34,6 +38,7 @@ void main() {
       ).thenAnswer((_) async {});
       container = ProviderContainer(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           draftStorageServiceProvider.overrideWithValue(
             mockDraftStorageService,
           ),

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -11,10 +11,12 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
@@ -22,8 +24,14 @@ void main() {
   group('VideoEditorProvider', () {
     late ProviderContainer container;
 
-    setUp(() {
-      container = ProviderContainer();
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+        ],
+      );
     });
 
     tearDown(() {
@@ -794,8 +802,14 @@ void main() {
   group('getActiveDraft', () {
     late ProviderContainer container;
 
-    setUp(() {
-      container = ProviderContainer();
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+        ],
+      );
     });
 
     tearDown(() {
@@ -910,8 +924,14 @@ void main() {
   group('getActiveDraft', () {
     late ProviderContainer container;
 
-    setUp(() {
-      container = ProviderContainer();
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+        ],
+      );
     });
 
     tearDown(() {
@@ -1059,10 +1079,13 @@ void main() {
       late _MockDraftStorageService mockDraftStorage;
       late ProviderContainer container;
 
-      setUp(() {
+      setUp(() async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
         mockDraftStorage = _MockDraftStorageService();
         container = ProviderContainer(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
             draftStorageServiceProvider.overrideWithValue(mockDraftStorage),
           ],
         );

--- a/mobile/test/router/explore_tab_navigation_test.dart
+++ b/mobile/test/router/explore_tab_navigation_test.dart
@@ -6,18 +6,28 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group('Explore Tab Navigation', () {
+    late SharedPreferences prefs;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
+    });
+
     testWidgets(
       'tapping Explore tab after viewing a video should reset to grid mode, not feed mode',
       (tester) async {
         // ARRANGE: Set up providers to simulate navigation flow
         final container = ProviderContainer(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
             // Simulate URL changes: explore grid → explore feed → home → explore grid
             routerLocationStreamProvider.overrideWith((ref) {
               return Stream.fromIterable([
@@ -86,6 +96,7 @@ void main() {
         // ARRANGE: Set up providers for grid mode
         final container = ProviderContainer(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(prefs),
             routerLocationStreamProvider.overrideWith(
               (ref) => Stream.value(ExploreScreen.path),
             ),

--- a/mobile/test/screens/video_metadata_preview_screen_test.dart
+++ b/mobile/test/screens/video_metadata_preview_screen_test.dart
@@ -14,8 +14,8 @@ import 'package:openvine/models/video_publish/video_publish_provider_state.dart'
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_preview_screen.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockVideoPublishNotifier extends VideoPublishNotifier {
   _MockVideoPublishNotifier(this._initialState);

--- a/mobile/test/screens/video_metadata_preview_screen_test.dart
+++ b/mobile/test/screens/video_metadata_preview_screen_test.dart
@@ -11,8 +11,10 @@ import 'package:models/models.dart' as models;
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_publish/video_publish_provider_state.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_preview_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 class _MockVideoPublishNotifier extends VideoPublishNotifier {
@@ -38,7 +40,11 @@ DivineVideoClip _createTestClip({String id = 'test-clip'}) {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  setUp(() {
+  late SharedPreferences prefs;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
     DivineVideoPlayerController.resetIdCounterForTesting();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(const MethodChannel('divine_video_player'), (
@@ -66,6 +72,7 @@ void main() {
       // to the video_player → DivineVideoPlayer migration.
       return ProviderScope(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           videoPublishProvider.overrideWith(
             () => _MockVideoPublishNotifier(const VideoPublishProviderState()),
           ),

--- a/mobile/test/screens/video_metadata_screen_test.dart
+++ b/mobile/test/screens/video_metadata_screen_test.dart
@@ -13,9 +13,11 @@ import 'package:openvine/models/video_publish/video_publish_state.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/models/video_recorder/video_recorder_provider_state.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/providers/video_recorder_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_stack.dart';
 import 'package:openvine/widgets/video_metadata/modes/classic/video_metadata_classic_stack.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -34,8 +36,11 @@ DivineVideoClip _createTestClip({String id = 'test-clip'}) {
 void main() {
   group(VideoMetadataScreen, () {
     late DivineVideoClip testClip;
+    late SharedPreferences _prefs;
 
-    setUp(() {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      _prefs = await SharedPreferences.getInstance();
       testClip = _createTestClip();
     });
 
@@ -45,6 +50,7 @@ void main() {
       ) async {
         final container = ProviderContainer(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
             ),
@@ -85,6 +91,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              sharedPreferencesProvider.overrideWithValue(_prefs),
               clipManagerProvider.overrideWith(
                 () => _MockClipManagerNotifier([testClip]),
               ),
@@ -110,6 +117,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              sharedPreferencesProvider.overrideWithValue(_prefs),
               clipManagerProvider.overrideWith(
                 () => _MockClipManagerNotifier([testClip]),
               ),
@@ -138,6 +146,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              sharedPreferencesProvider.overrideWithValue(_prefs),
               clipManagerProvider.overrideWith(
                 () => _MockClipManagerNotifier([testClip]),
               ),

--- a/mobile/test/screens/video_metadata_screen_test.dart
+++ b/mobile/test/screens/video_metadata_screen_test.dart
@@ -17,10 +17,10 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/providers/video_recorder_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_stack.dart';
 import 'package:openvine/widgets/video_metadata/modes/classic/video_metadata_classic_stack.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 DivineVideoClip _createTestClip({String id = 'test-clip'}) {
   return DivineVideoClip(
@@ -36,11 +36,11 @@ DivineVideoClip _createTestClip({String id = 'test-clip'}) {
 void main() {
   group(VideoMetadataScreen, () {
     late DivineVideoClip testClip;
-    late SharedPreferences _prefs;
+    late SharedPreferences prefs;
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
-      _prefs = await SharedPreferences.getInstance();
+      prefs = await SharedPreferences.getInstance();
       testClip = _createTestClip();
     });
 
@@ -50,7 +50,7 @@ void main() {
       ) async {
         final container = ProviderContainer(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
             ),
@@ -91,7 +91,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
-              sharedPreferencesProvider.overrideWithValue(_prefs),
+              sharedPreferencesProvider.overrideWithValue(prefs),
               clipManagerProvider.overrideWith(
                 () => _MockClipManagerNotifier([testClip]),
               ),
@@ -117,7 +117,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
-              sharedPreferencesProvider.overrideWithValue(_prefs),
+              sharedPreferencesProvider.overrideWithValue(prefs),
               clipManagerProvider.overrideWith(
                 () => _MockClipManagerNotifier([testClip]),
               ),
@@ -146,7 +146,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
-              sharedPreferencesProvider.overrideWithValue(_prefs),
+              sharedPreferencesProvider.overrideWithValue(prefs),
               clipManagerProvider.overrideWith(
                 () => _MockClipManagerNotifier([testClip]),
               ),

--- a/mobile/test/screens/video_recorder_screen_test.dart
+++ b/mobile/test/screens/video_recorder_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_recorder_provider.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/services/clip_library_service.dart';
@@ -102,8 +103,12 @@ void main() {
   group('VideoRecorderScreen Tests', () {
     late ProviderContainer container;
 
-    setUp(() {
-      container = ProviderContainer();
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
     });
 
     tearDown(() {
@@ -469,6 +474,7 @@ void main() {
       ) async {
         // Skip the "why six seconds" prompt
         SharedPreferences.setMockInitialValues({'why_six_seconds_shown': true});
+        final prefs = await SharedPreferences.getInstance();
 
         final mockDraftStorage = _MockDraftStorageService();
         final editedDraft = DivineVideoDraft(
@@ -502,6 +508,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              sharedPreferencesProvider.overrideWithValue(prefs),
               draftStorageServiceProvider.overrideWithValue(mockDraftStorage),
               clipLibraryServiceProvider.overrideWithValue(mockClipLibrary),
             ],
@@ -532,6 +539,7 @@ void main() {
         tester,
       ) async {
         SharedPreferences.setMockInitialValues({'why_six_seconds_shown': true});
+        final prefs = await SharedPreferences.getInstance();
 
         final mockDraftStorage = _MockDraftStorageService();
         // Draft with clips but no metadata edits → hasBeenEdited = false
@@ -566,6 +574,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              sharedPreferencesProvider.overrideWithValue(prefs),
               draftStorageServiceProvider.overrideWithValue(mockDraftStorage),
               clipLibraryServiceProvider.overrideWithValue(mockClipLibrary),
             ],
@@ -592,6 +601,7 @@ void main() {
         tester,
       ) async {
         SharedPreferences.setMockInitialValues({'why_six_seconds_shown': true});
+        final prefs = await SharedPreferences.getInstance();
 
         final mockDraftStorage = _MockDraftStorageService();
         when(
@@ -604,6 +614,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              sharedPreferencesProvider.overrideWithValue(prefs),
               draftStorageServiceProvider.overrideWithValue(mockDraftStorage),
               clipLibraryServiceProvider.overrideWithValue(mockClipLibrary),
             ],

--- a/mobile/test/services/audio_sharing_preference_test.dart
+++ b/mobile/test/services/audio_sharing_preference_test.dart
@@ -15,8 +15,8 @@ void main() {
       service = AudioSharingPreferenceService(prefs);
     });
 
-    test('default preference is false (OFF)', () {
-      expect(service.isAudioSharingEnabled, isFalse);
+    test('default preference is true (ON)', () {
+      expect(service.isAudioSharingEnabled, isTrue);
     });
 
     test('can enable audio sharing', () async {

--- a/mobile/test/services/audio_sharing_preference_test.dart
+++ b/mobile/test/services/audio_sharing_preference_test.dart
@@ -11,35 +11,34 @@ void main() {
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
-      service = AudioSharingPreferenceService();
-      await service.initialize();
+      final prefs = await SharedPreferences.getInstance();
+      service = AudioSharingPreferenceService(prefs);
     });
 
     test('default preference is false (OFF)', () {
-      expect(service.isAudioSharingEnabled, false);
+      expect(service.isAudioSharingEnabled, isFalse);
     });
 
     test('can enable audio sharing', () async {
       await service.setAudioSharingEnabled(true);
-      expect(service.isAudioSharingEnabled, true);
+      expect(service.isAudioSharingEnabled, isTrue);
     });
 
     test('can disable audio sharing', () async {
       await service.setAudioSharingEnabled(true);
-      expect(service.isAudioSharingEnabled, true);
+      expect(service.isAudioSharingEnabled, isTrue);
 
       await service.setAudioSharingEnabled(false);
-      expect(service.isAudioSharingEnabled, false);
+      expect(service.isAudioSharingEnabled, isFalse);
     });
 
     test('preference persists after reinitialization', () async {
       await service.setAudioSharingEnabled(true);
 
-      // Create new instance and reinitialize
-      final newService = AudioSharingPreferenceService();
-      await newService.initialize();
+      final prefs = await SharedPreferences.getInstance();
+      final newService = AudioSharingPreferenceService(prefs);
 
-      expect(newService.isAudioSharingEnabled, true);
+      expect(newService.isAudioSharingEnabled, isTrue);
     });
 
     test('preference key is correct', () {

--- a/mobile/test/services/audio_sharing_preference_test.dart
+++ b/mobile/test/services/audio_sharing_preference_test.dart
@@ -41,6 +41,17 @@ void main() {
       expect(newService.isAudioSharingEnabled, isTrue);
     });
 
+    test('saved false preference is restored on a new service instance', () async {
+      SharedPreferences.setMockInitialValues({
+        AudioSharingPreferenceService.prefsKey: false,
+      });
+      final prefs = await SharedPreferences.getInstance();
+
+      final newService = AudioSharingPreferenceService(prefs);
+
+      expect(newService.isAudioSharingEnabled, isFalse);
+    });
+
     test('preference key is correct', () {
       expect(AudioSharingPreferenceService.prefsKey, 'audio_sharing_enabled');
     });

--- a/mobile/test/services/audio_sharing_preference_test.dart
+++ b/mobile/test/services/audio_sharing_preference_test.dart
@@ -41,16 +41,19 @@ void main() {
       expect(newService.isAudioSharingEnabled, isTrue);
     });
 
-    test('saved false preference is restored on a new service instance', () async {
-      SharedPreferences.setMockInitialValues({
-        AudioSharingPreferenceService.prefsKey: false,
-      });
-      final prefs = await SharedPreferences.getInstance();
+    test(
+      'saved false preference is restored on a new service instance',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          AudioSharingPreferenceService.prefsKey: false,
+        });
+        final prefs = await SharedPreferences.getInstance();
 
-      final newService = AudioSharingPreferenceService(prefs);
+        final newService = AudioSharingPreferenceService(prefs);
 
-      expect(newService.isAudioSharingEnabled, isFalse);
-    });
+        expect(newService.isAudioSharingEnabled, isFalse);
+      },
+    );
 
     test('preference key is correct', () {
       expect(AudioSharingPreferenceService.prefsKey, 'audio_sharing_enabled');

--- a/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
+++ b/mobile/test/widgets/video_editor/video_editor_scaffold_test.dart
@@ -10,10 +10,12 @@ import 'package:openvine/blocs/video_editor/filter_editor/video_editor_filter_bl
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/video_editor_scaffold.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group(VideoEditorScaffold, () {
@@ -21,8 +23,11 @@ void main() {
     late TimelineOverlayBloc overlayBloc;
     late ClipEditorBloc clipBloc;
     late VideoEditorFilterBloc filterBloc;
+    late SharedPreferences prefs;
 
-    setUp(() {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
       mainBloc = VideoEditorMainBloc();
       overlayBloc = TimelineOverlayBloc();
       clipBloc = ClipEditorBloc(onFinalClipInvalidated: () {});
@@ -41,6 +46,7 @@ void main() {
       final removeAreaKey = GlobalKey();
 
       return ProviderScope(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
         child: VideoEditorScope(
           editorKey: editorKey,
           removeAreaKey: removeAreaKey,

--- a/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar_test.dart
@@ -9,12 +9,12 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar.dart';
 import 'package:permissions_service/permissions_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
-import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockGallerySaveService extends Mock implements GallerySaveService {}

--- a/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar_test.dart
@@ -14,6 +14,7 @@ import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar.dart';
 import 'package:permissions_service/permissions_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockGallerySaveService extends Mock implements GallerySaveService {}
@@ -55,9 +56,11 @@ void main() {
   group(VideoMetadataCaptureBottomBar, () {
     late _MockGallerySaveService mockGallerySaveService;
     late _MockPermissionsService mockPermissionsService;
+    late SharedPreferences prefs;
 
-    setUp(() {
+    setUp(() async {
       SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
       mockGallerySaveService = _MockGallerySaveService();
       mockPermissionsService = _MockPermissionsService();
       when(
@@ -76,8 +79,9 @@ void main() {
 
     testWidgets('renders both Save draft and Post buttons', (tester) async {
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        ProviderScope(
+          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+          child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(body: VideoMetadataCaptureBottomBar()),
@@ -92,8 +96,9 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        ProviderScope(
+          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+          child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(body: VideoMetadataCaptureBottomBar()),

--- a/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview_test.dart
@@ -19,11 +19,11 @@ import 'package:shared_preferences/shared_preferences.dart';
 void main() {
   group(VideoMetadataCaptureClipPreview, () {
     late DivineVideoClip testClip;
-    late SharedPreferences _prefs;
+    late SharedPreferences prefs;
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
-      _prefs = await SharedPreferences.getInstance();
+      prefs = await SharedPreferences.getInstance();
       testClip = DivineVideoClip(
         id: 'test-clip',
         video: EditorVideo.file('test.mp4'),
@@ -39,7 +39,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
             ),
@@ -69,7 +69,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([clipNoThumbnail]),
             ),
@@ -187,7 +187,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
             ),
@@ -209,7 +209,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
             ),
@@ -230,7 +230,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
             ),
@@ -254,7 +254,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
             ),

--- a/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview_test.dart
@@ -9,16 +9,21 @@ import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/video_editor/video_editor_processing_overlay.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group(VideoMetadataCaptureClipPreview, () {
     late DivineVideoClip testClip;
+    late SharedPreferences _prefs;
 
-    setUp(() {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      _prefs = await SharedPreferences.getInstance();
       testClip = DivineVideoClip(
         id: 'test-clip',
         video: EditorVideo.file('test.mp4'),
@@ -34,6 +39,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
             ),
@@ -63,6 +69,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([clipNoThumbnail]),
             ),
@@ -180,6 +187,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
             ),
@@ -201,6 +209,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
             ),
@@ -221,6 +230,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
             ),
@@ -244,6 +254,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             clipManagerProvider.overrideWith(
               () => _MockClipManagerNotifier([testClip]),
             ),

--- a/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_bottom_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_bottom_bar_test.dart
@@ -5,6 +5,7 @@ import 'package:models/models.dart' as models;
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/video_metadata/modes/classic/video_metadata_classic_bottom_bar.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -12,14 +13,18 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group(VideoMetadataClassicBottomBar, () {
-    setUp(() {
+    late SharedPreferences prefs;
+
+    setUp(() async {
       SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
     });
 
     testWidgets('renders Post button labeled "Done"', (tester) async {
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        ProviderScope(
+          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+          child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(body: VideoMetadataClassicBottomBar()),
@@ -31,8 +36,9 @@ void main() {
 
     testWidgets('button is disabled when metadata is invalid', (tester) async {
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        ProviderScope(
+          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+          child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(body: VideoMetadataClassicBottomBar()),
@@ -116,8 +122,9 @@ void main() {
 
     testWidgets('button has correct semantics identifier', (tester) async {
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        ProviderScope(
+          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+          child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(body: VideoMetadataClassicBottomBar()),

--- a/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail_test.dart
@@ -25,12 +25,12 @@ import 'package:shared_preferences/shared_preferences.dart';
 void main() {
   group(VideoMetadataClassicPreviewThumbnail, () {
     late DivineVideoClip testClip;
-    late SharedPreferences _prefs;
+    late SharedPreferences prefs;
 
     setUp(() async {
       DivineVideoPlayerController.resetIdCounterForTesting();
       SharedPreferences.setMockInitialValues({});
-      _prefs = await SharedPreferences.getInstance();
+      prefs = await SharedPreferences.getInstance();
 
       testClip = DivineVideoClip(
         id: 'test-clip',
@@ -59,7 +59,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
-              sharedPreferencesProvider.overrideWithValue(_prefs),
+              sharedPreferencesProvider.overrideWithValue(prefs),
               clipManagerProvider.overrideWith(
                 () => _MockClipManagerNotifier([clipNoThumbnail]),
               ),
@@ -87,7 +87,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
-              sharedPreferencesProvider.overrideWithValue(_prefs),
+              sharedPreferencesProvider.overrideWithValue(prefs),
               clipManagerProvider.overrideWith(
                 () => _MockClipManagerNotifier([testClip]),
               ),

--- a/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail_test.dart
@@ -15,17 +15,22 @@ import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/video_editor/video_editor_processing_overlay.dart';
 import 'package:openvine/widgets/video_metadata/modes/classic/video_metadata_classic_preview_thumbnail.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group(VideoMetadataClassicPreviewThumbnail, () {
     late DivineVideoClip testClip;
+    late SharedPreferences _prefs;
 
-    setUp(() {
+    setUp(() async {
       DivineVideoPlayerController.resetIdCounterForTesting();
+      SharedPreferences.setMockInitialValues({});
+      _prefs = await SharedPreferences.getInstance();
 
       testClip = DivineVideoClip(
         id: 'test-clip',
@@ -54,6 +59,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              sharedPreferencesProvider.overrideWithValue(_prefs),
               clipManagerProvider.overrideWith(
                 () => _MockClipManagerNotifier([clipNoThumbnail]),
               ),
@@ -81,6 +87,7 @@ void main() {
         await tester.pumpWidget(
           ProviderScope(
             overrides: [
+              sharedPreferencesProvider.overrideWithValue(_prefs),
               clipManagerProvider.overrideWith(
                 () => _MockClipManagerNotifier([testClip]),
               ),

--- a/mobile/test/widgets/video_metadata/video_metadata_collaborators_input_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_collaborators_input_test.dart
@@ -7,9 +7,11 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_collaborators_input.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Mock for FollowRepository
 class _MockFollowRepository extends Mock implements FollowRepository {}
@@ -58,10 +60,18 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group(VideoMetadataCollaboratorsInput, () {
+    late SharedPreferences _prefs;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      _prefs = await SharedPreferences.getInstance();
+    });
+
     testWidgets('renders Collaborators label', (tester) async {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -81,6 +91,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -138,6 +149,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -160,6 +172,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -192,6 +205,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -291,6 +305,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),

--- a/mobile/test/widgets/video_metadata/video_metadata_collaborators_input_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_collaborators_input_test.dart
@@ -60,18 +60,18 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group(VideoMetadataCollaboratorsInput, () {
-    late SharedPreferences _prefs;
+    late SharedPreferences prefs;
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
-      _prefs = await SharedPreferences.getInstance();
+      prefs = await SharedPreferences.getInstance();
     });
 
     testWidgets('renders Collaborators label', (tester) async {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -91,7 +91,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -149,7 +149,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -172,7 +172,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -205,7 +205,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -305,7 +305,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),

--- a/mobile/test/widgets/video_metadata/video_metadata_expiration_selector_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_expiration_selector_test.dart
@@ -23,11 +23,11 @@ String _expirationLabel(VideoMetadataExpiration exp) {
 
 void main() {
   group('VideoMetadataExpirationSelector', () {
-    late SharedPreferences _prefs;
+    late SharedPreferences prefs;
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
-      _prefs = await SharedPreferences.getInstance();
+      prefs = await SharedPreferences.getInstance();
     });
 
     testWidgets('displays default expiration option', (tester) async {
@@ -35,7 +35,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [sharedPreferencesProvider.overrideWithValue(_prefs)],
+          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
           child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -83,7 +83,7 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [sharedPreferencesProvider.overrideWithValue(_prefs)],
+          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
           child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,

--- a/mobile/test/widgets/video_metadata/video_metadata_expiration_selector_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_expiration_selector_test.dart
@@ -4,8 +4,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_metadata/video_metadata_expiration.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_expiration_selector.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 // English labels matching app_en.arb values.
 String _expirationLabel(VideoMetadataExpiration exp) {
@@ -21,12 +23,20 @@ String _expirationLabel(VideoMetadataExpiration exp) {
 
 void main() {
   group('VideoMetadataExpirationSelector', () {
+    late SharedPreferences _prefs;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      _prefs = await SharedPreferences.getInstance();
+    });
+
     testWidgets('displays default expiration option', (tester) async {
       addTearDown(() => tester.view.resetPhysicalSize());
 
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        ProviderScope(
+          overrides: [sharedPreferencesProvider.overrideWithValue(_prefs)],
+          child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(body: VideoMetadataExpirationSelector()),
@@ -72,8 +82,9 @@ void main() {
       addTearDown(() => tester.view.resetPhysicalSize());
 
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        ProviderScope(
+          overrides: [sharedPreferencesProvider.overrideWithValue(_prefs)],
+          child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(body: VideoMetadataExpirationSelector()),

--- a/mobile/test/widgets/video_metadata/video_metadata_inspired_by_input_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_inspired_by_input_test.dart
@@ -72,18 +72,18 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group(VideoMetadataInspiredByInput, () {
-    late SharedPreferences _prefs;
+    late SharedPreferences prefs;
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
-      _prefs = await SharedPreferences.getInstance();
+      prefs = await SharedPreferences.getInstance();
     });
 
     testWidgets('renders "Inspired by" label', (tester) async {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -106,7 +106,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -131,7 +131,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -157,7 +157,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -193,7 +193,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -292,7 +292,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            sharedPreferencesProvider.overrideWithValue(_prefs),
+            sharedPreferencesProvider.overrideWithValue(prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),

--- a/mobile/test/widgets/video_metadata/video_metadata_inspired_by_input_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_inspired_by_input_test.dart
@@ -8,9 +8,11 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_inspired_by_input.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Mock for FollowRepository
 class _MockFollowRepository extends Mock implements FollowRepository {}
@@ -70,10 +72,18 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group(VideoMetadataInspiredByInput, () {
+    late SharedPreferences _prefs;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      _prefs = await SharedPreferences.getInstance();
+    });
+
     testWidgets('renders "Inspired by" label', (tester) async {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -96,6 +106,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -120,6 +131,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -145,6 +157,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -180,6 +193,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),
@@ -278,6 +292,7 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
+            sharedPreferencesProvider.overrideWithValue(_prefs),
             followRepositoryProvider.overrideWithValue(
               _createMockFollowRepository(),
             ),

--- a/mobile/test/widgets/video_metadata/video_metadata_tags_input_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_tags_input_test.dart
@@ -5,15 +5,25 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_tags_input.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group('VideoMetadataTagsInput', () {
+    late SharedPreferences _prefs;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      _prefs = await SharedPreferences.getInstance();
+    });
+
     testWidgets('displays empty state initially', (tester) async {
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        ProviderScope(
+          overrides: [sharedPreferencesProvider.overrideWithValue(_prefs)],
+          child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(body: VideoMetadataTagsInput()),
@@ -259,8 +269,9 @@ void main() {
 
     testWidgets('focuses input when tapped outside', (tester) async {
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        ProviderScope(
+          overrides: [sharedPreferencesProvider.overrideWithValue(_prefs)],
+          child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
             home: Scaffold(body: VideoMetadataTagsInput()),

--- a/mobile/test/widgets/video_metadata/video_metadata_tags_input_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_tags_input_test.dart
@@ -12,17 +12,17 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group('VideoMetadataTagsInput', () {
-    late SharedPreferences _prefs;
+    late SharedPreferences prefs;
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
-      _prefs = await SharedPreferences.getInstance();
+      prefs = await SharedPreferences.getInstance();
     });
 
     testWidgets('displays empty state initially', (tester) async {
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [sharedPreferencesProvider.overrideWithValue(_prefs)],
+          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
           child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -270,7 +270,7 @@ void main() {
     testWidgets('focuses input when tapped outside', (tester) async {
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [sharedPreferencesProvider.overrideWithValue(_prefs)],
+          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
           child: const MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,

--- a/mobile/test/widgets/video_recorder/video_recorder_top_bar_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_top_bar_test.dart
@@ -5,8 +5,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_recorder_provider.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_top_bar.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../mocks/mock_camera_service.dart';
 
@@ -15,8 +17,11 @@ void main() {
 
   group('VideoRecorderTopBar Widget Tests', () {
     late MockCameraService mockCamera;
+    late SharedPreferences prefs;
 
     setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
       mockCamera = MockCameraService.create(
         onUpdateState: ({forceCameraRebuild}) {},
         onAutoStopped: (_) {},
@@ -27,6 +32,7 @@ void main() {
     Widget buildTestWidget() {
       return ProviderScope(
         overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
           videoRecorderProvider.overrideWith(
             () => VideoRecorderNotifier(mockCamera),
           ),


### PR DESCRIPTION
## Description

Until now, there was a configuration in the general settings that allowed users to choose whether audio should be reused. However, this setting wasn’t used anywhere and its state wasn’t restored. This PR now applies the setting in the video editor and correctly restores the configuration.

Note that, by default, the setting was true in the video editor, so we've kept that value in the General Settings screen as well.

**Related Issue:** Closes #3739

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
