### PR TITLE
fix(security): restrict Nostr app bridge to main frame (#3357)

### DIFF
--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
@@ -35,6 +36,7 @@ class NostrAppSandboxScreen extends ConsumerStatefulWidget {
     this.javaScriptRunnerOverride,
     this.onBridgeMessageHandlerReady,
     this.currentUserPubkeyOverride,
+    this.bridgeNonceOverride,
     super.key,
   });
 
@@ -48,6 +50,8 @@ class NostrAppSandboxScreen extends ConsumerStatefulWidget {
   onBridgeMessageHandlerReady;
   @visibleForTesting
   final String? currentUserPubkeyOverride;
+  @visibleForTesting
+  final String? bridgeNonceOverride;
 
   static String pathForAppId(String appId) =>
       '/apps/${Uri.encodeComponent(appId)}/sandbox';
@@ -63,6 +67,7 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
   Uri? _blockedUri;
   Uri? _currentPageUri;
   http.Client? _ownedBootstrapHttpClient;
+  late final String _bridgeNonce;
 
   String? get _currentUserPubkey =>
       widget.currentUserPubkeyOverride ??
@@ -72,6 +77,7 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
   void initState() {
     super.initState();
     _currentPageUri = Uri.parse(widget.app.launchUrl);
+    _bridgeNonce = widget.bridgeNonceOverride ?? _generateBridgeNonce();
     widget.onNavigationHandlerReady?.call(_handleNavigationAttempt);
     widget.onBridgeMessageHandlerReady?.call(_handleBridgeMessage);
 
@@ -114,6 +120,12 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
       final parsedAllowed = Uri.tryParse(allowedOrigin);
       return parsedAllowed != null && parsedAllowed.origin == uri.origin;
     });
+  }
+
+  static String _generateBridgeNonce() {
+    final random = Random.secure();
+    final bytes = List<int>.generate(24, (_) => random.nextInt(256));
+    return base64Url.encode(bytes);
   }
 
   NostrAppBridgeService get _bridgeService =>
@@ -261,13 +273,14 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
 
     final contentController = await configuration.getUserContentController();
     final fullScript = buildBridgeBootstrapScript(
+      nonce: _bridgeNonce,
       pubkey: _currentUserPubkey,
       autoLoginScript: widget.app.autoLoginScript,
     );
     final userScript = WKUserScript(
       source: fullScript,
       injectionTime: UserScriptInjectionTime.atDocumentStart,
-      isForMainFrameOnly: false,
+      isForMainFrameOnly: true,
     );
 
     await contentController.addUserScript(userScript);
@@ -298,6 +311,7 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
         baseUri: resolvedUri,
         html: injectBridgeBootstrapIntoHtml(
           response.body,
+          nonce: _bridgeNonce,
           pubkey: _currentUserPubkey,
           autoLoginScript: widget.app.autoLoginScript,
         ),
@@ -314,6 +328,7 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
     }
 
     final fullScript = buildBridgeBootstrapScript(
+      nonce: _bridgeNonce,
       pubkey: _currentUserPubkey,
       autoLoginScript: widget.app.autoLoginScript,
     );
@@ -333,6 +348,17 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
         (key, value) => MapEntry(key.toString(), value),
       );
       responseId = request['id']?.toString() ?? 'unknown';
+      final nonce = request['nonce']?.toString();
+      if (nonce == null || nonce != _bridgeNonce) {
+        // Bridge message arrived without (or with the wrong) per-mount
+        // nonce — most likely an iframe calling the JS channel directly,
+        // bypassing the bootstrap script. Refuse before evaluating.
+        await _emitBridgeResponse(
+          id: responseId,
+          result: const BridgeResult.error('subframe_or_unauthorized'),
+        );
+        return;
+      }
       final method = request['method']?.toString();
       final args = request['args'];
 
@@ -488,11 +514,22 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
 
 /// Builds the bridge bootstrap JavaScript with optional eager pubkey,
 /// provider metadata, ready-event dispatch, and per-app auto-login.
+///
+/// [nonce] is a per-mount secret embedded in every outgoing bridge
+/// request. The host rejects messages whose nonce does not match,
+/// which prevents iframes that bypass `window.nostr` and call the
+/// `divineSandboxBridge` channel directly from impersonating the main
+/// frame.
 @visibleForTesting
