### PR TITLE
fix(router): preserve divine universal links during normalization

### DIFF
--- a/mobile/lib/router/providers/route_normalization_provider.dart
+++ b/mobile/lib/router/providers/route_normalization_provider.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Route normalization provider - ensures canonical URL format
 // ABOUTME: Redirects to canonical URLs for negative indices, encoding, unknown paths
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/router/router.dart';
@@ -9,7 +10,42 @@ import 'package:openvine/screens/auth/nostr_connect_screen.dart';
 import 'package:openvine/screens/auth/reset_password.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
+import 'package:openvine/services/deep_link_service.dart';
 import 'package:unified_logger/unified_logger.dart';
+
+@visibleForTesting
+bool shouldSkipRouteNormalization(String loc) {
+  // Skip normalization for auth-related routes.
+  // EmailVerificationScreen supports both token mode (?token=) and polling
+  // mode (?deviceCode=). Use contains() to handle both path-only and full URL
+  // formats (deep links include host).
+  if (loc.startsWith(WelcomeScreen.path) ||
+      loc.startsWith(NostrConnectScreen.path) ||
+      RegExp(r'^/apps/[^/]+/sandbox$').hasMatch(loc) ||
+      loc.contains('${ResetPasswordScreen.path}?token=') ||
+      loc.contains('${EmailVerificationScreen.path}?') ||
+      loc.startsWith(SearchResultsPage.pathPrefix)) {
+    return true;
+  }
+
+  final uri = Uri.tryParse(loc);
+  if (uri == null || !uri.scheme.startsWith('http')) {
+    return false;
+  }
+
+  final host = uri.host.toLowerCase();
+  final isCanonicalDivineHost =
+      host == 'divine.video' || host == 'www.divine.video';
+  if (!isCanonicalDivineHost) {
+    return false;
+  }
+
+  // Full divine.video universal links are resolved either in GoRouter's
+  // redirect or in the app-wide DeepLinkService listener. They are not part
+  // of the internal parseRoute/buildRoute contract, so normalizing them here
+  // can rewrite a valid deep link into an unrelated internal fallback.
+  return DeepLinkService.parseDeepLink(loc).type != DeepLinkType.unknown;
+}
 
 /// Watches router location changes and redirects to canonical URLs when needed.
 /// Safe to watch at app root; contains guards to avoid loops.
@@ -19,15 +55,7 @@ final routeNormalizationProvider = Provider<void>((ref) {
   // Set up listener on router delegate to detect navigation changes
   void listener() {
     final loc = router.routeInformationProvider.value.uri.toString();
-    // Skip normalization for auth-related routes
-    // EmailVerificationScreen supports both token mode (?token=) and polling mode (?deviceCode=)
-    // Use contains() to handle both path-only and full URL formats (deep links include host)
-    if (loc.startsWith(WelcomeScreen.path) ||
-        loc.startsWith(NostrConnectScreen.path) ||
-        RegExp(r'^/apps/[^/]+/sandbox$').hasMatch(loc) ||
-        loc.contains('${ResetPasswordScreen.path}?token=') ||
-        loc.contains('${EmailVerificationScreen.path}?') ||
-        loc.startsWith(SearchResultsPage.pathPrefix)) {
+    if (shouldSkipRouteNormalization(loc)) {
       Log.info(
         '🔄 RouteNormalizationProvider: skipping normalization for $loc',
         name: 'RouteNormalizationProvider',

--- a/mobile/test/router/route_normalization_test.dart
+++ b/mobile/test/router/route_normalization_test.dart
@@ -1,7 +1,49 @@
-// ABOUTME: Tests for route normalization (canonical URLs)
-// ABOUTME: Ensures negative indices, encoding, and unknown paths are normalized
-// TODO(any): Fix and re-enable this test
-void main() {}
+// ABOUTME: Tests for route normalization skip logic
+// ABOUTME: Prevents universal links from being rewritten by internal canonicalization
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/router/providers/route_normalization_provider.dart';
+
+void main() {
+  group('shouldSkipRouteNormalization', () {
+    test('skips divine video universal links', () {
+      expect(
+        shouldSkipRouteNormalization('https://divine.video/video/abc123'),
+        isTrue,
+      );
+    });
+
+    test('skips divine profile universal links', () {
+      expect(
+        shouldSkipRouteNormalization(
+          'https://divine.video/profile/npub1abc123',
+        ),
+        isTrue,
+      );
+    });
+
+    test('skips divine invite universal links', () {
+      expect(
+        shouldSkipRouteNormalization(
+          'https://divine.video/invite/ABCD-EFGH',
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not skip unrelated hosts', () {
+      expect(
+        shouldSkipRouteNormalization('https://example.com/video/abc123'),
+        isFalse,
+      );
+    });
+
+    test('does not skip canonical internal routes', () {
+      expect(shouldSkipRouteNormalization('/video/abc123'), isFalse);
+      expect(shouldSkipRouteNormalization('/home/0'), isFalse);
+    });
+  });
+}
 
 //import 'package:flutter/material.dart';
 //import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
## Related
- Related to #3843

## What changed
- exempted recognized `divine.video` universal links from app-level route normalization
- added a focused regression test for the route-normalization skip logic

## Why
Slack deep links were already reaching the app and being parsed correctly, but `RouteNormalizationProvider` was treating the full universal-link URL as an internal route candidate. For video links, that caused the router state to be normalized away from `/video/:id` and back to `/home/0` immediately after the deep link handler pushed the video screen.

## Impact
Video deep links opened from Slack or other universal-link sources should now stay on the intended destination instead of bouncing back to home.

## Root cause
`parseRoute/buildRoute` only define canonicalization for internal app routes. Applying that normalization pass to full `https://divine.video/...` URLs let a valid deep link fall through to an unrelated internal fallback.

## Notes
Issue #3843 tracks the external iOS universal-link handoff problem. This PR covers the separate app-side routing bug that shows up once the URL is successfully delivered to Divine.

## Validation
- `flutter test test/router/route_normalization_test.dart`
- `flutter test test/router/universal_link_resolver_test.dart`
