### PR TITLE
fix(security): drop non-loopback http URLs at video ingest (#3836)

### DIFF
--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -990,9 +990,9 @@ class VideosRepository {
   ///
   /// Use this when you have videos that were not produced by this
   /// repository's own parsing paths (e.g. entries restored from a local
-  /// cache). Videos that fail the block filter or content filter are
-  /// removed; surviving videos have their `warnLabels` rewritten to
-  /// reflect the current resolver output.
+  /// cache). Videos that fail the block filter, transport-scheme check
+  /// (#3836), or content filter are removed; surviving videos have their
+  /// `warnLabels` rewritten to reflect the current resolver output.
   ///
   /// This is a pure, synchronous operation. It does not touch the network
   /// or local storage.
@@ -1000,6 +1000,7 @@ class VideosRepository {
     final out = <VideoEvent>[];
     for (final video in videos) {
       if (_blockFilter?.call(video.pubkey) ?? false) continue;
+      if (!_hasAllowedTransportScheme(video)) continue;
       final processed = _applyContentPreferences(video);
       if (processed != null) out.add(processed);
     }

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -848,6 +848,9 @@ class VideosRepository {
             // Apply content filter if configured
             if (_blockFilter?.call(video.pubkey) ?? false) continue;
             if (!video.hasVideo) continue;
+            // Reject non-loopback http:// URLs that the OS layer blocks
+            // under release transport security (#3836).
+            if (!_hasAllowedTransportScheme(video)) continue;
             if (video.isExpired) continue;
 
             final processed = _applyContentPreferences(video);
@@ -890,6 +893,10 @@ class VideosRepository {
       // Skip videos without a playable URL
       if (!video.hasVideo) continue;
 
+      // Reject non-loopback http:// URLs that the OS layer blocks under
+      // release transport security (#3836).
+      if (!_hasAllowedTransportScheme(video)) continue;
+
       // Skip expired videos (NIP-40)
       if (video.isExpired) continue;
 
@@ -926,6 +933,10 @@ class VideosRepository {
     // Skip videos without a playable URL
     if (!video.hasVideo) return null;
 
+    // Reject non-loopback http:// URLs that the OS layer blocks under
+    // release transport security (#3836).
+    if (!_hasAllowedTransportScheme(video)) return null;
+
     // Skip expired videos (NIP-40)
     if (video.isExpired) return null;
 
@@ -943,6 +954,35 @@ class VideosRepository {
     }
 
     return video.copyWith(warnLabels: warnLabels);
+  }
+
+  /// Whether [video]'s primary playable URL uses a transport scheme that
+  /// the OS will actually load on the platforms we ship.
+  ///
+  /// Release-build native transport-security on Android, iOS, and macOS
+  /// rejects every cleartext request to a non-loopback host at the OS
+  /// layer (see #3358 / PR #3788). A `kind:22` event whose `videoUrl` is
+  /// non-loopback `http://` would be rejected by the OS at playback time;
+  /// the in-feed retry logic in `FullscreenFeedBloc` would then treat
+  /// the rejection as transient and keep the un-loadable entry visible
+  /// forever. Reject at repository ingest so it never reaches the player.
+  ///
+  /// Loopback `http://` (`10.0.2.2`, `localhost`, `127.0.0.1`) is allowed
+  /// so the local-stack development workflow keeps working. The host list
+  /// is pinned to match the loopback allowlist in the native configs:
+  ///   - mobile/android/app/src/main/res/xml/network_security_config.xml
+  ///   - mobile/ios/Runner/Info.plist (NSAllowsLocalNetworking)
+  ///   - mobile/macos/Runner/Info.plist (NSAllowsLocalNetworking)
+  bool _hasAllowedTransportScheme(VideoEvent video) {
+    final url = video.videoUrl;
+    if (url == null || url.isEmpty) return false;
+    final uri = Uri.tryParse(url);
+    if (uri == null || !uri.hasScheme) return false;
+    final scheme = uri.scheme.toLowerCase();
+    if (scheme == 'https') return true;
+    if (scheme != 'http') return false;
+    final host = uri.host.toLowerCase();
+    return host == '10.0.2.2' || host == 'localhost' || host == '127.0.0.1';
   }
 
   /// Applies the injected block filter, content filter, and warning-labels

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6639,6 +6639,199 @@ void main() {
         expect(result.single.warnLabels, isEmpty);
       });
     });
+
+    group('non-loopback http:// filtering (#3836)', () {
+      group('via _tryParseAndFilter (Nostr ingest)', () {
+        test('filters out non-loopback http:// video URLs', () async {
+          final cleartextEvent = _createVideoEvent(
+            id: 'cleartext-id',
+            pubkey: 'test-pubkey',
+            videoUrl: 'http://example.com/video.mp4',
+            createdAt: 1704067200,
+          );
+          final httpsEvent = _createVideoEvent(
+            id: 'https-id',
+            pubkey: 'test-pubkey',
+            videoUrl: 'https://example.com/video.mp4',
+            createdAt: 1704067201,
+          );
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [cleartextEvent, httpsEvent]);
+
+          final result = await repository.getNewVideos();
+
+          expect(result, hasLength(1));
+          expect(result.first.id, equals('https-id'));
+        });
+
+        test('allows loopback http://10.0.2.2', () async {
+          final loopbackEvent = _createVideoEvent(
+            id: 'android-emulator-host',
+            pubkey: 'test-pubkey',
+            videoUrl: 'http://10.0.2.2:8000/video.mp4',
+            createdAt: 1704067200,
+          );
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [loopbackEvent]);
+
+          final result = await repository.getNewVideos();
+
+          expect(result, hasLength(1));
+          expect(result.first.id, equals('android-emulator-host'));
+        });
+
+        test('allows loopback http://localhost', () async {
+          final loopbackEvent = _createVideoEvent(
+            id: 'localhost-host',
+            pubkey: 'test-pubkey',
+            videoUrl: 'http://localhost:8000/video.mp4',
+            createdAt: 1704067200,
+          );
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [loopbackEvent]);
+
+          final result = await repository.getNewVideos();
+
+          expect(result, hasLength(1));
+          expect(result.first.id, equals('localhost-host'));
+        });
+
+        test('allows loopback http://127.0.0.1', () async {
+          final loopbackEvent = _createVideoEvent(
+            id: 'ipv4-loopback',
+            pubkey: 'test-pubkey',
+            videoUrl: 'http://127.0.0.1:8000/video.mp4',
+            createdAt: 1704067200,
+          );
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [loopbackEvent]);
+
+          final result = await repository.getNewVideos();
+
+          expect(result, hasLength(1));
+          expect(result.first.id, equals('ipv4-loopback'));
+        });
+
+        test(
+          'rejects hostnames that contain but do not equal a loopback host',
+          () async {
+            final spoofA = _createVideoEvent(
+              id: 'spoof-a',
+              pubkey: 'test-pubkey',
+              videoUrl: 'http://10.0.2.2.example.com/video.mp4',
+              createdAt: 1704067200,
+            );
+            final spoofB = _createVideoEvent(
+              id: 'spoof-b',
+              pubkey: 'test-pubkey',
+              videoUrl: 'http://localhost.evil.com/video.mp4',
+              createdAt: 1704067201,
+            );
+            when(
+              () => mockNostrClient.queryEvents(any()),
+            ).thenAnswer((_) async => [spoofA, spoofB]);
+
+            final result = await repository.getNewVideos();
+
+            expect(result, isEmpty);
+          },
+        );
+      });
+
+      group('via _transformVideoStats (Funnelcake API path)', () {
+        late MockFunnelcakeApiClient mockFunnelcakeClient;
+
+        setUp(() {
+          mockFunnelcakeClient = MockFunnelcakeApiClient();
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+        });
+
+        test('filters out non-loopback http:// video URLs', () async {
+          when(
+            () => mockFunnelcakeClient.getRecentVideos(
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              _createVideoStats(
+                id: 'cleartext-id',
+                pubkey: 'pubkey-1',
+                dTag: 'dtag-1',
+                videoUrl: 'http://example.com/video.mp4',
+              ),
+              _createVideoStats(
+                id: 'https-id',
+                pubkey: 'pubkey-2',
+                dTag: 'dtag-2',
+                videoUrl: 'https://example.com/video.mp4',
+              ),
+            ],
+          );
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repositoryWithApi.getNewVideos();
+
+          expect(result, hasLength(1));
+          expect(result.first.id, equals('https-id'));
+        });
+      });
+
+      group(
+        'via _fetchMissingVideosFromFunnelcake (addressable-id fallback)',
+        () {
+          late MockFunnelcakeApiClient mockFunnelcakeClient;
+
+          setUp(() {
+            mockFunnelcakeClient = MockFunnelcakeApiClient();
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          });
+
+          test('filters out non-loopback http:// video URLs', () async {
+            when(
+              () => mockNostrClient.queryEvents(any()),
+            ).thenAnswer((_) async => <Event>[]);
+
+            final cleartextStats = _createVideoStats(
+              id: 'cleartext-id',
+              pubkey: 'pubkey1',
+              dTag: 'dtag1',
+              videoUrl: 'http://example.com/video.mp4',
+            );
+
+            when(
+              () => mockFunnelcakeClient.getVideosByAuthor(
+                pubkey: 'pubkey1',
+                limit: any(named: 'limit'),
+                before: any(named: 'before'),
+              ),
+            ).thenAnswer(
+              (_) async => VideosByAuthorResponse(videos: [cleartextStats]),
+            );
+
+            final repositoryWithFunnelcake = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            final result = await repositoryWithFunnelcake
+                .getVideosByAddressableIds([
+                  '${EventKind.videoVertical}:pubkey1:dtag1',
+                ]);
+
+            expect(result, isEmpty);
+          });
+        },
+      );
+    });
   });
 }
 

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6831,6 +6831,86 @@ void main() {
           });
         },
       );
