### PR TITLE
feat(audio): restore saved sounds editor tab

### DIFF
--- a/mobile/lib/widgets/video_editor/audio_editor/audio_category_bar.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_category_bar.dart
@@ -30,6 +30,11 @@ class AudioCategoryBar extends StatelessWidget {
             isSelected: category == .community,
             label: context.l10n.videoEditorAudioCategoryCommunity,
           ),
+          _Chip(
+            onTap: () => onSelect(.mySounds),
+            isSelected: category == .mySounds,
+            label: context.l10n.soundsSavedLibraryTitle,
+          ),
         ],
       ),
     );
@@ -76,4 +81,4 @@ class _Chip extends StatelessWidget {
   }
 }
 
-enum AudioCategory { diVine, community }
+enum AudioCategory { diVine, community, mySounds }

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/saved_sounds_provider.dart';
 import 'package:openvine/providers/sound_library_service_provider.dart';
 import 'package:openvine/providers/sounds_providers.dart';
 import 'package:openvine/screens/video_editor/video_audio_editor_timing_screen.dart';
@@ -226,6 +227,7 @@ class _AudioSelectionBottomSheetState
   Widget build(BuildContext context) {
     final bundledSoundsAsync = ref.watch(soundLibraryServiceProvider);
     final nostrSoundsAsync = ref.watch(trendingSoundsProvider);
+    final savedSounds = ref.watch(savedSoundsProvider);
 
     // Convert bundled VineSounds to AudioEvents
     final bundledSounds =
@@ -254,6 +256,10 @@ class _AudioSelectionBottomSheetState
                     selectedSound: _selectedItem,
                     audioService: _audioService,
                     onSelect: _selectSound,
+                    emptyTitle:
+                        context.l10n.videoEditorAudioNoSoundsAvailableTitle,
+                    emptySubtitle:
+                        context.l10n.videoEditorAudioNoSoundsAvailableSubtitle,
                   ),
 
                   nostrSoundsAsync.when(
@@ -264,11 +270,26 @@ class _AudioSelectionBottomSheetState
                         selectedSound: _selectedItem,
                         audioService: _audioService,
                         onSelect: _selectSound,
+                        emptyTitle:
+                            context.l10n.videoEditorAudioNoSoundsAvailableTitle,
+                        emptySubtitle: context
+                            .l10n
+                            .videoEditorAudioNoSoundsAvailableSubtitle,
                       );
                     },
                     loading: () =>
                         const Center(child: BrandedLoadingIndicator()),
                     error: (error, stack) => _ErrorState(error: error),
+                  ),
+
+                  _SoundsContent(
+                    scrollController: widget.scrollController,
+                    sounds: savedSounds,
+                    selectedSound: _selectedItem,
+                    audioService: _audioService,
+                    onSelect: _selectSound,
+                    emptyTitle: context.l10n.soundsSavedEmptyTitle,
+                    emptySubtitle: context.l10n.soundsSavedEmptyDescription,
                   ),
                 ],
               ),
@@ -302,6 +323,8 @@ class _SoundsContent extends StatelessWidget {
     required this.selectedSound,
     required this.audioService,
     required this.onSelect,
+    required this.emptyTitle,
+    required this.emptySubtitle,
   });
 
   final ScrollController scrollController;
