### PR TITLE
fix(ios): claim www Divine universal links

### DIFF
--- a/mobile/docs/DEEP_LINK_SERVER_SETUP.md
+++ b/mobile/docs/DEEP_LINK_SERVER_SETUP.md
@@ -1,9 +1,10 @@
 # Deep Link Server Setup for divine.video
 
 To enable iOS universal links and Android app links, you need to host the
-verification files on every hostname the app claims. Today that means the apex
-`divine.video` host and, if `www` links are expected to open the app too,
-`www.divine.video` as well.
+verification files on the hostnames each platform claims. This change only
+expands Apple associated-domain coverage to `www.divine.video`, so the `www`
+guidance below is specific to Apple universal links. Android host coverage is
+tracked separately.
 
 ## Files to Create
 
@@ -12,7 +13,7 @@ verification files on every hostname the app claims. Today that means the apex
 **File**: `apple-app-site-association` (no file extension)
 **Primary Location**: `https://divine.video/.well-known/apple-app-site-association`
 **Alternative Location**: `https://divine.video/apple-app-site-association`
-**If `www` links are supported**: also serve the same file from
+**If Apple `www` links are supported**: also serve the same file from
 `https://www.divine.video/.well-known/apple-app-site-association`
 
 ```json
@@ -100,7 +101,8 @@ https://divine.video/.well-known/
 └── assetlinks.json
 ```
 
-If the app claims `www.divine.video` too, mirror the AASA file there:
+If Apple universal links should also claim `www.divine.video`, mirror the AASA
+file there:
 ```
 https://www.divine.video/.well-known/
 └── apple-app-site-association

--- a/mobile/docs/DEEP_LINK_SERVER_SETUP.md
+++ b/mobile/docs/DEEP_LINK_SERVER_SETUP.md
@@ -1,14 +1,19 @@
 # Deep Link Server Setup for divine.video
 
-To enable iOS universal links and Android app links, you need to host two verification files on the divine.video server.
+To enable iOS universal links and Android app links, you need to host the
+verification files on every hostname the app claims. Today that means the apex
+`divine.video` host and, if `www` links are expected to open the app too,
+`www.divine.video` as well.
 
 ## Files to Create
 
 ### 1. iOS Universal Links Verification
 
 **File**: `apple-app-site-association` (no file extension)
-**Location**: `https://divine.video/.well-known/apple-app-site-association`
+**Primary Location**: `https://divine.video/.well-known/apple-app-site-association`
 **Alternative Location**: `https://divine.video/apple-app-site-association`
+**If `www` links are supported**: also serve the same file from
+`https://www.divine.video/.well-known/apple-app-site-association`
 
 ```json
 {
@@ -95,6 +100,12 @@ https://divine.video/.well-known/
 └── assetlinks.json
 ```
 
+If the app claims `www.divine.video` too, mirror the AASA file there:
+```
+https://www.divine.video/.well-known/
+└── apple-app-site-association
+```
+
 ### CORS Headers (if needed)
 
 If you're hosting these files on a different domain or CDN, ensure CORS headers allow access:
@@ -158,6 +169,7 @@ co.openvine.app:
 
 - **Links open in Safari instead of app**:
   - Verify the `apple-app-site-association` file is accessible
+  - Verify the `www.divine.video` AASA file too if the failing link used `www`
   - Check that Team ID matches your Apple Developer account
   - Reinstall the app (iOS caches the association file)
 

--- a/mobile/docs/DEEP_LINK_TESTING_GUIDE.md
+++ b/mobile/docs/DEEP_LINK_TESTING_GUIDE.md
@@ -8,8 +8,8 @@ This guide helps you test deep linking functionality on iOS and Android devices.
 - OR Android device/emulator (Android app links work on both)
 - App installed on device
 - Server verification files deployed at `https://divine.video/.well-known/`
-- If `www.divine.video` links are expected to open the app too, the same
-  verification file must also be served from `https://www.divine.video/.well-known/`
+- If Apple `www.divine.video` links are expected to open the app too, the AASA
+  file must also be served from `https://www.divine.video/.well-known/`
 
 ## Quick Test URLs
 
@@ -64,6 +64,8 @@ https://divine.video/search/{search-term}
 1. **Open Safari (iOS) or Chrome (Android)**
 
 2. **Type/paste the URL**: `https://divine.video/video/test123`
+   - For the Apple-specific `www` host coverage in this PR, also try
+     `https://www.divine.video/video/test123`
 
 3. **Tap the link or press Enter**
 
@@ -214,6 +216,8 @@ Before marking deep linking as complete:
   - [ ] Links from Chrome work
   - [ ] ADB test commands work
   - [ ] `pm get-app-links` shows "verified"
