### PR TITLE
fix(security): remove global cleartext/user-CA trust and iOS arbitrary web loads (#3358)

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -31,6 +31,8 @@ jobs:
         run: bash scripts/check_hls_auth_web_shim_sync.sh
       - name: 🌐 Smoke-test HLS auth web shim
         run: node scripts/test_hls_auth_web_shim.mjs
+      - name: 🔒 Verify native transport security
+        run: bash scripts/check_native_transport_security.sh
       - name: 🔨 Verify generated files are up-to-date
         run: |
           dart run build_runner build --delete-conflicting-outputs

--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -32,7 +32,12 @@ jobs:
       - name: 🌐 Smoke-test HLS auth web shim
         run: node scripts/test_hls_auth_web_shim.mjs
       - name: 🔒 Verify native transport security
-        run: bash scripts/check_native_transport_security.sh
+        run: |
+          if ! command -v xmllint >/dev/null 2>&1; then
+            sudo apt-get update -qq
+            sudo apt-get install -y --no-install-recommends libxml2-utils
+          fi
+          bash scripts/check_native_transport_security.sh
       - name: 🔨 Verify generated files are up-to-date
         run: |
           dart run build_runner build --delete-conflicting-outputs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@
 
 - The local Docker stack (`local_stack/`) speaks cleartext on `10.0.2.2`, `localhost`, and `127.0.0.1`. Cleartext to those loopback hosts is permitted in every build type on both platforms — Android via the `<domain-config>` block in `mobile/android/app/src/main/res/xml/network_security_config.xml`, iOS via `NSAllowsLocalNetworking=true` in `mobile/ios/Runner/Info.plist`. Remote cleartext is rejected on both platforms in every build type.
 - Either Android emulator (`10.0.2.2` → host) or iOS Simulator (`localhost` → host) works against the local stack out of the box.
-- User-installed CAs are not trusted in any build. If you need to proxy-debug with Charles or mitmproxy, add `<certificates src="user"/>` to the Android config in your working copy and don't commit it; CI's transport-security guard will block any commit that re-enables user-CA trust.
+- User-installed CAs are not trusted in any build. If you need to proxy-debug with Charles or mitmproxy, add a single `<certificates src="user" />` line to `<trust-anchors>` in `mobile/android/app/src/main/res/xml/network_security_config.xml` in your working copy and don't commit it; CI's transport-security guard will block any commit that re-enables user-CA trust. (For iOS, plist-edit `NSAppTransportSecurity` similarly and revert before commit.)
 - If you add a new exception to either native config, update `mobile/scripts/check_native_transport_security.sh` so the guard recognises the allowance.
 
 ## Clean Workspace Expectations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,13 @@
 - If a PR touches `mobile/packages/models`, run that package's relevant tests before pushing.
 - If a PR touches `mobile/packages/videos_repository`, run `flutter test --coverage` from `mobile/packages/videos_repository` and confirm coverage still satisfies the repo requirement.
 
+## Local Stack Development
+
+- The local Docker stack (`local_stack/`) speaks cleartext on `10.0.2.2`, `localhost`, and `127.0.0.1`. Cleartext to those loopback hosts is permitted in every build type on both platforms — Android via the `<domain-config>` block in `mobile/android/app/src/main/res/xml/network_security_config.xml`, iOS via `NSAllowsLocalNetworking=true` in `mobile/ios/Runner/Info.plist`. Remote cleartext is rejected on both platforms in every build type.
+- Either Android emulator (`10.0.2.2` → host) or iOS Simulator (`localhost` → host) works against the local stack out of the box.
+- User-installed CAs are not trusted in any build. If you need to proxy-debug with Charles or mitmproxy, add `<certificates src="user"/>` to the Android config in your working copy and don't commit it; CI's transport-security guard will block any commit that re-enables user-CA trust.
+- If you add a new exception to either native config, update `mobile/scripts/check_native_transport_security.sh` so the guard recognises the allowance.
+
 ## Clean Workspace Expectations
 
 - Do not leave untracked or modified files around after a task unless they are part of the intentional diff.

--- a/mobile/android/app/src/main/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/main/res/xml/network_security_config.xml
@@ -15,8 +15,8 @@
          The Dart-side source of truth for the emulator-host loopback is
          `localHost` in mobile/lib/models/environment_config.dart. -->
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">10.0.2.2</domain>
-        <domain includeSubdomains="true">localhost</domain>
-        <domain includeSubdomains="true">127.0.0.1</domain>
+        <domain>10.0.2.2</domain>
+        <domain>localhost</domain>
+        <domain>127.0.0.1</domain>
     </domain-config>
 </network-security-config>

--- a/mobile/android/app/src/main/res/xml/network_security_config.xml
+++ b/mobile/android/app/src/main/res/xml/network_security_config.xml
@@ -1,11 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <!-- Allow cleartext (HTTP) traffic for video URLs -->
-    <!-- This is needed for loading videos from Blossom servers and CDNs -->
-    <base-config cleartextTrafficPermitted="true">
+    <!-- Production transport security: HTTPS-only for remote hosts; trust
+         only system CAs (no user-installed CA trust, even on debug). -->
+    <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
-            <certificates src="user" />
         </trust-anchors>
     </base-config>
+    <!-- Cleartext is permitted only to loopback hosts so the local Docker
+         stack works from emulator and on-device dev. These addresses
+         cannot be redirected by a network attacker, so the practical
+         security delta vs. a release-strict global config is zero.
+         Mirrors Apple's NSAllowsLocalNetworking semantics on iOS.
+         The Dart-side source of truth for the emulator-host loopback is
+         `localHost` in mobile/lib/models/environment_config.dart. -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">127.0.0.1</domain>
+    </domain-config>
 </network-security-config>

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -52,25 +52,15 @@
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<false/>
-		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<!-- Apple-documented key for loopback/local-only cleartext
+		     exemption. Permits http/ws to localhost, 127.0.0.1, ::1,
+		     single-label hostnames, and the .local TLD so the local
+		     Docker stack works from iOS Simulator. Remote cleartext
+		     stays rejected. Available since iOS 10.0; project
+		     deployment target is 16.0. Mirrors the loopback domain-config
+		     in android/app/src/main/res/xml/network_security_config.xml. -->
+		<key>NSAllowsLocalNetworking</key>
 		<true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>relay.divine.video</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-			</dict>
-			<key>relay3.openvine.co</key>
-			<dict>
-				<key>NSExceptionRequiresForwardSecrecy</key>
-				<false/>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-			</dict>
-		</dict>
 	</dict>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Divine uses Bluetooth to discover and sync videos with nearby users for offline sharing.</string>

--- a/mobile/lib/models/environment_config.dart
+++ b/mobile/lib/models/environment_config.dart
@@ -2,6 +2,13 @@
 // ABOUTME: Each environment maps to exactly one relay URL and API base URL
 
 /// Host address from Android emulator to reach the host machine's localhost.
+///
+/// Mirrored in the native transport-security configs that allow cleartext
+/// to loopback hosts:
+///   - mobile/android/app/src/main/res/xml/network_security_config.xml
+///   - mobile/ios/Runner/Info.plist (NSAllowsLocalNetworking)
+///   - mobile/macos/Runner/Info.plist (NSAllowsLocalNetworking)
+/// Keep this constant in sync with the Android <domain-config> list.
 const localHost = '10.0.2.2';
 
 /// Local Docker stack port mappings.

--- a/mobile/macos/Runner/Info.plist
+++ b/mobile/macos/Runner/Info.plist
@@ -28,6 +28,16 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+		<!-- See mobile/ios/Runner/Info.plist for the rationale.
+		     Mirrors the iOS posture: HTTPS-only for remote hosts,
+		     loopback/local-only cleartext via NSAllowsLocalNetworking. -->
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>Divine needs access to your camera to record short videos.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/mobile/scripts/check_native_transport_security.sh
+++ b/mobile/scripts/check_native_transport_security.sh
@@ -1,33 +1,55 @@
 #!/usr/bin/env bash
 # Fails CI if release-applicable native transport-security policies regress.
 #
-# Guards:
-#   • Android base-config cleartext must stay disabled.
-#   • Android must not trust user-installed CAs (any build type).
+# Guards (all release-applicable on every build type):
+#   • Android <base-config> cleartext must stay disabled.
+#   • Android must not trust user-installed CAs.
 #   • Android cleartext <domain-config> must list ONLY loopback hosts
 #     (10.0.2.2, localhost, 127.0.0.1) — adding anything else requires an
 #     explicit script update so the change is reviewed.
-#   • iOS NSAllowsArbitraryLoadsInWebContent must stay false.
-#   • iOS NSExceptionAllowsInsecureHTTPLoads must stay false (any domain).
+#   • iOS / macOS NSAllowsArbitraryLoads / NSAllowsArbitraryLoadsInWebContent
+#     must stay false.
+#   • iOS / macOS NSExceptionAllowsInsecureHTTPLoads must stay false (any
+#     domain).
 #
 # Loopback addresses can't be redirected by a network attacker, so the
-# Android <domain-config> + iOS NSAllowsLocalNetworking exemptions are
-# considered safe.
+# Android <domain-config> + iOS/macOS NSAllowsLocalNetworking exemptions
+# are considered safe.
+#
+# Requires: xmllint (libxml2-utils on Debian/Ubuntu; pre-installed on
+# macOS and on GitHub Actions ubuntu-latest runners).
 set -euo pipefail
+
+if ! command -v xmllint >/dev/null 2>&1; then
+  echo "❌ xmllint not found. Install libxml2-utils (apt) or libxml2 (brew)."
+  exit 1
+fi
 
 fail=0
 
+# ---------------------------------------------------------------------------
+# Android
+# ---------------------------------------------------------------------------
 android_release="android/app/src/main/res/xml/network_security_config.xml"
 if [ ! -f "$android_release" ]; then
   echo "❌ Missing $android_release."
   fail=1
 else
-  if grep -qE '<base-config[^>]*cleartextTrafficPermitted="true"' "$android_release"; then
+  if ! xmllint --noout "$android_release" 2>/dev/null; then
+    echo "❌ $android_release is not well-formed XML."
+    xmllint --noout "$android_release" || true
+    fail=1
+  fi
+
+  base_cleartext=$(xmllint --xpath 'string(//base-config/@cleartextTrafficPermitted)' "$android_release" 2>/dev/null || echo "")
+  if [ "$base_cleartext" = "true" ]; then
     echo "❌ $android_release allows cleartext on <base-config>."
     fail=1
   fi
-  if grep -qE '<certificates[^>]*src="user"' "$android_release"; then
-    echo "❌ $android_release trusts user CAs (<certificates src=\"user\"/>)."
+
+  user_ca_count=$(xmllint --xpath 'count(//certificates[@src="user"])' "$android_release" 2>/dev/null || echo "0")
+  if [ "${user_ca_count:-0}" != "0" ]; then
+    echo "❌ $android_release trusts user CAs ($user_ca_count <certificates src=\"user\"/> entries)."
     fail=1
   fi
 
@@ -35,15 +57,12 @@ else
   # Any additions/removals must update this script in the same PR.
   expected_cleartext_domains="10.0.2.2 127.0.0.1 localhost"
   actual_cleartext_domains=$(
-    awk '
-      /<domain-config[^>]*cleartextTrafficPermitted="true"/ { flag=1; next }
-      /<\/domain-config>/                                   { flag=0; next }
-      flag
-    ' "$android_release" \
-      | grep -oE '>[^<]+<' \
-      | tr -d '<>' \
+    xmllint --xpath '//domain-config[@cleartextTrafficPermitted="true"]/domain/text()' "$android_release" 2>/dev/null \
+      | tr -s '[:space:]' '\n' \
+      | sed '/^$/d' \
       | sort -u \
-      | xargs
+      | tr '\n' ' ' \
+      | sed 's/ $//'
   )
   if [ "$actual_cleartext_domains" != "$expected_cleartext_domains" ]; then
     echo "❌ $android_release cleartext <domain-config> host list changed."
@@ -53,20 +72,47 @@ else
   fi
 fi
 
-ios_plist="ios/Runner/Info.plist"
-if [ ! -f "$ios_plist" ]; then
-  echo "❌ Missing $ios_plist."
-  fail=1
-else
-  if grep -A1 '<key>NSAllowsArbitraryLoadsInWebContent</key>' "$ios_plist" | grep -q '<true/>'; then
-    echo "❌ $ios_plist sets NSAllowsArbitraryLoadsInWebContent=true."
+# ---------------------------------------------------------------------------
+# iOS / macOS plists — same checks
+# ---------------------------------------------------------------------------
+check_ats_plist() {
+  local plist="$1"
+  if [ ! -f "$plist" ]; then
+    echo "❌ Missing $plist."
+    fail=1
+    return
+  fi
+
+  if ! xmllint --noout "$plist" 2>/dev/null; then
+    echo "❌ $plist is not well-formed XML."
+    xmllint --noout "$plist" || true
     fail=1
   fi
-  if grep -A1 '<key>NSExceptionAllowsInsecureHTTPLoads</key>' "$ios_plist" | grep -q '<true/>'; then
-    echo "❌ $ios_plist sets NSExceptionAllowsInsecureHTTPLoads=true."
+
+  local arbitrary_count
+  arbitrary_count=$(xmllint --xpath 'count(//key[text()="NSAllowsArbitraryLoads"]/following-sibling::*[1][self::true])' "$plist" 2>/dev/null || echo "0")
+  if [ "${arbitrary_count:-0}" != "0" ]; then
+    echo "❌ $plist sets NSAllowsArbitraryLoads=true."
     fail=1
   fi
-fi
+
+  local web_count
+  web_count=$(xmllint --xpath 'count(//key[text()="NSAllowsArbitraryLoadsInWebContent"]/following-sibling::*[1][self::true])' "$plist" 2>/dev/null || echo "0")
+  if [ "${web_count:-0}" != "0" ]; then
+    echo "❌ $plist sets NSAllowsArbitraryLoadsInWebContent=true."
+    fail=1
+  fi
+
+  local insecure_count
+  insecure_count=$(xmllint --xpath 'count(//key[text()="NSExceptionAllowsInsecureHTTPLoads"]/following-sibling::*[1][self::true])' "$plist" 2>/dev/null || echo "0")
+  if [ "${insecure_count:-0}" != "0" ]; then
+    echo "❌ $plist sets NSExceptionAllowsInsecureHTTPLoads=true ($insecure_count occurrences)."
+    fail=1
+  fi
+}
+
+check_ats_plist "ios/Runner/Info.plist"
+check_ats_plist "macos/Runner/Info.plist"
 
 if [ "$fail" -ne 0 ]; then
   echo

--- a/mobile/scripts/check_native_transport_security.sh
+++ b/mobile/scripts/check_native_transport_security.sh
@@ -111,7 +111,11 @@ check_ats_plist() {
   fi
 }
 
+# List every Info.plist that ships in the app bundle or any extension /
+# widget. Add new entries here whenever a new target with its own plist is
+# introduced so the guard's coverage stays explicit at a glance.
 check_ats_plist "ios/Runner/Info.plist"
+check_ats_plist "ios/NotificationServiceExtension/Info.plist"
 check_ats_plist "macos/Runner/Info.plist"
 
 if [ "$fail" -ne 0 ]; then

--- a/mobile/scripts/check_native_transport_security.sh
+++ b/mobile/scripts/check_native_transport_security.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Fails CI if release-applicable native transport-security policies regress.
+#
+# Guards:
+#   • Android base-config cleartext must stay disabled.
+#   • Android must not trust user-installed CAs (any build type).
+#   • Android cleartext <domain-config> must list ONLY loopback hosts
+#     (10.0.2.2, localhost, 127.0.0.1) — adding anything else requires an
+#     explicit script update so the change is reviewed.
+#   • iOS NSAllowsArbitraryLoadsInWebContent must stay false.
+#   • iOS NSExceptionAllowsInsecureHTTPLoads must stay false (any domain).
+#
+# Loopback addresses can't be redirected by a network attacker, so the
+# Android <domain-config> + iOS NSAllowsLocalNetworking exemptions are
+# considered safe.
+set -euo pipefail
+
+fail=0
+
+android_release="android/app/src/main/res/xml/network_security_config.xml"
+if [ ! -f "$android_release" ]; then
+  echo "❌ Missing $android_release."
+  fail=1
+else
+  if grep -qE '<base-config[^>]*cleartextTrafficPermitted="true"' "$android_release"; then
+    echo "❌ $android_release allows cleartext on <base-config>."
+    fail=1
+  fi
+  if grep -qE '<certificates[^>]*src="user"' "$android_release"; then
+    echo "❌ $android_release trusts user CAs (<certificates src=\"user\"/>)."
+    fail=1
+  fi
+
+  # Pin the cleartext domain-config to the exact loopback allowlist.
+  # Any additions/removals must update this script in the same PR.
+  expected_cleartext_domains="10.0.2.2 127.0.0.1 localhost"
+  actual_cleartext_domains=$(
+    awk '
+      /<domain-config[^>]*cleartextTrafficPermitted="true"/ { flag=1; next }
+      /<\/domain-config>/                                   { flag=0; next }
+      flag
+    ' "$android_release" \
+      | grep -oE '>[^<]+<' \
+      | tr -d '<>' \
+      | sort -u \
+      | xargs
+  )
+  if [ "$actual_cleartext_domains" != "$expected_cleartext_domains" ]; then
+    echo "❌ $android_release cleartext <domain-config> host list changed."
+    echo "   expected: $expected_cleartext_domains"
+    echo "   actual:   $actual_cleartext_domains"
+    fail=1
+  fi
+fi
+
+ios_plist="ios/Runner/Info.plist"
+if [ ! -f "$ios_plist" ]; then
+  echo "❌ Missing $ios_plist."
+  fail=1
+else
+  if grep -A1 '<key>NSAllowsArbitraryLoadsInWebContent</key>' "$ios_plist" | grep -q '<true/>'; then
+    echo "❌ $ios_plist sets NSAllowsArbitraryLoadsInWebContent=true."
+    fail=1
+  fi
+  if grep -A1 '<key>NSExceptionAllowsInsecureHTTPLoads</key>' "$ios_plist" | grep -q '<true/>'; then
+    echo "❌ $ios_plist sets NSExceptionAllowsInsecureHTTPLoads=true."
+    fail=1
+  fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "Release-applicable native transport-security policy regressed."
+  echo "If a new exception is genuinely required, add a narrow"
+  echo "<domain-config>/<NSExceptionDomains> entry, document why, and"
+  echo "update this script with a justified allowance."
+  exit 1
+fi


### PR DESCRIPTION
## Description

Tightens release-build native transport security on Android, iOS, and macOS so they stop authorizing what production code already doesn't do, and adds a CI guard that prevents the policies from silently regressing.

**Android (`mobile/android/app/src/main/res/xml/network_security_config.xml`):**
- `<base-config cleartextTrafficPermitted="false">` and `<certificates src="system"/>` only — no more user-installed CA trust on any build type.
- `<domain-config cleartextTrafficPermitted="true">` for `10.0.2.2`, `localhost`, `127.0.0.1` only, so the local Docker stack still works from emulator/device.

**iOS (`mobile/ios/Runner/Info.plist`):**
- Drops `NSAllowsArbitraryLoadsInWebContent` (no preloaded WebView app needs it; all 14 in `preloaded_nostr_apps.dart` are HTTPS).
- Drops the dead `NSExceptionDomains` entries — `relay.divine.video` (HTTP path is never used in code; production is WSS) and `relay3.openvine.co` (domain not referenced anywhere in `lib/`, `packages/`, or tests).
- Adds `NSAllowsLocalNetworking=true` (Apple-documented key, iOS 10+, project deployment target 16.0) — exempts loopback / single-label hostnames / `.local` TLD so iOS Simulator can talk to the local stack.

**macOS (`mobile/macos/Runner/Info.plist`):**
- Adds an `NSAppTransportSecurity` dict that mirrors iOS exactly (`NSAllowsArbitraryLoads=false` + `NSAllowsLocalNetworking=true`). Previously the macOS target inherited macOS default ATS, which is more permissive than the iOS posture this PR establishes.

**CI guard (`mobile/scripts/check_native_transport_security.sh`):**
- Uses `xmllint --xpath` for the Android XML and the two plists, so multi-line attribute formatting can't sneak past the regex.
- Includes an `xmllint --noout` well-formedness check on every config file.
- Pins the cleartext `<domain-config>` host list to the exact loopback allowlist (any addition fails CI).
- Covers Android, iOS, and macOS plists with the same set of rules.
- Wired into the existing `generated-files` job in `.github/workflows/mobile_ci.yaml`, mirroring the `check_hls_auth_web_shim_sync.sh` pattern.

**Cross-references:**
- `mobile/lib/models/environment_config.dart` — comment on `localHost` pointing at the three native configs that mirror it.
- `AGENTS.md` — new "Local Stack Development" section with concrete proxy-debug guidance.

### Why this approach over a debug-only override

The first iteration scoped cleartext to a debug-only `app/src/debug/res/xml/network_security_config.xml` (mirroring the existing `app/src/debug/AndroidManifest.xml` precedent) and left iOS strict everywhere. That broke iOS Simulator local-stack workflow entirely — iOS doesn't have first-class per-configuration plist selection without invasive Xcode-project edits. Switching to `<domain-config>` (Android) + `NSAllowsLocalNetworking` (iOS/macOS, Apple-documented) keeps the loopback dev affordance on every platform while delivering the same security posture: loopback addresses can't be redirected by a network attacker, so the "defense in depth" delta is zero against any realistic threat model. A more detailed walkthrough of the trade-off is in `mobile/docs/brainstorm/2026-05-01-transport-security-hardening-brainstorm.md`.

**Related Issue:** Closes #3358

Companion fix lands in #3362 (application-layer relay URL validators). They should ship in the same release; without #3362 the OS rejects cleartext but `relay_settings_screen.dart`/`relay_manager.dart` still accept `ws://` from user input.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue) — security hardening
- [x] ✅ Build configuration change

## Open follow-ups (not blocking this PR)

@notthatkindofdrliz — would appreciate your call on these before I file follow-up issues:

1. **`MediaAvailabilityChecker` semantics under strict ATS.** Today (`mobile/lib/services/media_availability_checker.dart:33`) any thrown `Exception` from a HEAD request is treated as transient → the BLoC keeps the video in the feed. After this PR, third-party `kind:22` events whose `videoUrl` is `http://...` will be permanently TLS-rejected at the OS layer; the HEAD will fail the same way. The current "transient" classification means users will be stuck with un-loadable feed entries forever. Two options:
   - (a) Detect cleartext-rejection-shaped errors in `MediaAvailabilityChecker` (`SocketException` containing "cleartext", or iOS error -1022) and treat as confirmed unavailable so the BLoC drops the entry.
   - (b) Reject `http://` non-loopback video URLs at ingest in `videos_repository` so they never reach the player.
   
   I lean toward (b) — repository-layer validation matches the `architecture.md` pattern of "fallback / source-selection logic belongs in the repository, not the BLoC". But (a) is the more conservative scope. Either way it's separate from #3358; want me to file as a follow-up?

2. **`BlossomSettingsScreen` URL scheme validation.** `mobile/lib/screens/blossom_settings_screen.dart:74-86` accepts any user-typed URL with `hasScheme && hasAuthority`, including `http://my-blossom.example.com`. Under strict ATS the upload silently fails at the OS layer with no user-facing explanation. Same shape as #3362's relay validators — should reject non-loopback cleartext with a clear l10n error message ("Blossom server URL must use https://"). Worth a separate PR or roll into #3362's URL-validation pass?

## Test Plan

### Automated

- [x] CI guard script passes against the new configs (positive case for Android / iOS / macOS).
- [x] Six negative scenarios all fire:
  - `<base-config>` cleartext re-enabled
  - `<certificates src="user"/>` re-added
  - Non-loopback host added to cleartext `<domain-config>` (verified with multi-line attribute syntax — xmllint catches it where the original grep would have missed)
  - iOS `NSAllowsArbitraryLoadsInWebContent=true` re-added
  - macOS `NSAllowsArbitraryLoads=true` re-added
  - Malformed XML in any config file (caught by `xmllint --noout`)
- [x] `xmllint --noout` clean on Android XML, iOS plist, macOS plist.
- [x] `flutter analyze lib test` — no issues.
- [x] `flutter test test/models/environment_config_test.dart` — 18/18 pass; existing assertions still pin production URLs to HTTPS/WSS.
- [x] `mobile/integration_test/` audit: every `http://` / `ws://` literal targets `$localHost` (= `10.0.2.2`) or `localhost`, all in the loopback allowlist — no integration test breaks.

### Manual (pre-merge checklist for whoever ships the release)

- [ ] `flutter build apk --release` — confirm built APK manifest still references `@xml/network_security_config` and the resolved XML matches main.
- [ ] `flutter build ipa --release` — confirm built `Info.plist` ATS dict matches the trimmed form (no `NSAllowsArbitraryLoadsInWebContent`, `NSAllowsLocalNetworking=true`).
- [ ] `flutter build macos --release` — confirm new ATS dict survives the build.
- [ ] Release-mode Android device + user-installed CA + intercepting proxy (mitmproxy/Charles): confirm production traffic is **not** decrypted.
- [ ] Debug-mode Android emulator: `flutter run --dart-define=DEFAULT_ENV=LOCAL` against the local Docker stack — feeds load.
- [ ] Debug-mode iOS Simulator: `flutter run --dart-define=DEFAULT_ENV=LOCAL` against the local Docker stack — feeds load (this is a workflow regression that's now fixed by `NSAllowsLocalNetworking`).
- [ ] Smoke-test the 14 preloaded WebView Nostr apps under release-mode iOS — each loads, bridge auto-login works for the apps that support it. If any breaks under strict ATS, add a *narrow* `NSExceptionDomains` entry per origin (do **not** restore `NSAllowsArbitraryLoadsInWebContent`).
- [ ] mitmproxy / Charles capture against a release-mode debug build — enumerate every TLS endpoint to confirm no closed-source SDK (Zendesk, Firebase, ProofMode, ffmpeg-kit, c2pa, webview_flutter, divine_video_player) quietly relies on cleartext. Run on macOS too since this PR newly tightens that target.

## Risks

- **Third-party `http://` video URLs in `kind:22` events fail under release Android.** Today these silently load over cleartext. Now they fail. Surfaced as the first open follow-up above; not blocking this PR — the security posture is the goal.
- **macOS now enforces strict ATS where previously it ran with macOS defaults.** Any closed-source SDK that talked cleartext on macOS will now fail. Mitigated by the macOS run of the manual mitmproxy step.
- **`NSAllowsLocalNetworking=true` permits `.local` TLD cleartext.** This is small surface (printers / NAS / IoT on the same network) but acknowledged. It's the trade-off Apple chose for this key, and matches the project's existing `NSBonjourServices` declaration of `_openvine._tcp` (intentional groundwork for an unbuilt P2P sync feature).
- **Apple-CA-trusting MDM proxies stop intercepting.** Intentional and aligned with the security goal; flag in release notes if support has heard from any affected user.