@@ -309,13 +332,15 @@ class _SoundsContent extends StatelessWidget {
   final AudioEvent? selectedSound;
   final AudioPlaybackService audioService;
   final ValueChanged<AudioEvent> onSelect;
+  final String emptyTitle;
+  final String emptySubtitle;
 
   static const _bottomSpace = 120.0;
 
   @override
   Widget build(BuildContext context) {
     if (sounds.isEmpty) {
-      return const _EmptyState();
+      return _EmptyState(title: emptyTitle, subtitle: emptySubtitle);
     }
 
     return CustomScrollView(
@@ -361,7 +386,10 @@ class _SoundsContent extends StatelessWidget {
 }
 
 class _EmptyState extends StatelessWidget {
-  const _EmptyState();
+  const _EmptyState({required this.title, required this.subtitle});
+
+  final String title;
+  final String subtitle;
 
   @override
   Widget build(BuildContext context) {
@@ -371,13 +399,10 @@ class _EmptyState extends StatelessWidget {
         children: [
           const Icon(Icons.music_off, size: 64, color: VineTheme.secondaryText),
           const SizedBox(height: 16),
-          Text(
-            context.l10n.videoEditorAudioNoSoundsAvailableTitle,
-            style: VineTheme.bodyLargeFont(),
-          ),
+          Text(title, style: VineTheme.bodyLargeFont()),
           const SizedBox(height: 8),
           Text(
-            context.l10n.videoEditorAudioNoSoundsAvailableSubtitle,
+            subtitle,
             style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
             textAlign: TextAlign.center,
           ),

--- a/mobile/test/widgets/video_editor/audio_editor/audio_category_bar_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_category_bar_test.dart
@@ -23,7 +23,7 @@ void main() {
       );
     }
 
-    testWidgets('renders both category chips', (tester) async {
+    testWidgets('renders all category chips', (tester) async {
       await tester.pumpWidget(
         buildWidget(category: AudioCategory.diVine, onSelect: (_) {}),
       );
@@ -32,6 +32,7 @@ void main() {
       final l10n = lookupAppLocalizations(const Locale('en'));
       expect(find.text(l10n.videoEditorAudioCategoryDivine), findsOneWidget);
       expect(find.text(l10n.videoEditorAudioCategoryCommunity), findsOneWidget);
+      expect(find.text(l10n.soundsSavedLibraryTitle), findsOneWidget);
     });
 
     testWidgets('calls onSelect with diVine when first chip is tapped', (
@@ -72,11 +73,30 @@ void main() {
       expect(selected, equals(AudioCategory.community));
     });
 
+    testWidgets('calls onSelect with mySounds when third chip is tapped', (
+      tester,
+    ) async {
+      AudioCategory? selected;
+      await tester.pumpWidget(
+        buildWidget(
+          category: AudioCategory.diVine,
+          onSelect: (c) => selected = c,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.tap(find.text(l10n.soundsSavedLibraryTitle));
+      await tester.pumpAndSettle();
+
+      expect(selected, equals(AudioCategory.mySounds));
+    });
+
     testWidgets('marks the selected chip with Semantics.selected', (
       tester,
     ) async {
       await tester.pumpWidget(
-        buildWidget(category: AudioCategory.diVine, onSelect: (_) {}),
+        buildWidget(category: AudioCategory.mySounds, onSelect: (_) {}),
       );
       await tester.pumpAndSettle();
 
@@ -97,9 +117,18 @@ void main() {
           ),
         ),
       );
+      final mySoundsSemantics = tester.widget<Semantics>(
+        find.ancestor(
+          of: find.text(l10n.soundsSavedLibraryTitle),
+          matching: find.byWidgetPredicate(
+            (w) => w is Semantics && w.properties.selected != null,
+          ),
+        ),
+      );
 
-      expect(divineSemantics.properties.selected, isTrue);
+      expect(divineSemantics.properties.selected, isFalse);
       expect(communitySemantics.properties.selected, isFalse);
+      expect(mySoundsSemantics.properties.selected, isTrue);
     });
   });
 }

--- a/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
@@ -7,15 +7,21 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/sound_library_service_provider.dart';
 import 'package:openvine/providers/sounds_providers.dart';
+import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:openvine/services/sound_library_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_category_bar.dart';
+import 'package:openvine/widgets/video_editor/audio_editor/audio_editor_selection_overlay.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_list_tile.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 AudioEvent _createTestAudioEvent({
   String id = 'test-sound-id',
@@ -42,8 +48,11 @@ void main() {
 
   group(AudioSelectionBottomSheet, () {
     late ScrollController scrollController;
+    late SharedPreferences sharedPreferences;
 
-    setUp(() {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      sharedPreferences = await SharedPreferences.getInstance();
       scrollController = ScrollController();
     });
 
@@ -51,17 +60,24 @@ void main() {
       scrollController.dispose();
     });
 
+    List<Override> providerOverrides({
+      AsyncValue<List<AudioEvent>>? trendingSoundsAsync,
+    }) {
+      return [
+        sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+        soundLibraryServiceProvider.overrideWith((_) => SoundLibraryService()),
+        if (trendingSoundsAsync != null)
+          trendingSoundsProvider.overrideWith(
+            () => _FakeTrendingSounds(trendingSoundsAsync),
+          ),
+      ];
+    }
+
     Widget buildWidget({AsyncValue<List<AudioEvent>>? trendingSoundsAsync}) {
       return ProviderScope(
-        overrides: [
-          soundLibraryServiceProvider.overrideWith(
-            (_) => SoundLibraryService(),
-          ),
-          if (trendingSoundsAsync != null)
-            trendingSoundsProvider.overrideWith(
-              () => _FakeTrendingSounds(trendingSoundsAsync),
-            ),
-        ],
+        overrides: providerOverrides(
+          trendingSoundsAsync: trendingSoundsAsync,
+        ),
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
@@ -100,6 +116,7 @@ void main() {
         expect(find.byType(AudioCategoryBar), findsOneWidget);
         expect(find.text(l10n.videoEditorAudioCategoryDivine), findsWidgets);
         expect(find.text(l10n.videoEditorAudioCategoryCommunity), findsWidgets);
+        expect(find.text(l10n.soundsSavedLibraryTitle), findsWidgets);
       });
     });
 
@@ -137,6 +154,152 @@ void main() {
         );
         expect(find.byIcon(Icons.music_off), findsOneWidget);
       });
+
+      testWidgets('renders saved sounds empty state on my sounds tab', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(trendingSoundsAsync: const AsyncValue.data([])),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.soundsSavedLibraryTitle));
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.soundsSavedEmptyTitle), findsOneWidget);
+        expect(find.text(l10n.soundsSavedEmptyDescription), findsOneWidget);
+      });
+    });
+
+    group('My Sounds', () {
+      testWidgets('shows saved sounds on my sounds tab', (tester) async {
+        await SavedSoundsService(sharedPreferences).saveSound(
+          _createTestAudioEvent(
+            id: 'saved-sound-1',
+            title: 'Saved Loop',
+            source: 'Original Sound',
+          ),
+        );
+
+        await tester.pumpWidget(
+          buildWidget(trendingSoundsAsync: const AsyncValue.data([])),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.soundsSavedLibraryTitle));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Saved Loop'), findsOneWidget);
+      });
+
+      testWidgets('returns the selected saved sound when done is tapped', (
+        tester,
+      ) async {
+        final savedSound = _createTestAudioEvent(
+          id: 'saved-sound-1',
+          title: 'Saved Loop',
+          source: 'Original Sound',
+          url: 'https://invalid.example/audio.mp3',
+          duration: 5,
+        );
+        await SavedSoundsService(sharedPreferences).saveSound(savedSound);
+
+        AudioEvent? result;
+        final router = GoRouter(
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) => Scaffold(
+                body: Builder(
+                  builder: (context) {
+                    return Center(
+                      child: ElevatedButton(
+                        onPressed: () async {
+                          result = await AudioSelectionBottomSheet.show(
+                            context,
+                          );
+                        },
+                        child: const Text('Open'),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ],
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: providerOverrides(
+              trendingSoundsAsync: const AsyncValue.data([]),
+            ),
+            child: MaterialApp.router(
+              routerConfig: router,
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text('Open'));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text(l10n.soundsSavedLibraryTitle));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text('Saved Loop'));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 250));
+
+        expect(find.byType(AudioEditorSelectionOverlay), findsOneWidget);
+        expect(find.text('Saved Loop'), findsWidgets);
+
+        await tester.tap(
+          find.bySemanticsLabel(l10n.videoEditorDoneSemanticLabel),
+        );
+        await tester.pumpAndSettle();
+
+        expect(result?.id, equals(savedSound.id));
+      });
+
+      testWidgets(
+        'keeps the selected saved sound visible across tab switches',
+        (
+          tester,
+        ) async {
+          await SavedSoundsService(sharedPreferences).saveSound(
+            _createTestAudioEvent(
+              id: 'saved-sound-1',
+              title: 'Saved Loop',
+              source: 'Original Sound',
+              url: 'https://invalid.example/audio.mp3',
+            ),
+          );
+
+          await tester.pumpWidget(
+            buildWidget(trendingSoundsAsync: AsyncValue.data(testSounds)),
+          );
+          await tester.pumpAndSettle();
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          await tester.tap(find.text(l10n.soundsSavedLibraryTitle));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Saved Loop'));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 250));
+
+          expect(find.byType(AudioEditorSelectionOverlay), findsOneWidget);
+
+          await tester.tap(find.text(l10n.videoEditorAudioCategoryCommunity));
+          await tester.pumpAndSettle();
+
+          expect(find.byType(AudioEditorSelectionOverlay), findsOneWidget);
+          expect(find.text('Saved Loop'), findsWidgets);
+        },
+      );
     });
 
     group('Error state', () {


### PR DESCRIPTION
Restores the saved-sounds editor tab that was reverted from `feat/audio-upload-reuse-fix`.

This PR reapplies the original `#3873` change on top of the current base branch after revert commit `291e1e4d2`.

Verification:
- `flutter analyze --no-pub lib/widgets/video_editor/audio_editor test/widgets/video_editor/audio_editor`
- `flutter test --no-pub test/widgets/video_editor/audio_editor/audio_category_bar_test.dart test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart`