### PR TITLE
fix(auth): retry invite consumption on 409 + accept divine.video subdomains

### DIFF
--- a/mobile/lib/blocs/email_verification/email_verification_cubit.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_cubit.dart
@@ -316,6 +316,15 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
   /// Delay between exchange retries
   static const _exchangeRetryDelay = Duration(seconds: 2);
 
+  /// Maximum retries for invite consumption when the server returns
+  /// HTTP 409 ("Another consumption is in progress; retry"). The conflict
+  /// happens when the server is briefly serializing concurrent attempts
+  /// for the same invite — clearing in a few hundred ms.
+  static const _maxConsumeRetries = 3;
+
+  /// Delay between invite-consumption retries on 409 conflict.
+  static const _consumeRetryDelay = Duration(milliseconds: 500);
+
   Future<void> _exchangeCodeAndLogin(String code, String verifier) async {
     for (var attempt = 1; attempt <= _maxExchangeRetries; attempt++) {
       try {
@@ -461,11 +470,29 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
       return;
     }
 
-    await inviteApiClient.consumeInviteWithSession(
-      code: inviteCode,
-      oauthConfig: _oauthClient.config,
-      session: session,
-    );
+    for (var attempt = 1; attempt <= _maxConsumeRetries; attempt++) {
+      try {
+        await inviteApiClient.consumeInviteWithSession(
+          code: inviteCode,
+          oauthConfig: _oauthClient.config,
+          session: session,
+        );
+        return;
+      } on InviteApiException catch (e) {
+        final isLastAttempt = attempt == _maxConsumeRetries;
+        if (e.statusCode != 409 || isLastAttempt) {
+          rethrow;
+        }
+        Log.warning(
+          'Invite consumption conflict, retrying in '
+          '${_consumeRetryDelay.inMilliseconds}ms '
+          '(attempt $attempt/$_maxConsumeRetries): ${e.message}',
+          name: 'EmailVerificationCubit',
+          category: LogCategory.auth,
+        );
+        await Future<void>.delayed(_consumeRetryDelay);
+      }
+    }
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4180,6 +4180,13 @@ class AppLocalizationsAm extends AppLocalizations {
   String get reportSelectReason => 'እባክዎ ይህን ይዘት ሪፖርት ለማድረግ ምክንያት ይምረጡ';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'አይፈለጌ መልእክት ወይም የማይፈለግ ይዘት';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4319,6 +4319,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Избери причина за докладване на това съдържание';
 
   @override
+  String get reportOtherRequiresDetails =>
+      'Please describe the issue when selecting Other';
+
+  @override
+  String get reportDetailsRequired => 'Please describe the issue';
+
+  @override
   String get reportReasonSpam => 'Спам или нежелано съдържание';
 
   @override

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -124,9 +124,14 @@ class DeepLinkService {
         return const DeepLink(type: DeepLinkType.signerCallback);
       }
 
-      // Only handle canonical Divine web hosts.
+      // Accept divine.video itself plus any subdomain
+      // (login.divine.video, staging.divine.video, etc.). Sibling and
+      // lookalike hosts like notdivine.video or divine.video.evil.com
+      // must still be rejected.
       final host = uri.host.toLowerCase();
-      if (host != 'divine.video' && host != 'www.divine.video') {
+      final isDivineHost =
+          host == 'divine.video' || host.endsWith('.divine.video');
+      if (!isDivineHost) {
         Log.warning(
           'Ignoring deep link from non-divine.video domain: ${uri.host}',
           name: 'DeepLinkService',

--- a/mobile/mise.toml
+++ b/mobile/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-flutter = "3.41.4-stable"
+flutter = "3.41.4"
 
 [tasks.local_up]
 description = "Start all local E2E services"

--- a/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
+++ b/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
@@ -212,6 +212,207 @@ void main() {
           fake.flushMicrotasks();
         });
       });
+
+      // Regression: server returns 409 "Another consumption is in progress;
+      // retry" when invite consumption races (e.g. user double-taps the
+      // verification link or the polling timer hits the same code twice).
+      // The server message literally tells the client to retry, but the
+      // cubit used to give up immediately, leaving the user stuck on the
+      // verify-email screen.
+      test(
+        'retries invite consumption on 409 conflict and succeeds on retry',
+        () {
+          when(() => mockAuthService.isRegistered).thenReturn(false);
+          when(() => mockAuthService.isAuthenticated).thenReturn(false);
+          when(() => mockAuthService.isAnonymous).thenReturn(false);
+          when(() => mockOAuth.config).thenReturn(
+            const OAuthConfig(
+              serverUrl: 'https://login.divine.video',
+              clientId: 'client-id',
+              redirectUri: 'divine://auth',
+            ),
+          );
+          when(
+            () => mockOAuth.pollForCode(testDeviceCode),
+          ).thenAnswer((_) async => PollResult.complete(testCode));
+          when(
+            () =>
+                mockOAuth.exchangeCode(code: testCode, verifier: testVerifier),
+          ).thenAnswer(
+            (_) async => const TokenResponse(bunkerUrl: 'wss://relay.test'),
+          );
+
+          var consumeCallCount = 0;
+          when(
+            () => mockInviteApiClient.consumeInviteWithSession(
+              code: any(named: 'code'),
+              oauthConfig: any(named: 'oauthConfig'),
+              session: any(named: 'session'),
+            ),
+          ).thenAnswer((_) async {
+            consumeCallCount++;
+            if (consumeCallCount == 1) {
+              throw const InviteApiException(
+                'Another consumption is in progress; retry',
+                statusCode: 409,
+              );
+            }
+            return const InviteConsumeResult(
+              message: 'Welcome',
+              codesAllocated: 5,
+            );
+          });
+          when(
+            () => mockAuthService.signInWithDivineOAuth(any()),
+          ).thenAnswer((_) async {});
+
+          fakeAsync((fake) {
+            final cubit = buildCubit();
+            cubit.startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+              inviteCode: 'ab12ef34',
+            );
+
+            // Poll fires after 3s; retry waits another ~500ms.
+            fake.elapse(const Duration(seconds: 5));
+
+            expect(cubit.state.status, EmailVerificationStatus.success);
+            expect(
+              consumeCallCount,
+              equals(2),
+              reason:
+                  'Cubit should retry once on 409 before considering '
+                  'invite consumption successful.',
+            );
+            verify(
+              () => mockAuthService.signInWithDivineOAuth(any()),
+            ).called(1);
+
+            cubit.close();
+            fake.flushMicrotasks();
+          });
+        },
+      );
+
+      test('gives up after exhausting retries on persistent 409', () {
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockOAuth.config).thenReturn(
+          const OAuthConfig(
+            serverUrl: 'https://login.divine.video',
+            clientId: 'client-id',
+            redirectUri: 'divine://auth',
+          ),
+        );
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.complete(testCode));
+        when(
+          () => mockOAuth.exchangeCode(code: testCode, verifier: testVerifier),
+        ).thenAnswer(
+          (_) async => const TokenResponse(bunkerUrl: 'wss://relay.test'),
+        );
+
+        var consumeCallCount = 0;
+        when(
+          () => mockInviteApiClient.consumeInviteWithSession(
+            code: any(named: 'code'),
+            oauthConfig: any(named: 'oauthConfig'),
+            session: any(named: 'session'),
+          ),
+        ).thenAnswer((_) async {
+          consumeCallCount++;
+          throw const InviteApiException(
+            'Another consumption is in progress; retry',
+            statusCode: 409,
+          );
+        });
+
+        fakeAsync((fake) {
+          final cubit = buildCubit();
+          cubit.startPolling(
+            deviceCode: testDeviceCode,
+            verifier: testVerifier,
+            email: testEmail,
+            inviteCode: 'ab12ef34',
+          );
+
+          // Generous elapse so all retries can play out.
+          fake.elapse(const Duration(seconds: 30));
+
+          expect(cubit.state.status, EmailVerificationStatus.failure);
+          expect(
+            consumeCallCount,
+            greaterThan(1),
+            reason:
+                'Cubit should retry at least once on 409 before giving '
+                'up.',
+          );
+          verifyNever(() => mockAuthService.signInWithDivineOAuth(any()));
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('does NOT retry on non-conflict InviteApiException (e.g. 400)', () {
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockOAuth.config).thenReturn(
+          const OAuthConfig(
+            serverUrl: 'https://login.divine.video',
+            clientId: 'client-id',
+            redirectUri: 'divine://auth',
+          ),
+        );
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.complete(testCode));
+        when(
+          () => mockOAuth.exchangeCode(code: testCode, verifier: testVerifier),
+        ).thenAnswer(
+          (_) async => const TokenResponse(bunkerUrl: 'wss://relay.test'),
+        );
+
+        var consumeCallCount = 0;
+        when(
+          () => mockInviteApiClient.consumeInviteWithSession(
+            code: any(named: 'code'),
+            oauthConfig: any(named: 'oauthConfig'),
+            session: any(named: 'session'),
+          ),
+        ).thenAnswer((_) async {
+          consumeCallCount++;
+          throw const InviteApiException(
+            'Invite is not valid',
+            statusCode: 400,
+          );
+        });
+
+        fakeAsync((fake) {
+          final cubit = buildCubit();
+          cubit.startPolling(
+            deviceCode: testDeviceCode,
+            verifier: testVerifier,
+            email: testEmail,
+            inviteCode: 'ab12ef34',
+          );
+
+          fake.elapse(const Duration(seconds: 5));
+
+          expect(cubit.state.status, EmailVerificationStatus.failure);
+          expect(
+            consumeCallCount,
+            equals(1),
+            reason: 'Non-409 invite errors must not be retried.',
+          );
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
     });
 
     group('stopPolling', () {

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -341,6 +341,12 @@ const _knownUntranslatedDebt = {
   'authConfirmPasswordRequired',
   'authPasswordsDoNotMatch',
   'authConfirmNewPasswordLabel',
+  // Added by the report-reason validation fix (#3475). The strings exist
+  // in app_en.arb but were not added to app_am.arb / app_bg.arb at the
+  // time. Generated locale files fall back to English until translators
+  // pick them up.
+  'reportOtherRequiresDetails',
+  'reportDetailsRequired',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -272,6 +272,70 @@ void main() {
         expect(result.type, equals(DeepLinkType.video));
         expect(result.videoId, equals(videoId));
       });
+
+      // Regression: an email verification link
+      // (https://login.divine.video/verify-email?...) was previously
+      // rejected with "Ignoring deep link from non-divine.video domain:
+      // login.divine.video". Subdomains of divine.video are still part
+      // of our deployment and must not be rejected at the host check.
+      test('accepts login.divine.video subdomain', () {
+        const videoId = 'abc123';
+        const url = 'https://login.divine.video/video/$videoId';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(
+          result.type,
+          equals(DeepLinkType.video),
+          reason:
+              'Subdomains of divine.video must be accepted as Divine '
+              'hosts. login.divine.video is the OAuth host used by '
+              'verification deep links.',
+        );
+        expect(result.videoId, equals(videoId));
+      });
+
+      test('accepts arbitrary subdomain of divine.video', () {
+        const videoId = 'abc123';
+        const url = 'https://staging.divine.video/video/$videoId';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.video));
+        expect(result.videoId, equals(videoId));
+      });
+
+      test('rejects lookalike domain (divine.video.evil.com)', () {
+        const url = 'https://divine.video.evil.com/video/abc123';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(
+          result.type,
+          equals(DeepLinkType.unknown),
+          reason:
+              'Hosts that merely contain "divine.video" as a non-suffix '
+              'must still be rejected.',
+        );
+      });
+
+      test(
+        'rejects domain that ends with divine.video without separator '
+        '(notdivine.video)',
+        () {
+          const url = 'https://notdivine.video/video/abc123';
+
+          final result = DeepLinkService.parseDeepLink(url);
+
+          expect(
+            result.type,
+            equals(DeepLinkType.unknown),
+            reason:
+                'Only divine.video and *.divine.video should be '
+                'accepted; sibling domains must not match.',
+          );
+        },
+      );
     });
 
     group('DeepLink Data Class', () {


### PR DESCRIPTION
## Summary

Two related fixes for the email-verification deep-link flow that was leaving registering users stranded on `/verify-email`. Reproduced from a real user's logs.

## What was broken

A user opened the verification email link (`https://login.divine.video/verify-email?…`). The app received it, verification polled successfully, but then the cubit failed with:

```
[EmailVerificationCubit] Invite activation failed: Another consumption is in progress; retry
```

…and never retried, even though the server's own message says **retry**. Because `signInWithDivineOAuth` was never called, auth state stayed `unauthenticated`, the screen's auth listener never fired `context.go(ExploreScreen.path)`, and the user remained on `/verify-email`. Eventually `WelcomeBloc` auto-signed them into a *previously registered* account, which is its own UX confusion.

A second, less impactful issue showed up in the same logs:

```
[DeepLinkService] Ignoring deep link from non-divine.video domain: login.divine.video
```

`login.divine.video` is a legitimate Divine subdomain. The host whitelist was too strict.

## Fixes

### 1. `EmailVerificationCubit` retries `409` invite-consumption conflicts

In `_consumeInviteWithSessionIfNeeded`, retry up to 3 times with 500ms backoff when `InviteApiException.statusCode == 409`. Other `InviteApiException` codes still terminate immediately. Token exchange is **not** re-run, so the one-shot OAuth code isn't burned by the retry. (`lib/blocs/email_verification/email_verification_cubit.dart`)

### 2. `DeepLinkService` accepts `*.divine.video`

Host check now accepts `host == 'divine.video'` or `host.endsWith('.divine.video')`. Lookalikes like `notdivine.video` and `divine.video.evil.com` remain rejected (test coverage). (`lib/services/deep_link_service.dart`)

## Tests

**`EmailVerificationCubit`** (3 new tests — TDD red→green):
- Retries invite consumption on 409 conflict and succeeds on retry
- Gives up after exhausting retries on persistent 409
- Does NOT retry on non-conflict `InviteApiException` (e.g. 400)

**`DeepLinkService`** (4 new tests — TDD red→green):
- Accepts `login.divine.video` subdomain
- Accepts arbitrary subdomain of `divine.video`
- Rejects lookalike `divine.video.evil.com`
- Rejects sibling `notdivine.video`

Full sweep: `test/blocs/email_verification/`, `test/services/deep_link_service_test.dart`, `test/providers/deep_link_provider_test.dart`, `test/router/universal_link_resolver_test.dart` — **89 pass / 0 fail**.

## Server-side follow-up (out of scope)

The 409 race itself shouldn't be happening. If two `consumeInviteWithSession` calls fire concurrently for the same invite, the server is currently serializing them via "in progress" status. Worth filing on the funnelcake side to either make this idempotent or block earlier. The client retry covers the symptom but not the cause.

## Infra commit (separate)

The first commit on this branch is the same infra unblock as #3899:
- `mobile/mise.toml`: drop trailing `-stable` from the Flutter pin so the asdf-flutter URL pattern resolves.
- `mobile/lib/l10n/generated/app_localizations_{am,bg}.dart`: regenerate for `reportOtherRequiresDetails` / `reportDetailsRequired` (added in #3475 but not regenerated for those locales).

When #3899 lands first, those changes will already be on main and this branch will rebase cleanly.

## Test plan

- [x] `flutter test test/blocs/email_verification/email_verification_cubit_test.dart` — 26 pass
- [x] `flutter test test/services/deep_link_service_test.dart` — 43 pass
- [x] `flutter analyze` on touched files — clean
- [x] `dart format` clean
- [ ] Manually re-test the registration → email click flow end-to-end. The 409 race may not reproduce on demand, but the new retry should make it self-recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)