### PR TITLE
test(collabs): cover lowercase collaborator marker in edit video path

### DIFF
--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -24,6 +24,7 @@ import 'package:openvine/services/personal_event_cache_service.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
+import 'package:openvine/utils/collaborator_tags.dart';
 import 'package:openvine/utils/proofmode_publishing_helpers.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -315,9 +316,7 @@ class VideoEventPublisher {
       try {
         sentEvent = await _nostrService
             .publishEvent(event)
-            .timeout(
-              outerTimeout,
-            );
+            .timeout(outerTimeout);
       } on TimeoutException {
         Log.error(
           '⏱️ publishEvent timed out after ${outerTimeout.inSeconds}s for '
@@ -772,7 +771,7 @@ class VideoEventPublisher {
 
       // Add collaborator p-tags (standard NIP-71 format)
       for (final pubkey in collaboratorPubkeys) {
-        tags.add(['p', pubkey, 'wss://relay.divine.video', 'collaborator']);
+        tags.add(buildCollaboratorPTag(pubkey));
       }
 
       // Add Inspired By a-tag (specific video reference)

--- a/mobile/lib/utils/collaborator_tags.dart
+++ b/mobile/lib/utils/collaborator_tags.dart
@@ -1,0 +1,13 @@
+// ABOUTME: Shared NIP-71 collaborator p-tag builder used by both the
+// ABOUTME: direct-upload and edit-video publish paths.
+
+/// Default relay hint embedded in collaborator invite p-tags.
+const collaboratorInviteRelayHint = 'wss://relay.divine.video';
+
+/// Builds the standard NIP-71 collaborator p-tag for [pubkey].
+List<String> buildCollaboratorPTag(String pubkey) => [
+  'p',
+  pubkey,
+  collaboratorInviteRelayHint,
+  'collaborator',
+];

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -763,11 +763,10 @@ class _ProfileStatsRowState extends State<_ProfileStatsRow> {
       enableSwitchAnimation: true,
       effect: vineSkeletonEffect,
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
           for (int i = 0; i < columns.length; i++) ...[
             if (i > 0) const _StatDivider(),
-            columns[i],
+            Expanded(child: columns[i]),
           ],
         ],
       ),

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -38,8 +38,12 @@ import 'package:unified_logger/unified_logger.dart';
 const _collaboratorInviteRelayHint = 'wss://relay.divine.video';
 
 @visibleForTesting
-List<String> buildCollaboratorPTag(String pubkey) =>
-    ['p', pubkey, _collaboratorInviteRelayHint, 'collaborator'];
+List<String> buildCollaboratorPTag(String pubkey) => [
+  'p',
+  pubkey,
+  _collaboratorInviteRelayHint,
+  'collaborator',
+];
 
 @visibleForTesting
 Future<Map<String, CollaboratorInviteResult>>

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -23,6 +23,7 @@ import 'package:openvine/services/bookmark_service.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/content_deletion_service.dart';
 import 'package:openvine/services/content_moderation_service.dart';
+import 'package:openvine/utils/collaborator_tags.dart';
 import 'package:openvine/utils/delete_failure_localization.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/watermark_text_resolver.dart';
@@ -35,16 +36,6 @@ import 'package:openvine/widgets/watermark_download_progress_sheet.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-const _collaboratorInviteRelayHint = 'wss://relay.divine.video';
-
-@visibleForTesting
-List<String> buildCollaboratorPTag(String pubkey) => [
-  'p',
-  pubkey,
-  _collaboratorInviteRelayHint,
-  'collaborator',
-];
-
 @visibleForTesting
 Future<Map<String, CollaboratorInviteResult>>
 sendPostPublishCollaboratorInvites({
@@ -52,7 +43,7 @@ sendPostPublishCollaboratorInvites({
   required VideoEvent video,
   required Iterable<String> previousCollaboratorPubkeys,
   required Iterable<String> updatedCollaboratorPubkeys,
-  String relayHint = _collaboratorInviteRelayHint,
+  String relayHint = collaboratorInviteRelayHint,
 }) async {
   final previous = previousCollaboratorPubkeys.toSet();
   final newCollaborators = updatedCollaboratorPubkeys

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -38,6 +38,10 @@ import 'package:unified_logger/unified_logger.dart';
 const _collaboratorInviteRelayHint = 'wss://relay.divine.video';
 
 @visibleForTesting
+List<String> buildCollaboratorPTag(String pubkey) =>
+    ['p', pubkey, _collaboratorInviteRelayHint, 'collaborator'];
+
+@visibleForTesting
 Future<Map<String, CollaboratorInviteResult>>
 sendPostPublishCollaboratorInvites({
   required CollaboratorInviteService inviteService,
@@ -1527,7 +1531,7 @@ class _EditVideoDialogState extends ConsumerState<_EditVideoDialog> {
 
       // Add collaborator p-tags
       for (final pubkey in _collaboratorPubkeys) {
-        tags.add(['p', pubkey, 'wss://relay.divine.video', 'collaborator']);
+        tags.add(buildCollaboratorPTag(pubkey));
       }
 
       // Add inspired-by a-tag (video reference)

--- a/mobile/test/services/video_event_publisher_collaborator_tags_test.dart
+++ b/mobile/test/services/video_event_publisher_collaborator_tags_test.dart
@@ -13,6 +13,7 @@ import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/services/video_event_publisher.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/utils/collaborator_tags.dart';
 
 class _MockUploadManager extends Mock implements UploadManager {}
 
@@ -69,12 +70,12 @@ void main() {
     when(() => nostrClient.isInitialized).thenReturn(true);
     when(() => nostrClient.configuredRelayCount).thenReturn(1);
     when(() => nostrClient.connectedRelayCount).thenReturn(1);
-    when(() => nostrClient.configuredRelays).thenReturn([
-      'wss://relay.divine.video',
-    ]);
-    when(() => nostrClient.connectedRelays).thenReturn([
-      'wss://relay.divine.video',
-    ]);
+    when(
+      () => nostrClient.configuredRelays,
+    ).thenReturn(['wss://relay.divine.video']);
+    when(
+      () => nostrClient.connectedRelays,
+    ).thenReturn(['wss://relay.divine.video']);
     when(() => nostrClient.publicKey).thenReturn('');
 
     when(() => authService.isAuthenticated).thenReturn(true);
@@ -122,9 +123,9 @@ void main() {
       return publishedEvent;
     });
 
-    when(() => nostrClient.publishEvent(any())).thenAnswer(
-      (_) async => publishedEvent,
-    );
+    when(
+      () => nostrClient.publishEvent(any()),
+    ).thenAnswer((_) async => publishedEvent);
     when(
       () => nostrClient.queryEvents(
         any(),
@@ -149,12 +150,7 @@ void main() {
 
       expect(result, isTrue);
       expect(
-        _containsTag(capturedTags, const [
-          'p',
-          collaboratorPubkey,
-          'wss://relay.divine.video',
-          'collaborator',
-        ]),
+        _containsTag(capturedTags, buildCollaboratorPTag(collaboratorPubkey)),
         isTrue,
       );
       // Verify no capitalized form is emitted

--- a/mobile/test/widgets/share_video_menu_edit_collaborator_tags_test.dart
+++ b/mobile/test/widgets/share_video_menu_edit_collaborator_tags_test.dart
@@ -1,49 +1,225 @@
-// ABOUTME: Regression test for collaborator p-tag marker in the edit-video path.
-// ABOUTME: Tests the shared buildCollaboratorPTag helper used by
-// ABOUTME: _EditVideoDialogState._updateVideo. Sibling of
-// ABOUTME: video_event_publisher_collaborator_tags_test.dart (covers direct upload).
+// ABOUTME: Regression coverage for collaborator p-tags in the edit-video flow.
+// ABOUTME: Verifies the shared collaborator tag builder contract and that
+// ABOUTME: ShareVideoMenu's edit dialog emits that tag when republishing.
 
-import 'package:collection/collection.dart';
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/bookmark_service.dart';
+import 'package:openvine/services/personal_event_cache_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/utils/collaborator_tags.dart';
 import 'package:openvine/widgets/share_video_menu.dart';
 
-const _deepEquals = DeepCollectionEquality();
+import '../helpers/test_provider_overrides.dart';
+
+class _MockBookmarkService extends Mock implements BookmarkService {}
+
+class _MockDmRepository extends Mock implements DmRepository {}
+
+class _MockPersonalEventCacheService extends Mock
+    implements PersonalEventCacheService {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _FakeCuratedListsState extends CuratedListsState {
+  @override
+  Future<List<CuratedList>> build() async => const [];
+}
+
+class _FakeEvent extends Fake implements Event {}
+
+class _FakeVideoEvent extends Fake implements VideoEvent {}
+
+VideoEvent _testVideo({
+  required String ownerPubkey,
+  required String collaboratorPubkey,
+}) {
+  return VideoEvent(
+    id: 'event-id',
+    pubkey: ownerPubkey,
+    createdAt: 1757385263,
+    content: 'Test video content',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+    videoUrl: 'https://cdn.example.com/video.mp4',
+    title: 'Test Video Title',
+    vineId: 'video-d-tag',
+    collaboratorPubkeys: [collaboratorPubkey],
+    nostrEventTags: const [
+      ['imeta', 'url https://cdn.example.com/video.mp4', 'm video/mp4'],
+    ],
+  );
+}
 
 void main() {
+  const ownerPubkey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
   const collaboratorPubkey =
       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  final l10n = lookupAppLocalizations(const Locale('en'));
 
-  test('buildCollaboratorPTag emits lowercase collaborator marker', () {
-    final tag = buildCollaboratorPTag(collaboratorPubkey);
+  late MockAuthService mockAuthService;
+  late MockNostrClient mockNostrService;
+  late _MockBookmarkService mockBookmarkService;
+  late _MockDmRepository mockDmRepository;
+  late _MockPersonalEventCacheService mockPersonalEventCacheService;
+  late _MockVideoEventService mockVideoEventService;
+  late List<List<String>> capturedTags;
 
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+    registerFallbackValue(_FakeVideoEvent());
+  });
+
+  setUp(() {
+    mockAuthService = createMockAuthService();
+    mockNostrService = createMockNostrService();
+    mockBookmarkService = _MockBookmarkService();
+    mockDmRepository = _MockDmRepository();
+    mockPersonalEventCacheService = _MockPersonalEventCacheService();
+    mockVideoEventService = _MockVideoEventService();
+    capturedTags = [];
+
+    when(() => mockAuthService.isAuthenticated).thenReturn(true);
+    when(() => mockAuthService.currentPublicKeyHex).thenReturn(ownerPubkey);
+
+    late Event signedEvent;
+    when(
+      () => mockAuthService.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+        createdAt: any(named: 'createdAt'),
+      ),
+    ).thenAnswer((invocation) async {
+      capturedTags = List<List<String>>.from(
+        invocation.namedArguments[#tags] as List<List<String>>,
+      );
+      signedEvent = Event(
+        ownerPubkey,
+        NIP71VideoKinds.addressableShortVideo,
+        capturedTags,
+        invocation.namedArguments[#content] as String,
+      );
+      return signedEvent;
+    });
+
+    when(
+      () => mockNostrService.publishEvent(any()),
+    ).thenAnswer((_) async => signedEvent);
+
+    when(
+      () => mockBookmarkService.isVideoBookmarkedGlobally(any()),
+    ).thenReturn(false);
+    when(
+      () => mockBookmarkService.getVideoBookmarkSummary(any()),
+    ).thenReturn('Not bookmarked');
+    when(
+      () => mockBookmarkService.toggleVideoInGlobalBookmarks(any()),
+    ).thenAnswer((_) async => true);
+
+    when(
+      () => mockPersonalEventCacheService.cacheUserEvent(any()),
+    ).thenReturn(null);
+    when(() => mockVideoEventService.updateVideoEvent(any())).thenReturn(null);
+  });
+
+  Widget buildSubject() {
+    return testProviderScope(
+      mockAuthService: mockAuthService,
+      mockNostrService: mockNostrService,
+      additionalOverrides: [
+        bookmarkServiceProvider.overrideWith((ref) => mockBookmarkService),
+        curatedListsStateProvider.overrideWith(_FakeCuratedListsState.new),
+        isFeatureEnabledProvider(
+          FeatureFlag.curatedLists,
+        ).overrideWithValue(false),
+        isFeatureEnabledProvider(
+          FeatureFlag.debugTools,
+        ).overrideWithValue(false),
+        dmRepositoryProvider.overrideWithValue(mockDmRepository),
+        personalEventCacheServiceProvider.overrideWithValue(
+          mockPersonalEventCacheService,
+        ),
+        videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ShareVideoMenu(
+            video: _testVideo(
+              ownerPubkey: ownerPubkey,
+              collaboratorPubkey: collaboratorPubkey,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  test('buildCollaboratorPTag emits the exact lowercase collaborator tag', () {
     expect(
-      _deepEquals.equals(tag, const [
+      buildCollaboratorPTag(collaboratorPubkey),
+      equals(const [
         'p',
         collaboratorPubkey,
-        'wss://relay.divine.video',
+        collaboratorInviteRelayHint,
         'collaborator',
       ]),
-      isTrue,
     );
-
-    expect(tag[3], isNot(equals('Collaborator')));
   });
 
-  test('edit-video path emits one p-tag per collaborator', () {
-    const secondPubkey =
-        'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
-    final tags = [
-      buildCollaboratorPTag(collaboratorPubkey),
-      buildCollaboratorPTag(secondPubkey),
-    ];
+  testWidgets(
+    'edit-video flow republishes collaborator p-tags with lowercase marker',
+    (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
 
-    expect(tags.length, equals(2));
-    expect(tags[0][3], equals('collaborator'));
-    expect(tags[1][3], equals('collaborator'));
-  });
+      await tester.dragUntilVisible(
+        find.text(l10n.shareMenuEditVideo),
+        find.byType(ShareVideoMenu),
+        const Offset(0, -120),
+      );
+      await tester.pumpAndSettle();
 
-  test('buildCollaboratorPTag uses relay hint from share_video_menu', () {
-    final tag = buildCollaboratorPTag(collaboratorPubkey);
-    expect(tag[2], equals('wss://relay.divine.video'));
-  });
+      await tester.tap(find.text(l10n.shareMenuEditVideo));
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text(l10n.shareMenuUpdate));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(l10n.shareMenuUpdate));
+      await tester.pumpAndSettle();
+
+      expect(
+        capturedTags.where((tag) => tag.isNotEmpty && tag.first == 'p'),
+        hasLength(1),
+      );
+      expect(
+        capturedTags,
+        contains(equals(buildCollaboratorPTag(collaboratorPubkey))),
+      );
+      expect(
+        capturedTags,
+        isNot(
+          contains(
+            equals(const [
+              'p',
+              collaboratorPubkey,
+              collaboratorInviteRelayHint,
+              'Collaborator',
+            ]),
+          ),
+        ),
+      );
+    },
+  );
 }

--- a/mobile/test/widgets/share_video_menu_edit_collaborator_tags_test.dart
+++ b/mobile/test/widgets/share_video_menu_edit_collaborator_tags_test.dart
@@ -1,40 +1,23 @@
 // ABOUTME: Regression test for collaborator p-tag marker in the edit-video path.
-// ABOUTME: Mirrors tag construction in _EditVideoDialogState._updateVideo to
-// ABOUTME: ensure the marker stays lowercase. Sibling of
+// ABOUTME: Tests the shared buildCollaboratorPTag helper used by
+// ABOUTME: _EditVideoDialogState._updateVideo. Sibling of
 // ABOUTME: video_event_publisher_collaborator_tags_test.dart (covers direct upload).
 
 import 'package:collection/collection.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/share_video_menu.dart';
 
 const _deepEquals = DeepCollectionEquality();
-
-bool _containsTag(List<List<String>> tags, List<String> expected) {
-  return tags.any((tag) => _deepEquals.equals(tag, expected));
-}
-
-/// Mirrors the collaborator p-tag loop in
-/// _EditVideoDialogState._updateVideo (share_video_menu.dart ~line 1528-1531).
-List<List<String>> _buildEditVideoTags({
-  required List<String> collaboratorPubkeys,
-}) {
-  final tags = <List<String>>[];
-  for (final pubkey in collaboratorPubkeys) {
-    tags.add(['p', pubkey, 'wss://relay.divine.video', 'collaborator']);
-  }
-  return tags;
-}
 
 void main() {
   const collaboratorPubkey =
       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
-  test('edit-video path emits lowercase collaborator marker', () {
-    final tags = _buildEditVideoTags(
-      collaboratorPubkeys: const [collaboratorPubkey],
-    );
+  test('buildCollaboratorPTag emits lowercase collaborator marker', () {
+    final tag = buildCollaboratorPTag(collaboratorPubkey);
 
     expect(
-      _containsTag(tags, const [
+      _deepEquals.equals(tag, const [
         'p',
         collaboratorPubkey,
         'wss://relay.divine.video',
@@ -43,31 +26,24 @@ void main() {
       isTrue,
     );
 
-    expect(
-      _containsTag(tags, const [
-        'p',
-        collaboratorPubkey,
-        'wss://relay.divine.video',
-        'Collaborator',
-      ]),
-      isFalse,
-    );
+    expect(tag[3], isNot(equals('Collaborator')));
   });
 
   test('edit-video path emits one p-tag per collaborator', () {
     const secondPubkey =
         'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
-    final tags = _buildEditVideoTags(
-      collaboratorPubkeys: const [collaboratorPubkey, secondPubkey],
-    );
+    final tags = [
+      buildCollaboratorPTag(collaboratorPubkey),
+      buildCollaboratorPTag(secondPubkey),
+    ];
 
     expect(tags.length, equals(2));
     expect(tags[0][3], equals('collaborator'));
     expect(tags[1][3], equals('collaborator'));
   });
 
-  test('edit-video path emits no p-tags when collaborators list is empty', () {
-    final tags = _buildEditVideoTags(collaboratorPubkeys: const []);
-    expect(tags, isEmpty);
+  test('buildCollaboratorPTag uses relay hint from share_video_menu', () {
+    final tag = buildCollaboratorPTag(collaboratorPubkey);
+    expect(tag[2], equals('wss://relay.divine.video'));
   });
 }

--- a/mobile/test/widgets/share_video_menu_edit_collaborator_tags_test.dart
+++ b/mobile/test/widgets/share_video_menu_edit_collaborator_tags_test.dart
@@ -1,0 +1,73 @@
+// ABOUTME: Regression test for collaborator p-tag marker in the edit-video path.
+// ABOUTME: Mirrors tag construction in _EditVideoDialogState._updateVideo to
+// ABOUTME: ensure the marker stays lowercase. Sibling of
+// ABOUTME: video_event_publisher_collaborator_tags_test.dart (covers direct upload).
+
+import 'package:collection/collection.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _deepEquals = DeepCollectionEquality();
+
+bool _containsTag(List<List<String>> tags, List<String> expected) {
+  return tags.any((tag) => _deepEquals.equals(tag, expected));
+}
+
+/// Mirrors the collaborator p-tag loop in
+/// _EditVideoDialogState._updateVideo (share_video_menu.dart ~line 1528-1531).
+List<List<String>> _buildEditVideoTags({
+  required List<String> collaboratorPubkeys,
+}) {
+  final tags = <List<String>>[];
+  for (final pubkey in collaboratorPubkeys) {
+    tags.add(['p', pubkey, 'wss://relay.divine.video', 'collaborator']);
+  }
+  return tags;
+}
+
+void main() {
+  const collaboratorPubkey =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  test('edit-video path emits lowercase collaborator marker', () {
+    final tags = _buildEditVideoTags(
+      collaboratorPubkeys: const [collaboratorPubkey],
+    );
+
+    expect(
+      _containsTag(tags, const [
+        'p',
+        collaboratorPubkey,
+        'wss://relay.divine.video',
+        'collaborator',
+      ]),
+      isTrue,
+    );
+
+    expect(
+      _containsTag(tags, const [
+        'p',
+        collaboratorPubkey,
+        'wss://relay.divine.video',
+        'Collaborator',
+      ]),
+      isFalse,
+    );
+  });
+
+  test('edit-video path emits one p-tag per collaborator', () {
+    const secondPubkey =
+        'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+    final tags = _buildEditVideoTags(
+      collaboratorPubkeys: const [collaboratorPubkey, secondPubkey],
+    );
+
+    expect(tags.length, equals(2));
+    expect(tags[0][3], equals('collaborator'));
+    expect(tags[1][3], equals('collaborator'));
+  });
+
+  test('edit-video path emits no p-tags when collaborators list is empty', () {
+    final tags = _buildEditVideoTags(collaboratorPubkeys: const []);
+    expect(tags, isEmpty);
+  });
+}


### PR DESCRIPTION
## Description

Extracts the collaborator p-tag construction into a shared `@visibleForTesting` helper (`buildCollaboratorPTag`) in `share_video_menu.dart`, reusing `_collaboratorInviteRelayHint`. The edit-video collaborator tag test imports and tests the real production code instead of mirroring the private loop.

Sibling of `video_event_publisher_collaborator_tags_test.dart` which covers the direct upload path.

**Related Issue:** Closes #3687, Closes #3847

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore