### PR TITLE
chore: bump Flutter to 3.41.9 and align CI pins

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.4"
+          flutter-version: "3.41.9"
           channel: "stable"
           cache: true
       - name: 📦 Install dependencies
@@ -65,7 +65,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.4"
+          flutter-version: "3.41.9"
           channel: "stable"
           cache: true
       - name: 📦 Install dependencies
@@ -83,7 +83,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.4"
+          flutter-version: "3.41.9"
           channel: "stable"
           cache: true
       - name: 📦 Install dependencies
@@ -101,7 +101,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.4"
+          flutter-version: "3.41.9"
           channel: "stable"
           cache: true
       - name: 📦 Install dependencies

--- a/.github/workflows/mobile_pr_preview_build.yml
+++ b/.github/workflows/mobile_pr_preview_build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.4"
+          flutter-version: "3.41.9"
           channel: stable
           cache: true
 

--- a/.github/workflows/mobile_service_integration_tests.yaml
+++ b/.github/workflows/mobile_service_integration_tests.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: 🐦 Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.4"
+          flutter-version: "3.41.9"
           channel: "stable"
           cache: true
       - name: 🐳 Start local stack

--- a/.github/workflows/mobile_web_production_deploy.yml
+++ b/.github/workflows/mobile_web_production_deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.41.4"
+          flutter-version: "3.41.9"
           channel: stable
           cache: true
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -354,7 +354,7 @@ workflows:
           - "NO"
           - "YES"
     environment:
-      flutter: 3.41.1
+      flutter: 3.41.9
       xcode: latest
       cocoapods: default
       groups:
@@ -415,7 +415,7 @@ workflows:
           - TEST
           - POC
     environment:
-      flutter: 3.41.1
+      flutter: 3.41.9
       xcode: 16.1  # Pinned to avoid FFmpeg Kit linker issues with newer Xcode
       cocoapods: default
       groups:
@@ -460,7 +460,7 @@ workflows:
           - "NO"
           - "YES"
     environment:
-      flutter: 3.41.1
+      flutter: 3.41.9
       java: 17
       groups:
         - zendesk_credentials
@@ -513,7 +513,7 @@ workflows:
           - "NO"
           - "YES"
     environment:
-      flutter: 3.41.1
+      flutter: 3.41.9
       xcode: latest
       cocoapods: default
       groups:
@@ -544,7 +544,7 @@ workflows:
     max_build_duration: 60
     instance_type: mac_mini_m2
     environment:
-      flutter: 3.41.1
+      flutter: 3.41.9
       xcode: 16.1
       cocoapods: default
       groups:
@@ -580,7 +580,7 @@ workflows:
     max_build_duration: 60
     instance_type: linux_x2
     environment:
-      flutter: 3.41.1
+      flutter: 3.41.9
       java: 17
       groups:
         - zendesk_credentials

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-flutter = "3.41.4"
+flutter = "3.41.9"
 
 [tasks.local_up]
 description = "Start all local E2E services"


### PR DESCRIPTION
Closes #3896

## Summary

- Bumps `mobile/mise.toml` Flutter pin from `3.41.4` to `3.41.9`.
- Aligns three previously divergent Flutter pin surfaces on `3.41.9`:
  - `mobile/mise.toml`          (was `3.41.4`)
  - `.github/workflows/*`       (was `3.41.4`)
  - `codemagic.yaml`            (was `3.41.1`)
- Keeps the project on the same stable Flutter release line while removing patch-version drift across local tooling and CI.
- Existing Flutter and Dart caret constraints already accept this patch-level bump, so `pubspec.lock` is unchanged and there is no transitive dependency churn.

## Test plan

- [x] `mise install` succeeds and `mise exec -- flutter --version` reports `Flutter 3.41.9 • channel stable`
- [x] `mise exec -- flutter pub get` — no `pubspec.lock` diff
- [x] `mise exec -- flutter analyze lib test integration_test` — `No issues found`
- [x] `mise exec -- flutter test test/widgets/clickable_hashtag_text_test.dart test/widgets/comprehensive_clickable_hashtag_text_test.dart` — all green
- [x] CI on this PR (GitHub Actions + Codemagic) succeeds against `3.41.9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
