### PR TITLE
chore: remove FFmpeg residue from Android, iOS, and tests

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -416,7 +416,7 @@ workflows:
           - POC
     environment:
       flutter: 3.41.1
-      xcode: 16.1  # Pinned to avoid FFmpeg Kit linker issues with newer Xcode
+      xcode: latest
       cocoapods: default
       groups:
         - zendesk_credentials
@@ -545,7 +545,7 @@ workflows:
     instance_type: mac_mini_m2
     environment:
       flutter: 3.41.1
-      xcode: 16.1
+      xcode: latest
       cocoapods: default
       groups:
         - zendesk_credentials

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -106,7 +106,7 @@ android {
             // Handle duplicate OSGI manifests from BouncyCastle
             pickFirsts.add("META-INF/versions/9/OSGI-INF/MANIFEST.MF")
         }
-        // Handle duplicate libc++_shared.so from c2pa-android and ffmpeg-kit
+        // Handle duplicate libc++_shared.so from c2pa-android
         jniLibs {
             pickFirsts.add("lib/arm64-v8a/libc++_shared.so")
             pickFirsts.add("lib/armeabi-v7a/libc++_shared.so")
@@ -120,11 +120,7 @@ flutter {
     source = "../.."
 }
 
-// Exclude FFmpeg native libraries on Android (not needed - using continuous recording)
 configurations.all {
-    exclude(group = "com.arthenica.ffmpegkit", module = "flutter")
-    exclude(group = "com.arthenica.ffmpegkit", module = "ffmpeg-kit-android")
-    exclude(group = "com.arthenica.ffmpegkit", module = "ffmpeg-kit-android-min")
     // Exclude older BouncyCastle jdk15to18 versions to avoid conflicts with c2pa's jdk18on versions
     exclude(group = "org.bouncycastle", module = "bcprov-jdk15to18")
     exclude(group = "org.bouncycastle", module = "bcpkix-jdk15to18")

--- a/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt
@@ -61,23 +61,7 @@ class MainActivity : FlutterActivity() {
     private var nostrSignerPlugin: NostrSignerPlugin? = null
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
-        try {
-            super.configureFlutterEngine(flutterEngine)
-        } catch (e: Exception) {
-            Log.e(PROOFMODE_TAG, "Exception during FlutterEngine configuration", e)
-            Log.e(PROOFMODE_TAG, "Exception message: ${e.message}")
-            Log.e(PROOFMODE_TAG, "Exception cause: ${e.cause?.message}")
-
-            // Handle FFmpegKit initialization failure on Android (not needed - using continuous recording)
-            // FFmpegKit is only used on iOS/macOS for video processing
-            if (e.message?.contains("FFmpegKit") == true || e.cause?.message?.contains("ffmpegkit") == true) {
-                Log.w(PROOFMODE_TAG, "FFmpegKit plugin failed to initialize (expected on Android)", e)
-                // Continue without FFmpegKit - Android uses camera-based continuous recording
-            } else {
-                // Re-throw other exceptions
-                throw e
-            }
-        }
+        super.configureFlutterEngine(flutterEngine)
 
         // Set up ProofMode platform channel
         setupProofModeChannel(flutterEngine)

--- a/mobile/test/services/audio_extraction_service_test.dart
+++ b/mobile/test/services/audio_extraction_service_test.dart
@@ -138,12 +138,12 @@ void main() {
 
     test('toString includes cause when present', () {
       const exception = AudioExtractionException(
-        'FFmpeg failed',
+        'Audio extraction failed',
         cause: 'Error: No audio stream found',
       );
 
       final str = exception.toString();
-      expect(str, contains('FFmpeg failed'));
+      expect(str, contains('Audio extraction failed'));
       expect(str, contains('caused by:'));
       expect(str, contains('No audio stream found'));
     });


### PR DESCRIPTION
Closes #3907

## Summary

FFmpeg-kit was removed from the app some time ago (no Dart imports, no `pubspec.yaml` entry), but defensive shims and stale comments remained in build configs and one test fixture. This sweep clears them out so the build configs reflect actual reality.

- **`codemagic.yaml`** — drop the `xcode: 16.1` pin (and its FFmpeg-Kit linker comment) on the two iOS workflows that still carried it. Remaining iOS workflows already use `xcode: latest`; this aligns the rest.
- **`mobile/android/app/build.gradle.kts`** — drop the three `com.arthenica.ffmpegkit` excludes from `configurations.all` and the trailing `// Exclude FFmpeg native libraries…` comment. Update the `libc++_shared.so` packaging comment to reflect that c2pa-android is the only remaining duplicate-shared-lib source.
- **`mobile/android/app/src/main/kotlin/co/openvine/app/MainActivity.kt`** — remove the try/catch that swallowed `FFmpegKit`-named init failures around `super.configureFlutterEngine`. With the plugin gone, the branch was dead code that masked any real engine-init exception.
- **`mobile/test/services/audio_extraction_service_test.dart`** — replace the `'FFmpeg failed'` test fixture string with `'Audio extraction failed'`. The literal is arbitrary (the assertion is on `AudioExtractionException.toString()` echoing whatever message it was constructed with), but the old value implied a backend that no longer exists.

## Test plan

- [x] `flutter analyze lib test integration_test` — clean
- [x] `flutter test test/services/audio_extraction_service_test.dart` — all 20 tests pass
- [ ] CI: Android build succeeds without the FFmpegKit excludes (no project still depends on it)
- [ ] CI: iOS workflows succeed on `xcode: latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)