### PR TITLE
fix(comments): keep keyboard open when tapping inside comment input bubble (#3770)

### DIFF
--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -248,7 +248,6 @@ class _CommentTextField extends StatelessWidget {
           controller: controller,
           focusNode: focusNode,
           onChanged: onChanged,
-          onTapOutside: (_) => FocusScope.of(context).unfocus(),
           enableInteractiveSelection: true,
           style: VineTheme.bodyLargeFont(color: VineTheme.onSurface),
           cursorColor: VineTheme.tabIndicatorGreen,

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -378,19 +378,16 @@ class _CommentContent extends StatelessWidget {
       fontSize: isEmoji ? _emojiOnlyFontSize : 14,
       height: isEmoji ? null : 20 / 14,
     );
-    return TapRegion(
-      onTapOutside: (_) => FocusScope.of(context).unfocus(),
-      child: ClickableHashtagText(
-        text: content,
-        style: baseStyle,
-        hashtagStyle: baseStyle.copyWith(
-          color: VineTheme.info,
-          fontWeight: FontWeight.w500,
-        ),
-        mentionStyle: baseStyle.copyWith(
-          color: VineTheme.tabIndicatorGreen,
-          fontWeight: FontWeight.w600,
-        ),
+    return ClickableHashtagText(
+      text: content,
+      style: baseStyle,
+      hashtagStyle: baseStyle.copyWith(
+        color: VineTheme.info,
+        fontWeight: FontWeight.w500,
+      ),
+      mentionStyle: baseStyle.copyWith(
+        color: VineTheme.tabIndicatorGreen,
+        fontWeight: FontWeight.w600,
       ),
     );
   }

--- a/mobile/lib/screens/comments/widgets/comments_list.dart
+++ b/mobile/lib/screens/comments/widgets/comments_list.dart
@@ -45,33 +45,49 @@ class _CommentsListState extends State<CommentsList> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<CommentsBloc, CommentsState>(
-      builder: (context, state) {
-        if (state.status == CommentsStatus.loading) {
-          return const _LoadingState();
-        }
+    // Match TikTok / Instagram Reels: any interaction with the comments
+    // area (tap on a comment, drag to scroll) dismisses the keyboard so
+    // the user can read other comments unobstructed. Draft text in the
+    // input is retained — re-tapping the input restores focus.
+    //
+    // The Listener catches taps anywhere in the list (including dead
+    // space and on comment items themselves) without competing in the
+    // gesture arena, so existing tap handlers (reply, vote, navigate to
+    // profile) still run normally afterwards. The ListView's
+    // [ScrollViewKeyboardDismissBehavior.onDrag] covers the scroll case
+    // idiomatically.
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: (_) => FocusManager.instance.primaryFocus?.unfocus(),
+      child: BlocBuilder<CommentsBloc, CommentsState>(
+        builder: (context, state) {
+          if (state.status == CommentsStatus.loading) {
+            return const _LoadingState();
+          }
 
-        if (state.status == CommentsStatus.failure) {
-          return const _ErrorState();
-        }
+          if (state.status == CommentsStatus.failure) {
+            return const _ErrorState();
+          }
 
-        final threaded = state.threadedComments;
+          final threaded = state.threadedComments;
 
-        if (threaded.isEmpty) {
-          return CommentsEmptyState(
-            isClassicVine: widget.showClassicVineNotice,
+          if (threaded.isEmpty) {
+            return CommentsEmptyState(
+              isClassicVine: widget.showClassicVineNotice,
+            );
+          }
+
+          return ListView.builder(
+            controller: widget.scrollController,
+            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+            itemCount: threaded.length,
+            itemBuilder: (context, index) {
+              final node = threaded[index];
+              return CommentItem(comment: node.comment, depth: node.depth);
+            },
           );
-        }
-
-        return ListView.builder(
-          controller: widget.scrollController,
-          itemCount: threaded.length,
-          itemBuilder: (context, index) {
-            final node = threaded[index];
-            return CommentItem(comment: node.comment, depth: node.depth);
-          },
-        );
-      },
+        },
+      ),
     );
   }
 }

--- a/mobile/test/screens/comments/comment_input_test.dart
+++ b/mobile/test/screens/comments/comment_input_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Widget tests for CommentInput component
 // ABOUTME: Tests input field, send button, and posting state behavior
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
@@ -127,5 +128,96 @@ void main() {
 
       expect(controller.text, equals('Test comment'));
     });
+
+    testWidgets(
+      'tap inside the bubble but above the TextField keeps focus on iOS '
+      '(regression: issue #3770)',
+      (tester) async {
+        // The visible "bubble" Container is taller than the inner TextField
+        // because of vertical padding around the field. A tap that lands in
+        // that padding strip is outside the TextField's TapRegion. With a
+        // `onTapOutside: (_) => unfocus()` override on the TextField, that
+        // tap dismissed the keyboard. The override has been removed; iOS's
+        // default tap-outside action is a no-op for touch events, so focus
+        // must be retained.
+        debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        try {
+          controller.text = 'hello typo wolrd';
+          final focusNode = FocusNode();
+          addTearDown(focusNode.dispose);
+
+          await tester.pumpWidget(
+            MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                // Mirror the production setup: the comment input lives
+                // inside a sheet whose surface is wrapped in an opaque
+                // GestureDetector that absorbs taps not claimed by an inner
+                // widget. Without an opaque ancestor, taps in the bubble
+                // padding don't register any hit and TapRegionSurface
+                // short-circuits the event.
+                body: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: () {},
+                    ),
+                    Align(
+                      alignment: Alignment.bottomCenter,
+                      child: CommentInput(
+                        controller: controller,
+                        focusNode: focusNode,
+                        onSubmit: () {},
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+
+          focusNode.requestFocus();
+          await tester.pump();
+          expect(focusNode.hasFocus, isTrue);
+
+          // The bubble is the inner Container with `minHeight: 48` —
+          // uniquely identifiable vs. the outer padding-only Container and
+          // the SendButton's smaller circular Container.
+          final bubbleFinder = find.byWidgetPredicate(
+            (widget) =>
+                widget is Container &&
+                widget.constraints == const BoxConstraints(minHeight: 48),
+          );
+          expect(bubbleFinder, findsOneWidget);
+
+          final bubbleRect = tester.getRect(bubbleFinder);
+          final textFieldRect = tester.getRect(find.byType(TextField));
+          expect(
+            textFieldRect.top - bubbleRect.top,
+            greaterThan(4),
+            reason:
+                'There must be padding above the TextField inside the '
+                'bubble for this regression test to be meaningful.',
+          );
+
+          await tester.tapAt(
+            Offset(bubbleRect.center.dx, bubbleRect.top + 4),
+          );
+          await tester.pump();
+
+          expect(
+            focusNode.hasFocus,
+            isTrue,
+            reason:
+                'Tap inside the comment bubble (in the padding above the '
+                'TextField) must not dismiss the keyboard. See issue #3770.',
+          );
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      },
+    );
   });
 }

--- a/mobile/test/screens/comments/comments_list_test.dart
+++ b/mobile/test/screens/comments/comments_list_test.dart
@@ -175,5 +175,106 @@ void main() {
 
       scrollController.dispose();
     });
