### PR TITLE
fix(invites): classify server error codes in invite activation failures

### DIFF
--- a/mobile/lib/utils/invite_error_utils.dart
+++ b/mobile/lib/utils/invite_error_utils.dart
@@ -29,30 +29,39 @@ enum InviteActivationFailureReason {
 }
 
 class InviteErrorUtils {
+  static const Set<String> _authCodes = {
+    InviteApiErrorCode.authRequired,
+    InviteApiErrorCode.authInvalid,
+    InviteApiErrorCode.authExpired,
+    InviteApiErrorCode.authInvalidBinding,
+    InviteApiErrorCode.clientAuthFailed,
+  };
+
+  static const Set<String> _invalidCodes = {
+    InviteApiErrorCode.inviteNotFound,
+    InviteApiErrorCode.inviteInvalidFormat,
+    InviteApiErrorCode.inviteRevoked,
+    InviteApiErrorCode.inviteCodeRotated,
+    InviteApiErrorCode.creatorPageDisabled,
+  };
+
+  static const Set<String> _usedCodes = {
+    InviteApiErrorCode.inviteAlreadyUsed,
+    InviteApiErrorCode.userAlreadyJoined,
+  };
+
+  static const Set<String> _temporaryCodes = {
+    InviteApiErrorCode.tooManyRequests,
+    InviteApiErrorCode.storageError,
+    InviteApiErrorCode.internalError,
+    InviteApiErrorCode.clientTimeout,
+    InviteApiErrorCode.clientNetworkError,
+  };
+
   /// Classifies an [InviteApiException] into a reason code.
   ///
   /// Use this from the cubit/BLoC layer so state never carries English copy.
   /// The UI layer maps the reason to a localized string.
-  static const _authCodes = {
-    'auth_required',
-    'auth_invalid',
-    'auth_expired',
-    'auth_invalid_binding',
-  };
-
-  static const _invalidCodes = {
-    'invite_not_found',
-    'invite_invalid_format',
-    'invite_revoked',
-    'invite_code_rotated',
-    'creator_page_disabled',
-  };
-
-  static const _usedCodes = {
-    'invite_already_used',
-    'user_already_joined',
-  };
-
   static InviteActivationFailureReason activationFailureReason(
     InviteApiException error,
   ) {
@@ -60,9 +69,8 @@ class InviteErrorUtils {
     final normalizedMessage = error.message.toLowerCase();
     final code = error.code;
 
-    // Server error code takes priority over keyword matching.
     if (code != null) {
-      if (code == 'creator_page_full') {
+      if (code == InviteApiErrorCode.creatorPageFull) {
         return InviteActivationFailureReason.creatorFull;
       }
       if (_authCodes.contains(code)) {
@@ -74,19 +82,16 @@ class InviteErrorUtils {
       if (_invalidCodes.contains(code)) {
         return InviteActivationFailureReason.invalid;
       }
-      if (code == 'too_many_requests' ||
-          code == 'timeout' ||
-          code == 'storage_error' ||
-          code == 'internal_error') {
+      if (_temporaryCodes.contains(code)) {
         return InviteActivationFailureReason.temporary;
       }
-      if (code == 'client_error') {
+      if (code == InviteApiErrorCode.clientError) {
         return InviteActivationFailureReason.unknown;
       }
     }
 
     // Fall back to status code + keyword matching for exceptions that
-    // don't carry a server error code (timeouts, network errors, etc.).
+    // don't carry a structured error code.
     if (statusCode == 401) {
       return InviteActivationFailureReason.authFailure;
     }
@@ -105,7 +110,9 @@ class InviteErrorUtils {
     final isInvalidError =
         statusCode == 403 ||
         statusCode == 404 ||
+        normalizedMessage.contains('invalid') ||
         normalizedMessage.contains('revoked') ||
+        normalizedMessage.contains('expired') ||
         normalizedMessage.contains('not eligible');
 
     if (isInvalidError) {
@@ -168,8 +175,6 @@ class InviteErrorUtils {
         return "This creator's invites are full. Join the waitlist and "
             "we'll send an invite when there's room.";
       case InviteActivationFailureReason.authFailure:
-        return "We couldn't verify your account for this invite. "
-            'Go back to your invite code and try again, or contact support.';
       case InviteActivationFailureReason.temporary:
         return "We couldn't confirm your invite right now. "
             'Go back to your invite code and try again, or contact support.';

--- a/mobile/lib/utils/invite_error_utils.dart
+++ b/mobile/lib/utils/invite_error_utils.dart
@@ -74,8 +74,14 @@ class InviteErrorUtils {
       if (_invalidCodes.contains(code)) {
         return InviteActivationFailureReason.invalid;
       }
-      if (code == 'too_many_requests') {
+      if (code == 'too_many_requests' ||
+          code == 'timeout' ||
+          code == 'storage_error' ||
+          code == 'internal_error') {
         return InviteActivationFailureReason.temporary;
+      }
+      if (code == 'client_error') {
+        return InviteActivationFailureReason.unknown;
       }
     }
 

--- a/mobile/lib/utils/invite_error_utils.dart
+++ b/mobile/lib/utils/invite_error_utils.dart
@@ -18,6 +18,9 @@ enum InviteActivationFailureReason {
   /// Creator invite cap has been reached.
   creatorFull,
 
+  /// NIP-98 auth failed (signing, clock skew, or binding mismatch).
+  authFailure,
+
   /// Temporary server or network problem (retryable).
   temporary,
 
@@ -30,6 +33,26 @@ class InviteErrorUtils {
   ///
   /// Use this from the cubit/BLoC layer so state never carries English copy.
   /// The UI layer maps the reason to a localized string.
+  static const _authCodes = {
+    'auth_required',
+    'auth_invalid',
+    'auth_expired',
+    'auth_invalid_binding',
+  };
+
+  static const _invalidCodes = {
+    'invite_not_found',
+    'invite_invalid_format',
+    'invite_revoked',
+    'invite_code_rotated',
+    'creator_page_disabled',
+  };
+
+  static const _usedCodes = {
+    'invite_already_used',
+    'user_already_joined',
+  };
+
   static InviteActivationFailureReason activationFailureReason(
     InviteApiException error,
   ) {
@@ -37,8 +60,29 @@ class InviteErrorUtils {
     final normalizedMessage = error.message.toLowerCase();
     final code = error.code;
 
-    if (code == 'creator_page_full') {
-      return InviteActivationFailureReason.creatorFull;
+    // Server error code takes priority over keyword matching.
+    if (code != null) {
+      if (code == 'creator_page_full') {
+        return InviteActivationFailureReason.creatorFull;
+      }
+      if (_authCodes.contains(code)) {
+        return InviteActivationFailureReason.authFailure;
+      }
+      if (_usedCodes.contains(code)) {
+        return InviteActivationFailureReason.alreadyUsed;
+      }
+      if (_invalidCodes.contains(code)) {
+        return InviteActivationFailureReason.invalid;
+      }
+      if (code == 'too_many_requests') {
+        return InviteActivationFailureReason.temporary;
+      }
+    }
+
+    // Fall back to status code + keyword matching for exceptions that
+    // don't carry a server error code (timeouts, network errors, etc.).
+    if (statusCode == 401) {
+      return InviteActivationFailureReason.authFailure;
     }
 
     final isUsedError =
@@ -55,9 +99,7 @@ class InviteErrorUtils {
     final isInvalidError =
         statusCode == 403 ||
         statusCode == 404 ||
-        normalizedMessage.contains('invalid') ||
         normalizedMessage.contains('revoked') ||
-        normalizedMessage.contains('expired') ||
         normalizedMessage.contains('not eligible');
 
     if (isInvalidError) {
@@ -91,6 +133,7 @@ class InviteErrorUtils {
       case InviteActivationFailureReason.invalid:
       case InviteActivationFailureReason.creatorFull:
         return EmailVerificationError.inviteInvalid;
+      case InviteActivationFailureReason.authFailure:
       case InviteActivationFailureReason.temporary:
         return EmailVerificationError.inviteTemporary;
       case InviteActivationFailureReason.unknown:
@@ -118,6 +161,9 @@ class InviteErrorUtils {
       case InviteActivationFailureReason.creatorFull:
         return "This creator's invites are full. Join the waitlist and "
             "we'll send an invite when there's room.";
+      case InviteActivationFailureReason.authFailure:
+        return "We couldn't verify your account for this invite. "
+            'Go back to your invite code and try again, or contact support.';
       case InviteActivationFailureReason.temporary:
         return "We couldn't confirm your invite right now. "
             'Go back to your invite code and try again, or contact support.';

--- a/mobile/packages/invite_api_client/lib/src/invite_api_client.dart
+++ b/mobile/packages/invite_api_client/lib/src/invite_api_client.dart
@@ -255,10 +255,16 @@ class InviteApiClient {
       final json = jsonDecode(response.body) as Map<String, dynamic>;
       return InviteConsumeResult.fromJson(json);
     } on TimeoutException {
-      throw const InviteApiException('Invite activation timed out');
+      throw const InviteApiException(
+        'Invite activation timed out',
+        code: 'timeout',
+      );
     } catch (error) {
       if (error is InviteApiException) rethrow;
-      throw InviteApiException('Failed to activate invite code: $error');
+      throw InviteApiException(
+        'Failed to activate invite code: $error',
+        code: 'client_error',
+      );
     }
   }
 

--- a/mobile/packages/invite_api_client/lib/src/invite_api_client.dart
+++ b/mobile/packages/invite_api_client/lib/src/invite_api_client.dart
@@ -89,11 +89,12 @@ class InviteApiClient {
         mode: OnboardingMode.open,
         supportEmail: config.supportEmail,
       );
-    } on TimeoutException {
-      throw const InviteApiException('Invite configuration request timed out');
     } catch (error) {
-      if (error is InviteApiException) rethrow;
-      throw InviteApiException('Failed to load invite configuration: $error');
+      throw _wrapClientException(
+        error: error,
+        timeoutMessage: 'Invite configuration request timed out',
+        failureMessage: 'Failed to load invite configuration',
+      );
     }
   }
 
@@ -129,11 +130,12 @@ class InviteApiClient {
         message: 'Failed to validate invite code',
         response: response,
       );
-    } on TimeoutException {
-      throw const InviteApiException('Invite code validation timed out');
     } catch (error) {
-      if (error is InviteApiException) rethrow;
-      throw InviteApiException('Failed to validate invite code: $error');
+      throw _wrapClientException(
+        error: error,
+        timeoutMessage: 'Invite code validation timed out',
+        failureMessage: 'Failed to validate invite code',
+      );
     }
   }
 
@@ -172,11 +174,12 @@ class InviteApiClient {
 
       final json = jsonDecode(response.body) as Map<String, dynamic>;
       return WaitlistJoinResult.fromJson(json);
-    } on TimeoutException {
-      throw const InviteApiException('Waitlist request timed out');
     } catch (error) {
-      if (error is InviteApiException) rethrow;
-      throw InviteApiException('Failed to join waitlist: $error');
+      throw _wrapClientException(
+        error: error,
+        timeoutMessage: 'Waitlist request timed out',
+        failureMessage: 'Failed to join waitlist',
+      );
     }
   }
 
@@ -189,9 +192,16 @@ class InviteApiClient {
     required SecureKeyContainer keyContainer,
   }) async {
     late final LocalNostrSigner signer;
-    keyContainer.withPrivateKey<void>((privateKeyHex) {
-      signer = LocalNostrSigner(privateKeyHex);
-    });
+    try {
+      keyContainer.withPrivateKey<void>((privateKeyHex) {
+        signer = LocalNostrSigner(privateKeyHex);
+      });
+    } catch (error) {
+      throw InviteApiException(
+        'Failed to authenticate invite request: $error',
+        code: InviteApiErrorCode.clientAuthFailed,
+      );
+    }
 
     try {
       return _consumeInvite(code: code, signer: signer);
@@ -205,7 +215,15 @@ class InviteApiClient {
     required OAuthConfig oauthConfig,
     required KeycastSession session,
   }) async {
-    final signer = KeycastRpc.fromSession(oauthConfig, session);
+    late final KeycastRpc signer;
+    try {
+      signer = KeycastRpc.fromSession(oauthConfig, session);
+    } catch (error) {
+      throw InviteApiException(
+        'Failed to authenticate invite request: $error',
+        code: InviteApiErrorCode.clientAuthFailed,
+      );
+    }
     try {
       return _consumeInvite(code: code, signer: signer);
     } finally {
@@ -238,7 +256,8 @@ class InviteApiClient {
 
       if (response.statusCode != 200) {
         final alreadyJoined =
-            _parseErrorCode(response.body) == 'user_already_joined';
+            _parseErrorCode(response.body) ==
+            InviteApiErrorCode.userAlreadyJoined;
         if (alreadyJoined) {
           return InviteConsumeResult.fromJson({
             'result': 'user_already_joined',
@@ -254,16 +273,11 @@ class InviteApiClient {
 
       final json = jsonDecode(response.body) as Map<String, dynamic>;
       return InviteConsumeResult.fromJson(json);
-    } on TimeoutException {
-      throw const InviteApiException(
-        'Invite activation timed out',
-        code: 'timeout',
-      );
     } catch (error) {
-      if (error is InviteApiException) rethrow;
-      throw InviteApiException(
-        'Failed to activate invite code: $error',
-        code: 'client_error',
+      throw _wrapClientException(
+        error: error,
+        timeoutMessage: 'Invite activation timed out',
+        failureMessage: 'Failed to activate invite code',
       );
     }
   }
@@ -288,11 +302,12 @@ class InviteApiClient {
 
       final json = jsonDecode(response.body) as Map<String, dynamic>;
       return InviteStatus.fromJson(json);
-    } on TimeoutException {
-      throw const InviteApiException('Invite status request timed out');
     } catch (error) {
-      if (error is InviteApiException) rethrow;
-      throw InviteApiException('Failed to fetch invite status: $error');
+      throw _wrapClientException(
+        error: error,
+        timeoutMessage: 'Invite status request timed out',
+        failureMessage: 'Failed to fetch invite status',
+      );
     }
   }
 
@@ -320,11 +335,12 @@ class InviteApiClient {
 
       final json = jsonDecode(response.body) as Map<String, dynamic>;
       return GenerateInviteResult.fromJson(json);
-    } on TimeoutException {
-      throw const InviteApiException('Generate invite request timed out');
     } catch (error) {
-      if (error is InviteApiException) rethrow;
-      throw InviteApiException('Failed to generate invite code: $error');
+      throw _wrapClientException(
+        error: error,
+        timeoutMessage: 'Generate invite request timed out',
+        failureMessage: 'Failed to generate invite code',
+      );
     }
   }
 
@@ -375,38 +391,72 @@ class InviteApiClient {
     required InviteRequestMethod method,
     String? payload,
   }) async {
-    final normalizedUrl = url.contains('#')
-        ? url.substring(0, url.indexOf('#'))
-        : url;
-    final publicKeyHex = await signer.getPublicKey();
+    try {
+      final normalizedUrl = url.contains('#')
+          ? url.substring(0, url.indexOf('#'))
+          : url;
+      final publicKeyHex = await signer.getPublicKey();
 
-    if (publicKeyHex == null || publicKeyHex.isEmpty) {
-      throw const InviteApiException('Failed to authenticate invite request');
+      if (publicKeyHex == null || publicKeyHex.isEmpty) {
+        throw const InviteApiException(
+          'Failed to authenticate invite request',
+          code: InviteApiErrorCode.clientAuthFailed,
+        );
+      }
+
+      final timestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+      final tags = <List<String>>[
+        ['u', normalizedUrl],
+        ['method', method.value],
+        ['created_at', timestamp.toString()],
+      ];
+
+      if (method == InviteRequestMethod.post ||
+          method == InviteRequestMethod.put ||
+          method == InviteRequestMethod.patch) {
+        final payloadHash = sha256.convert(utf8.encode(payload ?? ''));
+        tags.add(['payload', payloadHash.toString()]);
+      }
+
+      final event = Event(publicKeyHex, 27235, tags, '', createdAt: timestamp);
+      final signedEvent = await signer.signEvent(event);
+
+      if (signedEvent == null || !signedEvent.isSigned) {
+        throw const InviteApiException(
+          'Failed to authenticate invite request',
+          code: InviteApiErrorCode.clientAuthFailed,
+        );
+      }
+
+      final eventJson = jsonEncode(signedEvent.toJson());
+      return 'Nostr ${base64Encode(utf8.encode(eventJson))}';
+    } on InviteApiException {
+      rethrow;
+    } catch (error) {
+      throw InviteApiException(
+        'Failed to authenticate invite request: $error',
+        code: InviteApiErrorCode.clientAuthFailed,
+      );
+    }
+  }
+
+  InviteApiException _wrapClientException({
+    required Object error,
+    required String timeoutMessage,
+    required String failureMessage,
+  }) {
+    if (error is InviteApiException) return error;
+    if (error is TimeoutException) {
+      return InviteApiException(
+        timeoutMessage,
+        code: InviteApiErrorCode.clientTimeout,
+      );
     }
 
-    final timestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    final tags = <List<String>>[
-      ['u', normalizedUrl],
-      ['method', method.value],
-      ['created_at', timestamp.toString()],
-    ];
-
-    if (method == InviteRequestMethod.post ||
-        method == InviteRequestMethod.put ||
-        method == InviteRequestMethod.patch) {
-      final payloadHash = sha256.convert(utf8.encode(payload ?? ''));
-      tags.add(['payload', payloadHash.toString()]);
-    }
-
-    final event = Event(publicKeyHex, 27235, tags, '', createdAt: timestamp);
-    final signedEvent = await signer.signEvent(event);
-
-    if (signedEvent == null || !signedEvent.isSigned) {
-      throw const InviteApiException('Failed to authenticate invite request');
-    }
-
-    final eventJson = jsonEncode(signedEvent.toJson());
-    return 'Nostr ${base64Encode(utf8.encode(eventJson))}';
+    final code = _isNetworkError(error)
+        ? InviteApiErrorCode.clientNetworkError
+        : InviteApiErrorCode.clientError;
+    return InviteApiException('$failureMessage: $error', code: code);
   }
 
   InviteApiException _requestFailed({
@@ -501,5 +551,13 @@ class InviteApiClient {
       // Ignore malformed bodies and fall back to null.
     }
     return null;
+  }
+
+  bool _isNetworkError(Object error) {
+    if (error is http.ClientException) return true;
+    final message = error.toString().toLowerCase();
+    return message.contains('network') ||
+        message.contains('socket') ||
+        message.contains('connection');
   }
 }

--- a/mobile/packages/invite_api_client/lib/src/invite_api_exception.dart
+++ b/mobile/packages/invite_api_client/lib/src/invite_api_exception.dart
@@ -1,3 +1,30 @@
+abstract final class InviteApiErrorCode {
+  const InviteApiErrorCode._();
+
+  // Server-returned codes.
+  static const creatorPageFull = 'creator_page_full';
+  static const authRequired = 'auth_required';
+  static const authInvalid = 'auth_invalid';
+  static const authExpired = 'auth_expired';
+  static const authInvalidBinding = 'auth_invalid_binding';
+  static const inviteNotFound = 'invite_not_found';
+  static const inviteInvalidFormat = 'invite_invalid_format';
+  static const inviteRevoked = 'invite_revoked';
+  static const inviteCodeRotated = 'invite_code_rotated';
+  static const creatorPageDisabled = 'creator_page_disabled';
+  static const inviteAlreadyUsed = 'invite_already_used';
+  static const userAlreadyJoined = 'user_already_joined';
+  static const tooManyRequests = 'too_many_requests';
+  static const storageError = 'storage_error';
+  static const internalError = 'internal_error';
+
+  // Client-synthesized codes.
+  static const clientTimeout = 'client_timeout';
+  static const clientNetworkError = 'client_network_error';
+  static const clientAuthFailed = 'client_auth_failed';
+  static const clientError = 'client_error';
+}
+
 class InviteApiException implements Exception {
   const InviteApiException(
     this.message, {

--- a/mobile/packages/invite_api_client/test/src/invite_api_client_test.dart
+++ b/mobile/packages/invite_api_client/test/src/invite_api_client_test.dart
@@ -186,19 +186,23 @@ void main() {
             body: any(named: 'body'),
           ),
         ).thenAnswer(
-          (_) => Future<http.Response>.error(
-            TimeoutException('timed out'),
-          ),
+          (_) => Future<http.Response>.error(TimeoutException('timed out')),
         );
 
         await expectLater(
           client.validateCode('ab12ef34'),
           throwsA(
-            isA<InviteApiException>().having(
-              (error) => error.message,
-              'message',
-              'Invite code validation timed out',
-            ),
+            isA<InviteApiException>()
+                .having(
+                  (error) => error.message,
+                  'message',
+                  'Invite code validation timed out',
+                )
+                .having(
+                  (error) => error.code,
+                  'code',
+                  InviteApiErrorCode.clientTimeout,
+                ),
           ),
         );
       },
@@ -218,11 +222,17 @@ void main() {
         await expectLater(
           client.validateCode('ab12ef34'),
           throwsA(
-            isA<InviteApiException>().having(
-              (error) => error.message,
-              'message',
-              contains('Failed to validate invite code'),
-            ),
+            isA<InviteApiException>()
+                .having(
+                  (error) => error.message,
+                  'message',
+                  contains('Failed to validate invite code'),
+                )
+                .having(
+                  (error) => error.code,
+                  'code',
+                  InviteApiErrorCode.clientNetworkError,
+                ),
           ),
         );
       },
@@ -234,13 +244,10 @@ void main() {
         client: MockClient((request) async {
           expect(request.method, 'POST');
           expect(request.url.path, contains('/v1/waitlist'));
-          expect(
-            jsonDecode(request.body),
-            {
-              'contact': 'test@example.com',
-              'pubkey': 'pubkey-123',
-            },
-          );
+          expect(jsonDecode(request.body), {
+            'contact': 'test@example.com',
+            'pubkey': 'pubkey-123',
+          });
           return http.Response(
             jsonEncode({
               'id': 'waitlist-entry-1',
@@ -266,13 +273,10 @@ void main() {
         client: MockClient((request) async {
           expect(request.method, 'POST');
           expect(request.url.path, contains('/v1/waitlist'));
-          expect(
-            jsonDecode(request.body),
-            {
-              'contact': 'test@example.com',
-              'source_slug': 'lele-pons',
-            },
-          );
+          expect(jsonDecode(request.body), {
+            'contact': 'test@example.com',
+            'source_slug': 'lele-pons',
+          });
           return http.Response(
             jsonEncode({
               'id': 'waitlist-entry-1',
@@ -430,7 +434,7 @@ void main() {
         throwsA(
           isA<InviteApiException>()
               .having((e) => e.statusCode, 'statusCode', 409)
-              .having((e) => e.code, 'code', 'creator_page_full')
+              .having((e) => e.code, 'code', InviteApiErrorCode.creatorPageFull)
               .having((e) => e.creatorSlug, 'creatorSlug', 'lele-pons'),
         ),
       );
@@ -459,6 +463,104 @@ void main() {
       expect(result.result, InviteConsumeStatus.userAlreadyJoined);
       expect(result.code, 'LELE-PONS');
     });
+
+    test(
+      'surfaces consumeInvite timeout failures with a structured code',
+      () async {
+        when(
+          () => mockClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenAnswer(
+          (_) => Future<http.Response>.error(TimeoutException('timed out')),
+        );
+
+        await expectLater(
+          client.consumeInvite('ab12ef34'),
+          throwsA(
+            isA<InviteApiException>()
+                .having(
+                  (error) => error.message,
+                  'message',
+                  'Invite activation timed out',
+                )
+                .having(
+                  (error) => error.code,
+                  'code',
+                  InviteApiErrorCode.clientTimeout,
+                ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'surfaces consumeInvite network failures with a structured code',
+      () async {
+        when(
+          () => mockClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenThrow(const SocketException('Connection failed'));
+
+        await expectLater(
+          client.consumeInvite('ab12ef34'),
+          throwsA(
+            isA<InviteApiException>()
+                .having(
+                  (error) => error.message,
+                  'message',
+                  contains('Failed to activate invite code'),
+                )
+                .having(
+                  (error) => error.code,
+                  'code',
+                  InviteApiErrorCode.clientNetworkError,
+                ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'surfaces invite signing failures with a structured auth code',
+      () async {
+        final keyContainer = SecureKeyContainer.fromNsec(_testNsec);
+        when(
+          () => mockClient.post(
+            any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
+          ),
+        ).thenThrow(StateError('should not hit network'));
+
+        keyContainer.dispose();
+
+        await expectLater(
+          client.consumeInviteWithKeyContainer(
+            code: 'ab12ef34',
+            keyContainer: keyContainer,
+          ),
+          throwsA(
+            isA<InviteApiException>()
+                .having(
+                  (error) => error.message,
+                  'message',
+                  contains('Failed to authenticate invite request'),
+                )
+                .having(
+                  (error) => error.code,
+                  'code',
+                  InviteApiErrorCode.clientAuthFailed,
+                ),
+          ),
+        );
+      },
+    );
 
     test('surfaces server errors as InviteApiException', () async {
       final response = _MockResponse();
@@ -525,9 +627,9 @@ void main() {
       test('includes pubkey when provided', () async {
         final response = _MockResponse();
         when(() => response.statusCode).thenReturn(201);
-        when(() => response.body).thenReturn(
-          jsonEncode({'id': 'wl-789', 'message': 'Added'}),
-        );
+        when(
+          () => response.body,
+        ).thenReturn(jsonEncode({'id': 'wl-789', 'message': 'Added'}));
         when(
           () => mockClient.post(
             any(),
@@ -536,10 +638,7 @@ void main() {
           ),
         ).thenAnswer((_) async => response);
 
-        await client.joinWaitlist(
-          contact: 'user@test.com',
-          pubkey: 'abc123',
-        );
+        await client.joinWaitlist(contact: 'user@test.com', pubkey: 'abc123');
 
         final captured =
             verify(
@@ -558,9 +657,9 @@ void main() {
       test('throws on server error', () async {
         final response = _MockResponse();
         when(() => response.statusCode).thenReturn(500);
-        when(() => response.body).thenReturn(
-          jsonEncode({'error': 'Internal error'}),
-        );
+        when(
+          () => response.body,
+        ).thenReturn(jsonEncode({'error': 'Internal error'}));
         when(
           () => mockClient.post(
             any(),
@@ -582,9 +681,7 @@ void main() {
             headers: any(named: 'headers'),
             body: any(named: 'body'),
           ),
-        ).thenAnswer(
-          (_) async => throw TimeoutException('timed out'),
-        );
+        ).thenAnswer((_) async => throw TimeoutException('timed out'));
 
         await expectLater(
           client.joinWaitlist(contact: 'user@test.com'),
@@ -623,9 +720,9 @@ void main() {
       test('maps 403 rejection to invalid result', () async {
         final response = _MockResponse();
         when(() => response.statusCode).thenReturn(403);
-        when(() => response.body).thenReturn(
-          jsonEncode({'valid': false, 'used': false}),
-        );
+        when(
+          () => response.body,
+        ).thenReturn(jsonEncode({'valid': false, 'used': false}));
         when(
           () => mockClient.post(
             any(),
@@ -642,9 +739,9 @@ void main() {
       test('maps 404 rejection to invalid result', () async {
         final response = _MockResponse();
         when(() => response.statusCode).thenReturn(404);
-        when(() => response.body).thenReturn(
-          jsonEncode({'valid': false, 'used': false}),
-        );
+        when(
+          () => response.body,
+        ).thenReturn(jsonEncode({'valid': false, 'used': false}));
         when(
           () => mockClient.post(
             any(),
@@ -700,9 +797,9 @@ void main() {
       test('throws on non-rejection server error', () async {
         final response = _MockResponse();
         when(() => response.statusCode).thenReturn(500);
-        when(() => response.body).thenReturn(
-          jsonEncode({'error': 'Internal server error'}),
-        );
+        when(
+          () => response.body,
+        ).thenReturn(jsonEncode({'error': 'Internal server error'}));
         when(
           () => mockClient.post(
             any(),
@@ -730,9 +827,7 @@ void main() {
             headers: any(named: 'headers'),
             body: any(named: 'body'),
           ),
-        ).thenAnswer(
-          (_) async => throw TimeoutException('timed out'),
-        );
+        ).thenAnswer((_) async => throw TimeoutException('timed out'));
 
         await expectLater(
           client.validateCode('ab12ef34'),
@@ -766,9 +861,7 @@ void main() {
       test('throws on timeout', () async {
         when(
           () => mockClient.get(any(), headers: any(named: 'headers')),
-        ).thenAnswer(
-          (_) async => throw TimeoutException('timed out'),
-        );
+        ).thenAnswer((_) async => throw TimeoutException('timed out'));
 
         await expectLater(
           client.getClientConfig(),

--- a/mobile/test/utils/invite_error_utils_test.dart
+++ b/mobile/test/utils/invite_error_utils_test.dart
@@ -1,5 +1,4 @@
-// ABOUTME: Tests for InviteErrorUtils error classification.
-// ABOUTME: Verifies server error codes map to correct failure reasons.
+// ABOUTME: Tests for invite activation error classification and mapping.
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:invite_api_client/invite_api_client.dart';
@@ -13,28 +12,28 @@ void main() {
     int? statusCode,
     String? code,
   }) {
-    return InviteApiException(
-      message,
-      statusCode: statusCode,
-      code: code,
-    );
+    return InviteApiException(message, statusCode: statusCode, code: code);
   }
 
   group('server error code classification', () {
     test('creator_page_full maps to creatorFull', () {
       expect(
         InviteErrorUtils.activationFailureReason(
-          makeException(code: 'creator_page_full', statusCode: 409),
+          makeException(
+            code: InviteApiErrorCode.creatorPageFull,
+            statusCode: 409,
+          ),
         ),
         InviteActivationFailureReason.creatorFull,
       );
     });
 
     for (final code in [
-      'auth_required',
-      'auth_invalid',
-      'auth_expired',
-      'auth_invalid_binding',
+      InviteApiErrorCode.authRequired,
+      InviteApiErrorCode.authInvalid,
+      InviteApiErrorCode.authExpired,
+      InviteApiErrorCode.authInvalidBinding,
+      InviteApiErrorCode.clientAuthFailed,
     ]) {
       test('$code maps to authFailure', () {
         expect(
@@ -46,7 +45,10 @@ void main() {
       });
     }
 
-    for (final code in ['invite_already_used', 'user_already_joined']) {
+    for (final code in [
+      InviteApiErrorCode.inviteAlreadyUsed,
+      InviteApiErrorCode.userAlreadyJoined,
+    ]) {
       test('$code maps to alreadyUsed', () {
         expect(
           InviteErrorUtils.activationFailureReason(
@@ -58,30 +60,36 @@ void main() {
     }
 
     for (final code in [
-      'invite_not_found',
-      'invite_invalid_format',
-      'invite_revoked',
-      'invite_code_rotated',
-      'creator_page_disabled',
+      InviteApiErrorCode.inviteNotFound,
+      InviteApiErrorCode.inviteInvalidFormat,
+      InviteApiErrorCode.inviteRevoked,
+      InviteApiErrorCode.inviteCodeRotated,
+      InviteApiErrorCode.creatorPageDisabled,
     ]) {
       test('$code maps to invalid', () {
         expect(
-          InviteErrorUtils.activationFailureReason(
-            makeException(code: code),
-          ),
+          InviteErrorUtils.activationFailureReason(makeException(code: code)),
           InviteActivationFailureReason.invalid,
         );
       });
     }
 
-    test('too_many_requests maps to temporary', () {
-      expect(
-        InviteErrorUtils.activationFailureReason(
-          makeException(code: 'too_many_requests', statusCode: 429),
-        ),
-        InviteActivationFailureReason.temporary,
-      );
-    });
+    for (final code in [
+      InviteApiErrorCode.tooManyRequests,
+      InviteApiErrorCode.storageError,
+      InviteApiErrorCode.internalError,
+      InviteApiErrorCode.clientTimeout,
+      InviteApiErrorCode.clientNetworkError,
+    ]) {
+      test('$code maps to temporary', () {
+        expect(
+          InviteErrorUtils.activationFailureReason(
+            makeException(code: code, statusCode: 429),
+          ),
+          InviteActivationFailureReason.temporary,
+        );
+      });
+    }
   });
 
   group('status code fallback classification', () {
@@ -150,6 +158,24 @@ void main() {
       );
     });
 
+    test('invalid in message maps to invalid', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(message: 'Invalid invite code'),
+        ),
+        InviteActivationFailureReason.invalid,
+      );
+    });
+
+    test('expired in message maps to invalid', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(message: 'Invite code expired'),
+        ),
+        InviteActivationFailureReason.invalid,
+      );
+    });
+
     test('unrecognized error falls to unknown', () {
       expect(
         InviteErrorUtils.activationFailureReason(
@@ -164,7 +190,7 @@ void main() {
     test('auth_invalid at 401 maps to authFailure not invalid', () {
       expect(
         InviteErrorUtils.activationFailureReason(
-          makeException(code: 'auth_invalid', statusCode: 401),
+          makeException(code: InviteApiErrorCode.authInvalid, statusCode: 401),
         ),
         InviteActivationFailureReason.authFailure,
       );
@@ -173,7 +199,10 @@ void main() {
     test('invite_revoked at 409 maps to invalid not alreadyUsed', () {
       expect(
         InviteErrorUtils.activationFailureReason(
-          makeException(code: 'invite_revoked', statusCode: 409),
+          makeException(
+            code: InviteApiErrorCode.inviteRevoked,
+            statusCode: 409,
+          ),
         ),
         InviteActivationFailureReason.invalid,
       );
@@ -181,30 +210,12 @@ void main() {
   });
 
   group('client-synthesized codes', () {
-    test('timeout code maps to temporary', () {
-      expect(
-        InviteErrorUtils.activationFailureReason(
-          makeException(code: 'timeout'),
-        ),
-        InviteActivationFailureReason.temporary,
-      );
-    });
-
     test('client_error code maps to unknown', () {
       expect(
         InviteErrorUtils.activationFailureReason(
-          makeException(code: 'client_error'),
+          makeException(code: InviteApiErrorCode.clientError),
         ),
         InviteActivationFailureReason.unknown,
-      );
-    });
-
-    test('storage_error code maps to temporary', () {
-      expect(
-        InviteErrorUtils.activationFailureReason(
-          makeException(code: 'storage_error', statusCode: 502),
-        ),
-        InviteActivationFailureReason.temporary,
       );
     });
   });
@@ -213,7 +224,7 @@ void main() {
     test('authFailure maps to inviteTemporary', () {
       expect(
         InviteErrorUtils.toEmailVerificationError(
-          makeException(code: 'auth_invalid', statusCode: 401),
+          makeException(code: InviteApiErrorCode.authInvalid, statusCode: 401),
         ),
         EmailVerificationError.inviteTemporary,
       );
@@ -222,7 +233,10 @@ void main() {
     test('creatorFull maps to inviteInvalid', () {
       expect(
         InviteErrorUtils.toEmailVerificationError(
-          makeException(code: 'creator_page_full', statusCode: 409),
+          makeException(
+            code: InviteApiErrorCode.creatorPageFull,
+            statusCode: 409,
+          ),
         ),
         EmailVerificationError.inviteInvalid,
       );
@@ -231,7 +245,7 @@ void main() {
     test('unknown maps to inviteUnknown', () {
       expect(
         InviteErrorUtils.toEmailVerificationError(
-          makeException(message: 'unexpected'),
+          makeException(code: InviteApiErrorCode.clientError),
         ),
         EmailVerificationError.inviteUnknown,
       );
@@ -241,7 +255,10 @@ void main() {
   group('activationFailureMessage', () {
     test('authFailure message suggests trying again', () {
       final message = InviteErrorUtils.activationFailureMessage(
-        makeException(code: 'auth_invalid', statusCode: 401),
+        makeException(
+          code: InviteApiErrorCode.clientAuthFailed,
+          statusCode: 401,
+        ),
       );
       expect(message, contains('try again'));
     });

--- a/mobile/test/utils/invite_error_utils_test.dart
+++ b/mobile/test/utils/invite_error_utils_test.dart
@@ -3,6 +3,8 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:invite_api_client/invite_api_client.dart';
+import 'package:openvine/blocs/email_verification/email_verification_cubit.dart'
+    show EmailVerificationError;
 import 'package:openvine/utils/invite_error_utils.dart';
 
 void main() {
@@ -174,6 +176,64 @@ void main() {
           makeException(code: 'invite_revoked', statusCode: 409),
         ),
         InviteActivationFailureReason.invalid,
+      );
+    });
+  });
+
+  group('client-synthesized codes', () {
+    test('timeout code maps to temporary', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(code: 'timeout'),
+        ),
+        InviteActivationFailureReason.temporary,
+      );
+    });
+
+    test('client_error code maps to unknown', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(code: 'client_error'),
+        ),
+        InviteActivationFailureReason.unknown,
+      );
+    });
+
+    test('storage_error code maps to temporary', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(code: 'storage_error', statusCode: 502),
+        ),
+        InviteActivationFailureReason.temporary,
+      );
+    });
+  });
+
+  group('toEmailVerificationError', () {
+    test('authFailure maps to inviteTemporary', () {
+      expect(
+        InviteErrorUtils.toEmailVerificationError(
+          makeException(code: 'auth_invalid', statusCode: 401),
+        ),
+        EmailVerificationError.inviteTemporary,
+      );
+    });
+
+    test('creatorFull maps to inviteInvalid', () {
+      expect(
+        InviteErrorUtils.toEmailVerificationError(
+          makeException(code: 'creator_page_full', statusCode: 409),
+        ),
+        EmailVerificationError.inviteInvalid,
+      );
+    });
+
+    test('unknown maps to inviteUnknown', () {
+      expect(
+        InviteErrorUtils.toEmailVerificationError(
+          makeException(message: 'unexpected'),
+        ),
+        EmailVerificationError.inviteUnknown,
       );
     });
   });

--- a/mobile/test/utils/invite_error_utils_test.dart
+++ b/mobile/test/utils/invite_error_utils_test.dart
@@ -1,0 +1,196 @@
+// ABOUTME: Tests for InviteErrorUtils error classification.
+// ABOUTME: Verifies server error codes map to correct failure reasons.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:invite_api_client/invite_api_client.dart';
+import 'package:openvine/utils/invite_error_utils.dart';
+
+void main() {
+  InviteApiException makeException({
+    String message = 'test',
+    int? statusCode,
+    String? code,
+  }) {
+    return InviteApiException(
+      message,
+      statusCode: statusCode,
+      code: code,
+    );
+  }
+
+  group('server error code classification', () {
+    test('creator_page_full maps to creatorFull', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(code: 'creator_page_full', statusCode: 409),
+        ),
+        InviteActivationFailureReason.creatorFull,
+      );
+    });
+
+    for (final code in [
+      'auth_required',
+      'auth_invalid',
+      'auth_expired',
+      'auth_invalid_binding',
+    ]) {
+      test('$code maps to authFailure', () {
+        expect(
+          InviteErrorUtils.activationFailureReason(
+            makeException(code: code, statusCode: 401),
+          ),
+          InviteActivationFailureReason.authFailure,
+        );
+      });
+    }
+
+    for (final code in ['invite_already_used', 'user_already_joined']) {
+      test('$code maps to alreadyUsed', () {
+        expect(
+          InviteErrorUtils.activationFailureReason(
+            makeException(code: code, statusCode: 409),
+          ),
+          InviteActivationFailureReason.alreadyUsed,
+        );
+      });
+    }
+
+    for (final code in [
+      'invite_not_found',
+      'invite_invalid_format',
+      'invite_revoked',
+      'invite_code_rotated',
+      'creator_page_disabled',
+    ]) {
+      test('$code maps to invalid', () {
+        expect(
+          InviteErrorUtils.activationFailureReason(
+            makeException(code: code),
+          ),
+          InviteActivationFailureReason.invalid,
+        );
+      });
+    }
+
+    test('too_many_requests maps to temporary', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(code: 'too_many_requests', statusCode: 429),
+        ),
+        InviteActivationFailureReason.temporary,
+      );
+    });
+  });
+
+  group('status code fallback classification', () {
+    test('401 without error code maps to authFailure', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(statusCode: 401),
+        ),
+        InviteActivationFailureReason.authFailure,
+      );
+    });
+
+    test('409 without error code maps to alreadyUsed', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(statusCode: 409),
+        ),
+        InviteActivationFailureReason.alreadyUsed,
+      );
+    });
+
+    test('404 without error code maps to invalid', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(statusCode: 404),
+        ),
+        InviteActivationFailureReason.invalid,
+      );
+    });
+
+    test('500 without error code maps to temporary', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(statusCode: 500),
+        ),
+        InviteActivationFailureReason.temporary,
+      );
+    });
+
+    test('429 without error code maps to temporary', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(statusCode: 429),
+        ),
+        InviteActivationFailureReason.temporary,
+      );
+    });
+  });
+
+  group('keyword fallback classification', () {
+    test('timeout in message maps to temporary', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(message: 'Invite activation timed out'),
+        ),
+        InviteActivationFailureReason.temporary,
+      );
+    });
+
+    test('network error in message maps to temporary', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(message: 'network error'),
+        ),
+        InviteActivationFailureReason.temporary,
+      );
+    });
+
+    test('unrecognized error falls to unknown', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(message: 'something completely unexpected'),
+        ),
+        InviteActivationFailureReason.unknown,
+      );
+    });
+  });
+
+  group('server error code takes priority over status code', () {
+    test('auth_invalid at 401 maps to authFailure not invalid', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(code: 'auth_invalid', statusCode: 401),
+        ),
+        InviteActivationFailureReason.authFailure,
+      );
+    });
+
+    test('invite_revoked at 409 maps to invalid not alreadyUsed', () {
+      expect(
+        InviteErrorUtils.activationFailureReason(
+          makeException(code: 'invite_revoked', statusCode: 409),
+        ),
+        InviteActivationFailureReason.invalid,
+      );
+    });
+  });
+
+  group('activationFailureMessage', () {
+    test('authFailure message suggests trying again', () {
+      final message = InviteErrorUtils.activationFailureMessage(
+        makeException(code: 'auth_invalid', statusCode: 401),
+      );
+      expect(message, contains('try again'));
+    });
+
+    test('unknown message is the generic dead-end', () {
+      final message = InviteErrorUtils.activationFailureMessage(
+        makeException(message: 'something unexpected'),
+      );
+      expect(message, contains("couldn't activate"));
+    });
+  });
+}


### PR DESCRIPTION
## Description

The invite error classifier keyword-matched response bodies but ignored the server's error code field. Auth failures (401), revoked codes, rotated codes, and disabled creator pages all fell to the generic "unknown" bucket, showing users a dead-end "We couldn't activate your invite" message with no retry option.

Now checks `error.code` against the full set of divine-invite-darshan error codes before falling back to status code and keyword matching. Adds `authFailure` reason for 401s so the UI prompts retry instead of a dead end. Timeout and client exceptions carry a `code` field for reliable classification.

**Related Issue:** Closes #3795

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore