### PR TITLE
fix(blossom): use resumable upload for images

### DIFF
--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -1516,14 +1516,57 @@ class BlossomUploadService {
             category: LogCategory.video,
           );
 
-          final result = await _uploadToServer(
-            serverUrl: serverUrl,
-            file: strippedFile,
-            fileHash: fileHash,
-            fileSize: fileSize,
-            contentType: mimeType,
-            onProgress: onProgress,
-          );
+          final capability = await _fetchDivineUploadCapability(serverUrl);
+
+          late BlossomUploadResult result;
+          if (capability.supportsResumable) {
+            try {
+              result = await _uploadToServerResumable(
+                serverUrl: serverUrl,
+                file: strippedFile,
+                fileHash: fileHash,
+                fileSize: fileSize,
+                contentType: mimeType,
+                onProgress: onProgress,
+              );
+            } catch (error) {
+              if (!_isDivineOwnedUploadHost(serverUrl)) {
+                rethrow;
+              }
+
+              result = await _uploadToServerLegacyFallback(
+                serverUrl: serverUrl,
+                file: strippedFile,
+                fileHash: fileHash,
+                fileSize: fileSize,
+                contentType: mimeType,
+                fallbackReason: error.toString(),
+                onProgress: onProgress,
+              );
+            }
+
+            if (!result.success && _isDivineOwnedUploadHost(serverUrl)) {
+              result = await _uploadToServerLegacyFallback(
+                serverUrl: serverUrl,
+                file: strippedFile,
+                fileHash: fileHash,
+                fileSize: fileSize,
+                contentType: mimeType,
+                fallbackReason:
+                    result.errorMessage ?? 'unknown resumable failure',
+                onProgress: onProgress,
+              );
+            }
+          } else {
+            result = await _uploadToServer(
+              serverUrl: serverUrl,
+              file: strippedFile,
+              fileHash: fileHash,
+              fileSize: fileSize,
+              contentType: mimeType,
+              onProgress: onProgress,
+            );
+          }
 
           if (result.success) {
             // Construct canonical Blossom URL from server + hash

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -426,6 +426,44 @@ class BlossomUploadService {
     );
   }
 
