### PR TITLE
fix(android): claim www Divine app links

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -114,13 +114,14 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
-            <!-- Deep links for divine.video and the canonical login hostname -->
+            <!-- Deep links for apex/www Divine hosts and the canonical login hostname -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
 
                 <data android:scheme="https" android:host="divine.video" />
+                <data android:scheme="https" android:host="www.divine.video" />
                 <data android:scheme="https" android:host="login.divine.video" />
 
                 <data android:pathPrefix="/video"/>

--- a/mobile/docs/DEEP_LINK_SERVER_SETUP.md
+++ b/mobile/docs/DEEP_LINK_SERVER_SETUP.md
@@ -1,10 +1,9 @@
 # Deep Link Server Setup for divine.video
 
-To enable iOS universal links and Android app links, you need to host the
-verification files on the hostnames each platform claims. This change only
-expands Apple associated-domain coverage to `www.divine.video`, so the `www`
-guidance below is specific to Apple universal links. Android host coverage is
-tracked separately.
+To enable iOS universal links and Android app links, you need to host two
+verification files on every claimed Divine hostname. For the current mobile app
+that means `divine.video`, `www.divine.video`, and `login.divine.video` for
+Android App Links, plus the Apple-associated hosts for universal links.
 
 ## Files to Create
 
@@ -13,7 +12,7 @@ tracked separately.
 **File**: `apple-app-site-association` (no file extension)
 **Primary Location**: `https://divine.video/.well-known/apple-app-site-association`
 **Alternative Location**: `https://divine.video/apple-app-site-association`
-**If Apple `www` links are supported**: also serve the same file from
+**Also serve on `www` if claimed**:
 `https://www.divine.video/.well-known/apple-app-site-association`
 
 ```json
@@ -49,6 +48,9 @@ tracked separately.
 
 **File**: `assetlinks.json`
 **Location**: `https://divine.video/.well-known/assetlinks.json`
+**Also serve on every claimed Android host**:
+- `https://www.divine.video/.well-known/assetlinks.json`
+- `https://login.divine.video/.well-known/assetlinks.json`
 
 ```json
 [
@@ -94,18 +96,23 @@ SHA256: AB:CD:EF:12:34:56:78:90:AB:CD:EF:12:34:56:78:90:AB:CD:EF:12:34:56:78:90:
 
 ### .well-known Directory
 
-Both files should be placed in the `.well-known` directory:
+Both files should be placed in the `.well-known` directory on every hostname claimed by the app:
 ```
 https://divine.video/.well-known/
 ├── apple-app-site-association
 └── assetlinks.json
 ```
 
-If Apple universal links should also claim `www.divine.video`, mirror the AASA
-file there:
+If additional hosts are also claimed, mirror the same files there:
 ```
 https://www.divine.video/.well-known/
-└── apple-app-site-association
+├── apple-app-site-association
+└── assetlinks.json
+```
+
+```text
+https://login.divine.video/.well-known/
+└── assetlinks.json
 ```
 
 ### CORS Headers (if needed)
@@ -146,11 +153,14 @@ location /.well-known/assetlinks.json {
 
 1. Build and install the app on a device
 2. Test the link in a browser or messaging app: `https://divine.video/video/abc123`
-3. The link should automatically open in the app (no disambiguation dialog)
+3. If `www.divine.video` is supported, also test: `https://www.divine.video/video/abc123`
+4. The link should automatically open in the app (no disambiguation dialog)
+5. Do not ship new manifest hosts until every claimed host returns HTTP 200 for its `assetlinks.json` file.
 
 **Verification Command**:
 ```bash
 adb shell am start -a android.intent.action.VIEW -d "https://divine.video/video/test123"
+adb shell am start -a android.intent.action.VIEW -d "https://www.divine.video/video/test123"
 ```
 
 **Check verification status**:
@@ -163,6 +173,8 @@ Should show:
 co.openvine.app:
   ...
   divine.video: verified
+  www.divine.video: verified
+  login.divine.video: verified
 ```
 
 ## Troubleshooting

--- a/mobile/docs/DEEP_LINK_TESTING_GUIDE.md
+++ b/mobile/docs/DEEP_LINK_TESTING_GUIDE.md
@@ -8,8 +8,8 @@ This guide helps you test deep linking functionality on iOS and Android devices.
 - OR Android device/emulator (Android app links work on both)
 - App installed on device
 - Server verification files deployed at `https://divine.video/.well-known/`
-- If Apple `www.divine.video` links are expected to open the app too, the AASA
-  file must also be served from `https://www.divine.video/.well-known/`
+- If `www.divine.video` is claimed too, the same files deployed at `https://www.divine.video/.well-known/`
+- If `login.divine.video` is claimed too, `assetlinks.json` must also be deployed at `https://login.divine.video/.well-known/`
 
 ## Quick Test URLs
 
