### PR TITLE
fix(security): enforce NIP-46 nostrconnect secret match (#3355)

### DIFF
--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 import 'dart:developer';
 
+import 'package:flutter/foundation.dart';
+
 import '../event.dart';
 import '../event_kind.dart';
 import '../filter.dart';
@@ -404,8 +406,9 @@ class NostrConnectSession {
     }
 
     log(
-      '[NostrConnectSession] Decrypted response: '
-      'id=${response.id}, result=${response.result}, error=${response.error}',
+      '[NostrConnectSession] Decrypted response: id=${response.id}, '
+      'hasResult=${response.result.isNotEmpty}, '
+      'hasError=${(response.error ?? '').isNotEmpty}',
     );
 
     // Check for auth_url challenge (bunker needs approval)
@@ -417,42 +420,49 @@ class NostrConnectSession {
       return;
     }
 
-    // Validate the secret - CRITICAL for nostrconnect:// security
-    // Per NIP-46, the response.result must equal our secret
-    final expectedSecret = _info?.optionalSecret;
-    if (expectedSecret == null || expectedSecret.isEmpty) {
-      log('[NostrConnectSession] No expected secret - cannot validate');
-      _errorMessage = 'Invalid session state: no secret to validate';
-      _setState(NostrConnectState.error);
-      return;
-    }
+    // Validate the secret per NIP-46. Accept ONLY an exact match;
+    // "ack"/"connect" belong to the bunker:// flow's connect method
+    // and are not valid for nostrconnect://. Non-matching, non-error
+    // responses are dropped silently — treating them as terminal would
+    // let any pubkey on the listening relays DoS pairing by racing
+    // a junk response in front of the legitimate signer's reply.
+    final validation = validateConnectResponse(
+      response: response,
+      expectedSecret: _info?.optionalSecret,
+    );
 
-    // For connect response, result should be "ack" or the secret itself
-    // depending on bunker implementation
-    final isValidSecret =
-        response.result == expectedSecret ||
-        response.result == 'ack' ||
-        response.result == 'connect';
+    switch (validation) {
+      case NostrConnectResponseValidation.invalidSession:
+        log('[NostrConnectSession] No expected secret - cannot validate');
+        _errorMessage = 'Invalid session state: no secret to validate';
+        _setState(NostrConnectState.error);
+        return;
 
-    // Also check if this is an error response
-    if (response.error != null && response.error!.isNotEmpty) {
-      log('[NostrConnectSession] Bunker returned error: ${response.error}');
-      _errorMessage = 'Bunker rejected connection: ${response.error}';
-      _setState(NostrConnectState.error);
-      if (_connectionCompleter != null && !_connectionCompleter!.isCompleted) {
-        _connectionCompleter!.complete(null);
-      }
-      return;
-    }
+      case NostrConnectResponseValidation.rejectedByBunker:
+        log(
+          '[NostrConnectSession] Bunker rejected connection from '
+          '${event.pubkey}',
+        );
+        _errorMessage = 'Bunker rejected connection';
+        _setState(NostrConnectState.error);
+        if (_connectionCompleter != null &&
+            !_connectionCompleter!.isCompleted) {
+          _connectionCompleter!.complete(null);
+        }
+        return;
 
-    if (!isValidSecret) {
-      // Be lenient - some bunkers may respond differently
-      // Just log and continue if we got a response at all
-      log(
-        '[NostrConnectSession] Warning: Response result "${response.result}" '
-        'does not match expected secret "$expectedSecret", '
-        'but accepting anyway as bunker connected',
-      );
+      case NostrConnectResponseValidation.ignore:
+        // Drop silently and keep listening; the hard timeout in
+        // waitForConnection terminates the wait if no valid response
+        // ever arrives.
+        log(
+          '[NostrConnectSession] Ignoring response from ${event.pubkey}: '
+          'result did not match the expected secret',
+        );
+        return;
+
+      case NostrConnectResponseValidation.match:
+        break; // fall through to the success path below
     }
 
     // Success! Extract remote signer pubkey from the event
@@ -489,4 +499,59 @@ class NostrConnectSession {
     // Clean up relays - NostrRemoteSigner will create its own connections
     _cleanup();
   }
+}
+
+/// Outcome of validating a `nostrconnect://` connect response per NIP-46.
+@visibleForTesting
+enum NostrConnectResponseValidation {
+  /// `response.result` exactly matches the expected secret. Proceed to
+  /// bind the session.
+  match,
+
+  /// `response.error` is set; the signer explicitly rejected the
+  /// connection. Surface a terminal error to the user.
+  rejectedByBunker,
+
+  /// Programmer error: the session is missing an expected secret.
+  /// Surface a terminal error.
+  invalidSession,
+
+  /// `response.result` did not match and `response.error` is empty.
+  /// Drop silently per the policy decision in #3355 — treating this
+  /// as terminal would let any pubkey on the listening relays DoS
+  /// pairing by racing junk responses in front of the legitimate
+  /// signer's reply.
+  ignore,
+}
+
+/// Pure validation of a NIP-46 nostrconnect:// connect response against
+/// the expected secret. Public-by-test so the security-critical decision
+/// is exhaustively unit-testable.
+@visibleForTesting
+NostrConnectResponseValidation validateConnectResponse({
+  required NostrRemoteResponse response,
+  required String? expectedSecret,
+}) {
+  if (expectedSecret == null || expectedSecret.isEmpty) {
+    return NostrConnectResponseValidation.invalidSession;
+  }
+  final error = response.error;
+  if (error != null && error.isNotEmpty) {
+    return NostrConnectResponseValidation.rejectedByBunker;
+  }
+  if (_constantTimeEqual(response.result, expectedSecret)) {
+    return NostrConnectResponseValidation.match;
+  }
+  return NostrConnectResponseValidation.ignore;
+}
+
+bool _constantTimeEqual(String a, String b) {
+  if (a.length != b.length) {
+    return false;
+  }
+  var diff = 0;
+  for (var i = 0; i < a.length; i++) {
+    diff |= a.codeUnitAt(i) ^ b.codeUnitAt(i);
+  }
+  return diff == 0;
 }

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
@@ -411,15 +411,6 @@ class NostrConnectSession {
       'hasError=${(response.error ?? '').isNotEmpty}',
     );
 
-    // Check for auth_url challenge (bunker needs approval)
-    if (response.result == 'auth_url' && response.error != null) {
-      log('[NostrConnectSession] Auth URL challenge: ${response.error}');
-      // For nostrconnect://, we typically don't expect auth_url since
-      // the user already scanned/pasted the URL in their signer app.
-      // But handle it just in case.
-      return;
-    }
-
     // Validate the secret per NIP-46. Accept ONLY an exact match;
     // "ack"/"connect" belong to the bunker:// flow's connect method
     // and are not valid for nostrconnect://. Non-matching, non-error
@@ -546,6 +537,9 @@ NostrConnectResponseValidation validateConnectResponse({
 }
 
 bool _constantTimeEqual(String a, String b) {
+  // This still leaks length, which is acceptable here because the
+  // compared value is an ephemeral per-session secret. We only need
+  // to avoid content-dependent early exit for equal-length strings.
   if (a.length != b.length) {
     return false;
   }

--- a/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
@@ -1,6 +1,9 @@
 // ABOUTME: Unit tests for NostrConnectSession class
 // ABOUTME: Tests state machine transitions and URL generation
 
+import 'dart:io';
+
+import 'package:nostr_sdk/nip46/nostr_remote_response.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:test/test.dart';
 
@@ -330,5 +333,123 @@ void main() {
 
       expect(result.userPubkey, isNull);
     });
+  });
+
+  group('validateConnectResponse', () {
+    NostrRemoteResponse buildResponse(String result, {String? error}) {
+      return NostrRemoteResponse('req-id', result, error: error);
+    }
+
+    test('returns match when response.result equals the secret exactly', () {
+      final validation = validateConnectResponse(
+        response: buildResponse('s3cret'),
+        expectedSecret: 's3cret',
+      );
+      expect(validation, equals(NostrConnectResponseValidation.match));
+    });
+
+    test(
+      'returns ignore when response.result is "ack" (bunker:// flow token)',
+      () {
+        final validation = validateConnectResponse(
+          response: buildResponse('ack'),
+          expectedSecret: 's3cret',
+        );
+        expect(validation, equals(NostrConnectResponseValidation.ignore));
+      },
+    );
+
+    test('returns ignore when response.result is "connect"', () {
+      final validation = validateConnectResponse(
+        response: buildResponse('connect'),
+        expectedSecret: 's3cret',
+      );
+      expect(validation, equals(NostrConnectResponseValidation.ignore));
+    });
+
+    test('returns ignore on any other non-matching result', () {
+      final validation = validateConnectResponse(
+        response: buildResponse('attacker-guess'),
+        expectedSecret: 's3cret',
+      );
+      expect(validation, equals(NostrConnectResponseValidation.ignore));
+    });
+
+    test('returns ignore on an empty result string', () {
+      final validation = validateConnectResponse(
+        response: buildResponse(''),
+        expectedSecret: 's3cret',
+      );
+      expect(validation, equals(NostrConnectResponseValidation.ignore));
+    });
+
+    test('returns rejectedByBunker when response.error is non-empty', () {
+      final validation = validateConnectResponse(
+        response: buildResponse('', error: 'user denied'),
+        expectedSecret: 's3cret',
+      );
+      expect(
+        validation,
+        equals(NostrConnectResponseValidation.rejectedByBunker),
+      );
+    });
+
+    test('returns rejectedByBunker even when result happens to match — '
+        'an explicit error must always win', () {
+      final validation = validateConnectResponse(
+        response: buildResponse('s3cret', error: 'user denied'),
+        expectedSecret: 's3cret',
+      );
+      expect(
+        validation,
+        equals(NostrConnectResponseValidation.rejectedByBunker),
+      );
+    });
+
+    test('returns invalidSession when expectedSecret is null', () {
+      final validation = validateConnectResponse(
+        response: buildResponse('anything'),
+        expectedSecret: null,
+      );
+      expect(validation, equals(NostrConnectResponseValidation.invalidSession));
+    });
+
+    test('returns invalidSession when expectedSecret is empty', () {
+      final validation = validateConnectResponse(
+        response: buildResponse('anything'),
+        expectedSecret: '',
+      );
+      expect(validation, equals(NostrConnectResponseValidation.invalidSession));
+    });
+
+    test(
+      'returns ignore on equal-length secret with one differing character '
+      '(constant-time compare path runs to end without short-circuiting)',
+      () {
+        final validation = validateConnectResponse(
+          response: buildResponse('s3cretA'),
+          expectedSecret: 's3cretB',
+        );
+        expect(validation, equals(NostrConnectResponseValidation.ignore));
+      },
+    );
+  });
+
+  group('nostr_connect_session.dart log redaction', () {
+    test(
+      'source file does not log the response.result or the expected secret',
+      () {
+        final source = File(
+          'lib/nip46/nostr_connect_session.dart',
+        ).readAsStringSync();
+        // The pre-fix code logged both `result=${response.result}` in the
+        // up-front decoded-response line and `"$expectedSecret"` in the
+        // mismatch warning. Pin the absence of those substrings so any
+        // future regression that re-introduces secret material into logs
+        // fails this test loudly.
+        expect(source, isNot(contains(r'result=${response.result}')));
+        expect(source, isNot(contains(r'"$expectedSecret"')));
+      },
+    );
   });
 }