-String buildBridgeBootstrapScript({String? pubkey, String? autoLoginScript}) {
+String buildBridgeBootstrapScript({
+  required String nonce,
+  String? pubkey,
+  String? autoLoginScript,
+}) {
   final escapedPubkey = pubkey != null && pubkey.isNotEmpty
       ? _escapeJs(pubkey)
       : '';
+  final escapedNonce = _escapeJs(nonce);
   final loginJs = autoLoginScript != null && autoLoginScript.isNotEmpty
       ? autoLoginScript.replaceAll('{{PUBKEY}}', escapedPubkey)
       : '';
@@ -503,6 +540,17 @@ String buildBridgeBootstrapScript({String? pubkey, String? autoLoginScript}) {
     return;
   }
 
+  // Refuse to install in non-main frames. Cross-origin access to
+  // window.top throws; treat that as "not main frame" and bail.
+  try {
+    if (window.top !== window.self) {
+      return;
+    }
+  } catch (_) {
+    return;
+  }
+
+  const __divineBridgeNonce = '$escapedNonce';
   const pending = new Map();
   let nextId = 0;
 
@@ -512,6 +560,7 @@ String buildBridgeBootstrapScript({String? pubkey, String? autoLoginScript}) {
       id,
       method,
       args: args ?? {},
+      nonce: __divineBridgeNonce,
     });
 
     return new Promise((resolve, reject) => {
@@ -667,10 +716,12 @@ class _BootstrappedSandboxPage {
 @visibleForTesting
 String injectBridgeBootstrapIntoHtml(
   String html, {
+  required String nonce,
   String? pubkey,
   String? autoLoginScript,
 }) {
   final script = buildBridgeBootstrapScript(
+    nonce: nonce,
     pubkey: pubkey,
     autoLoginScript: autoLoginScript,
   );

--- a/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
+++ b/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
@@ -215,6 +215,7 @@ void main() {
               executedScripts.add(script);
             },
             onBridgeMessageHandlerReady: (handler) => bridgeHandler = handler,
+            bridgeNonceOverride: 'test-nonce',
           ),
         ),
       );
@@ -224,6 +225,7 @@ void main() {
           'id': 'req-1',
           'method': 'getPublicKey',
           'args': <String, dynamic>{},
+          'nonce': 'test-nonce',
         }),
       );
       await tester.pump();
@@ -233,25 +235,113 @@ void main() {
       expect(executedScripts.single, contains('f' * 64));
     });
 
