### PR TITLE
fix(profile): claim username before publishing kind 0

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -1,10 +1,11 @@
 // ABOUTME: BLoC for orchestrating profile save and username claiming
-// ABOUTME: Handles rollback when username claim fails
+// ABOUTME: Claims the username on the registry before publishing kind 0,
+// ABOUTME: so kind 0 with a divine.video nip05 is never broadcast unless the
+// ABOUTME: corresponding registry entry is in place.
 
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:models/models.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:stream_transform/stream_transform.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -349,7 +350,14 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     }
   }
 
-  /// Core profile save logic (extracted for reuse)
+  /// Core profile save logic (extracted for reuse).
+  ///
+  /// Order of operations is **claim first, publish second**: when a divine.video
+  /// username is requested, the registry claim runs before the kind 0 metadata
+  /// event is broadcast. Kind 0 is gossiped to relays and effectively immutable
+  /// once sent, so publishing it before confirming the claim could leave the
+  /// user advertising a `_@<name>.divine.video` identifier that the registry
+  /// has no record of — irrecoverable without manual intervention.
   Future<void> _saveProfile(
     ProfileSaved event,
     Emitter<ProfileEditorState> emit,
@@ -389,10 +397,55 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       name: 'ProfileEditorBloc',
     );
 
-    // 1. Publish profile
-    UserProfile savedProfile;
+    // 1. Claim the divine.video username FIRST when one is requested.
+    //
+    // If the claim fails for any reason — taken, reserved, network error,
+    // server unreachable — we abort *before* publishing kind 0. This keeps
+    // the user's metadata in sync with the registry by construction.
+    if (username != null) {
+      Log.info(
+        '📝 Attempting to claim username: $username',
+        name: 'ProfileEditorBloc',
+      );
+
+      final result = await _profileRepository.claimUsername(username: username);
+
+      Log.info('📝 Username claim result: $result', name: 'ProfileEditorBloc');
+
+      final claimError = switch (result) {
+        UsernameClaimSuccess() => null,
+        UsernameClaimTaken() => ProfileEditorError.usernameTaken,
+        UsernameClaimReserved() => ProfileEditorError.usernameReserved,
+        UsernameClaimError() => ProfileEditorError.claimFailed,
+      };
+
+      if (claimError != null) {
+        final usernameStatus = switch (claimError) {
+          ProfileEditorError.usernameReserved => UsernameStatus.reserved,
+          ProfileEditorError.usernameTaken => UsernameStatus.taken,
+          _ => null,
+        };
+
+        final reservedUsernames = usernameStatus == UsernameStatus.reserved
+            ? {...state.reservedUsernames, username}
+            : null;
+
+        emit(
+          state.copyWith(
+            status: ProfileEditorStatus.failure,
+            error: claimError,
+            usernameStatus: usernameStatus,
+            reservedUsernames: reservedUsernames,
+          ),
+        );
+        return;
+      }
+    }
+
+    // 2. Publish kind 0 metadata. By this point either no divine.video
+    // username was requested, or the claim has been confirmed.
     try {
-      savedProfile = await _profileRepository.saveProfileEvent(
+      final savedProfile = await _profileRepository.saveProfileEvent(
         displayName: displayName,
         about: about,
         username: username,
@@ -407,6 +460,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
         name: 'ProfileEditorBloc',
       );
       await _profileRepository.cacheProfile(savedProfile);
+      emit(state.copyWith(status: ProfileEditorStatus.success));
     } catch (error, stackTrace) {
       addError(error, stackTrace);
       Log.error('Failed to publish profile: $error', name: 'ProfileEditorBloc');
@@ -419,80 +473,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
           error: profileError,
         ),
       );
-      return;
     }
