### PR TITLE
fix(security): strip BYOK nsec from Keycast OAuth wire (#3359)

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -95,12 +95,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: 🔧 Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
       - name: 🛡️ Verify production code does not use nsec as a payload key
         # Locks in Phase 1 of divinevideo/divine-mobile#3359 — fails if any
         # production .dart file under mobile/lib or mobile/packages
-        # re-introduces nsec as a JSON / map key in an HTTP body.
+        # re-introduces nsec as a JSON / map key in an HTTP body. The
+        # guard script uses POSIX find + grep -E, no extra deps needed.
         run: bash mobile/tools/ci/grep_for_nsec_payload.sh
   tests:
     name: Tests

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -90,6 +90,18 @@ jobs:
         run: flutter pub get
       - name: 🕵️ Analyze code
         run: flutter analyze lib test integration_test
+  nsec-leak-guard:
+    name: NSec Leak Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: 🔧 Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+      - name: 🛡️ Verify production code does not use nsec as a payload key
+        # Locks in Phase 1 of divinevideo/divine-mobile#3359 — fails if any
+        # production .dart file under mobile/lib or mobile/packages
+        # re-introduces nsec as a JSON / map key in an HTTP body.
+        run: bash mobile/tools/ci/grep_for_nsec_payload.sh
   tests:
     name: Tests
     runs-on: ubuntu-latest

--- a/mobile/integration_test/auth/session_expired_banner_test.dart
+++ b/mobile/integration_test/auth/session_expired_banner_test.dart
@@ -27,6 +27,19 @@ void main() {
     patrolTest(
       'tapping Sign in navigates to login options instead of bouncing home',
       ($) async {
+        // Phase 1 of divinevideo/divine-mobile#3359 disabled the BYOK
+        // identity-preservation flow this test depends on
+        // (`headlessRegister(nsec: ...)` no longer transmits the nsec, so
+        // the OAuth-registered pubkey no longer matches the locally
+        // generated one). Re-enable once the proof-of-possession contract
+        // from divinevideo/keycast#197 ships and Phase 2 lands the new
+        // BYOK preservation path.
+        markTestSkipped(
+          'Pending Phase 2 of divinevideo/divine-mobile#3359 — BYOK '
+          'identity preservation requires server-side proof-of-possession.',
+        );
+        return;
+        // ignore: dead_code
         final tester = $.tester;
         // ── Setup ──
         final originalOnError = suppressSetStateErrors();
@@ -66,7 +79,6 @@ void main() {
           () => oauthClient.headlessRegister(
             email: testEmail,
             password: testPassword,
-            nsec: nsec,
             scope: 'policy:full',
           ),
         ))!;

--- a/mobile/integration_test/auth/session_expired_banner_test.dart
+++ b/mobile/integration_test/auth/session_expired_banner_test.dart
@@ -3,241 +3,27 @@
 // ABOUTME: options screen instead of bouncing to home feed.
 // ABOUTME: Requires: local Docker stack (mise run local_up)
 
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:keycast_flutter/keycast_flutter.dart';
-import 'package:nostr_sdk/nostr_sdk.dart';
-import 'package:openvine/main.dart' as app;
-import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/services/auth_service.dart';
 import 'package:patrol/patrol.dart';
-
-import '../helpers/db_helpers.dart';
-import '../helpers/http_helpers.dart';
-import '../helpers/navigation_helpers.dart';
-import '../helpers/test_setup.dart';
 
 void main() {
   group('Session Expired Banner', () {
-    final testEmail =
-        'banner-${DateTime.now().millisecondsSinceEpoch}@test.divine.video';
-    const testPassword = 'TestPass123!';
-
     patrolTest(
       'tapping Sign in navigates to login options instead of bouncing home',
       ($) async {
         // Phase 1 of divinevideo/divine-mobile#3359 disabled the BYOK
-        // identity-preservation flow this test depends on
-        // (`headlessRegister(nsec: ...)` no longer transmits the nsec, so
-        // the OAuth-registered pubkey no longer matches the locally
-        // generated one). Re-enable once the proof-of-possession contract
-        // from divinevideo/keycast#197 ships and Phase 2 lands the new
-        // BYOK preservation path.
+        // identity-preservation flow this test depends on: the OAuth
+        // flow no longer transmits the local nsec, so the server-issued
+        // pubkey diverges from the locally generated one and the
+        // expired-session setup the test relied on cannot be staged.
+        //
+        // Restore the body once divinevideo/keycast#197 ships the
+        // proof-of-possession contract and Phase 2 lands the new BYOK
+        // preservation path. The pre-skip body lives in commit feb110b4f.
         markTestSkipped(
           'Pending Phase 2 of divinevideo/divine-mobile#3359 — BYOK '
           'identity preservation requires server-side proof-of-possession.',
         );
-        return;
-        // ignore: dead_code
-        final tester = $.tester;
-        // ── Setup ──
-        final originalOnError = suppressSetStateErrors();
-        final originalErrorBuilder = saveErrorWidgetBuilder();
-        final semanticsHandle = tester.ensureSemantics();
-
-        launchAppGuarded(app.main);
-        await tester.pumpAndSettle(const Duration(seconds: 3));
-
-        final container = ProviderScope.containerOf(
-          tester.element(find.byType(MaterialApp)),
-        );
-        final authService = container.read(authServiceProvider);
-
-        // ════════════════════════════════════════════════════════════
-        // Phase 1: Generate local keys, then register with Keycast
-        //          passing the nsec so both share the same pubkey.
-        //
-        // This mirrors the real "started anonymous → secured account"
-        // flow where the user's local nsec is imported into Keycast
-        // via headlessRegister(nsec: ...).
-        // ════════════════════════════════════════════════════════════
-
-        // 1a. Generate local private key
-        final keyStorage = container.read(secureKeyStorageProvider);
-        final privateKey = generatePrivateKey();
-        final nsec = Nip19.encodePrivateKey(privateKey);
-        final keyContainer = await tester.runAsync(
-          () => keyStorage.importFromNsec(nsec),
-        );
-        final localPubkey = keyContainer!.publicKeyHex;
-        logPhase('Phase 1a: local keys generated — pubkey=$localPubkey');
-
-        // 1b. Register with Keycast passing the same nsec
-        final oauthClient = container.read(oauthClientProvider);
-        final result = (await tester.runAsync(
-          () => oauthClient.headlessRegister(
-            email: testEmail,
-            password: testPassword,
-            scope: 'policy:full',
-          ),
-        ))!;
-        final registerResult = result.$1;
-        final verifier = result.$2;
-        expect(
-          registerResult.success,
-          isTrue,
-          reason: 'headlessRegister with nsec should succeed',
-        );
-        logPhase(
-          'Phase 1b: registered with Keycast — '
-          'pubkey=${registerResult.pubkey}',
-        );
-
-        // 1c. Verify email + exchange code + sign in
-        final verifyToken = await getVerificationToken(testEmail);
-        expect(verifyToken, isNotEmpty);
-        await callVerifyEmail(verifyToken);
-
-        // Poll until Keycast issues the authorization code
-        String? authCode;
-        for (var i = 0; i < 30; i++) {
-          final poll = await tester.runAsync(
-            () => oauthClient.pollForCode(registerResult.deviceCode!),
-          );
-          if (poll!.code != null) {
-            authCode = poll.code;
-            break;
-          }
-          await tester.pump(const Duration(milliseconds: 500));
-        }
-        expect(authCode, isNotNull, reason: 'Polling should return auth code');
-
-        final tokenResponse = await tester.runAsync(
-          () => oauthClient.exchangeCode(code: authCode!, verifier: verifier),
-        );
-        final session = KeycastSession.fromTokenResponse(tokenResponse!);
-        await tester.runAsync(
-          () => authService.signInWithDivineOAuth(session),
-        );
-        await pumpUntilSettled(tester);
-
-        expect(authService.isAuthenticated, isTrue);
-        expect(
-          authService.authenticationSource,
-          equals(AuthenticationSource.divineOAuth),
-        );
-        expect(
-          authService.currentPublicKeyHex,
-          equals(localPubkey),
-          reason: 'OAuth pubkey must match local key pubkey',
-        );
-
-        logPhase('Phase 1c: authenticated via OAuth with matching local key');
-
-        // ════════════════════════════════════════════════════════════
-        // Phase 2: Kill both tokens to trigger expired session state
-        // ════════════════════════════════════════════════════════════
-
-        // 2a. Expire the locally stored session
-        final secureStorage = container.read(flutterSecureStorageProvider);
-        final storedSession = await KeycastSession.load(secureStorage);
-        expect(storedSession, isNotNull);
-        final expiredSession = storedSession!.copyWith(
-          expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
-        );
-        await expiredSession.save(secureStorage);
-
-        // 2b. Consume all refresh tokens in DB so refresh fails
-        final userPubkey = await getUserPubkeyByEmail(testEmail);
-        expect(userPubkey, isNotNull);
-        final consumedCount = await consumeAllRefreshTokens(userPubkey!);
-        logPhase(
-          'Phase 2: expired local session, consumed $consumedCount DB tokens',
-        );
-
-        // ════════════════════════════════════════════════════════════
-        // Phase 3: Reinitialize auth (simulates cold app restart)
-        // ════════════════════════════════════════════════════════════
-
-        await authService.initialize();
-        await pumpUntilSettled(tester, maxSeconds: 10);
-
-        expect(
-          authService.hasExpiredOAuthSession,
-          isTrue,
-          reason: 'Should detect expired OAuth session after reinit',
-        );
-        expect(
-          authService.isAuthenticated,
-          isTrue,
-          reason: 'Should still be authenticated via local key fallback',
-        );
-
-        logPhase(
-          'Phase 3 complete: hasExpiredOAuthSession=${authService.hasExpiredOAuthSession}',
-        );
-
-        // ════════════════════════════════════════════════════════════
-        // Phase 4: Navigate to profile, find banner, tap "Sign in"
-        // ════════════════════════════════════════════════════════════
-
-        await tapBottomNavTab(tester, 'profile_tab');
-        await pumpUntilSettled(tester);
-
-        final foundBanner = await waitForText(tester, 'Session Expired');
-        expect(
-          foundBanner,
-          isTrue,
-          reason: 'Profile should show "Session Expired" banner',
-        );
-
-        // Tap the "Sign in" button on the banner
-        final signInButton = find.widgetWithText(ElevatedButton, 'Sign in');
-        expect(signInButton, findsOneWidget);
-        await tester.tap(signInButton);
-        await pumpUntilSettled(tester, maxSeconds: 10);
-
-        logPhase('Phase 4: tapped Sign in on expired session banner');
-
-        // ════════════════════════════════════════════════════════════
-        // Phase 5: Assert user reaches login options (not bounced home)
-        // ════════════════════════════════════════════════════════════
-
-        // Login options screen shows "Forgot password?" and auth fields
-        final foundLoginScreen = await waitForText(
-          tester,
-          'Forgot password?',
-          maxSeconds: 10,
-        );
-        expect(
-          foundLoginScreen,
-          isTrue,
-          reason: 'Should reach login options screen, not be bounced to home',
-        );
-
-        logPhase('Phase 5: reached login options screen successfully');
-
-        // ════════════════════════════════════════════════════════════
-        // Phase 6: Login with credentials, verify banner disappears
-        // ════════════════════════════════════════════════════════════
-
-        await loginWithCredentials(tester, testEmail, testPassword);
-        await pumpUntilSettled(tester, maxSeconds: 15);
-
-        expect(authService.isAuthenticated, isTrue);
-        expect(
-          authService.hasExpiredOAuthSession,
-          isFalse,
-          reason: 'Banner flag should clear after successful login',
-        );
-
-        logPhase('Phase 6: logged in, expired session banner cleared');
-
-        semanticsHandle.dispose();
-        drainAsyncErrors(tester);
-        restoreErrorHandler(originalOnError);
-        restoreErrorWidgetBuilder(originalErrorBuilder);
       },
       timeout: const Timeout(Duration(minutes: 5)),
     );

--- a/mobile/lib/blocs/email_verification/email_verification_cubit.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_cubit.dart
@@ -243,10 +243,15 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
           if (result.code != null && _pendingVerifier != null) {
             await _exchangeCodeAndLogin(result.code!, _pendingVerifier!);
           } else {
-            // Edge case: completion detected but missing code or verifier
+            // Edge case: completion detected but missing code or verifier.
+            // Do NOT interpolate the verifier value: pre-Phase-1 builds may
+            // still hold a nsec-bearing verifier in memory and we must not
+            // forward it to the unified logger / Crashlytics
+            // (divinevideo/divine-mobile#3359).
             Log.error(
               'Verification complete but missing code or verifier! '
-              'code=${result.code}, verifier=$_pendingVerifier',
+              'hasCode=${result.code != null}, '
+              'hasVerifier=${_pendingVerifier != null}',
               name: 'EmailVerificationCubit',
               category: LogCategory.auth,
             );

--- a/mobile/lib/screens/auth/secure_account_screen.dart
+++ b/mobile/lib/screens/auth/secure_account_screen.dart
@@ -97,21 +97,16 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
       final email = _emailController.text.trim();
       final password = _passwordController.text;
 
-      // Use authService.exportNsec() which accesses keys from secure storage
-      // This works for both auto-generated and imported keys
-      final authService = ref.read(authServiceProvider);
-      final nsec = await authService.exportNsec();
-
-      if (nsec == null) {
-        _setGeneralError(l10n.authUnableToAccessKeys);
-        return;
-      }
-
+      // Phase 1 of divinevideo/divine-mobile#3359: do NOT export the local
+      // nsec or pass it to the OAuth client. Until the server-side
+      // proof-of-possession ceremony lands (divinevideo/keycast#197), the
+      // server will auto-generate a fresh keypair for this account, so the
+      // user's existing local pubkey identity is not preserved across the
+      // upgrade. Phase 2 restores BYOK identity binding.
       await _handleRegister(
         oauth: oauth,
         email: email,
         password: password,
-        nsec: nsec,
       );
     } catch (e) {
       Log.error(
@@ -131,11 +126,9 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
     required KeycastOAuth oauth,
     required String email,
     required String password,
-    required String nsec,
   }) async {
     final (result, verifier) = await oauth.headlessRegister(
       email: email,
-      nsec: nsec,
       password: password,
       scope: 'policy:full',
     );

--- a/mobile/lib/services/pending_verification_service.dart
+++ b/mobile/lib/services/pending_verification_service.dart
@@ -105,10 +105,15 @@ class PendingVerificationService {
       }
 
       // Phase 1 of divinevideo/divine-mobile#3359: discard any persisted
-      // verifier that still carries the legacy `<random>.<nsec1...>` shape.
-      // Replaying it through OAuth code exchange would re-leak the user's
-      // nsec to the server. Clearing forces a clean re-registration.
-      if (verifier.contains('.nsec1')) {
+      // verifier that still carries an embedded `nsec1...`. The legacy
+      // shape was `<random>.<nsec1...>` with a literal `.` separator, but
+      // we match on the bare prefix as defense-in-depth against any
+      // historical variant. A random base64url verifier contains the
+      // 5-char literal `nsec1` only at ~1e-7 probability, so false
+      // positives are negligible. Replaying a tainted verifier through
+      // OAuth code exchange would re-leak the user's nsec to the server;
+      // clearing forces a clean re-registration.
+      if (verifier.contains('nsec1')) {
         Log.warning(
           'Discarding pre-fix pending verification for $email '
           '(legacy nsec-bearing verifier).',

--- a/mobile/lib/services/pending_verification_service.dart
+++ b/mobile/lib/services/pending_verification_service.dart
@@ -104,6 +104,21 @@ class PendingVerificationService {
         return null;
       }
 
+      // Phase 1 of divinevideo/divine-mobile#3359: discard any persisted
+      // verifier that still carries the legacy `<random>.<nsec1...>` shape.
+      // Replaying it through OAuth code exchange would re-leak the user's
+      // nsec to the server. Clearing forces a clean re-registration.
+      if (verifier.contains('.nsec1')) {
+        Log.warning(
+          'Discarding pre-fix pending verification for $email '
+          '(legacy nsec-bearing verifier).',
+          name: 'PendingVerificationService',
+          category: LogCategory.auth,
+        );
+        await clear();
+        return null;
+      }
+
       // Parse createdAt, default to epoch if missing (legacy data)
       final createdAt = createdAtStr != null
           ? DateTime.tryParse(createdAtStr) ??

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
-import 'package:keycast_flutter/src/crypto/key_utils.dart';
 import 'package:keycast_flutter/src/models/exceptions.dart';
 import 'package:keycast_flutter/src/models/keycast_session.dart';
 import 'package:keycast_flutter/src/oauth/callback_result.dart';
@@ -153,21 +152,12 @@ class KeycastOAuth {
   ///   - 'consent': Force consent screen even if previously approved
   ///   - 'none': Silent auth only, fail if interaction required
   Future<(String url, String verifier)> getAuthorizationUrl({
-    String? nsec,
     String scope = 'policy:social',
     bool defaultRegister = true,
     String? authorizationHandle,
     String? prompt,
   }) async {
-    String? byokPubkey;
-    if (nsec != null) {
-      byokPubkey = KeyUtils.derivePublicKeyFromNsec(nsec);
-      if (byokPubkey == null) {
-        return ('', '');
-      }
-    }
-
-    final verifier = Pkce.generateVerifier(nsec: nsec);
+    final verifier = Pkce.generateVerifier();
     final challenge = Pkce.generateChallenge(verifier);
 
     final params = <String, String>{
@@ -178,10 +168,6 @@ class KeycastOAuth {
       'code_challenge_method': 'S256',
       'default_register': defaultRegister.toString(),
     };
-
-    if (byokPubkey != null) {
-      params['byok_pubkey'] = byokPubkey;
-    }
 
     final handle = authorizationHandle ?? await getAuthorizationHandle();
     if (handle != null) {
@@ -269,20 +255,18 @@ class KeycastOAuth {
   /// After registration, poll [pollForCode] until email is verified, then
   /// [exchangeCode].
   ///
-  /// [nsec] - Optional: import existing Nostr key instead of generating new one
+  /// BYOK identity preservation is intentionally not exposed on this method:
+  /// the previous shape transmitted the user's nsec (private key) to the
+  /// server. Restoring BYOK identity binding requires a server-side
+  /// proof-of-possession ceremony tracked in divinevideo/keycast#197 and
+  /// divinevideo/divine-mobile#3359.
   Future<(HeadlessRegisterResult, String verifier)> headlessRegister({
     required String email,
     required String password,
     String scope = 'policy:social',
-    String? nsec,
     String? state,
   }) async {
-    String? byokPubkey;
-    if (nsec != null) {
-      byokPubkey = KeyUtils.derivePublicKeyFromNsec(nsec);
-    }
-
-    final verifier = Pkce.generateVerifier(nsec: nsec);
+    final verifier = Pkce.generateVerifier();
     final challenge = Pkce.generateChallenge(verifier);
 
     try {
@@ -295,10 +279,6 @@ class KeycastOAuth {
         'code_challenge': challenge,
         'code_challenge_method': 'S256',
       };
-
-      if (byokPubkey != null) {
-        body['nsec'] = nsec;
-      }
 
       if (state != null) {
         body['state'] = state;

--- a/mobile/packages/keycast_flutter/lib/src/oauth/pkce.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/pkce.dart
@@ -1,24 +1,19 @@
 // ABOUTME: PKCE (Proof Key for Code Exchange) utilities for OAuth 2.0
-// ABOUTME: Generates verifiers and challenges, with optional BYOK nsec embedding
+// ABOUTME: Generates random verifiers and SHA256 challenges per RFC 7636
 
 import 'dart:convert';
 import 'dart:math';
 import 'package:crypto/crypto.dart';
 
 class Pkce {
-  static String generateVerifier({String? nsec}) {
-    final random = _generateRandomPart();
-    return nsec != null ? '$random.$nsec' : random;
+  static String generateVerifier() {
+    final random = Random.secure();
+    final bytes = List<int>.generate(32, (_) => random.nextInt(256));
+    return base64Url.encode(bytes).replaceAll('=', '');
   }
 
   static String generateChallenge(String verifier) {
     final hash = sha256.convert(utf8.encode(verifier));
     return base64Url.encode(hash.bytes).replaceAll('=', '');
-  }
-
-  static String _generateRandomPart() {
-    final random = Random.secure();
-    final bytes = List<int>.generate(32, (_) => random.nextInt(256));
-    return base64Url.encode(bytes).replaceAll('=', '');
   }
 }

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -71,32 +71,22 @@ void main() {
         expect(uri.queryParameters['default_register'], 'false');
       });
 
-      test('omits byok_pubkey when nsec not provided', () async {
-        final oauth = KeycastOAuth(config: config);
-        final (url, _) = await oauth.getAuthorizationUrl();
+      test(
+        'never sets byok_pubkey or embeds an nsec — leak-prevention guard',
+        () async {
+          // Phase 1 of divinevideo/divine-mobile#3359 removed the BYOK
+          // surface from this method. byok_pubkey is reintroduced in Phase 2
+          // paired with a proof-of-possession; until then the URL must not
+          // carry it and the verifier must not embed an nsec.
+          final oauth = KeycastOAuth(config: config);
+          final (url, verifier) = await oauth.getAuthorizationUrl();
 
-        final uri = Uri.parse(url);
-        expect(uri.queryParameters.containsKey('byok_pubkey'), isFalse);
-      });
-
-      test('includes byok_pubkey when nsec provided', () async {
-        final oauth = KeycastOAuth(config: config);
-        final (url, verifier) = await oauth.getAuthorizationUrl(
-          nsec:
-              'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5',
-        );
-
-        final uri = Uri.parse(url);
-        expect(uri.queryParameters.containsKey('byok_pubkey'), isTrue);
-        expect(uri.queryParameters['byok_pubkey']?.length, 64);
-        expect(verifier, contains('.nsec1'));
-      });
-
-      test('returns null URL for invalid nsec', () async {
-        final oauth = KeycastOAuth(config: config);
-        final (url, _) = await oauth.getAuthorizationUrl(nsec: 'invalid');
-        expect(url, isEmpty);
-      });
+          final uri = Uri.parse(url);
+          expect(uri.queryParameters.containsKey('byok_pubkey'), isFalse);
+          expect(verifier, isNot(contains('nsec1')));
+          expect(verifier, isNot(contains('.')));
+        },
+      );
     });
 
     group('parseCallback', () {
@@ -368,28 +358,36 @@ void main() {
         expect(result.success, isTrue);
       });
 
-      test('includes nsec in body when provided', () async {
-        final mockClient = MockClient((request) async {
-          final body = jsonDecode(request.body) as Map<String, dynamic>;
-          expect(body['nsec'], contains('nsec1'));
-          return http.Response(
-            jsonEncode({
-              'success': true,
-              'pubkey': 'byok_pubkey',
-              'verification_required': true,
-            }),
-            200,
-          );
-        });
+      test(
+        'never sends nsec in body or embeds it in the verifier '
+        '— leak-prevention guard',
+        () async {
+          // Phase 1 of divinevideo/divine-mobile#3359 removed the BYOK
+          // parameter from this method. The request body must not carry an
+          // `nsec` field and the returned verifier must not embed one.
+          final mockClient = MockClient((request) async {
+            final body = jsonDecode(request.body) as Map<String, dynamic>;
+            expect(body.containsKey('nsec'), isFalse);
+            expect(jsonEncode(body), isNot(contains('nsec1')));
+            return http.Response(
+              jsonEncode({
+                'success': true,
+                'pubkey': 'pubkey',
+                'verification_required': true,
+              }),
+              200,
+            );
+          });
 
-        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
-        await oauth.headlessRegister(
-          email: 'test@example.com',
-          password: 'password123',
-          nsec:
-              'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5',
-        );
-      });
+          final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+          final (_, verifier) = await oauth.headlessRegister(
+            email: 'test@example.com',
+            password: 'password123',
+          );
+          expect(verifier, isNot(contains('nsec1')));
+          expect(verifier, isNot(contains('.')));
+        },
+      );
 
       test('includes state parameter when provided', () async {
         final mockClient = MockClient((request) async {

--- a/mobile/packages/keycast_flutter/test/pkce_test.dart
+++ b/mobile/packages/keycast_flutter/test/pkce_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests for PKCE (Proof Key for Code Exchange) utilities
-// ABOUTME: Verifies verifier generation, challenge computation, and BYOK embedding
+// ABOUTME: Verifies verifier generation and challenge computation per RFC 7636
 
 import 'dart:convert';
 import 'package:crypto/crypto.dart';
@@ -27,30 +27,16 @@ void main() {
         final verifier = Pkce.generateVerifier();
         expect(verifier.length, greaterThanOrEqualTo(43));
       });
-    });
 
-    group('generateVerifier with BYOK', () {
-      test('embeds nsec in format {random}.{nsec}', () {
-        const nsec = 'nsec1test123';
-        final verifier = Pkce.generateVerifier(nsec: nsec);
-        expect(verifier, contains('.'));
-        expect(verifier, endsWith('.nsec1test123'));
-      });
-
-      test('random part is base64url without padding', () {
-        const nsec = 'nsec1abc';
-        final verifier = Pkce.generateVerifier(nsec: nsec);
-        final parts = verifier.split('.');
-        expect(parts.length, 2);
-        final randomPart = parts[0];
-        expect(randomPart, isNot(contains('=')));
-        expect(randomPart, isNot(contains('+')));
-        expect(randomPart, isNot(contains('/')));
-      });
-
-      test('without nsec, returns plain verifier (no dot)', () {
-        final verifier = Pkce.generateVerifier();
-        expect(verifier, isNot(contains('.')));
+      test('never embeds an nsec — leak-prevention regression guard', () {
+        // Phase 1 of divinevideo/divine-mobile#3359 strips the legacy BYOK
+        // embedding (`<random>.<nsec1...>`). The verifier must never contain
+        // an `nsec1` substring or the `.` separator regardless of input.
+        for (var i = 0; i < 64; i++) {
+          final verifier = Pkce.generateVerifier();
+          expect(verifier, isNot(contains('nsec1')));
+          expect(verifier, isNot(contains('.')));
+        }
       });
     });
 
@@ -93,21 +79,6 @@ void main() {
         final challenge1 = Pkce.generateChallenge('verifier1');
         final challenge2 = Pkce.generateChallenge('verifier2');
         expect(challenge1, isNot(equals(challenge2)));
-      });
-    });
-
-    group('BYOK verifier with challenge', () {
-      test('challenge is computed on full verifier including nsec', () {
-        const nsec = 'nsec1secret';
-        final verifier = Pkce.generateVerifier(nsec: nsec);
-        final challenge = Pkce.generateChallenge(verifier);
-
-        final expectedHash = sha256.convert(utf8.encode(verifier));
-        final expectedChallenge = base64Url
-            .encode(expectedHash.bytes)
-            .replaceAll('=', '');
-
-        expect(challenge, equals(expectedChallenge));
       });
     });
   });

--- a/mobile/test/screens/auth/secure_account_screen_test.dart
+++ b/mobile/test/screens/auth/secure_account_screen_test.dart
@@ -32,14 +32,14 @@ void main() {
       mockOAuth = _MockKeycastOAuth();
       mockAuthService = _MockAuthService();
 
-      // Default stubs
+      // Default stubs. Note: exportNsec() is intentionally NOT stubbed —
+      // Phase 1 of divinevideo/divine-mobile#3359 removed the only call site
+      // that used it from this screen, and an accidental future call must
+      // fail loudly rather than silently exfiltrate the nsec.
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
       when(() => mockAuthService.isAnonymous).thenReturn(true);
       when(() => mockAuthService.isRegistered).thenReturn(false);
       when(() => mockAuthService.currentNpub).thenReturn('npub1test...');
-      when(
-        () => mockAuthService.exportNsec(),
-      ).thenAnswer((_) async => 'nsec1testabc123xyz');
     });
 
     setUpAll(() async {
@@ -270,7 +270,6 @@ void main() {
           () => mockOAuth.headlessRegister(
             email: any(named: 'email'),
             password: any(named: 'password'),
-            nsec: any(named: 'nsec'),
             scope: any(named: 'scope'),
           ),
         ).thenAnswer(
@@ -319,7 +318,6 @@ void main() {
           () => mockOAuth.headlessRegister(
             email: 'test@example.com',
             password: 'SecurePass123!',
-            nsec: any(named: 'nsec'),
             scope: 'policy:full',
           ),
         ).called(1);
@@ -332,7 +330,6 @@ void main() {
           () => mockOAuth.headlessRegister(
             email: any(named: 'email'),
             password: any(named: 'password'),
-            nsec: any(named: 'nsec'),
             scope: any(named: 'scope'),
           ),
         ).thenAnswer(
@@ -373,8 +370,28 @@ void main() {
         expect(find.text('Email already registered'), findsOneWidget);
       });
 
-      testWidgets('shows error when nsec export fails', (tester) async {
-        when(() => mockAuthService.exportNsec()).thenAnswer((_) async => null);
+      testWidgets('never exports the local nsec or forwards it to OAuth '
+          '— leak-prevention regression guard', (tester) async {
+        // Phase 1 of divinevideo/divine-mobile#3359: the screen must not
+        // call exportNsec() and must not pass any nsec-bearing argument to
+        // headlessRegister.
+        when(
+          () => mockOAuth.headlessRegister(
+            email: any(named: 'email'),
+            password: any(named: 'password'),
+            scope: any(named: 'scope'),
+          ),
+        ).thenAnswer(
+          (_) async => (
+            HeadlessRegisterResult(
+              success: true,
+              pubkey: 'test-pubkey',
+              verificationRequired: false,
+              email: 'test@example.com',
+            ),
+            'test-verifier',
+          ),
+        );
 
         await tester.pumpWidget(buildTestWidget());
         await tester.pumpAndSettle();
@@ -402,12 +419,10 @@ void main() {
         );
 
         await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
-        await tester.pumpAndSettle();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
 
-        expect(
-          find.text('Unable to access your keys. Please try again.'),
-          findsOneWidget,
-        );
+        verifyNever(() => mockAuthService.exportNsec());
       });
     });
 
@@ -422,7 +437,6 @@ void main() {
             () => mockOAuth.headlessRegister(
               email: any(named: 'email'),
               password: any(named: 'password'),
-              nsec: any(named: 'nsec'),
               scope: any(named: 'scope'),
             ),
           ).thenAnswer(
@@ -523,7 +537,6 @@ void main() {
           () => mockOAuth.headlessRegister(
             email: any(named: 'email'),
             password: any(named: 'password'),
-            nsec: any(named: 'nsec'),
             scope: any(named: 'scope'),
           ),
         ).thenAnswer(
@@ -611,7 +624,6 @@ void main() {
           () => mockOAuth.headlessRegister(
             email: any(named: 'email'),
             password: any(named: 'password'),
-            nsec: any(named: 'nsec'),
             scope: any(named: 'scope'),
           ),
         ).thenAnswer(

--- a/mobile/test/services/pending_verification_service_test.dart
+++ b/mobile/test/services/pending_verification_service_test.dart
@@ -85,6 +85,32 @@ void main() {
         },
       );
 
+      test(
+        'discards a persisted verifier with a bare `nsec1` substring '
+        '(no leading dot) — defense-in-depth against variant shapes',
+        () async {
+          // The documented legacy shape was `<random>.<nsec1...>`, but the
+          // load() guard intentionally matches `nsec1` anywhere so any
+          // historical variant is caught. Pure-random base64url verifiers
+          // do not contain the 5-char literal `nsec1` at meaningful
+          // probability.
+          stubReads(
+            deviceCode: 'device-123',
+            verifier: 'nsec1abc123secret_no_separator',
+            email: 'user@example.com',
+            createdAt: DateTime.now().toIso8601String(),
+            inviteCode: null,
+          );
+
+          final result = await service.load();
+
+          expect(result, isNull);
+          verify(
+            () => storage.delete(key: 'pending_verification_verifier'),
+          ).called(1);
+        },
+      );
+
       test('returns parsed value for a clean (random-only) verifier', () async {
         final now = DateTime.now().toIso8601String();
         stubReads(

--- a/mobile/test/services/pending_verification_service_test.dart
+++ b/mobile/test/services/pending_verification_service_test.dart
@@ -1,0 +1,121 @@
+// ABOUTME: Tests for PendingVerificationService — leak-prevention migration
+// ABOUTME: Verifies pre-fix nsec-bearing verifiers are discarded on load
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/pending_verification_service.dart';
+
+class _MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+
+void main() {
+  group(PendingVerificationService, () {
+    late _MockFlutterSecureStorage storage;
+    late PendingVerificationService service;
+
+    setUp(() {
+      storage = _MockFlutterSecureStorage();
+      service = PendingVerificationService(storage);
+
+      when(
+        () => storage.write(
+          key: any(named: 'key'),
+          value: any(named: 'value'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => storage.delete(key: any(named: 'key')),
+      ).thenAnswer((_) async {});
+    });
+
+    void stubReads({
+      required String? deviceCode,
+      required String? verifier,
+      required String? email,
+      required String? createdAt,
+      required String? inviteCode,
+    }) {
+      when(
+        () => storage.read(key: 'pending_verification_device_code'),
+      ).thenAnswer((_) async => deviceCode);
+      when(
+        () => storage.read(key: 'pending_verification_verifier'),
+      ).thenAnswer((_) async => verifier);
+      when(
+        () => storage.read(key: 'pending_verification_email'),
+      ).thenAnswer((_) async => email);
+      when(
+        () => storage.read(key: 'pending_verification_created_at'),
+      ).thenAnswer((_) async => createdAt);
+      when(
+        () => storage.read(key: 'pending_verification_invite_code'),
+      ).thenAnswer((_) async => inviteCode);
+    }
+
+    group('load', () {
+      test(
+        'discards a persisted verifier that still carries an embedded nsec '
+        '— Phase 1 leak-prevention guard',
+        () async {
+          // Pre-fix builds persisted verifiers of shape `<random>.<nsec1...>`.
+          // Replaying them through OAuth code exchange would re-leak the
+          // nsec to the server (divinevideo/divine-mobile#3359). The load
+          // path must drop and clear them, returning null so the caller
+          // forces a clean re-registration.
+          stubReads(
+            deviceCode: 'device-123',
+            verifier: 'random_part.nsec1abc123secret',
+            email: 'user@example.com',
+            createdAt: DateTime.now().toIso8601String(),
+            inviteCode: null,
+          );
+
+          final result = await service.load();
+
+          expect(result, isNull);
+          verify(
+            () => storage.delete(key: 'pending_verification_device_code'),
+          ).called(1);
+          verify(
+            () => storage.delete(key: 'pending_verification_verifier'),
+          ).called(1);
+          verify(
+            () => storage.delete(key: 'pending_verification_email'),
+          ).called(1);
+        },
+      );
+
+      test('returns parsed value for a clean (random-only) verifier', () async {
+        final now = DateTime.now().toIso8601String();
+        stubReads(
+          deviceCode: 'device-123',
+          verifier: 'random_only_verifier_no_dot_no_nsec',
+          email: 'user@example.com',
+          createdAt: now,
+          inviteCode: 'invite-abc',
+        );
+
+        final result = await service.load();
+
+        expect(result, isNotNull);
+        expect(result!.deviceCode, 'device-123');
+        expect(result.verifier, 'random_only_verifier_no_dot_no_nsec');
+        expect(result.email, 'user@example.com');
+        expect(result.inviteCode, 'invite-abc');
+      });
+
+      test('returns null when no pending data is stored', () async {
+        stubReads(
+          deviceCode: null,
+          verifier: null,
+          email: null,
+          createdAt: null,
+          inviteCode: null,
+        );
+
+        final result = await service.load();
+        expect(result, isNull);
+      });
+    });
+  });
+}

--- a/mobile/tools/ci/grep_for_nsec_payload.sh
+++ b/mobile/tools/ci/grep_for_nsec_payload.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# ABOUTME: Fails CI if production code uses `nsec` as an HTTP payload key.
+# ABOUTME: Locks in Phase 1 of divinevideo/divine-mobile#3359.
+#
+# Background: pre-fix code in `keycast_flutter` set `body['nsec'] = nsec`
+# in OAuth registration requests, transmitting the user's Nostr private
+# key over the wire. The fix removes that surface entirely. This guard
+# fires if a future change re-introduces the same shape (or a moral
+# equivalent like `'nsec':` / `"nsec":` in a map literal) anywhere in
+# production code outside the deprecated legacy paths.
+#
+# Legitimate uses NOT flagged:
+# - `nsec:` as a Dart named parameter (no quotes).
+# - `'nsec'` in test assertions like `containsKey('nsec')` (no colon
+#   immediately after the closing quote).
+# - Comments and doc strings.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Search roots: production code only.
+ROOTS=(
+  "mobile/lib"
+  "mobile/packages"
+)
+
+# Patterns that uniquely indicate `nsec` is being used as a payload key.
+PATTERN="(body\[['\"]nsec['\"]\])|(['\"]nsec['\"][[:space:]]*:)"
+
+# File suffixes / paths to exclude.
+EXCLUDES=(
+  "_test.dart"
+  ".g.dart"
+  ".freezed.dart"
+  ".mocks.dart"
+  "/l10n/generated/"
+)
+
+tmpfile="$(mktemp)"
+trap 'rm -f "$tmpfile"' EXIT
+
+# Find dart files, run grep, exclude generated/test files in post-filter.
+find "${ROOTS[@]}" -type f -name "*.dart" 2>/dev/null \
+  | while IFS= read -r f; do
+      skip=0
+      for ex in "${EXCLUDES[@]}"; do
+        case "$f" in *"$ex"*) skip=1; break;; esac
+      done
+      [ "$skip" -eq 1 ] && continue
+      grep -nE "$PATTERN" "$f" 2>/dev/null \
+        | sed "s|^|$f:|" \
+        || true
+    done > "$tmpfile"
+
+if [ -s "$tmpfile" ]; then
+  cat "$tmpfile"
+  echo
+  echo "❌ One or more files use 'nsec' as a payload key in production code."
+  echo "   This pattern is banned by Phase 1 of"
+  echo "   divinevideo/divine-mobile#3359 (BYOK nsec leak prevention)."
+  echo
+  echo "   If you are intentionally re-introducing BYOK identity binding,"
+  echo "   use the proof-of-possession contract from divinevideo/keycast#197"
+  echo "   (byok_pubkey + byok_proof) instead of forwarding the nsec."
+  exit 1
+fi
+
+echo "✅ No nsec-as-payload-key usages detected in production code."


### PR DESCRIPTION
## Description

Phase 1 emergency block for #3359 — strips the user's nsec from the
Keycast OAuth registration wire on both channels:

- `body['nsec']` field in `POST /api/headless/register`
- `<random>.<nsec1...>` suffix embedded in the PKCE `code_verifier`
  (later POSTed as `code_verifier` to `/api/oauth/token`)

The fix removes the parameters from the `keycast_flutter` package API
entirely so a future caller cannot re-introduce the leak. A POSIX-grep
CI guard locks the rule in.

**Related Issue:** Closes #3359

**Cross-repo coordination:** divinevideo/keycast#197 tracks the
server-side proof-of-possession redesign that Phase 2 depends on.
This PR ships **without** preserving BYOK identity binding — that is
restored once Phase 2 lands.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (the public `KeycastOAuth.headlessRegister` and `KeycastOAuth.getAuthorizationUrl` APIs no longer accept `nsec` — intentional, for security)

## Trade-off

Until Phase 2 ships, BYOK secure-account upgrades fall through to the
server's auto-generate path. The user's existing local pubkey identity
is **not preserved** across the upgrade, but the local nsec stays
on-device and never crosses the network. This is the intentional
emergency-block trade-off — stop the leak today, restore identity
preservation in Phase 2 (depends on divinevideo/keycast#197).

## What's in this PR

| File | Change |
|------|--------|
| `mobile/packages/keycast_flutter/lib/src/oauth/pkce.dart` | `generateVerifier` no longer takes `nsec`; verifier is always pure-random base64url |
| `mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart` | `getAuthorizationUrl` & `headlessRegister` drop `nsec`/`byokPubkey` parameters; `body['nsec']` removed; `byok_pubkey` URL param removed |
| `mobile/packages/keycast_flutter/test/{pkce,oauth_client}_test.dart` | Leak-as-feature tests flipped to negative regression guards |
| `mobile/lib/services/pending_verification_service.dart` | `load()` discards any persisted verifier containing `.nsec1` and clears storage (defense-in-depth migration) |
| `mobile/lib/blocs/email_verification/email_verification_cubit.dart` | Error log no longer interpolates `_pendingVerifier` value |
| `mobile/lib/screens/auth/secure_account_screen.dart` | Removed `authService.exportNsec()` and the `nsec:` arg |
| `mobile/test/services/pending_verification_service_test.dart` | **New** — three tests for the migration |
| `mobile/tools/ci/grep_for_nsec_payload.sh` | **New** — POSIX-grep guard for production code |
| `.github/workflows/mobile_ci.yaml` | New `nsec-leak-guard` job |
| `mobile/integration_test/auth/session_expired_banner_test.dart` | `markTestSkipped` until Phase 2 — depends on BYOK preservation |

## Test plan

- [x] `flutter analyze lib test integration_test packages/keycast_flutter/{lib,test}` — no issues
- [x] `flutter test packages/keycast_flutter/` — 167/167 passing
- [x] `flutter test test/services/pending_verification_service_test.dart test/screens/auth/secure_account_screen_test.dart test/blocs/email_verification/email_verification_cubit_test.dart` — 38/38 passing
- [x] `flutter test test/blocs/divine_auth/` — 64/64 passing (regression-safety on the path that never carried nsec)
- [x] `bash mobile/tools/ci/grep_for_nsec_payload.sh` — exits 0 on this branch
- [x] Guard regex verified: matches `body['nsec']` + `'nsec':`; ignores `containsKey('nsec')` + `any(named: 'nsec')`
- [ ] Manual: e2e secure-account upgrade flow on a local dev stack (post-merge or staging)
- [ ] Coordinate with infra/security on retention review for any pre-fix request bodies that infra-layer components may have captured (separate workstream)

## Follow-ups (not in this PR)

- divinevideo/keycast#197 — server-side proof-of-possession contract (Phase 2A)
- A separate Phase 2 mobile PR — restores BYOK identity preservation via the new server contract (depends on keycast#197 being in production)
- Orphaned ARB key `authUnableToAccessKeys` (no longer referenced from Dart) — left in place to avoid touching 16 locale files; safe to remove in a follow-up