+  - Note: `www.divine.video` Android coverage is tracked separately from this
+    Apple host-claim PR
 
 - [ ] Server verification
   - [ ] Apple file returns HTTP 200

--- a/mobile/docs/DEEP_LINK_TESTING_GUIDE.md
+++ b/mobile/docs/DEEP_LINK_TESTING_GUIDE.md
@@ -8,6 +8,8 @@ This guide helps you test deep linking functionality on iOS and Android devices.
 - OR Android device/emulator (Android app links work on both)
 - App installed on device
 - Server verification files deployed at `https://divine.video/.well-known/`
+- If `www.divine.video` links are expected to open the app too, the same
+  verification file must also be served from `https://www.divine.video/.well-known/`
 
 ## Quick Test URLs
 
@@ -17,12 +19,14 @@ Use these test URLs for verification:
 ```
 https://divine.video/video/abc123
 https://divine.video/video/{actual-video-event-id}
+https://www.divine.video/video/{actual-video-event-id}
 ```
 
 ### Profile Links
 ```
 https://divine.video/profile/npub1abc...xyz
 https://divine.video/profile/{actual-npub}
+https://www.divine.video/profile/{actual-npub}
 ```
 
 ### Hashtag Links
@@ -105,6 +109,7 @@ adb shell pm verify-app-links --re-verify co.openvine.app
 1. **Browser stays open** instead of app opening
    - Means server verification file not accessible/correct
    - Check: `curl -I https://divine.video/.well-known/apple-app-site-association`
+   - Check: `curl -I https://www.divine.video/.well-known/apple-app-site-association`
    - Check: `curl -I https://divine.video/.well-known/assetlinks.json`
 
 2. **"Open with" dialog appears**
@@ -199,6 +204,7 @@ Before marking deep linking as complete:
 - [ ] iOS universal links work (physical device)
   - [ ] Video link opens app and shows video
   - [ ] Profile link opens app and shows profile
+  - [ ] `www.divine.video` video/profile links open app too, if supported
   - [ ] Links from Messages work
   - [ ] Links from Safari work
 

--- a/mobile/ios/Runner/Runner.entitlements
+++ b/mobile/ios/Runner/Runner.entitlements
@@ -4,8 +4,11 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<!-- divine.video plus the canonical login hostname -->
+		<!-- Claim both the apex and canonical www host so externally shared
+		     Divine links can hand off to the app regardless of which host a
+		     browser or chat client surfaces. -->
 		<string>applinks:divine.video</string>
+		<string>applinks:www.divine.video</string>
 		<string>applinks:login.divine.video</string>
 		<string>webcredentials:divine.video</string>
 		<string>webcredentials:login.divine.video</string>

--- a/mobile/macos/Runner/DebugProfile.entitlements
+++ b/mobile/macos/Runner/DebugProfile.entitlements
@@ -39,6 +39,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:divine.video</string>
+		<string>applinks:www.divine.video</string>
 	</array>
 	<key>com.apple.security.photos.library.add-only</key>
 	<true/>

--- a/mobile/macos/Runner/Release.entitlements
+++ b/mobile/macos/Runner/Release.entitlements
@@ -31,6 +31,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:divine.video</string>
+		<string>applinks:www.divine.video</string>
 	</array>
 	<key>com.apple.security.photos.library.add-only</key>
 	<true/>


### PR DESCRIPTION
## Description

Adds the missing associated-domain claim for `www.divine.video` so iOS/macOS builds can open externally shared Divine links regardless of whether the source app surfaces the apex or canonical `www` hostname.

This PR intentionally handles only the **mobile-side entitlement gap**. It does **not** fix the currently broken live AASA hosting for `divine.video`, which is tracked separately and still required for OS-level universal-link verification to work.

Changes:
- add `applinks:www.divine.video` to `mobile/ios/Runner/Runner.entitlements`
- mirror the same associated-domain coverage in macOS entitlements for parity
- update deep-link setup/testing docs to call out that AASA must be served from every claimed hostname, including `www` if supported

**Related Issue:** Part of #3843

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change
- [ ] ✨ New feature
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation

## Test Plan

- [x] Manual code review of associated-domain entitlements for iOS + macOS
- [x] Verified docs now cover both `divine.video` and `www.divine.video` AASA hosting expectations
- [ ] Physical-device universal-link test after AASA hosting is fixed externally

## Notes

Known external blocker:
- `https://divine.video/.well-known/apple-app-site-association` is currently not being served correctly, so this PR alone will not restore universal-link handoff until the web/domain side is fixed.
