### PR TITLE
fix: invite count not updating after generation

### DIFF
--- a/mobile/lib/blocs/invite_status/invite_status_state.dart
+++ b/mobile/lib/blocs/invite_status/invite_status_state.dart
@@ -25,6 +25,10 @@ class InviteStatusState extends Equatable {
   /// Whether the user has remaining invite capacity.
   bool get hasAvailableInvites => availableInviteCount > 0;
 
+  /// Whether the user has any invite activity (codes or remaining capacity).
+  bool get hasInviteActivity =>
+      hasAvailableInvites || (inviteStatus?.codes.isNotEmpty ?? false);
+
   /// Number of invites the user can still generate.
   int get availableInviteCount => inviteStatus?.remaining ?? 0;
 

--- a/mobile/lib/blocs/invite_status/invite_status_state.dart
+++ b/mobile/lib/blocs/invite_status/invite_status_state.dart
@@ -22,15 +22,11 @@ class InviteStatusState extends Equatable {
   /// The number of unclaimed invite codes.
   int get unclaimedCount => inviteStatus?.unclaimedCodes.length ?? 0;
 
-  /// Whether there are generated or still-generatable invites.
+  /// Whether the user has remaining invite capacity.
   bool get hasAvailableInvites => availableInviteCount > 0;
 
-  /// Count of invites the user can share now or generate from allocation.
-  int get availableInviteCount {
-    final status = inviteStatus;
-    if (status == null) return 0;
-    return status.remaining + status.unclaimedCodes.length;
-  }
+  /// Number of invites the user can still generate.
+  int get availableInviteCount => inviteStatus?.remaining ?? 0;
 
   /// Returns a copy with the given fields replaced.
   InviteStatusState copyWith({

--- a/mobile/lib/screens/notifications_screen.dart
+++ b/mobile/lib/screens/notifications_screen.dart
@@ -339,15 +339,17 @@ class _NotificationTabContentState
               },
               child: BlocBuilder<InviteStatusCubit, InviteStatusState>(
                 builder: (context, inviteState) {
+                  final inviteRemaining =
+                      inviteState.inviteStatus?.remaining ?? 0;
                   final showInviteCard =
-                      widget.filter == null && inviteState.hasAvailableInvites;
+                      widget.filter == null && inviteRemaining > 0;
                   if (showInviteCard) {
                     return ListView(
                       physics: const AlwaysScrollableScrollPhysics(),
                       controller: _scrollController,
                       children: [
                         _InviteNotificationCard(
-                          count: inviteState.availableInviteCount,
+                          count: inviteRemaining,
                         ),
                       ],
                     );
@@ -423,8 +425,10 @@ class _NotificationTabContentState
             },
             child: BlocBuilder<InviteStatusCubit, InviteStatusState>(
               builder: (context, inviteState) {
+                final inviteRemaining =
+                    inviteState.inviteStatus?.remaining ?? 0;
                 final showInviteCard =
-                    widget.filter == null && inviteState.hasAvailableInvites;
+                    widget.filter == null && inviteRemaining > 0;
                 final inviteCardOffset = showInviteCard ? 1 : 0;
                 final hasLoadingIndicator =
                     feedState.hasMoreContent &&
@@ -442,7 +446,7 @@ class _NotificationTabContentState
                     // Invite card at top of All tab
                     if (showInviteCard && index == 0) {
                       return _InviteNotificationCard(
-                        count: inviteState.availableInviteCount,
+                        count: inviteRemaining,
                       );
                     }
                     final adjustedIndex = index - inviteCardOffset;

--- a/mobile/lib/screens/notifications_screen.dart
+++ b/mobile/lib/screens/notifications_screen.dart
@@ -339,17 +339,15 @@ class _NotificationTabContentState
               },
               child: BlocBuilder<InviteStatusCubit, InviteStatusState>(
                 builder: (context, inviteState) {
-                  final inviteRemaining =
-                      inviteState.inviteStatus?.remaining ?? 0;
                   final showInviteCard =
-                      widget.filter == null && inviteRemaining > 0;
+                      widget.filter == null && inviteState.hasAvailableInvites;
                   if (showInviteCard) {
                     return ListView(
                       physics: const AlwaysScrollableScrollPhysics(),
                       controller: _scrollController,
                       children: [
                         _InviteNotificationCard(
-                          count: inviteRemaining,
+                          count: inviteState.availableInviteCount,
                         ),
                       ],
                     );
@@ -425,10 +423,8 @@ class _NotificationTabContentState
             },
             child: BlocBuilder<InviteStatusCubit, InviteStatusState>(
               builder: (context, inviteState) {
-                final inviteRemaining =
-                    inviteState.inviteStatus?.remaining ?? 0;
                 final showInviteCard =
-                    widget.filter == null && inviteRemaining > 0;
+                    widget.filter == null && inviteState.hasAvailableInvites;
                 final inviteCardOffset = showInviteCard ? 1 : 0;
                 final hasLoadingIndicator =
                     feedState.hasMoreContent &&
@@ -446,7 +442,7 @@ class _NotificationTabContentState
                     // Invite card at top of All tab
                     if (showInviteCard && index == 0) {
                       return _InviteNotificationCard(
-                        count: inviteRemaining,
+                        count: inviteState.availableInviteCount,
                       );
                     }
                     final adjustedIndex = index - inviteCardOffset;

--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -315,7 +315,7 @@ class _AccountHeader extends StatelessWidget {
               _AccountHeaderProfile(pubkey: pubkey),
               BlocBuilder<InviteStatusCubit, InviteStatusState>(
                 builder: (context, inviteState) {
-                  if (!inviteState.hasAvailableInvites) {
+                  if (!inviteState.hasInviteActivity) {
                     return const SizedBox.shrink();
                   }
                   return Semantics(
@@ -351,22 +351,23 @@ class _AccountHeader extends StatelessWidget {
                                 color: VineTheme.vineGreen,
                               ),
                             ),
-                            Container(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 8,
-                                vertical: 2,
-                              ),
-                              decoration: BoxDecoration(
-                                color: VineTheme.vineGreen,
-                                borderRadius: BorderRadius.circular(12),
-                              ),
-                              child: Text(
-                                '${inviteState.availableInviteCount}',
-                                style: VineTheme.labelSmallFont(
-                                  color: VineTheme.backgroundColor,
+                            if (inviteState.hasAvailableInvites)
+                              Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 8,
+                                  vertical: 2,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: VineTheme.vineGreen,
+                                  borderRadius: BorderRadius.circular(12),
+                                ),
+                                child: Text(
+                                  '${inviteState.availableInviteCount}',
+                                  style: VineTheme.labelSmallFont(
+                                    color: VineTheme.backgroundColor,
+                                  ),
                                 ),
                               ),
-                            ),
                           ],
                         ),
                       ),

--- a/mobile/test/blocs/invite_status/invite_status_cubit_test.dart
+++ b/mobile/test/blocs/invite_status/invite_status_cubit_test.dart
@@ -159,7 +159,7 @@ void main() {
         expect(state.hasUnclaimedCodes, isTrue);
         expect(state.unclaimedCount, equals(1));
         expect(state.hasAvailableInvites, isTrue);
-        expect(state.availableInviteCount, equals(2));
+        expect(state.availableInviteCount, equals(1));
       });
 
       test('hasUnclaimedCodes returns false when all claimed', () {

--- a/mobile/test/screens/notifications_screen_test.dart
+++ b/mobile/test/screens/notifications_screen_test.dart
@@ -368,7 +368,7 @@ void main() {
         expect(find.byType(NotificationListItem), findsNothing);
       });
 
-      testWidgets('shows invite card when only invites are available', (
+      testWidgets('hides invite card when remaining is zero', (
         WidgetTester tester,
       ) async {
         final mockNotifier = _MockEmptyRelayNotifications();
@@ -393,10 +393,8 @@ void main() {
 
         expect(
           find.text('You have 2 invites to share with friends!'),
-          findsOneWidget,
+          findsNothing,
         );
-        expect(find.text('No notifications yet'), findsNothing);
-        expect(find.byType(NotificationListItem), findsNothing);
       });
 
       testWidgets('shows invite card when invite capacity is available', (

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -207,7 +207,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Invites'), findsOneWidget);
-      expect(find.text('1'), findsOneWidget);
+      expect(find.text('1'), findsNothing);
 
       await tester.pumpWidget(const SizedBox());
       await tester.pump();


### PR DESCRIPTION
## Summary

Fixes #3771 -- invite notification card shows stale count after generating an invite code.

**Root cause:** `availableInviteCount` in `InviteStatusState` summed `remaining + unclaimedCodes.length`. When an invite is generated, the server decrements `remaining` by 1 and adds a new unclaimed code (+1), so the sum was invariant. The BlocBuilder saw no change and the UI appeared stuck.

**Fix:** Redefine `availableInviteCount` in the model to return `remaining` only. Generation is treated as the proxy for handoff -- it's the only discrete, reliable signal (share sheet completion, copy actions, screenshots are all uncapturable). All surfaces (notifications card, settings badge) use the model getters, so they stay consistent.

**Additional fix found in manual testing:** After generating all invites, the Settings invite button disappeared entirely because it gated on `hasAvailableInvites` (remaining > 0). Users need to access their generated codes to re-share them. Added `hasInviteActivity` getter (remaining > 0 OR any codes exist) for the settings entry point. Count badge hides at zero remaining, but the button stays visible. Notification card still disappears at zero -- that's a generation prompt, not a code retrieval path.

## Changes

- `invite_status_state.dart`: `availableInviteCount` returns `remaining` only; new `hasInviteActivity` getter for settings visibility
- `settings_screen.dart`: gate button on `hasInviteActivity`, hide count badge when remaining is 0
- `notifications_screen.dart`: no net change (reverted per-screen patches, uses model getters)
- Tests updated to match new semantics

## Diagnosis

| Step | remaining | unclaimedCodes | old availableInviteCount | new availableInviteCount |
|------|-----------|----------------|------------------------|------------------------|
| Initial (5 invites) | 5 | 0 | 5 | 5 |
| Generate 1 | 4 | 1 | 5 (unchanged!) | 4 |
| Generate all 5 | 0 | 5 | 5 (unchanged!) | 0 |

## Test plan

- [x] Generate an invite code, confirm notification card count decrements
- [x] Verify settings badge shows same count as notification card
- [x] Use all remaining invites, confirm notification card disappears
- [x] Use all remaining invites, confirm settings badge count disappears
- [x] Use all remaining invites, confirm settings Invites button stays visible (no count badge)
- [x] Tap into invites screen from settings at zero remaining, confirm codes are accessible
- [x] Pull-to-refresh on notifications tab, confirm count reflects server state
- [x] Switch tabs and return, confirm count persists correctly