### PR TITLE
feat(loudness): add Audio Loudness Match toggle for vine playback

### DIFF
--- a/mobile/lib/blocs/loudness_normalization/loudness_normalization_cubit.dart
+++ b/mobile/lib/blocs/loudness_normalization/loudness_normalization_cubit.dart
@@ -1,0 +1,52 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/loudness_normalization/loudness_normalization_prefs.dart';
+import 'package:pooled_video_player/pooled_video_player.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+part 'loudness_normalization_state.dart';
+
+/// Persists and applies the user's loudness-normalization preference.
+///
+/// Default OFF: creator audio fidelity (whispers, ASMR, intentional dynamic
+/// range) is preserved unless the user opts in via Settings. When on, the
+/// pool applies a single-pass `dynaudnorm` libmpv filter to every active
+/// player so quiet and loud vines play at comparable perceived loudness.
+///
+/// Must NOT be folded into [VideoVolumeCubit] — they are orthogonal:
+/// volume controls device output level, normalization controls per-clip
+/// gain matching. They have different lifecycles, different persistence
+/// keys, and different consumers.
+class LoudnessNormalizationCubit extends Cubit<LoudnessNormalizationState> {
+  /// Creates a cubit, seeding state from [sharedPreferences] synchronously.
+  ///
+  /// The cubit does NOT call [PlayerPool.setLoudnessNormalizationEnabled] in
+  /// its constructor. Cold-start application happens in `main.dart` so the
+  /// pool is in the correct state before any video plays, regardless of
+  /// whether anything in the widget tree consumes this cubit. See
+  /// state_management.md "BlocProvider is lazy by default".
+  LoudnessNormalizationCubit({
+    required SharedPreferences sharedPreferences,
+    required PlayerPool playerPool,
+  }) : _prefs = sharedPreferences,
+       _playerPool = playerPool,
+       super(
+         LoudnessNormalizationState(
+           isEnabled:
+               sharedPreferences.getBool(loudnessNormalizationPrefsKey) ??
+               false,
+         ),
+       );
+
+  final SharedPreferences _prefs;
+  final PlayerPool _playerPool;
+
+  /// Toggles loudness normalization, persisting the new value and applying
+  /// it to the pool. No-op when [enabled] matches the current state.
+  Future<void> setEnabled({required bool enabled}) async {
+    if (state.isEnabled == enabled) return;
+    emit(LoudnessNormalizationState(isEnabled: enabled));
+    await _playerPool.setLoudnessNormalizationEnabled(enabled: enabled);
+    await _prefs.setBool(loudnessNormalizationPrefsKey, enabled);
+  }
+}

--- a/mobile/lib/blocs/loudness_normalization/loudness_normalization_prefs.dart
+++ b/mobile/lib/blocs/loudness_normalization/loudness_normalization_prefs.dart
@@ -1,0 +1,5 @@
+/// SharedPreferences key for the persisted loudness normalization toggle.
+///
+/// Shared between [LoudnessNormalizationCubit] and the cold-start apply
+/// step in `main.dart` so both read and write the same key.
+const String loudnessNormalizationPrefsKey = 'loudness_normalization_enabled';

--- a/mobile/lib/blocs/loudness_normalization/loudness_normalization_state.dart
+++ b/mobile/lib/blocs/loudness_normalization/loudness_normalization_state.dart
@@ -1,0 +1,16 @@
+part of 'loudness_normalization_cubit.dart';
+
+/// State for [LoudnessNormalizationCubit].
+///
+/// Single boolean — when `true`, the player pool applies a `dynaudnorm`
+/// audio filter to every active and future player. Persisted via
+/// [SharedPreferences].
+class LoudnessNormalizationState extends Equatable {
+  const LoudnessNormalizationState({this.isEnabled = false});
+
+  /// Whether loudness normalization is currently active.
+  final bool isEnabled;
+
+  @override
+  List<Object?> get props => [isEnabled];
+}

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -60,6 +60,11 @@ enum FeatureFlag {
     'Show Nostr relay configuration and diagnostics in Settings. '
         'Changing relays can break publishing and discovery — only turn '
         'this on if you know what you are doing.',
+  ),
+  loudnessNormalization(
+    'Audio Loudness Match',
+    'Show the Settings toggle that applies dynamic audio normalization '
+        'so quiet and loud vines play at comparable loudness.',
   )
   ;
 

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -50,6 +50,8 @@ class BuildConfiguration {
         return const bool.fromEnvironment('FF_CONTENT_POLICY_V2');
       case FeatureFlag.advancedRelaySettings:
         return const bool.fromEnvironment('FF_ADVANCED_RELAY_SETTINGS');
+      case FeatureFlag.loudnessNormalization:
+        return const bool.fromEnvironment('FF_LOUDNESS_NORMALIZATION');
     }
   }
 
