### PR TITLE
chore(skills): add /check-l10n pre-push localization check

### DIFF
--- a/.claude/skills/check-l10n/SKILL.md
+++ b/.claude/skills/check-l10n/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: check-l10n
+description: |
+  Run before pushing a PR that touched UI to find untranslated keys in
+  any of the 16 non-English locales and to catch user-visible English
+  strings that bypass context.l10n. Reports findings as a checklist;
+  refuses to declare clean until all are addressed or explicitly waived.
+  Invoke with /check-l10n.
+author: Claude Code
+version: 1.0.0
+date: 2026-05-02
+user_invocable: true
+invocation_hint: /check-l10n
+arguments: |
+  Optional: Scope to specific paths under mobile/lib/.
+  Example: /check-l10n
+  Example: /check-l10n mobile/lib/screens/auth
+---
+
+# Check L10n Skill
+
+## Purpose
+
+Catch the two ways localization breaks in this repo before users see English
+in a non-English build:
+
+1. **Untranslated keys.** A key added to `app_en.arb` but never translated
+   into one of the 16 non-English locales (`ar`, `am`, `bg`, `de`, `es`,
+   `fr`, `id`, `it`, `ja`, `ko`, `nl`, `pl`, `pt`, `ro`, `sv`, `tr`).
+2. **Hardcoded user-visible English.** Strings rendered straight to the user
+   from widget code without going through `context.l10n.<key>`. These never
+   show up in `.arb` files because they were never extracted, so no amount
+   of translation work fixes them.
+
+Run this before every PR push that touches `mobile/lib/`.
+
+## Workflow
+
+### Step 1: Determine scope
+
+If the user passed paths after `/check-l10n`, scan those. Otherwise scan the
+union of staged + unstaged changes vs the working tree.
+
+```bash
+# Default: changed files
+git -C mobile status --porcelain | awk '{print $NF}' | grep '\.dart$'
+
+# Or explicit: argument paths
+```
+
+### Step 2: Run the arb consistency test (if present)
+
+```bash
+cd mobile && flutter test test/l10n/arb_consistency_test.dart
+```
+
+This test compares every `.arb` file against `app_en.arb` and fails if any
+locale is missing keys that aren't on the explicit `_knownUntranslatedDebt`
+allow-list.
+
+If the test file does not exist on this branch, skip this step and rely
+entirely on Step 3 plus the inline check below. Note in the report that
+arb consistency was not verified.
+
+#### Inline fallback when the test doesn't exist
+
+If `mobile/test/l10n/arb_consistency_test.dart` is missing, do the
+equivalent check by hand:
+
+```bash
+cd mobile/lib/l10n
+python3 - <<'PY'
+import json, glob
+en = json.load(open('app_en.arb'))
+en_keys = {k for k in en if not k.startswith('@') and k != '@@locale'}
+for f in sorted(glob.glob('app_*.arb')):
+    if f == 'app_en.arb':
+        continue
+    other = json.load(open(f))
+    other_keys = {k for k in other if not k.startswith('@') and k != '@@locale'}
+    missing = en_keys - other_keys
+    if missing:
+        print(f"{f}: {len(missing)} missing key(s)")
+        for k in sorted(missing)[:20]:
+            print(f"  - {k}")
+PY
+```
+
+### Step 3: Scan for hardcoded English in changed files
+
+```bash
+python3 .claude/skills/check-l10n/scan_strings.py
+```
+
+Or with explicit paths:
+
+```bash
+python3 .claude/skills/check-l10n/scan_strings.py mobile/lib/screens/auth/foo.dart
+```
+
+The scanner emits one line per candidate, formatted
+`<path>:<line>:<col>  [<rule>]  '<literal>'`. Exit code is `1` when there
+are findings, `0` otherwise.
+
+The scanner only inspects files under `mobile/lib/`. It excludes generated
+files (`*.g.dart`, `*.freezed.dart`, `*.mocks.dart`), the `l10n/` directory,
+and any `test/` or `integration_test/` tree. It also skips lines inside
+`Log.*()`, `developer.log()`, `print()`, `assert()`, `throw <Type>Exception()`,
+and route-name constants — those literals are not user-visible.
+
+### Step 4: Report as a checklist
+
+Output one section per category. Use the literal output of the underlying
+tools rather than paraphrasing — the user should be able to copy a path and
+jump straight to the line.
+
+```
+## Localization check — <branch>
+
+### 1. ARB consistency
+- ✅ All 17 locales have every key in app_en.arb
+  (or)
+- ❌ app_de.arb missing 7 keys: authConfirmPasswordLabel, ...
+  (or)
+- ⚠️  arb_consistency_test.dart not present on this branch — used inline
+     fallback. Verify before merge.
+
+### 2. Hardcoded English in changed UI files
+- ✅ No likely user-visible English literals found.
+  (or)
+- ❌ 5 candidate(s):
+  mobile/lib/screens/auth/login_options_screen.dart
+    L147:26  [Text-literal]  'Amber app is not installed'
+    L316:27  [label-arg]  'Sign in'
+  ...
+```
+
+End with one of:
+
+- ✅ **OK to push** — both checks passed.
+- ❌ **Do not push** — list the actions required.
+- ⚠️ **Push with caveat** — only after the user explicitly waives a finding,
+  documenting why in the report.
+
+## Fixing findings
+
+### Untranslated keys
+
+If the missing locale is one we ship to native speakers (the user can confirm
+the current launch list), translate. Otherwise, add the key to the
+`_knownUntranslatedDebt` set in `mobile/test/l10n/arb_consistency_test.dart`
+with a comment naming which locales still need a pass. Don't expand the debt
+set silently — it should always be reviewable as "the list of stuff that
+isn't translated yet, on purpose".
+
+### Hardcoded English
+
+Each finding has three resolutions, in order of preference:
+
+1. **Add an l10n key** to `mobile/lib/l10n/app_en.arb`, then route the
+   widget through `context.l10n.<key>`. If the value already exists under a
+   slightly different name, reuse it instead of creating a duplicate.
+2. **Mark as not user-visible.** If the literal really isn't reaching the
+   user (e.g., a debug-only widget, a developer-only flag, semantic test
+   identifier), consider whether the scanner needs an additional skip line
+   pattern. A skip rule should be earned by at least 3 distinct examples;
+   one-offs aren't worth the regex maintenance.
+3. **Waive with reason.** Brand strings that should NEVER be translated
+   ("OpenVine", "Divine") are legitimate hardcoded English. Note the waiver
+   in the PR description rather than silencing the scanner — future readers
+   should be able to see why this finding was accepted.
+
+## Common rule meanings
+
+| Rule | Catches |
+|------|---------|
+| `Text-literal` | `Text('Foo')` and `const Text("Bar")` |
+| `AppBar-title-Text` | `title: Text('Foo')` (specialization of Text-literal) |
+| `label-arg` | `label: 'Foo'` named param to any widget |
+| `title-arg` | `title: 'Foo'` named param to any widget |
+| `hintText-arg` | `hintText: 'Foo'` (form fields) |
+| `helperText-arg` | `helperText: 'Foo'` (form fields) |
+| `tooltip-arg` / `Tooltip-message` | tooltip text |
+| `semanticLabel-arg` / `semanticsLabel-arg` | accessibility labels |
+| `user-message-call` | first positional arg of a method whose name includes Error/Message/Snackbar/Toast/Dialog/Banner/Notification |
+
+## Limitations
+
+- The scanner is regex-based and will miss heavily templated code (string
+  builders, `.padLeft(...)`, `'$prefix - $suffix'` constructions). Treat a
+  clean run as "no obvious leaks", not "all leaks ruled out".
+- Brand strings ("Divine", "OpenVine", "Vine") will sometimes trip the
+  user-visible heuristic. Waive them in the PR description rather than
+  trying to silence them in the scanner.
+- The scanner only flags strings starting with a capital letter and
+  containing a space — purely lowercase or single-word UI copy
+  ("ok", "submit") will not be caught. This is a deliberate trade-off
+  for signal-to-noise; manual review remains necessary for short labels.