--- a/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
@@ -406,6 +406,20 @@ void main() {
       );
     });
 
+    test('returns rejectedByBunker for auth_url challenge responses', () {
+      final validation = validateConnectResponse(
+        response: buildResponse(
+          'auth_url',
+          error: 'https://example.com/approve?token=untrusted',
+        ),
+        expectedSecret: 's3cret',
+      );
+      expect(
+        validation,
+        equals(NostrConnectResponseValidation.rejectedByBunker),
+      );
+    });
+
     test('returns invalidSession when expectedSecret is null', () {
       final validation = validateConnectResponse(
         response: buildResponse('anything'),
@@ -439,9 +453,13 @@ void main() {
     test(
       'source file does not log the response.result or the expected secret',
       () {
-        final source = File(
-          'lib/nip46/nostr_connect_session.dart',
-        ).readAsStringSync();
+        final sourceFile = File('lib/nip46/nostr_connect_session.dart');
+        expect(
+          sourceFile.existsSync(),
+          isTrue,
+          reason: 'Test must run from the nostr_sdk package root',
+        );
+        final source = sourceFile.readAsStringSync();
         // The pre-fix code logged both `result=${response.result}` in the
         // up-front decoded-response line and `"$expectedSecret"` in the
         // mismatch warning. Pin the absence of those substrings so any


### PR DESCRIPTION
## Description

Closes #3355.

`NostrConnectSession._handleResponse` claimed to enforce NIP-46's "client MUST validate the `secret` returned by `connect` response" rule but didn't:

```dart
// before
final isValidSecret =
    response.result == expectedSecret ||
    response.result == 'ack' ||
    response.result == 'connect';
// ...
if (!isValidSecret) {
  log('...does not match expected secret "$expectedSecret"...accepting anyway');
}
// falls through to success
```

The `isValidSecret` flag was computed but only consulted for log severity. Any pubkey on the listening relays could publish a junk response and the client would bind to that pubkey as the remote signer.

`"ack"` and `"connect"` are response tokens for the **`bunker://`** flow's `connect` method — they are not legal results for **`nostrconnect://`** (client-initiated). Conflating the two flows was the original mistake.

## Fix (Approach E from the brainstorm)

1. **Extract `validateConnectResponse`** as a `@visibleForTesting` pure function returning a four-case enum (`match`, `rejectedByBunker`, `invalidSession`, `ignore`). The security-critical decision is now exhaustively unit-testable with no state, no signer, no relays.

2. **`_handleResponse` dispatches on the enum** via an exhaustive switch — the compiler enforces that no fallthrough to success is possible. Mismatched non-error responses transition to `ignore` (silent drop, keep listening); the existing 2-minute timeout in `waitForConnection` terminates the wait if no valid response ever arrives.

   *Why silent-drop instead of immediate-error on mismatch?* Treating mismatches as terminal would let any pubkey on the listening relays DoS pairing by racing the legitimate signer's reply with a junk response — strictly worse than today's broken-but-permissive behavior in adversarial scenarios. The brainstorm doc captures the trade-off: see `mobile/docs/brainstorm/2026-05-01-issue-3355-nip46-mismatch-handling-brainstorm.md`.

3. **Log redaction.** Sanitize the up-front decrypted-response log to emit `hasResult` / `hasError` booleans instead of the raw strings, drop `expectedSecret` from all log lines, and add a source-level test that pins the absence of the offending substrings so future regressions fail loudly.

Constant-time string compare on the secret is defense-in-depth — the secret is ephemeral per session, but the cost is one tight loop and zero excuse not to.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes a critical security issue)

## Test Plan

11 new tests in `mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart`:

| Test | Branch covered |
|------|----------------|
| returns match when response.result equals the secret exactly | happy path |
| returns ignore when response.result is "ack" (bunker:// flow token) | the leniency footgun |
| returns ignore when response.result is "connect" | the leniency footgun |
| returns ignore on any other non-matching result | attacker noise |
| returns ignore on an empty result string | edge case |
| returns rejectedByBunker when response.error is non-empty | legitimate rejection |
| returns rejectedByBunker even when result happens to match — error must always win | precedence |
| returns invalidSession when expectedSecret is null | programmer error |
| returns invalidSession when expectedSecret is empty | programmer error |
| returns ignore on equal-length secret with one differing character | constant-time path |
| source file does not log response.result or expected secret | log-redaction regression guard |

Local verification:
- `dart format` → no changes
- `flutter analyze packages/nostr_sdk` → No issues found
- `flutter test packages/nostr_sdk/test/unit/nostr_connect_session_test.dart` → all 33 tests pass (22 existing + 11 new)

## Acceptance Criteria

- [x] Non-matching result, `"ack"`, and `"connect"` responses are rejected (covered by three dedicated tests).
- [x] Regression tests cover mismatch, missing secret, error response, and exact secret success.
- [x] Logs never include the expected or received secret (source-level test pins the contract).

## Two Open Questions for Review

1. **Counter for ops visibility?** Right now the silent-drop case logs at debug level with the responder pubkey but no count. If you want a per-session mismatch counter exposed in `state` for ops dashboards, easy to add. Default in this PR: log only.
2. **Responder pubkey in the log line?** Currently included (it's a Nostr ID, not a secret, and per CLAUDE.md we never truncate Nostr IDs). Excluded on request if you prefer.

## Out of Scope (follow-ups)

- Per-bunker compatibility audit — confirm none of the integrated signers (nsec.app, alby, primal, etc.) intentionally respond with `"ack"` to `nostrconnect://`. Per spec none should, but worth a quick check. Filing as a separate operational issue if you want.
- The general NIP-46 timeout error message UX — a misbehaving signer that sends a wrong result (theoretically nonexistent) now surfaces as a generic 2-min timeout instead of an immediate "secret mismatch." If we ever see this in the wild we can layer on a soft-warning counter; out of scope here.
- Note: this fix scope is **`nostrconnect://` only**. The `bunker://` flow (`NostrRemoteSigner`) is unaffected — that path's `connect` method legitimately accepts `"ack"`.