+    testWidgets('rejects bridge messages with no nonce as unauthorized', (
+      tester,
+    ) async {
+      Future<void> Function(String message)? bridgeHandler;
+      final executedScripts = <String>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: NostrAppSandboxScreen(
+            app: _fixtureApp(),
+            sandboxBuilder: (_) => const SizedBox.shrink(),
+            javaScriptRunnerOverride: (script) async {
+              executedScripts.add(script);
+            },
+            onBridgeMessageHandlerReady: (handler) => bridgeHandler = handler,
+            bridgeNonceOverride: 'expected-nonce',
+            currentUserPubkeyOverride: 'f' * 64,
+          ),
+        ),
+      );
+
+      await bridgeHandler!(
+        jsonEncode({
+          'id': 'subframe-1',
+          'method': 'signEvent',
+          'args': <String, dynamic>{
+            'event': {'kind': 1},
+          },
+          // Note: no 'nonce' field — simulates an iframe calling
+          // divineSandboxBridge.postMessage directly without the
+          // main-frame bootstrap context.
+        }),
+      );
+      await tester.pump();
+
+      expect(executedScripts, hasLength(1));
+      expect(executedScripts.single, contains('subframe-1'));
+      expect(executedScripts.single, contains('subframe_or_unauthorized'));
+      expect(
+        executedScripts.single,
+        isNot(contains('"success":true')),
+      );
+    });
+
+    testWidgets(
+      'rejects bridge messages with a mismatched nonce as unauthorized',
+      (tester) async {
+        Future<void> Function(String message)? bridgeHandler;
+        final executedScripts = <String>[];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: NostrAppSandboxScreen(
+              app: _fixtureApp(),
+              sandboxBuilder: (_) => const SizedBox.shrink(),
+              javaScriptRunnerOverride: (script) async {
+                executedScripts.add(script);
+              },
+              onBridgeMessageHandlerReady: (handler) => bridgeHandler = handler,
+              bridgeNonceOverride: 'expected-nonce',
+              currentUserPubkeyOverride: 'f' * 64,
+            ),
+          ),
+        );
+
+        await bridgeHandler!(
+          jsonEncode({
+            'id': 'subframe-2',
+            'method': 'getPublicKey',
+            'args': <String, dynamic>{},
+            'nonce': 'attacker-guessed-nonce',
+          }),
+        );
+        await tester.pump();
+
+        expect(executedScripts, hasLength(1));
+        expect(executedScripts.single, contains('subframe-2'));
+        expect(executedScripts.single, contains('subframe_or_unauthorized'));
+      },
+    );
+
     group('bridge bootstrap script', () {
       test('includes eager pubkey when provided', () {
-        final script = buildBridgeBootstrapScript(pubkey: 'abc123');
+        final script = buildBridgeBootstrapScript(
+          nonce: 'n',
+          pubkey: 'abc123',
+        );
         expect(script, contains("_pubkey: 'abc123'"));
       });
 
       test('sets pubkey to null when not provided', () {
-        final script = buildBridgeBootstrapScript();
+        final script = buildBridgeBootstrapScript(nonce: 'n');
         expect(script, contains("_pubkey: '' || null"));
       });
 
       test('includes provider metadata', () {
-        final script = buildBridgeBootstrapScript();
+        final script = buildBridgeBootstrapScript(nonce: 'n');
         expect(script, contains("name: 'diVine'"));
         expect(script, contains("'nip04', 'nip44'"));
       });
 
       test('dispatches nostr:ready event', () {
-        final script = buildBridgeBootstrapScript();
+        final script = buildBridgeBootstrapScript(nonce: 'n');
         expect(
           script,
           contains("window.dispatchEvent(new Event('nostr:ready'))"),
@@ -259,7 +349,7 @@ void main() {
       });
 
       test('dispatches nlAuth event for nostr-login compat', () {
-        final script = buildBridgeBootstrapScript();
+        final script = buildBridgeBootstrapScript(nonce: 'n');
         expect(
           script,
           contains("document.dispatchEvent(new CustomEvent('nlAuth'"),
@@ -268,6 +358,7 @@ void main() {
 
       test('injects auto-login script with pubkey substituted', () {
         final script = buildBridgeBootstrapScript(
+          nonce: 'n',
           pubkey: 'deadbeef',
           autoLoginScript: "localStorage.setItem('pubkey', '{{PUBKEY}}');",
         );
@@ -276,28 +367,54 @@ void main() {
       });
 
       test('skips auto-login when script is null', () {
-        final script = buildBridgeBootstrapScript(pubkey: 'abc');
+        final script = buildBridgeBootstrapScript(nonce: 'n', pubkey: 'abc');
         expect(script, isNot(contains('localStorage.setItem')));
       });
 
       test('escapes single quotes in pubkey', () {
-        final script = buildBridgeBootstrapScript(pubkey: "a'b");
+        final script = buildBridgeBootstrapScript(nonce: 'n', pubkey: "a'b");
         expect(script, contains(r"_pubkey: 'a\'b'"));
       });
 
       test('escapes backslashes in pubkey', () {
-        final script = buildBridgeBootstrapScript(pubkey: r'a\b');
+        final script = buildBridgeBootstrapScript(nonce: 'n', pubkey: r'a\b');
         expect(script, contains(r"_pubkey: 'a\\b'"));
       });
 
       test('escapes backticks in pubkey', () {
-        final script = buildBridgeBootstrapScript(pubkey: 'a`b');
+        final script = buildBridgeBootstrapScript(nonce: 'n', pubkey: 'a`b');
         expect(script, contains(r"_pubkey: 'a\`b'"));
       });
 
       test('escapes newlines in pubkey', () {
-        final script = buildBridgeBootstrapScript(pubkey: 'a\nb');
+        final script = buildBridgeBootstrapScript(nonce: 'n', pubkey: 'a\nb');
         expect(script, contains(r"_pubkey: 'a\nb'"));
+      });
+
+      test('refuses to install in non-main frames', () {
+        final script = buildBridgeBootstrapScript(nonce: 'n');
+        expect(script, contains('window.top !== window.self'));
+      });
+
+      test('embeds the per-mount nonce in the bootstrap closure', () {
+        final script = buildBridgeBootstrapScript(nonce: 'NONCE-XYZ');
+        expect(
+          script,
+          contains("const __divineBridgeNonce = 'NONCE-XYZ';"),
+        );
+      });
+
+      test('includes the nonce on every outgoing bridge request', () {
+        final script = buildBridgeBootstrapScript(nonce: 'n');
+        expect(script, contains('nonce: __divineBridgeNonce'));
+      });
+
+      test('escapes single quotes in the nonce', () {
+        final script = buildBridgeBootstrapScript(nonce: "a'b");
+        expect(
+          script,
+          contains(r"const __divineBridgeNonce = 'a\'b';"),
+        );
       });
     });
 
@@ -305,6 +422,7 @@ void main() {
       test('inserts bridge after head tag', () {
         final html = injectBridgeBootstrapIntoHtml(
           '<html><head></head><body></body></html>',
+          nonce: 'n',
           pubkey: 'abc',
         );
         expect(html, contains('<!-- divine-nostr-bridge -->'));
@@ -315,12 +433,25 @@ void main() {
       test('includes auto-login in injected HTML', () {
         final html = injectBridgeBootstrapIntoHtml(
           '<html><head></head><body></body></html>',
+          nonce: 'n',
           pubkey: 'abc',
           autoLoginScript: "localStorage.setItem('loginType', 'extension');",
         );
         expect(
           html,
           contains("localStorage.setItem('loginType', 'extension')"),
+        );
+      });
+
+      test('forwards the nonce into the embedded bootstrap script', () {
+        final html = injectBridgeBootstrapIntoHtml(
+          '<html><head></head><body></body></html>',
+          nonce: 'NONCE-XYZ',
+          pubkey: 'abc',
+        );
+        expect(
+          html,
+          contains("const __divineBridgeNonce = 'NONCE-XYZ';"),
         );
       });
     });

--- a/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
+++ b/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
@@ -320,6 +320,48 @@ void main() {
       },
     );
 
+    testWidgets(
+      'rejects nip44.decrypt bridge messages with a mismatched nonce as unauthorized',
+      (tester) async {
+        Future<void> Function(String message)? bridgeHandler;
+        final executedScripts = <String>[];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: NostrAppSandboxScreen(
+              app: _fixtureApp(),
+              sandboxBuilder: (_) => const SizedBox.shrink(),
+              javaScriptRunnerOverride: (script) async {
+                executedScripts.add(script);
+              },
+              onBridgeMessageHandlerReady: (handler) => bridgeHandler = handler,
+              bridgeNonceOverride: 'expected-nonce',
+              currentUserPubkeyOverride: 'f' * 64,
+            ),
+          ),
+        );
+
+        await bridgeHandler!(
+          jsonEncode({
+            'id': 'subframe-3',
+            'method': 'nip44.decrypt',
+            'args': <String, dynamic>{
+              'pubkey': 'f' * 64,
+              'ciphertext': 'ciphertext',
+            },
+            'nonce': 'attacker-guessed-nonce',
+          }),
+        );
+        await tester.pump();
+
+        expect(executedScripts, hasLength(1));
+        expect(executedScripts.single, contains('subframe-3'));
+        expect(executedScripts.single, contains('subframe_or_unauthorized'));
+      },
+    );
+
     group('bridge bootstrap script', () {
       test('includes eager pubkey when provided', () {
         final script = buildBridgeBootstrapScript(


### PR DESCRIPTION
## Description

Closes #3357.

A third-party iframe loaded inside any approved Nostr app could hijack the signed-in user's signing key:

- **iOS** — the bridge `WKUserScript` was installed with `isForMainFrameOnly: false`, so iframes received `window.nostr` directly.
- **Android** — `addJavaScriptChannel` exposes `divineSandboxBridge` to all frames; an iframe could bypass `window.nostr` entirely and post raw JSON to the channel.
- **Both** — the host used `_currentPageUri` (the top-level navigation URL) as the request origin, so the policy approved the iframe's call as if it came from the allowed parent app.

End-to-end exploit: any iframe calling `window.nostr.signEvent({...})` or `divineSandboxBridge.postMessage(JSON.stringify(...))` got the parent app's signing capabilities, including for `signEvent` kinds the user had already granted.

## Fix (three layers, all required)

1. **iOS WKUserScript → main-frame-only.** Stops the bootstrap script from running inside iframes on iOS.
2. **Bootstrap script self-defends.** Early-exits when `window.top !== window.self`, and stamps every outgoing request with a per-mount nonce held in IIFE-scoped closure (not on `window`, so cross-origin same-origin iframe inspection of `parent` can't read it).
3. **Host validates the nonce on receipt.** `_handleBridgeMessage` rejects messages with no nonce or a mismatched nonce as `subframe_or_unauthorized` before evaluating against policy. This closes the Android JS-channel direct-post path.

The single layer most often suggested (`isForMainFrameOnly: true` on its own) is **not** sufficient — the JS channel is still callable from iframes on both platforms, and on Android the user-script setting doesn't apply at all. The nonce gate on the host is the actually-effective defense; the main-frame-only injection and the JS-side frame guard are defense-in-depth.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes a critical security issue)

## Test Plan

Added to `mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart`:

| Test | What it proves |
|------|----------------|
| `rejects bridge messages with no nonce as unauthorized` | Iframe call without bootstrap context → rejected before evaluation |
| `rejects bridge messages with a mismatched nonce as unauthorized` | Wrong nonce (e.g., guessed) → rejected |
| `bridge bootstrap script refuses to install in non-main frames` | The `window.top !== window.self` guard is present |
| `bridge bootstrap script embeds the per-mount nonce in the bootstrap closure` | Nonce is present in the IIFE |
| `bridge bootstrap script includes the nonce on every outgoing bridge request` | Every `request()` payload carries the nonce |
| `bridge bootstrap script escapes single quotes in the nonce` | Nonce is JS-string-safe |
| `injectBridgeBootstrapIntoHtml forwards the nonce into the embedded bootstrap script` | Android bootstrap path also gets the nonce |

Existing test `handles bridge messages and emits JavaScript responses` updated to pass `bridgeNonceOverride: 'test-nonce'` and include the matching nonce in its message — proves legitimate requests still pass through.

Local verification:
- `dart format` → no changes
- `flutter analyze lib test integration_test` → No issues found
- `flutter test test/screens/apps/nostr_app_sandbox_screen_test.dart` → all 27 tests pass (20 existing + 7 new)

## Acceptance Criteria

- [x] iOS user script uses main-frame-only injection (`isForMainFrameOnly: true`).
- [x] Android bootstrapped HTML does not expose bridge to untrusted frames — channel direct-post path is blocked by host-side nonce validation.
- [x] Tests prove a nested iframe cannot call `getPublicKey`, `signEvent`, or `nip44.decrypt` (the two new "rejects ... as unauthorized" tests cover these methods).

## Behavior Change

Same-origin iframes inside an allowed Nostr app no longer get a working `window.nostr`. They share the parent's trust boundary in principle, but the platform layer cannot reliably distinguish a same-origin first-party iframe from a same-origin third-party widget that an XSS in the parent could inject — so the safer default is to refuse all subframe access. If an existing app actually relies on this, we should hear about it in this PR's review (see open question to @NotThatKindOfDrLiz on #3357).

## Out of Scope (follow-ups)

- True per-frame origin attestation via `WKScriptMessage.frameInfo.securityOrigin` (iOS) / `WebMessageListener.sourceOrigin` (Android). The `webview_flutter` public API doesn't expose these today; would need a fork/upstream contribution. Worth a separate hardening issue.
- Apps directory audit for entries that intentionally embed third-party iframes (separate operational task; see open question on #3357).