+
+    testWidgets(
+      'tap on a comment dismisses the keyboard (TikTok / Reels parity)',
+      (tester) async {
+        // When the comment input is focused and the user taps a comment in
+        // the list, the keyboard should dismiss so the user can read other
+        // comments unobstructed. Draft text in the input is retained
+        // (verified by the input retaining its FocusNode and controller
+        // separately — this test covers the focus-drop side).
+        final comment = CommentBuilder()
+            .withId(TestCommentIds.comment1Id)
+            .withContent('First comment')
+            .build();
+
+        final state = CommentsState(
+          rootEventId: testVideoEventId,
+          rootAuthorPubkey: testVideoAuthorPubkey,
+          status: CommentsStatus.success,
+          commentsById: {comment.id: comment},
+        );
+
+        when(() => mockCommentsBloc.state).thenReturn(state);
+
+        final focusNode = FocusNode();
+        addTearDown(focusNode.dispose);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              nostrServiceProvider.overrideWithValue(mockNostrClient),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: BlocProvider<CommentsBloc>.value(
+                  value: mockCommentsBloc,
+                  // A focused TextField mimics the production scenario:
+                  // CommentInput has the keyboard up while CommentsList
+                  // is visible. The Column layout matches the bottom
+                  // sheet's scrollable-body / bottom-input split.
+                  child: Column(
+                    children: [
+                      Expanded(
+                        child: CommentsList(
+                          showClassicVineNotice: false,
+                          scrollController: ScrollController(),
+                        ),
+                      ),
+                      TextField(focusNode: focusNode),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        focusNode.requestFocus();
+        await tester.pump();
+        expect(focusNode.hasFocus, isTrue);
+
+        await tester.tap(find.text('First comment'));
+        await tester.pump();
+
+        expect(
+          focusNode.hasFocus,
+          isFalse,
+          reason:
+              'Tapping a comment in the list must dismiss the keyboard '
+              'so the user can read other comments without being '
+              'blocked. Matches TikTok / Instagram Reels behavior.',
+        );
+      },
+    );
+
+    testWidgets(
+      'ListView declares onDrag keyboard-dismiss behavior',
+      (tester) async {
+        // Idiomatic Flutter signal: the comments scroll view dismisses
+        // the keyboard when the user starts dragging it. Complements the
+        // tap-dismiss above for the scroll-to-read case.
+        final comment = CommentBuilder().build();
+        final state = CommentsState(
+          rootEventId: testVideoEventId,
+          rootAuthorPubkey: testVideoAuthorPubkey,
+          status: CommentsStatus.success,
+          commentsById: {comment.id: comment},
+        );
+
+        await tester.pumpWidget(buildTestWidget(commentsState: state));
+        await tester.pump();
+
+        final listView = tester.widget<ListView>(find.byType(ListView));
+        expect(
+          listView.keyboardDismissBehavior,
+          ScrollViewKeyboardDismissBehavior.onDrag,
+        );
+      },
+    );
   });
 }

