### PR TITLE
fix(dm): clear optimistic on send failure, surface retry, key bloc on repo identity

### DIFF
--- a/.claude/rules/accessibility.md
+++ b/.claude/rules/accessibility.md
@@ -82,21 +82,25 @@ Semantics(
 
 ## Dynamic Announcements
 
-When the UI changes asynchronously (upload complete, error, navigation), announce the change to screen readers using `SemanticsService.announce`:
+When the UI changes asynchronously (upload complete, error, navigation), announce the change to screen readers using `SemanticsService.sendAnnouncement`. Prefer it over the older 2-arg `SemanticsService.announce` — `announce` was deprecated in Flutter 3.27 in favor of the view-aware form. All in-repo precedents (`feed_auto_advance_cubit.dart`, `feed_settings_menu.dart`, `paused_video_play_overlay.dart`, `conversation_view.dart`) already use the newer API.
 
 ```dart
 import 'package:flutter/semantics.dart';
 
 // After async operation completes
-SemanticsService.announce(
+SemanticsService.sendAnnouncement(
+  View.of(context),
   'Video uploaded successfully',
-  TextDirection.ltr,
+  Directionality.of(context),
 );
 
-// After error
-SemanticsService.announce(
+// After error — use Directionality.of(context) (not a hardcoded
+// TextDirection.ltr) so RTL locales like ar get the correct
+// reading direction.
+SemanticsService.sendAnnouncement(
+  View.of(context),
   'Upload failed. Please try again.',
-  TextDirection.ltr,
+  Directionality.of(context),
 );
 ```
 
@@ -304,7 +308,7 @@ When writing or reviewing code, flag these accessibility issues.
 - **Meaningful image or thumbnail without `semanticLabel`** — screen reader announces nothing useful
 - **Decorative image not wrapped in `ExcludeSemantics`** — clutters the semantics tree
 - **Fixed `SizedBox(height:)` around text-bearing widget** → suggest `ConstrainedBox(minHeight:)` for font scaling
-- **Missing `SemanticsService.announce()` after async state change** that updates visible content (upload, delete, error)
+- **Missing `SemanticsService.sendAnnouncement()` after async state change** that updates visible content (upload, delete, error)
 - **Semantic identifier as inline magic string** → suggest constant from `SemanticIds`
 
 ### Nitpick

--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -77,8 +77,12 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
     Emitter<ConversationState> emit,
   ) async {
     // Optimistic insert: show the message instantly before the network
-    // round-trip. The stream from watchMessages will replace this with the
-    // persisted version once sendMessage completes and writes to the DB.
+    // round-trip. On success, the stream from watchMessages replaces this
+    // with the persisted version. On failure we strip the optimistic row
+    // ourselves — the watch stream cannot do it because no DB write
+    // happened, and a phantom optimistic that lingers until the bloc is
+    // disposed reproduces as "looks sent, then disappeared" once the user
+    // navigates away and back.
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     final pendingId = 'pending-$now';
     final optimisticMessage = DmMessage(
@@ -94,6 +98,8 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
       state.copyWith(
         sendStatus: SendStatus.sending,
         messages: [optimisticMessage, ...state.messages],
+        // A new attempt always supersedes a prior failure — retry replaces it.
+        clearLastFailedSend: true,
       ),
     );
 
@@ -120,7 +126,18 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
       emit(state.copyWith(sendStatus: SendStatus.sent));
     } catch (e, stackTrace) {
       addError(e, stackTrace);
-      emit(state.copyWith(sendStatus: SendStatus.failed));
+      emit(
+        state.copyWith(
+          sendStatus: SendStatus.failed,
+          messages: state.messages
+              .where((m) => m.id != pendingId)
+              .toList(growable: false),
+          lastFailedSend: FailedSend(
+            content: event.content,
+            recipientPubkeys: event.recipientPubkeys,
+          ),
+        ),
+      );
     }
   }
 }

--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -111,7 +111,6 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
       state.copyWith(
         sendStatus: SendStatus.sending,
         messages: [optimisticMessage, ...state.messages],
-        // A new attempt always supersedes a prior failure — retry replaces it.
         clearLastFailedSend: true,
       ),
     );

--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -117,6 +117,19 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
     );
 
     try {
+      // Partial-delivery: recipient got the message and DmRepository
+      // persisted it locally, but the self-addressed gift wrap did not
+      // reach relays. The sender's other devices will not see this
+      // message on relay-only restore. Surface as a distinct status so
+      // the UI can offer a retry-sync path without claiming the send
+      // failed (the optimistic stays — the message *was* sent).
+      //
+      // Retrying redispatches the full send via [lastFailedSend], which
+      // double-delivers to the recipient on success. That tradeoff is
+      // accepted here: silent loss of cross-device sync is worse than a
+      // duplicate bubble. The principled fix — a durable outgoing queue
+      // that retries the self-wrap only — is tracked in #3909.
+      var selfWrapPublished = true;
       if (event.recipientPubkeys.length == 1) {
         final result = await _dmRepository.sendMessage(
           recipientPubkey: event.recipientPubkeys.first,
@@ -125,6 +138,7 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
         if (!result.success) {
           throw Exception(result.error ?? 'Failed to send message');
         }
+        selfWrapPublished = result.selfWrapPublished;
       } else {
         final results = await _dmRepository.sendGroupMessage(
           recipientPubkeys: event.recipientPubkeys,
@@ -135,6 +149,25 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
             results.first.error ?? 'Failed to send group message',
           );
         }
+        // For groups, "self-wrap" is per-recipient. We treat the send as
+        // partial if any successful per-recipient send had its self-wrap
+        // fail, because that recipient's copy will not sync to the
+        // sender's other devices.
+        selfWrapPublished = results
+            .where((r) => r.success)
+            .every((r) => r.selfWrapPublished);
+      }
+      if (!selfWrapPublished) {
+        emit(
+          state.copyWith(
+            sendStatus: SendStatus.sentPartial,
+            lastFailedSend: FailedSend(
+              content: event.content,
+              recipientPubkeys: event.recipientPubkeys,
+            ),
+          ),
+        );
+        return;
       }
       emit(state.copyWith(sendStatus: SendStatus.sent));
     } catch (e, stackTrace) {

--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -8,7 +8,9 @@ import 'package:bloc/bloc.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
 import 'package:models/models.dart';
+import 'package:uuid/uuid.dart';
 
 part 'conversation_event.dart';
 part 'conversation_state.dart';
@@ -18,9 +20,11 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
     required DmRepository dmRepository,
     required String conversationId,
     required String currentUserPubkey,
+    @visibleForTesting String Function()? pendingIdFactory,
   }) : _dmRepository = dmRepository,
        _conversationId = conversationId,
        _currentUserPubkey = currentUserPubkey,