-
-    // 2. No username to claim - done (external NIP-05 or no NIP-05)
-    if (username == null) {
-      Log.info(
-        '📝 No username to claim '
-        '${externalNip05 != null ? "(external NIP-05)" : ""}, SUCCESS',
-        name: 'ProfileEditorBloc',
-      );
-      emit(state.copyWith(status: ProfileEditorStatus.success));
-      return;
-    }
-
-    // 3. Claim username
-    Log.info(
-      '📝 Attempting to claim username: $username',
-      name: 'ProfileEditorBloc',
-    );
-
-    final result = await _profileRepository.claimUsername(username: username);
-
-    Log.info('📝 Username claim result: $result', name: 'ProfileEditorBloc');
-
-    final error = switch (result) {
-      UsernameClaimSuccess() => null,
-      UsernameClaimTaken() => ProfileEditorError.usernameTaken,
-      UsernameClaimReserved() => ProfileEditorError.usernameReserved,
-      UsernameClaimError() => ProfileEditorError.claimFailed,
-    };
-
-    if (error == null) {
-      Log.info('📝 Username claim SUCCESS', name: 'ProfileEditorBloc');
-      emit(state.copyWith(status: ProfileEditorStatus.success));
-      return;
-    }
-
-    // 4. Rollback on failure
-    Log.info(
-      '📝 Rolling back to nip05=${currentProfile?.nip05}',
-      name: 'ProfileEditorBloc',
-    );
-    try {
-      final rolledBack = await _profileRepository.saveProfileEvent(
-        displayName: displayName,
-        about: about,
-        picture: picture,
-        banner: banner,
-        currentProfile: currentProfile,
-      );
-      await _profileRepository.cacheProfile(rolledBack);
-      Log.info('📝 Rollback complete', name: 'ProfileEditorBloc');
-    } catch (e) {
-      Log.error('Rollback failed: $e', name: 'ProfileEditorBloc');
-    }
-
-    final usernameStatus = switch (error) {
-      ProfileEditorError.usernameReserved => UsernameStatus.reserved,
-      ProfileEditorError.usernameTaken => UsernameStatus.taken,
-      _ => null,
-    };
-
-    final reservedUsernames = usernameStatus == UsernameStatus.reserved
-        ? {...state.reservedUsernames, username}
-        : null;
-
-    emit(
-      state.copyWith(
-        status: ProfileEditorStatus.failure,
-        error: error,
-        usernameStatus: usernameStatus,
-        reservedUsernames: reservedUsernames,
-      ),
-    );
   }
 }
 

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2203,6 +2203,8 @@
   "reportCancel": "ሰርዝ",
   "reportSubmit": "ሪፖርት አድርግ",
   "reportSelectReason": "እባክዎ ይህን ይዘት ሪፖርት ለማድረግ ምክንያት ይምረጡ",
+  "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+  "reportDetailsRequired": "Please describe the issue",
   "reportReasonSpam": "አይፈለጌ መልእክት ወይም የማይፈለግ ይዘት",
   "reportReasonHarassment": "ማስፈራራት፣ ማስፈራራት ወይም ማስፈራራት",
   "reportReasonViolence": "የጥቃት ወይም ጽንፈኛ ይዘት",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2104,6 +2104,8 @@
   "reportCancel": "Отказ",
   "reportSubmit": "Докладвай",
   "reportSelectReason": "Избери причина за докладване на това съдържание",
+  "reportOtherRequiresDetails": "Please describe the issue when selecting Other",
+  "reportDetailsRequired": "Please describe the issue",
   "reportReasonSpam": "Спам или нежелано съдържание",
   "reportReasonHarassment": "Тормоз, малтретиране или заплахи",
   "reportReasonViolence": "Насилствено или екстремистко съдържание",

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4180,6 +4180,13 @@ class AppLocalizationsAm extends AppLocalizations {
   String get reportSelectReason => 'እባክዎ ይህን ይዘት ሪፖርት ለማድረግ ምክንያት ይምረጡ';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'አይፈለጌ መልእክት ወይም የማይፈለግ ይዘት';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4319,6 +4319,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Избери причина за докладване на това съдържание';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'Спам или нежелано съдържание';
 
   @override

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -1,5 +1,6 @@
 // ABOUTME: Unit tests for ProfileEditorBloc
-// ABOUTME: Tests profile publishing and username claiming with rollback on failure
+// ABOUTME: Asserts claim-before-publish ordering — kind 0 must never be
+// ABOUTME: broadcast unless the username claim succeeded first.
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -295,17 +296,17 @@ void main() {
             ),
           ],
           verify: (_) {
-            verify(
+            // Claim must run before publish so kind 0 is only broadcast
+            // after the registry confirms the name belongs to this pubkey.
+            verifyInOrder([
+              () => mockProfileRepository.claimUsername(username: testUsername),
               () => mockProfileRepository.saveProfileEvent(
                 displayName: testDisplayName,
                 about: testAbout,
                 username: testUsername,
                 picture: testPicture,
               ),
-            ).called(1);
-            verify(
-              () => mockProfileRepository.claimUsername(username: testUsername),
-            ).called(1);
+            ]);
           },
         );
 
