### PR TITLE
feat(router): add /explore/tab/:name URL for direct tab landing

### DIFF
--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -297,7 +297,15 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           GoRoute(
             path: ExploreScreen.pathTabSubpath,
             pageBuilder: (ctx, st) {
-              final tabName = st.pathParameters['name'];
+              final tabName = ExploreScreen.tabNameFromPathParameter(
+                st.pathParameters['name'],
+              );
+              if (tabName == null) {
+                return NoTransitionPage(
+                  key: st.pageKey,
+                  child: RouteErrorScreen(message: ctx.l10n.routeUnknownPath),
+                );
+              }
               return NoTransitionPage(
                 key: st.pageKey,
                 child: Navigator(

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -293,6 +293,26 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             ),
           ),
 
+          // EXPLORE tab - select a specific tab by name (grid mode)
+          GoRoute(
+            path: ExploreScreen.pathTabSubpath,
+            pageBuilder: (ctx, st) {
+              final tabName = st.pathParameters['name'];
+              return NoTransitionPage(
+                key: st.pageKey,
+                child: Navigator(
+                  key: NavigatorKeys.exploreGrid,
+                  onGenerateRoute: (r) => MaterialPageRoute(
+                    builder: (_) => ExploreScreen(initialTabName: tabName),
+                    settings: const RouteSettings(
+                      name: ExploreScreen.routeName,
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+
           // EXPLORE tab - feed mode (with video index)
           GoRoute(
             path: ExploreScreen.pathWithIndex,

--- a/mobile/lib/router/providers/redirect_provider.dart
+++ b/mobile/lib/router/providers/redirect_provider.dart
@@ -83,12 +83,13 @@ final ProviderFamily<String?, String> checkEmptyFollowingRedirectProvider =
       );
 
       if (!hasFollowing) {
+        final target = ExploreScreen.pathForTab('popular');
         Log.debug(
-          'Redirecting to /explore because no following list found',
+          'Redirecting to $target because no following list found',
           name: 'AppRouter',
           category: LogCategory.ui,
         );
-        return ExploreScreen.path;
+        return target;
       }
 
       return null;

--- a/mobile/lib/screens/explore_screen.dart
+++ b/mobile/lib/screens/explore_screen.dart
@@ -47,6 +47,18 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// Pure ExploreScreen using revolutionary Riverpod architecture
 class ExploreScreen extends ConsumerStatefulWidget {
+  static const _forYouTabName = 'for_you';
+  static const _forYouTabSlug = 'for-you';
+  static const _routeTabNames = <String>{
+    'classics',
+    'new',
+    'popular',
+    'categories',
+    _forYouTabName,
+    'lists',
+    'apps',
+  };
+
   /// Route name for this screen.
   static const routeName = 'explore';
 
@@ -57,8 +69,8 @@ class ExploreScreen extends ConsumerStatefulWidget {
   static const pathWithIndex = '/explore/:index';
 
   /// Path for selecting a specific tab by name (grid mode).
-  /// Valid tab names: 'classics', 'new', 'popular', 'categories',
-  /// 'for_you', 'lists', 'apps'.
+  /// Valid URL slugs: 'classics', 'new', 'popular', 'categories',
+  /// 'for-you', 'lists', 'apps'.
   static const pathTabSubpath = '/explore/tab/:name';
 
   /// Build path for grid mode or specific index.
@@ -66,7 +78,25 @@ class ExploreScreen extends ConsumerStatefulWidget {
       index == null ? path : '$path/$index';
 
   /// Build path for selecting a specific tab by name.
-  static String pathForTab(String name) => '/explore/tab/$name';
+  static String pathForTab(String name) =>
+      '/explore/tab/${tabSlugForName(name)}';
+
+  /// Convert an internal tab name to the public URL slug.
+  static String tabSlugForName(String name) => switch (name) {
+    _forYouTabName => _forYouTabSlug,
+    _ => name,
+  };
+
+  /// Convert a URL path parameter to the internal tab name.
+  static String? tabNameFromPathParameter(String? slug) {
+    if (slug == null) return null;
+    if (slug.contains('_')) return null;
+    final name = switch (slug) {
+      _forYouTabSlug => _forYouTabName,
+      _ => slug,
+    };
+    return _routeTabNames.contains(name) ? name : null;
+  }
 
   const ExploreScreen({super.key, this.initialTabName});
 
@@ -117,7 +147,7 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
     final names = <String>[];
     if (_classicsAvailable) names.add('classics');
     names.addAll(['new', 'popular', 'categories']);
-    if (_forYouAvailable) names.add('for_you');
+    if (_forYouAvailable) names.add(ExploreScreen._forYouTabName);
     names.add('lists');
     if (_appsAvailable) names.add('apps');
     return names;
@@ -126,7 +156,10 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
   /// Convert a tab name to index based on current availability
   int _tabNameToIndex(String name) {
     final index = _tabNames.indexOf(name);
-    return index >= 0 ? index : 1; // Default to index 1 if not found
+    if (index >= 0) {
+      return index;
+    }
+    return _tabNames.indexOf('new');
   }
 
   /// Convert a tab index to name based on current availability

--- a/mobile/lib/screens/explore_screen.dart
+++ b/mobile/lib/screens/explore_screen.dart
@@ -56,11 +56,23 @@ class ExploreScreen extends ConsumerStatefulWidget {
   /// Path for this route with index (feed mode).
   static const pathWithIndex = '/explore/:index';
 
+  /// Path for selecting a specific tab by name (grid mode).
+  /// Valid tab names: 'classics', 'new', 'popular', 'categories',
+  /// 'for_you', 'lists', 'apps'.
+  static const pathTabSubpath = '/explore/tab/:name';
+
   /// Build path for grid mode or specific index.
   static String pathForIndex(int? index) =>
       index == null ? path : '$path/$index';
 
-  const ExploreScreen({super.key});
+  /// Build path for selecting a specific tab by name.
+  static String pathForTab(String name) => '/explore/tab/$name';
+
+  const ExploreScreen({super.key, this.initialTabName});
+
+  /// Optional tab name to select on first build. Takes precedence over
+  /// [forceExploreTabNameProvider] and the saved [exploreTabIndexProvider].
+  final String? initialTabName;
 
   @override
   ConsumerState<ExploreScreen> createState() => _ExploreScreenState();
@@ -128,15 +140,17 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
 
   /// Build a new [TabController]. [previousTabName] is the name of the
   /// tab the user was on before a rebuild (resolved while the old
-  /// availability flags were still in effect). When set, the forced-tab
-  /// provider still takes priority. Falls back to the 'new' tab by name —
+  /// availability flags were still in effect). Resolution order:
+  /// [ExploreScreen.initialTabName] > [forceExploreTabNameProvider] >
+  /// previous tab > 'new'. Falls back to the 'new' tab by name —
   /// never by raw index, because indices shift when optional tabs appear
   /// or disappear.
   void _initTabController({String? previousTabName}) {
     final forcedTabName = ref.read(forceExploreTabNameProvider);
 
-    // Resolve the target tab name: forced provider > previous tab > default.
-    final targetTabName = forcedTabName ?? previousTabName;
+    // Resolve the target tab name: route arg > forced provider > previous > default.
+    final targetTabName =
+        widget.initialTabName ?? forcedTabName ?? previousTabName;
     final initialIndex = _tabNameToIndex(targetTabName ?? 'new');
 
     if (targetTabName != null) {

--- a/mobile/test/router/empty_contacts_redirect_test.dart
+++ b/mobile/test/router/empty_contacts_redirect_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
+import 'package:openvine/screens/auth/welcome_screen.dart';
+import 'package:openvine/screens/explore_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -142,6 +144,77 @@ void main() {
 
         // Should not crash, and should return false since JSON is invalid
         expect(hasFollowing, isFalse);
+      });
+    });
+
+    group('checkEmptyFollowingRedirectProvider', () {
+      test(
+        'returns /explore/tab/popular for empty-following users on /welcome',
+        () async {
+          SharedPreferences.setMockInitialValues({
+            'age_verified_16_plus': true,
+            'current_user_pubkey_hex': testUserPubkey,
+            // No following_list cache for this user → empty.
+          });
+
+          final prefs = await SharedPreferences.getInstance();
+          final container = ProviderContainer(
+            overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+          );
+          addTearDown(container.dispose);
+
+          final redirect = container.read(
+            checkEmptyFollowingRedirectProvider(WelcomeScreen.path),
+          );
+
+          expect(
+            redirect,
+            equals(ExploreScreen.pathForTab('popular')),
+            reason:
+                'Empty-following users coming from /welcome should land '
+                'on the Popular tab, not the explore root.',
+          );
+        },
+      );
+
+      test('returns null when user has a non-empty following list', () async {
+        SharedPreferences.setMockInitialValues({
+          'age_verified_16_plus': true,
+          'current_user_pubkey_hex': testUserPubkey,
+          'following_list_$testUserPubkey': '["pubkey1"]',
+        });
+
+        final prefs = await SharedPreferences.getInstance();
+        final container = ProviderContainer(
+          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+        );
+        addTearDown(container.dispose);
+
+        final redirect = container.read(
+          checkEmptyFollowingRedirectProvider(WelcomeScreen.path),
+        );
+
+        expect(redirect, isNull);
+      });
+
+      test('returns null when location is not /welcome', () async {
+        SharedPreferences.setMockInitialValues({
+          'age_verified_16_plus': true,
+          'current_user_pubkey_hex': testUserPubkey,
+          // Empty follows, but caller is not coming from /welcome.
+        });
+
+        final prefs = await SharedPreferences.getInstance();
+        final container = ProviderContainer(
+          overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+        );
+        addTearDown(container.dispose);
+
+        final redirect = container.read(
+          checkEmptyFollowingRedirectProvider('/some-other-route'),
+        );
+
+        expect(redirect, isNull);
       });
     });
   });

--- a/mobile/test/router/explore_tab_route_test.dart
+++ b/mobile/test/router/explore_tab_route_test.dart
@@ -1,0 +1,245 @@
+// ABOUTME: Tests for /explore/tab/:name URL route and ExploreScreen tab arg
+// ABOUTME: Verifies pathForTab helper, route registration, and initial tab selection
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_foreground_provider.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/classic_vines_provider.dart';
+import 'package:openvine/providers/for_you_provider.dart';
+import 'package:openvine/providers/list_providers.dart';
+import 'package:openvine/providers/route_feed_providers.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/screens/explore_screen.dart';
+import 'package:openvine/services/curated_list_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _FakeAppForeground extends AppForeground {
+  @override
+  bool build() => true;
+}
+
+class _FakeCuratedListsState extends CuratedListsState {
+  @override
+  CuratedListService? get service => null;
+
+  @override
+  Future<List<CuratedList>> build() async => const [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(SubscriptionType.discovery);
+    registerFallbackValue(() {});
+  });
+
+  late _MockVideoEventService videoEventService;
+
+  setUp(() {
+    videoEventService = _MockVideoEventService();
+
+    when(
+      () => videoEventService.addVideoUpdateListener(any()),
+    ).thenReturn(() {});
+    when(() => videoEventService.filterVideoList(any())).thenAnswer(
+      (invocation) => invocation.positionalArguments.first as List<VideoEvent>,
+    );
+    when(() => videoEventService.discoveryVideos).thenReturn([]);
+    when(() => videoEventService.popularNowVideos).thenReturn([]);
+    when(() => videoEventService.isSubscribed(any())).thenReturn(false);
+    // ignore: invalid_use_of_protected_member
+    when(() => videoEventService.hasListeners).thenReturn(false);
+  });
+
+  group('ExploreScreen.pathForTab', () {
+    test('returns /explore/tab/<name>', () {
+      expect(
+        ExploreScreen.pathForTab('popular'),
+        equals('/explore/tab/popular'),
+      );
+      expect(ExploreScreen.pathForTab('new'), equals('/explore/tab/new'));
+      expect(
+        ExploreScreen.pathForTab('categories'),
+        equals('/explore/tab/categories'),
+      );
+    });
+
+    test('pathTabSubpath constant equals /explore/tab/:name', () {
+      expect(ExploreScreen.pathTabSubpath, equals('/explore/tab/:name'));
+    });
+  });
+
+  group('GoRouter /explore/tab/:name', () {
+    testWidgets('captures the tab name as a path parameter', (tester) async {
+      String? capturedName;
+
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: ExploreScreen.pathTabSubpath,
+            builder: (ctx, st) {
+              capturedName = st.pathParameters['name'];
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+      router.go(ExploreScreen.pathForTab('popular'));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(capturedName, equals('popular'));
+    });
+
+    test(
+      'production app_router.dart registers ExploreScreen.pathTabSubpath '
+      'and threads :name into ExploreScreen.initialTabName',
+      () {
+        final source = File('lib/router/app_router.dart').readAsStringSync();
+
+        final tabRouteOffset = source.indexOf(
+          'path: ExploreScreen.pathTabSubpath',
+        );
+        expect(
+          tabRouteOffset,
+          isNonNegative,
+          reason:
+              'app_router.dart must register a GoRoute at '
+              'ExploreScreen.pathTabSubpath so /explore/tab/<name> is '
+              'a valid URL.',
+        );
+
+        // The pageBuilder for this route must read the :name path
+        // parameter and pass it to ExploreScreen as initialTabName,
+        // otherwise the URL has no effect on the rendered tab.
+        final nextGoRouteAfter = source.indexOf('GoRoute(', tabRouteOffset + 1);
+        final region = source.substring(
+          tabRouteOffset,
+          nextGoRouteAfter == -1 ? source.length : nextGoRouteAfter,
+        );
+        expect(
+          region.contains("pathParameters['name']"),
+          isTrue,
+          reason:
+              'The /explore/tab/:name route must read '
+              "state.pathParameters['name'] in its pageBuilder.",
+        );
+        expect(
+          region.contains('initialTabName:'),
+          isTrue,
+          reason:
+              'The /explore/tab/:name route must thread the :name '
+              'parameter into ExploreScreen(initialTabName: …).',
+        );
+      },
+    );
+  });
+
+  group('ExploreScreen initialTabName', () {
+    testWidgets(
+      'with initialTabName="popular" selects the popular tab on mount',
+      (tester) async {
+        await tester.pumpWidget(
+          testProviderScope(
+            additionalOverrides: [
+              appForegroundProvider.overrideWith(_FakeAppForeground.new),
+              videoEventServiceProvider.overrideWithValue(videoEventService),
+              routerLocationStreamProvider.overrideWith(
+                (ref) => Stream.value(ExploreScreen.pathForTab('popular')),
+              ),
+              exploreTabVideosProvider.overrideWith((ref) => null),
+              classicVinesAvailableProvider.overrideWith((ref) async => false),
+              forYouAvailableProvider.overrideWithValue(false),
+              allListsProvider.overrideWith(
+                (ref) async =>
+                    (userLists: <UserList>[], curatedLists: <CuratedList>[]),
+              ),
+              curatedListsStateProvider.overrideWith(
+                _FakeCuratedListsState.new,
+              ),
+              isFeatureEnabledProvider(
+                FeatureFlag.integratedApps,
+              ).overrideWithValue(false),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(body: ExploreScreen(initialTabName: 'popular')),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // With Classics, ForYou, and Apps disabled, the tab order is:
+        // new(0), popular(1), categories(2), lists(3).
+        final tabBar = tester.widget<TabBar>(find.byType(TabBar));
+        expect(
+          tabBar.controller?.index,
+          equals(1),
+          reason: 'Popular tab should be selected at index 1',
+        );
+      },
+    );
+
+    testWidgets('with initialTabName="new" selects the new tab on mount', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        testProviderScope(
+          additionalOverrides: [
+            appForegroundProvider.overrideWith(_FakeAppForeground.new),
+            videoEventServiceProvider.overrideWithValue(videoEventService),
+            routerLocationStreamProvider.overrideWith(
+              (ref) => Stream.value(ExploreScreen.pathForTab('new')),
+            ),
+            exploreTabVideosProvider.overrideWith((ref) => null),
+            classicVinesAvailableProvider.overrideWith((ref) async => false),
+            forYouAvailableProvider.overrideWithValue(false),
+            allListsProvider.overrideWith(
+              (ref) async =>
+                  (userLists: <UserList>[], curatedLists: <CuratedList>[]),
+            ),
+            curatedListsStateProvider.overrideWith(_FakeCuratedListsState.new),
+            isFeatureEnabledProvider(
+              FeatureFlag.integratedApps,
+            ).overrideWithValue(false),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: ExploreScreen(initialTabName: 'new')),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final tabBar = tester.widget<TabBar>(find.byType(TabBar));
+      expect(
+        tabBar.controller?.index,
+        equals(0),
+        reason: 'New tab should be selected at index 0',
+      );
+    });
+  });
+}

--- a/mobile/test/router/explore_tab_route_test.dart
+++ b/mobile/test/router/explore_tab_route_test.dart
@@ -10,7 +10,8 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
-import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/l10n/generated/app_localizations_en.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/classic_vines_provider.dart';
@@ -76,10 +77,32 @@ void main() {
         ExploreScreen.pathForTab('categories'),
         equals('/explore/tab/categories'),
       );
+      expect(
+        ExploreScreen.pathForTab('for_you'),
+        equals('/explore/tab/for-you'),
+      );
     });
 
     test('pathTabSubpath constant equals /explore/tab/:name', () {
       expect(ExploreScreen.pathTabSubpath, equals('/explore/tab/:name'));
+    });
+  });
+
+  group('ExploreScreen.tabNameFromPathParameter', () {
+    test('maps URL slugs to internal tab names', () {
+      expect(
+        ExploreScreen.tabNameFromPathParameter('popular'),
+        equals('popular'),
+      );
+      expect(
+        ExploreScreen.tabNameFromPathParameter('for-you'),
+        equals('for_you'),
+      );
+    });
+
+    test('rejects unknown and underscore tab slugs', () {
+      expect(ExploreScreen.tabNameFromPathParameter('garbage'), isNull);
+      expect(ExploreScreen.tabNameFromPathParameter('for_you'), isNull);
     });
   });
 
@@ -111,8 +134,8 @@ void main() {
     });
 
     test(
-      'production app_router.dart registers ExploreScreen.pathTabSubpath '
-      'and threads :name into ExploreScreen.initialTabName',
+      'production app_router.dart validates :name before threading it into '
+      'ExploreScreen.initialTabName',
       () {
         final source = File('lib/router/app_router.dart').readAsStringSync();
 
@@ -128,9 +151,10 @@ void main() {
               'a valid URL.',
         );
 
-        // The pageBuilder for this route must read the :name path
-        // parameter and pass it to ExploreScreen as initialTabName,
-        // otherwise the URL has no effect on the rendered tab.
+        // The pageBuilder for this route must read and validate the :name
+        // path parameter before passing it to ExploreScreen. Invalid slugs
+        // should render RouteErrorScreen instead of silently coercing to some
+        // other tab.
         final nextGoRouteAfter = source.indexOf('GoRoute(', tabRouteOffset + 1);
         final region = source.substring(
           tabRouteOffset,
@@ -144,14 +168,72 @@ void main() {
               "state.pathParameters['name'] in its pageBuilder.",
         );
         expect(
+          region.contains('tabNameFromPathParameter'),
+          isTrue,
+          reason:
+              'The /explore/tab/:name route must validate the slug with '
+              'ExploreScreen.tabNameFromPathParameter before rendering.',
+        );
+        expect(
+          region.contains('RouteErrorScreen'),
+          isTrue,
+          reason:
+              'The /explore/tab/:name route must render RouteErrorScreen '
+              'for an invalid tab slug.',
+        );
+        expect(
+          region.contains('routeUnknownPath'),
+          isTrue,
+          reason:
+              'The invalid-tab route error should use the shared localized '
+              'routeUnknownPath copy.',
+        );
+        expect(
           region.contains('initialTabName:'),
           isTrue,
           reason:
-              'The /explore/tab/:name route must thread the :name '
-              'parameter into ExploreScreen(initialTabName: …).',
+              'A valid /explore/tab/:name route must still thread the '
+              'validated name into ExploreScreen(initialTabName: …).',
         );
       },
     );
+
+    testWidgets('invalid tab slug renders RouteErrorScreen', (tester) async {
+      final strings = AppLocalizationsEn();
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink()),
+          GoRoute(
+            path: ExploreScreen.pathTabSubpath,
+            pageBuilder: (ctx, st) {
+              final tabName = ExploreScreen.tabNameFromPathParameter(
+                st.pathParameters['name'],
+              );
+              if (tabName == null) {
+                return NoTransitionPage(
+                  child: RouteErrorScreen(message: ctx.l10n.routeUnknownPath),
+                );
+              }
+              return NoTransitionPage(child: Text(tabName));
+            },
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      );
+      router.go('/explore/tab/garbage');
+      await tester.pumpAndSettle();
+
+      expect(find.text(strings.routeUnknownPath), findsOneWidget);
+    });
   });
 
   group('ExploreScreen initialTabName', () {


### PR DESCRIPTION
## Summary

- Adds `/explore/tab/:name` as a real, deep-linkable URL for landing on a specific Explore tab (e.g. `/explore/tab/popular`).
- New users with no follow list now land directly on **Popular** via this URL instead of `/explore` plus the implicit `forceExploreTabNameProvider` workaround.
- Sets up the path so the existing force-provider mechanism can be retired in a follow-up.

## What changed

**ExploreScreen** (`lib/screens/explore_screen.dart`)
- New `pathTabSubpath` constant (`/explore/tab/:name`) and `pathForTab(name)` helper, alongside the existing `pathForIndex`.
- New optional `initialTabName` constructor arg. `_initTabController` resolves the target tab in the order: route arg → `forceExploreTabNameProvider` → previous tab → `'new'`. This survives Classics/ForYou/Apps appearing and disappearing because resolution is by name, never by raw index.

**Router** (`lib/router/app_router.dart`)
- New `GoRoute` under the shell at `pathTabSubpath`, sharing `NavigatorKeys.exploreGrid` so it behaves like the bare `/explore` grid route but with a preselected tab. Reads `state.pathParameters['name']` and threads it as `initialTabName`.

**Empty-following redirect** (`lib/router/providers/redirect_provider.dart`)
- `checkEmptyFollowingRedirectProvider` returns `ExploreScreen.pathForTab('popular')` for empty-following users on `/welcome`, instead of `ExploreScreen.path`.

**Tests** (177 pass, 65 skipped — no regressions)
- New `test/router/explore_tab_route_test.dart` (6 tests):
  - `pathForTab` URL helper
  - `pathTabSubpath` constant
  - GoRouter path-parameter round-trip for `:name`
  - Static-source regression guard that `app_router.dart` registers the route and threads `pathParameters['name']` into `initialTabName` (mirrors the existing `#3413` guard)
  - Two widget tests that `initialTabName: 'popular'` and `initialTabName: 'new'` select the right tab on mount
- `test/router/empty_contacts_redirect_test.dart` (+3 tests): `checkEmptyFollowingRedirectProvider` returns `/explore/tab/popular` for empty-following on `/welcome`, `null` for users with follows, `null` for non-`/welcome` origins.

## Backward compatibility

Existing call sites that pair `forceExploreTabNameProvider` with `context.go(ExploreScreen.path)` (`email_verification_screen.dart`, `settings_screen.dart`) still work — the new constructor arg is the highest priority, but the force provider is the fallback. Migrating those to `pathForTab` and retiring the provider is a clean follow-up.

## Infra commit (separate)

The first commit on this branch is unrelated infra cleanup so the worktree can run tests:
- `mobile/mise.toml`: drop trailing `-stable` from the Flutter pin so the asdf-flutter URL pattern resolves (the plugin appends the channel, so `3.41.4-stable` produced a doubled URL that 404s).
- `mobile/lib/l10n/generated/app_localizations_{am,bg}.dart`: regenerate for `reportOtherRequiresDetails` / `reportDetailsRequired` (added in #3475 but not regenerated in those locales).

## Test plan

- [x] `flutter test test/router/` — 177 pass / 65 skip
- [x] `flutter test test/screens/explore_screen_apps_tab_test.dart test/screens/explore_screen_lists_tab_test.dart test/screens/explore_screen_hashtag_loading_test.dart` — all pass
- [x] `flutter analyze lib test` — no issues
- [x] `dart format --output=none --set-exit-if-changed lib test integration_test` — clean
- [ ] Manually verify `/explore/tab/popular` deep-link selects the Popular tab on a real device
- [ ] Manually verify a brand-new user (no follow list cache) lands on Popular after first auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)