+       _pendingIdFactory = pendingIdFactory ?? _defaultPendingIdFactory,
        super(const ConversationState()) {
     on<ConversationStarted>(_onStarted, transformer: restartable());
     on<ConversationMessageSent>(_onMessageSent, transformer: sequential());
@@ -30,6 +34,10 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
   final DmRepository _dmRepository;
   final String _conversationId;
   final String _currentUserPubkey;
+  final String Function() _pendingIdFactory;
+
+  static const _uuid = Uuid();
+  static String _defaultPendingIdFactory() => 'pending-${_uuid.v4()}';
 
   Future<void> _onStarted(
     ConversationStarted event,
@@ -83,8 +91,13 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
     // happened, and a phantom optimistic that lingers until the bloc is
     // disposed reproduces as "looks sent, then disappeared" once the user
     // navigates away and back.
+    //
+    // [pendingId] must be unique per attempt. The failure cleanup strips by
+    // `m.id != pendingId`, so any two coincident pending rows that share an
+    // id would both be removed when one fails. Second-resolution timestamps
+    // collide on rapid sends; a UUID does not.
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    final pendingId = 'pending-$now';
+    final pendingId = _pendingIdFactory();
     final optimisticMessage = DmMessage(
       id: pendingId,
       conversationId: _conversationId,

--- a/mobile/lib/blocs/dm/conversation/conversation_state.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_state.dart
@@ -4,7 +4,13 @@ part of 'conversation_bloc.dart';
 
 enum ConversationStatus { initial, loading, loaded, error }
 
-enum SendStatus { idle, sending, sent, failed }
+/// Outcome of the most recent send attempt.
+///
+/// [sentPartial] indicates the recipient received the message but the
+/// sender's self-addressed NIP-17 gift wrap did not reach relays, so the
+/// sender's other devices will not see this message on relay-only restore.
+/// Distinct from [sent] (full success) and [failed] (recipient never got it).
+enum SendStatus { idle, sending, sent, sentPartial, failed }
 
 /// Snapshot of the most recent send attempt that did not reach the relay.
 ///

--- a/mobile/lib/blocs/dm/conversation/conversation_state.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_state.dart
@@ -6,29 +6,59 @@ enum ConversationStatus { initial, loading, loaded, error }
 
 enum SendStatus { idle, sending, sent, failed }
 
+/// Snapshot of the most recent send attempt that did not reach the relay.
+///
+/// Carried in [ConversationState] so the UI can offer a retry action without
+/// re-collecting the input from the user. Cleared on the next send attempt
+/// (success or failure path both replace it).
+class FailedSend extends Equatable {
+  const FailedSend({required this.content, required this.recipientPubkeys});
+
+  /// Plaintext content the user attempted to send.
+  final String content;
+
+  /// Recipient pubkeys for the failed attempt (1 for 1:1, ≥2 for groups).
+  final List<String> recipientPubkeys;
+
+  @override
+  List<Object?> get props => [content, recipientPubkeys];
+}
+
 class ConversationState extends Equatable {
   const ConversationState({
     this.status = ConversationStatus.initial,
     this.messages = const [],
     this.sendStatus = SendStatus.idle,
+    this.lastFailedSend,
   });
 
   final ConversationStatus status;
   final List<DmMessage> messages;
   final SendStatus sendStatus;
 
+  /// The last send attempt that failed and has not yet been retried.
+  ///
+  /// `null` when the most recent transition was a successful send, when no
+  /// send has been attempted, or once the user has retried.
+  final FailedSend? lastFailedSend;
+
   ConversationState copyWith({
     ConversationStatus? status,
     List<DmMessage>? messages,
     SendStatus? sendStatus,
+    FailedSend? lastFailedSend,
+    bool clearLastFailedSend = false,
   }) {
     return ConversationState(
       status: status ?? this.status,
       messages: messages ?? this.messages,
       sendStatus: sendStatus ?? this.sendStatus,
+      lastFailedSend: clearLastFailedSend
+          ? null
+          : (lastFailedSend ?? this.lastFailedSend),
     );
   }
 
   @override
-  List<Object?> get props => [status, messages, sendStatus];
+  List<Object?> get props => [status, messages, sendStatus, lastFailedSend];
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2608,8 +2608,9 @@
     "collaboratorInviteDmBody": "በ{title} ላይ እንድትተባበር ተጋብዘሃል፦ {url}\n\nOpen diVine to review and accept.",
     "collaboratorInviteDmBodyUntitled": "በቪዲዮ ላይ እንድትተባበር ተጋብዘሃል፦ {url}\n\nOpen diVine to review and accept.",
     "dmSendFailedMessage": "መልዕክቱ መላክ አልተሳካም",
-  "dmSendFailedRetry": "እንደገና ይሞክሩ",
-  "reportDialogCancel": "ሰርዝ",
+    "dmSendFailedRetry": "እንደገና ይሞክሩ",
+    "dmSendPartialMessage": "ተልኳል፣ ግን ወደ ሌሎች መሣሪያዎች አልተመሳሰለም",
+    "reportDialogCancel": "ሰርዝ",
     "reportDialogReport": "ሪፖርት አድርግ",
     "exploreVideoId": "ID: {id}",
     "@exploreVideoId": {

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2610,6 +2610,7 @@
     "dmSendFailedMessage": "መልዕክቱ መላክ አልተሳካም",
     "dmSendFailedRetry": "እንደገና ይሞክሩ",
     "dmSendPartialMessage": "ተልኳል፣ ግን ወደ ሌሎች መሣሪያዎች አልተመሳሰለም",
+    "dmConversationLoadError": "መልዕክቶችን መጫን አልተቻለም",
     "reportDialogCancel": "ሰርዝ",
     "reportDialogReport": "ሪፖርት አድርግ",
     "exploreVideoId": "ID: {id}",

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2607,7 +2607,9 @@
     },
     "collaboratorInviteDmBody": "በ{title} ላይ እንድትተባበር ተጋብዘሃል፦ {url}\n\nOpen diVine to review and accept.",
     "collaboratorInviteDmBodyUntitled": "በቪዲዮ ላይ እንድትተባበር ተጋብዘሃል፦ {url}\n\nOpen diVine to review and accept.",
-    "reportDialogCancel": "ሰርዝ",
+    "dmSendFailedMessage": "መልዕክቱ መላክ አልተሳካም",
+  "dmSendFailedRetry": "እንደገና ይሞክሩ",
+  "reportDialogCancel": "ሰርዝ",
     "reportDialogReport": "ሪፖርት አድርግ",
     "exploreVideoId": "ID: {id}",
     "@exploreVideoId": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2428,6 +2428,7 @@
     "dmSendFailedMessage": "تعذّر إرسال الرسالة",
     "dmSendFailedRetry": "إعادة المحاولة",
     "dmSendPartialMessage": "أُرسلت، لكنّها لم تُزامَن مع أجهزتك الأخرى",
+    "dmConversationLoadError": "تعذّر تحميل الرسائل",
     "reportDialogCancel": "إلغاء",
     "reportDialogReport": "إبلاغ",
     "routerInvalidCreator": "منشئ غير صالح",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2425,6 +2425,8 @@
     "notificationFollowBack": "متابعة بالمقابل",
     "profileSetupUploadSuccess": "تم رفع صورة الملف الشخصي بنجاح!",
     "proofmodeCheckAiGenerated": "التحقق إذا كان مُنشأً بالذكاء الاصطناعي",
+    "dmSendFailedMessage": "تعذّر إرسال الرسالة",
+    "dmSendFailedRetry": "إعادة المحاولة",
     "reportDialogCancel": "إلغاء",
     "reportDialogReport": "إبلاغ",
     "routerInvalidCreator": "منشئ غير صالح",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2427,6 +2427,7 @@
     "proofmodeCheckAiGenerated": "التحقق إذا كان مُنشأً بالذكاء الاصطناعي",
     "dmSendFailedMessage": "تعذّر إرسال الرسالة",
     "dmSendFailedRetry": "إعادة المحاولة",
+    "dmSendPartialMessage": "أُرسلت، لكنّها لم تُزامَن مع أجهزتك الأخرى",
     "reportDialogCancel": "إلغاء",
     "reportDialogReport": "إبلاغ",
     "routerInvalidCreator": "منشئ غير صالح",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2484,6 +2484,7 @@
     "dmSendFailedMessage": "Съобщението не мина",
     "dmSendFailedRetry": "Опитай пак",
     "dmSendPartialMessage": "Изпратено, но не се синхронизира с другите ти устройства",
+    "dmConversationLoadError": "Съобщенията не се заредиха",
     "reportDialogCancel": "Отказ",
     "reportDialogReport": "Докладвай",
     "exploreVideoId": "ID: {id}",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2482,8 +2482,9 @@
     "collaboratorInviteDmBody": "Поканени сте да си сътрудничите по {title}: {url}\n\nOpen diVine to review and accept.",
     "collaboratorInviteDmBodyUntitled": "Поканени сте да си сътрудничите по видеоклип: {url}\n\nOpen diVine to review and accept.",
     "dmSendFailedMessage": "Съобщението не мина",
-  "dmSendFailedRetry": "Опитай пак",
-  "reportDialogCancel": "Отказ",
+    "dmSendFailedRetry": "Опитай пак",
+    "dmSendPartialMessage": "Изпратено, но не се синхронизира с другите ти устройства",
+    "reportDialogCancel": "Отказ",
     "reportDialogReport": "Докладвай",
     "exploreVideoId": "ID: {id}",
     "@exploreVideoId": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2481,7 +2481,9 @@
     },
     "collaboratorInviteDmBody": "Поканени сте да си сътрудничите по {title}: {url}\n\nOpen diVine to review and accept.",
     "collaboratorInviteDmBodyUntitled": "Поканени сте да си сътрудничите по видеоклип: {url}\n\nOpen diVine to review and accept.",
-    "reportDialogCancel": "Отказ",
+    "dmSendFailedMessage": "Съобщението не мина",
+  "dmSendFailedRetry": "Опитай пак",
+  "reportDialogCancel": "Отказ",
     "reportDialogReport": "Докладвай",
     "exploreVideoId": "ID: {id}",
     "@exploreVideoId": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2435,6 +2435,7 @@
     "proofmodeCheckAiGenerated": "Prüfen, ob KI-generiert",
     "dmSendFailedMessage": "Nachricht konnte nicht gesendet werden",
     "dmSendFailedRetry": "Erneut versuchen",
+    "dmSendPartialMessage": "Gesendet, aber nicht mit deinen anderen Geräten synchronisiert",
     "reportDialogCancel": "Abbrechen",
     "reportDialogReport": "Melden",
     "routerInvalidCreator": "Ungültiger Ersteller",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2433,6 +2433,8 @@
     "notificationFollowBack": "Zurückfolgen",
     "profileSetupUploadSuccess": "Profilbild erfolgreich hochgeladen!",
     "proofmodeCheckAiGenerated": "Prüfen, ob KI-generiert",
+    "dmSendFailedMessage": "Nachricht konnte nicht gesendet werden",
+    "dmSendFailedRetry": "Erneut versuchen",
     "reportDialogCancel": "Abbrechen",
     "reportDialogReport": "Melden",
     "routerInvalidCreator": "Ungültiger Ersteller",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2436,6 +2436,7 @@
     "dmSendFailedMessage": "Nachricht konnte nicht gesendet werden",
     "dmSendFailedRetry": "Erneut versuchen",
     "dmSendPartialMessage": "Gesendet, aber nicht mit deinen anderen Geräten synchronisiert",
+    "dmConversationLoadError": "Nachrichten konnten nicht geladen werden",
     "reportDialogCancel": "Abbrechen",
     "reportDialogReport": "Melden",
     "routerInvalidCreator": "Ungültiger Ersteller",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2721,6 +2721,10 @@
   "@dmSendFailedRetry": {
     "description": "SnackBarAction button label that retries the failed DM send. Keep short — fits next to the SnackBar message."
   },
+  "dmSendPartialMessage": "Sent, but didn't sync to your other devices",
+  "@dmSendPartialMessage": {
+    "description": "SnackBar text shown in a DM conversation after a send where the recipient received the message but the sender's self-addressed gift wrap failed to publish. The sender's other devices won't see this message on relay-only restore. Paired with the retry action `dmSendFailedRetry`."
+  },
 
   "reportDialogCancel": "Cancel",
   "reportDialogReport": "Report",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2713,6 +2713,15 @@
     }
   },
 
+  "dmSendFailedMessage": "Message couldn't be sent",
+  "@dmSendFailedMessage": {
+    "description": "SnackBar text shown in a DM conversation when a send fails (relay error, signer error, network error). Paired with the retry action `dmSendFailedRetry`."
+  },
+  "dmSendFailedRetry": "Retry",
+  "@dmSendFailedRetry": {
+    "description": "SnackBarAction button label that retries the failed DM send. Keep short — fits next to the SnackBar message."
+  },
+
   "reportDialogCancel": "Cancel",
   "reportDialogReport": "Report",
 

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2725,6 +2725,10 @@
   "@dmSendPartialMessage": {
     "description": "SnackBar text shown in a DM conversation after a send where the recipient received the message but the sender's self-addressed gift wrap failed to publish. The sender's other devices won't see this message on relay-only restore. Paired with the retry action `dmSendFailedRetry`."
   },
+  "dmConversationLoadError": "Could not load messages",
+  "@dmConversationLoadError": {
+    "description": "Error text shown in place of the message list when DmRepository.watchMessages emits an error (e.g. local DB read failure). Distinct from send failures (which use `dmSendFailedMessage`)."
+  },
 
   "reportDialogCancel": "Cancel",
   "reportDialogReport": "Report",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2441,6 +2441,8 @@
     "notificationFollowBack": "Seguir de vuelta",
     "profileSetupUploadSuccess": "¡Foto de perfil subida con éxito!",
     "proofmodeCheckAiGenerated": "Verificar si fue generado por IA",
+    "dmSendFailedMessage": "No se pudo enviar el mensaje",
+    "dmSendFailedRetry": "Reintentar",
     "reportDialogCancel": "Cancelar",
     "reportDialogReport": "Reportar",
     "routerInvalidCreator": "Creador no válido",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2444,6 +2444,7 @@
     "dmSendFailedMessage": "No se pudo enviar el mensaje",
     "dmSendFailedRetry": "Reintentar",
     "dmSendPartialMessage": "Enviado, pero no se sincronizó con tus otros dispositivos",
+    "dmConversationLoadError": "No se pudieron cargar los mensajes",
     "reportDialogCancel": "Cancelar",
     "reportDialogReport": "Reportar",
     "routerInvalidCreator": "Creador no válido",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2443,6 +2443,7 @@
     "proofmodeCheckAiGenerated": "Verificar si fue generado por IA",
     "dmSendFailedMessage": "No se pudo enviar el mensaje",
     "dmSendFailedRetry": "Reintentar",
+    "dmSendPartialMessage": "Enviado, pero no se sincronizó con tus otros dispositivos",
     "reportDialogCancel": "Cancelar",
     "reportDialogReport": "Reportar",
     "routerInvalidCreator": "Creador no válido",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2435,6 +2435,7 @@
     "proofmodeCheckAiGenerated": "Vérifier si généré par IA",
     "dmSendFailedMessage": "Impossible d'envoyer le message",
     "dmSendFailedRetry": "Réessayer",
+    "dmSendPartialMessage": "Envoyé, mais pas synchronisé avec tes autres appareils",
     "reportDialogCancel": "Annuler",
     "reportDialogReport": "Signaler",
     "routerInvalidCreator": "Créateur non valide",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2436,6 +2436,7 @@
     "dmSendFailedMessage": "Impossible d'envoyer le message",
     "dmSendFailedRetry": "Réessayer",
     "dmSendPartialMessage": "Envoyé, mais pas synchronisé avec tes autres appareils",
+    "dmConversationLoadError": "Impossible de charger les messages",
     "reportDialogCancel": "Annuler",
     "reportDialogReport": "Signaler",
     "routerInvalidCreator": "Créateur non valide",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2433,6 +2433,8 @@
     "notificationFollowBack": "Suivre en retour",
     "profileSetupUploadSuccess": "Photo de profil importée avec succès !",
     "proofmodeCheckAiGenerated": "Vérifier si généré par IA",
+    "dmSendFailedMessage": "Impossible d'envoyer le message",
+    "dmSendFailedRetry": "Réessayer",
     "reportDialogCancel": "Annuler",
     "reportDialogReport": "Signaler",
     "routerInvalidCreator": "Créateur non valide",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2434,6 +2434,7 @@
     "proofmodeCheckAiGenerated": "Periksa apakah dibuat oleh AI",
     "dmSendFailedMessage": "Pesan gagal dikirim",
     "dmSendFailedRetry": "Coba Lagi",
+    "dmSendPartialMessage": "Terkirim, tapi tidak tersinkron ke perangkat lainmu",
     "reportDialogCancel": "Batal",
     "reportDialogReport": "Laporkan",
     "routerInvalidCreator": "Kreator tidak valid",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2435,6 +2435,7 @@
     "dmSendFailedMessage": "Pesan gagal dikirim",
     "dmSendFailedRetry": "Coba Lagi",
     "dmSendPartialMessage": "Terkirim, tapi tidak tersinkron ke perangkat lainmu",
+    "dmConversationLoadError": "Pesan tidak dapat dimuat",
     "reportDialogCancel": "Batal",
     "reportDialogReport": "Laporkan",
     "routerInvalidCreator": "Kreator tidak valid",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2432,6 +2432,8 @@
     "notificationFollowBack": "Ikuti balik",
     "profileSetupUploadSuccess": "Foto profil berhasil diunggah!",
     "proofmodeCheckAiGenerated": "Periksa apakah dibuat oleh AI",
+    "dmSendFailedMessage": "Pesan gagal dikirim",
+    "dmSendFailedRetry": "Coba Lagi",
     "reportDialogCancel": "Batal",
     "reportDialogReport": "Laporkan",
     "routerInvalidCreator": "Kreator tidak valid",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2433,6 +2433,8 @@
     "notificationFollowBack": "Segui a tua volta",
     "profileSetupUploadSuccess": "Foto profilo caricata con successo!",
     "proofmodeCheckAiGenerated": "Verifica se generato dall'IA",
+    "dmSendFailedMessage": "Impossibile inviare il messaggio",
+    "dmSendFailedRetry": "Riprova",
     "reportDialogCancel": "Annulla",
     "reportDialogReport": "Segnala",
     "routerInvalidCreator": "Creatore non valido",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2436,6 +2436,7 @@
     "dmSendFailedMessage": "Impossibile inviare il messaggio",
     "dmSendFailedRetry": "Riprova",
     "dmSendPartialMessage": "Inviato, ma non sincronizzato con gli altri tuoi dispositivi",
+    "dmConversationLoadError": "Impossibile caricare i messaggi",
     "reportDialogCancel": "Annulla",
     "reportDialogReport": "Segnala",
     "routerInvalidCreator": "Creatore non valido",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2435,6 +2435,7 @@
     "proofmodeCheckAiGenerated": "Verifica se generato dall'IA",
     "dmSendFailedMessage": "Impossibile inviare il messaggio",
     "dmSendFailedRetry": "Riprova",
+    "dmSendPartialMessage": "Inviato, ma non sincronizzato con gli altri tuoi dispositivi",
     "reportDialogCancel": "Annulla",
     "reportDialogReport": "Segnala",
     "routerInvalidCreator": "Creatore non valido",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2428,6 +2428,7 @@
     "dmSendFailedMessage": "メッセージを送信できなかった",
     "dmSendFailedRetry": "もう一回",
     "dmSendPartialMessage": "送信したけど、ほかのデバイスには同期できなかった",
+    "dmConversationLoadError": "メッセージを読み込めなかった",
     "reportDialogCancel": "キャンセル",
     "reportDialogReport": "報告",
     "routerInvalidCreator": "無効なクリエイター",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2425,6 +2425,8 @@
     "notificationFollowBack": "フォローバック",
     "profileSetupUploadSuccess": "プロフィール写真をアップロードしたよ！",
     "proofmodeCheckAiGenerated": "AI生成かチェック",
+    "dmSendFailedMessage": "メッセージを送信できなかった",
+    "dmSendFailedRetry": "もう一回",
     "reportDialogCancel": "キャンセル",
     "reportDialogReport": "報告",
     "routerInvalidCreator": "無効なクリエイター",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2427,6 +2427,7 @@
     "proofmodeCheckAiGenerated": "AI生成かチェック",
     "dmSendFailedMessage": "メッセージを送信できなかった",
     "dmSendFailedRetry": "もう一回",
+    "dmSendPartialMessage": "送信したけど、ほかのデバイスには同期できなかった",
     "reportDialogCancel": "キャンセル",
     "reportDialogReport": "報告",
     "routerInvalidCreator": "無効なクリエイター",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1723,6 +1723,7 @@
     "proofmodeCheckAiGenerated": "AI 생성 여부 확인",
     "dmSendFailedMessage": "메시지를 보내지 못했어요",
     "dmSendFailedRetry": "다시 시도",
+    "dmSendPartialMessage": "보냈지만 다른 기기에 동기화되지 않았어요",
     "reportDialogCancel": "취소",
     "reportDialogReport": "신고",
     "routerInvalidCreator": "유효하지 않은 크리에이터",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1724,6 +1724,7 @@
     "dmSendFailedMessage": "메시지를 보내지 못했어요",
     "dmSendFailedRetry": "다시 시도",
     "dmSendPartialMessage": "보냈지만 다른 기기에 동기화되지 않았어요",
+    "dmConversationLoadError": "메시지를 불러오지 못했어요",
     "reportDialogCancel": "취소",
     "reportDialogReport": "신고",
     "routerInvalidCreator": "유효하지 않은 크리에이터",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1721,6 +1721,8 @@
     "notificationFollowBack": "맞팔로우",
     "profileSetupUploadSuccess": "프로필 사진이 성공적으로 업로드되었어요!",
     "proofmodeCheckAiGenerated": "AI 생성 여부 확인",
+    "dmSendFailedMessage": "메시지를 보내지 못했어요",
+    "dmSendFailedRetry": "다시 시도",
     "reportDialogCancel": "취소",
     "reportDialogReport": "신고",
     "routerInvalidCreator": "유효하지 않은 크리에이터",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2436,6 +2436,7 @@
     "dmSendFailedMessage": "Bericht kon niet worden verzonden",
     "dmSendFailedRetry": "Opnieuw",
     "dmSendPartialMessage": "Verzonden, maar niet gesynchroniseerd met je andere apparaten",
+    "dmConversationLoadError": "Berichten konden niet worden geladen",
     "reportDialogCancel": "Annuleren",
     "reportDialogReport": "Rapporteren",
     "routerInvalidCreator": "Ongeldige maker",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2433,6 +2433,8 @@
     "notificationFollowBack": "Terugvolgen",
     "profileSetupUploadSuccess": "Profielfoto succesvol geüpload!",
     "proofmodeCheckAiGenerated": "Controleren of AI-gegenereerd",
+    "dmSendFailedMessage": "Bericht kon niet worden verzonden",
+    "dmSendFailedRetry": "Opnieuw",
     "reportDialogCancel": "Annuleren",
     "reportDialogReport": "Rapporteren",
     "routerInvalidCreator": "Ongeldige maker",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2435,6 +2435,7 @@
     "proofmodeCheckAiGenerated": "Controleren of AI-gegenereerd",
     "dmSendFailedMessage": "Bericht kon niet worden verzonden",
     "dmSendFailedRetry": "Opnieuw",
+    "dmSendPartialMessage": "Verzonden, maar niet gesynchroniseerd met je andere apparaten",
     "reportDialogCancel": "Annuleren",
     "reportDialogReport": "Rapporteren",
     "routerInvalidCreator": "Ongeldige maker",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2435,6 +2435,7 @@
     "proofmodeCheckAiGenerated": "Sprawdź, czy wygenerowane przez AI",
     "dmSendFailedMessage": "Nie udało się wysłać wiadomości",
     "dmSendFailedRetry": "Spróbuj ponownie",
+    "dmSendPartialMessage": "Wysłano, ale nie zsynchronizowano z twoimi innymi urządzeniami",
     "reportDialogCancel": "Anuluj",
     "reportDialogReport": "Zgłoś",
     "routerInvalidCreator": "Nieprawidłowy twórca",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2436,6 +2436,7 @@
     "dmSendFailedMessage": "Nie udało się wysłać wiadomości",
     "dmSendFailedRetry": "Spróbuj ponownie",
     "dmSendPartialMessage": "Wysłano, ale nie zsynchronizowano z twoimi innymi urządzeniami",
+    "dmConversationLoadError": "Nie udało się wczytać wiadomości",
     "reportDialogCancel": "Anuluj",
     "reportDialogReport": "Zgłoś",
     "routerInvalidCreator": "Nieprawidłowy twórca",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2433,6 +2433,8 @@
     "notificationFollowBack": "Zaobserwuj",
     "profileSetupUploadSuccess": "Zdjęcie profilowe przesłane pomyślnie!",
     "proofmodeCheckAiGenerated": "Sprawdź, czy wygenerowane przez AI",
+    "dmSendFailedMessage": "Nie udało się wysłać wiadomości",
+    "dmSendFailedRetry": "Spróbuj ponownie",
     "reportDialogCancel": "Anuluj",
     "reportDialogReport": "Zgłoś",
     "routerInvalidCreator": "Nieprawidłowy twórca",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2433,6 +2433,8 @@
     "notificationFollowBack": "Seguir de volta",
     "profileSetupUploadSuccess": "Foto de perfil enviada com sucesso!",
     "proofmodeCheckAiGenerated": "Verificar se gerado por IA",
+    "dmSendFailedMessage": "Falha ao enviar a mensagem",
+    "dmSendFailedRetry": "Tentar novamente",
     "reportDialogCancel": "Cancelar",
     "reportDialogReport": "Denunciar",
     "routerInvalidCreator": "Criador inválido",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2435,6 +2435,7 @@
     "proofmodeCheckAiGenerated": "Verificar se gerado por IA",
     "dmSendFailedMessage": "Falha ao enviar a mensagem",
     "dmSendFailedRetry": "Tentar novamente",
+    "dmSendPartialMessage": "Enviado, mas não sincronizou com seus outros dispositivos",
     "reportDialogCancel": "Cancelar",
     "reportDialogReport": "Denunciar",
     "routerInvalidCreator": "Criador inválido",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2436,6 +2436,7 @@
     "dmSendFailedMessage": "Falha ao enviar a mensagem",
     "dmSendFailedRetry": "Tentar novamente",
     "dmSendPartialMessage": "Enviado, mas não sincronizou com seus outros dispositivos",
+    "dmConversationLoadError": "Não foi possível carregar as mensagens",
     "reportDialogCancel": "Cancelar",
     "reportDialogReport": "Denunciar",
     "routerInvalidCreator": "Criador inválido",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2435,6 +2435,7 @@
     "proofmodeCheckAiGenerated": "Verifică dacă este generat de AI",
     "dmSendFailedMessage": "Mesajul nu a putut fi trimis",
     "dmSendFailedRetry": "Reîncearcă",
+    "dmSendPartialMessage": "Trimis, dar nu s-a sincronizat cu celelalte dispozitive",
     "reportDialogCancel": "Anulează",
     "reportDialogReport": "Raportează",
     "routerInvalidCreator": "Creator invalid",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2436,6 +2436,7 @@
     "dmSendFailedMessage": "Mesajul nu a putut fi trimis",
     "dmSendFailedRetry": "Reîncearcă",
     "dmSendPartialMessage": "Trimis, dar nu s-a sincronizat cu celelalte dispozitive",
+    "dmConversationLoadError": "Mesajele nu au putut fi încărcate",
     "reportDialogCancel": "Anulează",
     "reportDialogReport": "Raportează",
     "routerInvalidCreator": "Creator invalid",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2433,6 +2433,8 @@
     "notificationFollowBack": "Urmărește înapoi",
     "profileSetupUploadSuccess": "Fotografia de profil a fost încărcată cu succes!",
     "proofmodeCheckAiGenerated": "Verifică dacă este generat de AI",
+    "dmSendFailedMessage": "Mesajul nu a putut fi trimis",
+    "dmSendFailedRetry": "Reîncearcă",
     "reportDialogCancel": "Anulează",
     "reportDialogReport": "Raportează",
     "routerInvalidCreator": "Creator invalid",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2435,6 +2435,7 @@
     "proofmodeCheckAiGenerated": "Kontrollera om AI-genererat",
     "dmSendFailedMessage": "Meddelandet kunde inte skickas",
     "dmSendFailedRetry": "Försök igen",
+    "dmSendPartialMessage": "Skickat, men inte synkat till dina andra enheter",
     "reportDialogCancel": "Avbryt",
     "reportDialogReport": "Rapportera",
     "routerInvalidCreator": "Ogiltig skapare",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2433,6 +2433,8 @@
     "notificationFollowBack": "Följ tillbaka",
     "profileSetupUploadSuccess": "Profilbilden laddades upp!",
     "proofmodeCheckAiGenerated": "Kontrollera om AI-genererat",
+    "dmSendFailedMessage": "Meddelandet kunde inte skickas",
+    "dmSendFailedRetry": "Försök igen",
     "reportDialogCancel": "Avbryt",
     "reportDialogReport": "Rapportera",
     "routerInvalidCreator": "Ogiltig skapare",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2436,6 +2436,7 @@
     "dmSendFailedMessage": "Meddelandet kunde inte skickas",
     "dmSendFailedRetry": "Försök igen",
     "dmSendPartialMessage": "Skickat, men inte synkat till dina andra enheter",
+    "dmConversationLoadError": "Det gick inte att läsa in meddelandena",
     "reportDialogCancel": "Avbryt",
     "reportDialogReport": "Rapportera",
     "routerInvalidCreator": "Ogiltig skapare",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2432,6 +2432,8 @@
     "notificationFollowBack": "Geri takip et",
     "profileSetupUploadSuccess": "Profil fotoğrafı başarıyla yüklendi!",
     "proofmodeCheckAiGenerated": "Yapay zeka ile oluşturulup oluşturulmadığını kontrol et",
+    "dmSendFailedMessage": "Mesaj gönderilemedi",
+    "dmSendFailedRetry": "Tekrar Dene",
     "reportDialogCancel": "İptal",
     "reportDialogReport": "Bildir",
     "routerInvalidCreator": "Geçersiz içerik üretici",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2434,6 +2434,7 @@
     "proofmodeCheckAiGenerated": "Yapay zeka ile oluşturulup oluşturulmadığını kontrol et",
     "dmSendFailedMessage": "Mesaj gönderilemedi",
     "dmSendFailedRetry": "Tekrar Dene",
+    "dmSendPartialMessage": "Gönderildi, ama diğer cihazlarınla eşitlenmedi",
     "reportDialogCancel": "İptal",
     "reportDialogReport": "Bildir",
     "routerInvalidCreator": "Geçersiz içerik üretici",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2435,6 +2435,7 @@
     "dmSendFailedMessage": "Mesaj gönderilemedi",
     "dmSendFailedRetry": "Tekrar Dene",
     "dmSendPartialMessage": "Gönderildi, ama diğer cihazlarınla eşitlenmedi",
+    "dmConversationLoadError": "Mesajlar yüklenemedi",
     "reportDialogCancel": "İptal",
     "reportDialogReport": "Bildir",
     "routerInvalidCreator": "Geçersiz içerik üretici",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9222,6 +9222,12 @@ abstract class AppLocalizations {
   /// **'Retry'**
   String get dmSendFailedRetry;
 
+  /// SnackBar text shown in a DM conversation after a send where the recipient received the message but the sender's self-addressed gift wrap failed to publish. The sender's other devices won't see this message on relay-only restore. Paired with the retry action `dmSendFailedRetry`.
+  ///
+  /// In en, this message translates to:
+  /// **'Sent, but didn\'t sync to your other devices'**
+  String get dmSendPartialMessage;
+
   /// No description provided for @reportDialogCancel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9228,6 +9228,12 @@ abstract class AppLocalizations {
   /// **'Sent, but didn\'t sync to your other devices'**
   String get dmSendPartialMessage;
 
+  /// Error text shown in place of the message list when DmRepository.watchMessages emits an error (e.g. local DB read failure). Distinct from send failures (which use `dmSendFailedMessage`).
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load messages'**
+  String get dmConversationLoadError;
+
   /// No description provided for @reportDialogCancel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9210,6 +9210,18 @@ abstract class AppLocalizations {
   /// **'You were invited to collaborate on a video: {url}\n\nOpen diVine to review and accept.'**
   String collaboratorInviteDmBodyUntitled(String url);
 
+  /// SnackBar text shown in a DM conversation when a send fails (relay error, signer error, network error). Paired with the retry action `dmSendFailedRetry`.
+  ///
+  /// In en, this message translates to:
+  /// **'Message couldn\'t be sent'**
+  String get dmSendFailedMessage;
+
+  /// SnackBarAction button label that retries the failed DM send. Keep short — fits next to the SnackBar message.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get dmSendFailedRetry;
+
   /// No description provided for @reportDialogCancel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5089,6 +5089,12 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'ሰርዝ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5095,6 +5095,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get dmSendFailedRetry => 'እንደገና ይሞክሩ';
 
   @override
+  String get dmSendPartialMessage => 'ተልኳል፣ ግን ወደ ሌሎች መሣሪያዎች አልተመሳሰለም';
+
+  @override
   String get reportDialogCancel => 'ሰርዝ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5089,10 +5089,10 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'መልዕክቱ መላክ አልተሳካም';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'እንደገና ይሞክሩ';
 
   @override
   String get reportDialogCancel => 'ሰርዝ';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5098,6 +5098,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get dmSendPartialMessage => 'ተልኳል፣ ግን ወደ ሌሎች መሣሪያዎች አልተመሳሰለም';
 
   @override
+  String get dmConversationLoadError => 'መልዕክቶችን መጫን አልተቻለም';
+
+  @override
   String get reportDialogCancel => 'ሰርዝ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5151,6 +5151,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get dmSendFailedRetry => 'إعادة المحاولة';
 
   @override
+  String get dmSendPartialMessage =>
+      'أُرسلت، لكنّها لم تُزامَن مع أجهزتك الأخرى';
+
+  @override
   String get reportDialogCancel => 'إلغاء';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5145,10 +5145,10 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'تعذّر إرسال الرسالة';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'إعادة المحاولة';
 
   @override
   String get reportDialogCancel => 'إلغاء';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5155,6 +5155,9 @@ class AppLocalizationsAr extends AppLocalizations {
       'أُرسلت، لكنّها لم تُزامَن مع أجهزتك الأخرى';
 
   @override
+  String get dmConversationLoadError => 'تعذّر تحميل الرسائل';
+
+  @override
   String get reportDialogCancel => 'إلغاء';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5145,6 +5145,12 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'إلغاء';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5241,6 +5241,12 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'Отказ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5247,6 +5247,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get dmSendFailedRetry => 'Опитай пак';
 
   @override
+  String get dmSendPartialMessage =>
+      'Изпратено, но не се синхронизира с другите ти устройства';
+
+  @override
   String get reportDialogCancel => 'Отказ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5251,6 +5251,9 @@ class AppLocalizationsBg extends AppLocalizations {
       'Изпратено, но не се синхронизира с другите ти устройства';
 
   @override
+  String get dmConversationLoadError => 'Съобщенията не се заредиха';
+
+  @override
   String get reportDialogCancel => 'Отказ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5241,10 +5241,10 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'Съобщението не мина';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'Опитай пак';
 
   @override
   String get reportDialogCancel => 'Отказ';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5259,6 +5259,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get dmSendFailedRetry => 'Erneut versuchen';
 
   @override
+  String get dmSendPartialMessage =>
+      'Gesendet, aber nicht mit deinen anderen Geräten synchronisiert';
+
+  @override
   String get reportDialogCancel => 'Abbrechen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5253,6 +5253,12 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'Abbrechen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5263,6 +5263,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Gesendet, aber nicht mit deinen anderen Geräten synchronisiert';
 
   @override
+  String get dmConversationLoadError =>
+      'Nachrichten konnten nicht geladen werden';
+
+  @override
   String get reportDialogCancel => 'Abbrechen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5253,10 +5253,10 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'Nachricht konnte nicht gesendet werden';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'Erneut versuchen';
 
   @override
   String get reportDialogCancel => 'Abbrechen';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5204,6 +5204,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Sent, but didn\'t sync to your other devices';
 
   @override
+  String get dmConversationLoadError => 'Could not load messages';
+
+  @override
   String get reportDialogCancel => 'Cancel';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5200,6 +5200,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dmSendFailedRetry => 'Retry';
 
   @override
+  String get dmSendPartialMessage =>
+      'Sent, but didn\'t sync to your other devices';
+
+  @override
   String get reportDialogCancel => 'Cancel';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5194,6 +5194,12 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'Cancel';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5239,10 +5239,10 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'No se pudo enviar el mensaje';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'Reintentar';
 
   @override
   String get reportDialogCancel => 'Cancelar';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5239,6 +5239,12 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5245,6 +5245,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get dmSendFailedRetry => 'Reintentar';
 
   @override
+  String get dmSendPartialMessage =>
+      'Enviado, pero no se sincronizó con tus otros dispositivos';
+
+  @override
   String get reportDialogCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5249,6 +5249,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Enviado, pero no se sincronizó con tus otros dispositivos';
 
   @override
+  String get dmConversationLoadError => 'No se pudieron cargar los mensajes';
+
+  @override
   String get reportDialogCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5261,10 +5261,10 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'Impossible d\'envoyer le message';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'Réessayer';
 
   @override
   String get reportDialogCancel => 'Annuler';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5271,6 +5271,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Envoyé, mais pas synchronisé avec tes autres appareils';
 
   @override
+  String get dmConversationLoadError => 'Impossible de charger les messages';
+
+  @override
   String get reportDialogCancel => 'Annuler';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5261,6 +5261,12 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'Annuler';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5267,6 +5267,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get dmSendFailedRetry => 'Réessayer';
 
   @override
+  String get dmSendPartialMessage =>
+      'Envoyé, mais pas synchronisé avec tes autres appareils';
+
+  @override
   String get reportDialogCancel => 'Annuler';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5169,6 +5169,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get dmSendFailedRetry => 'Coba Lagi';
 
   @override
+  String get dmSendPartialMessage =>
+      'Terkirim, tapi tidak tersinkron ke perangkat lainmu';
+
+  @override
   String get reportDialogCancel => 'Batal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5173,6 +5173,9 @@ class AppLocalizationsId extends AppLocalizations {
       'Terkirim, tapi tidak tersinkron ke perangkat lainmu';
 
   @override
+  String get dmConversationLoadError => 'Pesan tidak dapat dimuat';
+
+  @override
   String get reportDialogCancel => 'Batal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5163,10 +5163,10 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'Pesan gagal dikirim';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'Coba Lagi';
 
   @override
   String get reportDialogCancel => 'Batal';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5163,6 +5163,12 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'Batal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5245,6 +5245,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get dmSendFailedRetry => 'Riprova';
 
   @override
+  String get dmSendPartialMessage =>
+      'Inviato, ma non sincronizzato con gli altri tuoi dispositivi';
+
+  @override
   String get reportDialogCancel => 'Annulla';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5249,6 +5249,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Inviato, ma non sincronizzato con gli altri tuoi dispositivi';
 
   @override
+  String get dmConversationLoadError => 'Impossibile caricare i messaggi';
+
+  @override
   String get reportDialogCancel => 'Annulla';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5239,6 +5239,12 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'Annulla';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5239,10 +5239,10 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'Impossibile inviare il messaggio';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'Riprova';
 
   @override
   String get reportDialogCancel => 'Annulla';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4983,6 +4983,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dmSendFailedRetry => 'もう一回';
 
   @override
+  String get dmSendPartialMessage => '送信したけど、ほかのデバイスには同期できなかった';
+
+  @override
   String get reportDialogCancel => 'キャンセル';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4986,6 +4986,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dmSendPartialMessage => '送信したけど、ほかのデバイスには同期できなかった';
 
   @override
+  String get dmConversationLoadError => 'メッセージを読み込めなかった';
+
+  @override
   String get reportDialogCancel => 'キャンセル';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4977,6 +4977,12 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'キャンセル';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4977,10 +4977,10 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'メッセージを送信できなかった';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'もう一回';
 
   @override
   String get reportDialogCancel => 'キャンセル';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5000,6 +5000,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dmSendFailedRetry => '다시 시도';
 
   @override
+  String get dmSendPartialMessage => '보냈지만 다른 기기에 동기화되지 않았어요';
+
+  @override
   String get reportDialogCancel => '취소';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5003,6 +5003,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dmSendPartialMessage => '보냈지만 다른 기기에 동기화되지 않았어요';
 
   @override
+  String get dmConversationLoadError => '메시지를 불러오지 못했어요';
+
+  @override
   String get reportDialogCancel => '취소';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4994,6 +4994,12 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => '취소';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4994,10 +4994,10 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => '메시지를 보내지 못했어요';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => '다시 시도';
 
   @override
   String get reportDialogCancel => '취소';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5220,6 +5220,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'Verzonden, maar niet gesynchroniseerd met je andere apparaten';
 
   @override
+  String get dmConversationLoadError => 'Berichten konden niet worden geladen';
+
+  @override
   String get reportDialogCancel => 'Annuleren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5210,10 +5210,10 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'Bericht kon niet worden verzonden';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'Opnieuw';
 
   @override
   String get reportDialogCancel => 'Annuleren';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5210,6 +5210,12 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'Annuleren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5216,6 +5216,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get dmSendFailedRetry => 'Opnieuw';
 
   @override
+  String get dmSendPartialMessage =>
+      'Verzonden, maar niet gesynchroniseerd met je andere apparaten';
+
+  @override
   String get reportDialogCancel => 'Annuleren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5323,10 +5323,10 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'Nie udało się wysłać wiadomości';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'Spróbuj ponownie';
 
   @override
   String get reportDialogCancel => 'Anuluj';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5333,6 +5333,9 @@ class AppLocalizationsPl extends AppLocalizations {
       'Wysłano, ale nie zsynchronizowano z twoimi innymi urządzeniami';
 
   @override
+  String get dmConversationLoadError => 'Nie udało się wczytać wiadomości';
+
+  @override
   String get reportDialogCancel => 'Anuluj';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5323,6 +5323,12 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'Anuluj';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5329,6 +5329,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get dmSendFailedRetry => 'Spróbuj ponownie';
 
   @override
+  String get dmSendPartialMessage =>
+      'Wysłano, ale nie zsynchronizowano z twoimi innymi urządzeniami';
+
+  @override
   String get reportDialogCancel => 'Anuluj';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5228,6 +5228,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get dmSendFailedRetry => 'Tentar novamente';
 
   @override
+  String get dmSendPartialMessage =>
+      'Enviado, mas não sincronizou com seus outros dispositivos';
+
+  @override
   String get reportDialogCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5232,6 +5232,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Enviado, mas não sincronizou com seus outros dispositivos';
 
   @override
+  String get dmConversationLoadError =>
+      'Não foi possível carregar as mensagens';
+
+  @override
   String get reportDialogCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5222,10 +5222,10 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'Falha ao enviar a mensagem';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'Tentar novamente';
 
   @override
   String get reportDialogCancel => 'Cancelar';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5222,6 +5222,12 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5348,6 +5348,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Trimis, dar nu s-a sincronizat cu celelalte dispozitive';
 
   @override
+  String get dmConversationLoadError => 'Mesajele nu au putut fi încărcate';
+
+  @override
   String get reportDialogCancel => 'Anulează';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5338,6 +5338,12 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'Anulează';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5344,6 +5344,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get dmSendFailedRetry => 'Reîncearcă';
 
   @override
+  String get dmSendPartialMessage =>
+      'Trimis, dar nu s-a sincronizat cu celelalte dispozitive';
+
+  @override
   String get reportDialogCancel => 'Anulează';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5338,10 +5338,10 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'Mesajul nu a putut fi trimis';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'Reîncearcă';
 
   @override
   String get reportDialogCancel => 'Anulează';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5194,6 +5194,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get dmSendFailedRetry => 'Försök igen';
 
   @override
+  String get dmSendPartialMessage =>
+      'Skickat, men inte synkat till dina andra enheter';
+
+  @override
   String get reportDialogCancel => 'Avbryt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5188,10 +5188,10 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'Meddelandet kunde inte skickas';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'Försök igen';
 
   @override
   String get reportDialogCancel => 'Avbryt';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5188,6 +5188,12 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'Avbryt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5198,6 +5198,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Skickat, men inte synkat till dina andra enheter';
 
   @override
+  String get dmConversationLoadError =>
+      'Det gick inte att läsa in meddelandena';
+
+  @override
   String get reportDialogCancel => 'Avbryt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5182,6 +5182,9 @@ class AppLocalizationsTr extends AppLocalizations {
       'Gönderildi, ama diğer cihazlarınla eşitlenmedi';
 
   @override
+  String get dmConversationLoadError => 'Mesajlar yüklenemedi';
+
+  @override
   String get reportDialogCancel => 'İptal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5172,6 +5172,12 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+
+  @override
+  String get dmSendFailedRetry => 'Retry';
+
+  @override
   String get reportDialogCancel => 'İptal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5178,6 +5178,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get dmSendFailedRetry => 'Tekrar Dene';
 
   @override
+  String get dmSendPartialMessage =>
+      'Gönderildi, ama diğer cihazlarınla eşitlenmedi';
+
+  @override
   String get reportDialogCancel => 'İptal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5172,10 +5172,10 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
-  String get dmSendFailedMessage => 'Message couldn\'t be sent';
+  String get dmSendFailedMessage => 'Mesaj gönderilemedi';
 
   @override
-  String get dmSendFailedRetry => 'Retry';
+  String get dmSendFailedRetry => 'Tekrar Dene';
 
   @override
   String get reportDialogCancel => 'İptal';

--- a/mobile/lib/screens/inbox/conversation/conversation_page.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_page.dart
@@ -41,6 +41,10 @@ class ConversationPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final dmRepository = ref.watch(dmRepositoryProvider);
+    final inviteStateStore = ref.watch(collaboratorInviteStateStoreProvider);
+    final inviteResponseService = ref.watch(
+      collaboratorResponseServiceProvider,
+    );
     final authService = ref.watch(authServiceProvider);
     final currentPubkey = authService.currentPublicKeyHex ?? '';
 
@@ -63,10 +67,21 @@ class ConversationPage extends ConsumerWidget {
             currentUserPubkey: currentPubkey,
           )..add(const ConversationStarted()),
         ),
-        BlocProvider(
+        // Same identity-keying as ConversationBloc above: the response
+        // service composes `authServiceProvider` + `nostrServiceProvider`
+        // (`app_providers.dart`), so its identity flips on auth changes.
+        // Without the key, accept-invite would publish through whichever
+        // signer/relay the cubit captured at first build, even after
+        // auth flipped.
+        BlocProvider<CollaboratorInviteActionsCubit>(
+          key: ValueKey((
+            inviteStateStore,
+            inviteResponseService,
+            currentPubkey,
+          )),
           create: (_) => CollaboratorInviteActionsCubit(
-            stateStore: ref.watch(collaboratorInviteStateStoreProvider),
-            responseService: ref.watch(collaboratorResponseServiceProvider),
+            stateStore: inviteStateStore,
+            responseService: inviteResponseService,
             currentUserPubkey: currentPubkey,
           ),
         ),

--- a/mobile/lib/screens/inbox/conversation/conversation_page.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_page.dart
@@ -46,7 +46,17 @@ class ConversationPage extends ConsumerWidget {
 
     return MultiBlocProvider(
       providers: [
-        BlocProvider(
+        // Key tracks the captured Riverpod-provided dependencies so the
+        // bloc is recreated when their identity flips (auth flip, account
+        // switch, sign-out). Without this key, a stale `dmRepository`
+        // captured during a brief unauthenticated window would scope all
+        // reads/writes by an empty/wrong `_userPubkey` for the lifetime of
+        // the bloc, causing sent messages to "disappear" on re-entry.
+        // See `state_management.md` → "Bridging Riverpod-provided
+        // dependencies into BlocProvider" and the canonical four sites in
+        // `video_feed_page.dart` / `pooled_fullscreen_video_feed_screen.dart`.
+        BlocProvider<ConversationBloc>(
+          key: ValueKey((dmRepository, currentPubkey)),
           create: (_) => ConversationBloc(
             dmRepository: dmRepository,
             conversationId: conversationId,

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -102,34 +102,63 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
 
     return Scaffold(
       backgroundColor: VineTheme.surfaceBackground,
-      body: Column(
-        children: [
-          ConversationAppBar(
-            displayName: displayName,
-            handle: handle,
-            onBack: () => context.pop(),
-            onTitleTap: otherPubkey.isNotEmpty
-                ? () => context.push(
-                    '${OtherProfileScreen.path}/${NostrKeyUtils.encodePubKey(otherPubkey)}',
-                  )
-                : null,
-            onOptions: () => _onOptions(otherPubkey, displayName),
-          ),
-          Expanded(
-            child: _ConversationContent(
-              currentPubkey: currentPubkey,
-              otherPubkey: otherPubkey,
+      body: BlocListener<ConversationBloc, ConversationState>(
+        listenWhen: (previous, current) =>
+            previous.sendStatus != current.sendStatus &&
+            current.sendStatus == SendStatus.failed,
+        listener: _onSendFailed,
+        child: Column(
+          children: [
+            ConversationAppBar(
               displayName: displayName,
-              imageUrl: profile?.picture,
-              nip05: profile?.displayNip05,
-              onViewProfile: () {
-                final npub = NostrKeyUtils.encodePubKey(otherPubkey);
-                context.push('${OtherProfileScreen.path}/$npub');
-              },
+              handle: handle,
+              onBack: () => context.pop(),
+              onTitleTap: otherPubkey.isNotEmpty
+                  ? () => context.push(
+                      '${OtherProfileScreen.path}/${NostrKeyUtils.encodePubKey(otherPubkey)}',
+                    )
+                  : null,
+              onOptions: () => _onOptions(otherPubkey, displayName),
             ),
-          ),
-          _SendBar(participantPubkeys: widget.participantPubkeys),
-        ],
+            Expanded(
+              child: _ConversationContent(
+                currentPubkey: currentPubkey,
+                otherPubkey: otherPubkey,
+                displayName: displayName,
+                imageUrl: profile?.picture,
+                nip05: profile?.displayNip05,
+                onViewProfile: () {
+                  final npub = NostrKeyUtils.encodePubKey(otherPubkey);
+                  context.push('${OtherProfileScreen.path}/$npub');
+                },
+              ),
+            ),
+            _SendBar(participantPubkeys: widget.participantPubkeys),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _onSendFailed(BuildContext context, ConversationState state) {
+    final lastFailedSend = state.lastFailedSend;
+    if (lastFailedSend == null) return;
+    final l10n = context.l10n;
+    final messenger = ScaffoldMessenger.of(context)..hideCurrentSnackBar();
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(l10n.dmSendFailedMessage),
+        action: SnackBarAction(
+          label: l10n.dmSendFailedRetry,
+          onPressed: () {
+            context.read<ConversationBloc>().add(
+              ConversationMessageSent(
+                recipientPubkeys: lastFailedSend.recipientPubkeys,
+                content: lastFailedSend.content,
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -239,7 +239,7 @@ class _ConversationContent extends StatelessWidget {
           ),
           ConversationStatus.error => Center(
             child: Text(
-              'Could not load messages',
+              context.l10n.dmConversationLoadError,
               style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceMuted),
             ),
           ),

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -3,6 +3,7 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart' show SemanticsService;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -160,6 +161,14 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
           },
         ),
       ),
+    );
+    // Per `accessibility.md`, async visible state changes must announce
+    // explicitly — relying on Material's default SnackBar semantics is
+    // weaker than the written rule and not guaranteed across platforms.
+    SemanticsService.sendAnnouncement(
+      View.of(context),
+      l10n.dmSendFailedMessage,
+      Directionality.of(context),
     );
   }
 }

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -106,8 +106,9 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
       body: BlocListener<ConversationBloc, ConversationState>(
         listenWhen: (previous, current) =>
             previous.sendStatus != current.sendStatus &&
-            current.sendStatus == SendStatus.failed,
-        listener: _onSendFailed,
+            (current.sendStatus == SendStatus.failed ||
+                current.sendStatus == SendStatus.sentPartial),
+        listener: _onSendOutcome,
         child: Column(
           children: [
             ConversationAppBar(
@@ -141,14 +142,17 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     );
   }
 
-  void _onSendFailed(BuildContext context, ConversationState state) {
+  void _onSendOutcome(BuildContext context, ConversationState state) {
     final lastFailedSend = state.lastFailedSend;
     if (lastFailedSend == null) return;
     final l10n = context.l10n;
+    final message = state.sendStatus == SendStatus.sentPartial
+        ? l10n.dmSendPartialMessage
+        : l10n.dmSendFailedMessage;
     final messenger = ScaffoldMessenger.of(context)..hideCurrentSnackBar();
     messenger.showSnackBar(
       SnackBar(
-        content: Text(l10n.dmSendFailedMessage),
+        content: Text(message),
         action: SnackBarAction(
           label: l10n.dmSendFailedRetry,
           onPressed: () {
@@ -167,7 +171,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     // weaker than the written rule and not guaranteed across platforms.
     SemanticsService.sendAnnouncement(
       View.of(context),
-      l10n.dmSendFailedMessage,
+      message,
       Directionality.of(context),
     );
   }

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -115,6 +115,9 @@ class NIP17MessageService {
       // are recoverable from relays after reinstall or data loss.
       // Wrapped in its own try-catch because the message was already
       // delivered to the recipient — self-wrap failure is non-fatal.
+      // The result is reported as `selfWrapPublished` so callers can
+      // distinguish full success from recipient-only partial success.
+      var selfWrapPublished = false;
       try {
         final selfWrapEvent = await GiftWrapUtil.getGiftWrapEvent(
           nostr,
@@ -122,11 +125,20 @@ class NIP17MessageService {
           _senderPublicKey,
         );
         if (selfWrapEvent != null) {
-          await _nostrService.publishEvent(selfWrapEvent);
+          final selfSent = await _nostrService.publishEvent(selfWrapEvent);
+          selfWrapPublished = selfSent != null;
         }
       } on Object catch (e) {
         Log.error(
           'Self-wrap failed (non-fatal): $e',
+          category: LogCategory.system,
+        );
+      }
+
+      if (!selfWrapPublished) {
+        Log.warning(
+          'NIP-17 self-wrap not published — sender other devices will not '
+          'see this message on relay restore',
           category: LogCategory.system,
         );
       }
@@ -139,6 +151,7 @@ class NIP17MessageService {
         rumorEventId: rumorEvent.id,
         messageEventId: giftWrapEvent.id,
         recipientPubkey: recipientPubkey,
+        selfWrapPublished: selfWrapPublished,
       );
     } on Object catch (e, stackTrace) {
       Log.error(

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -220,7 +220,8 @@ void main() {
       });
 
       test(
-        'returns success even when self-wrap publish throws',
+        'returns success with selfWrapPublished=false '
+        'when self-wrap publish throws',
         () async {
           var callCount = 0;
           when(() => mockNostrClient.publishEvent(any())).thenAnswer(
@@ -230,7 +231,8 @@ void main() {
                 // Recipient publish succeeds.
                 return invocation.positionalArguments[0] as Event;
               }
-              // Self-wrap publish throws — should be non-fatal.
+              // Self-wrap publish throws — should be non-fatal but
+              // surfaced via selfWrapPublished so callers can react.
               throw Exception('self-wrap relay error');
             },
           );
@@ -242,11 +244,53 @@ void main() {
 
           expect(result.success, isTrue);
           expect(result.rumorEventId, isNotNull);
+          expect(result.selfWrapPublished, isFalse);
         },
       );
 
       test(
-        'publishes a self-wrap when sender pubkey matches the signer',
+        'returns success with selfWrapPublished=false '
+        'when self-wrap publish returns null',
+        () async {
+          // Mirrors the silent-failure shape the reviewer flagged on
+          // PR #3908: publishEvent returns null with no exception, so
+          // the previous version of sendPrivateMessage marked the send
+          // as fully successful even though the sender's other devices
+          // would never see the message on a relay-only restore.
+          final signer = LocalNostrSigner(_testPrivateKey);
+          final senderPublicKey = (await signer.getPublicKey())!;
+          final matchingService = NIP17MessageService(
+            signer: signer,
+            senderPublicKey: senderPublicKey,
+            nostrService: mockNostrClient,
+          );
+          var callCount = 0;
+          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+            (invocation) async {
+              callCount++;
+              if (callCount == 1) {
+                // Recipient publish succeeds.
+                return invocation.positionalArguments[0] as Event;
+              }
+              // Self-wrap publish returns null (silent failure).
+              return null;
+            },
+          );
+
+          final result = await matchingService.sendPrivateMessage(
+            recipientPubkey: _recipientPubkey,
+            content: 'Test message',
+          );
+
+          expect(result.success, isTrue);
+          expect(result.rumorEventId, isNotNull);
+          expect(result.selfWrapPublished, isFalse);
+        },
+      );
+
+      test(
+        'publishes a self-wrap with selfWrapPublished=true '
+        'when sender pubkey matches the signer and publish succeeds',
         () async {
           final signer = LocalNostrSigner(_testPrivateKey);
           final senderPublicKey = (await signer.getPublicKey())!;
@@ -272,6 +316,7 @@ void main() {
           );
 
           expect(result.success, isTrue);
+          expect(result.selfWrapPublished, isTrue);
           expect(capturedEvents, hasLength(2));
           expect(capturedEvents[0].kind, EventKind.giftWrap);
           expect(capturedEvents[1].kind, EventKind.giftWrap);

--- a/mobile/packages/models/lib/src/nip17_send_result.dart
+++ b/mobile/packages/models/lib/src/nip17_send_result.dart
@@ -10,19 +10,28 @@ class NIP17SendResult {
     this.recipientPubkey,
     this.error,
     this.timestamp,
+    this.selfWrapPublished = true,
   });
 
-  /// Create success result
+  /// Create success result.
+  ///
+  /// [selfWrapPublished] indicates whether the sender's self-addressed gift
+  /// wrap (NIP-17) was also delivered to relays. When `false`, the recipient
+  /// got the message but the sender's other devices won't see it on a
+  /// relay-only restore. The send is still considered a success because the
+  /// recipient was reached.
   factory NIP17SendResult.success({
     required String rumorEventId,
     required String messageEventId,
     required String recipientPubkey,
+    bool selfWrapPublished = true,
   }) => NIP17SendResult(
     success: true,
     rumorEventId: rumorEventId,
     messageEventId: messageEventId,
     recipientPubkey: recipientPubkey,
     timestamp: DateTime.now(),
+    selfWrapPublished: selfWrapPublished,
   );
 
   /// Create failure result
@@ -42,12 +51,22 @@ class NIP17SendResult {
   final String? error;
   final DateTime? timestamp;
 
+  /// Whether the sender's self-addressed gift wrap reached relays.
+  ///
+  /// When `success` is `true` and this is `false`, the message was delivered
+  /// to the recipient but cross-device sync for the sender is degraded. UI
+  /// can surface this as a partial-delivery state distinct from a full
+  /// failure. Defaults to `true` for failure results and for callers that
+  /// do not yet track this signal.
+  final bool selfWrapPublished;
+
   @override
   String toString() {
     if (success) {
       return 'NIP17SendResult(success: true, '
           'rumorEventId: $rumorEventId, '
-          'messageEventId: $messageEventId, recipient: $recipientPubkey)';
+          'messageEventId: $messageEventId, recipient: $recipientPubkey, '
+          'selfWrapPublished: $selfWrapPublished)';
     } else {
       return 'NIP17SendResult(success: false, error: $error)';
     }

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -332,6 +332,64 @@ void main() {
                 .having((s) => s.lastFailedSend, 'lastFailedSend', isNull),
           ],
         );
+
+        blocTest<ConversationBloc, ConversationState>(
+          'emits [sending with optimistic, sentPartial with lastFailedSend] '
+          'when sendMessage succeeds but the self-wrap was not published',
+          setUp: () {
+            when(
+              () => mockDmRepository.sendMessage(
+                recipientPubkey: recipientPubkey,
+                content: 'Hello',
+              ),
+            ).thenAnswer(
+              (_) async => NIP17SendResult.success(
+                rumorEventId: sentEventId,
+                messageEventId: sentEventId,
+                recipientPubkey: recipientPubkey,
+                selfWrapPublished: false,
+              ),
+            );
+          },
+          build: buildBloc,
+          act: (bloc) => bloc.add(
+            const ConversationMessageSent(
+              recipientPubkeys: [recipientPubkey],
+              content: 'Hello',
+            ),
+          ),
+          // Partial-delivery: the recipient got the message and the local
+          // DB persist already happened inside DmRepository.sendMessage,
+          // so the optimistic stays — stripping it would race with the
+          // watchMessages re-emit and cause a brief disappearance.
+          // lastFailedSend is recorded so the UI can offer retry.
+          expect: () => [
+            isA<ConversationState>()
+                .having((s) => s.sendStatus, 'sendStatus', SendStatus.sending)
+                .having((s) => s.messages.length, 'messages.length', 1),
+            isA<ConversationState>()
+                .having(
+                  (s) => s.sendStatus,
+                  'sendStatus',
+                  SendStatus.sentPartial,
+                )
+                .having(
+                  (s) => s.messages.length,
+                  'optimistic preserved',
+                  1,
+                )
+                .having(
+                  (s) => s.lastFailedSend,
+                  'lastFailedSend',
+                  equals(
+                    const FailedSend(
+                      content: 'Hello',
+                      recipientPubkeys: [recipientPubkey],
+                    ),
+                  ),
+                ),
+          ],
+        );
       });
 
       group('group message', () {
@@ -420,6 +478,63 @@ void main() {
                 ),
           ],
           errors: () => [isA<Exception>()],
+        );
+
+        blocTest<ConversationBloc, ConversationState>(
+          'emits [sending, sentPartial] when any successful per-recipient '
+          'sendGroupMessage had its self-wrap unpublished',
+          setUp: () {
+            when(
+              () => mockDmRepository.sendGroupMessage(
+                recipientPubkeys: [recipientPubkey, recipientPubkey2],
+                content: 'Group hello',
+              ),
+            ).thenAnswer(
+              (_) async => [
+                NIP17SendResult.success(
+                  rumorEventId: sentEventId,
+                  messageEventId: sentEventId,
+                  recipientPubkey: recipientPubkey,
+                ),
+                NIP17SendResult.success(
+                  rumorEventId: sentEventId,
+                  messageEventId: sentEventId,
+                  recipientPubkey: recipientPubkey2,
+                  selfWrapPublished: false,
+                ),
+              ],
+            );
+          },
+          build: buildBloc,
+          act: (bloc) => bloc.add(
+            const ConversationMessageSent(
+              recipientPubkeys: [recipientPubkey, recipientPubkey2],
+              content: 'Group hello',
+            ),
+          ),
+          expect: () => [
+            isA<ConversationState>().having(
+              (s) => s.sendStatus,
+              'sendStatus',
+              SendStatus.sending,
+            ),
+            isA<ConversationState>()
+                .having(
+                  (s) => s.sendStatus,
+                  'sendStatus',
+                  SendStatus.sentPartial,
+                )
+                .having(
+                  (s) => s.lastFailedSend,
+                  'lastFailedSend',
+                  equals(
+                    const FailedSend(
+                      content: 'Group hello',
+                      recipientPubkeys: [recipientPubkey, recipientPubkey2],
+                    ),
+                  ),
+                ),
+          ],
         );
       });
 

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -46,11 +46,13 @@ void main() {
       mockDmRepository = _MockDmRepository();
     });
 
-    ConversationBloc buildBloc() => ConversationBloc(
-      dmRepository: mockDmRepository,
-      conversationId: conversationId,
-      currentUserPubkey: senderPubkey,
-    );
+    ConversationBloc buildBloc({String Function()? pendingIdFactory}) =>
+        ConversationBloc(
+          dmRepository: mockDmRepository,
+          conversationId: conversationId,
+          currentUserPubkey: senderPubkey,
+          pendingIdFactory: pendingIdFactory,
+        );
 
     test('initial state is correct', () {
       when(
@@ -532,6 +534,124 @@ void main() {
                   (s) => s.messages,
                   'messages preserves existing testMessage',
                   equals(const [testMessage]),
+                ),
+          ],
+          errors: () => [isA<Exception>()],
+        );
+      });
+
+      // Regression for #3908 review feedback. The failure cleanup strips by
+      // `m.id != pendingId`, so the contract relies on every optimistic row
+      // having a unique id. The original implementation derived `pendingId`
+      // from a second-resolution timestamp; two sends within the same second
+      // collided, and the second one's failure stripped the first one's row
+      // along with its own. The fix replaces the timestamp with a UUID v4
+      // and exposes a test-only [ConversationBloc.pendingIdFactory] hook so
+      // this regression can be pinned without depending on real wall-clock
+      // timing.
+      group('pendingId uniqueness', () {
+        blocTest<ConversationBloc, ConversationState>(
+          "failure cleanup strips only the failing attempt's optimistic "
+          'when a sibling optimistic from a prior send is still in state',
+          setUp: () {
+            var callCount = 0;
+            when(
+              () => mockDmRepository.sendMessage(
+                recipientPubkey: recipientPubkey,
+                content: any(named: 'content'),
+              ),
+            ).thenAnswer((_) async {
+              callCount++;
+              if (callCount == 1) {
+                // First send resolves successfully but `watchMessages`
+                // stays silent — this models the production window where
+                // the DB write has committed but the stream emission has
+                // not yet reached the bloc, so the optimistic row from
+                // the first send is still present in `state.messages`.
+                return NIP17SendResult.success(
+                  rumorEventId: sentEventId,
+                  messageEventId: sentEventId,
+                  recipientPubkey: recipientPubkey,
+                );
+              }
+              return NIP17SendResult.failure('Relay timeout');
+            });
+          },
+          build: () {
+            var counter = 0;
+            return buildBloc(
+              pendingIdFactory: () => 'pending-${++counter}',
+            );
+          },
+          act: (bloc) async {
+            bloc.add(
+              const ConversationMessageSent(
+                recipientPubkeys: [recipientPubkey],
+                content: 'First',
+              ),
+            );
+            // Sequential() already serialises the two events; the explicit
+            // wait makes the timeline observable in the captured states.
+            await Future<void>.delayed(const Duration(milliseconds: 5));
+            bloc.add(
+              const ConversationMessageSent(
+                recipientPubkeys: [recipientPubkey],
+                content: 'Second',
+              ),
+            );
+          },
+          wait: const Duration(milliseconds: 30),
+          expect: () => [
+            // First attempt: optimistic added with pending-1.
+            isA<ConversationState>()
+                .having((s) => s.sendStatus, 'sendStatus', SendStatus.sending)
+                .having((s) => s.messages.length, 'messages.length', 1)
+                .having(
+                  (s) => s.messages.first.id,
+                  'first attempt pending id',
+                  'pending-1',
+                ),
+            isA<ConversationState>().having(
+              (s) => s.sendStatus,
+              'sendStatus',
+              SendStatus.sent,
+            ),
+            // Second attempt starts before the watch stream has cleared
+            // the first's optimistic — both rows coexist, with distinct
+            // ids so the upcoming strip can target the right one.
+            isA<ConversationState>()
+                .having((s) => s.sendStatus, 'sendStatus', SendStatus.sending)
+                .having((s) => s.messages.length, 'messages.length', 2)
+                .having(
+                  (s) => s.messages.first.id,
+                  'second attempt pending id',
+                  'pending-2',
+                )
+                .having(
+                  (s) => s.messages.last.id,
+                  'first attempt sibling still present',
+                  'pending-1',
+                ),
+            // Second attempt fails. Cleanup strips pending-2 only; the
+            // sibling pending-1 row remains. Under the old timestamp-
+            // based id this state would be `messages: isEmpty`.
+            isA<ConversationState>()
+                .having((s) => s.sendStatus, 'sendStatus', SendStatus.failed)
+                .having((s) => s.messages.length, 'messages.length', 1)
+                .having(
+                  (s) => s.messages.single.id,
+                  'sibling optimistic preserved',
+                  'pending-1',
+                )
+                .having(
+                  (s) => s.lastFailedSend,
+                  'lastFailedSend records the failing attempt only',
+                  equals(
+                    const FailedSend(
+                      content: 'Second',
+                      recipientPubkeys: [recipientPubkey],
+                    ),
+                  ),
                 ),
           ],
           errors: () => [isA<Exception>()],

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -232,8 +232,8 @@ void main() {
         );
 
         blocTest<ConversationBloc, ConversationState>(
-          'emits [sending with optimistic message, failed] '
-          'on failed sendMessage',
+          'emits [sending with optimistic message, failed without '
+          'optimistic and with lastFailedSend] on failed sendMessage',
           setUp: () {
             when(
               () => mockDmRepository.sendMessage(
@@ -252,16 +252,83 @@ void main() {
             ),
           ),
           expect: () => [
+            // Sending: optimistic added.
             isA<ConversationState>()
                 .having((s) => s.sendStatus, 'sendStatus', SendStatus.sending)
-                .having((s) => s.messages.length, 'messages.length', 1),
-            isA<ConversationState>().having(
-              (s) => s.sendStatus,
-              'sendStatus',
-              SendStatus.failed,
-            ),
+                .having((s) => s.messages.length, 'messages.length', 1)
+                .having(
+                  (s) => s.lastFailedSend,
+                  'lastFailedSend cleared on new attempt',
+                  isNull,
+                ),
+            // Failed: optimistic stripped, lastFailedSend populated so the
+            // UI can offer a retry. Without the strip, the optimistic
+            // would survive in bloc memory until pop, then vanish on
+            // re-entry — the "looks sent, then disappeared" bug.
+            isA<ConversationState>()
+                .having((s) => s.sendStatus, 'sendStatus', SendStatus.failed)
+                .having(
+                  (s) => s.messages,
+                  'messages',
+                  isEmpty,
+                )
+                .having(
+                  (s) => s.lastFailedSend,
+                  'lastFailedSend',
+                  equals(
+                    const FailedSend(
+                      content: 'Hello',
+                      recipientPubkeys: [recipientPubkey],
+                    ),
+                  ),
+                ),
           ],
           errors: () => [isA<Exception>()],
+        );
+
+        blocTest<ConversationBloc, ConversationState>(
+          'retry attempt clears prior lastFailedSend and reinserts '
+          'an optimistic row',
+          seed: () => const ConversationState(
+            sendStatus: SendStatus.failed,
+            lastFailedSend: FailedSend(
+              content: 'Hello',
+              recipientPubkeys: [recipientPubkey],
+            ),
+          ),
+          setUp: () {
+            when(
+              () => mockDmRepository.sendMessage(
+                recipientPubkey: recipientPubkey,
+                content: 'Hello',
+              ),
+            ).thenAnswer(
+              (_) async => NIP17SendResult.success(
+                rumorEventId: sentEventId,
+                messageEventId: sentEventId,
+                recipientPubkey: recipientPubkey,
+              ),
+            );
+          },
+          build: buildBloc,
+          act: (bloc) => bloc.add(
+            const ConversationMessageSent(
+              recipientPubkeys: [recipientPubkey],
+              content: 'Hello',
+            ),
+          ),
+          expect: () => [
+            // New attempt: optimistic added, lastFailedSend cleared so a
+            // stale SnackBar can't refire from a previous failure.
+            isA<ConversationState>()
+                .having((s) => s.sendStatus, 'sendStatus', SendStatus.sending)
+                .having((s) => s.messages.length, 'messages.length', 1)
+                .having((s) => s.lastFailedSend, 'lastFailedSend', isNull),
+            // Success: status flips, lastFailedSend stays null.
+            isA<ConversationState>()
+                .having((s) => s.sendStatus, 'sendStatus', SendStatus.sent)
+                .having((s) => s.lastFailedSend, 'lastFailedSend', isNull),
+          ],
         );
       });
 
@@ -310,8 +377,8 @@ void main() {
         );
 
         blocTest<ConversationBloc, ConversationState>(
-          'emits [sending with optimistic message, failed] '
-          'when all sendGroupMessage fail',
+          'emits [sending with optimistic message, failed without '
+          'optimistic and with lastFailedSend] when all sendGroupMessage fail',
           setUp: () {
             when(
               () => mockDmRepository.sendGroupMessage(
@@ -336,11 +403,19 @@ void main() {
             isA<ConversationState>()
                 .having((s) => s.sendStatus, 'sendStatus', SendStatus.sending)
                 .having((s) => s.messages.length, 'messages.length', 1),
-            isA<ConversationState>().having(
-              (s) => s.sendStatus,
-              'sendStatus',
-              SendStatus.failed,
-            ),
+            isA<ConversationState>()
+                .having((s) => s.sendStatus, 'sendStatus', SendStatus.failed)
+                .having((s) => s.messages, 'messages', isEmpty)
+                .having(
+                  (s) => s.lastFailedSend,
+                  'lastFailedSend',
+                  equals(
+                    const FailedSend(
+                      content: 'Group hello',
+                      recipientPubkeys: [recipientPubkey, recipientPubkey2],
+                    ),
+                  ),
+                ),
           ],
           errors: () => [isA<Exception>()],
         );
@@ -348,7 +423,7 @@ void main() {
 
       group('exception handling', () {
         blocTest<ConversationBloc, ConversationState>(
-          'emits [sending with optimistic message, failed] '
+          'strips optimistic and records lastFailedSend '
           'when sendMessage throws an exception',
           setUp: () {
             when(
@@ -369,17 +444,25 @@ void main() {
             isA<ConversationState>()
                 .having((s) => s.sendStatus, 'sendStatus', SendStatus.sending)
                 .having((s) => s.messages.length, 'messages.length', 1),
-            isA<ConversationState>().having(
-              (s) => s.sendStatus,
-              'sendStatus',
-              SendStatus.failed,
-            ),
+            isA<ConversationState>()
+                .having((s) => s.sendStatus, 'sendStatus', SendStatus.failed)
+                .having((s) => s.messages, 'messages', isEmpty)
+                .having(
+                  (s) => s.lastFailedSend,
+                  'lastFailedSend',
+                  equals(
+                    const FailedSend(
+                      content: 'Hello',
+                      recipientPubkeys: [recipientPubkey],
+                    ),
+                  ),
+                ),
           ],
           errors: () => [isA<Exception>()],
         );
 
         blocTest<ConversationBloc, ConversationState>(
-          'emits [sending with optimistic message, failed] '
+          'strips optimistic and records lastFailedSend '
           'when sendGroupMessage throws an exception',
           setUp: () {
             when(
@@ -400,11 +483,56 @@ void main() {
             isA<ConversationState>()
                 .having((s) => s.sendStatus, 'sendStatus', SendStatus.sending)
                 .having((s) => s.messages.length, 'messages.length', 1),
-            isA<ConversationState>().having(
-              (s) => s.sendStatus,
-              'sendStatus',
-              SendStatus.failed,
+            isA<ConversationState>()
+                .having((s) => s.sendStatus, 'sendStatus', SendStatus.failed)
+                .having((s) => s.messages, 'messages', isEmpty)
+                .having(
+                  (s) => s.lastFailedSend,
+                  'lastFailedSend',
+                  equals(
+                    const FailedSend(
+                      content: 'Group hello',
+                      recipientPubkeys: [recipientPubkey, recipientPubkey2],
+                    ),
+                  ),
+                ),
+          ],
+          errors: () => [isA<Exception>()],
+        );
+
+        blocTest<ConversationBloc, ConversationState>(
+          'strips only the optimistic for the failed attempt — '
+          'preserves persisted messages already in state',
+          seed: () => const ConversationState(
+            status: ConversationStatus.loaded,
+            messages: [testMessage],
+          ),
+          setUp: () {
+            when(
+              () => mockDmRepository.sendMessage(
+                recipientPubkey: recipientPubkey,
+                content: 'Hello',
+              ),
+            ).thenThrow(Exception('Network error'));
+          },
+          build: buildBloc,
+          act: (bloc) => bloc.add(
+            const ConversationMessageSent(
+              recipientPubkeys: [recipientPubkey],
+              content: 'Hello',
             ),
+          ),
+          expect: () => [
+            isA<ConversationState>()
+                .having((s) => s.sendStatus, 'sendStatus', SendStatus.sending)
+                .having((s) => s.messages.length, 'messages.length', 2),
+            isA<ConversationState>()
+                .having((s) => s.sendStatus, 'sendStatus', SendStatus.failed)
+                .having(
+                  (s) => s.messages,
+                  'messages preserves existing testMessage',
+                  equals(const [testMessage]),
+                ),
           ],
           errors: () => [isA<Exception>()],
         );
@@ -729,8 +857,53 @@ void main() {
     test('props are correct', () {
       expect(
         const ConversationState().props,
-        equals([ConversationStatus.initial, <DmMessage>[], SendStatus.idle]),
+        equals([
+          ConversationStatus.initial,
+          <DmMessage>[],
+          SendStatus.idle,
+          null,
+        ]),
       );
+    });
+
+    test('states with different lastFailedSend are not equal', () {
+      expect(
+        const ConversationState(),
+        isNot(
+          equals(
+            const ConversationState(
+              lastFailedSend: FailedSend(
+                content: 'Hello',
+                recipientPubkeys: [recipientPubkey],
+              ),
+            ),
+          ),
+        ),
+      );
+    });
+
+    test('copyWith carries lastFailedSend forward when not overridden', () {
+      const failed = FailedSend(
+        content: 'Hello',
+        recipientPubkeys: [recipientPubkey],
+      );
+      const seeded = ConversationState(lastFailedSend: failed);
+
+      // Copying without specifying lastFailedSend keeps the existing value.
+      expect(
+        seeded.copyWith(sendStatus: SendStatus.sending).lastFailedSend,
+        equals(failed),
+      );
+    });
+
+    test('copyWith(clearLastFailedSend: true) wipes lastFailedSend', () {
+      const failed = FailedSend(
+        content: 'Hello',
+        recipientPubkeys: [recipientPubkey],
+      );
+      const seeded = ConversationState(lastFailedSend: failed);
+
+      expect(seeded.copyWith(clearLastFailedSend: true).lastFailedSend, isNull);
     });
 
     test('states with different status are not equal', () {

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -373,6 +373,10 @@ const _knownUntranslatedDebt = {
   // divine.video/safety" link). Falls back to English in non-English
   // locales until translated.
   'reportLearnMoreAt',
+  // Added by #3908 (DM send-failure SnackBar + retry). Non-English locales
+  // fall back to English until the next translation pass.
+  'dmSendFailedMessage',
+  'dmSendFailedRetry',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -373,10 +373,6 @@ const _knownUntranslatedDebt = {
   // divine.video/safety" link). Falls back to English in non-English
   // locales until translated.
   'reportLearnMoreAt',
-  // Added by #3908 (DM send-failure SnackBar + retry). Non-English locales
-  // fall back to English until the next translation pass.
-  'dmSendFailedMessage',
-  'dmSendFailedRetry',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/screens/inbox/conversation/conversation_page_repo_swap_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_page_repo_swap_test.dart
@@ -1,0 +1,257 @@
+// ABOUTME: Regression test for the BlocProvider repo-swap pattern in
+// ABOUTME: ConversationPage — verifies the ConversationBloc is recreated
+// ABOUTME: when dmRepositoryProvider rebuilds (auth flip / sign-out /
+// ABOUTME: account switch), so reads/writes never split between a stale
+// ABOUTME: captured repo and the active one.
+//
+// Mirrors `pooled_video_feed_item_repo_swap_test.dart` (#3503). The
+// production site is `conversation_page.dart`'s `BlocProvider<
+// ConversationBloc>(key: ValueKey((dmRepository, currentPubkey)), …)`.
+// Without this key, a `dmRepository` captured during a brief
+// unauthenticated window scopes all message reads/writes by the wrong
+// `_userPubkey` for the lifetime of the bloc, reproducing the
+// "looks sent, then disappeared" bug.
+
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
+import 'package:openvine/screens/inbox/conversation/conversation_view.dart';
+import 'package:openvine/services/auth_service.dart';
+
+import '../../../helpers/test_provider_overrides.dart';
+
+class _MockDmRepository extends Mock implements DmRepository {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+/// Toggle a `StateProvider<int>` to force `dmRepositoryProvider` to
+/// rebuild and return a different mock — mirrors what happens in
+/// production when auth flips (the real provider rebuilds when
+/// `nostrServiceProvider` rebuilds, which happens via
+/// `_onAuthStateChanged` in `nostr_client_provider.dart`).
+final _dmRepoSwap = StateProvider<int>((ref) => 0);
+
+void main() {
+  const testPubkey =
+      'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
+  const otherPubkey =
+      '1122334455667788112233445566778811223344556677881122334455667788';
+  const testConversationId =
+      'ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00';
+
+  group('ConversationPage — BlocProvider repo-swap', () {
+    late _MockDmRepository mockRepoA;
+    late _MockDmRepository mockRepoB;
+    late _MockAuthService mockAuthService;
+
+    setUp(() {
+      mockRepoA = _MockDmRepository();
+      mockRepoB = _MockDmRepository();
+      mockAuthService = _MockAuthService();
+
+      // ConversationBloc subscribes to watchMessages on construction
+      // (ConversationStarted) and marks the conversation as read.
+      // Stub both mocks so the bloc can run without throwing.
+      for (final repo in [mockRepoA, mockRepoB]) {
+        when(
+          () => repo.markConversationAsRead(any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => repo.watchMessages(any()),
+        ).thenAnswer((_) => const Stream<List<DmMessage>>.empty());
+      }
+
+      when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkey);
+      when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.authState).thenReturn(AuthState.authenticated);
+      when(
+        () => mockAuthService.authStateStream,
+      ).thenAnswer((_) => const Stream<AuthState>.empty());
+    });
+
+    testWidgets(
+      'recreates ConversationBloc when dmRepositoryProvider rebuilds with '
+      'a new repository instance',
+      (tester) async {
+        await tester.pumpWidget(
+          testMaterialApp(
+            mockAuthService: mockAuthService,
+            additionalOverrides: [
+              dmRepositoryProvider.overrideWith((ref) {
+                final v = ref.watch(_dmRepoSwap);
+                return v == 0 ? mockRepoA : mockRepoB;
+              }),
+              fetchUserProfileProvider(
+                otherPubkey,
+              ).overrideWith((ref) async => null),
+            ],
+            home: const ConversationPage(
+              conversationId: testConversationId,
+              participantPubkeys: [otherPubkey],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // Capture the bloc that was created when the page first built.
+        final viewContextBefore = tester.element(find.byType(ConversationView));
+        final blocA = BlocProvider.of<ConversationBloc>(viewContextBefore);
+        expect(blocA.isClosed, isFalse, reason: 'initial bloc should be alive');
+
+        // Flip the toggle. dmRepositoryProvider rebuilds, ConversationPage's
+        // ref.watch fires, the composite ValueKey changes, BlocProvider
+        // unmounts blocA and creates a new bloc wrapping mockRepoB.
+        final providerScope = ProviderScope.containerOf(
+          tester.element(find.byType(ConversationPage)),
+        );
+        providerScope.read(_dmRepoSwap.notifier).state = 1;
+        await tester.pump();
+
+        final viewContextAfter = tester.element(find.byType(ConversationView));
+        final blocB = BlocProvider.of<ConversationBloc>(viewContextAfter);
+
+        expect(
+          blocB,
+          isNot(same(blocA)),
+          reason:
+              'BlocProvider must create a new ConversationBloc when '
+              'dmRepository identity flips. Without the ValueKey on the '
+              'BlocProvider, the bloc would keep using a stale '
+              'DmRepository whose `_userPubkey` could be empty (or scope '
+              'rows under a different ownerPubkey), causing watchMessages '
+              'to return nothing and sent messages to "disappear".',
+        );
+      },
+    );
+
+    testWidgets(
+      'preserves the same ConversationBloc when the dmRepository identity '
+      'does not change across rebuilds',
+      (tester) async {
+        await tester.pumpWidget(
+          testMaterialApp(
+            mockAuthService: mockAuthService,
+            additionalOverrides: [
+              dmRepositoryProvider.overrideWith((ref) {
+                ref.watch(_dmRepoSwap);
+                return mockRepoA; // identity stays the same
+              }),
+              fetchUserProfileProvider(
+                otherPubkey,
+              ).overrideWith((ref) async => null),
+            ],
+            home: const ConversationPage(
+              conversationId: testConversationId,
+              participantPubkeys: [otherPubkey],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final blocA = BlocProvider.of<ConversationBloc>(
+          tester.element(find.byType(ConversationView)),
+        );
+
+        // Force the provider to rebuild but return the same instance.
+        // The record-typed ValueKey compares structurally on `==`; for
+        // classes that don't override `==`, equality falls through to
+        // identity, so the key stays equal and the bloc is preserved.
+        final providerScope = ProviderScope.containerOf(
+          tester.element(find.byType(ConversationPage)),
+        );
+        providerScope.read(_dmRepoSwap.notifier).state = 1;
+        await tester.pump();
+
+        final blocAfter = BlocProvider.of<ConversationBloc>(
+          tester.element(find.byType(ConversationView)),
+        );
+
+        expect(
+          blocAfter,
+          same(blocA),
+          reason:
+              'Identical dmRepository identity should keep the same bloc '
+              '— the record key prevents unnecessary churn on rebuilds.',
+        );
+      },
+    );
+
+    // Documents an intentional trade-off mirroring the four canonical
+    // sites (`video_feed_page.dart` / `pooled_fullscreen_video_feed_screen
+    // .dart`): when the composite key changes, the old bloc is closed and
+    // the new one starts from initial state. Optimistic message rows and
+    // any in-flight `_onMessageSent` against the previous repo are
+    // intentionally dropped — the new repo points at a different
+    // `NostrClient` (different signer, possibly different user) so
+    // replaying them would be unsafe.
+    //
+    // Today the only paths that flip this key are auth state transitions
+    // (cold-launch race, sign-in/out, account switch). If a future change
+    // adds a non-auth invalidation of `dmRepositoryProvider`, this test
+    // will fail loudly so the state-loss can be re-evaluated.
+    testWidgets(
+      'resets bloc state when dmRepositoryProvider rebuilds (intentional)',
+      (tester) async {
+        await tester.pumpWidget(
+          testMaterialApp(
+            mockAuthService: mockAuthService,
+            additionalOverrides: [
+              dmRepositoryProvider.overrideWith((ref) {
+                final v = ref.watch(_dmRepoSwap);
+                return v == 0 ? mockRepoA : mockRepoB;
+              }),
+              fetchUserProfileProvider(
+                otherPubkey,
+              ).overrideWith((ref) async => null),
+            ],
+            home: const ConversationPage(
+              conversationId: testConversationId,
+              participantPubkeys: [otherPubkey],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final blocBefore = BlocProvider.of<ConversationBloc>(
+          tester.element(find.byType(ConversationView)),
+        );
+
+        // Synthesise a non-initial state to prove it actually gets lost
+        // on swap — mirrors what an in-flight optimistic + failure would
+        // look like.
+        blocBefore.emit(
+          const ConversationState(
+            status: ConversationStatus.loaded,
+            sendStatus: SendStatus.failed,
+            lastFailedSend: FailedSend(
+              content: 'Hello',
+              recipientPubkeys: [otherPubkey],
+            ),
+          ),
+        );
+
+        final providerScope = ProviderScope.containerOf(
+          tester.element(find.byType(ConversationPage)),
+        );
+        providerScope.read(_dmRepoSwap.notifier).state = 1;
+        await tester.pump();
+
+        final blocAfter = BlocProvider.of<ConversationBloc>(
+          tester.element(find.byType(ConversationView)),
+        );
+        expect(blocAfter, isNot(same(blocBefore)));
+        // Fresh bloc starts from initial state.
+        expect(blocAfter.state.sendStatus, equals(SendStatus.idle));
+        expect(blocAfter.state.lastFailedSend, isNull);
+      },
+    );
+  });
+}

--- a/mobile/test/screens/inbox/conversation/conversation_page_repo_swap_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_page_repo_swap_test.dart
@@ -19,12 +19,15 @@ import 'package:flutter_riverpod/legacy.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/dm/conversation/collaborator_invite_actions_cubit.dart';
 import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_view.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/collaborator_invite_state_store.dart';
+import 'package:openvine/services/collaborator_response_service.dart';
 
 import '../../../helpers/test_provider_overrides.dart';
 
@@ -32,12 +35,23 @@ class _MockDmRepository extends Mock implements DmRepository {}
 
 class _MockAuthService extends Mock implements AuthService {}
 
+class _MockCollaboratorInviteStateStore extends Mock
+    implements CollaboratorInviteStateStore {}
+
+class _MockCollaboratorResponseService extends Mock
+    implements CollaboratorResponseService {}
+
 /// Toggle a `StateProvider<int>` to force `dmRepositoryProvider` to
 /// rebuild and return a different mock — mirrors what happens in
 /// production when auth flips (the real provider rebuilds when
 /// `nostrServiceProvider` rebuilds, which happens via
 /// `_onAuthStateChanged` in `nostr_client_provider.dart`).
 final _dmRepoSwap = StateProvider<int>((ref) => 0);
+
+/// Toggle for [collaboratorResponseServiceProvider] swaps. The real
+/// provider composes `authServiceProvider` + `nostrServiceProvider` in
+/// `app_providers.dart`, so it rebuilds on auth flips.
+final _responseSvcSwap = StateProvider<int>((ref) => 0);
 
 void main() {
   const testPubkey =
@@ -61,9 +75,7 @@ void main() {
       // (ConversationStarted) and marks the conversation as read.
       // Stub both mocks so the bloc can run without throwing.
       for (final repo in [mockRepoA, mockRepoB]) {
-        when(
-          () => repo.markConversationAsRead(any()),
-        ).thenAnswer((_) async {});
+        when(() => repo.markConversationAsRead(any())).thenAnswer((_) async {});
         when(
           () => repo.watchMessages(any()),
         ).thenAnswer((_) => const Stream<List<DmMessage>>.empty());
@@ -251,6 +263,140 @@ void main() {
         // Fresh bloc starts from initial state.
         expect(blocAfter.state.sendStatus, equals(SendStatus.idle));
         expect(blocAfter.state.lastFailedSend, isNull);
+      },
+    );
+  });
+
+  // The sibling BlocProvider in `conversation_page.dart` carries the same
+  // ValueKey treatment for `CollaboratorInviteActionsCubit`. The cubit's
+  // `responseService` composes `authServiceProvider` + `nostrServiceProvider`
+  // (see `app_providers.dart`), so its identity flips on auth changes —
+  // without the key, accept-invite would publish through a stale signer
+  // for the cubit's lifetime.
+  group('ConversationPage — invite cubit repo-swap', () {
+    late _MockDmRepository mockDmRepository;
+    late _MockAuthService mockAuthService;
+    late _MockCollaboratorInviteStateStore mockStateStore;
+    late _MockCollaboratorResponseService mockResponseSvcA;
+    late _MockCollaboratorResponseService mockResponseSvcB;
+
+    setUp(() {
+      mockDmRepository = _MockDmRepository();
+      mockAuthService = _MockAuthService();
+      mockStateStore = _MockCollaboratorInviteStateStore();
+      mockResponseSvcA = _MockCollaboratorResponseService();
+      mockResponseSvcB = _MockCollaboratorResponseService();
+
+      when(
+        () => mockDmRepository.markConversationAsRead(any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockDmRepository.watchMessages(any()),
+      ).thenAnswer((_) => const Stream<List<DmMessage>>.empty());
+
+      when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkey);
+      when(() => mockAuthService.isAuthenticated).thenReturn(true);
+      when(() => mockAuthService.authState).thenReturn(AuthState.authenticated);
+      when(
+        () => mockAuthService.authStateStream,
+      ).thenAnswer((_) => const Stream<AuthState>.empty());
+    });
+
+    testWidgets('recreates CollaboratorInviteActionsCubit when '
+        'collaboratorResponseServiceProvider rebuilds with a new instance', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        testMaterialApp(
+          mockAuthService: mockAuthService,
+          additionalOverrides: [
+            dmRepositoryProvider.overrideWith((ref) => mockDmRepository),
+            collaboratorInviteStateStoreProvider.overrideWith(
+              (ref) => mockStateStore,
+            ),
+            collaboratorResponseServiceProvider.overrideWith((ref) {
+              final v = ref.watch(_responseSvcSwap);
+              return v == 0 ? mockResponseSvcA : mockResponseSvcB;
+            }),
+            fetchUserProfileProvider(
+              otherPubkey,
+            ).overrideWith((ref) async => null),
+          ],
+          home: const ConversationPage(
+            conversationId: testConversationId,
+            participantPubkeys: [otherPubkey],
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final cubitA = BlocProvider.of<CollaboratorInviteActionsCubit>(
+        tester.element(find.byType(ConversationView)),
+      );
+      expect(cubitA.isClosed, isFalse);
+
+      final providerScope = ProviderScope.containerOf(
+        tester.element(find.byType(ConversationPage)),
+      );
+      providerScope.read(_responseSvcSwap.notifier).state = 1;
+      await tester.pump();
+
+      final cubitB = BlocProvider.of<CollaboratorInviteActionsCubit>(
+        tester.element(find.byType(ConversationView)),
+      );
+      expect(
+        cubitB,
+        isNot(same(cubitA)),
+        reason:
+            'BlocProvider must recreate the cubit when '
+            'collaboratorResponseServiceProvider identity flips. Without '
+            'the ValueKey, accept-invite publishes would route through a '
+            'stale signer/relay captured at first build.',
+      );
+    });
+
+    testWidgets(
+      'preserves the same CollaboratorInviteActionsCubit when the response '
+      'service identity does not change across rebuilds',
+      (tester) async {
+        await tester.pumpWidget(
+          testMaterialApp(
+            mockAuthService: mockAuthService,
+            additionalOverrides: [
+              dmRepositoryProvider.overrideWith((ref) => mockDmRepository),
+              collaboratorInviteStateStoreProvider.overrideWith(
+                (ref) => mockStateStore,
+              ),
+              collaboratorResponseServiceProvider.overrideWith((ref) {
+                ref.watch(_responseSvcSwap);
+                return mockResponseSvcA; // identity stays the same
+              }),
+              fetchUserProfileProvider(
+                otherPubkey,
+              ).overrideWith((ref) async => null),
+            ],
+            home: const ConversationPage(
+              conversationId: testConversationId,
+              participantPubkeys: [otherPubkey],
+            ),
+          ),
+        );
+        await tester.pump();
+
+        final cubitBefore = BlocProvider.of<CollaboratorInviteActionsCubit>(
+          tester.element(find.byType(ConversationView)),
+        );
+
+        final providerScope = ProviderScope.containerOf(
+          tester.element(find.byType(ConversationPage)),
+        );
+        providerScope.read(_responseSvcSwap.notifier).state = 1;
+        await tester.pump();
+
+        final cubitAfter = BlocProvider.of<CollaboratorInviteActionsCubit>(
+          tester.element(find.byType(ConversationView)),
+        );
+        expect(cubitAfter, same(cubitBefore));
       },
     );
   });

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -63,6 +63,12 @@ void main() {
     setUpAll(() {
       registerFallbackValue(fallbackInvite);
       registerFallbackValue(<CollaboratorInvite>[]);
+      registerFallbackValue(
+        const ConversationMessageSent(
+          recipientPubkeys: [otherPubkey],
+          content: '',
+        ),
+      );
     });
 
     setUp(() {
@@ -446,6 +452,181 @@ void main() {
             find.text('Hey, want to ride together this weekend?'),
             findsOneWidget,
           );
+        },
+      );
+    });
+
+    // Send-failure UX (companion to ConversationBloc's clear-optimistic-on-
+    // failure behavior). On `SendStatus.failed`, the bloc strips the
+    // optimistic message; the UI's job is to surface a retry SnackBar so
+    // the user knows the send actually failed and has a one-tap recovery.
+    // Without this listener, the only visible change would be a brief
+    // spinner flicker, and the user would discover the loss only after
+    // navigating away and back — the "looks sent, then disappeared" bug.
+    group('send-failure SnackBar', () {
+      const failedSendContent = 'Hi there';
+      const failedSend = FailedSend(
+        content: failedSendContent,
+        recipientPubkeys: [otherPubkey],
+      );
+
+      testWidgets(
+        'shows a localized retry SnackBar when sendStatus transitions to '
+        'failed',
+        (tester) async {
+          // Emit loaded → failed so the listenWhen guard fires.
+          whenListen(
+            mockBloc,
+            Stream<ConversationState>.fromIterable(const [
+              ConversationState(status: ConversationStatus.loaded),
+              ConversationState(
+                status: ConversationStatus.loaded,
+                sendStatus: SendStatus.failed,
+                lastFailedSend: failedSend,
+              ),
+            ]),
+            initialState: const ConversationState(
+              status: ConversationStatus.loaded,
+            ),
+          );
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              mockAuthService: mockAuthService,
+              additionalOverrides: [
+                fetchUserProfileProvider(
+                  otherPubkey,
+                ).overrideWith((ref) async => null),
+              ],
+              home: BlocProvider<ConversationBloc>.value(
+                value: mockBloc,
+                child: BlocProvider<CollaboratorInviteActionsCubit>.value(
+                  value: mockInviteActionsCubit,
+                  child: const ConversationView(
+                    participantPubkeys: [otherPubkey],
+                  ),
+                ),
+              ),
+            ),
+          );
+          // Drain the controlled stream + SnackBar enter animation.
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          expect(
+            find.text(l10n.dmSendFailedMessage),
+            findsOneWidget,
+            reason: 'localized failure message must come from context.l10n',
+          );
+          expect(find.text(l10n.dmSendFailedRetry), findsOneWidget);
+          // Hardcoded English would silently regress if the widget stopped
+          // reading l10n — guard via the German variant.
+          final lookupGermanFailureMessage = lookupAppLocalizations(
+            const Locale('de'),
+          ).dmSendFailedMessage;
+          if (lookupGermanFailureMessage != l10n.dmSendFailedMessage) {
+            expect(find.text(lookupGermanFailureMessage), findsNothing);
+          }
+        },
+      );
+
+      testWidgets(
+        'does not show a SnackBar when sendStatus stays non-failed '
+        '(e.g. sending → sent)',
+        (tester) async {
+          whenListen(
+            mockBloc,
+            Stream<ConversationState>.fromIterable(const [
+              ConversationState(
+                status: ConversationStatus.loaded,
+                sendStatus: SendStatus.sending,
+              ),
+              ConversationState(
+                status: ConversationStatus.loaded,
+                sendStatus: SendStatus.sent,
+              ),
+            ]),
+            initialState: const ConversationState(
+              status: ConversationStatus.loaded,
+            ),
+          );
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              mockAuthService: mockAuthService,
+              additionalOverrides: [
+                fetchUserProfileProvider(
+                  otherPubkey,
+                ).overrideWith((ref) async => null),
+              ],
+              home: BlocProvider<ConversationBloc>.value(
+                value: mockBloc,
+                child: BlocProvider<CollaboratorInviteActionsCubit>.value(
+                  value: mockInviteActionsCubit,
+                  child: const ConversationView(
+                    participantPubkeys: [otherPubkey],
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          expect(find.text(l10n.dmSendFailedMessage), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'tapping Retry redispatches ConversationMessageSent with the '
+        'last failed content + recipients',
+        (tester) async {
+          whenListen(
+            mockBloc,
+            Stream<ConversationState>.fromIterable(const [
+              ConversationState(status: ConversationStatus.loaded),
+              ConversationState(
+                status: ConversationStatus.loaded,
+                sendStatus: SendStatus.failed,
+                lastFailedSend: failedSend,
+              ),
+            ]),
+            initialState: const ConversationState(
+              status: ConversationStatus.loaded,
+            ),
+          );
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              mockAuthService: mockAuthService,
+              additionalOverrides: [
+                fetchUserProfileProvider(
+                  otherPubkey,
+                ).overrideWith((ref) async => null),
+              ],
+              home: BlocProvider<ConversationBloc>.value(
+                value: mockBloc,
+                child: BlocProvider<CollaboratorInviteActionsCubit>.value(
+                  value: mockInviteActionsCubit,
+                  child: const ConversationView(
+                    participantPubkeys: [otherPubkey],
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          await tester.tap(find.text(l10n.dmSendFailedRetry));
+          // Allow the SnackBar dismissal to settle.
+          await tester.pump();
+
+          final captured = verify(() => mockBloc.add(captureAny())).captured;
+          expect(captured, isNotEmpty);
+          final retryEvent = captured.last as ConversationMessageSent;
+          expect(retryEvent.content, equals(failedSendContent));
+          expect(retryEvent.recipientPubkeys, equals(const [otherPubkey]));
         },
       );
     });

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -715,6 +715,65 @@ void main() {
           );
         },
       );
+
+      // The recipient-only partial-delivery path: NIP17MessageService
+      // returned `success: true, selfWrapPublished: false`, so the bloc
+      // emits SendStatus.sentPartial. The UI must show distinct copy
+      // (the message *was* delivered) while still offering retry, so the
+      // sender can attempt to re-publish their self-wrap and restore
+      // cross-device sync. Pinned per PR #3908 review feedback.
+      testWidgets(
+        'shows the partial-delivery SnackBar copy when sendStatus '
+        'transitions to sentPartial',
+        (tester) async {
+          whenListen(
+            mockBloc,
+            Stream<ConversationState>.fromIterable(const [
+              ConversationState(status: ConversationStatus.loaded),
+              ConversationState(
+                status: ConversationStatus.loaded,
+                sendStatus: SendStatus.sentPartial,
+                lastFailedSend: failedSend,
+              ),
+            ]),
+            initialState: const ConversationState(
+              status: ConversationStatus.loaded,
+            ),
+          );
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              mockAuthService: mockAuthService,
+              additionalOverrides: [
+                fetchUserProfileProvider(
+                  otherPubkey,
+                ).overrideWith((ref) async => null),
+              ],
+              home: BlocProvider<ConversationBloc>.value(
+                value: mockBloc,
+                child: BlocProvider<CollaboratorInviteActionsCubit>.value(
+                  value: mockInviteActionsCubit,
+                  child: const ConversationView(
+                    participantPubkeys: [otherPubkey],
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          expect(
+            find.text(l10n.dmSendPartialMessage),
+            findsOneWidget,
+            reason:
+                'partial-delivery copy must come from context.l10n and be '
+                'distinct from the full-failure copy',
+          );
+          expect(find.text(l10n.dmSendFailedMessage), findsNothing);
+          expect(find.text(l10n.dmSendFailedRetry), findsOneWidget);
+        },
+      );
     });
   });
 }

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -158,7 +158,22 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.text('Could not load messages'), findsOneWidget);
+        final l10n = AppLocalizations.of(
+          tester.element(find.byType(ConversationView)),
+        );
+        expect(find.text(l10n.dmConversationLoadError), findsOneWidget);
+        // Cross-check that the widget actually reads from l10n: the German
+        // copy must NOT appear in an en-locale render. Catches a regression
+        // where the migration accidentally hardcodes the English string
+        // alongside the l10n key.
+        expect(
+          find.text(
+            lookupAppLocalizations(
+              const Locale('de'),
+            ).dmConversationLoadError,
+          ),
+          findsNothing,
+        );
       });
 
       testWidgets('renders $EmptyConversation when loaded with no messages', (

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -627,6 +628,91 @@ void main() {
           final retryEvent = captured.last as ConversationMessageSent;
           expect(retryEvent.content, equals(failedSendContent));
           expect(retryEvent.recipientPubkeys, equals(const [otherPubkey]));
+        },
+      );
+
+      // accessibility.md requires explicit `SemanticsService.announce` (or
+      // its non-deprecated `sendAnnouncement` form) on async visible state
+      // changes — Material's default SnackBar semantics are platform-
+      // dependent and weaker than the written rule. The test intercepts
+      // the platform's accessibility channel, where both APIs ultimately
+      // deliver the announcement, and pins the localized failure string.
+      testWidgets(
+        'announces the localized failure message via SemanticsService '
+        'when the SnackBar fires',
+        (tester) async {
+          final announcements = <Map<Object?, Object?>>[];
+          tester.binding.defaultBinaryMessenger
+              .setMockDecodedMessageHandler<Object?>(
+                SystemChannels.accessibility,
+                (Object? message) async {
+                  if (message is Map) announcements.add(message);
+                  return null;
+                },
+              );
+          addTearDown(
+            () => tester.binding.defaultBinaryMessenger
+                .setMockDecodedMessageHandler<Object?>(
+                  SystemChannels.accessibility,
+                  null,
+                ),
+          );
+
+          whenListen(
+            mockBloc,
+            Stream<ConversationState>.fromIterable(const [
+              ConversationState(status: ConversationStatus.loaded),
+              ConversationState(
+                status: ConversationStatus.loaded,
+                sendStatus: SendStatus.failed,
+                lastFailedSend: failedSend,
+              ),
+            ]),
+            initialState: const ConversationState(
+              status: ConversationStatus.loaded,
+            ),
+          );
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              mockAuthService: mockAuthService,
+              additionalOverrides: [
+                fetchUserProfileProvider(
+                  otherPubkey,
+                ).overrideWith((ref) async => null),
+              ],
+              home: BlocProvider<ConversationBloc>.value(
+                value: mockBloc,
+                child: BlocProvider<CollaboratorInviteActionsCubit>.value(
+                  value: mockInviteActionsCubit,
+                  child: const ConversationView(
+                    participantPubkeys: [otherPubkey],
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          final announceCalls = announcements.where(
+            (m) => m['type'] == 'announce',
+          );
+          expect(
+            announceCalls,
+            isNotEmpty,
+            reason:
+                'expected SemanticsService.sendAnnouncement to deliver an '
+                "'announce' event on SystemChannels.accessibility",
+          );
+          final announcedMessages = announceCalls
+              .map((m) => (m['data'] as Map?)?['message'])
+              .toList();
+          expect(
+            announcedMessages,
+            contains(l10n.dmSendFailedMessage),
+            reason: 'announce payload must carry the localized failure copy',
+          );
         },
       );
     });


### PR DESCRIPTION
## Description

Fixes the user-reported bug where sent DMs **look sent, then disappear**
once the user navigates away and re-enters the conversation.

**Related Issue:** Closes #3902

### What the user saw

> "Every time it looks like my messages have sent — when I look again
> it's disappeared. The recipient never received them and when I
> exited the chat the whole chatbox disappeared from my Messages inbox."

### Reproducing the bug (pre-fix)

1. Sign in with a Divine OAuth session that uses Keycast RPC signing
   (no local nsec on device — common for new users).
2. Open a 1:1 conversation with any peer.
3. Send a message. The message bubble appears (optimistic insert).
4. Force any of: a slow Keycast RPC round (≥3-4 s), a relay reject, a
   transient network drop, or sign-out mid-send. Today these fail
   silently — the spinner flickers back to "ready" with no UI cue.
5. Tap back to leave the conversation, then re-enter it.

**Result before this PR:** the conversation is empty (or missing the
message you "sent"). The optimistic row lived only in
`ConversationBloc` memory; on failure no DB row was ever written, so
when the bloc closed the row was gone forever.

**Result after this PR:**
- On failure, the optimistic row is removed immediately and a
  localized SnackBar appears: **"Message couldn't be sent" — [Retry]**.
- Tapping Retry redispatches the same content + recipients without
  the user re-typing.
- Successful retries publish + persist normally; the SnackBar
  doesn't refire from a stale failure.

### Root-cause one-liner

`ConversationBloc._onMessageSent` only updated `sendStatus` on
failure. The `watchMessages` stream — the *only* thing that ever
removed the optimistic from `state.messages` — never fires when the
DB write doesn't happen.

A second, latent path to the same symptom: `conversation_page.dart`
captured `dmRepository` from Riverpod without a `ValueKey` over its
identity, so an auth-flip during the bloc's lifetime would split
reads/writes between a stale repo and the active one. Pinned per
`state_management.md` → "Bridging Riverpod-provided dependencies
into BlocProvider".

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Changes

**`conversation_bloc.dart` + `conversation_state.dart` (Approach A)**
- New `FailedSend` model + `lastFailedSend` field.
- On `SendStatus.failed`: strip the optimistic for `pendingId`, record
  `lastFailedSend`.
- On a new attempt (incl. retry): clear `lastFailedSend`.

**`conversation_view.dart` (Approach B)**
- `BlocListener` on `sendStatus → failed` → localized retry SnackBar.
- Retry redispatches `ConversationMessageSent` from `lastFailedSend`;
  UI never holds non-UI state.

**`conversation_page.dart` (Approach E — defense-in-depth)**
- `BlocProvider<ConversationBloc>` now carries
  `key: ValueKey((dmRepository, currentPubkey))`. Mirrors the four
  canonical sites (`video_feed_page.dart` x2,
  `pooled_fullscreen_video_feed_screen.dart` x2).

**l10n**
- New keys: `dmSendFailedMessage` ("Message couldn't be sent"),
  `dmSendFailedRetry` ("Retry"), with `@`-metadata. Generated files
  regenerated via `flutter gen-l10n`.

## Test plan

Automated:
- [x] `flutter analyze lib test` — clean.
- [x] `dart format` — no changes.
- [x] `flutter test test/blocs/dm test/screens/inbox` — **292 / 292 passing**.

Tightened existing tests + added new ones:

- `conversation_bloc_test.dart` (36 / 36): every failure path now pins
  `messages: isEmpty` *and* `lastFailedSend == FailedSend(...)` so a
  regression cannot land silently. New: retry round-trip, "preserves
  persisted messages already in state on failure", state lifecycle
  tests for `lastFailedSend`.
- `conversation_view_test.dart` (14 / 14): new "send-failure SnackBar"
  group — shown on failure (with German-variant cross-check per
  `localization.md`), **not** shown on `sending → sent`, Retry tap
  redispatches `ConversationMessageSent` with captured content +
  recipients.
- `conversation_page_repo_swap_test.dart` (NEW, 3 / 3): mirrors
  `pooled_video_feed_item_repo_swap_test.dart` — recreate-on-flip,
  preserve-on-equal-identity, documented intentional-state-loss-on-flip.

Manual verification (please confirm during review):
- [ ] Send a DM with airplane mode toggled mid-send → optimistic
  disappears, SnackBar shows, Retry works once connectivity returns.
- [ ] Send a DM, kill the relay socket via OS network restrictions →
  same SnackBar appears.
- [ ] Send a DM successfully → no SnackBar, message persists across
  pop + re-enter.
- [ ] VoiceOver / TalkBack: SnackBar content is announced (Material
  default behavior — flagged for verification).

## What was deferred (follow-ups, not in this PR)

These are the right answer long-term but out of scope for a bug fix
per `code_style.md` ("Don't add features beyond what the task
requires"):

- **Durable outgoing-message queue** — DB-backed pending rows so
  in-flight sends survive bloc disposal & app restart. Pairs with…
- **Self-wrap publish failure detection** — `nip17_message_service.dart:118-132`
  silently ignores the publish result of the self-addressed gift wrap,
  which is what allows a sender's own messages to be recoverable from
  the relay on a different device.

Will file as a single follow-up issue ("DM outgoing durability") after
this PR lands; both can reference `UploadManager` as the in-repo
precedent.

## Investigation notes

Full layered trace (UI → BLoC → Repository → NIP17MessageService →
NostrClient → relay, plus the Drift watch return path), failure-mode
catalogue, and evaluation of approaches A–E against
`.claude/rules/*.md` were captured during diagnosis from the user's
log export (`Untitled.txt`, ~20 K lines). The ranking that produced
this fix:

| Approach | Status | Rationale |
|---|---|---|
| A — clear optimistic on failure | ✅ in this PR | Minimum to fix the reported bug |
| B — retry SnackBar | ✅ in this PR | Required by `error_handling.md` and matches `inbox_view.dart` precedent |
| E — `ValueKey` on `BlocProvider` | ✅ in this PR | Hard requirement per `state_management.md`; latent path to same symptom |
| C — durable outgoing queue | Deferred (follow-up issue) | Right long-term; ~5–10× this PR |
| D — split persisted vs. optimistic state fields | Not needed | Same observable behavior as A+B |