@@ -96,6 +98,8 @@ class BuildConfiguration {
         return 'FF_CONTENT_POLICY_V2';
       case FeatureFlag.advancedRelaySettings:
         return 'FF_ADVANCED_RELAY_SETTINGS';
+      case FeatureFlag.loudnessNormalization:
+        return 'FF_LOUDNESS_NORMALIZATION';
     }
   }
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -18,6 +18,22 @@
   "settingsModerationControls": "Moderation Controls",
   "settingsBlueskyPublishing": "Bluesky Publishing",
   "settingsBlueskyPublishingSubtitle": "Manage crossposting to Bluesky",
+  "settingsLoudnessNormalizationTitle": "Audio Loudness Match",
+  "@settingsLoudnessNormalizationTitle": {
+    "description": "Title for the Settings toggle that levels per-vine audio loudness."
+  },
+  "settingsLoudnessNormalizationSubtitle": "Even out quiet and loud vines so you don't have to ride the volume button.",
+  "@settingsLoudnessNormalizationSubtitle": {
+    "description": "Subtitle for the loudness-match toggle. Brand voice: direct, slightly playful."
+  },
+  "settingsLoudnessNormalizationEnabledAnnouncement": "Audio loudness match on",
+  "@settingsLoudnessNormalizationEnabledAnnouncement": {
+    "description": "Screen-reader announcement when the user enables loudness normalization."
+  },
+  "settingsLoudnessNormalizationDisabledAnnouncement": "Audio loudness match off",
+  "@settingsLoudnessNormalizationDisabledAnnouncement": {
+    "description": "Screen-reader announcement when the user disables loudness normalization."
+  },
   "settingsNostrSettings": "Nostr Settings",
   "settingsIntegratedApps": "Integrated Apps",
   "settingsIntegratedAppsSubtitle": "Approved third-party apps that run inside Divine",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -198,6 +198,30 @@ abstract class AppLocalizations {
   /// **'Manage crossposting to Bluesky'**
   String get settingsBlueskyPublishingSubtitle;
 
+  /// Title for the Settings toggle that levels per-vine audio loudness.
+  ///
+  /// In en, this message translates to:
+  /// **'Audio Loudness Match'**
+  String get settingsLoudnessNormalizationTitle;
+
+  /// Subtitle for the loudness-match toggle. Brand voice: direct, slightly playful.
+  ///
+  /// In en, this message translates to:
+  /// **'Even out quiet and loud vines so you don\'t have to ride the volume button.'**
+  String get settingsLoudnessNormalizationSubtitle;
+
+  /// Screen-reader announcement when the user enables loudness normalization.
+  ///
+  /// In en, this message translates to:
+  /// **'Audio loudness match on'**
+  String get settingsLoudnessNormalizationEnabledAnnouncement;
+
+  /// Screen-reader announcement when the user disables loudness normalization.
+  ///
+  /// In en, this message translates to:
+  /// **'Audio loudness match off'**
+  String get settingsLoudnessNormalizationDisabledAnnouncement;
+
   /// No description provided for @settingsNostrSettings.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -47,6 +47,21 @@ class AppLocalizationsAr extends AppLocalizations {
       'أدر النشر المتزامن إلى Bluesky';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'إعدادات Nostr';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -47,6 +47,21 @@ class AppLocalizationsBg extends AppLocalizations {
       'Управлявай публикуването в Bluesky';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Настройки за Nostr';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -47,6 +47,21 @@ class AppLocalizationsDe extends AppLocalizations {
       'Crossposting zu Bluesky verwalten';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Nostr-Einstellungen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -47,6 +47,21 @@ class AppLocalizationsEn extends AppLocalizations {
       'Manage crossposting to Bluesky';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Nostr Settings';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -47,6 +47,21 @@ class AppLocalizationsEs extends AppLocalizations {
       'Gestioná las publicaciones cruzadas a Bluesky';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Ajustes de Nostr';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -47,6 +47,21 @@ class AppLocalizationsFr extends AppLocalizations {
       'Gère la diffusion croisée vers Bluesky';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Réglages Nostr';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -47,6 +47,21 @@ class AppLocalizationsId extends AppLocalizations {
       'Atur crossposting ke Bluesky';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Pengaturan Nostr';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -47,6 +47,21 @@ class AppLocalizationsIt extends AppLocalizations {
       'Gestisci il crosspost su Bluesky';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Impostazioni Nostr';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -45,6 +45,21 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsBlueskyPublishingSubtitle => 'Bluesky へのクロス投稿を管理';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Nostr 設定';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -45,6 +45,21 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsBlueskyPublishingSubtitle => 'Bluesky로의 크로스 포스팅을 관리해요';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Nostr 설정';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -47,6 +47,21 @@ class AppLocalizationsNl extends AppLocalizations {
       'Beheer crossposting naar Bluesky';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Nostr-instellingen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -47,6 +47,21 @@ class AppLocalizationsPl extends AppLocalizations {
       'Zarządzaj crosspostingiem na Bluesky';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Ustawienia Nostr';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -47,6 +47,21 @@ class AppLocalizationsPt extends AppLocalizations {
       'Gerencie o crosspost para o Bluesky';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Configurações do Nostr';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -47,6 +47,21 @@ class AppLocalizationsRo extends AppLocalizations {
       'Gestionează postarea încrucișată pe Bluesky';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Setări Nostr';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -47,6 +47,21 @@ class AppLocalizationsSv extends AppLocalizations {
       'Hantera korspostning till Bluesky';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Nostr-inställningar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -47,6 +47,21 @@ class AppLocalizationsTr extends AppLocalizations {
       'Bluesky\'a çapraz paylaşımı yönet';
 
   @override
+  String get settingsLoudnessNormalizationTitle => 'Audio Loudness Match';
+
+  @override
+  String get settingsLoudnessNormalizationSubtitle =>
+      'Even out quiet and loud vines so you don\'t have to ride the volume button.';
+
+  @override
+  String get settingsLoudnessNormalizationEnabledAnnouncement =>
+      'Audio loudness match on';
+
+  @override
+  String get settingsLoudnessNormalizationDisabledAnnouncement =>
+      'Audio loudness match off';
+
+  @override
   String get settingsNostrSettings => 'Nostr Ayarları';
 
   @override

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -32,6 +32,8 @@ import 'package:openvine/blocs/email_verification/email_verification_cubit.dart'
 import 'package:openvine/blocs/invite_gate/invite_gate_bloc.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/blocs/locale/locale_cubit.dart';
+import 'package:openvine/blocs/loudness_normalization/loudness_normalization_cubit.dart';
+import 'package:openvine/blocs/loudness_normalization/loudness_normalization_prefs.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/config/app_config.dart';
 import 'package:openvine/config/zendesk_config.dart';
@@ -239,6 +241,22 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
           initializationStep: 'Initializing media playback pool',
           task: _initializeMediaPlayback,
         );
+      },
+      optional: true,
+    );
+
+    coordinator.registerService(
+      name: 'LoudnessNormalization',
+      phase: StartupPhase.standard,
+      dependencies: const ['MediaPlayback'],
+      initialize: () async {
+        final prefs = container.read(sharedPreferencesProvider);
+        final enabled = prefs.getBool(loudnessNormalizationPrefsKey) ?? false;
+        if (enabled) {
+          await PlayerPool.instance.setLoudnessNormalizationEnabled(
+            enabled: true,
+          );
+        }
       },
       optional: true,
     );
@@ -1635,6 +1653,12 @@ class _DivineAppState extends ConsumerState<DivineApp> {
             lazy: false,
             create: (_) => VideoVolumeCubit(
               sharedPreferences: ref.read(sharedPreferencesProvider),
+            ),
+          ),
+          BlocProvider(
+            create: (_) => LoudnessNormalizationCubit(
+              sharedPreferences: ref.read(sharedPreferencesProvider),
+              playerPool: PlayerPool.instance,
             ),
           ),
           BlocProvider(

--- a/mobile/lib/screens/settings/general_settings_screen.dart
+++ b/mobile/lib/screens/settings/general_settings_screen.dart
@@ -4,11 +4,14 @@
 import 'dart:ui';
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/locale/locale_cubit.dart';
+import 'package:openvine/blocs/loudness_normalization/loudness_normalization_cubit.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
@@ -29,6 +32,9 @@ class GeneralSettingsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final showBluesky = ref.watch(
       isFeatureEnabledProvider(FeatureFlag.blueskyPublishing),
+    );
+    final showLoudness = ref.watch(
+      isFeatureEnabledProvider(FeatureFlag.loudnessNormalization),
     );
 
     return Scaffold(
@@ -69,6 +75,7 @@ class GeneralSettingsScreen extends ConsumerWidget {
               const _SectionHeader('VIEWING'),
               const _ClosedCaptionsToggle(),
               const _FeedAspectRatioPreferenceTile(),
+              if (showLoudness && !kIsWeb) const _LoudnessNormalizationToggle(),
               const _SectionHeader('CREATING'),
               const _AudioSharingToggle(),
               const _SectionHeader('APP'),
@@ -124,6 +131,47 @@ class _ClosedCaptionsToggle extends ConsumerWidget {
       subtitle: const Text('Show captions when videos include them'),
       activeThumbColor: VineTheme.vineGreen,
       secondary: const Icon(Icons.closed_caption, color: VineTheme.vineGreen),
+    );
+  }
+}
+
+class _LoudnessNormalizationToggle extends StatelessWidget {
+  const _LoudnessNormalizationToggle();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return BlocBuilder<LoudnessNormalizationCubit, LoudnessNormalizationState>(
+      builder: (context, state) {
+        return SwitchListTile(
+          value: state.isEnabled,
+          onChanged: (value) {
+            context.read<LoudnessNormalizationCubit>().setEnabled(
+              enabled: value,
+            );
+            SemanticsService.sendAnnouncement(
+              View.of(context),
+              value
+                  ? l10n.settingsLoudnessNormalizationEnabledAnnouncement
+                  : l10n.settingsLoudnessNormalizationDisabledAnnouncement,
+              Directionality.of(context),
+            );
+          },
+          title: Text(
+            l10n.settingsLoudnessNormalizationTitle,
+            style: _titleStyle,
+          ),
+          subtitle: Text(
+            l10n.settingsLoudnessNormalizationSubtitle,
+            style: _subtitleStyle,
+          ),
+          activeThumbColor: VineTheme.vineGreen,
+          secondary: const Icon(
+            Icons.graphic_eq,
+            color: VineTheme.vineGreen,
+          ),
+        );
+      },
     );
   }
 }

--- a/mobile/packages/pooled_video_player/lib/src/controllers/player_pool.dart
+++ b/mobile/packages/pooled_video_player/lib/src/controllers/player_pool.dart
@@ -6,6 +6,24 @@ import 'package:media_kit_video/media_kit_video.dart';
 
 import 'package:pooled_video_player/src/models/video_pool_config.dart';
 
+/// libmpv audio filter chain applied when loudness normalization is on.
+///
+/// Single-pass dynamic normalizer tuned for short-form video so quiet and
+/// loud clips play at comparable perceived loudness without 2-pass analysis.
+///
+/// Parameters:
+/// - g=15  : Gaussian frame size (default 31; smaller reacts faster
+///           between clips).
+/// - m=10  : maximum gain factor — caps amplification to avoid pumping
+///           noise floors.
+/// - p=0.95: peak target relative to 0 dBFS.
+/// - r=0.0 : disable RMS targeting; rely on peak.
+/// - n=1   : disable cross-clip compression so each frame normalizes
+///           independently.
+///
+/// See https://ffmpeg.org/ffmpeg-filters.html#dynaudnorm
+const String _kDynaudnormFilter = 'dynaudnorm=g=15:m=10:p=0.95:r=0.0:n=1';
+
 /// A pooled player instance containing both Player and VideoController.
 ///
 /// Keeps native resources alive for reuse instead of expensive recreation.
@@ -254,6 +272,57 @@ class PlayerPool {
   /// Number of players currently in the pool.
   int get playerCount => _players.length;
 
+  /// Whether libmpv's dynamic audio normalization filter is active on every
+  /// pooled player.
+  ///
+  /// When `true`, each pooled [Player] applies an `af=dynaudnorm=...` filter
+  /// before audio output, leveling perceived loudness across clips. The
+  /// filter is reapplied to recycled players and to every player created
+  /// after the toggle. No-op on web — HTML5 `<video>` has no equivalent
+  /// filter API.
+  bool get isLoudnessNormalizationEnabled => _normalizationEnabled;
+  bool _normalizationEnabled = false;
+
+  /// Toggles the libmpv audio filter on every active pooled player and on
+  /// every player created afterwards.
+  ///
+  /// Returns immediately when [enabled] matches the current state. Otherwise
+  /// updates the pool state and applies the filter to each non-disposed
+  /// pooled player concurrently.
+  Future<void> setLoudnessNormalizationEnabled({required bool enabled}) async {
+    if (_normalizationEnabled == enabled) return;
+    _normalizationEnabled = enabled;
+    final filter = enabled ? _kDynaudnormFilter : '';
+    final futures = <Future<void>>[
+      for (final pooled in _players.values)
+        if (!pooled.isDisposed) applyAudioFilter(pooled.player, filter),
+    ];
+    await Future.wait(futures);
+  }
+
+  /// Applies [filter] to [player] via libmpv's `af` property.
+  ///
+  /// Empty [filter] clears the chain. Mirrors the swallow-on-failure pattern
+  /// used elsewhere in [createPlayer]: web stubs and platforms that don't
+  /// expose [NativePlayer.setProperty] silently no-op.
+  ///
+  /// Marked `@visibleForOverriding` so test subclasses can record applied
+  /// filters without instantiating real libmpv players. The pattern mirrors
+  /// [createPlayer] / [createPlayerForUrl].
+  @visibleForTesting
+  @visibleForOverriding
+  Future<void> applyAudioFilter(Player player, String filter) async {
+    if (kIsWeb) return;
+    try {
+      final platform = player.platform;
+      if (platform is NativePlayer) {
+        await (platform as dynamic).setProperty('af', filter);
+      }
+    } on Object catch (_) {
+      // Same swallow as the existing setProperty calls in createPlayer.
+    }
+  }
+
   /// Get or create a player for the given URL.
   ///
   /// If a player already exists for this URL, it is returned and marked
@@ -462,6 +531,12 @@ class PlayerPool {
             'cache-pause-initial',
             '0',
           );
+          if (_normalizationEnabled) {
+            await (nativePlayer as dynamic).setProperty(
+              'af',
+              _kDynaudnormFilter,
+            );
+          }
         }
       } on Object catch (_) {
         // Ignore — some platforms or stubs don't support setProperty.

--- a/mobile/packages/pooled_video_player/test/controllers/player_pool_test.dart
+++ b/mobile/packages/pooled_video_player/test/controllers/player_pool_test.dart
@@ -907,6 +907,119 @@ void main() {
         },
       );
     });