@@ -439,11 +440,14 @@ void main() {
         );
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'does not attempt username claim when profile publish fails',
+          'still emits publishFailed when claim succeeds but publish fails',
           setUp: () {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
+            when(
+              () => mockProfileRepository.claimUsername(username: testUsername),
+            ).thenAnswer((_) async => const UsernameClaimSuccess());
             when(
               () => mockProfileRepository.saveProfileEvent(
                 displayName: testDisplayName,
@@ -463,12 +467,32 @@ void main() {
               username: testUsername,
             ),
           ),
+          expect: () => [
+            isA<ProfileEditorState>().having(
+              (s) => s.status,
+              'status',
+              ProfileEditorStatus.loading,
+            ),
+            isA<ProfileEditorState>()
+                .having((s) => s.status, 'status', ProfileEditorStatus.failure)
+                .having(
+                  (s) => s.error,
+                  'error',
+                  ProfileEditorError.publishFailed,
+                ),
+          ],
           verify: (_) {
-            verifyNever(
-              () => mockProfileRepository.claimUsername(
-                username: any(named: 'username'),
+            // Claim happens first; saveProfileEvent is then attempted and
+            // throws. There is no rollback publish.
+            verifyInOrder([
+              () => mockProfileRepository.claimUsername(username: testUsername),
+              () => mockProfileRepository.saveProfileEvent(
+                displayName: testDisplayName,
+                about: testAbout,
+                username: testUsername,
+                picture: testPicture,
               ),
-            );
+            ]);
           },
         );
       });
