### PR TITLE
fix(comments): improve "Re:" reply indicator visibility

### DIFF
--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2438,6 +2438,7 @@
     "searchListsSectionHeader": "القوائم",
   "searchListsLoadingLabel": "جارٍ تحميل نتائج القوائم",
     "searchForLists": "البحث عن قوائم",
+    "commentReplyToPrefix": "رد:",
     "searchSomethingWentWrong": "حدث خطأ ما",
     "searchTryAgain": "حاول مجددًا",
     "trendingTitle": "الرائج",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2439,6 +2439,7 @@
     "searchListsSectionHeader": "Listen",
   "searchListsLoadingLabel": "Listenergebnisse werden geladen",
     "searchForLists": "Nach Listen suchen",
+    "commentReplyToPrefix": "Re:",
     "searchSomethingWentWrong": "Etwas ist schiefgelaufen",
     "searchTryAgain": "Erneut versuchen",
     "trendingTitle": "Im Trend",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2876,6 +2876,11 @@
     }
   },
 
+  "commentReplyToPrefix": "Re:",
+  "@commentReplyToPrefix": {
+    "description": "Short prefix shown before a replied-to username (e.g. 'Re: alice'). Used in the orphaned-reply chip on a comment item and above the comment input when actively replying."
+  },
+
   "searchSomethingWentWrong": "Something went wrong",
   "searchTryAgain": "Try again",
   "draftUntitled": "Untitled",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2439,6 +2439,7 @@
     "searchListsSectionHeader": "Listas",
   "searchListsLoadingLabel": "Cargando resultados de listas",
     "searchForLists": "Buscar listas",
+    "commentReplyToPrefix": "Re:",
     "searchSomethingWentWrong": "Algo salió mal",
     "searchTryAgain": "Reintentar",
     "trendingTitle": "Tendencias",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2439,6 +2439,7 @@
     "searchListsSectionHeader": "Listes",
   "searchListsLoadingLabel": "Chargement des résultats de listes",
     "searchForLists": "Rechercher des listes",
+    "commentReplyToPrefix": "Re :",
     "searchSomethingWentWrong": "Quelque chose s'est mal passé",
     "searchTryAgain": "Réessayer",
     "trendingTitle": "Tendances",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2438,6 +2438,7 @@
     "searchListsSectionHeader": "Daftar",
   "searchListsLoadingLabel": "Memuat hasil daftar",
     "searchForLists": "Cari daftar",
+    "commentReplyToPrefix": "Bls:",
     "searchSomethingWentWrong": "Terjadi kesalahan",
     "searchTryAgain": "Coba lagi",
     "trendingTitle": "Trending",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2439,6 +2439,7 @@
     "searchListsSectionHeader": "Liste",
   "searchListsLoadingLabel": "Caricamento risultati liste",
     "searchForLists": "Cerca liste",
+    "commentReplyToPrefix": "Re:",
     "searchSomethingWentWrong": "Qualcosa è andato storto",
     "searchTryAgain": "Riprova",
     "trendingTitle": "Di tendenza",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2438,6 +2438,7 @@
     "searchListsSectionHeader": "リスト",
   "searchListsLoadingLabel": "リスト結果を読み込み中",
     "searchForLists": "リストを検索",
+    "commentReplyToPrefix": "Re:",
     "searchSomethingWentWrong": "なんかうまくいかなかった",
     "searchTryAgain": "もう一回",
     "trendingTitle": "トレンド",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1727,6 +1727,7 @@
     "searchListsSectionHeader": "목록",
   "searchListsLoadingLabel": "목록 결과 불러오는 중",
     "searchForLists": "목록 검색",
+    "commentReplyToPrefix": "Re:",
     "searchSomethingWentWrong": "문제가 발생했어요",
     "searchTryAgain": "다시 시도",
     "trendingTitle": "트렌딩",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2439,6 +2439,7 @@
     "searchListsSectionHeader": "Lijsten",
   "searchListsLoadingLabel": "Lijstresultaten laden",
     "searchForLists": "Zoek naar lijsten",
+    "commentReplyToPrefix": "Re:",
     "searchSomethingWentWrong": "Er ging iets mis",
     "searchTryAgain": "Opnieuw proberen",
     "trendingTitle": "Trending",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2439,6 +2439,7 @@
     "searchListsSectionHeader": "Listy",
   "searchListsLoadingLabel": "Ładowanie wyników list",
     "searchForLists": "Szukaj list",