+
+      group('via applyContentPreferences (cache-restoration path)', () {
+        VideoEvent buildVideo({required String id, required String videoUrl}) {
+          return VideoEvent(
+            id: id,
+            pubkey: 'test-pubkey',
+            createdAt: 1704067200,
+            content: '',
+            timestamp: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
+            videoUrl: videoUrl,
+          );
+        }
+
+        test('filters out non-loopback http:// video URLs', () {
+          final repo = VideosRepository(nostrClient: mockNostrClient);
+          final cleartext = buildVideo(
+            id: 'cleartext-id',
+            videoUrl: 'http://example.com/video.mp4',
+          );
+          final secure = buildVideo(
+            id: 'https-id',
+            videoUrl: 'https://example.com/video.mp4',
+          );
+
+          final result = repo.applyContentPreferences([cleartext, secure]);
+
+          expect(result, hasLength(1));
+          expect(result.single.id, equals('https-id'));
+        });
+
+        test('allows loopback http:// hosts', () {
+          final repo = VideosRepository(nostrClient: mockNostrClient);
+          final emulator = buildVideo(
+            id: 'android-emulator-host',
+            videoUrl: 'http://10.0.2.2:8000/video.mp4',
+          );
+          final localhost = buildVideo(
+            id: 'localhost-host',
+            videoUrl: 'http://localhost:8000/video.mp4',
+          );
+          final ipv4 = buildVideo(
+            id: 'ipv4-loopback',
+            videoUrl: 'http://127.0.0.1:8000/video.mp4',
+          );
+
+          final result = repo.applyContentPreferences([
+            emulator,
+            localhost,
+            ipv4,
+          ]);
+
+          expect(
+            result.map((v) => v.id),
+            equals([
+              'android-emulator-host',
+              'localhost-host',
+              'ipv4-loopback',
+            ]),
+          );
+        });
+
+        test(
+          'rejects hostnames that contain but do not equal a loopback host',
+          () {
+            final repo = VideosRepository(nostrClient: mockNostrClient);
+            final spoofA = buildVideo(
+              id: 'spoof-a',
+              videoUrl: 'http://10.0.2.2.example.com/video.mp4',
+            );
+            final spoofB = buildVideo(
+              id: 'spoof-b',
+              videoUrl: 'http://localhost.evil.com/video.mp4',
+            );
+
+            final result = repo.applyContentPreferences([spoofA, spoofB]);
+
+            expect(result, isEmpty);
+          },
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

After #3358 (PR #3788) tightened native transport security, non-loopback `http://` requests are permanently rejected by the OS on Android, iOS, and macOS release builds. `MediaAvailabilityChecker.isConfirmedMissing` (`mobile/lib/services/media_availability_checker.dart:33`) treats every thrown `Exception` from a HEAD request as transient, so `FullscreenFeedBloc._onVideoUnavailable` keeps un-loadable feed entries visible indefinitely. This PR rejects non-loopback `http://` video URLs at `videos_repository` ingest so they never reach the player.

**Implementation:**

- New private `_hasAllowedTransportScheme(VideoEvent)` helper in `videos_repository.dart`. Allows `https://` everywhere; allows `http://` only when host equals `10.0.2.2`, `localhost`, or `127.0.0.1` — exact mirror of the loopback allowlist pinned in the native transport-security configs (`network_security_config.xml` + iOS / macOS `NSAllowsLocalNetworking`).
- Wired into all three ingest paths: `_tryParseAndFilter` (Nostr), `_transformVideoStats` (Funnelcake API), `_fetchMissingVideosFromFunnelcake` (addressable-id fallback).
- Tests cover all three paths plus a host-spoofing regression (`10.0.2.2.example.com`, `localhost.evil.com` → rejected).

**Architectural fit:** Repository-layer rejection matches the rule in `.claude/rules/architecture.md` — fallback / source-selection logic belongs in the repository layer, not the BLoC. Considered alternative was detecting cleartext-rejection error shapes inside `MediaAvailabilityChecker` (e.g. `SocketException` containing "cleartext", iOS `NSError` -1022); rejected because it pushes URL-shape logic into a service that should only do "is this URL reachable right now."

**Related Issue:** Closes #3836

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `flutter test test/src/videos_repository_test.dart` — 238 / 238 pass (231 prior + 7 new)
- [x] `flutter test --coverage` — 416 / 416 lines hit (100% coverage maintained for the package)
- [x] `flutter analyze` — no issues
- [x] `dart format --set-exit-if-changed` — clean