@@ -20,6 +20,7 @@ Use these test URLs for verification:
 https://divine.video/video/abc123
 https://divine.video/video/{actual-video-event-id}
 https://www.divine.video/video/{actual-video-event-id}
+https://www.divine.video/video/abc123
 ```
 
 ### Profile Links
@@ -27,6 +28,7 @@ https://www.divine.video/video/{actual-video-event-id}
 https://divine.video/profile/npub1abc...xyz
 https://divine.video/profile/{actual-npub}
 https://www.divine.video/profile/{actual-npub}
+https://www.divine.video/profile/npub1abc...xyz
 ```
 
 ### Hashtag Links
@@ -50,9 +52,11 @@ https://divine.video/search/{search-term}
    - iMessage (iOS)
    - SMS
    - Email
-   - Slack/Discord
+   - Notes
 
 2. **Tap the link**
+   - Prefer iMessage, Mail, or Notes for OS-level universal-link testing
+   - Slack/Discord may keep links inside an in-app browser instead of handing off to the OS
 
 3. **Expected behavior**:
    - App opens automatically
@@ -64,8 +68,7 @@ https://divine.video/search/{search-term}
 1. **Open Safari (iOS) or Chrome (Android)**
 
 2. **Type/paste the URL**: `https://divine.video/video/test123`
-   - For the Apple-specific `www` host coverage in this PR, also try
-     `https://www.divine.video/video/test123`
+   - If `www` is supported, also try: `https://www.divine.video/video/test123`
 
 3. **Tap the link or press Enter**
 
@@ -78,6 +81,7 @@ https://divine.video/search/{search-term}
 ```bash
 # Test video link
 adb shell am start -a android.intent.action.VIEW -d "https://divine.video/video/test123"
+adb shell am start -a android.intent.action.VIEW -d "https://www.divine.video/video/test123"
 
 # Test profile link
 adb shell am start -a android.intent.action.VIEW -d "https://divine.video/profile/npub1test"
@@ -113,6 +117,7 @@ adb shell pm verify-app-links --re-verify co.openvine.app
    - Check: `curl -I https://divine.video/.well-known/apple-app-site-association`
    - Check: `curl -I https://www.divine.video/.well-known/apple-app-site-association`
    - Check: `curl -I https://divine.video/.well-known/assetlinks.json`
+   - If `www` is claimed, also check the same two URLs on `https://www.divine.video`
 
 2. **"Open with" dialog appears**
    - iOS: Means associated domains not configured correctly
@@ -174,6 +179,8 @@ adb shell pm get-app-links co.openvine.app
 # Should show:
 # co.openvine.app:
 #   divine.video: verified
+#   www.divine.video: verified
+#   login.divine.video: verified
 
 # If not verified, re-verify
 adb shell pm verify-app-links --re-verify co.openvine.app
@@ -216,12 +223,14 @@ Before marking deep linking as complete:
   - [ ] Links from Chrome work
   - [ ] ADB test commands work
   - [ ] `pm get-app-links` shows "verified"
-  - Note: `www.divine.video` Android coverage is tracked separately from this
-    Apple host-claim PR
+  - [ ] `www.divine.video` shows "verified" if claimed
+  - [ ] `login.divine.video` shows "verified" if claimed
 
 - [ ] Server verification
   - [ ] Apple file returns HTTP 200
   - [ ] Android file returns HTTP 200
+  - [ ] `www` verification files return HTTP 200 if claimed
+  - [ ] `login.divine.video/.well-known/assetlinks.json` returns HTTP 200 if claimed
   - [ ] Apple validator passes
 
 - [ ] Console logging

--- a/mobile/docs/DEEP_LINK_TESTING_GUIDE.md
+++ b/mobile/docs/DEEP_LINK_TESTING_GUIDE.md
@@ -19,7 +19,6 @@ Use these test URLs for verification:
 ```
 https://divine.video/video/abc123
 https://divine.video/video/{actual-video-event-id}
-https://www.divine.video/video/{actual-video-event-id}
 https://www.divine.video/video/abc123
 ```
 
@@ -27,7 +26,6 @@ https://www.divine.video/video/abc123
 ```
 https://divine.video/profile/npub1abc...xyz
 https://divine.video/profile/{actual-npub}
-https://www.divine.video/profile/{actual-npub}
 https://www.divine.video/profile/npub1abc...xyz
 ```
 
@@ -117,7 +115,8 @@ adb shell pm verify-app-links --re-verify co.openvine.app
    - Check: `curl -I https://divine.video/.well-known/apple-app-site-association`
    - Check: `curl -I https://www.divine.video/.well-known/apple-app-site-association`
    - Check: `curl -I https://divine.video/.well-known/assetlinks.json`