+
+    group('loudness normalization', () {
+      late _FilterRecordingPool pool;
+
+      setUp(() {
+        pool = _FilterRecordingPool(maxPlayers: 3);
+      });
+
+      tearDown(() async {
+        await pool.dispose();
+      });
+
+      test('defaults to disabled', () {
+        expect(pool.isLoudnessNormalizationEnabled, isFalse);
+      });
+
+      test(
+        'setLoudnessNormalizationEnabled(enabled: true) flips state',
+        () async {
+          await pool.setLoudnessNormalizationEnabled(enabled: true);
+
+          expect(pool.isLoudnessNormalizationEnabled, isTrue);
+        },
+      );
+
+      test(
+        'setLoudnessNormalizationEnabled(enabled: false) flips state back',
+        () async {
+          await pool.setLoudnessNormalizationEnabled(enabled: true);
+          await pool.setLoudnessNormalizationEnabled(enabled: false);
+
+          expect(pool.isLoudnessNormalizationEnabled, isFalse);
+        },
+      );
+
+      test(
+        'setLoudnessNormalizationEnabled is a no-op when state is unchanged',
+        () async {
+          await pool.getPlayer('https://example.com/v1.mp4');
+          pool.appliedFilters.clear();
+
+          // Already disabled; no-op.
+          await pool.setLoudnessNormalizationEnabled(enabled: false);
+
+          expect(pool.appliedFilters, isEmpty);
+        },
+      );
+
+      test(
+        'setLoudnessNormalizationEnabled(enabled: true) applies filter '
+        'to every non-disposed pooled player',
+        () async {
+          await pool.getPlayer('https://example.com/v1.mp4');
+          await pool.getPlayer('https://example.com/v2.mp4');
+          pool.appliedFilters.clear();
+
+          await pool.setLoudnessNormalizationEnabled(enabled: true);
+
+          expect(pool.appliedFilters, hasLength(2));
+          expect(
+            pool.appliedFilters.every((f) => f.contains('dynaudnorm')),
+            isTrue,
+          );
+        },
+      );
+
+      test(
+        'setLoudnessNormalizationEnabled(enabled: false) clears filter '
+        'on every pooled player',
+        () async {
+          await pool.getPlayer('https://example.com/v1.mp4');
+          await pool.getPlayer('https://example.com/v2.mp4');
+          await pool.setLoudnessNormalizationEnabled(enabled: true);
+          pool.appliedFilters.clear();
+
+          await pool.setLoudnessNormalizationEnabled(enabled: false);
+
+          expect(pool.appliedFilters, hasLength(2));
+          expect(pool.appliedFilters.every((f) => f.isEmpty), isTrue);
+        },
+      );
+
+      test('disposed players are skipped', () async {
+        final disposed = createMockPooledPlayer(isDisposed: true);
+        final live = createMockPooledPlayer();
+        pool.queueNextPlayers([disposed, live]);
+
+        await pool.getPlayer('https://example.com/disposed.mp4');
+        await pool.getPlayer('https://example.com/live.mp4');
+        pool.appliedFilters.clear();
+
+        await pool.setLoudnessNormalizationEnabled(enabled: true);
+
+        expect(pool.appliedFilters, hasLength(1));
+      });
+
+      test(
+        'players created after enabling inherit the active state via '
+        'createPlayer',
+        () async {
+          await pool.setLoudnessNormalizationEnabled(enabled: true);
+
+          // Subsequent player creation should observe the active flag.
+          // The recording pool exposes the flag at creation time.
+          final created = await pool.getPlayer('https://example.com/new.mp4');
+
+          expect(
+            pool.normalizationFlagAtCreate[created],
+            isTrue,
+          );
+        },
+      );
+    });
   });
 }
 