--- a/mobile/test/screens/comments/comments_list_test.dart
+++ b/mobile/test/screens/comments/comments_list_test.dart
@@ -199,7 +199,11 @@ void main() {
         when(() => mockCommentsBloc.state).thenReturn(state);
 
         final focusNode = FocusNode();
+        final textController = TextEditingController(text: 'draft comment');
+        final scrollController = ScrollController();
         addTearDown(focusNode.dispose);
+        addTearDown(textController.dispose);
+        addTearDown(scrollController.dispose);
 
         await tester.pumpWidget(
           ProviderScope(
@@ -221,10 +225,13 @@ void main() {
                       Expanded(
                         child: CommentsList(
                           showClassicVineNotice: false,
-                          scrollController: ScrollController(),
+                          scrollController: scrollController,
                         ),
                       ),
-                      TextField(focusNode: focusNode),
+                      TextField(
+                        focusNode: focusNode,
+                        controller: textController,
+                      ),
                     ],
                   ),
                 ),
@@ -248,6 +255,13 @@ void main() {
               'Tapping a comment in the list must dismiss the keyboard '
               'so the user can read other comments without being '
               'blocked. Matches TikTok / Instagram Reels behavior.',
+        );
+        expect(
+          textController.text,
+          equals('draft comment'),
+          reason:
+              'Dismissing the keyboard by tapping the list must not clear '
+              'the draft text.',
         );
       },
     );


### PR DESCRIPTION
## Description

Fixes #3770. Tapping inside the comment input bubble was dismissing the keyboard and not moving the cursor, reported on iPhone 16 Pro Max / iOS 26.4.2 but reproducible on any platform.

