### PR TITLE
refactor: thread SendProfileResult from NostrClient

### DIFF
--- a/mobile/packages/nostr_client/lib/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/nostr_client.dart
@@ -8,3 +8,4 @@ library;
 export 'src/models/models.dart';
 export 'src/nostr_client.dart';
 export 'src/relay_manager.dart';
+export 'src/send_profile_result.dart';

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -6,6 +6,7 @@ import 'package:db_client/db_client.dart' hide Filter;
 import 'package:meta/meta.dart';
 import 'package:nostr_client/src/models/models.dart';
 import 'package:nostr_client/src/relay_manager.dart';
+import 'package:nostr_client/src/send_profile_result.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:nostr_sdk/utils/hash_util.dart';
 
@@ -827,10 +828,15 @@ class NostrClient {
 
   /// Sends a user profile (Kind 0 metadata event).
   ///
-  /// Routes through [publishEvent] to ensure relay health checks and
-  /// reconnection logic run before broadcasting. Kind 0 is replaceable,
-  /// so the event is cached only on successful publish.
-  Future<Event?> sendProfile({
+  /// Checks relay connectivity (with retry) before broadcasting. Kind 0 is
+  /// replaceable, so the event is cached only on successful publish.
+  ///
+  /// Returns a [SendProfileResult] that callers can switch exhaustively over:
+  /// - [SendProfileSuccess] — the event was broadcast to at least one relay.
+  /// - [SendProfileNoRelays] — no relays were connected even after retry.
+  /// - [SendProfileFailed] — the SDK send call returned null for a reason
+  ///   other than empty relay list (e.g. serialisation error).
+  Future<SendProfileResult> sendProfile({
     required Map<String, dynamic> profileContent,
   }) async {
     final event = Event(
@@ -839,7 +845,28 @@ class NostrClient {
       [],
       jsonEncode(profileContent),
     );
-    return publishEvent(event);
+
+    // Fast-path: check relay connectivity before attempting to send, and
+    // surface the no-relays case as a first-class result variant rather than
+    // returning null and forcing callers to infer from a subsequent
+    // connectedRelays snapshot.
+    if (_relayManager.connectedRelays.isEmpty) {
+      await retryDisconnectedRelays();
+      if (_relayManager.connectedRelays.isEmpty) {
+        return const SendProfileNoRelays();
+      }
+    }
+
+    final sentEvent = await _nostr.sendEvent(event);
+    if (sentEvent == null) {
+      return const SendProfileFailed();
+    }
+
+    // Kind 0 is replaceable — cache on success only (not optimistically).
+    _cacheEvent(sentEvent);
+    statisticsObserver?.onEventSent();
+
+    return SendProfileSuccess(event: sentEvent);
   }
 
   /// Sends a repost

--- a/mobile/packages/nostr_client/lib/src/send_profile_result.dart
+++ b/mobile/packages/nostr_client/lib/src/send_profile_result.dart
@@ -1,0 +1,37 @@
+// ABOUTME: Typed result for sendProfile, distinguishing success from
+// ABOUTME: no-relays and generic send-failure outcomes.
+
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+/// The outcome of a Kind 0 profile publish call.
+///
+/// Callers can switch exhaustively over the three variants rather than
+/// inferring failure reason from a post-failure relay-list snapshot.
+sealed class SendProfileResult {
+  const SendProfileResult();
+}
+
+/// The Kind 0 event was accepted and broadcast to at least one relay.
+final class SendProfileSuccess extends SendProfileResult {
+  /// Creates a successful send result wrapping the sent [event].
+  const SendProfileSuccess({required this.event});
+
+  /// The signed and sent Kind 0 [Event].
+  final Event event;
+}
+
+/// The publish attempt was aborted before sending because no relays were
+/// connected, even after a reconnection attempt.
+final class SendProfileNoRelays extends SendProfileResult {
+  /// Creates a no-relays result.
+  const SendProfileNoRelays();
+}
+
+/// The relay pool was reachable but the underlying send call returned null —
+/// e.g. the SDK could not serialise or write the frame.
+/// This is distinct from [SendProfileNoRelays]: at least one relay was
+/// connected, but the send still failed.
+final class SendProfileFailed extends SendProfileResult {
+  /// Creates a send-failed result.
+  const SendProfileFailed();
+}

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1374,7 +1374,7 @@ void main() {
     });
 
     group('sendProfile', () {
-      test('creates Kind 0 event and routes through publishEvent', () async {
+      test('returns SendProfileSuccess with Kind 0 event on success', () async {
         final profileContent = {'display_name': 'Alice', 'about': 'Hello'};
         final sentEvent = _createTestEvent(kind: EventKind.metadata);
 
@@ -1390,7 +1390,8 @@ void main() {
           profileContent: profileContent,
         );
 
-        expect(result, equals(sentEvent));
+        expect(result, isA<SendProfileSuccess>());
+        expect((result as SendProfileSuccess).event, equals(sentEvent));
         verify(
           () => mockNostr.sendEvent(
             any(
@@ -1406,28 +1407,32 @@ void main() {
         ).called(1);
       });
 
-      test('returns null when no relays connected and retry fails', () async {
-        when(() => mockRelayManager.connectedRelays).thenReturn([]);
-        when(
-          mockRelayManager.retryDisconnectedRelays,
-        ).thenAnswer((_) async {});
+      test(
+        'returns SendProfileNoRelays when no relays connected and retry fails',
+        () async {
+          when(() => mockRelayManager.connectedRelays).thenReturn([]);
+          when(
+            mockRelayManager.retryDisconnectedRelays,
+          ).thenAnswer((_) async {});
 
-        final result = await client.sendProfile(
-          profileContent: {'display_name': 'Alice'},
-        );
+          final result = await client.sendProfile(
+            profileContent: {'display_name': 'Alice'},
+          );
 
-        expect(result, isNull);
-        verify(mockRelayManager.retryDisconnectedRelays).called(1);
-        verifyNever(
-          () => mockNostr.sendEvent(
-            any(),
-            tempRelays: any(named: 'tempRelays'),
-            targetRelays: any(named: 'targetRelays'),
-          ),
-        );
-      });
+          expect(result, isA<SendProfileNoRelays>());
+          verify(mockRelayManager.retryDisconnectedRelays).called(1);
+          verifyNever(
+            () => mockNostr.sendEvent(
+              any(),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          );
+        },
+      );
 
-      test('retries disconnected relays and succeeds', () async {
+      test('retries disconnected relays and returns SendProfileSuccess',
+          () async {
         final sentEvent = _createTestEvent(kind: EventKind.metadata);
         final connectedRelays = ['wss://relay1.example.com'];
 
@@ -1449,13 +1454,30 @@ void main() {
           profileContent: {'display_name': 'Alice'},
         );
 
-        expect(result, equals(sentEvent));
+        expect(result, isA<SendProfileSuccess>());
+        expect((result as SendProfileSuccess).event, equals(sentEvent));
         verify(mockRelayManager.retryDisconnectedRelays).called(1);
         verify(
           () => mockNostr.sendEvent(
             any(),
           ),
         ).called(1);
+      });
+
+      test('returns SendProfileFailed when sendEvent returns null', () async {
+        when(
+          () => mockNostr.sendEvent(
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        final result = await client.sendProfile(
+          profileContent: {'display_name': 'Alice'},
+        );
+
+        expect(result, isA<SendProfileFailed>());
       });
     });
 

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1431,38 +1431,40 @@ void main() {
         },
       );
 
-      test('retries disconnected relays and returns SendProfileSuccess',
-          () async {
-        final sentEvent = _createTestEvent(kind: EventKind.metadata);
-        final connectedRelays = ['wss://relay1.example.com'];
+      test(
+        'retries disconnected relays and returns SendProfileSuccess',
+        () async {
+          final sentEvent = _createTestEvent(kind: EventKind.metadata);
+          final connectedRelays = ['wss://relay1.example.com'];
 
-        when(() => mockRelayManager.connectedRelays).thenReturn([]);
-        when(mockRelayManager.retryDisconnectedRelays).thenAnswer((_) async {
+          when(() => mockRelayManager.connectedRelays).thenReturn([]);
+          when(mockRelayManager.retryDisconnectedRelays).thenAnswer((_) async {
+            when(
+              () => mockRelayManager.connectedRelays,
+            ).thenReturn(connectedRelays);
+          });
           when(
-            () => mockRelayManager.connectedRelays,
-          ).thenReturn(connectedRelays);
-        });
-        when(
-          () => mockNostr.sendEvent(
-            any(),
-            tempRelays: any(named: 'tempRelays'),
-            targetRelays: any(named: 'targetRelays'),
-          ),
-        ).thenAnswer((_) async => sentEvent);
+            () => mockNostr.sendEvent(
+              any(),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async => sentEvent);
 
-        final result = await client.sendProfile(
-          profileContent: {'display_name': 'Alice'},
-        );
+          final result = await client.sendProfile(
+            profileContent: {'display_name': 'Alice'},
+          );
 
-        expect(result, isA<SendProfileSuccess>());
-        expect((result as SendProfileSuccess).event, equals(sentEvent));
-        verify(mockRelayManager.retryDisconnectedRelays).called(1);
-        verify(
-          () => mockNostr.sendEvent(
-            any(),
-          ),
-        ).called(1);
-      });
+          expect(result, isA<SendProfileSuccess>());
+          expect((result as SendProfileSuccess).event, equals(sentEvent));
+          verify(mockRelayManager.retryDisconnectedRelays).called(1);
+          verify(
+            () => mockNostr.sendEvent(
+              any(),
+            ),
+          ).called(1);
+        },
+      );
 
       test('returns SendProfileFailed when sendEvent returns null', () async {
         when(

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Repository for fetching and publishing user profiles (Kind 0).
 // ABOUTME: Delegates to NostrClient for relay operations.
-// ABOUTME: Throws ProfilePublishFailedException on publish failure.
+// ABOUTME: Throws typed ProfileRepositoryException subclasses on publish
+// ABOUTME: failure.
 
 import 'dart:async';
 import 'dart:convert';
@@ -499,7 +500,8 @@ class ProfileRepository {
   /// After successful publish, the profile is cached locally for immediate
   /// subsequent reads.
   ///
-  /// Throws `ProfilePublishFailedException` if the operation fails.
+  /// Throws [NoRelaysConnectedException] when no relays are connected.
+  /// Throws [ProfilePublishFailedException] for other send failures.
   Future<UserProfile> saveProfileEvent({
     required String displayName,
     String? about,
@@ -531,38 +533,38 @@ class ProfileRepository {
       profileContent.remove('nip05');
     }
 
-    final profileEvent = await _nostrClient.sendProfile(
+    final result = await _nostrClient.sendProfile(
       profileContent: profileContent,
     );
 
-    if (profileEvent == null) {
-      // Distinguish "no relays at all" from "relay rejected / send error".
-      // publishEvent already called retryDisconnectedRelays() internally, so
-      // if connectedRelays is still empty the device has no relay connections.
-      if (_nostrClient.connectedRelays.isEmpty) {
+    // Switch exhaustively over the typed result — no post-failure
+    // connectedRelays snapshot needed.
+    switch (result) {
+      case SendProfileSuccess(:final event):
+        final profile = UserProfile.fromNostrEvent(event);
+        await _userProfilesDao.upsertProfile(profile);
+        return profile;
+
+      case SendProfileNoRelays():
         Log.error(
-          'sendProfile returned null — no connected relays after retry',
+          'sendProfile: no connected relays after retry',
           name: 'ProfileRepository.saveProfileEvent',
           category: LogCategory.relay,
         );
         throw const NoRelaysConnectedException(
           'No relays connected. Check your connection and try again.',
         );
-      }
-      Log.error(
-        'sendProfile returned null '
-        '(relay rejected the event or send failed)',
-        name: 'ProfileRepository.saveProfileEvent',
-        category: LogCategory.relay,
-      );
-      throw const ProfilePublishFailedException(
-        'Failed to publish profile. Please try again.',
-      );
-    }
 
-    final profile = UserProfile.fromNostrEvent(profileEvent);
-    await _userProfilesDao.upsertProfile(profile);
-    return profile;
+      case SendProfileFailed():
+        Log.error(
+          'sendProfile: relay rejected the event or send failed',
+          name: 'ProfileRepository.saveProfileEvent',
+          category: LogCategory.relay,
+        );
+        throw const ProfilePublishFailedException(
+          'Failed to publish profile. Please try again.',
+        );
+    }
   }
 
   /// Claims a username via NIP-98 authenticated request.

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -101,7 +101,7 @@ void main() {
         () => mockNostrClient.sendProfile(
           profileContent: any(named: 'profileContent'),
         ),
-      ).thenAnswer((_) async => mockProfileEvent);
+      ).thenAnswer((_) async => SendProfileSuccess(event: mockProfileEvent));
       when(() => mockUserProfilesDao.getProfile(any())).thenAnswer((
         invocation,
       ) async {
@@ -1426,10 +1426,7 @@ void main() {
             () => mockNostrClient.sendProfile(
               profileContent: any(named: 'profileContent'),
             ),
-          ).thenAnswer((_) async => null);
-          when(
-            () => mockNostrClient.connectedRelays,
-          ).thenReturn(['wss://relay.example.com']);
+          ).thenAnswer((_) async => const SendProfileFailed());
 
           await expectLater(
             profileRepository.saveProfileEvent(displayName: 'Test'),
@@ -1446,10 +1443,7 @@ void main() {
             () => mockNostrClient.sendProfile(
               profileContent: any(named: 'profileContent'),
             ),
-          ).thenAnswer((_) async => null);
-          when(
-            () => mockNostrClient.connectedRelays,
-          ).thenReturn([]);
+          ).thenAnswer((_) async => const SendProfileNoRelays());
 
           await expectLater(
             profileRepository.saveProfileEvent(displayName: 'Test'),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
`NostrClient.sendProfile` previously returned `Event?`, forcing `ProfileRepository` to infer the failure reason by reading `connectedRelays` after the fact - a best-effort snapshot with a narrow TOCTOU window. This introduces a sealed `SendProfileResult` type (`SendProfileSuccess`, `SendProfileNoRelays`, `SendProfileFailed`) so callers can switch exhaustively over the outcome without a secondary relay-state read. `ProfileRepository.saveProfileEvent` now pattern-matches on the result directly, removing the post-failure `connectedRelays` check from #3528.

`sendProfile` is also pulled out of the shared `publishEvent` path so it can return a typed no-relays outcome directly from the send attempt rather than wrapping a generic `Event?` result. The implementation preserves the existing Kind 0 behavior: it still performs relay connectivity checks with retry, skips optimistic caching for replaceable metadata events, caches the sent event on success, and fires the existing statistics observer hook.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #3542
## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