+  /// Run the resumable upload first, then fall back to legacy PUT at most once
+  /// for Divine-owned hosts when resumable upload either throws or returns a
+  /// failure result.
+  Future<BlossomUploadResult> _uploadWithSingleLegacyFallback({
+    required String serverUrl,
+    required Future<BlossomUploadResult> Function() uploadResumable,
+    required Future<BlossomUploadResult> Function(String fallbackReason)
+    uploadLegacyFallback,
+  }) async {
+    final isDivineOwnedHost = _isDivineOwnedUploadHost(serverUrl);
+    Object? resumableError;
+    late BlossomUploadResult result;
+
+    try {
+      result = await uploadResumable();
+    } catch (error) {
+      if (!isDivineOwnedHost) {
+        rethrow;
+      }
+
+      resumableError = error;
+      result = BlossomUploadResult(
+        success: false,
+        errorMessage: error.toString(),
+      );
+    }
+
+    if (!isDivineOwnedHost || result.success) {
+      return result;
+    }
+
+    return uploadLegacyFallback(
+      resumableError?.toString() ??
+          result.errorMessage ??
+          'unknown resumable failure',
+    );
+  }
+
   Map<String, String>? _parseRequiredHeaders(dynamic headersData) {
     if (headersData is! Map) {
       return null;
@@ -1287,8 +1325,9 @@ class BlossomUploadService {
 
           late BlossomUploadResult result;
           if (useResumable) {
-            try {
-              result = await _uploadToServerResumable(
+            result = await _uploadWithSingleLegacyFallback(
+              serverUrl: serverUrl,
+              uploadResumable: () => _uploadToServerResumable(
                 serverUrl: serverUrl,
                 file: videoFile,
                 fileHash: fileHash,
@@ -1298,37 +1337,19 @@ class BlossomUploadService {
                 resumableSession: resumableSession,
                 onProgress: onProgress,
                 onResumableSessionUpdated: onResumableSessionUpdated,
-              );
-            } catch (error) {
-              if (!_isDivineOwnedUploadHost(serverUrl)) {
-                rethrow;
-              }
-
-              result = await _uploadToServerLegacyFallback(
-                serverUrl: serverUrl,
-                file: videoFile,
-                fileHash: fileHash,
-                fileSize: fileSize,
-                contentType: 'video/mp4',
-                proofManifestJson: proofManifestJson,
-                onProgress: onProgress,
-                fallbackReason: error.toString(),
-              );
-            }
-
-            if (!result.success && _isDivineOwnedUploadHost(serverUrl)) {
-              result = await _uploadToServerLegacyFallback(
-                serverUrl: serverUrl,
-                file: videoFile,
-                fileHash: fileHash,
-                fileSize: fileSize,
-                contentType: 'video/mp4',
-                proofManifestJson: proofManifestJson,
-                onProgress: onProgress,
-                fallbackReason:
-                    result.errorMessage ?? 'unknown resumable failure',
-              );
-            }
+              ),
+              uploadLegacyFallback: (fallbackReason) =>
+                  _uploadToServerLegacyFallback(
+                    serverUrl: serverUrl,
+                    file: videoFile,
+                    fileHash: fileHash,
+                    fileSize: fileSize,
+                    contentType: 'video/mp4',
+                    proofManifestJson: proofManifestJson,
+                    onProgress: onProgress,
+                    fallbackReason: fallbackReason,
+                  ),
+            );
           } else {
             result = await _uploadToServer(
               serverUrl: serverUrl,
@@ -1520,43 +1541,27 @@ class BlossomUploadService {
 
           late BlossomUploadResult result;
           if (capability.supportsResumable) {
-            try {
-              result = await _uploadToServerResumable(
+            result = await _uploadWithSingleLegacyFallback(
+              serverUrl: serverUrl,
+              uploadResumable: () => _uploadToServerResumable(
                 serverUrl: serverUrl,
                 file: strippedFile,
                 fileHash: fileHash,
                 fileSize: fileSize,
                 contentType: mimeType,
                 onProgress: onProgress,
-              );
-            } catch (error) {
-              if (!_isDivineOwnedUploadHost(serverUrl)) {
-                rethrow;
-              }
-
-              result = await _uploadToServerLegacyFallback(
-                serverUrl: serverUrl,
-                file: strippedFile,
-                fileHash: fileHash,
-                fileSize: fileSize,
-                contentType: mimeType,
-                fallbackReason: error.toString(),
-                onProgress: onProgress,
-              );
-            }
-
-            if (!result.success && _isDivineOwnedUploadHost(serverUrl)) {
-              result = await _uploadToServerLegacyFallback(
-                serverUrl: serverUrl,
-                file: strippedFile,
-                fileHash: fileHash,
-                fileSize: fileSize,
-                contentType: mimeType,
-                fallbackReason:
-                    result.errorMessage ?? 'unknown resumable failure',
-                onProgress: onProgress,
-              );
-            }
+              ),
+              uploadLegacyFallback: (fallbackReason) =>
+                  _uploadToServerLegacyFallback(
+                    serverUrl: serverUrl,
+                    file: strippedFile,
+                    fileHash: fileHash,
+                    fileSize: fileSize,
+                    contentType: mimeType,
+                    fallbackReason: fallbackReason,
+                    onProgress: onProgress,
+                  ),
+            );
           } else {
             result = await _uploadToServer(
               serverUrl: serverUrl,

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -4550,6 +4550,206 @@ void main() {
         },
       );
 
+      test(
+        'tries Divine image legacy fallback only once when resumable init '
+        'and fallback both fail',
+        () async {
+          when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthProvider.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async =>
+                _signedEvent(_testPublicKey, 24242, const [], 'upload'),
+          );
+
+          final tempDir = await Directory.systemTemp.createTemp(
+            'image_single_fallback_attempt_test_',
+          );
+          final imageFile = File('${tempDir.path}/image.jpg')
+            ..writeAsBytesSync([0xFF, 0xD8, 0xFF]);
+
+          when(
+            () => mockDio.head<dynamic>(
+              any(),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.extensions: [
+                  DivineUploadExtensions.resumableSessions,
+                ],
+              }),
+            ),
+          );
+
+          when(
+            () => mockDio.post<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload/init'),
+              statusCode: 403,
+              data: {'error': 'init unavailable'},
+            ),
+          );
+
+          final putUrls = <String>[];
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer((invocation) async {
+            final url = invocation.positionalArguments.first as String;
+            putUrls.add(url);
+
+            return Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 503,
+              data: {'error': 'legacy upload unavailable'},
+            );
+          });
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(result.success, isFalse);
+          expect(
+            putUrls.where((url) => url == 'https://media.divine.video/upload'),
+            hasLength(1),
+          );
+
+          await tempDir.delete(recursive: true);
+        },
+      );
+
+      test(
+        'does not use legacy fallback for third-party image resumable '
+        'failures',
+        () async {
+          SharedPreferences.setMockInitialValues({
+            'blossom_server_url': 'https://third-party.com',
+            'use_blossom_upload': true,
+          });
+          service = BlossomUploadService(
+            authProvider: mockAuthProvider,
+            dio: mockDio,
+          );
+
+          when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthProvider.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async =>
+                _signedEvent(_testPublicKey, 24242, const [], 'upload'),
+          );
+
+          final tempDir = await Directory.systemTemp.createTemp(
+            'image_third_party_no_fallback_test_',
+          );
+          final imageFile = File('${tempDir.path}/image.jpg')
+            ..writeAsBytesSync([0xFF, 0xD8, 0xFF]);
+
+          when(
+            () => mockDio.head<dynamic>(
+              any(),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer((invocation) async {
+            final url = invocation.positionalArguments.first as String;
+
+            if (url == 'https://third-party.com/upload') {
+              return Response(
+                requestOptions: RequestOptions(path: '/upload'),
+                statusCode: 200,
+                headers: Headers.fromMap({
+                  DivineUploadHeaders.extensions: [
+                    DivineUploadExtensions.resumableSessions,
+                  ],
+                }),
+              );
+            }
+
+            return Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers(),
+            );
+          });
+
+          when(
+            () => mockDio.post<dynamic>(
+              'https://third-party.com/upload/init',
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+            ),
+          ).thenThrow(
+            const BlossomResumableUploadException('init failed'),
+          );
+
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              data: {
+                'url': 'https://media.divine.video/fallback-image',
+                'fallbackUrl': 'https://media.divine.video/fallback-image',
+              },
+            ),
+          );
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(result.success, isTrue);
+          verifyNever(
+            () => mockDio.put<dynamic>(
+              'https://third-party.com/upload',
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          );
+          verify(
+            () => mockDio.put<dynamic>(
+              'https://media.divine.video/upload',
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).called(1);
+
+          await tempDir.delete(recursive: true);
+        },
+      );
+
       test('catches server DioException and tries next server', () async {
         when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
         when(

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -4342,6 +4342,214 @@ void main() {
         },
       );
 
+      test(
+        'falls back to legacy upload when Divine image resumable init fails',
+        () async {
+          when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthProvider.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async =>
+                _signedEvent(_testPublicKey, 24242, const [], 'upload'),
+          );
+
+          final tempDir = await Directory.systemTemp.createTemp(
+            'image_resumable_init_fallback_test_',
+          );
+          final imageFile = File('${tempDir.path}/image.jpg')
+            ..writeAsBytesSync([0xFF, 0xD8, 0xFF]);
+
+          when(
+            () => mockDio.head<dynamic>(
+              any(),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.extensions: [
+                  DivineUploadExtensions.resumableSessions,
+                ],
+              }),
+            ),
+          );
+
+          when(
+            () => mockDio.post<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload/init'),
+              statusCode: 403,
+              data: {'error': 'init unavailable'},
+            ),
+          );
+
+          final putUrls = <String>[];
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer((invocation) async {
+            final url = invocation.positionalArguments.first as String;
+            putUrls.add(url);
+
+            return Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              data: {
+                'url': 'https://media.divine.video/fallback-image',
+                'fallbackUrl': 'https://media.divine.video/fallback-image',
+              },
+            );
+          });
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(result.success, isTrue);
+          expect(putUrls, contains('https://media.divine.video/upload'));
+
+          await tempDir.delete(recursive: true);
+        },
+      );
+
+      test(
+        'falls back to legacy upload when Divine image completion fails',
+        () async {
+          when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthProvider.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async =>
+                _signedEvent(_testPublicKey, 24242, const [], 'upload'),
+          );
+
+          final tempDir = await Directory.systemTemp.createTemp(
+            'image_resumable_result_fallback_test_',
+          );
+          final imageFile = File('${tempDir.path}/image.jpg')
+            ..writeAsBytesSync([0xFF, 0xD8, 0xFF]);
+
+          when(
+            () => mockDio.head<dynamic>(
+              any(),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.extensions: [
+                  DivineUploadExtensions.resumableSessions,
+                ],
+              }),
+            ),
+          );
+
+          when(
+            () => mockDio.post<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer((invocation) async {
+            final url = invocation.positionalArguments.first as String;
+
+            if (url.endsWith('/upload/init')) {
+              return Response(
+                requestOptions: RequestOptions(path: '/upload/init'),
+                statusCode: 201,
+                data: {
+                  'uploadId': 'up_image',
+                  'uploadUrl': 'https://upload.divine.video/sessions/up_image',
+                  'chunkSize': 1024,
+                  'nextOffset': 0,
+                  'expiresAt': 9999999999,
+                },
+              );
+            }
+
+            if (url.endsWith('/upload/up_image/complete')) {
+              return Response(
+                requestOptions: RequestOptions(
+                  path: '/upload/up_image/complete',
+                ),
+                statusCode: 200,
+                data: {'sha256': 'image-hash'},
+              );
+            }
+
+            throw StateError('Unexpected POST url: $url');
+          });
+
+          final putUrls = <String>[];
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer((invocation) async {
+            final url = invocation.positionalArguments.first as String;
+            putUrls.add(url);
+
+            if (url == 'https://upload.divine.video/sessions/up_image') {
+              return Response(
+                requestOptions: RequestOptions(path: '/sessions/up_image'),
+                statusCode: 204,
+                headers: Headers.fromMap({
+                  DivineUploadHeaders.uploadOffset: ['3'],
+                }),
+              );
+            }
+
+            return Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              data: {
+                'url': 'https://media.divine.video/fallback-image',
+                'fallbackUrl': 'https://media.divine.video/fallback-image',
+              },
+            );
+          });
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(result.success, isTrue);
+          expect(
+            putUrls,
+            contains('https://upload.divine.video/sessions/up_image'),
+          );
+          expect(putUrls, contains('https://media.divine.video/upload'));
+
+          await tempDir.delete(recursive: true);
+        },
+      );
+
       test('catches server DioException and tries next server', () async {
         when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
         when(

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -4214,6 +4214,134 @@ void main() {
         await tempDir.delete(recursive: true);
       });
 
+      test(
+        'uses resumable upload when Divine image server advertises support',
+        () async {
+          when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthProvider.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async =>
+                _signedEvent(_testPublicKey, 24242, const [], 'upload'),
+          );
+
+          final tempDir = await Directory.systemTemp.createTemp(
+            'image_resumable_test_',
+          );
+          final imageFile = File('${tempDir.path}/image.jpg')
+            ..writeAsBytesSync([0xFF, 0xD8, 0xFF]);
+
+          when(
+            () => mockDio.head<dynamic>(
+              any(),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.extensions: [
+                  DivineUploadExtensions.resumableSessions,
+                ],
+                DivineUploadHeaders.dataHost: [
+                  'https://upload.divine.video',
+                ],
+              }),
+            ),
+          );
+
+          when(
+            () => mockDio.post<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer((invocation) async {
+            final url = invocation.positionalArguments.first as String;
+
+            if (url.endsWith('/upload/init')) {
+              return Response(
+                requestOptions: RequestOptions(path: '/upload/init'),
+                statusCode: 201,
+                data: {
+                  'uploadId': 'up_image',
+                  'uploadUrl': 'https://upload.divine.video/sessions/up_image',
+                  'chunkSize': 1024,
+                  'nextOffset': 0,
+                  'expiresAt': 9999999999,
+                },
+              );
+            }
+
+            if (url.endsWith('/upload/up_image/complete')) {
+              return Response(
+                requestOptions: RequestOptions(
+                  path: '/upload/up_image/complete',
+                ),
+                statusCode: 200,
+                data: {
+                  'url': 'https://media.divine.video/image-hash',
+                  'fallbackUrl': 'https://media.divine.video/image-hash',
+                },
+              );
+            }
+
+            throw StateError('Unexpected POST url: $url');
+          });
+
+          final putUrls = <String>[];
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer((invocation) async {
+            final url = invocation.positionalArguments.first as String;
+            putUrls.add(url);
+
+            if (url == 'https://upload.divine.video/sessions/up_image') {
+              return Response(
+                requestOptions: RequestOptions(path: '/sessions/up_image'),
+                statusCode: 204,
+                headers: Headers.fromMap({
+                  DivineUploadHeaders.uploadOffset: ['3'],
+                }),
+              );
+            }
+
+            return Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 503,
+              data: {'error': 'legacy upload unavailable'},
+            );
+          });
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(result.success, isTrue);
+          expect(
+            putUrls,
+            isNot(contains('https://media.divine.video/upload')),
+          );
+          expect(
+            putUrls,
+            contains('https://upload.divine.video/sessions/up_image'),
+          );
+
+          await tempDir.delete(recursive: true);
+        },
+      );
+
       test('catches server DioException and tries next server', () async {
         when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
         when(

--- a/mobile/test/screens/settings/app_language_screen_test.dart
+++ b/mobile/test/screens/settings/app_language_screen_test.dart
@@ -34,6 +34,20 @@ void main() {
       );
     }
 
+    Future<ListTile> findLocaleTile(
+      WidgetTester tester,
+      String nativeName,
+    ) async {
+      final tileFinder = find.widgetWithText(ListTile, nativeName);
+      await tester.scrollUntilVisible(
+        tileFinder,
+        160,
+        scrollable: find.byType(Scrollable),
+      );
+      await tester.pumpAndSettle();
+      return tester.widget<ListTile>(tileFinder);
+    }
+
     testWidgets('renders Device default tile', (tester) async {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
@@ -81,9 +95,7 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
-      final frenchTile = tester.widget<ListTile>(
-        find.widgetWithText(ListTile, 'Français'),
-      );
+      final frenchTile = await findLocaleTile(tester, 'Français');
       final icon = frenchTile.leading! as Icon;
       expect(icon.icon, equals(Icons.radio_button_checked));
     });
@@ -113,12 +125,12 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
-      // ListView is lazy — only a subset of tiles are built at once.
-      // Verify a few visible ones from the top of the list. Full map
-      // coverage is asserted in locale_preference_service_test.dart.
-      expect(find.text('Deutsch'), findsOneWidget);
-      expect(find.text('Español'), findsOneWidget);
-      expect(find.text('Français'), findsOneWidget);
+      // ListView is lazy, and the full suite can run this file after tests
+      // that change the global test viewport. Scroll to each sample locale so
+      // this remains independent of the current viewport height.
+      await findLocaleTile(tester, 'Deutsch');
+      await findLocaleTile(tester, 'Español');
+      await findLocaleTile(tester, 'Français');
     });
   });
 }


### PR DESCRIPTION
Closes #3852

## Summary
- route profile image uploads through the Blossom resumable upload flow when the server advertises support
- preserve legacy upload fallback for Divine failures and non-resumable servers
- add regression coverage for Divine and third-party image fallback behavior



## Test Plan
- [x] `flutter test test/src/blossom_upload_service_test.dart` from `mobile/packages/blossom_upload_service`
- [x] `flutter test --coverage test/src/blossom_upload_service_test.dart` from `mobile/packages/blossom_upload_service`
- [x] `flutter analyze` from `mobile/packages/blossom_upload_service`
- [x] pre-commit format/analyze hook
- [x] pre-push changed-file test hook