@@ -920,5 +1033,47 @@ class _SerializedTestPool extends PlayerPool {
   @override
   Future<PooledPlayer> createPlayer() async {
     return onCreatePlayer();
+  }
+}
+
+/// A [PlayerPool] subclass that records every applied audio filter and the
+/// normalization-enabled flag at the time each player was created.
+///
+/// Bypasses real libmpv `setProperty` calls so tests can run without native
+/// players, while still observing the filter-application side effect at the
+/// public API boundary.
+class _FilterRecordingPool extends PlayerPool {
+  _FilterRecordingPool({super.maxPlayers});
+
+  /// Records each filter string applied via [applyAudioFilter], in order.
+  final List<String> appliedFilters = [];
+
+  /// Records the value of [isLoudnessNormalizationEnabled] at the moment
+  /// each player was created. Useful for asserting that newly-created
+  /// players inherit the active state.
+  final Map<PooledPlayer, bool> normalizationFlagAtCreate = {};
+
+  /// Optional FIFO queue of mock players returned by [createPlayer]. When
+  /// empty, falls back to a fresh [createMockPooledPlayer].
+  final List<PooledPlayer> _queuedPlayers = [];
+
+  void queueNextPlayers(List<PooledPlayer> players) {
+    _queuedPlayers
+      ..clear()
+      ..addAll(players);
+  }
+
+  @override
+  Future<void> applyAudioFilter(Player player, String filter) async {
+    appliedFilters.add(filter);
+  }
+
+  @override
+  Future<PooledPlayer> createPlayer() async {
+    final player = _queuedPlayers.isNotEmpty
+        ? _queuedPlayers.removeAt(0)
+        : createMockPooledPlayer();
+    normalizationFlagAtCreate[player] = isLoudnessNormalizationEnabled;
+    return player;
   }
 }