@@ -516,11 +540,15 @@ void main() {
         );
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'does not attempt username claim when no relays are connected',
+          'still emits noRelaysConnected when claim succeeded but publish '
+          'cannot reach any relay',
           setUp: () {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
+            when(
+              () => mockProfileRepository.claimUsername(username: testUsername),
+            ).thenAnswer((_) async => const UsernameClaimSuccess());
             when(
               () => mockProfileRepository.saveProfileEvent(
                 displayName: testDisplayName,
@@ -540,57 +568,6 @@ void main() {
               username: testUsername,
             ),
           ),
-          verify: (_) {
-            verifyNever(
-              () => mockProfileRepository.claimUsername(
-                username: any(named: 'username'),
-              ),
-            );
-          },
-        );
-      });
-
-      group('username taken', () {
-        blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'emits [loading, failure] with usernameTaken error',
-          setUp: () {
-            final existingProfile = createTestProfile(
-              nip05: 'original@example.com',
-            );
-            when(
-              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
-            ).thenAnswer((_) async => existingProfile);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-            when(
-              () => mockProfileRepository.claimUsername(username: testUsername),
-            ).thenAnswer((_) async => const UsernameClaimTaken());
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-          },
-          build: createBloc,
-          act: (bloc) => bloc.add(
-            const ProfileSaved(
-              pubkey: testPubkey,
-              displayName: testDisplayName,
-              about: testAbout,
-              picture: testPicture,
-              username: testUsername,
-            ),
-          ),
           expect: () => [
             isA<ProfileEditorState>().having(
               (s) => s.status,
@@ -602,153 +579,115 @@ void main() {
                 .having(
                   (s) => s.error,
                   'error',
-                  ProfileEditorError.usernameTaken,
+                  ProfileEditorError.noRelaysConnected,
                 ),
           ],
+          errors: () => [isA<NoRelaysConnectedException>()],
         );
+      });
 
-        blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'rolls back profile preserving original nip05 via currentProfile',
-          setUp: () {
-            final existingProfile = createTestProfile(
-              nip05: 'original@example.com',
-            );
-            when(
-              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
-            ).thenAnswer((_) async => existingProfile);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-            when(
-              () => mockProfileRepository.claimUsername(username: testUsername),
-            ).thenAnswer((_) async => const UsernameClaimTaken());
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-          },
-          build: createBloc,
-          act: (bloc) => bloc.add(
-            const ProfileSaved(
-              pubkey: testPubkey,
-              displayName: testDisplayName,
-              about: testAbout,
-              picture: testPicture,
-              username: testUsername,
-            ),
+      // Regression: kind 0 metadata is gossiped to relays and effectively
+      // immutable once broadcast. If we publish before confirming the username
+      // claim, a single name-server hiccup leaves the user advertising a
+      // _@<name>.divine.video identifier with no registry record. These tests
+      // assert that saveProfileEvent is never called when the claim fails.
+      group('claim failure does not broadcast kind 0', () {
+        for (final scenario in [
+          (
+            label: 'username taken',
+            result: const UsernameClaimTaken(),
+            expectedError: ProfileEditorError.usernameTaken,
+            expectedUsernameStatus: UsernameStatus.taken,
           ),
-          verify: (_) {
-            verifyInOrder([
-              () => mockProfileRepository.saveProfileEvent(
+          (
+            label: 'username reserved',
+            result: const UsernameClaimReserved(),
+            expectedError: ProfileEditorError.usernameReserved,
+            expectedUsernameStatus: UsernameStatus.reserved,
+          ),
+          (
+            label: 'name server error',
+            result: const UsernameClaimError('Server unavailable'),
+            expectedError: ProfileEditorError.claimFailed,
+            expectedUsernameStatus: null,
+          ),
+        ]) {
+          blocTest<ProfileEditorBloc, ProfileEditorState>(
+            'emits failure and never calls saveProfileEvent on '
+            '${scenario.label}',
+            setUp: () {
+              final existingProfile = createTestProfile(
+                nip05: 'original@example.com',
+              );
+              when(
+                () =>
+                    mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+              ).thenAnswer((_) async => existingProfile);
+              when(
+                () =>
+                    mockProfileRepository.claimUsername(username: testUsername),
+              ).thenAnswer((_) async => scenario.result);
+            },
+            build: createBloc,
+            act: (bloc) => bloc.add(
+              const ProfileSaved(
+                pubkey: testPubkey,
                 displayName: testDisplayName,
                 about: testAbout,
+                picture: testPicture,
                 username: testUsername,
-                picture: testPicture,
-                currentProfile: any(named: 'currentProfile'),
               ),
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                currentProfile: any(named: 'currentProfile'),
+            ),
+            expect: () => [
+              isA<ProfileEditorState>().having(
+                (s) => s.status,
+                'status',
+                ProfileEditorStatus.loading,
               ),
-            ]);
-          },
-        );
+              isA<ProfileEditorState>()
+                  .having(
+                    (s) => s.status,
+                    'status',
+                    ProfileEditorStatus.failure,
+                  )
+                  .having((s) => s.error, 'error', scenario.expectedError)
+                  .having(
+                    (s) => s.usernameStatus,
+                    'usernameStatus',
+                    scenario.expectedUsernameStatus ?? UsernameStatus.idle,
+                  ),
+            ],
+            verify: (_) {
+              verify(
+                () =>
+                    mockProfileRepository.claimUsername(username: testUsername),
+              ).called(1);
+              verifyNever(
+                () => mockProfileRepository.saveProfileEvent(
+                  displayName: any(named: 'displayName'),
+                  about: any(named: 'about'),
+                  username: any(named: 'username'),
+                  nip05: any(named: 'nip05'),
+                  clearNip05: any(named: 'clearNip05'),
+                  picture: any(named: 'picture'),
+                  banner: any(named: 'banner'),
+                  currentProfile: any(named: 'currentProfile'),
+                ),
+              );
+              verifyNever(() => mockProfileRepository.cacheProfile(any()));
+            },
+          );
+        }
 
         blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'rolls back with null currentProfile when no existing profile',
+          'records reserved username in state for re-check support',
           setUp: () {
             when(
               () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
             ).thenAnswer((_) async => null);
             when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-            when(
-              () => mockProfileRepository.claimUsername(username: testUsername),
-            ).thenAnswer((_) async => const UsernameClaimTaken());
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-          },
-          build: createBloc,
-          act: (bloc) => bloc.add(
-            const ProfileSaved(
-              pubkey: testPubkey,
-              displayName: testDisplayName,
-              about: testAbout,
-              picture: testPicture,
-              username: testUsername,
-            ),
-          ),
-          verify: (_) {
-            verifyInOrder([
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-              ),
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-              ),
-            ]);
-          },
-        );
-      });
-
-      group('username reserved', () {
-        blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'emits [loading, failure] with usernameReserved error',
-          setUp: () {
-            final existingProfile = createTestProfile(
-              nip05: 'original@example.com',
-            );
-            when(
-              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
-            ).thenAnswer((_) async => existingProfile);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-            when(
               () => mockProfileRepository.claimUsername(username: testUsername),
             ).thenAnswer((_) async => const UsernameClaimReserved());
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
           },
           build: createBloc,
           act: (bloc) => bloc.add(
@@ -769,186 +708,9 @@ void main() {
             isA<ProfileEditorState>()
                 .having((s) => s.status, 'status', ProfileEditorStatus.failure)
                 .having(
-                  (s) => s.error,
-                  'error',
-                  ProfileEditorError.usernameReserved,
-                ),
-          ],
-        );
-
-        blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'rolls back profile when username is reserved',
-          setUp: () {
-            final existingProfile = createTestProfile(
-              nip05: 'original@example.com',
-            );
-            when(
-              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
-            ).thenAnswer((_) async => existingProfile);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-            when(
-              () => mockProfileRepository.claimUsername(username: testUsername),
-            ).thenAnswer((_) async => const UsernameClaimReserved());
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-          },
-          build: createBloc,
-          act: (bloc) => bloc.add(
-            const ProfileSaved(
-              pubkey: testPubkey,
-              displayName: testDisplayName,
-              about: testAbout,
-              picture: testPicture,
-              username: testUsername,
-            ),
-          ),
-          verify: (_) {
-            verifyInOrder([
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-                currentProfile: any(named: 'currentProfile'),
-              ),
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                currentProfile: any(named: 'currentProfile'),
-              ),
-            ]);
-          },
-        );
-      });
-
-      group('username claim error', () {
-        blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'emits [loading, failure] with claimFailed error',
-          setUp: () {
-            final existingProfile = createTestProfile(
-              nip05: 'original@example.com',
-            );
-            when(
-              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
-            ).thenAnswer((_) async => existingProfile);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-            when(
-              () => mockProfileRepository.claimUsername(username: testUsername),
-            ).thenAnswer(
-              (_) async => const UsernameClaimError('Server unavailable'),
-            );
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-          },
-          build: createBloc,
-          act: (bloc) => bloc.add(
-            const ProfileSaved(
-              pubkey: testPubkey,
-              displayName: testDisplayName,
-              about: testAbout,
-              picture: testPicture,
-              username: testUsername,
-            ),
-          ),
-          expect: () => [
-            isA<ProfileEditorState>().having(
-              (s) => s.status,
-              'status',
-              ProfileEditorStatus.loading,
-            ),
-            isA<ProfileEditorState>()
-                .having((s) => s.status, 'status', ProfileEditorStatus.failure)
-                .having(
-                  (s) => s.error,
-                  'error',
-                  ProfileEditorError.claimFailed,
-                ),
-          ],
-        );
-      });
-
-      group('rollback failure', () {
-        blocTest<ProfileEditorBloc, ProfileEditorState>(
-          'still returns correct error when rollback fails',
-          setUp: () {
-            final existingProfile = createTestProfile(
-              nip05: 'original@example.com',
-            );
-            when(
-              () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
-            ).thenAnswer((_) async => existingProfile);
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                username: testUsername,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenAnswer((_) async => createTestProfile());
-            when(
-              () => mockProfileRepository.claimUsername(username: testUsername),
-            ).thenAnswer((_) async => const UsernameClaimTaken());
-            when(
-              () => mockProfileRepository.saveProfileEvent(
-                displayName: testDisplayName,
-                about: testAbout,
-                picture: testPicture,
-                currentProfile: existingProfile,
-              ),
-            ).thenThrow(const ProfilePublishFailedException('Rollback failed'));
-          },
-          build: createBloc,
-          act: (bloc) => bloc.add(
-            const ProfileSaved(
-              pubkey: testPubkey,
-              displayName: testDisplayName,
-              about: testAbout,
-              picture: testPicture,
-              username: testUsername,
-            ),
-          ),
-          expect: () => [
-            isA<ProfileEditorState>().having(
-              (s) => s.status,
-              'status',
-              ProfileEditorStatus.loading,
-            ),
-            isA<ProfileEditorState>()
-                .having((s) => s.status, 'status', ProfileEditorStatus.failure)
-                .having(
-                  (s) => s.error,
-                  'error',
-                  ProfileEditorError.usernameTaken,
+                  (s) => s.reservedUsernames,
+                  'reservedUsernames',
+                  contains(testUsername),
                 ),
           ],
         );


### PR DESCRIPTION
## Description

`ProfileEditorBloc._saveProfile` published the kind 0 metadata event before
attempting the username claim, then tried a best-effort rollback if the claim
failed. Because kind 0 is gossiped immutably to relays, any failure mode on
the second step left users advertising a `_@<name>.divine.video` identifier
that the username registry had no record of — and the rollback could not
reliably take the broadcast back.

Observed in the wild on 2026-05-03: a brand-new user signed up via
divine-mobile, hit a name-server hiccup mid-save, and ended up with
`nip05: "_@<name>.divine.video"` in her cached/published kind 0 while
`https://<name>.divine.video/.well-known/nostr.json` returns empty and the
divine-router KV has no `user:<name>` entry. The funnelcake REST API shows
`nip05_verified: false` and the public profile page renders the badge struck
through.

This PR reverses the order: claim first, publish second.

- If the claim fails (taken / reserved / network / 5xx / timeout / NIP-98
  signing returned null), `saveProfileEvent` is **never called**, so kind 0
  is never broadcast with an unregistered nip05.
- If the claim succeeds and the publish then fails, the user owns the name
  on the registry and can retry the metadata save without losing the claim.
  The state surfaces `publishFailed` (or `noRelaysConnected`) just as it did
  before.
- The rollback path is removed entirely — it was best-effort, swallowed
  errors with a single `Log.error`, and could not unbroadcast a kind 0 that
  some indexers had already cached.

The behavior change is invisible to the happy path. Only the failure modes
collapse to safer ones.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Tests

- Updated the existing \"happy path\" test to assert the new ordering with
  \`verifyInOrder([claimUsername, saveProfileEvent])\`.
- New \`claim failure does not broadcast kind 0\` group: parameterized over
  \`UsernameClaimTaken\`, \`UsernameClaimReserved\`, and \`UsernameClaimError\`,
  asserts that \`saveProfileEvent\` and \`cacheProfile\` are **never called**
  when the claim fails. This is the regression guard for the bug above.
- Updated the publish-failure tests for the with-username case to expect
  the claim to succeed first, since publish only runs after a confirmed
  claim.
- Removed the \"rolls back ...\" and \"rollback failure\" tests, which
  asserted the now-deleted rollback behavior.

\`flutter analyze lib test integration_test\` clean.
\`flutter test test/blocs/profile_editor/ test/screens/profile_setup_screen_test.dart\`
all pass (97 tests).

## Test plan

- [ ] CI green
- [ ] Smoke test new-user onboarding with username on a debug build:
      pick available name → save → kind 0 has nip05 only on success
- [ ] Force a name-server failure (block names.divine.video) and confirm
      no kind 0 with the divine.video nip05 is broadcast
- [ ] Confirm existing-user "change avatar" flow (no username typed) still
      saves cleanly

## Follow-ups (not in this PR)

- For affected users like the one referenced above, support will need to
  either manually claim the name on names.divine.video for their pubkey,
  or the user can toggle to external NIP-05 mode and back to clear the
  bad nip05 from kind 0.
- Worth auditing the names.divine.video → divine-router KV write to
  confirm it is write-then-respond rather than respond-then-write — a
  successful claim that does not durably persist would still produce the
  same symptom under this fix.