+    "commentReplyToPrefix": "Odp.:",
     "searchSomethingWentWrong": "Coś poszło nie tak",
     "searchTryAgain": "Spróbuj ponownie",
     "trendingTitle": "Na czasie",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2439,6 +2439,7 @@
     "searchListsSectionHeader": "Listas",
   "searchListsLoadingLabel": "Carregando resultados de listas",
     "searchForLists": "Buscar listas",
+    "commentReplyToPrefix": "Re:",
     "searchSomethingWentWrong": "Algo deu errado",
     "searchTryAgain": "Tentar novamente",
     "trendingTitle": "Em alta",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2439,6 +2439,7 @@
     "searchListsSectionHeader": "Liste",
     "searchListsLoadingLabel": "Se încarcă rezultatele listelor",
     "searchForLists": "Caută liste",
+    "commentReplyToPrefix": "Re:",
     "searchSomethingWentWrong": "Ceva nu a mers bine",
     "searchTryAgain": "Încearcă din nou",
     "trendingTitle": "În tendințe",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2439,6 +2439,7 @@
     "searchListsSectionHeader": "Listor",
     "searchListsLoadingLabel": "Laddar listresultat",
     "searchForLists": "Sök efter listor",
+    "commentReplyToPrefix": "Sv:",
     "searchSomethingWentWrong": "Något gick fel",
     "searchTryAgain": "Försök igen",
     "trendingTitle": "Trendande",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2438,6 +2438,7 @@
     "searchListsSectionHeader": "Listeler",
   "searchListsLoadingLabel": "Liste sonuçları yükleniyor",
     "searchForLists": "Liste ara",
+    "commentReplyToPrefix": "Yan:",
     "searchSomethingWentWrong": "Bir şeyler ters gitti",
     "searchTryAgain": "Tekrar dene",
     "trendingTitle": "Gündemde",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9284,6 +9284,12 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{1 other} other{{count} others}}'**
   String notificationOthersCount(int count);
 
+  /// Short prefix shown before a replied-to username (e.g. 'Re: alice'). Used in the orphaned-reply chip on a comment item and above the comment input when actively replying.
+  ///
+  /// In en, this message translates to:
+  /// **'Re:'**
+  String get commentReplyToPrefix;
+
   /// No description provided for @draftUntitled.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5226,7 +5226,7 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get commentReplyToPrefix => 'Re:';
+  String get commentReplyToPrefix => 'رد:';
 
   @override
   String get draftUntitled => 'بدون عنوان';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5226,6 +5226,9 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => 'بدون عنوان';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5335,6 +5335,9 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => 'Ohne Titel';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5277,6 +5277,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => 'Untitled';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5324,6 +5324,9 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => 'Sin título';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5340,6 +5340,9 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => 'Sans titre';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5340,7 +5340,7 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get commentReplyToPrefix => 'Re:';
+  String get commentReplyToPrefix => 'Re :';
 
   @override
   String get draftUntitled => 'Sans titre';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5245,7 +5245,7 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get commentReplyToPrefix => 'Re:';
+  String get commentReplyToPrefix => 'Bls:';
 
   @override
   String get draftUntitled => 'Tanpa judul';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5245,6 +5245,9 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => 'Tanpa judul';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5320,6 +5320,9 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => 'Senza titolo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5063,6 +5063,9 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => '無題';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5085,6 +5085,9 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => '제목 없음';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5296,6 +5296,9 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => 'Naamloos';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5411,7 +5411,7 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get commentReplyToPrefix => 'Re:';
+  String get commentReplyToPrefix => 'Odp.:';
 
   @override
   String get draftUntitled => 'Bez tytułu';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5411,6 +5411,9 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => 'Bez tytułu';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5306,6 +5306,9 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => 'Sem título';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5407,6 +5407,9 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => 'Fără titlu';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5265,6 +5265,9 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => 'Namnlös';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5265,7 +5265,7 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get commentReplyToPrefix => 'Re:';
+  String get commentReplyToPrefix => 'Sv:';
 
   @override
   String get draftUntitled => 'Namnlös';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5254,7 +5254,7 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get commentReplyToPrefix => 'Re:';
+  String get commentReplyToPrefix => 'Yan:';
 
   @override
   String get draftUntitled => 'Başlıksız';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5254,6 +5254,9 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String get commentReplyToPrefix => 'Re:';
+
+  @override
   String get draftUntitled => 'Başlıksız';
 
   @override

--- a/mobile/lib/screens/comments/widgets/comment_input.dart
+++ b/mobile/lib/screens/comments/widgets/comment_input.dart
@@ -4,6 +4,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:openvine/blocs/comments/comments_bloc.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/comments/widgets/mention_overlay.dart';
 
 /// Input widget for posting new top-level comments.