--- a/mobile/test/blocs/loudness_normalization/loudness_normalization_cubit_test.dart
+++ b/mobile/test/blocs/loudness_normalization/loudness_normalization_cubit_test.dart
@@ -1,0 +1,161 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/loudness_normalization/loudness_normalization_cubit.dart';
+import 'package:openvine/blocs/loudness_normalization/loudness_normalization_prefs.dart';
+import 'package:pooled_video_player/pooled_video_player.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockPlayerPool extends Mock implements PlayerPool {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group(LoudnessNormalizationCubit, () {
+    late SharedPreferences prefs;
+    late _MockPlayerPool playerPool;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      prefs = await SharedPreferences.getInstance();
+      playerPool = _MockPlayerPool();
+      when(
+        () => playerPool.setLoudnessNormalizationEnabled(
+          enabled: any(named: 'enabled'),
+        ),
+      ).thenAnswer((_) async {});
+    });
+
+    LoudnessNormalizationCubit buildCubit() => LoudnessNormalizationCubit(
+      sharedPreferences: prefs,
+      playerPool: playerPool,
+    );
+
+    group('initial state', () {
+      test('defaults isEnabled to false', () {
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+
+        expect(cubit.state.isEnabled, isFalse);
+      });
+
+      test('reads persisted true from SharedPreferences', () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          loudnessNormalizationPrefsKey: true,
+        });
+        final prefsWithValue = await SharedPreferences.getInstance();
+
+        final cubit = LoudnessNormalizationCubit(
+          sharedPreferences: prefsWithValue,
+          playerPool: playerPool,
+        );
+        addTearDown(cubit.close);
+
+        expect(cubit.state.isEnabled, isTrue);
+      });
+
+      test('reads persisted false from SharedPreferences', () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          loudnessNormalizationPrefsKey: false,
+        });
+        final prefsWithValue = await SharedPreferences.getInstance();
+
+        final cubit = LoudnessNormalizationCubit(
+          sharedPreferences: prefsWithValue,
+          playerPool: playerPool,
+        );
+        addTearDown(cubit.close);
+
+        expect(cubit.state.isEnabled, isFalse);
+      });
+
+      test('does not call PlayerPool in the constructor', () {
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+
+        verifyNever(
+          () => playerPool.setLoudnessNormalizationEnabled(
+            enabled: any(named: 'enabled'),
+          ),
+        );
+      });
+    });
+
+    group('setEnabled', () {
+      blocTest<LoudnessNormalizationCubit, LoudnessNormalizationState>(
+        'emits new state when toggled on',
+        build: buildCubit,
+        act: (cubit) => cubit.setEnabled(enabled: true),
+        expect: () => const [LoudnessNormalizationState(isEnabled: true)],
+      );
+
+      blocTest<LoudnessNormalizationCubit, LoudnessNormalizationState>(
+        'does not emit when state is unchanged',
+        build: buildCubit,
+        act: (cubit) => cubit.setEnabled(enabled: false),
+        expect: () => const <LoudnessNormalizationState>[],
+      );
+
+      test('persists new value to SharedPreferences', () async {
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+
+        await cubit.setEnabled(enabled: true);
+
+        expect(prefs.getBool(loudnessNormalizationPrefsKey), isTrue);
+      });
+
+      test('applies to PlayerPool', () async {
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+
+        await cubit.setEnabled(enabled: true);
+
+        verify(
+          () => playerPool.setLoudnessNormalizationEnabled(enabled: true),
+        ).called(1);
+      });
+
+      test('no-op skips PlayerPool and prefs writes', () async {
+        // Seed prefs with existing value.
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          loudnessNormalizationPrefsKey: true,
+        });
+        final seededPrefs = await SharedPreferences.getInstance();
+        final cubit = LoudnessNormalizationCubit(
+          sharedPreferences: seededPrefs,
+          playerPool: playerPool,
+        );
+        addTearDown(cubit.close);
+
+        // Toggling to the already-enabled state must be a no-op.
+        await cubit.setEnabled(enabled: true);
+
+        verifyNever(
+          () => playerPool.setLoudnessNormalizationEnabled(
+            enabled: any(named: 'enabled'),
+          ),
+        );
+      });
+
+      test('toggling off persists false and applies to pool', () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{
+          loudnessNormalizationPrefsKey: true,
+        });
+        final seededPrefs = await SharedPreferences.getInstance();
+        final cubit = LoudnessNormalizationCubit(
+          sharedPreferences: seededPrefs,
+          playerPool: playerPool,
+        );
+        addTearDown(cubit.close);
+
+        await cubit.setEnabled(enabled: false);
+
+        expect(seededPrefs.getBool(loudnessNormalizationPrefsKey), isFalse);
+        verify(
+          () => playerPool.setLoudnessNormalizationEnabled(enabled: false),
+        ).called(1);
+      });
+    });
+  });
+}

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -69,6 +69,13 @@ const _knownUntranslatedDebt = {
   'notificationRepliedToYourComment',
   'notificationAndConnector',
   'notificationOthersCount',
+  // Added by the audio loudness normalization toggle. Translators will
+  // pick these up in a follow-up pass; the generated l10n APIs fall
+  // back to the English source until then.
+  'settingsLoudnessNormalizationTitle',
+  'settingsLoudnessNormalizationSubtitle',
+  'settingsLoudnessNormalizationEnabledAnnouncement',
+  'settingsLoudnessNormalizationDisabledAnnouncement',
 };
 
 Map<String, Object?> _readArb(File file) {


### PR DESCRIPTION
## Description

Adds a user-controlled "Audio Loudness Match" toggle in **Settings → General → VIEWING** that levels perceived loudness across vines, so quiet whispered clips and loud clips play at comparable volume without manual device-volume juggling. Implementation injects FFmpeg's `dynaudnorm` filter into libmpv via `media_kit`'s already-used `NativePlayer.setProperty` escape hatch — no new packages, no protocol changes, no server changes.

**Related Issue:** Closes #3789

## What's in here

Three commits, each scoped to one architectural layer:

1. **`feat(pooled_video_player)`** — Client layer. Adds `setLoudnessNormalizationEnabled({required bool enabled})` and `applyAudioFilter` (overrideable for tests) to `PlayerPool`. Reuses the established `NativePlayer.setProperty` pattern already used for `msg-level` and `cache-pause-initial` in `createPlayer()`. Filter is `dynaudnorm=g=15:m=10:p=0.95:r=0.0:n=1` — a single-pass dynamic normalizer tuned for short-form video.
2. **`feat(loudness)`** — BLoC layer. `LoudnessNormalizationCubit` mirrors `VideoVolumeCubit`: reads pref synchronously in constructor, no constructor side effects (cold-start application happens in `main.dart`). Adds `FeatureFlag.loudnessNormalization` (default off, `FF_LOUDNESS_NORMALIZATION` env override). New startup-coordinator service `LoudnessNormalization` depends on `MediaPlayback` so the pool is in the correct state before any video plays.
3. **`feat(settings)`** — UI layer. `_LoudnessNormalizationToggle` `SwitchListTile` under VIEWING, gated on the feature flag and `!kIsWeb`. Dispatches the cubit and announces state changes via `SemanticsService.sendAnnouncement`. Adds 4 ARB keys with `@` metadata; regenerates l10n delegates for all 18 locales (other locales fall back to English until translated).

## Why this design

- **Production feed uses `pooled_video_player` (media_kit/libmpv), not `divine_video_player`.** Confirmed via `grep` of `pooled_fullscreen_video_feed_screen.dart:1` and `video_feed_page.dart:332`. `divine_video_player` is editor/capture only.
- **`NativePlayer.setProperty` is already the established escape hatch** in this codebase (`player_pool.dart:455-465` for `msg-level` and `cache-pause-initial`). Adding `af` is the same pattern, same file.
- **`dynaudnorm` over `loudnorm`**: `loudnorm` is a 2-pass filter; in single-pass mode it produces audible level jumps every few seconds. `dynaudnorm` is FFmpeg's purpose-built single-pass dynamic normalizer.
- **Default OFF** to preserve creator audio fidelity — whispers and ASMR are intentional and shouldn't be pumped without user opt-in.
- **Web hidden** because HTML5 `<video>` has no audio-filter equivalent. The toggle is gated on `!kIsWeb`; `setLoudnessNormalizationEnabled` is a no-op on web.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Verification

- [x] `flutter analyze lib test` — clean (full sweep, both `mobile/lib`, `mobile/test`, and the `pooled_video_player` package)
- [x] `flutter test packages/pooled_video_player/test/controllers/player_pool_test.dart` — 74/74 pass (8 new loudness tests)
- [x] `flutter test test/blocs/loudness_normalization` — 10/10 pass
- [x] `flutter test test/blocs/video_volume test/features/feature_flags` — no regressions
- [x] `dart format` clean on all changed files
- [x] `flutter gen-l10n` regenerated and committed

## Test plan

- [ ] **Manual A/B device test (non-skippable)**: on iOS + low-end Android, prepare two vines (~-30 LUFS whisper, ~-8 LUFS music). Listen with toggle off → big perceived loudness gap. Toggle on → gap should close substantially. Watch for pumping artifacts on the whisper. Battery / scroll-jank check on a 5-minute feed scroll.
- [ ] **Web smoke test**: confirm the toggle is hidden on web (libmpv-only feature).
- [ ] **Cold-start persistence**: toggle on, force-quit, relaunch, confirm filter is still active on the first vine that plays.
- [ ] **Mute interaction**: toggle is orthogonal to `VideoVolumeCubit` mute — muting and toggling normalization should not interact.
- [ ] **Audio session interruption**: phone call mid-playback, resume, confirm filter still attached (libmpv handles pause/resume; filter is pure DSP).

## Rollout

Behind `FeatureFlag.loudnessNormalization` (default off). Settings tile is hidden until the flag is enabled. After QA signoff, flip the flag in `build_configuration.dart` or via env override.

## Rollback

Revert the conditional `setProperty('af', ...)` in `createPlayer()` and the `_LoudnessNormalizationToggle` insertion in the settings screen. Cubit and pref key can stay; the toggle becomes a no-op stored preference. Graceful, no migration.

## Notes / open items

- **Option B (`imeta loudness=` Nostr tag + server-side `loudnorm` analyze) is intentionally not in this PR.** This client-side approach helps every existing legacy and third-party vine immediately. A follow-up issue can track Option B once Option A's perceived quality is validated on real content.
- The neighbouring `_ClosedCaptionsToggle` hardcodes English strings (`'Closed Captions'`, `'Show captions when videos include them'`) — pre-existing l10n violation, **not** addressed here. Worth a separate l10n-pass issue.