### PR TITLE
fix(video-recorder): cache overlay visibility notifier to avoid unsafe ref usage on dispose

### DIFF
--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -54,6 +54,7 @@ class _VideoRecorderScreenState extends ConsumerState<VideoRecorderScreen>
     with WidgetsBindingObserver {
   VideoRecorderNotifier? _notifier;
   ProviderSubscription<AudioEvent?>? _soundSubscription;
+  OverlayVisibility? _overlayVisibilityNotifier;
 
   bool get _isAutosavedDraft => ref.read(videoEditorProvider).isAutosavedDraft;
 
@@ -213,7 +214,8 @@ class _VideoRecorderScreenState extends ConsumerState<VideoRecorderScreen>
   /// Force all background video playback to pause while camera is open.
   void _pauseBackgroundPlayback() {
     try {
-      ref.read(overlayVisibilityProvider.notifier).setPageOpen(true);
+      _overlayVisibilityNotifier = ref.read(overlayVisibilityProvider.notifier);
+      _overlayVisibilityNotifier!.setPageOpen(true);
       ref.read(videoVisibilityManagerProvider).pauseAllVideos();
       _disposeVideoControllers();
       Log.info(
@@ -311,7 +313,7 @@ class _VideoRecorderScreenState extends ConsumerState<VideoRecorderScreen>
   @override
   Future<void> dispose() async {
     try {
-      ref.read(overlayVisibilityProvider.notifier).setPageOpen(false);
+      _overlayVisibilityNotifier?.setPageOpen(false);
     } catch (e) {
       Log.warning(
         '📹 Failed to clear overlay visibility on dispose: $e',

--- a/mobile/test/screens/video_recorder_screen_test.dart
+++ b/mobile/test/screens/video_recorder_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_recorder_provider.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
@@ -255,6 +256,67 @@ void main() {
         // Should have disposed cleanly
         expect(find.byType(VideoRecorderScreen), findsNothing);
       });
+
+      testWidgets(
+        'clears overlayVisibility isPageOpen to false on dispose',
+        (tester) async {
+          final mockDraftStorage = _MockDraftStorageService();
+          when(
+            () => mockDraftStorage.getDraftById(any()),
+          ).thenAnswer((_) async => null);
+          final mockClipLibrary = _MockClipLibraryService();
+          when(mockClipLibrary.getAllClips).thenAnswer((_) async => []);
+
+          final container = ProviderContainer(
+            overrides: [
+              draftStorageServiceProvider.overrideWithValue(
+                mockDraftStorage,
+              ),
+              clipLibraryServiceProvider.overrideWithValue(mockClipLibrary),
+            ],
+          );
+          addTearDown(container.dispose);
+
+          await tester.pumpWidget(
+            UncontrolledProviderScope(
+              container: container,
+              child: BlocProvider<CameraPermissionBloc>(
+                create: (_) => MockCameraPermissionBloc(),
+                child: const MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: VideoRecorderScreen(),
+                ),
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(
+            container.read(overlayVisibilityProvider).isPageOpen,
+            isTrue,
+          );
+
+          await tester.pumpWidget(
+            UncontrolledProviderScope(
+              container: container,
+              child: const MaterialApp(
+                localizationsDelegates:
+                    AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: Scaffold(body: Text('Other screen')),
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(
+            container.read(overlayVisibilityProvider).isPageOpen,
+            isFalse,
+          );
+        },
+      );
     });
 
     group('Screen Layout', () {

--- a/mobile/test/screens/video_recorder_screen_test.dart
+++ b/mobile/test/screens/video_recorder_screen_test.dart
@@ -302,8 +302,7 @@ void main() {
             UncontrolledProviderScope(
               container: container,
               child: const MaterialApp(
-                localizationsDelegates:
-                    AppLocalizations.localizationsDelegates,
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
                 supportedLocales: AppLocalizations.supportedLocales,
                 home: Scaffold(body: Text('Other screen')),
               ),


### PR DESCRIPTION
Closes #3797

## Description

In `_VideoRecorderScreenState.dispose()`, `ref` was accessed after the widget was already unmounted, triggering a Riverpod unsafe-ref warning. Fix: the `OverlayVisibility` notifier reference is now cached in `_overlayVisibilityNotifier` during `_pauseBackgroundPlayback()` (called from `initState`) and reused directly in `dispose()`.


**Related Issue:** 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore