### PR TITLE
fix(theme): update track color for selected widget state in VineTheme

### DIFF
--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -625,11 +625,10 @@ class VineTheme {
         return onSurfaceDisabled;
       }),
       trackColor: WidgetStateProperty.resolveWith((states) {
-        if (states.contains(WidgetState.selected)) return primary;
+        if (states.contains(WidgetState.selected)) return onPrimary;
         return surfaceContainer;
       }),
       trackOutlineColor: WidgetStateProperty.resolveWith((states) {
-        if (states.contains(WidgetState.selected)) return Colors.transparent;
         return outlineVariant;
       }),
     ),

--- a/mobile/packages/divine_ui/test/src/theme/vine_theme_switch_theme_test.dart
+++ b/mobile/packages/divine_ui/test/src/theme/vine_theme_switch_theme_test.dart
@@ -22,8 +22,9 @@ void main() {
       });
 
       test('trackColor resolves to onPrimary when selected', () {
-        final color = switchTheme.trackColor!
-            .resolve(<WidgetState>{WidgetState.selected});
+        final color = switchTheme.trackColor!.resolve(<WidgetState>{
+          WidgetState.selected,
+        });
         expect(color, equals(VineTheme.onPrimary));
       });
 
@@ -36,8 +37,9 @@ void main() {
       );
 
       test('trackOutlineColor resolves to outlineVariant when selected', () {
-        final color = switchTheme.trackOutlineColor!
-            .resolve(<WidgetState>{WidgetState.selected});
+        final color = switchTheme.trackOutlineColor!.resolve(<WidgetState>{
+          WidgetState.selected,
+        });
         expect(color, equals(VineTheme.outlineVariant));
       });
     });

--- a/mobile/packages/divine_ui/test/src/theme/vine_theme_switch_theme_test.dart
+++ b/mobile/packages/divine_ui/test/src/theme/vine_theme_switch_theme_test.dart
@@ -21,6 +21,12 @@ void main() {
         expect(color, equals(VineTheme.surfaceContainer));
       });
 
+      test('trackColor resolves to onPrimary when selected', () {
+        final color = switchTheme.trackColor!
+            .resolve(<WidgetState>{WidgetState.selected});
+        expect(color, equals(VineTheme.onPrimary));
+      });
+
       test(
         'trackOutlineColor resolves to outlineVariant when not selected',
         () {
@@ -28,6 +34,12 @@ void main() {
           expect(color, equals(VineTheme.outlineVariant));
         },
       );
+
+      test('trackOutlineColor resolves to outlineVariant when selected', () {
+        final color = switchTheme.trackOutlineColor!
+            .resolve(<WidgetState>{WidgetState.selected});
+        expect(color, equals(VineTheme.outlineVariant));
+      });
     });
   });
 }


### PR DESCRIPTION
Closes #3747

## Description

Every switch in the app was hard to recognize because of a color issue, where the entire switch turned the primary color when selected. This PR updates the styling so switches are now clearly visible.


| Before | After |
| ------- | -----|
|     <img width="333" alt="image" src="https://github.com/user-attachments/assets/8725c55b-6af2-41be-88bc-4c68a8fe89ae" />   |       <img width="333" alt="image" src="https://github.com/user-attachments/assets/d77c689e-3f98-49dd-8be9-9bc88f66e0a8" />        |

**Related Issue:** 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore