### PR TITLE
fix(models): require collaborator p-tag marker

### DIFF
--- a/mobile/docs/NOSTR_VIDEO_EVENTS.md
+++ b/mobile/docs/NOSTR_VIDEO_EVENTS.md
@@ -64,6 +64,20 @@ Tags: Array of [tagName, tagValue, ...additionalParams]
 |-----|--------|-------------|----------|
 | `t` | `["t", "funny"]` | Hashtag (without #) | Optional |
 
+### Divine Collaborator Tags
+
+Divine uses a project-specific collaborator marker on top of the standard `p`
+tag shape for NIP-71 video events:
+
+| Tag | Format | Description |
+|-----|--------|-------------|
+| `p` | `["p", "<pubkey>", "<relay>", "collaborator"]` | Marks a tagged pubkey as a collaborator rather than a generic mention. |
+
+This role marker is a Divine convention, not a NIP-71 standardized field.
+Publishing is centralized in `mobile/lib/utils/collaborator_tags.dart`, and
+parsing is enforced in `mobile/packages/models/lib/src/video_event.dart` and
+`mobile/packages/models/lib/src/video_stats.dart`.
+
 ### Event Metadata
 
 | Tag | Format | Description | Required |

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -769,7 +769,7 @@ class VideoEventPublisher {
         tags.add(['expiration', expirationTimestamp.toString()]);
       }
 
-      // Add collaborator p-tags (standard NIP-71 format)
+      // Add Divine collaborator-marked p-tags for this NIP-71 video event.
       for (final pubkey in collaboratorPubkeys) {
         tags.add(buildCollaboratorPTag(pubkey));
       }

--- a/mobile/lib/utils/collaborator_tags.dart
+++ b/mobile/lib/utils/collaborator_tags.dart
@@ -1,10 +1,10 @@
-// ABOUTME: Shared NIP-71 collaborator p-tag builder used by both the
+// ABOUTME: Shared Divine collaborator p-tag builder used by both the
 // ABOUTME: direct-upload and edit-video publish paths.
 
-/// Default relay hint embedded in collaborator invite p-tags.
+/// Default relay hint embedded in Divine collaborator p-tags.
 const collaboratorInviteRelayHint = 'wss://relay.divine.video';
 
-/// Builds the standard NIP-71 collaborator p-tag for [pubkey].
+/// Builds the Divine collaborator-marked `p` tag for [pubkey].
 List<String> buildCollaboratorPTag(String pubkey) => [
   'p',
   pubkey,

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -433,10 +433,10 @@ class VideoEvent {
             );
           }
         case 'p':
-          // NIP-71 collaborator p-tag:
+          // Divine collaborator p-tag convention on NIP-71 video events:
           // ["p", "<pubkey>", "<relay>", "collaborator"]
           if (tagValue.isNotEmpty && tagValue != event.pubkey) {
-            final role = tag.length >= 4 ? tag[3] : null;
+            final role = tag.length >= 4 ? tag[3].toLowerCase() : null;
             if (role == 'collaborator' &&
                 !collaboratorPubkeys.contains(tagValue)) {
               collaboratorPubkeys.add(tagValue);
@@ -730,7 +730,7 @@ class VideoEvent {
   final String? authorAvatar;
 
   // Attribution fields (collaborators and Inspired By)
-  /// Pubkeys of collaborators (non-author p-tags).
+  /// Pubkeys of collaborators from Divine's collaborator-marked `p` tags.
   final List<String> collaboratorPubkeys;
 
   /// Reference to the video that inspired this one (a-tag with 34236: prefix).

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -433,9 +433,12 @@ class VideoEvent {
             );
           }
         case 'p':
-          // NIP-71 p-tag: collaborator if pubkey differs from event author
+          // NIP-71 collaborator p-tag:
+          // ["p", "<pubkey>", "<relay>", "collaborator"]
           if (tagValue.isNotEmpty && tagValue != event.pubkey) {
-            if (!collaboratorPubkeys.contains(tagValue)) {
+            final role = tag.length >= 4 ? tag[3] : null;
+            if (role == 'collaborator' &&
+                !collaboratorPubkeys.contains(tagValue)) {
               collaboratorPubkeys.add(tagValue);
             }
           }

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -271,7 +271,9 @@ class VideoStats {
           }
           if (tagName == 'p' && tagValue.isNotEmpty) {
             final normalized = tagValue.toLowerCase();
-            if (normalized != pubkey &&
+            final role = tag.length >= 4 ? tag[3].toString() : null;
+            if (role == 'collaborator' &&
+                normalized != pubkey &&
                 !collaboratorPubkeys.contains(normalized)) {
               collaboratorPubkeys.add(normalized);
             }

--- a/mobile/packages/models/lib/src/video_stats.dart
+++ b/mobile/packages/models/lib/src/video_stats.dart
@@ -271,7 +271,9 @@ class VideoStats {
           }
           if (tagName == 'p' && tagValue.isNotEmpty) {
             final normalized = tagValue.toLowerCase();
-            final role = tag.length >= 4 ? tag[3].toString() : null;
+            final role = tag.length >= 4
+                ? (tag[3] as String).toLowerCase()
+                : null;
             if (role == 'collaborator' &&
                 normalized != pubkey &&
                 !collaboratorPubkeys.contains(normalized)) {
@@ -469,9 +471,9 @@ class VideoStats {
   /// Author-applied content warning labels parsed from NIP-32/NIP-36 tags.
   final List<String> contentWarningLabels;
 
-  /// Pubkeys of NIP-71 collaborators (`p` tags whose value differs from the
-  /// event author). Empty when the event has no collaborators or when the
-  /// REST payload did not include tag data.
+  /// Pubkeys from Divine's collaborator-marked `p` tags whose value differs
+  /// from the event author. Empty when the event has no collaborator markers
+  /// or when the REST payload did not include tag data.
   final List<String> collaboratorPubkeys;
 
   /// Addressable coordinates for subtitle event (from `text-track` tag or

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -393,6 +393,30 @@ void main() {
       expect(videoEvent.collaboratorPubkeys, equals([collabPubkey1]));
     });
 
+    test('should accept historical capitalized collaborator markers', () {
+      final nostrEvent = Event(
+        authorPubkey,
+        34236,
+        [
+          ['url', 'https://example.com/video.mp4'],
+          ['p', collabPubkey1, 'wss://relay.divine.video', 'Collaborator'],
+          ['p', collabPubkey2, 'wss://relay.divine.video', 'COLLABORATOR'],
+        ],
+        'Test video',
+        createdAt: 1757385263,
+      );
+
+      final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+      expect(
+        videoEvent.collaboratorPubkeys,
+        equals([
+          collabPubkey1,
+          collabPubkey2,
+        ]),
+      );
+    });
+
     test('should return empty collaborators when no p-tags', () {
       final nostrEvent = Event(
         authorPubkey,

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -301,8 +301,8 @@ void main() {
         34236,
         [
           ['url', 'https://example.com/video.mp4'],
-          ['p', collabPubkey1, 'wss://relay.divine.video'],
-          ['p', collabPubkey2, 'wss://relay.divine.video'],
+          ['p', collabPubkey1, 'wss://relay.divine.video', 'collaborator'],
+          ['p', collabPubkey2, 'wss://relay.divine.video', 'collaborator'],
         ],
         'Test video',
         createdAt: 1757385263,
@@ -322,8 +322,13 @@ void main() {
         34236,
         [
           ['url', 'https://example.com/video.mp4'],
-          ['p', authorPubkey, 'wss://relay.divine.video'], // Author self-tag
-          ['p', collabPubkey1, 'wss://relay.divine.video'],
+          [
+            'p',
+            authorPubkey,
+            'wss://relay.divine.video',
+            'collaborator',
+          ], // Author self-tag
+          ['p', collabPubkey1, 'wss://relay.divine.video', 'collaborator'],
         ],
         'Test video',
         createdAt: 1757385263,
@@ -345,8 +350,13 @@ void main() {
         34236,
         [
           ['url', 'https://example.com/video.mp4'],
-          ['p', collabPubkey1, 'wss://relay.divine.video'],
-          ['p', collabPubkey1, 'wss://relay.divine.video'], // Duplicate
+          ['p', collabPubkey1, 'wss://relay.divine.video', 'collaborator'],
+          [
+            'p',
+            collabPubkey1,
+            'wss://relay.divine.video',
+            'collaborator',
+          ], // Duplicate
         ],
         'Test video',
         createdAt: 1757385263,
@@ -355,6 +365,32 @@ void main() {
       final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
 
       expect(videoEvent.collaboratorPubkeys, hasLength(1));
+    });
+
+    test('should only include collaborator-marked p-tags', () {
+      const strayMentionPubkey =
+          'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+      final nostrEvent = Event(
+        authorPubkey,
+        34236,
+        [
+          ['url', 'https://example.com/video.mp4'],
+          [
+            'p',
+            collabPubkey1,
+            'wss://relay.divine.video',
+            'collaborator',
+          ],
+          ['p', strayMentionPubkey, 'wss://relay.divine.video', 'mention'],
+          ['p', collabPubkey2, 'wss://relay.divine.video'],
+        ],
+        'Test video',
+        createdAt: 1757385263,
+      );
+
+      final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+      expect(videoEvent.collaboratorPubkeys, equals([collabPubkey1]));
     });
 
     test('should return empty collaborators when no p-tags', () {

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -1039,8 +1039,8 @@ void main() {
       test('extracts p-tag pubkeys from flat JSON', () {
         final stats = VideoStats.fromJson(
           buildJson([
-            ['p', collaborator1],
-            ['p', collaborator2],
+            ['p', collaborator1, '', 'collaborator'],
+            ['p', collaborator2, '', 'collaborator'],
           ]),
         );
 
@@ -1060,7 +1060,7 @@ void main() {
             'tags': [
               ['d', 'video-1'],
               ['url', 'https://example.com/video.mp4'],
-              ['p', collaborator1],
+              ['p', collaborator1, '', 'collaborator'],
             ],
           },
           'stats': {
@@ -1077,8 +1077,8 @@ void main() {
       test('excludes the event author pubkey', () {
         final stats = VideoStats.fromJson(
           buildJson([
-            ['p', authorPubkey],
-            ['p', collaborator1],
+            ['p', authorPubkey, '', 'collaborator'],
+            ['p', collaborator1, '', 'collaborator'],
           ]),
         );
 
@@ -1088,9 +1088,9 @@ void main() {
       test('deduplicates repeated p tags', () {
         final stats = VideoStats.fromJson(
           buildJson([
-            ['p', collaborator1],
-            ['p', collaborator1],
-            ['p', collaborator2],
+            ['p', collaborator1, '', 'collaborator'],
+            ['p', collaborator1, '', 'collaborator'],
+            ['p', collaborator2, '', 'collaborator'],
           ]),
         );
 
@@ -1103,8 +1103,8 @@ void main() {
       test('lowercases uppercase p-tag values and compares against author', () {
         final stats = VideoStats.fromJson(
           buildJson([
-            ['p', collaborator1.toUpperCase()],
-            ['p', authorPubkey.toUpperCase()],
+            ['p', collaborator1.toUpperCase(), '', 'collaborator'],
+            ['p', authorPubkey.toUpperCase(), '', 'collaborator'],
           ]),
         );
 
@@ -1114,8 +1114,8 @@ void main() {
       test('ignores empty p tags', () {
         final stats = VideoStats.fromJson(
           buildJson([
-            ['p', ''],
-            ['p', collaborator1],
+            ['p', '', '', 'collaborator'],
+            ['p', collaborator1, '', 'collaborator'],
           ]),
         );
 
@@ -1136,8 +1136,8 @@ void main() {
       test('forwards collaboratorPubkeys through toVideoEvent', () {
         final stats = VideoStats.fromJson(
           buildJson([
-            ['p', collaborator1],
-            ['p', collaborator2],
+            ['p', collaborator1, '', 'collaborator'],
+            ['p', collaborator2, '', 'collaborator'],
           ]),
         );
 
@@ -1148,6 +1148,18 @@ void main() {
           equals([collaborator1, collaborator2]),
         );
         expect(event.hasCollaborators, isTrue);
+      });
+
+      test('ignores non-collaborator p-tag markers and unmarked p-tags', () {
+        final stats = VideoStats.fromJson(
+          buildJson([
+            ['p', collaborator1, '', 'collaborator'],
+            ['p', collaborator2, '', 'mention'],
+            ['p', collaborator2],
+          ]),
+        );
+
+        expect(stats.collaboratorPubkeys, equals([collaborator1]));
       });
     });
 

--- a/mobile/packages/models/test/src/video_stats_test.dart
+++ b/mobile/packages/models/test/src/video_stats_test.dart
@@ -1161,6 +1161,20 @@ void main() {
 
         expect(stats.collaboratorPubkeys, equals([collaborator1]));
       });
+
+      test('accepts historical capitalized collaborator markers', () {
+        final stats = VideoStats.fromJson(
+          buildJson([
+            ['p', collaborator1, '', 'Collaborator'],
+            ['p', collaborator2, '', 'COLLABORATOR'],
+          ]),
+        );
+
+        expect(
+          stats.collaboratorPubkeys,
+          equals([collaborator1, collaborator2]),
+        );
+      });
     });
 
     group('toVideoEvent', () {


### PR DESCRIPTION
Closes #3889

Summary
- require the collaborator role marker before treating a p tag as a video collaborator in both parser paths
- accept historical capitalized collaborator markers so events published during the 2026-04-24 to 2026-04-29 transition window still parse correctly
- update collaborator parser fixtures to use explicit collaborator markers
- add regression coverage for mention, unmarked, and historical capitalized p tags so stray mentions do not surface as collaborators
- document that the collaborator role marker is a Divine convention layered on top of NIP-71, not a standardized NIP-71 field

Root cause
The video parsers treated any non-author p tag as a collaborator even after the publisher side standardized on a collaborator role marker. That let reply mentions, notification targets, and other non-collaborator p tags leak into collaborator UI.

Behavior note
Pre-marker events published before the collaborator role-marker convention shipped on 2026-04-24 will silently lose collaborator chips with this change. Those legacy `p` tags do not distinguish collaborators from generic mentions, and adding a parser fallback would reintroduce the false-positive bug this PR fixes.

Validation
- flutter test test/src/video_event_parsing_test.dart
- flutter test test/src/video_stats_test.dart
- flutter test test/services/video_event_publisher_collaborator_tags_test.dart
- pre-commit analyzer
- pre-push analyzer and changed-file test run