@@ -383,7 +384,7 @@ class _ReplyIndicator extends StatelessWidget {
           children: [
             Flexible(
               child: Text(
-                'Re: $displayName',
+                '${context.l10n.commentReplyToPrefix} $displayName',
                 style: VineTheme.bodySmallFont(
                   color: VineTheme.tabIndicatorGreen,
                 ),

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -602,24 +602,18 @@ class _ReplyIndicator extends ConsumerWidget {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Container(
-          height: 20,
-          padding: const EdgeInsets.symmetric(vertical: 2),
-          alignment: Alignment.center,
-          child: Text(
-            'Re:',
-            style: VineTheme.bodyMediumFont(color: VineTheme.tabIndicatorGreen),
-          ),
+        Text(
+          'Re:',
+          style: VineTheme.bodyMediumFont(color: VineTheme.tabIndicatorGreen),
         ),
         const SizedBox(width: 8),
         Flexible(
           child: Container(
-            height: 20,
             decoration: BoxDecoration(
               color: VineTheme.containerLow,
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: BorderRadius.circular(6),
             ),
-            padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+            padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 6),
             child: Text(
               displayName,
               style: VineTheme.bodyMediumFont(

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -603,20 +603,20 @@ class _ReplyIndicator extends ConsumerWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         Text(
-          'Re:',
-          style: VineTheme.bodyMediumFont(color: VineTheme.tabIndicatorGreen),
+          context.l10n.commentReplyToPrefix,
+          style: VineTheme.bodySmallFont(color: VineTheme.tabIndicatorGreen),
         ),
-        const SizedBox(width: 8),
+        const SizedBox(width: 4),
         Flexible(
           child: Container(
             decoration: BoxDecoration(
               color: VineTheme.containerLow,
-              borderRadius: BorderRadius.circular(6),
+              borderRadius: BorderRadius.circular(8),
             ),
-            padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 6),
+            padding: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
             child: Text(
               displayName,
-              style: VineTheme.bodyMediumFont(
+              style: VineTheme.bodySmallFont(
                 color: VineTheme.tabIndicatorGreen,
               ),
               overflow: TextOverflow.ellipsis,

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -113,10 +113,6 @@ const _knownUntranslatedDebt = {
   'peopleListsUndo',
   'peopleListsVideoNotAvailable',
   'peopleListsViewProfileHint',
-  // Added by the comment-reply indicator l10n migration (#3783).
-  // Translators will pick this up in a follow-up pass; until then the
-  // generated l10n APIs fall back to the English source.
-  'commentReplyToPrefix',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -113,6 +113,10 @@ const _knownUntranslatedDebt = {
   'peopleListsUndo',
   'peopleListsVideoNotAvailable',
   'peopleListsViewProfileHint',
+  // Added by the comment-reply indicator l10n migration (#3783).
+  // Translators will pick this up in a follow-up pass; until then the
+  // generated l10n APIs fall back to the English source.
+  'commentReplyToPrefix',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -228,7 +228,11 @@ void main() {
         await tester.pumpWidget(buildTestWidget(commentsState: commentsState));
         await tester.pumpAndSettle();
 
-        expect(find.text('Re: TestUser'), findsOneWidget);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.text('${l10n.commentReplyToPrefix} TestUser'),
+          findsOneWidget,
+        );
         // Verify close icon exists (there may be multiple close icons on the screen)
         expect(find.byIcon(Icons.close), findsWidgets);
       });


### PR DESCRIPTION
## Description

The "Re: $display_name" indicator on orphaned reply comments was barely readable: the chip text and chip background sat too close in luminance, and fixed `height: 20` wrappers clipped the 14px (20px line-height) `bodyMedium` text.

This change in `_ReplyIndicator` (`mobile/lib/screens/comments/widgets/comment_item.dart`):

- Drops the redundant `Container(height: 20, ...)` wrapper around `Re:` — plain `Text` already lays out at the right height.
- Drops `height: 20` from the username chip so the text isn't clipped.
- Tightens the chip to `borderRadius: 6` and `padding: vertical 2, horizontal 6`.
- Lets the username inherit the same `tabIndicatorGreen` as "Re:" so the two read as a single phrase.

**Related Issue:** Closes #3782

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Test plan

- [ ] Open a comment thread containing an orphaned reply (depth-0 comment with a non-null `replyToAuthorPubkey`).
- [ ] Confirm "Re: <display_name>" reads as one phrase in the same green tone, no text clipping.
- [ ] Confirm long display names ellipsize cleanly inside the chip.
- [ ] Run `flutter analyze lib test integration_test` from `mobile/`.
- [ ] Run `flutter test test/screens/comments/comment_item_test.dart` from `mobile/`.