### Root cause

`comment_input.dart:251` had:

```dart
onTapOutside: (_) => FocusScope.of(context).unfocus(),
```

Flutter's `TextFieldTapRegion` only covers the inner `EditableText` render box — for a single-line input, ~20–24px tall. The visible "bubble" (`Container(minHeight: 48, …)` with rounded background) is taller, with ~14px of vertical padding around the field. Taps that land in that padding band are *visually* inside the bubble but *outside* the TapRegion, so `onTapOutside` fires, calls `FocusScope.unfocus()`, and the keyboard collapses while the cursor never moves.

Frame-by-frame analysis of the user's screen recording confirmed:
- Focus drops in a single frame (~67 ms) — synchronous `unfocus()` call, not a timing race.
- Keyboard animates down only after focus drops (iOS reacts to the focus-loss, not the inverse).
- Bug reproduces twice in the same recording at the same step ("tap to position cursor").

The override was added in PR #786 ("dismiss keyboard on tap outside") and overrides Flutter's deliberately-mobile-friendly default (`_defaultOnTapOutside` in `editable_text.dart:5538` is a no-op for touch events on iOS/Android — see `_EditableTextTapOutsideAction.invoke`).

### Changes

1. **`comment_input.dart`** — drop the `onTapOutside` override. Restores Flutter's mobile default: tap-anywhere-on-the-TextField keeps the keyboard up and positions the cursor.
2. **`comment_item.dart`** — drop the stale `TapRegion(onTapOutside: unfocus)` wrapper around `ClickableHashtagText`. It was originally added (PR #1161) for `SelectableText`'s selection-toolbar dismissal; obsolete after the migration to `ClickableHashtagText` (no selection toolbar). It also dismissed focus on every list tap because each comment's per-instance region treated taps on every other comment as outside.
3. **`comments_list.dart`** — wrap the list body in `Listener(onPointerDown: → unfocus)` and add `keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag` to the ListView. Result: tapping a comment or scrolling the list dismisses the keyboard while draft text is retained, matching TikTok / Instagram Reels behavior.

### UX after this PR

| Action | Before | After |
|---|---|---|
| Tap inside the input bubble (text or padding) | Keyboard dismisses, cursor doesn't move | Cursor moves; keyboard stays up |
| Double-tap a word in the input | Keyboard dismisses; selection fails | Word selects; selection toolbar appears |
| Tap a comment in the list | Keyboard dismisses (but for the wrong reason) | Keyboard dismisses (TikTok/Reels parity); draft retained |
| Drag the comments list to scroll | Keyboard stays up | Keyboard dismisses on drag (TikTok/Reels parity) |
| Tap above the sheet (dimmed video area) | Sheet closes | Sheet closes (unchanged) |

**Related Issue:** Closes #3770

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Test plan

Three new tests added; all 56 tests in `mobile/test/screens/comments/` pass.

- `comment_input_test.dart` — pumps a focused `CommentInput` (with iOS platform override and an opaque ancestor mirroring the production bottom sheet), taps inside the bubble's top padding strip, asserts focus is retained. Verified the test fails on the buggy code (`focusNode.hasFocus == false` after tap) and passes on the fix.
- `comments_list_test.dart` — pumps `CommentsList` with a focused `TextField` sibling, taps a comment, asserts focus drops (TikTok parity). Second test verifies the ListView declares `keyboardDismissBehavior: onDrag`.

Manual checks recommended on a real device:
- [ ] Type a comment, tap a typo mid-word — cursor moves, keyboard stays.
- [ ] Type a comment, double-tap a word — word selects, toolbar appears.
- [ ] Type a draft, tap a comment in the list — keyboard dismisses, draft retained, re-tap input restores keyboard.
- [ ] Type a draft, scroll the comments list — keyboard dismisses on drag.
- [ ] Tap above the sheet — sheet closes.