-   - If `www` is claimed, also check the same two URLs on `https://www.divine.video`
+   - If `www` is claimed, also check `https://www.divine.video/.well-known/assetlinks.json`
+   - If `login.divine.video` is claimed, also check `https://login.divine.video/.well-known/assetlinks.json`
 
 2. **"Open with" dialog appears**
    - iOS: Means associated domains not configured correctly

--- a/mobile/docs/SERVER_DEPLOYMENT_CHECKLIST.md
+++ b/mobile/docs/SERVER_DEPLOYMENT_CHECKLIST.md
@@ -25,20 +25,25 @@ For production builds, you'll need to:
 
 ## Deployment Steps
 
-### 1. Create .well-known directory on divine.video server
+### 1. Create .well-known directory on every claimed host
 
 ```bash
 mkdir -p /var/www/divine.video/.well-known
+mkdir -p /var/www/www.divine.video/.well-known
+mkdir -p /var/www/login.divine.video/.well-known
 ```
 
-### 2. Copy files to server
+### 2. Copy files to every claimed host
 
 ```bash
 # iOS file (no extension!)
 cp mobile/docs/apple-app-site-association /var/www/divine.video/.well-known/
+cp mobile/docs/apple-app-site-association /var/www/www.divine.video/.well-known/
 
 # Android file (for testing with debug builds)
 cp mobile/docs/assetlinks.json /var/www/divine.video/.well-known/
+cp mobile/docs/assetlinks.json /var/www/www.divine.video/.well-known/
+cp mobile/docs/assetlinks.json /var/www/login.divine.video/.well-known/
 
 # For production, use assetlinks-production.json after adding release fingerprint
 # cp mobile/docs/assetlinks-production.json /var/www/divine.video/.well-known/assetlinks.json
@@ -49,6 +54,9 @@ cp mobile/docs/assetlinks.json /var/www/divine.video/.well-known/
 ```bash
 chmod 644 /var/www/divine.video/.well-known/apple-app-site-association
 chmod 644 /var/www/divine.video/.well-known/assetlinks.json
+chmod 644 /var/www/www.divine.video/.well-known/apple-app-site-association
+chmod 644 /var/www/www.divine.video/.well-known/assetlinks.json
+chmod 644 /var/www/login.divine.video/.well-known/assetlinks.json
 ```
 
 ### 4. Configure web server
@@ -110,10 +118,15 @@ sudo apachectl configtest && sudo systemctl reload apache2
 
 ## Verification
 
+Do not ship the Android manifest host change until all claimed hosts return
+HTTP 200 for their verification files. Android 11 and lower require manifest
+hosts to verify together before the app becomes the default handler.
+
 ### Test iOS file is accessible
 
 ```bash
 curl -I https://divine.video/.well-known/apple-app-site-association
+curl -I https://www.divine.video/.well-known/apple-app-site-association
 ```
 
 Expected:
@@ -123,6 +136,7 @@ Expected:
 Verify content:
 ```bash
 curl https://divine.video/.well-known/apple-app-site-association
+curl https://www.divine.video/.well-known/apple-app-site-association
 ```
 
 Should return the JSON with your Team ID (GZCZBKH7MY).
@@ -131,6 +145,8 @@ Should return the JSON with your Team ID (GZCZBKH7MY).
 
 ```bash
 curl -I https://divine.video/.well-known/assetlinks.json
+curl -I https://www.divine.video/.well-known/assetlinks.json
+curl -I https://login.divine.video/.well-known/assetlinks.json
 ```
 
 Expected:
@@ -140,6 +156,8 @@ Expected:
 Verify content:
 ```bash
 curl https://divine.video/.well-known/assetlinks.json
+curl https://www.divine.video/.well-known/assetlinks.json
+curl https://login.divine.video/.well-known/assetlinks.json
 ```
 
 Should return the JSON array with your package name and SHA-256 fingerprint.
@@ -168,6 +186,8 @@ Should show:
 ```
 co.openvine.app:
   divine.video: verified
+  www.divine.video: verified
+  login.divine.video: verified
 ```
 
 ## Testing Deep Links


### PR DESCRIPTION
## Summary
- add www.divine.video to Android app-link host claims
- update Android-facing rollout docs to include every claimed host: divine.video, www.divine.video, and login.divine.video
- document that the manifest change must ship only after assetlinks.json is live on every claimed Android host

## Scope
This PR is Android-only. Apple associated-domain coverage for www.divine.video is tracked separately in #3844.

## Testing
- not run (manifest/docs only)

## Rollout dependency
Do not merge this into a release branch until the web-side verification files are live on every claimed Android host. The current server fix is tracked separately and is required before Android auto-verification can succeed.

Related Issue: Part of #3843