--- a/.claude/skills/check-l10n/scan_strings.py
+++ b/.claude/skills/check-l10n/scan_strings.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""
+Scan changed Dart files for likely user-visible English strings that
+bypass localization (l10n).
+
+Usage:
+    scan_strings.py [FILES...]
+
+If no files are given, scans the union of staged + unstaged changes
+relative to the working tree.
+
+Exit code:
+    0 → no findings
+    1 → one or more candidate leaks; details printed to stdout
+
+The scanner is intentionally noisy in the "you might have missed this"
+direction; final judgment is human. False positives are easier to
+dismiss than false negatives are to debug in production.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT_MARKER = "mobile/pubspec.yaml"
+
+
+def find_repo_root(start: Path) -> Path:
+    cur = start.resolve()
+    while cur != cur.parent:
+        if (cur / REPO_ROOT_MARKER).exists():
+            return cur
+        cur = cur.parent
+    raise SystemExit(f"Could not find {REPO_ROOT_MARKER} above {start}")
+
+
+# Paths we never scan. Patterns are matched against the path relative
+# to the repo root.
+EXCLUDED_PREFIXES = (
+    "mobile/test/",
+    "mobile/integration_test/",
+    "mobile/lib/l10n/",
+    "mobile/build/",
+    "mobile/.dart_tool/",
+)
+EXCLUDED_SUFFIXES = (
+    ".g.dart",
+    ".freezed.dart",
+    ".gr.dart",
+    ".mocks.dart",
+)
+
+
+# Lines to skip wholesale because the literal string is going to logs,
+# analytics, or developer-only surfaces — not the user.
+SKIP_LINE_PATTERNS = [
+    re.compile(r"\bLog\.(?:debug|info|warning|error|fatal|trace)\("),
+    re.compile(r"\bdeveloper\.log\("),
+    re.compile(r"\bdebugPrint\("),
+    re.compile(r"\bprint\("),
+    re.compile(r"\bassert\("),
+    re.compile(r"\bthrow\s+\w*Exception\("),
+    re.compile(r"\bthrow\s+ArgumentError\("),
+    re.compile(r"\bthrow\s+StateError\("),
+    re.compile(r"\bSemantics\(\s*identifier:"),
+    re.compile(r"\bidentifier:\s*['\"]"),
+    re.compile(r"\bRouteNames?\."),
+    # Common pure-debug / diagnostic strings
+    re.compile(r"category:\s*LogCategory"),
+    re.compile(r"name:\s*['\"][A-Z][A-Za-z]+['\"]"),  # name: 'ProfileFeedProvider'
+]
+
+
+@dataclass
+class Finding:
+    path: str
+    line_no: int
+    col: int
+    text: str
+    rule: str
+
+    def format(self) -> str:
+        return f"{self.path}:{self.line_no}:{self.col}  [{self.rule}]  {self.text}"
+
+
+# Each rule is (name, regex). The capture group `s` holds the literal.
+RULES = [
+    (
+        "Text-literal",
+        re.compile(
+            r"""\b(?:const\s+)?Text\(\s*(?P<q>['"])(?P<s>(?:(?!(?P=q)).)+)(?P=q)"""
+        ),
+    ),
+    (
+        "AppBar-title-Text",
+        re.compile(
+            r"""\btitle:\s*(?:const\s+)?Text\(\s*(?P<q>['"])(?P<s>(?:(?!(?P=q)).)+)(?P=q)"""
+        ),
+    ),
+    (
+        "label-arg",
+        re.compile(
+            r"""\blabel:\s*(?P<q>['"])(?P<s>(?:(?!(?P=q)).)+)(?P=q)"""
+        ),
+    ),
+    (
+        "title-arg",
+        re.compile(
+            r"""\btitle:\s*(?P<q>['"])(?P<s>(?:(?!(?P=q)).)+)(?P=q)"""
+        ),
+    ),
+    (
+        "hintText-arg",
+        re.compile(
+            r"""\bhintText:\s*(?P<q>['"])(?P<s>(?:(?!(?P=q)).)+)(?P=q)"""
+        ),
+    ),
+    (
+        "helperText-arg",
+        re.compile(
+            r"""\bhelperText:\s*(?P<q>['"])(?P<s>(?:(?!(?P=q)).)+)(?P=q)"""
+        ),
+    ),
+    (
+        "tooltip-arg",
+        re.compile(
+            r"""\btooltip:\s*(?P<q>['"])(?P<s>(?:(?!(?P=q)).)+)(?P=q)"""
+        ),
+    ),
+    (
+        "Tooltip-message",
+        re.compile(
+            r"""\bTooltip\([^)]*\bmessage:\s*(?P<q>['"])(?P<s>(?:(?!(?P=q)).)+)(?P=q)"""
+        ),
+    ),
+    (
+        "semanticLabel-arg",
+        re.compile(
+            r"""\bsemanticLabel:\s*(?P<q>['"])(?P<s>(?:(?!(?P=q)).)+)(?P=q)"""
+        ),
+    ),
+    (
+        "semanticsLabel-arg",
+        re.compile(
+            r"""\bsemanticsLabel:\s*(?P<q>['"])(?P<s>(?:(?!(?P=q)).)+)(?P=q)"""
+        ),
+    ),
+    # Positional string passed to a clearly user-visible setter/show call.
+    # Catches things like _setGeneralError('...'), showSnackBar('...'),
+    # showErrorDialog('...'), _setMessage("..."), etc.
+    # The (?:^|\W) anchor makes this work whether the method is at line
+    # start, after a `.`, after `_`, or after whitespace.
+    (
+        "user-message-call",
+        re.compile(
+            r"""(?:^|[^A-Za-z0-9])"""
+            r"""[_A-Za-z]*"""
+            r"""(?:[sS]how|[sS]et|[dD]isplay|[eE]mit)"""
+            r"""[A-Za-z_]*"""
+            r"""(?:Error|Message|Snackbar|SnackBar|Toast|Dialog|Banner|Notification)"""
+            r"""\(\s*(?P<q>['"])(?P<s>(?:(?!(?P=q)).)+)(?P=q)"""
+        ),
+    ),
+]
+
+
+def looks_user_visible_english(s: str) -> bool:
+    """Heuristic — does the string look like English UI copy?
+
+    True when it has at least one space-separated pair of words and
+    starts with a letter or punctuation. Excludes obvious identifiers,
+    asset paths, URLs, and machine-readable values.
+    """
+    s = s.strip()
+    if len(s) < 3:
+        return False
+    # URLs / asset paths / package URIs
+    if re.match(r"(https?:|wss?:|nostr:|asset|assets/|packages/)", s):
+        return False
+    # File-like
+    if re.fullmatch(r"[\w./-]+\.(png|jpg|svg|webp|json|dart|yaml|md)", s):
+        return False
+    # snake_case identifier
+    if re.fullmatch(r"[a-z][a-z0-9_]*", s):
+        return False
+    # SCREAMING_SNAKE
+    if re.fullmatch(r"[A-Z][A-Z0-9_]+", s):
+        return False
+    # camelCase identifier (no space)
+    if " " not in s and re.fullmatch(r"[a-zA-Z][a-zA-Z0-9]*", s):
+        return False
+    # Hex / numeric / color
+    if re.fullmatch(r"[0-9.,#xA-Fa-f-]+", s):
+        return False
+    # Format strings consisting only of placeholders
+    if re.fullmatch(r"[\s${}\w._-]*", s) and "$" in s and " " not in s:
+        return False
+    # Must contain a space OR be a clear UI sentence; if no space we
+    # probably don't have user copy unless it's a multi-word phrase
+    # already excluded above.
+    if " " not in s:
+        return False
+    # Must contain at least two letters
+    if len(re.findall(r"[A-Za-z]", s)) < 2:
+        return False
+    # If the string is already a localized lookup result it would be a
+    # variable name on the line, not a literal. Lines coming through
+    # context.l10n.* will not match the literal-string regexes above.
+    return True
+
+
+def is_skip_line(line: str) -> bool:
+    return any(p.search(line) for p in SKIP_LINE_PATTERNS)
+
+
+# Smaller number = more specific rule. Used when the same literal
+# matches multiple rules (e.g. `title: Text('Foo')` matches both
+# Text-literal and AppBar-title-Text).
+_RULE_RANK = {
+    "AppBar-title-Text": 0,
+    "Tooltip-message": 1,
+    "tooltip-arg": 2,
+    "hintText-arg": 3,
+    "helperText-arg": 4,
+    "semanticLabel-arg": 5,
+    "semanticsLabel-arg": 5,
+    "title-arg": 6,
+    "label-arg": 7,
+    "Text-literal": 99,
+}
+
+
+def _rule_specificity(rule: str) -> int:
+    return _RULE_RANK.get(rule, 50)
+
+
+def scan_file(path: Path, repo_root: Path) -> list[Finding]:
+    rel = str(path.relative_to(repo_root))
+    if any(rel.startswith(p) for p in EXCLUDED_PREFIXES):
+        return []
+    if any(rel.endswith(s) for s in EXCLUDED_SUFFIXES):
+        return []
+    if not rel.endswith(".dart"):
+        return []
+    if not rel.startswith("mobile/lib/"):
+        return []
+
+    findings: list[Finding] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, FileNotFoundError):
+        return []
+
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if is_skip_line(line):
+            continue
+        for rule_name, regex in RULES:
+            for m in regex.finditer(line):
+                literal = m.group("s")
+                if not looks_user_visible_english(literal):
+                    continue
+                findings.append(
+                    Finding(
+                        path=rel,
+                        line_no=line_no,
+                        col=m.start("s") + 1,
+                        text=literal,
+                        rule=rule_name,
+                    )
+                )
+    return findings
+
+
+def changed_files(repo_root: Path) -> list[Path]:
+    """Return files modified vs HEAD (staged + unstaged + untracked)."""
+    cmd = ["git", "-C", str(repo_root), "status", "--porcelain"]
+    out = subprocess.check_output(cmd, text=True)
+    files: list[Path] = []
+    for raw in out.splitlines():
+        if len(raw) < 4:
+            continue
+        # Format: XY <path> or XY <orig> -> <new>
+        rest = raw[3:]
+        if " -> " in rest:
+            rest = rest.split(" -> ", 1)[1]
+        candidate = repo_root / rest
+        if candidate.is_file():
+            files.append(candidate)
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Specific files to scan. Default: changed files vs working tree.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Override repo-root detection.",
+    )
+    args = parser.parse_args()
+
+    cwd = Path.cwd()
+    repo_root = (
+        Path(args.repo_root).resolve() if args.repo_root else find_repo_root(cwd)
+    )
+
+    if args.files:
+        targets = [Path(f).resolve() for f in args.files]
+    else:
+        targets = changed_files(repo_root)
+
+    all_findings: list[Finding] = []
+    for path in targets:
+        if not path.exists():
+            continue
+        all_findings.extend(scan_file(path, repo_root))
+
+    # Dedupe: a single literal on a line can match multiple rules
+    # (e.g. AppBar-title-Text and Text-literal). Keep the most specific
+    # rule by collapsing on (path, line, col, text).
+    seen: dict[tuple[str, int, int, str], Finding] = {}
+    for f in all_findings:
+        key = (f.path, f.line_no, f.col, f.text)
+        prev = seen.get(key)
+        if prev is None or _rule_specificity(f.rule) < _rule_specificity(prev.rule):
+            seen[key] = f
+    all_findings = list(seen.values())
+
+    # Group findings by file for readable output
+    if not all_findings:
+        print("No likely hardcoded English strings found.")
+        return 0
+
+    # Sort by path then line
+    all_findings.sort(key=lambda f: (f.path, f.line_no, f.col))
+
+    last_path = None
+    for f in all_findings:
+        if f.path != last_path:
+            print(f"\n  {f.path}")
+            last_path = f.path
+        print(f"    L{f.line_no}:{f.col}  [{f.rule}]  {f.text!r}")
+
+    print(
+        f"\n{len(all_findings)} candidate(s) found. Each line is a literal that "
+        "looks like user-visible English; route it through context.l10n.<key>, "
+        "or accept the false positive."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Git worktrees
 .worktrees/
+worktrees/
 
 # Flutter repo-specific
 /bin/cache/

--- a/docs/superpowers/plans/2026-04-26-subtitle-edit.md
+++ b/docs/superpowers/plans/2026-04-26-subtitle-edit.md
@@ -1,0 +1,2544 @@
+# Subtitle Edit (Author-Only) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an authenticated video author fix their own VTT captions in a focused editor; persist edits via a Kind 39307 publish + `PUT https://media.divine.video/v1/{sha256}/vtt` dual-write.
+
+**Architecture:** UI (BlocProvider page → View) → BLoC (`SubtitleEditorCubit`) → Repository (`SubtitleEditRepository`, in new `mobile/packages/subtitle_repository/`) → Clients (`BlossomVttClient` + existing `NostrClient`). VTT generation lives in the cubit (uses existing `SubtitleService`); repository takes raw bytes and a pre-signed `Event` so the package stays free of `AuthService`/Flutter deps.
+
+**Tech Stack:** Flutter, `flutter_bloc`, `equatable`, `http` (for Blossom PUT), existing `nostr_client` + `nostr_sdk`, `mocktail`, `bloc_test`, Patrol (E2E).
+
+**Spec:** `docs/superpowers/specs/2026-04-26-subtitle-edit-design.md`
+
+**Project rules to follow throughout:**
+- `mobile/.claude/CLAUDE.md` (worktree-first, BLoC for new features, never truncate Nostr IDs)
+- `mobile/.claude/rules/architecture.md` (UI → BLoC → Repository → Client; no BLoC↔BLoC)
+- `mobile/.claude/rules/state_management.md` (no error strings in state — use `addError`; use `BlocSelector`)
+- `mobile/.claude/rules/testing.md` (file structure mirrors lib/, descriptive names, single-purpose tests)
+- `mobile/.claude/rules/code_style.md` (widgets-not-methods, no hardcoded values)
+- `mobile/.claude/rules/ui_theming.md` (VineTheme, dark mode, DivineIcon)
+- 100% coverage on new files (project CI policy)
+
+---
+
+## File Structure
+
+**New package:**
+```
+mobile/packages/subtitle_repository/
+├── pubspec.yaml
+├── analysis_options.yaml
+├── README.md
+├── lib/
+│   ├── subtitle_repository.dart                     # barrel
+│   └── src/
+│       ├── blossom_vtt_client.dart                  # HTTP PUT to Blossom
+│       ├── blossom_vtt_exception.dart               # typed errors
+│       ├── save_result.dart                         # enum: full | partial
+│       └── subtitle_edit_repository.dart            # orchestrates dual-write
+└── test/
+    ├── blossom_vtt_client_test.dart
+    └── subtitle_edit_repository_test.dart
+```
+
+**New screen:**
+```
+mobile/lib/screens/subtitle_editor/
+├── subtitle_editor.dart                             # barrel
+├── cubit/
+│   ├── editable_cue.dart
+│   ├── subtitle_editor_cubit.dart
+│   └── subtitle_editor_state.dart
+└── view/
+    ├── subtitle_editor_page.dart                    # BlocProvider host
+    ├── subtitle_editor_view.dart                    # main UI
+    └── widgets/
+        ├── cue_row.dart
+        ├── single_cue_fallback.dart
+        └── widgets.dart                             # barrel
+```
+
+**New tests:**
+```
+mobile/test/screens/subtitle_editor/
+├── cubit/
+│   └── subtitle_editor_cubit_test.dart
+└── view/
+    ├── subtitle_editor_view_test.dart
+    └── widgets/
+        ├── cue_row_test.dart
+        └── single_cue_fallback_test.dart
+
+mobile/test/services/subtitle_service_test.dart      # extend (or create)
+mobile/integration_test/edit_captions_journey_test.dart
+```
+
+**Modify:**
+- `mobile/pubspec.yaml` — add `subtitle_repository` path dep.
+- `mobile/lib/widgets/video_feed_item/actions/cc_action_button.dart` — long-press for own videos.
+- `mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart` — add "Edit captions" row for own videos.
+- `mobile/lib/router/app_router.dart` — add `/edit-captions/:videoDTag` typed route.
+- `mobile/test/widgets/video_feed_item/actions/cc_action_button_test.dart` — add long-press tests.
+
+---
+
+## Chunk 1: Foundation — package skeleton + Blossom client (TDD)
+
+### Task 1.1: Create the `subtitle_repository` package skeleton
+
+**Files:**
+- Create: `mobile/packages/subtitle_repository/pubspec.yaml`
+- Create: `mobile/packages/subtitle_repository/analysis_options.yaml`
+- Create: `mobile/packages/subtitle_repository/README.md`
+- Create: `mobile/packages/subtitle_repository/lib/subtitle_repository.dart`
+
+- [ ] **Step 1: Write `pubspec.yaml`**
+
+```yaml
+name: subtitle_repository
+description: Repository for editing video subtitle (Kind 39307) tracks with dual-write to Nostr relay and Blossom media server.
+version: 0.1.0+1
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.11.0
+
+dependencies:
+  equatable: ^2.0.5
+  http: ^1.2.0
+  meta: ^1.16.0
+  nostr_sdk:
+    path: ../nostr_sdk
+  nostr_client:
+    path: ../nostr_client
+
+dev_dependencies:
+  mocktail: ^1.0.4
+  test: ^1.26.3
+  very_good_analysis: ^10.0.0
+```
+
+- [ ] **Step 2: Write `analysis_options.yaml`**
+
+```yaml
+include: package:very_good_analysis/analysis_options.yaml
+```
+
+- [ ] **Step 3: Write `README.md`**
+
+```markdown
+# subtitle_repository
+
+Repository for editing a video's subtitle track. Dual-writes a Kind 39307
+Nostr event (signed source of truth) and a `PUT /v1/{sha256}/vtt` to the
+Blossom media server (cache).
+
+Author-only writes in v1.
+```
+
+- [ ] **Step 4: Write empty barrel `lib/subtitle_repository.dart`**
+
+```dart
+// ABOUTME: Public surface of the subtitle_repository package.
+// ABOUTME: Re-exports the repository, client, result, and exception types.
+```
+
+- [ ] **Step 5: Run `flutter pub get` from `mobile/`**
+
+Expected: package resolves, no errors. Run from `mobile/`:
+
+```bash
+cd mobile && flutter pub get
+```
+
+(If pubspec workspace listing fails, append `subtitle_repository:` `path: packages/subtitle_repository` under `dependencies:` in `mobile/pubspec.yaml` first — see Task 5.1.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/packages/subtitle_repository
+git commit -m "feat(subtitle_repository): scaffold package"
+```
+
+---
+
+### Task 1.2: Define `SaveResult` and `BlossomVttException`
+
+**Files:**
+- Create: `mobile/packages/subtitle_repository/lib/src/save_result.dart`
+- Create: `mobile/packages/subtitle_repository/lib/src/blossom_vtt_exception.dart`
+- Modify: `mobile/packages/subtitle_repository/lib/subtitle_repository.dart`
+
+- [ ] **Step 1: Write `save_result.dart`**
+
+```dart
+// ABOUTME: Outcome of a dual-write subtitle save.
+// ABOUTME: `full` = relay + Blossom both succeeded; `partial` = relay
+// ABOUTME: succeeded but Blossom failed (cache will heal via reindex).
+
+/// Outcome of [SubtitleEditRepository.save].
+enum SaveResult {
+  /// Kind 39307 was published AND the Blossom PUT returned 200.
+  full,
+
+  /// Kind 39307 was published, but the Blossom PUT failed.
+  /// The cache will heal once funnelcake reindexes the new event.
+  partial,
+}
+```
+
+- [ ] **Step 2: Write `blossom_vtt_exception.dart`**
+
+```dart
+// ABOUTME: Typed errors thrown by [BlossomVttClient] for non-2xx responses.
+// ABOUTME: Maps each documented status code to a recognisable subtype.
+
+/// Base type for all Blossom VTT write failures.
+sealed class BlossomVttException implements Exception {
+  const BlossomVttException(this.statusCode, this.message);
+  final int statusCode;
+  final String message;
+
+  @override
+  String toString() => 'BlossomVttException($statusCode): $message';
+}
+
+class BlossomVttBadRequest extends BlossomVttException {
+  const BlossomVttBadRequest(String message) : super(400, message);
+}
+
+class BlossomVttUnauthorized extends BlossomVttException {
+  const BlossomVttUnauthorized(String message) : super(401, message);
+}
+
+class BlossomVttForbidden extends BlossomVttException {
+  const BlossomVttForbidden(String message) : super(403, message);
+}
+
+class BlossomVttNotFound extends BlossomVttException {
+  const BlossomVttNotFound(String message) : super(404, message);
+}
+
+class BlossomVttConflict extends BlossomVttException {
+  const BlossomVttConflict(String message) : super(409, message);
+}
+
+class BlossomVttServerError extends BlossomVttException {
+  const BlossomVttServerError(int statusCode, String message)
+      : super(statusCode, message);
+}
+```
+
+- [ ] **Step 3: Update barrel**
+
+Replace `lib/subtitle_repository.dart` contents with:
+
+```dart
+// ABOUTME: Public surface of the subtitle_repository package.
+// ABOUTME: Re-exports the repository, client, result, and exception types.
+
+export 'src/blossom_vtt_exception.dart';
+export 'src/save_result.dart';
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/packages/subtitle_repository
+git commit -m "feat(subtitle_repository): add SaveResult + BlossomVttException"
+```
+
+---
+
+### Task 1.3: TDD `BlossomVttClient` — happy path
+
+**Files:**
+- Create: `mobile/packages/subtitle_repository/test/blossom_vtt_client_test.dart`
+- Create: `mobile/packages/subtitle_repository/lib/src/blossom_vtt_client.dart`
+
+The client takes a pre-built NIP-98 `Authorization` header value (cubit owns NIP-98 construction), the sha256, and the VTT body. Keeps the package free of signing logic.
+
+- [ ] **Step 1: Write the failing test (happy path)**
+
+Create `test/blossom_vtt_client_test.dart`:
+
+```dart
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:subtitle_repository/src/blossom_vtt_client.dart';
+import 'package:subtitle_repository/subtitle_repository.dart';
+import 'package:test/test.dart';
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+class _FakeUri extends Fake implements Uri {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeUri());
+  });
+
+  group(BlossomVttClient, () {
+    late http.Client httpClient;
+    late BlossomVttClient client;
+
+    const sha256 =
+        '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8';
+    const vtt = 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhello\n';
+    const auth = 'Nostr base64encodedevent==';
+
+    setUp(() {
+      httpClient = _MockHttpClient();
+      client = BlossomVttClient(
+        httpClient: httpClient,
+        baseUri: Uri.parse('https://media.divine.video'),
+      );
+    });
+
+    group('put', () {
+      test('PUTs VTT to /v1/<sha256>/vtt with NIP-98 header on 200', () async {
+        when(() => httpClient.put(
+              any(),
+              headers: any(named: 'headers'),
+              body: any(named: 'body'),
+            )).thenAnswer(
+          (_) async => http.Response('', 200),
+        );
+
+        await client.put(sha256: sha256, vtt: vtt, nip98Authorization: auth);
+
+        final captured = verify(() => httpClient.put(
+              captureAny(),
+              headers: captureAny(named: 'headers'),
+              body: captureAny(named: 'body'),
+            )).captured;
+
+        final uri = captured[0] as Uri;
+        final headers = captured[1] as Map<String, String>;
+        final body = captured[2] as String;
+
+        expect(uri.toString(),
+            equals('https://media.divine.video/v1/$sha256/vtt'));
+        expect(headers['Authorization'], equals(auth));
+        expect(headers['Content-Type'], equals('text/vtt'));
+        expect(body, equals(vtt));
+      });
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd mobile/packages/subtitle_repository && dart test test/blossom_vtt_client_test.dart
+```
+
+Expected: COMPILE FAIL — `BlossomVttClient` not defined.
+
+- [ ] **Step 3: Write minimal implementation to pass**
+
+Create `lib/src/blossom_vtt_client.dart`:
+
+```dart
+// ABOUTME: HTTP client for `PUT /v1/{sha256}/vtt` on the Blossom media server.
+// ABOUTME: Caller supplies the NIP-98 Authorization header value.
+
+import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
+import 'package:subtitle_repository/src/blossom_vtt_exception.dart';
+
+/// Writes a corrected VTT file for the video identified by [sha256] to the
+/// Blossom media server. The caller must build and pass the NIP-98
+/// `Authorization` header value (the package stays free of signing deps).
+class BlossomVttClient {
+  BlossomVttClient({
+    required http.Client httpClient,
+    required Uri baseUri,
+  })  : _httpClient = httpClient,
+        _baseUri = baseUri;
+
+  final http.Client _httpClient;
+  final Uri _baseUri;
+
+  /// PUT the [vtt] body to `<baseUri>/v1/<sha256>/vtt`.
+  ///
+  /// Throws a [BlossomVttException] subtype on non-2xx responses.
+  @visibleForTesting
+  static const contentType = 'text/vtt';
+
+  Future<void> put({
+    required String sha256,
+    required String vtt,
+    required String nip98Authorization,
+  }) async {
+    final uri = _baseUri.replace(path: '/v1/$sha256/vtt');
+    final response = await _httpClient.put(
+      uri,
+      headers: {
+        'Authorization': nip98Authorization,
+        'Content-Type': contentType,
+      },
+      body: vtt,
+    );
+
+    if (response.statusCode == 200) return;
+
+    throw switch (response.statusCode) {
+      400 => BlossomVttBadRequest(response.body),
+      401 => BlossomVttUnauthorized(response.body),
+      403 => BlossomVttForbidden(response.body),
+      404 => BlossomVttNotFound(response.body),
+      409 => BlossomVttConflict(response.body),
+      final code when code >= 500 =>
+        BlossomVttServerError(code, response.body),
+      final code => BlossomVttServerError(code, response.body),
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd mobile/packages/subtitle_repository && dart test test/blossom_vtt_client_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/packages/subtitle_repository
+git commit -m "feat(subtitle_repository): BlossomVttClient happy-path PUT"
+```
+
+---
+
+### Task 1.4: TDD `BlossomVttClient` — error mapping
+
+- [ ] **Step 1: Add failing tests for each documented status code**
+
+Append to the `group('put', ...)` block in `blossom_vtt_client_test.dart`:
+
+```dart
+test('throws BlossomVttBadRequest on 400', () {
+  when(() => httpClient.put(any(),
+          headers: any(named: 'headers'), body: any(named: 'body')))
+      .thenAnswer((_) async => http.Response('bad vtt', 400));
+
+  expect(
+    () => client.put(sha256: sha256, vtt: vtt, nip98Authorization: auth),
+    throwsA(isA<BlossomVttBadRequest>()),
+  );
+});
+
+test('throws BlossomVttUnauthorized on 401', () {
+  when(() => httpClient.put(any(),
+          headers: any(named: 'headers'), body: any(named: 'body')))
+      .thenAnswer((_) async => http.Response('nope', 401));
+
+  expect(
+    () => client.put(sha256: sha256, vtt: vtt, nip98Authorization: auth),
+    throwsA(isA<BlossomVttUnauthorized>()),
+  );
+});
+
+test('throws BlossomVttForbidden on 403', () {
+  when(() => httpClient.put(any(),
+          headers: any(named: 'headers'), body: any(named: 'body')))
+      .thenAnswer((_) async => http.Response('not author', 403));
+
+  expect(
+    () => client.put(sha256: sha256, vtt: vtt, nip98Authorization: auth),
+    throwsA(isA<BlossomVttForbidden>()),
+  );
+});
+
+test('throws BlossomVttNotFound on 404', () {
+  when(() => httpClient.put(any(),
+          headers: any(named: 'headers'), body: any(named: 'body')))
+      .thenAnswer((_) async => http.Response('unknown sha', 404));
+
+  expect(
+    () => client.put(sha256: sha256, vtt: vtt, nip98Authorization: auth),
+    throwsA(isA<BlossomVttNotFound>()),
+  );
+});
+
+test('throws BlossomVttConflict on 409', () {
+  when(() => httpClient.put(any(),
+          headers: any(named: 'headers'), body: any(named: 'body')))
+      .thenAnswer((_) async => http.Response('conflict', 409));
+
+  expect(
+    () => client.put(sha256: sha256, vtt: vtt, nip98Authorization: auth),
+    throwsA(isA<BlossomVttConflict>()),
+  );
+});
+
+test('throws BlossomVttServerError on 500', () {
+  when(() => httpClient.put(any(),
+          headers: any(named: 'headers'), body: any(named: 'body')))
+      .thenAnswer((_) async => http.Response('boom', 500));
+
+  expect(
+    () => client.put(sha256: sha256, vtt: vtt, nip98Authorization: auth),
+    throwsA(isA<BlossomVttServerError>()),
+  );
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd mobile/packages/subtitle_repository && dart test test/blossom_vtt_client_test.dart
+```
+
+Expected: ALL PASS (mapping was already implemented in Task 1.3).
+
+- [ ] **Step 3: Update package barrel to export the client**
+
+Replace `lib/subtitle_repository.dart`:
+
+```dart
+// ABOUTME: Public surface of the subtitle_repository package.
+// ABOUTME: Re-exports the repository, client, result, and exception types.
+
+export 'src/blossom_vtt_client.dart';
+export 'src/blossom_vtt_exception.dart';
+export 'src/save_result.dart';
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/packages/subtitle_repository
+git commit -m "test(subtitle_repository): cover BlossomVttClient error mapping"
+```
+
+---
+
+## Chunk 2: SubtitleEditRepository (orchestrator, TDD)
+
+The repository takes:
+- a pre-built **signed Kind 39307 `Event`** (cubit handles signing)
+- the `sha256`, the raw `vtt` string, and the **NIP-98 Authorization header** for the Blossom PUT
+- a `NostrClient` to publish the event
+- a `BlossomVttClient` to PUT to Blossom
+
+Returns `SaveResult.full` on full success, `SaveResult.partial` if Blossom fails after relay succeeded. **Throws** if the relay publish fails (Blossom is never attempted).
+
+### Task 2.1: Write the contract test fixture
+
+**Files:**
+- Create: `mobile/packages/subtitle_repository/test/subtitle_edit_repository_test.dart`
+
+- [ ] **Step 1: Write a placeholder failing test that establishes mocks**
+
+```dart
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:subtitle_repository/src/blossom_vtt_client.dart';
+import 'package:subtitle_repository/src/subtitle_edit_repository.dart';
+import 'package:subtitle_repository/subtitle_repository.dart';
+import 'package:test/test.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockBlossomVttClient extends Mock implements BlossomVttClient {}
+
+class _FakeEvent extends Fake implements Event {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+  });
+
+  group(SubtitleEditRepository, () {
+    late _MockNostrClient nostrClient;
+    late _MockBlossomVttClient blossomClient;
+    late SubtitleEditRepository repo;
+    late Event signedEvent;
+
+    const sha256 =
+        '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8';
+    const vtt = 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhello\n';
+    const auth = 'Nostr base64encodedevent==';
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      blossomClient = _MockBlossomVttClient();
+      signedEvent = _FakeEvent();
+      repo = SubtitleEditRepository(
+        nostrClient: nostrClient,
+        blossomClient: blossomClient,
+      );
+    });
+
+    test('placeholder for contract', () {
+      expect(repo, isNotNull);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify compile failure**
+
+```bash
+cd mobile/packages/subtitle_repository && dart test test/subtitle_edit_repository_test.dart
+```
+
+Expected: COMPILE FAIL — `SubtitleEditRepository` not defined.
+
+- [ ] **Step 3: Write minimal `SubtitleEditRepository` skeleton**
+
+Create `lib/src/subtitle_edit_repository.dart`:
+
+```dart
+// ABOUTME: Orchestrates a dual-write subtitle save:
+// ABOUTME: Kind 39307 publish (must succeed) + Blossom PUT (best-effort).
+
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:subtitle_repository/src/blossom_vtt_client.dart';
+import 'package:subtitle_repository/src/save_result.dart';
+
+class SubtitleEditRepository {
+  SubtitleEditRepository({
+    required NostrClient nostrClient,
+    required BlossomVttClient blossomClient,
+  })  : _nostrClient = nostrClient,
+        _blossomClient = blossomClient;
+
+  final NostrClient _nostrClient;
+  final BlossomVttClient _blossomClient;
+
+  Future<SaveResult> save({
+    required Event signedKind39307Event,
+    required String sha256,
+    required String vtt,
+    required String nip98Authorization,
+  }) async {
+    throw UnimplementedError();
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it now compiles and passes the placeholder**
+
+```bash
+cd mobile/packages/subtitle_repository && dart test test/subtitle_edit_repository_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/packages/subtitle_repository
+git commit -m "feat(subtitle_repository): SubtitleEditRepository skeleton"
+```
+
+---
+
+### Task 2.2: TDD — relay-success + Blossom-success returns `full`
+
+- [ ] **Step 1: Replace placeholder with happy-path test**
+
+Replace the `test('placeholder for contract', ...)` block with:
+
+```dart
+test('publishes Kind 39307 then PUTs Blossom; returns full on success',
+    () async {
+  when(() => nostrClient.publishEvent(any())).thenAnswer((_) async {});
+  when(() => blossomClient.put(
+        sha256: any(named: 'sha256'),
+        vtt: any(named: 'vtt'),
+        nip98Authorization: any(named: 'nip98Authorization'),
+      )).thenAnswer((_) async {});
+
+  final result = await repo.save(
+    signedKind39307Event: signedEvent,
+    sha256: sha256,
+    vtt: vtt,
+    nip98Authorization: auth,
+  );
+
+  expect(result, equals(SaveResult.full));
+  verifyInOrder([
+    () => nostrClient.publishEvent(signedEvent),
+    () => blossomClient.put(
+          sha256: sha256,
+          vtt: vtt,
+          nip98Authorization: auth,
+        ),
+  ]);
+});
+```
+
+(Adjust `publishEvent` name to match the real `NostrClient` API — verify with `grep -n 'publishEvent\|publish(' mobile/packages/nostr_client/lib/`. If the actual method is `publish(Event)`, use that name throughout.)
+
+- [ ] **Step 2: Run, verify it fails**
+
+```bash
+cd mobile/packages/subtitle_repository && dart test test/subtitle_edit_repository_test.dart
+```
+
+Expected: FAIL — `UnimplementedError`.
+
+- [ ] **Step 3: Implement happy path**
+
+Replace `save` body:
+
+```dart
+Future<SaveResult> save({
+  required Event signedKind39307Event,
+  required String sha256,
+  required String vtt,
+  required String nip98Authorization,
+}) async {
+  await _nostrClient.publishEvent(signedKind39307Event);
+
+  try {
+    await _blossomClient.put(
+      sha256: sha256,
+      vtt: vtt,
+      nip98Authorization: nip98Authorization,
+    );
+  } catch (_) {
+    return SaveResult.partial;
+  }
+
+  return SaveResult.full;
+}
+```
+
+- [ ] **Step 4: Run, verify it passes**
+
+```bash
+cd mobile/packages/subtitle_repository && dart test test/subtitle_edit_repository_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/packages/subtitle_repository
+git commit -m "feat(subtitle_repository): happy-path dual-write returns full"
+```
+
+---
+
+### Task 2.3: TDD — Blossom failure returns `partial`
+
+- [ ] **Step 1: Add failing test**
+
+Append to the group:
+
+```dart
+test('returns partial when Blossom PUT throws (relay still succeeded)',
+    () async {
+  when(() => nostrClient.publishEvent(any())).thenAnswer((_) async {});
+  when(() => blossomClient.put(
+        sha256: any(named: 'sha256'),
+        vtt: any(named: 'vtt'),
+        nip98Authorization: any(named: 'nip98Authorization'),
+      )).thenThrow(const BlossomVttServerError(503, 'down'));
+
+  final result = await repo.save(
+    signedKind39307Event: signedEvent,
+    sha256: sha256,
+    vtt: vtt,
+    nip98Authorization: auth,
+  );
+
+  expect(result, equals(SaveResult.partial));
+  verify(() => nostrClient.publishEvent(signedEvent)).called(1);
+});
+```
+
+- [ ] **Step 2: Run; should already pass (logic written in 2.2)**
+
+```bash
+cd mobile/packages/subtitle_repository && dart test test/subtitle_edit_repository_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/packages/subtitle_repository
+git commit -m "test(subtitle_repository): Blossom failure → partial"
+```
+
+---
+
+### Task 2.4: TDD — relay failure aborts, never calls Blossom
+
+- [ ] **Step 1: Add failing test**
+
+```dart
+test('rethrows on relay failure and never calls Blossom', () async {
+  when(() => nostrClient.publishEvent(any())).thenThrow(StateError('relay'));
+
+  await expectLater(
+    () => repo.save(
+      signedKind39307Event: signedEvent,
+      sha256: sha256,
+      vtt: vtt,
+      nip98Authorization: auth,
+    ),
+    throwsA(isA<StateError>()),
+  );
+
+  verifyNever(() => blossomClient.put(
+        sha256: any(named: 'sha256'),
+        vtt: any(named: 'vtt'),
+        nip98Authorization: any(named: 'nip98Authorization'),
+      ));
+});
+```
+
+- [ ] **Step 2: Run, verify it passes** (already enforced by `await` order in 2.2)
+
+```bash
+cd mobile/packages/subtitle_repository && dart test test/subtitle_edit_repository_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Update package barrel to export the repository**
+
+Add to `lib/subtitle_repository.dart`:
+
+```dart
+export 'src/subtitle_edit_repository.dart';
+```
+
+- [ ] **Step 4: Run analyzer**
+
+```bash
+cd mobile/packages/subtitle_repository && dart analyze
+```
+
+Expected: 0 issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/packages/subtitle_repository
+git commit -m "test(subtitle_repository): relay failure aborts before Blossom"
+```
+
+---
+
+## Chunk 3: Cubit + state (TDD with `bloc_test`)
+
+### Task 3.1: Define `EditableCue` value object
+
+**Files:**
+- Create: `mobile/lib/screens/subtitle_editor/cubit/editable_cue.dart`
+- Create: `mobile/test/screens/subtitle_editor/cubit/editable_cue_test.dart`
+
+- [ ] **Step 1: Write failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/screens/subtitle_editor/cubit/editable_cue.dart';
+
+void main() {
+  group(EditableCue, () {
+    test('equates by value', () {
+      const a = EditableCue(startMs: 0, endMs: 1000, text: 'hi');
+      const b = EditableCue(startMs: 0, endMs: 1000, text: 'hi');
+      expect(a, equals(b));
+    });
+
+    test('copyWith replaces only specified fields', () {
+      const a = EditableCue(startMs: 0, endMs: 1000, text: 'hi');
+      expect(
+        a.copyWith(text: 'hey'),
+        equals(const EditableCue(startMs: 0, endMs: 1000, text: 'hey')),
+      );
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test, verify fail**
+
+```bash
+cd mobile && flutter test test/screens/subtitle_editor/cubit/editable_cue_test.dart
+```
+
+Expected: COMPILE FAIL.
+
+- [ ] **Step 3: Implement**
+
+```dart
+// ABOUTME: Mutable-text view of a SubtitleCue used by the editor cubit.
+// ABOUTME: Timing fields are immutable in v1; only `text` can change.
+
+import 'package:equatable/equatable.dart';
+
+class EditableCue extends Equatable {
+  const EditableCue({
+    required this.startMs,
+    required this.endMs,
+    required this.text,
+  });
+
+  final int startMs;
+  final int endMs;
+  final String text;
+
+  EditableCue copyWith({String? text}) => EditableCue(
+        startMs: startMs,
+        endMs: endMs,
+        text: text ?? this.text,
+      );
+
+  @override
+  List<Object?> get props => [startMs, endMs, text];
+}
+```
+
+- [ ] **Step 4: Run, pass, commit**
+
+```bash
+cd mobile && flutter test test/screens/subtitle_editor/cubit/editable_cue_test.dart
+git add mobile/lib/screens/subtitle_editor mobile/test/screens/subtitle_editor
+git commit -m "feat(subtitle_editor): EditableCue value object"
+```
+
+---
+
+### Task 3.2: Define `SubtitleEditorState`
+
+**Files:**
+- Create: `mobile/lib/screens/subtitle_editor/cubit/subtitle_editor_state.dart`
+- Create: `mobile/test/screens/subtitle_editor/cubit/subtitle_editor_state_test.dart`
+
+- [ ] **Step 1: Failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/screens/subtitle_editor/cubit/editable_cue.dart';
+import 'package:openvine/screens/subtitle_editor/cubit/subtitle_editor_state.dart';
+
+void main() {
+  group(SubtitleEditorState, () {
+    const cueA = EditableCue(startMs: 0, endMs: 500, text: 'hi');
+    const cueB = EditableCue(startMs: 500, endMs: 1000, text: 'world');
+
+    SubtitleEditorState base() => SubtitleEditorState(
+          status: SubtitleEditorStatus.editing,
+          cues: const [cueA, cueB],
+          originalCues: const [cueA, cueB],
+          videoId:
+              '64a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f',
+          videoDTag: 'my-vid',
+          sha256:
+              '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8',
+          videoDurationMs: 6000,
+          language: 'en',
+        );
+
+    test('isDirty is false when cues match originalCues', () {
+      expect(base().isDirty, isFalse);
+    });
+
+    test('isDirty is true when any cue text differs', () {
+      final s = base().copyWith(cues: [cueA.copyWith(text: 'HI'), cueB]);
+      expect(s.isDirty, isTrue);
+    });
+
+    test('isFallbackMode is true when originalCues has 1 empty cue', () {
+      final s = base().copyWith(
+        cues: const [EditableCue(startMs: 0, endMs: 6000, text: '')],
+        originalCues: const [EditableCue(startMs: 0, endMs: 6000, text: '')],
+      );
+      expect(s.isFallbackMode, isTrue);
+    });
+
+    test('isFallbackMode is false for normal cue lists', () {
+      expect(base().isFallbackMode, isFalse);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+```bash
+cd mobile && flutter test test/screens/subtitle_editor/cubit/subtitle_editor_state_test.dart
+```
+
+- [ ] **Step 3: Implement**
+
+```dart
+// ABOUTME: State for the subtitle editor screen.
+// ABOUTME: status enum drives UI; cues vs originalCues drives the dirty flag.
+// ABOUTME: No error fields — errors flow via cubit.addError per project rule.
+
+import 'package:equatable/equatable.dart';
+import 'package:openvine/screens/subtitle_editor/cubit/editable_cue.dart';
+
+enum SubtitleEditorStatus {
+  initial,
+  loading,
+  editing,
+  saving,
+  success,
+  partialSuccess,
+  failure,
+}
+
+class SubtitleEditorState extends Equatable {
+  const SubtitleEditorState({
+    this.status = SubtitleEditorStatus.initial,
+    this.cues = const [],
+    this.originalCues = const [],
+    this.videoId = '',
+    this.videoDTag = '',
+    this.sha256,
+    this.videoDurationMs = 0,
+    this.language = 'en',
+  });
+
+  final SubtitleEditorStatus status;
+  final List<EditableCue> cues;
+  final List<EditableCue> originalCues;
+  final String videoId;
+  final String videoDTag;
+  final String? sha256;
+  final int videoDurationMs;
+  final String language;
+
+  bool get isDirty {
+    if (cues.length != originalCues.length) return true;
+    for (var i = 0; i < cues.length; i++) {
+      if (cues[i] != originalCues[i]) return true;
+    }
+    return false;
+  }
+
+  bool get isFallbackMode =>
+      originalCues.length <= 1 &&
+      (originalCues.isEmpty || originalCues.first.text.isEmpty);
+
+  SubtitleEditorState copyWith({
+    SubtitleEditorStatus? status,
+    List<EditableCue>? cues,
+    List<EditableCue>? originalCues,
+    String? videoId,
+    String? videoDTag,
+    String? sha256,
+    int? videoDurationMs,
+    String? language,
+  }) =>
+      SubtitleEditorState(
+        status: status ?? this.status,
+        cues: cues ?? this.cues,
+        originalCues: originalCues ?? this.originalCues,
+        videoId: videoId ?? this.videoId,
+        videoDTag: videoDTag ?? this.videoDTag,
+        sha256: sha256 ?? this.sha256,
+        videoDurationMs: videoDurationMs ?? this.videoDurationMs,
+        language: language ?? this.language,
+      );
+
+  @override
+  List<Object?> get props => [
+        status,
+        cues,
+        originalCues,
+        videoId,
+        videoDTag,
+        sha256,
+        videoDurationMs,
+        language,
+      ];
+}
+```
+
+- [ ] **Step 4: Run, pass, commit**
+
+```bash
+cd mobile && flutter test test/screens/subtitle_editor/cubit/subtitle_editor_state_test.dart
+git add mobile/lib/screens/subtitle_editor mobile/test/screens/subtitle_editor
+git commit -m "feat(subtitle_editor): state object with isDirty/isFallbackMode"
+```
+
+---
+
+### Task 3.3: TDD `SubtitleEditorCubit` — initialization
+
+**Files:**
+- Create: `mobile/lib/screens/subtitle_editor/cubit/subtitle_editor_cubit.dart`
+- Create: `mobile/test/screens/subtitle_editor/cubit/subtitle_editor_cubit_test.dart`
+
+The cubit takes a small set of injected collaborators and a one-shot `init(...)` call from the page that hydrates state from the existing cues fetched via `subtitleCuesProvider`.
+
+The cubit's responsibilities:
+1. **start**: seed `cues`/`originalCues` from existing parsed cues; if empty, synthesize a single empty cue spanning the video duration.
+2. **updateCueText(index, text)**: replace cue at index.
+3. **save()**: build VTT, sign Kind 39307 via injected signer, build NIP-98 via injected signer, call repository, emit success/partialSuccess/failure.
+4. **discard()**: revert `cues` to `originalCues`.
+
+Inject signing/auth as **function references** to keep the cubit free of `AuthService` directly:
+```dart
+typedef SignKind39307 = Future<Event?> Function({
+  required String content,
+  required List<List<String>> tags,
+});
+
+typedef BuildNip98Authorization = Future<String> Function({
+  required String method,
+  required Uri url,
+  required String body,
+});
+```
+
+- [ ] **Step 1: Failing test for init**
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/screens/subtitle_editor/cubit/editable_cue.dart';
+import 'package:openvine/screens/subtitle_editor/cubit/subtitle_editor_cubit.dart';
+import 'package:openvine/screens/subtitle_editor/cubit/subtitle_editor_state.dart';
+import 'package:openvine/services/subtitle_service.dart';
+import 'package:subtitle_repository/subtitle_repository.dart';
+
+class _MockRepo extends Mock implements SubtitleEditRepository {}
+
+void main() {
+  group(SubtitleEditorCubit, () {
+    late _MockRepo repo;
+
+    setUp(() {
+      repo = _MockRepo();
+    });
+
+    SubtitleEditorCubit makeCubit() => SubtitleEditorCubit(
+          repository: repo,
+          signKind39307: ({required content, required tags}) async => null,
+          buildNip98Authorization:
+              ({required method, required url, required body}) async => '',
+        );
+
+    blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+      'init seeds cues from non-empty list',
+      build: makeCubit,
+      act: (c) => c.init(
+        videoId: 'vid-id-' + 'a' * 56,
+        videoDTag: 'my-vid',
+        sha256: 'b' * 64,
+        videoDurationMs: 6000,
+        language: 'en',
+        existingCues: const [
+          SubtitleCue(start: 0, end: 1000, text: 'hello'),
+          SubtitleCue(start: 1000, end: 2000, text: 'world'),
+        ],
+      ),
+      expect: () => [
+        isA<SubtitleEditorState>()
+            .having((s) => s.status, 'status', SubtitleEditorStatus.editing)
+            .having((s) => s.cues.length, 'cues.length', 2)
+            .having((s) => s.cues.first.text, 'cues[0].text', 'hello')
+            .having((s) => s.isDirty, 'isDirty', false)
+            .having((s) => s.isFallbackMode, 'isFallbackMode', false),
+      ],
+    );
+
+    blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+      'init falls back to single empty cue when existing cues are empty',
+      build: makeCubit,
+      act: (c) => c.init(
+        videoId: 'vid-id-' + 'a' * 56,
+        videoDTag: 'my-vid',
+        sha256: 'b' * 64,
+        videoDurationMs: 6000,
+        language: 'en',
+        existingCues: const [],
+      ),
+      expect: () => [
+        isA<SubtitleEditorState>()
+            .having((s) => s.cues.length, 'cues.length', 1)
+            .having((s) => s.cues.first.startMs, 'startMs', 0)
+            .having((s) => s.cues.first.endMs, 'endMs', 6000)
+            .having((s) => s.cues.first.text, 'text', '')
+            .having((s) => s.isFallbackMode, 'isFallbackMode', true),
+      ],
+    );
+
+    blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+      'init defaults videoDurationMs to 6000 when zero',
+      build: makeCubit,
+      act: (c) => c.init(
+        videoId: 'vid-id-' + 'a' * 56,
+        videoDTag: 'my-vid',
+        sha256: null,
+        videoDurationMs: 0,
+        language: 'en',
+        existingCues: const [],
+      ),
+      expect: () => [
+        isA<SubtitleEditorState>()
+            .having((s) => s.cues.first.endMs, 'endMs', 6000),
+      ],
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+```bash
+cd mobile && flutter test test/screens/subtitle_editor/cubit/subtitle_editor_cubit_test.dart
+```
+
+Expected: COMPILE FAIL.
+
+- [ ] **Step 3: Implement cubit (init only for now)**
+
+```dart
+// ABOUTME: Cubit for the subtitle editor screen.
+// ABOUTME: Hydrates cues, tracks dirty state, dual-writes via repository.
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/screens/subtitle_editor/cubit/editable_cue.dart';
+import 'package:openvine/screens/subtitle_editor/cubit/subtitle_editor_state.dart';
+import 'package:openvine/services/subtitle_service.dart';
+import 'package:subtitle_repository/subtitle_repository.dart';
+
+typedef SignKind39307 = Future<Event?> Function({
+  required String content,
+  required List<List<String>> tags,
+});
+
+typedef BuildNip98Authorization = Future<String> Function({
+  required String method,
+  required Uri url,
+  required String body,
+});
+
+class SubtitleEditorCubit extends Cubit<SubtitleEditorState> {
+  SubtitleEditorCubit({
+    required SubtitleEditRepository repository,
+    required SignKind39307 signKind39307,
+    required BuildNip98Authorization buildNip98Authorization,
+  })  : _repository = repository,
+        _signKind39307 = signKind39307,
+        _buildNip98Authorization = buildNip98Authorization,
+        super(const SubtitleEditorState());
+
+  final SubtitleEditRepository _repository;
+  final SignKind39307 _signKind39307;
+  final BuildNip98Authorization _buildNip98Authorization;
+
+  static const _defaultDurationMs = 6000;
+
+  void init({
+    required String videoId,
+    required String videoDTag,
+    required String? sha256,
+    required int videoDurationMs,
+    required String language,
+    required List<SubtitleCue> existingCues,
+  }) {
+    final durationMs =
+        videoDurationMs <= 0 ? _defaultDurationMs : videoDurationMs;
+
+    final seed = existingCues.isEmpty
+        ? <EditableCue>[
+            EditableCue(startMs: 0, endMs: durationMs, text: ''),
+          ]
+        : existingCues
+            .map((c) =>
+                EditableCue(startMs: c.start, endMs: c.end, text: c.text))
+            .toList(growable: false);
+
+    emit(SubtitleEditorState(
+      status: SubtitleEditorStatus.editing,
+      cues: seed,
+      originalCues: seed,
+      videoId: videoId,
+      videoDTag: videoDTag,
+      sha256: sha256,
+      videoDurationMs: durationMs,
+      language: language,
+    ));
+  }
+}
+```
+
+- [ ] **Step 4: Run, pass, commit**
+
+```bash
+cd mobile && flutter test test/screens/subtitle_editor/cubit/subtitle_editor_cubit_test.dart
+git add mobile/lib/screens/subtitle_editor mobile/test/screens/subtitle_editor
+git commit -m "feat(subtitle_editor): cubit init with single-cue fallback"
+```
+
+---
+
+### Task 3.4: TDD `updateCueText` and `discard`
+
+- [ ] **Step 1: Append tests**
+
+```dart
+blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+  'updateCueText replaces text at index and flips isDirty',
+  build: makeCubit,
+  seed: () => SubtitleEditorState(
+    status: SubtitleEditorStatus.editing,
+    cues: const [EditableCue(startMs: 0, endMs: 500, text: 'a')],
+    originalCues: const [EditableCue(startMs: 0, endMs: 500, text: 'a')],
+    videoDurationMs: 6000,
+  ),
+  act: (c) => c.updateCueText(0, 'b'),
+  expect: () => [
+    isA<SubtitleEditorState>()
+        .having((s) => s.cues.first.text, 'text', 'b')
+        .having((s) => s.isDirty, 'isDirty', true),
+  ],
+);
+
+blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+  'discard reverts cues to originalCues',
+  build: makeCubit,
+  seed: () => SubtitleEditorState(
+    status: SubtitleEditorStatus.editing,
+    cues: const [EditableCue(startMs: 0, endMs: 500, text: 'EDITED')],
+    originalCues: const [EditableCue(startMs: 0, endMs: 500, text: 'a')],
+    videoDurationMs: 6000,
+  ),
+  act: (c) => c.discard(),
+  expect: () => [
+    isA<SubtitleEditorState>()
+        .having((s) => s.cues.first.text, 'text', 'a')
+        .having((s) => s.isDirty, 'isDirty', false),
+  ],
+);
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+- [ ] **Step 3: Implement**
+
+Add to cubit:
+
+```dart
+void updateCueText(int index, String text) {
+  final next = [...state.cues];
+  next[index] = next[index].copyWith(text: text);
+  emit(state.copyWith(cues: next));
+}
+
+void discard() {
+  emit(state.copyWith(cues: state.originalCues));
+}
+```
+
+- [ ] **Step 4: Run, pass, commit**
+
+```bash
+cd mobile && flutter test test/screens/subtitle_editor/cubit/subtitle_editor_cubit_test.dart
+git add mobile/lib/screens/subtitle_editor mobile/test/screens/subtitle_editor
+git commit -m "feat(subtitle_editor): updateCueText + discard"
+```
+
+---
+
+### Task 3.5: TDD `save()` — happy path emits `success`
+
+- [ ] **Step 1: Append test**
+
+```dart
+blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+  'save emits saving → success when repo returns SaveResult.full',
+  build: () {
+    when(() => repo.save(
+          signedKind39307Event: any(named: 'signedKind39307Event'),
+          sha256: any(named: 'sha256'),
+          vtt: any(named: 'vtt'),
+          nip98Authorization: any(named: 'nip98Authorization'),
+        )).thenAnswer((_) async => SaveResult.full);
+    return SubtitleEditorCubit(
+      repository: repo,
+      signKind39307: ({required content, required tags}) async =>
+          _stubEvent(),
+      buildNip98Authorization:
+          ({required method, required url, required body}) async =>
+              'Nostr stubbed',
+    );
+  },
+  seed: () => SubtitleEditorState(
+    status: SubtitleEditorStatus.editing,
+    cues: const [EditableCue(startMs: 0, endMs: 500, text: 'edit')],
+    originalCues: const [EditableCue(startMs: 0, endMs: 500, text: 'orig')],
+    videoId: 'vid' + 'a' * 61,
+    videoDTag: 'd-tag',
+    sha256: 'b' * 64,
+    videoDurationMs: 6000,
+    language: 'en',
+  ),
+  act: (c) => c.save(),
+  expect: () => [
+    isA<SubtitleEditorState>()
+        .having((s) => s.status, 'status', SubtitleEditorStatus.saving),
+    isA<SubtitleEditorState>()
+        .having((s) => s.status, 'status', SubtitleEditorStatus.success),
+  ],
+);
+```
+
+Add helper at top of file:
+
+```dart
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+Event _stubEvent() => Event(
+      'a' * 64,
+      39307,
+      const [],
+      'WEBVTT\n\n00:00:00.000 --> 00:00:00.500\nedit\n',
+    );
+```
+
+- [ ] **Step 2: Run, verify fail (no save() yet)**
+
+- [ ] **Step 3: Implement save()**
+
+Add to cubit:
+
+```dart
+Future<void> save() async {
+  final sha256 = state.sha256;
+  if (sha256 == null || sha256.isEmpty) {
+    emit(state.copyWith(status: SubtitleEditorStatus.failure));
+    return;
+  }
+
+  emit(state.copyWith(status: SubtitleEditorStatus.saving));
+
+  try {
+    final vtt = SubtitleService.generateVtt(
+      state.cues
+          .map((c) => SubtitleCue(start: c.startMs, end: c.endMs, text: c.text))
+          .toList(),
+    );
+
+    final tags = <List<String>>[
+      ['d', 'subtitles:${state.videoDTag}'],
+      ['e', state.videoId],
+      ['language', state.language],
+      ['alt', 'Subtitle track'],
+    ];
+
+    final signed = await _signKind39307(content: vtt, tags: tags);
+    if (signed == null) {
+      emit(state.copyWith(status: SubtitleEditorStatus.failure));
+      return;
+    }
+
+    final url = Uri.parse('https://media.divine.video/v1/$sha256/vtt');
+    final auth = await _buildNip98Authorization(
+      method: 'PUT',
+      url: url,
+      body: vtt,
+    );
+
+    final result = await _repository.save(
+      signedKind39307Event: signed,
+      sha256: sha256,
+      vtt: vtt,
+      nip98Authorization: auth,
+    );
+
+    emit(state.copyWith(
+      status: result == SaveResult.full
+          ? SubtitleEditorStatus.success
+          : SubtitleEditorStatus.partialSuccess,
+      originalCues: state.cues,
+    ));
+  } catch (e, stack) {
+    addError(e, stack);
+    emit(state.copyWith(status: SubtitleEditorStatus.failure));
+  }
+}
+```
+
+- [ ] **Step 4: Run, pass, commit**
+
+```bash
+cd mobile && flutter test test/screens/subtitle_editor/cubit/subtitle_editor_cubit_test.dart
+git add mobile/lib/screens/subtitle_editor mobile/test/screens/subtitle_editor
+git commit -m "feat(subtitle_editor): save() happy path emits success"
+```
+
+---
+
+### Task 3.6: TDD `save()` partial + failure paths
+
+- [ ] **Step 1: Append tests**
+
+```dart
+blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+  'save emits partialSuccess when repo returns SaveResult.partial',
+  build: () {
+    when(() => repo.save(
+          signedKind39307Event: any(named: 'signedKind39307Event'),
+          sha256: any(named: 'sha256'),
+          vtt: any(named: 'vtt'),
+          nip98Authorization: any(named: 'nip98Authorization'),
+        )).thenAnswer((_) async => SaveResult.partial);
+    return SubtitleEditorCubit(
+      repository: repo,
+      signKind39307: ({required content, required tags}) async => _stubEvent(),
+      buildNip98Authorization:
+          ({required method, required url, required body}) async => 'auth',
+    );
+  },
+  seed: () => /* same seed as 3.5 */ ,
+  act: (c) => c.save(),
+  expect: () => [
+    isA<SubtitleEditorState>()
+        .having((s) => s.status, 'status', SubtitleEditorStatus.saving),
+    isA<SubtitleEditorState>()
+        .having(
+            (s) => s.status, 'status', SubtitleEditorStatus.partialSuccess),
+  ],
+);
+
+blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+  'save emits failure and reports error when repo throws',
+  build: () {
+    when(() => repo.save(
+          signedKind39307Event: any(named: 'signedKind39307Event'),
+          sha256: any(named: 'sha256'),
+          vtt: any(named: 'vtt'),
+          nip98Authorization: any(named: 'nip98Authorization'),
+        )).thenThrow(StateError('relay down'));
+    return SubtitleEditorCubit(
+      repository: repo,
+      signKind39307: ({required content, required tags}) async => _stubEvent(),
+      buildNip98Authorization:
+          ({required method, required url, required body}) async => 'auth',
+    );
+  },
+  seed: () => /* same seed */ ,
+  act: (c) => c.save(),
+  expect: () => [
+    isA<SubtitleEditorState>()
+        .having((s) => s.status, 'status', SubtitleEditorStatus.saving),
+    isA<SubtitleEditorState>()
+        .having((s) => s.status, 'status', SubtitleEditorStatus.failure),
+  ],
+  errors: () => [isA<StateError>()],
+);
+
+blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+  'save emits failure when sha256 is null',
+  build: makeCubit,
+  seed: () => SubtitleEditorState(
+    status: SubtitleEditorStatus.editing,
+    cues: const [EditableCue(startMs: 0, endMs: 500, text: 'edit')],
+    originalCues: const [EditableCue(startMs: 0, endMs: 500, text: 'orig')],
+    videoDurationMs: 6000,
+  ),
+  act: (c) => c.save(),
+  expect: () => [
+    isA<SubtitleEditorState>()
+        .having((s) => s.status, 'status', SubtitleEditorStatus.failure),
+  ],
+);
+```
+
+- [ ] **Step 2: Run, expect all pass** (logic already in 3.5).
+
+- [ ] **Step 3: Add barrel `mobile/lib/screens/subtitle_editor/subtitle_editor.dart`**
+
+```dart
+// ABOUTME: Public surface of the subtitle_editor feature.
+export 'cubit/editable_cue.dart';
+export 'cubit/subtitle_editor_cubit.dart';
+export 'cubit/subtitle_editor_state.dart';
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/lib/screens/subtitle_editor mobile/test/screens/subtitle_editor
+git commit -m "test(subtitle_editor): partial-success + failure + missing-sha"
+```
+
+---
+
+## Chunk 4: View + widgets
+
+### Task 4.1: `CueRow` widget (TDD)
+
+**Files:**
+- Create: `mobile/lib/screens/subtitle_editor/view/widgets/cue_row.dart`
+- Create: `mobile/test/screens/subtitle_editor/view/widgets/cue_row_test.dart`
+
+A row that renders timestamp range + a `TextField` bound to a cue's text. Pure widget — takes the text + `onChanged` callback.
+
+- [ ] **Step 1: Failing widget test**
+
+```dart
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/screens/subtitle_editor/view/widgets/cue_row.dart';
+
+void main() {
+  group(CueRow, () {
+    testWidgets('renders formatted timestamp range', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData.dark(),
+        home: Scaffold(
+          body: CueRow(
+            startMs: 1500,
+            endMs: 2750,
+            text: 'hello',
+            onChanged: (_) {},
+          ),
+        ),
+      ));
+
+      expect(find.text('00:01.500 – 00:02.750'), findsOneWidget);
+      expect(find.text('hello'), findsOneWidget);
+    });
+
+    testWidgets('calls onChanged when text edited', (tester) async {
+      var captured = '';
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData.dark(),
+        home: Scaffold(
+          body: CueRow(
+            startMs: 0,
+            endMs: 500,
+            text: 'hi',
+            onChanged: (v) => captured = v,
+          ),
+        ),
+      ));
+
+      await tester.enterText(find.byType(TextField), 'hey');
+      expect(captured, equals('hey'));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run, fail.**
+
+- [ ] **Step 3: Implement**
+
+```dart
+// ABOUTME: Renders one cue's timestamp + editable text field.
+// ABOUTME: Pure widget — parent cubit owns the data and handles changes.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+
+class CueRow extends StatelessWidget {
+  const CueRow({
+    required this.startMs,
+    required this.endMs,
+    required this.text,
+    required this.onChanged,
+    super.key,
+  });
+
+  final int startMs;
+  final int endMs;
+  final String text;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 6,
+        children: [
+          Text(
+            '${_format(startMs)} – ${_format(endMs)}',
+            style: VineTheme.labelSmallFont(color: VineTheme.secondaryText),
+          ),
+          TextFormField(
+            initialValue: text,
+            onChanged: onChanged,
+            maxLength: 2000,
+            maxLines: null,
+            style: VineTheme.bodyMediumFont(),
+            decoration: const InputDecoration(border: OutlineInputBorder()),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _format(int ms) {
+    final m = (ms ~/ 60000).toString().padLeft(2, '0');
+    final s = ((ms % 60000) ~/ 1000).toString().padLeft(2, '0');
+    final mmm = (ms % 1000).toString().padLeft(3, '0');
+    return '$m:$s.$mmm';
+  }
+}
+```
+
+(`TextFormField` with `initialValue` rebuilds correctly when the parent state's text matches; if the test fails because controller state desyncs, switch to a `StatefulWidget` with a `TextEditingController` keyed on `(startMs,endMs)`.)
+
+- [ ] **Step 4: Run, pass, commit**
+
+```bash
+cd mobile && flutter test test/screens/subtitle_editor/view/widgets/cue_row_test.dart
+git add mobile/lib/screens/subtitle_editor mobile/test/screens/subtitle_editor
+git commit -m "feat(subtitle_editor): CueRow widget"
+```
+
+---
+
+### Task 4.2: `SingleCueFallback` widget (TDD)
+
+**Files:**
+- Create: `mobile/lib/screens/subtitle_editor/view/widgets/single_cue_fallback.dart`
+- Create: `mobile/test/screens/subtitle_editor/view/widgets/single_cue_fallback_test.dart`
+
+- [ ] **Step 1: Failing test**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/screens/subtitle_editor/view/widgets/single_cue_fallback.dart';
+
+void main() {
+  group(SingleCueFallback, () {
+    testWidgets('shows duration in label and routes onChanged',
+        (tester) async {
+      var captured = '';
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData.dark(),
+        home: Scaffold(
+          body: SingleCueFallback(
+            durationMs: 6000,
+            text: '',
+            onChanged: (v) => captured = v,
+          ),
+        ),
+      ));
+
+      expect(find.text('Captions for full video (0:00 – 0:06)'),
+          findsOneWidget);
+      await tester.enterText(find.byType(TextField), 'all of it');
+      expect(captured, equals('all of it'));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Implement**
+
+```dart
+// ABOUTME: Single-textarea fallback when the parsed VTT had zero cues.
+// ABOUTME: One cue spans 0..durationMs; user types the whole transcript.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+
+class SingleCueFallback extends StatelessWidget {
+  const SingleCueFallback({
+    required this.durationMs,
+    required this.text,
+    required this.onChanged,
+    super.key,
+  });
+
+  final int durationMs;
+  final String text;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 8,
+        children: [
+          Text(
+            'Captions for full video (0:00 – ${_durationLabel(durationMs)})',
+            style: VineTheme.labelSmallFont(color: VineTheme.secondaryText),
+          ),
+          TextFormField(
+            initialValue: text,
+            onChanged: onChanged,
+            maxLines: 6,
+            maxLength: 2000,
+            style: VineTheme.bodyMediumFont(),
+            decoration: const InputDecoration(border: OutlineInputBorder()),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _durationLabel(int ms) {
+    final s = (ms / 1000).round();
+    return '0:${s.toString().padLeft(2, '0')}';
+  }
+}
+```
+
+- [ ] **Step 3: Run, pass, commit**
+
+```bash
+cd mobile && flutter test test/screens/subtitle_editor/view/widgets/single_cue_fallback_test.dart
+git add mobile/lib/screens/subtitle_editor mobile/test/screens/subtitle_editor
+git commit -m "feat(subtitle_editor): SingleCueFallback widget"
+```
+
+---
+
+### Task 4.3: `SubtitleEditorView` (TDD)
+
+**Files:**
+- Create: `mobile/lib/screens/subtitle_editor/view/subtitle_editor_view.dart`
+- Create: `mobile/test/screens/subtitle_editor/view/subtitle_editor_view_test.dart`
+
+The view assumes a `SubtitleEditorCubit` is provided above it. Renders:
+- AppBar with X (close) and Save (disabled when not dirty).
+- Body: cue list OR `SingleCueFallback`.
+- Listens for `success`/`partialSuccess`/`failure` to fire snackbars and pop on success.
+
+- [ ] **Step 1: Failing test — renders cue list, save disabled**
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/screens/subtitle_editor/cubit/editable_cue.dart';
+import 'package:openvine/screens/subtitle_editor/cubit/subtitle_editor_cubit.dart';
+import 'package:openvine/screens/subtitle_editor/cubit/subtitle_editor_state.dart';
+import 'package:openvine/screens/subtitle_editor/view/subtitle_editor_view.dart';
+
+class _MockCubit extends MockCubit<SubtitleEditorState>
+    implements SubtitleEditorCubit {}
+
+void main() {
+  group(SubtitleEditorView, () {
+    late _MockCubit cubit;
+
+    setUp(() {
+      cubit = _MockCubit();
+    });
+
+    testWidgets('renders cues and disables Save when not dirty',
+        (tester) async {
+      whenListen(
+        cubit,
+        const Stream<SubtitleEditorState>.empty(),
+        initialState: const SubtitleEditorState(
+          status: SubtitleEditorStatus.editing,
+          cues: [EditableCue(startMs: 0, endMs: 500, text: 'a')],
+          originalCues: [EditableCue(startMs: 0, endMs: 500, text: 'a')],
+          videoDurationMs: 6000,
+        ),
+      );
+
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData.dark(),
+        home: BlocProvider<SubtitleEditorCubit>.value(
+          value: cubit,
+          child: const SubtitleEditorView(),
+        ),
+      ));
+
+      expect(find.text('Edit captions'), findsOneWidget);
+      expect(find.text('a'), findsOneWidget);
+      final save = tester.widget<TextButton>(find.widgetWithText(TextButton, 'Save'));
+      expect(save.onPressed, isNull);
+    });
+
+    testWidgets('renders single-cue fallback when isFallbackMode',
+        (tester) async {
+      whenListen(
+        cubit,
+        const Stream<SubtitleEditorState>.empty(),
+        initialState: const SubtitleEditorState(
+          status: SubtitleEditorStatus.editing,
+          cues: [EditableCue(startMs: 0, endMs: 6000, text: '')],
+          originalCues: [EditableCue(startMs: 0, endMs: 6000, text: '')],
+          videoDurationMs: 6000,
+        ),
+      );
+
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData.dark(),
+        home: BlocProvider<SubtitleEditorCubit>.value(
+          value: cubit,
+          child: const SubtitleEditorView(),
+        ),
+      ));
+
+      expect(find.text('Captions for full video (0:00 – 0:06)'),
+          findsOneWidget);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Implement view**
+
+```dart
+// ABOUTME: Stateless view for the subtitle editor.
+// ABOUTME: Reacts to status via BlocListener; rebuilds list via BlocSelector.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:openvine/screens/subtitle_editor/cubit/subtitle_editor_cubit.dart';
+import 'package:openvine/screens/subtitle_editor/cubit/subtitle_editor_state.dart';
+import 'package:openvine/screens/subtitle_editor/view/widgets/cue_row.dart';
+import 'package:openvine/screens/subtitle_editor/view/widgets/single_cue_fallback.dart';
+
+class SubtitleEditorView extends StatelessWidget {
+  @visibleForTesting
+  const SubtitleEditorView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<SubtitleEditorCubit, SubtitleEditorState>(
+      listenWhen: (p, c) => p.status != c.status,
+      listener: _onStatusChange,
+      child: Scaffold(
+        backgroundColor: VineTheme.backgroundColor,
+        appBar: AppBar(
+          backgroundColor: VineTheme.backgroundColor,
+          leading: IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () => _onClose(context),
+          ),
+          title: const Text('Edit captions'),
+          actions: [
+            BlocBuilder<SubtitleEditorCubit, SubtitleEditorState>(
+              buildWhen: (p, c) =>
+                  p.isDirty != c.isDirty || p.status != c.status,
+              builder: (context, state) {
+                final canSave = state.isDirty &&
+                    state.status != SubtitleEditorStatus.saving;
+                return TextButton(
+                  onPressed: canSave
+                      ? () => context.read<SubtitleEditorCubit>().save()
+                      : null,
+                  child: const Text('Save'),
+                );
+              },
+            ),
+          ],
+        ),
+        body: const _Body(),
+      ),
+    );
+  }
+
+  void _onStatusChange(BuildContext context, SubtitleEditorState state) {
+    final messenger = ScaffoldMessenger.of(context);
+    switch (state.status) {
+      case SubtitleEditorStatus.success:
+        messenger.showSnackBar(
+            const SnackBar(content: Text('Captions updated')));
+        Navigator.of(context).maybePop();
+      case SubtitleEditorStatus.partialSuccess:
+        messenger.showSnackBar(const SnackBar(
+            content:
+                Text('Saved — may take a moment to appear everywhere.')));
+        Navigator.of(context).maybePop();
+      case SubtitleEditorStatus.failure:
+        messenger.showSnackBar(const SnackBar(
+            content: Text("Couldn't save captions. Try again.")));
+      case _:
+        break;
+    }
+  }
+
+  Future<void> _onClose(BuildContext context) async {
+    final cubit = context.read<SubtitleEditorCubit>();
+    if (!cubit.state.isDirty) {
+      Navigator.of(context).maybePop();
+      return;
+    }
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Discard changes?'),
+        content: const Text('Your edits will be lost.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Keep editing'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Discard'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed ?? false) {
+      cubit.discard();
+      if (context.mounted) Navigator.of(context).maybePop();
+    }
+  }
+}
+
+class _Body extends StatelessWidget {
+  const _Body();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SubtitleEditorCubit, SubtitleEditorState>(
+      builder: (context, state) {
+        if (state.isFallbackMode) {
+          return SingleCueFallback(
+            durationMs: state.videoDurationMs,
+            text: state.cues.first.text,
+            onChanged: (v) =>
+                context.read<SubtitleEditorCubit>().updateCueText(0, v),
+          );
+        }
+        return ListView.builder(
+          itemCount: state.cues.length,
+          itemBuilder: (context, i) {
+            final cue = state.cues[i];
+            return CueRow(
+              key: ValueKey('cue_${cue.startMs}_${cue.endMs}'),
+              startMs: cue.startMs,
+              endMs: cue.endMs,
+              text: cue.text,
+              onChanged: (v) =>
+                  context.read<SubtitleEditorCubit>().updateCueText(i, v),
+            );
+          },
+        );
+      },
+    );
+  }
+}
+```
+
+- [ ] **Step 3: Run, pass, commit**
+
+```bash
+cd mobile && flutter test test/screens/subtitle_editor/view/subtitle_editor_view_test.dart
+git add mobile/lib/screens/subtitle_editor mobile/test/screens/subtitle_editor
+git commit -m "feat(subtitle_editor): SubtitleEditorView (cue list + fallback)"
+```
+
+---
+
+### Task 4.4: `SubtitleEditorPage` (host that wires deps)
+
+**Files:**
+- Create: `mobile/lib/screens/subtitle_editor/view/subtitle_editor_page.dart`
+
+The page reads dependencies from `context` (Riverpod providers + BlocProvider/MultiRepositoryProvider, depending on how the app injects `AuthService` / `NostrClient`), constructs the cubit, and calls `init`. It also fetches existing cues using the existing `subtitleCuesProvider`.
+
+- [ ] **Step 1: Implement page**
+
+```dart
+// ABOUTME: BlocProvider host for SubtitleEditorView.
+// ABOUTME: Fetches existing cues, wires AuthService for signing + NIP-98.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:models/models.dart';
+import 'package:openvine/providers/subtitle_providers.dart';
+import 'package:openvine/screens/subtitle_editor/cubit/subtitle_editor_cubit.dart';
+import 'package:openvine/screens/subtitle_editor/view/subtitle_editor_view.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/utils/nip98.dart'; // create if missing — see note
+import 'package:subtitle_repository/subtitle_repository.dart';
+
+class SubtitleEditorPage extends ConsumerWidget {
+  const SubtitleEditorPage({required this.video, super.key});
+
+  final VideoEvent video;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final cuesAsync = ref.watch(subtitleCuesProvider(
+      videoId: video.id,
+      textTrackRef: video.textTrackRef,
+      textTrackContent: video.textTrackContent,
+      sha256: video.sha256,
+    ));
+
+    return cuesAsync.when(
+      loading: () => const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      ),
+      error: (e, _) => Scaffold(
+        body: Center(child: Text('Could not load captions: $e')),
+      ),
+      data: (existing) {
+        final repo = context.read<SubtitleEditRepository>();
+        final auth = context.read<AuthService>();
+
+        return BlocProvider(
+          create: (_) => SubtitleEditorCubit(
+            repository: repo,
+            signKind39307: ({required content, required tags}) =>
+                auth.createAndSignEvent(
+              kind: 39307,
+              content: content,
+              tags: tags,
+            ),
+            buildNip98Authorization: ({
+              required method,
+              required url,
+              required body,
+            }) =>
+                buildNip98Authorization(
+              authService: auth,
+              method: method,
+              url: url,
+              payload: body,
+            ),
+          )..init(
+              videoId: video.id,
+              videoDTag: video.dTag ?? video.id,
+              sha256: video.sha256,
+              videoDurationMs: (video.duration ?? 6) * 1000,
+              language: 'en',
+              existingCues: existing,
+            ),
+          child: const SubtitleEditorView(),
+        );
+      },
+    );
+  }
+}
+```
+
+**Note on `nip98.dart`:** if the project already has a NIP-98 builder (search `grep -rn "Nip98\|nip-98\|nip98" mobile/lib mobile/packages`), reuse it. Otherwise create `mobile/lib/utils/nip98.dart` with a small helper that builds a Kind 27235 event signed via `AuthService.createAndSignEvent` with tags `[["u", url], ["method", method], ["payload", sha256(body)]]`, base64-encodes the JSON, returns `'Nostr <base64>'`. Add tests for the helper before using it.
+
+- [ ] **Step 2: If `Nip98` builder is missing, create + test it as its own task**
+
+(Branch off here for a Task 4.4a if needed; same TDD discipline. Skip if existing infrastructure is reused.)
+
+- [ ] **Step 3: Wire `SubtitleEditRepository` provider**
+
+The repo needs to be available via `context.read<SubtitleEditRepository>()`. Add a `RepositoryProvider` near the top of `mobile/lib/main.dart` (or wherever app-level providers live):
+
+```dart
+RepositoryProvider<SubtitleEditRepository>(
+  create: (context) => SubtitleEditRepository(
+    nostrClient: context.read<NostrClient>(),
+    blossomClient: BlossomVttClient(
+      httpClient: http.Client(),
+      baseUri: Uri.parse('https://media.divine.video'),
+    ),
+  ),
+),
+```
+
+(Match this to the existing app-startup wiring style — likely already a `MultiRepositoryProvider` somewhere.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/lib mobile/test
+git commit -m "feat(subtitle_editor): SubtitleEditorPage + DI wiring"
+```
+
+---
+
+## Chunk 5: Entry points + routing
+
+### Task 5.1: Add the package to `mobile/pubspec.yaml`
+
+- [ ] **Step 1: Open `mobile/pubspec.yaml`** and add under `dependencies:`:
+
+```yaml
+  subtitle_repository:
+    path: packages/subtitle_repository
+```
+
+- [ ] **Step 2: Run `flutter pub get`**
+
+```bash
+cd mobile && flutter pub get
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/pubspec.yaml mobile/pubspec.lock
+git commit -m "chore(mobile): add subtitle_repository path dep"
+```
+
+---
+
+### Task 5.2: Add typed route in `app_router.dart`
+
+- [ ] **Step 1: Open `mobile/lib/router/app_router.dart`**, find a sibling typed route as a template (e.g. an existing video screen route).
+
+- [ ] **Step 2: Add typed route**
+
+```dart
+@TypedGoRoute<EditCaptionsRoute>(
+  name: 'editCaptions',
+  path: '/edit-captions/:videoId',
+)
+@immutable
+class EditCaptionsRoute extends GoRouteData {
+  const EditCaptionsRoute({required this.videoId, this.$extra});
+
+  final String videoId;
+  final VideoEvent? $extra;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    final video = $extra;
+    if (video == null) {
+      // Defense in depth — direct deep link without VideoEvent shouldn't happen
+      // because the entry points always have one in hand. Bounce back.
+      return const SizedBox.shrink();
+    }
+    return SubtitleEditorPage(video: video);
+  }
+}
+```
+
+(Follow the project's existing `extra` patterns. If they avoid `extra` per `routing.md`, refactor to fetch the `VideoEvent` from a provider keyed by `videoId`.)
+
+- [ ] **Step 3: Re-run codegen**
+
+```bash
+cd mobile && dart run build_runner build --delete-conflicting-outputs
+```
+
+- [ ] **Step 4: Commit (incl. generated files)**
+
+```bash
+git add mobile/lib/router
+git commit -m "feat(router): add /edit-captions/:videoId route"
+```
+
+---
+
+### Task 5.3: Long-press on `CcActionButton` opens the editor for the author
+
+**Files:**
+- Modify: `mobile/lib/widgets/video_feed_item/actions/cc_action_button.dart`
+- Modify: `mobile/test/widgets/video_feed_item/actions/cc_action_button_test.dart`
+
+- [ ] **Step 1: Failing test**
+
+Add to `cc_action_button_test.dart`:
+
+```dart
+testWidgets('long-press navigates to /edit-captions when current user is author',
+    (tester) async {
+  // Stub current user pubkey == video.pubkey, then long-press the CC button
+  // and verify GoRouter received the EditCaptionsRoute.
+  // (Use a captured router that records the last go() call.)
+});
+
+testWidgets('long-press is a no-op for non-authors', (tester) async {
+  // Stub current user pubkey != video.pubkey, long-press, expect no nav.
+});
+```
+
+(Implement using the project's existing test helpers for routing — search `mobile/test` for `GoRouter` mocks already in use.)
+
+- [ ] **Step 2: Implement long-press wiring**
+
+```dart
+@override
+Widget build(BuildContext context, WidgetRef ref) {
+  final isActive = ref.watch(subtitleVisibilityProvider);
+  final currentPubkey = ref.watch(currentUserPubkeyProvider); // existing
+  final isAuthor =
+      currentPubkey != null && currentPubkey == video.pubkey;
+
+  if (!video.hasSubtitles && !isAuthor) return const SizedBox.shrink();
+
+  return Semantics(
+    identifier: 'cc_button',
+    container: true,
+    explicitChildNodes: true,
+    button: true,
+    label: isActive ? 'Hide subtitles' : 'Show subtitles',
+    child: GestureDetector(
+      onLongPress: isAuthor
+          ? () => EditCaptionsRoute(videoId: video.id, $extra: video)
+              .push(context)
+          : null,
+      child: IconButton(
+        // ... existing IconButton unchanged ...
+      ),
+    ),
+  );
+}
+```
+
+(Wrap with `GestureDetector` rather than adding to `IconButton` because IconButton doesn't expose `onLongPress`.)
+
+- [ ] **Step 3: Run, pass, commit**
+
+```bash
+cd mobile && flutter test test/widgets/video_feed_item/actions/cc_action_button_test.dart
+git add mobile/lib/widgets mobile/test/widgets
+git commit -m "feat(cc_button): long-press opens editor for video author"
+```
+
+---
+
+### Task 5.4: Add "Edit captions" item to the metadata expanded sheet
+
+**Files:**
+- Modify: `mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart`
+- Modify (or create): tests for that sheet
+
+- [ ] **Step 1: Find an existing list-item pattern in the sheet** and add a new tile shown only when `currentPubkey == video.pubkey`. Tile copy: "Edit captions". On tap: close the sheet, then `EditCaptionsRoute(videoId: video.id, $extra: video).push(context)`.
+
+- [ ] **Step 2: Add a widget test that asserts:**
+  1. Tile is hidden for non-author.
+  2. Tile is visible for author.
+  3. Tapping tile triggers navigation (capture via mock router).
+
+- [ ] **Step 3: Run, pass, commit**
+
+```bash
+git add mobile/lib/widgets mobile/test/widgets
+git commit -m "feat(metadata_sheet): Edit captions item for video author"
+```
+
+---
+
+## Chunk 6: E2E + ship checks
+
+### Task 6.1: Round-trip tests for `SubtitleService`
+
+**Files:**
+- Create or extend: `mobile/test/services/subtitle_service_test.dart`
+
+- [ ] **Step 1: Add tests**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/subtitle_service.dart';
+
+void main() {
+  group(SubtitleService, () {
+    test('generate→parse round-trip preserves cues', () {
+      const input = [
+        SubtitleCue(start: 0, end: 1000, text: 'hello'),
+        SubtitleCue(start: 1000, end: 2500, text: 'world\nline 2'),
+      ];
+      final vtt = SubtitleService.generateVtt(input);
+      final parsed = SubtitleService.parseVtt(vtt);
+      expect(parsed.length, equals(2));
+      expect(parsed[0].start, equals(0));
+      expect(parsed[0].end, equals(1000));
+      expect(parsed[0].text, equals('hello'));
+      expect(parsed[1].text, equals('world\nline 2'));
+    });
+
+    test('parse returns empty list on garbage / JSON', () {
+      expect(SubtitleService.parseVtt(''), isEmpty);
+      expect(SubtitleService.parseVtt('[]'), isEmpty);
+      expect(SubtitleService.parseVtt('{"text":"x"}'), isEmpty);
+    });
+
+    test('generate single full-duration cue produces valid VTT', () {
+      const input = [SubtitleCue(start: 0, end: 6000, text: 'whole video')];
+      final vtt = SubtitleService.generateVtt(input);
+      expect(vtt, startsWith('WEBVTT'));
+      expect(vtt, contains('00:00:00.000 --> 00:00:06.000'));
+      expect(vtt, contains('whole video'));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run, commit**
+
+```bash
+cd mobile && flutter test test/services/subtitle_service_test.dart
+git add mobile/test/services/subtitle_service_test.dart
+git commit -m "test(subtitle_service): round-trip + garbage parse + full-duration"
+```
+
+---
+
+### Task 6.2: E2E — author edits their own captions
+
+**Files:**
+- Create: `mobile/integration_test/edit_captions_journey_test.dart`
+
+Follow `mobile/.claude/rules/e2e_testing.md` (uses Patrol + local Docker stack). Requires `mise run local_up` to be running.
+
+- [ ] **Step 1: Implement the journey**
+
+```dart
+// ABOUTME: E2E — register, publish a video, edit its captions, verify
+// ABOUTME: Kind 39307 lands on the local relay with the new content.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+
+import 'helpers/db_helpers.dart';
+import 'helpers/http_helpers.dart';
+import 'helpers/navigation_helpers.dart';
+import 'helpers/relay_helpers.dart';
+import 'helpers/test_setup.dart';
+
+void main() {
+  patrolTest('author can edit captions on their own video', ($) async {
+    final tester = $.tester;
+
+    final originalOnError = suppressSetStateErrors();
+    final originalErrorBuilder = saveErrorWidgetBuilder();
+
+    launchAppGuarded(/* main entrypoint */);
+    await tester.pumpAndSettle(const Duration(seconds: 3));
+
+    // 1. register a fresh user, verify, log in
+    // 2. publish a short video so we own a Kind 34236 + Kind 39307 stub
+    // 3. open the video, long-press CC button (or open 3-dot → Edit captions)
+    // 4. type into the first cue's textfield: "corrected words"
+    // 5. tap Save
+    // 6. await snackbar "Captions updated"
+    // 7. assert relay has Kind 39307 from our pubkey containing "corrected words"
+
+    restoreErrorWidgetBuilder(originalErrorBuilder);
+    restoreErrorHandler(originalOnError);
+    drainAsyncErrors(tester);
+  });
+}
+```
+
+(Fill in the journey using existing helpers. Pattern-match against `auth_journey_test.dart` for register-and-publish flow; use `relay_helpers.dart` to query Kind 39307 after save.)
+
+- [ ] **Step 2: Run E2E**
+
+```bash
+cd mobile && mise run local_up && mise run e2e_test integration_test/edit_captions_journey_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/integration_test/edit_captions_journey_test.dart
+git commit -m "test(e2e): author edits own captions, verifies Kind 39307 on relay"
+```
+
+---
+
+### Task 6.3: Final ship verification
+
+- [ ] **Step 1: `flutter analyze` clean**
+
+```bash
+cd mobile && flutter analyze lib test integration_test
+```
+
+Expected: 0 issues.
+
+- [ ] **Step 2: All tests pass**
+
+```bash
+cd mobile && flutter test --test-randomize-ordering-seed random
+```
+
+Expected: ALL PASS, randomized order.
+
+- [ ] **Step 3: Coverage on new files ≥ 100%**
+
+```bash
+cd mobile && flutter test --coverage
+# inspect coverage/lcov.info — focus on lib/screens/subtitle_editor/**
+# and packages/subtitle_repository/**
+```
+
+If gaps, add targeted tests; do not lower the threshold.
+
+- [ ] **Step 4: Manual smoke**
+
+```bash
+cd mobile && mise run local_up
+flutter run --dart-define=DEFAULT_ENV=LOCAL
+```
+
+- Sign in
+- Publish a short video
+- Open the video, 3-dot → Edit captions (and try long-press CC)
+- Edit a cue, Save
+- Verify the new text appears on next play of the same video
+- Verify a non-author CANNOT see "Edit captions" on someone else's video
+
+- [ ] **Step 5: Cross-check the Backend Contract section in the spec against the deployed Blossom endpoint**
+
+Coordinate with the parallel Blossom-side work. If the live response codes differ from the spec, update both the spec and `BlossomVttClient` mapping.
+
+- [ ] **Step 6: PR**
+
+```bash
+git push -u origin <branch>
+gh pr create \
+  --title "feat(captions): author-only caption editing" \
+  --body "$(cat <<'EOF'
+## Summary
+- New "Edit captions" entry point (3-dot + long-press CC) shown only on the author's own videos
+- Full-screen editor with cue-list + single-cue fallback for empty/garbage VTT
+- Dual-write: Kind 39307 (signed source of truth) + `PUT /v1/{sha256}/vtt` (cache, best-effort)
+- New `subtitle_repository` package with TDD-built BlossomVttClient + repository
+
+Spec: `docs/superpowers/specs/2026-04-26-subtitle-edit-design.md`
+Plan: `docs/superpowers/plans/2026-04-26-subtitle-edit.md`
+
+## Test plan
+- [ ] `flutter analyze lib test integration_test` clean
+- [ ] `flutter test --test-randomize-ordering-seed random` passes
+- [ ] Coverage 100% on new files
+- [ ] E2E `edit_captions_journey_test.dart` passes against local stack
+- [ ] Manual smoke: edit captions on own video, see new text on next play
+- [ ] Manual: non-author cannot see "Edit captions" entry
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## v2 / Future Work (NOT in this plan — captured in spec)
+
+- Collaborator editing (NIP-26 vs allowlist resolution)
+- Re-transcribe action
+- Timing edits / split / merge / add / delete cues
+- Multi-language tracks
+- Viewer "report bad captions" affordance

--- a/docs/superpowers/specs/2026-04-26-subtitle-edit-design.md
+++ b/docs/superpowers/specs/2026-04-26-subtitle-edit-design.md
@@ -1,0 +1,244 @@
+# Subtitle Edit (Author-Only) — Design
+
+**Date:** 2026-04-26
+**Status:** Approved (brainstorm complete, awaiting plan)
+**Owner:** rabble
+**Out of scope for v1:** re-transcribe, timing edits, add/delete cues, collaborator editing, multi-language, preview-while-playing, viewer "report bad captions" flow
+
+---
+
+## Problem
+
+Auto-generated VTT subtitles are sometimes wrong. Today the app reads VTT from three paths (REST embed → Blossom `/{sha256}/vtt` → Kind 39307) but exposes no way for the author to correct mistakes. We want a focused editor that lets a video's author fix the transcription text.
+
+## Goal
+
+Ship the smallest end-to-end editor that lets a signed-in author edit existing cue text on their own video and have those edits propagate to all read paths (Nostr relay, funnelcake REST embed, Blossom cache).
+
+## Non-Goals
+
+- **Re-transcribing audio.** Considered and deferred — model output is non-deterministic; user-controlled text edits give a better worst case.
+- **Timing edits, splits, merges, add/delete cues.** Vines are short; word-level transcription timing is usually fine. Re-evaluate after v1 ships.
+- **Collaborator editing.** Author can specify collaborators is a future ask. The Kind 39307 address includes the signer's pubkey, so collaborator edits break the video event's `text-track` pointer resolution. Deferred to v2 with a separate decision between NIP-26 delegation and an allowlist resolution model. See "v2 / Future Work" below.
+- **Community / viewer-side correction.** Same reasoning.
+- **Multi-language.** v1 edits the existing track only; we copy its language tag forward.
+- **Live preview** of captions over the playing video inside the editor.
+
+---
+
+## User Experience
+
+### Entry Point
+
+- Visible only when `videoEvent.pubkey == currentUser.pubkey`.
+- Two surfaces:
+  1. **Overflow (3-dot) menu on the video** → "Edit captions" (primary, discoverable).
+  2. **Long-press the CC button** → same destination (power-user shortcut).
+- Hidden entirely for non-authors.
+
+### Editor Screen
+
+Full-screen page, dark mode (per `ui_theming.md`).
+
+**App bar**
+- Title: "Edit captions"
+- Leading: discard (X) button
+- Trailing: "Save" — disabled until state is dirty
+
+**Body — two render modes**
+
+1. **Cue list mode** (existing VTT parsed to ≥1 cue):
+   - Scrollable list of cue rows.
+   - Each row: timestamp range (read-only, `mm:ss.SSS – mm:ss.SSS`) above an editable `TextField` containing the cue's current text.
+   - Soft per-cue length cap surfaced via helper text at 500 chars; hard cap at 2000 to keep WebVTT sane.
+
+2. **Single-cue fallback** (existing VTT parses to 0 cues, or no VTT at all):
+   - One textarea labelled "Captions for full video (0:00 – 0:0X)".
+   - Saved as a single cue spanning `0 → videoEvent.duration` (or 6s if duration unknown).
+
+### Save Flow
+
+1. User taps Save.
+2. Editor enters `saving` state; overlay disables further input.
+3. Repository runs the dual-write sequence (see "Architecture").
+4. **Success** → snackbar "Captions updated" → editor dismisses → subtitle provider invalidated → next render of the video shows new cues.
+5. **Partial success** (relay ok, Blossom failed) → snackbar "Saved — may take a moment to appear everywhere." → editor dismisses. The funnelcake reindexer will heal the REST/Blossom paths on its own.
+6. **Failure** (relay publish failed) → snackbar "Couldn't save captions. Try again." → editor stays open with edits intact and a Retry affordance.
+
+### Discard Flow
+
+- X button with no changes → dismiss immediately.
+- X button with `isDirty` → confirm dialog "Discard changes?" → confirm dismisses, cancel returns to editor.
+
+---
+
+## Architecture
+
+Layered per `architecture.md`: **UI → BLoC → Repository → Client.** New feature ⇒ BLoC (not Riverpod), per `state_management.md` migration policy.
+
+### Components
+
+| Layer | Component | Location | Responsibility |
+|---|---|---|---|
+| UI | `SubtitleEditorPage`, `SubtitleEditorView` | `mobile/lib/screens/subtitle_editor/` | Provides BLoC; renders cue list or single-cue fallback; dispatches edit/save/discard events |
+| BLoC | `SubtitleEditorCubit`, `SubtitleEditorState` | `mobile/lib/screens/subtitle_editor/cubit/` | Holds `List<EditableCue>`, `status` enum, `isDirty`. No error strings in state — uses `addError` |
+| Repository | `SubtitleEditRepository` | `mobile/packages/subtitle_repository/` (new package) | Orchestrates dual-write: build VTT → publish Kind 39307 → PUT Blossom → return composite result |
+| Client | `BlossomVttClient` | `mobile/packages/subtitle_repository/lib/src/` | HTTP `PUT` to `media.divine.video/v1/{sha256}/vtt` with NIP-98 auth |
+| Client | Kind 39307 publish path | Reuses existing `AuthService.createAndSignEvent` + `NostrClient.publish` | No new client; just a typed call site |
+| Read | `subtitleCuesProvider` (existing) | `mobile/lib/providers/subtitle_providers.dart` | Unchanged; we only invalidate it after a successful save |
+
+### State Shape
+
+```dart
+enum SubtitleEditorStatus { initial, loading, editing, saving, success, failure }
+
+class EditableCue {
+  final int startMs;        // immutable in v1
+  final int endMs;          // immutable in v1
+  final String text;        // mutable
+}
+
+class SubtitleEditorState {
+  final SubtitleEditorStatus status;
+  final List<EditableCue> cues;
+  final List<EditableCue> originalCues;   // for dirty check + discard
+  final String videoId;
+  final String? sha256;
+  final int videoDurationMs;
+  final String language;                  // copied from existing track or 'en'
+
+  bool get isDirty => !listEquals(cues, originalCues);
+  bool get isFallbackMode => originalCues.length <= 1 && (originalCues.firstOrNull?.text.isEmpty ?? true);
+}
+```
+
+Errors flow via `addError(e, stackTrace)` and surface as snackbars in the View. No error strings stored in state (project rule).
+
+### Write Sequence (on Save)
+
+```
+1. vtt = SubtitleService.generateVtt(state.cues)
+2. event = await authService.createAndSignEvent(
+     kind: 39307,
+     content: vtt,
+     tags: [
+       ["d",        "subtitles:${videoEvent.dTag}"],
+       ["e",        videoEvent.id],
+       ["a",        "34236:${videoEvent.pubkey}:${videoEvent.dTag}"],
+       ["language", state.language],
+       ["alt",      "Subtitle track"],
+     ],
+   )
+3. await nostrClient.publish(event)              // MUST succeed
+4. try {
+     await blossomVttClient.put(sha256, vtt)     // best-effort
+   } catch (e, s) {
+     addError(e, s);                             // log, do not abort
+     return SaveResult.partial;
+   }
+5. ref.invalidate(subtitleCuesProvider for videoId)
+6. return SaveResult.full;
+```
+
+**Why relay-first, Blossom best-effort:** Kind 39307 is the signed source of truth. Funnelcake's reindexer will heal `text_track_content` on the REST fast path even if Blossom write fails. Worst case is a stale `/{sha256}/vtt` cache for a window — acceptable. Hard-failing the user on a cache miss is the wrong tradeoff.
+
+**Why not reverse the order:** if we wrote to Blossom first and the relay publish then failed, the cache would carry edits not present in the signed source. Other clients reading from REST would see ghost edits.
+
+---
+
+## Backend Contract (Blossom Side)
+
+Negotiated separately with the Blossom server work. The mobile client assumes:
+
+```
+PUT https://media.divine.video/v1/<sha256>/vtt
+Headers:
+  Authorization: Nostr <base64(NIP-98 event)>
+  Content-Type: text/vtt
+Body: <raw VTT bytes, UTF-8>
+```
+
+**Server MUST:**
+- Verify NIP-98 event signature, method = `PUT`, URL = exact request URL.
+- Verify the NIP-98 event's pubkey matches the author of the Kind 34236 video event whose URL contains this `<sha256>`.
+- Replace the served VTT atomically; subsequent `GET /v1/<sha256>/vtt` returns the new content.
+
+**Response codes:**
+
+| Code | Meaning | Mobile handling |
+|---|---|---|
+| 200 | Success | Mark Blossom step complete |
+| 400 | Malformed VTT | Treat as save failure; show generic error |
+| 401 | Missing/invalid NIP-98 | Treat as save failure; log auth issue |
+| 403 | NIP-98 pubkey != video author | Defense in depth — surface "You can only edit captions on your own videos" |
+| 404 | Unknown sha256 | Treat as partial success (relay still wrote); log |
+| 409 | Version conflict | Show non-destructive banner: "Captions changed elsewhere — reload?" Reload discards local edits |
+| 5xx | Server error | Partial-success path; relay write already succeeded |
+
+This contract section travels with the spec so the Blossom-side work can negotiate against it.
+
+---
+
+## Read Path
+
+**Unchanged.** `subtitleCuesProvider` already implements REST embed → Blossom → Kind 39307 fallback. After a successful save, the editor calls `ref.invalidate()` on this provider for the affected `videoId`, triggering a refetch. Whichever path returns first wins; funnelcake reindex catches up the embedded path within seconds.
+
+---
+
+## Edge Cases
+
+| Case | Behavior |
+|---|---|
+| Existing VTT parses to ≥1 cue | List view, edit per-cue text |
+| Existing VTT parses to 0 cues (garbage / JSON / empty body) | Single-cue fallback, `0 → videoDuration`, empty text field |
+| No VTT at all (404 + no Kind 39307 + no embed) | Single-cue fallback — author can author from scratch |
+| Video has no `sha256` known to client | Disable entry point; editing requires a known content hash |
+| User signs out mid-edit | Discard local state, dismiss editor (no orphan saves) |
+| Relay publish succeeds, Blossom fails | Partial-success snackbar; editor dismisses; reindex heals REST path |
+| Relay publish fails | Hard error; editor stays open with edits intact and Retry; do **not** call Blossom |
+| Blossom returns 403 | "You can only edit captions on your own videos" — should not be reachable via UI |
+| Blossom returns 409 | Non-destructive reload banner |
+| Save tap with no changes | Save button disabled while not dirty; unreachable |
+| Cue text exceeds soft cap (500 chars) | Helper text warns; hard cap 2000 |
+| Video duration unknown | Use 6s default; surface tooltip |
+| App backgrounded mid-save | In-flight HTTP completes; on resume we still invalidate provider. No user-visible difference |
+
+---
+
+## Testing
+
+Per `testing.md`. Coverage target 100% on new files (per project CI policy).
+
+| Layer | Tests |
+|---|---|
+| `SubtitleService` | **Existing** parse tests retained. **Add:** generate→parse round-trip, garbage-in-empty-cues, single-cue full-duration synthesis |
+| `BlossomVttClient` | NIP-98 header construction, success / 400 / 401 / 403 / 404 / 409 / 5xx mapping. Mock `http.Client` |
+| `SubtitleEditRepository` | Dual-write happy path; relay-failure-aborts-Blossom; Blossom-failure-returns-partial. All clients mocked |
+| `SubtitleEditorCubit` | bloc_test: initial → editing on `CueTextChanged`, dirty flag transitions, saving → success / failure / partial transitions, discard-with-dirty fires confirmation event |
+| `SubtitleEditorView` | Renders cues, save disabled until dirty, single-cue fallback when 0 cues, entry point hidden for non-author |
+| Integration (E2E) | `integration_test/edit_captions_journey_test.dart`: register → publish video → open editor → change text → save → verify Kind 39307 on local relay carries new content. Uses local Docker stack per `e2e_testing.md` |
+
+---
+
+## Ship Checklist
+
+1. Unit + bloc + widget tests pass at 100% coverage on new files.
+2. New E2E test passes against `mise run e2e_test`.
+3. Backend contract section above matches what the Blossom-side work actually ships (cross-check before merging).
+4. Manual verification: edit a caption on your own video, observe new text on next play without app restart.
+5. `flutter analyze lib test integration_test` clean.
+6. Pre-commit and pre-push hooks pass (`mise run setup_hooks` if missing).
+
+---
+
+## v2 / Future Work (not in scope here, captured to keep options open)
+
+- **Collaborator editing.** Two open primitives:
+  - *NIP-26 delegated event signing.* Author signs a delegation token; collaborators sign Kind 39307 on the author's behalf so the address `39307:<author>:subtitles:<d-tag>` stays stable. Cleanest cryptographically but NIP-26 is rare in the wild and not implemented in this app today.
+  - *Allowlist resolution.* Clients query Kind 39307 with the d-tag from author OR any listed editor pubkey, picking the most recent. Loses pointer simplicity but avoids NIP-26.
+  - Pick one before shipping v2; both require Blossom server-side ACL changes the v1 server design should already accommodate.
+- **Re-transcribe.** Server endpoint to re-run transcription with a different model or prompt; client triggers and polls.
+- **Timing edits.** Per-cue start/end nudge, split, merge.
+- **Add/delete cues.**
+- **Multi-language tracks.** Author publishes multiple Kind 39307 events with different `language` tags; UI lets viewer pick.
+- **Viewer "report bad captions"** signal that surfaces to the author.


### PR DESCRIPTION
Closes #3892

## Summary

A new `/check-l10n` slash-command skill that runs before any PR push to catch the two recurring l10n failure modes in this repo:

1. **Keys added to `app_en.arb` but never translated** into any of the 16 non-English locales — the locale silently falls back to English on a real device.
2. **Hardcoded user-visible English** in widget code that bypasses `context.l10n` entirely. These strings never appear in any `.arb` file because they were never extracted, so no translation work fixes them.

The skill is at `.claude/skills/check-l10n/`:

- `SKILL.md` — workflow, fix guidance, rule reference, and limitations.
- `scan_strings.py` — regex scanner over changed files in `mobile/lib/`. Flags literals that look like user-visible English passed to `Text(...)`, `label:`/`title:`/`hintText:`/`tooltip:` named args, `Tooltip(message:)`, `semanticLabel`, and the first positional arg of `show*/set*/display*Error|Message|Snackbar|Dialog|Banner|Notification` calls. Skips lines inside `Log.*()`, `developer.log()`, `print()`, `assert()`, `throw <Type>Exception()`, route-name constants, and any path under `test/`, `integration_test/`, `lib/l10n/`, or generated files.
- The skill defers to `flutter test test/l10n/arb_consistency_test.dart` for arb consistency when present, with an inline Python fallback for branches that don't have the test yet.

## Verification

- Scanner correctly catches the `'Secure account'` and `'Registration complete...'` literals that PR #3883 had to manually fix.
- Scanner is quiet on the post-fix tree of PR #3883.
- Scanner flags 13 real candidate leaks on `login_options_screen.dart` and `email_verification_screen.dart` on current main — no false positives in that sample.
- Slash-command convention matches the existing `/review-before-commit` and `/pr-summary` skills (frontmatter `user_invocable: true`, `invocation_hint: /check-l10n`, optional path-scope argument).

## Test plan

- [ ] Run `/check-l10n` on a branch with at least one new `app_en.arb` key not yet translated → arb step reports the missing key for each locale.
- [ ] Run `/check-l10n` on a branch that hardcodes a Text/label literal → scanner step lists it with file:line.
- [ ] Run `/check-l10n` on a clean branch → both steps report ✅.
- [ ] Run `python3 .claude/skills/check-l10n/scan_strings.py mobile/lib/screens/auth/login_options_screen.dart` → flags 9 candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)