### PR TITLE
fix(inbox): open Divine DM links in app

### DIFF
--- a/mobile/lib/router/universal_link_resolver.dart
+++ b/mobile/lib/router/universal_link_resolver.dart
@@ -4,31 +4,25 @@
 import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/deep_link_service.dart';
 
-/// Converts a universal-link [uri] into an internal GoRouter path.
+/// Converts a Divine web URL into an internal drill-down route path.
 ///
-/// Returns the internal path (e.g. `/search-results/music`) when the URI is a
-/// divine.video universal link that maps to an in-app destination and the
-/// mapping should be applied at the router layer. Returns `null` otherwise —
-/// either because the URI is not a universal link, or because its handling is
-/// deferred to the [DeepLinkService] stream listener.
-///
-/// Video deep links (`/video/:id`) intentionally return `null`: the listener
-/// uses `router.push` to keep the home feed underneath the detail page so
-/// back-navigation returns to the main screen. Rewriting in the router
-/// redirect would replace the stack instead of stacking on top.
-///
-/// Only `divine.video` is accepted here, mirroring
-/// [DeepLinkService.parseDeepLink]. Paths on `login.divine.video`
-/// (OAuth callbacks) already match internal GoRoutes by coincidence of path
-/// (e.g. `/reset-password`, `/verify-email`) so no rewrite is needed for them.
-String? universalLinkToRouterPath(Uri uri) {
+/// Unlike [universalLinkToRouterPath], this helper includes video links
+/// because callers such as DM bubbles want to `push` the detail page on top
+/// of the current stack rather than defer to the app-wide deep-link listener.
+String? divineUrlToPushRoute(Uri uri) {
   if (!uri.scheme.startsWith('http')) return null;
-  if (uri.host != 'divine.video') return null;
+  final host = uri.host.toLowerCase();
+  if (host != 'divine.video' && host != 'www.divine.video') return null;
 
   final deepLink = DeepLinkService.parseDeepLink(uri.toString());
   switch (deepLink.type) {
+    case DeepLinkType.video:
+      final videoId = deepLink.videoId;
+      if (videoId == null || videoId.isEmpty) return null;
+      return VideoDetailScreen.pathForId(videoId);
     case DeepLinkType.profile:
       final npub = deepLink.npub;
       if (npub == null || npub.isEmpty) return null;
@@ -45,10 +39,42 @@ String? universalLinkToRouterPath(Uri uri) {
       final term = deepLink.searchTerm;
       if (term == null || term.isEmpty) return null;
       return SearchResultsPage.pathForQuery(term);
+    case DeepLinkType.invite:
+    case DeepLinkType.signerCallback:
+    case DeepLinkType.unknown:
+      return null;
+  }
+}
+
+/// Converts a universal-link [uri] into an internal GoRouter path.
+///
+/// Returns the internal path (e.g. `/search-results/music`) when the URI is a
+/// divine.video universal link that maps to an in-app destination and the
+/// mapping should be applied at the router layer. Returns `null` otherwise —
+/// either because the URI is not a universal link, or because its handling is
+/// deferred to the [DeepLinkService] stream listener.
+///
+/// Video deep links (`/video/:id`) intentionally return `null`: the listener
+/// uses `router.push` to keep the home feed underneath the detail page so
+/// back-navigation returns to the main screen. Rewriting in the router
+/// redirect would replace the stack instead of stacking on top.
+///
+/// Only canonical Divine web hosts are accepted here, mirroring
+/// [DeepLinkService.parseDeepLink]. Paths on `login.divine.video`
+/// (OAuth callbacks) already match internal GoRoutes by coincidence of path
+/// (e.g. `/reset-password`, `/verify-email`) so no rewrite is needed for them.
+String? universalLinkToRouterPath(Uri uri) {
+  final route = divineUrlToPushRoute(uri);
+  final deepLink = DeepLinkService.parseDeepLink(uri.toString());
+  switch (deepLink.type) {
     case DeepLinkType.video:
     case DeepLinkType.invite:
     case DeepLinkType.signerCallback:
     case DeepLinkType.unknown:
       return null;
+    case DeepLinkType.profile:
+    case DeepLinkType.hashtag:
+    case DeepLinkType.search:
+      return route;
   }
 }

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -13,6 +13,7 @@ import 'package:models/models.dart' hide AspectRatio, LogCategory;
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/video_link_preview_cubit.dart';
+import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -199,6 +200,34 @@ bool _isTrustedDomain(String host) {
   return _trustedDomains.any((d) => lower == d || lower.endsWith('.$d'));
 }
 
+/// Maps canonical Divine web URLs to in-app routes.
+String? _routeForDivineUrl(Uri uri) {
+  final host = uri.host.toLowerCase();
+  if (host != 'divine.video' && host != 'www.divine.video') {
+    return null;
+  }
+
+  final segments = uri.pathSegments;
+  if (segments.length == 2 && segments[0] == 'video') {
+    final videoId = segments[1];
+    if (videoId.isEmpty) return null;
+    return VideoDetailScreen.pathForId(videoId);
+  }
+
+  if ((segments.length == 2 || segments.length == 3) &&
+      segments[0] == 'profile') {
+    final npub = segments[1];
+    if (npub.isEmpty) return null;
+    if (segments.length == 3) {
+      final index = int.tryParse(segments[2]);
+      if (index != null) return ProfileScreenRouter.pathForIndex(npub, index);
+    }
+    return ProfileScreenRouter.pathForNpub(npub);
+  }
+
+  return null;
+}
+
 /// Renders message text with clickable URLs and email addresses.
 ///
 /// Links matching [_linkRegex] are styled as underlined links. URLs open in
@@ -315,6 +344,12 @@ class _MessageTextState extends State<_MessageText> {
       uri = Uri.tryParse(normalized);
     }
     if (uri == null) return;
+
+    final appRoute = _routeForDivineUrl(uri);
+    if (appRoute != null && context.mounted) {
+      await context.push(appRoute);
+      return;
+    }
 
     // Show a warning for external (non-Divine) URLs.
     if (uri.scheme != 'mailto' && !_isTrustedDomain(uri.host)) {

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -12,8 +12,8 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide AspectRatio, LogCategory;
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/router/universal_link_resolver.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/video_link_preview_cubit.dart';
-import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -200,34 +200,6 @@ bool _isTrustedDomain(String host) {
   return _trustedDomains.any((d) => lower == d || lower.endsWith('.$d'));
 }
 
-/// Maps canonical Divine web URLs to in-app routes.
-String? _routeForDivineUrl(Uri uri) {
-  final host = uri.host.toLowerCase();
-  if (host != 'divine.video' && host != 'www.divine.video') {
-    return null;
-  }
-
-  final segments = uri.pathSegments;
-  if (segments.length == 2 && segments[0] == 'video') {
-    final videoId = segments[1];
-    if (videoId.isEmpty) return null;
-    return VideoDetailScreen.pathForId(videoId);
-  }
-
-  if ((segments.length == 2 || segments.length == 3) &&
-      segments[0] == 'profile') {
-    final npub = segments[1];
-    if (npub.isEmpty) return null;
-    if (segments.length == 3) {
-      final index = int.tryParse(segments[2]);
-      if (index != null) return ProfileScreenRouter.pathForIndex(npub, index);
-    }
-    return ProfileScreenRouter.pathForNpub(npub);
-  }
-
-  return null;
-}
-
 /// Renders message text with clickable URLs and email addresses.
 ///
 /// Links matching [_linkRegex] are styled as underlined links. URLs open in
@@ -345,7 +317,7 @@ class _MessageTextState extends State<_MessageText> {
     }
     if (uri == null) return;
 
-    final appRoute = _routeForDivineUrl(uri);
+    final appRoute = divineUrlToPushRoute(uri);
     if (appRoute != null && context.mounted) {
       await context.push(appRoute);
       return;

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -124,8 +124,9 @@ class DeepLinkService {
         return const DeepLink(type: DeepLinkType.signerCallback);
       }
 
-      // Only handle divine.video domain
-      if (uri.host != 'divine.video') {
+      // Only handle canonical Divine web hosts.
+      final host = uri.host.toLowerCase();
+      if (host != 'divine.video' && host != 'www.divine.video') {
         Log.warning(
           'Ignoring deep link from non-divine.video domain: ${uri.host}',
           name: 'DeepLinkService',

--- a/mobile/test/router/universal_link_resolver_test.dart
+++ b/mobile/test/router/universal_link_resolver_test.dart
@@ -5,6 +5,33 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/router/universal_link_resolver.dart';
 
 void main() {
+  group('divineUrlToPushRoute', () {
+    test('maps video links to video detail routes', () {
+      expect(
+        divineUrlToPushRoute(Uri.parse('https://divine.video/video/abc123')),
+        equals('/video/abc123'),
+      );
+    });
+
+    test('accepts www.divine.video host alias', () {
+      expect(
+        divineUrlToPushRoute(
+          Uri.parse('https://www.divine.video/profile/npub1abc123'),
+        ),
+        equals('/profile/npub1abc123'),
+      );
+    });
+
+    test('returns null for invite links', () {
+      expect(
+        divineUrlToPushRoute(
+          Uri.parse('https://divine.video/invite/ABCD-EFGH'),
+        ),
+        isNull,
+      );
+    });
+  });
+
   group('universalLinkToRouterPath', () {
     group('host gating', () {
       test('returns null for non-http schemes', () {
@@ -31,6 +58,15 @@ void main() {
         expect(
           universalLinkToRouterPath(
             Uri.parse('https://divine.video/search/music'),
+          ),
+          equals('/search-results/music'),
+        );
+      });
+
+      test('accepts www.divine.video host alias', () {
+        expect(
+          universalLinkToRouterPath(
+            Uri.parse('https://www.divine.video/search/music'),
           ),
           equals('/search-results/music'),
         );

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
@@ -19,6 +20,77 @@ import 'package:openvine/widgets/video_thumbnail_widget.dart';
 import '../../../../helpers/test_provider_overrides.dart';
 
 class _MockVideoEventService extends Mock implements VideoEventService {}
+
+GoRouter _messageRouter(String message) {
+  return GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, state) => Scaffold(
+          body: MessageBubble(
+            message: message,
+            timestamp: '2:30 PM',
+            isSent: true,
+          ),
+        ),
+      ),
+      GoRoute(
+        path: '/profile/:npub',
+        builder: (context, state) => Scaffold(
+          body: Text('profile:${state.pathParameters['npub']}'),
+        ),
+      ),
+      GoRoute(
+        path: '/video/:id',
+        builder: (context, state) => Scaffold(
+          body: Text('video:${state.pathParameters['id']}'),
+        ),
+      ),
+    ],
+  );
+}
+
+Widget _routerTestApp(
+  GoRouter router, {
+  List<dynamic>? additionalOverrides,
+  MockNostrClient? mockNostrService,
+}) {
+  return testProviderScope(
+    additionalOverrides: additionalOverrides,
+    mockNostrService: mockNostrService,
+    child: MaterialApp.router(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      routerConfig: router,
+    ),
+  );
+}
+
+TapGestureRecognizer _linkRecognizer(WidgetTester tester, String linkText) {
+  final richText = tester.widget<RichText>(
+    find.byWidgetPredicate(
+      (widget) =>
+          widget is RichText && widget.text.toPlainText().contains(linkText),
+    ),
+  );
+  final recognizer = _findRecognizer(richText.text, linkText);
+  expect(recognizer, isNotNull);
+  return recognizer!;
+}
+
+TapGestureRecognizer? _findRecognizer(InlineSpan span, String linkText) {
+  if (span is TextSpan) {
+    final recognizer = span.recognizer;
+    if (span.text == linkText && recognizer is TapGestureRecognizer) {
+      return recognizer;
+    }
+    for (final child in span.children ?? const <InlineSpan>[]) {
+      final match = _findRecognizer(child, linkText);
+      if (match != null) return match;
+    }
+  }
+  return null;
+}
 
 void main() {
   group(MessageBubble, () {
@@ -370,6 +442,22 @@ void main() {
         );
         expect(richTextFinder, findsOneWidget);
       });
+
+      testWidgets('tapping Divine profile link navigates in-app', (
+        tester,
+      ) async {
+        const npub =
+            'npub1sn0wdenkukak0d9dfczzeacvhkrgz92ak56egt7vdgzn8pv2wfqqhrjdv9';
+        final router = _messageRouter('https://divine.video/profile/$npub');
+        addTearDown(router.dispose);
+
+        await tester.pumpWidget(_routerTestApp(router));
+
+        _linkRecognizer(tester, 'https://divine.video/profile/$npub').onTap!();
+        await tester.pumpAndSettle();
+
+        expect(find.text('profile:$npub'), findsOneWidget);
+      });
     });
 
     group('video preview card', () {
@@ -476,6 +564,34 @@ void main() {
         );
         expect(richTextFinder, findsOneWidget);
         expect(find.byType(VideoThumbnailWidget), findsNothing);
+      });
+
+      testWidgets('tapping unresolved Divine video link navigates in-app', (
+        tester,
+      ) async {
+        final router = _messageRouter('https://divine.video/video/unknown-id');
+        addTearDown(router.dispose);
+
+        await tester.pumpWidget(
+          _routerTestApp(
+            router,
+            mockNostrService: mockNostrClient,
+            additionalOverrides: [
+              videoEventServiceProvider.overrideWithValue(
+                mockVideoEventService,
+              ),
+            ],
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        _linkRecognizer(
+          tester,
+          'https://divine.video/video/unknown-id',
+        ).onTap!();
+        await tester.pumpAndSettle();
+
+        expect(find.text('video:unknown-id'), findsOneWidget);
       });
 
       testWidgets('preserves surrounding text alongside video preview', (

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -36,15 +36,13 @@ GoRouter _messageRouter(String message) {
       ),
       GoRoute(
         path: '/profile/:npub',
-        builder: (context, state) => Scaffold(
-          body: Text('profile:${state.pathParameters['npub']}'),
-        ),
+        builder: (context, state) =>
+            Scaffold(body: Text('profile:${state.pathParameters['npub']}')),
       ),
       GoRoute(
         path: '/video/:id',
-        builder: (context, state) => Scaffold(
-          body: Text('video:${state.pathParameters['id']}'),
-        ),
+        builder: (context, state) =>
+            Scaffold(body: Text('video:${state.pathParameters['id']}')),
       ),
     ],
   );

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -262,6 +262,16 @@ void main() {
         expect(result.type, equals(DeepLinkType.video));
         expect(result.videoId, equals(videoId));
       });
+
+      test('accepts www.divine.video host alias', () {
+        const videoId = 'abc123';
+        const url = 'https://www.divine.video/video/$videoId';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.video));
+        expect(result.videoId, equals(videoId));
+      });
     });
 
     group('DeepLink Data Class', () {


### PR DESCRIPTION
## Summary
- route divine.video video and profile links tapped inside DM bubbles through GoRouter
- keep unknown Divine paths and external links on the existing browser fallback
- add regression coverage for unresolved video links and profile links in message bubbles

**Related Issue:** Part of #3698

## Test Plan
- [x] flutter test test/screens/inbox/conversation/widgets/message_bubble_test.dart
- [x] flutter analyze lib/screens/inbox/conversation/widgets/message_bubble.dart test/screens/inbox/conversation/widgets/message_bubble_test.dart
- [x] pre-commit format + full mobile analyze hook
- [x] pre-push changed-file test hook
