### PR TITLE
fix(settings): navigate Integrated Apps tile directly to /apps screen

### DIFF
--- a/mobile/lib/screens/settings/settings_screen.dart
+++ b/mobile/lib/screens/settings/settings_screen.dart
@@ -20,13 +20,12 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/developer_mode_tap_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nip05_verification_provider.dart';
-import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/apps/apps_directory_screen.dart';
 import 'package:openvine/screens/apps/apps_permissions_screen.dart';
 import 'package:openvine/screens/auth/secure_account_screen.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/creator_analytics_screen.dart';
-import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/notification_settings_screen.dart';
 import 'package:openvine/screens/safety_settings_screen.dart';
 import 'package:openvine/screens/settings/general_settings_screen.dart';
@@ -246,11 +245,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                     icon: Icons.apps,
                     title: context.l10n.settingsIntegratedApps,
                     subtitle: context.l10n.settingsIntegratedAppsSubtitle,
-                    onTap: () {
-                      ref.read(forceExploreTabNameProvider.notifier).state =
-                          'apps';
-                      context.go(ExploreScreen.path);
-                    },
+                    onTap: () => context.push(AppsDirectoryScreen.path),
                   ),
                 _SettingsTile(
                   icon: Icons.science,

--- a/mobile/test/widgets/settings_screen_test.dart
+++ b/mobile/test/widgets/settings_screen_test.dart
@@ -16,11 +16,10 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/invite_models.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/apps/apps_directory_screen.dart';
 import 'package:openvine/screens/apps/apps_permissions_screen.dart';
-import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
@@ -325,46 +324,9 @@ void main() {
       tester,
     ) async {
       final mockGoRouter = MockGoRouter();
-      when(() => mockGoRouter.go(any())).thenReturn(null);
+      when(() => mockGoRouter.push(any())).thenAnswer((_) async => null);
 
-      final container = ProviderContainer(
-        overrides: [
-          sharedPreferencesProvider.overrideWithValue(sharedPreferences),
-          authServiceProvider.overrideWithValue(mockAuthService),
-          draftStorageServiceProvider.overrideWithValue(
-            mockDraftStorageService,
-          ),
-          currentAuthStateProvider.overrideWith(
-            (ref) => AuthState.authenticated,
-          ),
-          userProfileReactiveProvider.overrideWith(
-            (ref, pubkey) => Stream.value(null),
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
-
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: MockGoRouterProvider(
-            goRouter: mockGoRouter,
-            child: MaterialApp(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              home: MultiBlocProvider(
-                providers: [
-                  BlocProvider<InviteStatusCubit>.value(
-                    value: _createMockInviteCubit(),
-                  ),
-                  BlocProvider<LocaleCubit>.value(value: mockLocaleCubit),
-                ],
-                child: const SettingsScreen(),
-              ),
-            ),
-          ),
-        ),
-      );
+      await tester.pumpWidget(buildSubject(goRouter: mockGoRouter));
       await tester.pumpAndSettle();
 
       final scrollable = find.byType(Scrollable);
@@ -377,8 +339,7 @@ void main() {
       await tester.tap(find.text('Integrated Apps'));
       await tester.pumpAndSettle();
 
-      verify(() => mockGoRouter.go(ExploreScreen.path)).called(1);
-      expect(container.read(forceExploreTabNameProvider), 'apps');
+      verify(() => mockGoRouter.push(AppsDirectoryScreen.path)).called(1);
 
       await tester.pumpWidget(const SizedBox());
       await tester.pump();


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Tapping Integrated Apps in Settings was navigating to /explore with a forced tab state, which silently fell back to the Trending tab when the integratedApps feature flag was off in production. Route directly to AppsDirectoryScreen.path via context.push instead.

<!--- Describe your changes in detail -->

**Related Issue:** Closes #3744

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore