### PR TITLE
fix(dm): surface NIP-17 self-wrap publish failure via NIP17SendResult

### DIFF
--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -137,7 +137,7 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
         if (!result.success) {
           throw Exception(result.error ?? 'Failed to send message');
         }
-        selfWrapPublished = result.selfWrapPublished;
+        selfWrapPublished = result.selfWrapPublished!;
       } else {
         final results = await _dmRepository.sendGroupMessage(
           recipientPubkeys: event.recipientPubkeys,
@@ -154,7 +154,7 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
         // sender's other devices.
         selfWrapPublished = results
             .where((r) => r.success)
-            .every((r) => r.selfWrapPublished);
+            .every((r) => r.selfWrapPublished!);
       }
       if (!selfWrapPublished) {
         emit(

--- a/mobile/packages/dm_repository/lib/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/dm_repository.dart
@@ -1,4 +1,4 @@
 export 'src/dm_decryption_worker.dart';
 export 'src/dm_repository.dart';
 export 'src/dm_sync_state.dart';
-export 'src/nip17_message_service.dart';
+export 'src/nip17_message_service.dart' hide GiftWrapBuilder;

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1243,7 +1243,7 @@ class DmRepository {
 
     final publishResult = await _nostrClient.publishEvent(signed);
     if (publishResult is! PublishSuccess) {
-      return NIP17SendResult.failure('NIP-04 publish failed');
+      return const NIP17SendResult.failure('NIP-04 publish failed');
     }
 
     return NIP17SendResult.success(

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1224,12 +1224,12 @@ class DmRepository {
     // Reuses NIP17SendResult for simplicity — this is an internal helper.
     final signer = _signer;
     if (signer == null) {
-      return NIP17SendResult.failure('Signer not available');
+      return const NIP17SendResult.failure('Signer not available');
     }
 
     final ciphertext = await signer.encrypt(recipientPubkey, content);
     if (ciphertext == null) {
-      return NIP17SendResult.failure('NIP-04 encrypt returned null');
+      return const NIP17SendResult.failure('NIP-04 encrypt returned null');
     }
 
     final event = Event(_userPubkey, EventKind.directMessage, [
@@ -1238,7 +1238,7 @@ class DmRepository {
 
     final signed = await signer.signEvent(event);
     if (signed == null) {
-      return NIP17SendResult.failure('NIP-04 sign returned null');
+      return const NIP17SendResult.failure('NIP-04 sign returned null');
     }
 
     final publishResult = await _nostrClient.publishEvent(signed);

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -3,7 +3,7 @@
 // ABOUTME: (kind 14 rumor → kind 13 seal → kind 1059 gift wrap)
 // ABOUTME: Works with any NostrSigner (local keys, Keycast RPC, Amber, etc.)
 
-import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 import 'package:models/models.dart' show NIP17SendResult;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
@@ -22,6 +22,7 @@ import 'package:unified_logger/unified_logger.dart';
 /// Defaults to [GiftWrapUtil.getGiftWrapEvent]; injectable for tests
 /// so the `null`-return branch in [NIP17MessageService] can be
 /// exercised without conjuring valid gift-wrapped events by hand.
+@internal
 typedef GiftWrapBuilder =
     Future<Event?> Function(
       Nostr nostr,

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -108,7 +108,9 @@ class NIP17MessageService {
       );
 
       if (giftWrapEvent == null) {
-        return NIP17SendResult.failure('Failed to create gift wrap event');
+        return const NIP17SendResult.failure(
+          'Failed to create gift wrap event',
+        );
       }
 
       Log.debug(
@@ -123,7 +125,7 @@ class NIP17MessageService {
       if (sentEvent is! PublishSuccess) {
         const errorMsg = 'Message publish failed to relays';
         Log.error(errorMsg, category: LogCategory.system);
-        return NIP17SendResult.failure(errorMsg);
+        return const NIP17SendResult.failure(errorMsg);
       }
 
       // NIP-17: publish a self-addressed gift wrap so our own sent

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -3,6 +3,7 @@
 // ABOUTME: (kind 14 rumor → kind 13 seal → kind 1059 gift wrap)
 // ABOUTME: Works with any NostrSigner (local keys, Keycast RPC, Amber, etc.)
 
+import 'package:flutter/foundation.dart';
 import 'package:models/models.dart' show NIP17SendResult;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
@@ -12,6 +13,21 @@ import 'package:nostr_sdk/nostr.dart';
 import 'package:nostr_sdk/relay/relay.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
 import 'package:unified_logger/unified_logger.dart';
+
+/// Builds a NIP-59 gift-wrapped event for [recipientPubkey] from
+/// [rumorEvent], using [nostr] for signing. Returns `null` when the
+/// underlying SDK declines to produce one (e.g. an internal encryption
+/// step yields a null result without throwing).
+///
+/// Defaults to [GiftWrapUtil.getGiftWrapEvent]; injectable for tests
+/// so the `null`-return branch in [NIP17MessageService] can be
+/// exercised without conjuring valid gift-wrapped events by hand.
+typedef GiftWrapBuilder =
+    Future<Event?> Function(
+      Nostr nostr,
+      Event rumorEvent,
+      String recipientPubkey,
+    );
 
 /// Service for sending encrypted private messages using NIP-17 gift wrapping.
 ///
@@ -23,13 +39,16 @@ class NIP17MessageService {
     required NostrSigner signer,
     required String senderPublicKey,
     required NostrClient nostrService,
+    @visibleForTesting GiftWrapBuilder? giftWrapBuilder,
   }) : _signer = signer,
        _senderPublicKey = senderPublicKey,
-       _nostrService = nostrService;
+       _nostrService = nostrService,
+       _giftWrapBuilder = giftWrapBuilder ?? GiftWrapUtil.getGiftWrapEvent;
 
   final NostrSigner _signer;
   final String _senderPublicKey;
   final NostrClient _nostrService;
+  final GiftWrapBuilder _giftWrapBuilder;
 
   /// Access to the underlying NostrService for relay management
   NostrClient get nostrService => _nostrService;
@@ -73,12 +92,7 @@ class NIP17MessageService {
         ...additionalTags,
       ];
 
-      final rumorEvent = Event(
-        _senderPublicKey,
-        eventKind,
-        rumorTags,
-        content,
-      );
+      final rumorEvent = Event(_senderPublicKey, eventKind, rumorTags, content);
 
       Log.debug(
         'Created kind $eventKind rumor event',
@@ -86,7 +100,7 @@ class NIP17MessageService {
       );
 
       // Create gift wrap for the recipient
-      final giftWrapEvent = await GiftWrapUtil.getGiftWrapEvent(
+      final giftWrapEvent = await _giftWrapBuilder(
         nostr,
         rumorEvent,
         recipientPubkey,
@@ -111,40 +125,52 @@ class NIP17MessageService {
         return NIP17SendResult.failure(errorMsg);
       }
 
-      // NIP-17: publish a self-addressed gift wrap so our own sent messages
-      // are recoverable from relays after reinstall or data loss.
-      // Wrapped in its own try-catch because the message was already
-      // delivered to the recipient — self-wrap failure is non-fatal.
-      // The result is reported as `selfWrapPublished` so callers can
-      // distinguish full success from recipient-only partial success.
+      // NIP-17: publish a self-addressed gift wrap so our own sent
+      // messages are recoverable from relays after reinstall or data
+      // loss. Three independent failure modes — track them separately
+      // so the result can distinguish recipient-only delivery from
+      // full delivery. Re-publishing the recipient wrap would
+      // double-deliver, so any future retry handling must target only
+      // the self-wrap (see #3909).
       var selfWrapPublished = false;
       try {
-        final selfWrapEvent = await GiftWrapUtil.getGiftWrapEvent(
+        final selfWrapEvent = await _giftWrapBuilder(
           nostr,
           rumorEvent,
           _senderPublicKey,
         );
-        if (selfWrapEvent != null) {
-          final selfSent = await _nostrService.publishEvent(selfWrapEvent);
-          selfWrapPublished = selfSent is PublishSuccess;
+        if (selfWrapEvent == null) {
+          Log.warning(
+            'Self-wrap creation returned null — recipient was '
+            'delivered, but the sender will not see this message on '
+            'other devices or after a reinstall.',
+            category: LogCategory.system,
+          );
+        } else {
+          final published = await _nostrService.publishEvent(selfWrapEvent);
+          if (published is! PublishSuccess) {
+            Log.warning(
+              'Self-wrap publish failed — recipient was '
+              'delivered, but the sender will not see this message on '
+              'other devices or after a reinstall.',
+              category: LogCategory.system,
+            );
+          } else {
+            selfWrapPublished = true;
+          }
         }
       } on Object catch (e) {
         Log.error(
-          'Self-wrap failed (non-fatal): $e',
-          category: LogCategory.system,
-        );
-      }
-
-      if (!selfWrapPublished) {
-        Log.warning(
-          'NIP-17 self-wrap not published — sender other devices will not '
-          'see this message on relay restore',
+          'Self-wrap failed (non-fatal): recipient was delivered, but '
+          'the sender will not see this message on other devices or '
+          'after a reinstall: $e',
           category: LogCategory.system,
         );
       }
 
       Log.info(
-        'Successfully published NIP-17 message',
+        'Successfully published NIP-17 message '
+        '(selfWrapPublished=$selfWrapPublished)',
         category: LogCategory.system,
       );
       return NIP17SendResult.success(

--- a/mobile/packages/dm_repository/pubspec.yaml
+++ b/mobile/packages/dm_repository/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     path: ../db_client
   flutter:
     sdk: flutter
+  meta: ^1.17.0
   models:
     path: ../models
   nostr_client:

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -296,7 +296,7 @@ void main() {
             additionalTags: any(named: 'additionalTags'),
           ),
         ).thenAnswer(
-          (_) async => NIP17SendResult.failure('relay unavailable'),
+          (_) async => const NIP17SendResult.failure('relay unavailable'),
         );
 
         final repository = createRepository();
@@ -462,7 +462,7 @@ void main() {
             additionalTags: any(named: 'additionalTags'),
           ),
         ).thenAnswer(
-          (_) async => NIP17SendResult.failure('Relay rejected'),
+          (_) async => const NIP17SendResult.failure('Relay rejected'),
         );
 
         final repository = createRepository();
@@ -2989,7 +2989,7 @@ void main() {
             additionalTags: any(named: 'additionalTags'),
           ),
         ).thenAnswer(
-          (_) async => NIP17SendResult.failure('Relay rejected'),
+          (_) async => const NIP17SendResult.failure('Relay rejected'),
         );
 
         final repository = createRepository();
@@ -6416,7 +6416,7 @@ void main() {
                 recipientPubkey: _validPubkeyB,
               );
             }
-            return NIP17SendResult.failure('relay timeout');
+            return const NIP17SendResult.failure('relay timeout');
           });
           stubDaoInserts();
 
@@ -6457,7 +6457,7 @@ void main() {
               additionalTags: any(named: 'additionalTags'),
             ),
           ).thenAnswer(
-            (_) async => NIP17SendResult.failure('relay timeout'),
+            (_) async => const NIP17SendResult.failure('relay timeout'),
           );
 
           final repo = createRepository();

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -280,7 +280,9 @@ void main() {
         ) async {
           callCount++;
           if (callCount == 1) {
-            return invocation.positionalArguments[0] as Event;
+            return PublishSuccess(
+              event: invocation.positionalArguments[0] as Event,
+            );
           }
           throw Exception('keycast rpc timeout');
         });
@@ -480,7 +482,9 @@ void main() {
           await LogCaptureService().clearAllLogs();
 
           when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-            (invocation) async => invocation.positionalArguments[0] as Event,
+            (invocation) async => PublishSuccess(
+              event: invocation.positionalArguments[0] as Event,
+            ),
           );
 
           await realKeyService.sendPrivateMessage(

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -230,46 +230,44 @@ void main() {
         expect(result.rumorEventId, isNotNull);
       });
 
+      test('returns success with selfWrapPublished=false when self-wrap '
+          'publish throws (recipient delivered, sender will not see this '
+          'message on other devices)', () async {
+        var callCount = 0;
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+          (invocation) async {
+            callCount++;
+            if (callCount == 1) {
+              return PublishSuccess(
+                event: invocation.positionalArguments[0] as Event,
+              );
+            }
+            throw Exception('self-wrap relay error');
+          },
+        );
+
+        final result = await service.sendPrivateMessage(
+          recipientPubkey: _recipientPubkey,
+          content: 'Test message',
+        );
+
+        expect(result.success, isTrue);
+        expect(result.rumorEventId, isNotNull);
+        expect(
+          result.selfWrapPublished,
+          isFalse,
+          reason:
+              'Self-wrap throws were silently swallowed before; the '
+              'result must now reflect that the sender will not see '
+              'this message on other devices until the self-wrap is '
+              're-published (#3909 tracks the future retry path).',
+        );
+      });
+
       test(
         'returns success with selfWrapPublished=false '
-        'when self-wrap publish throws',
+        'when self-wrap publish returns PublishFailed',
         () async {
-          var callCount = 0;
-          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-            (invocation) async {
-              callCount++;
-              if (callCount == 1) {
-                // Recipient publish succeeds.
-                return PublishSuccess(
-                  event: invocation.positionalArguments[0] as Event,
-                );
-              }
-              // Self-wrap publish throws — should be non-fatal but
-              // surfaced via selfWrapPublished so callers can react.
-              throw Exception('self-wrap relay error');
-            },
-          );
-
-          final result = await service.sendPrivateMessage(
-            recipientPubkey: _recipientPubkey,
-            content: 'Test message',
-          );
-
-          expect(result.success, isTrue);
-          expect(result.rumorEventId, isNotNull);
-          expect(result.selfWrapPublished, isFalse);
-        },
-      );
-
-      test(
-        'returns success with selfWrapPublished=false '
-        'when self-wrap publish returns null',
-        () async {
-          // Mirrors the silent-failure shape the reviewer flagged on
-          // PR #3908: publishEvent returns null with no exception, so
-          // the previous version of sendPrivateMessage marked the send
-          // as fully successful even though the sender's other devices
-          // would never see the message on a relay-only restore.
           final signer = LocalNostrSigner(_testPrivateKey);
           final senderPublicKey = (await signer.getPublicKey())!;
           final matchingService = NIP17MessageService(
@@ -282,12 +280,10 @@ void main() {
             (invocation) async {
               callCount++;
               if (callCount == 1) {
-                // Recipient publish succeeds.
                 return PublishSuccess(
                   event: invocation.positionalArguments[0] as Event,
                 );
               }
-              // Self-wrap publish fails silently.
               return const PublishFailed();
             },
           );
@@ -338,6 +334,31 @@ void main() {
         },
       );
 
+      test('returns success with selfWrapPublished=false when self-wrap '
+          'publish returns PublishFailed (relay rejected with no exception)',
+          () async {
+        var callCount = 0;
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+          (invocation) async {
+            callCount++;
+            if (callCount == 1) {
+              return PublishSuccess(
+                event: invocation.positionalArguments[0] as Event,
+              );
+            }
+            return const PublishFailed();
+          },
+        );
+
+        final result = await service.sendPrivateMessage(
+          recipientPubkey: _recipientPubkey,
+          content: 'Test message',
+        );
+
+        expect(result.success, isTrue);
+        expect(result.selfWrapPublished, isFalse);
+      });
+
       test(
         'publishes a self-wrap with selfWrapPublished=true '
         'when sender pubkey matches the signer and publish succeeds',
@@ -378,7 +399,7 @@ void main() {
         // valid secp256k1 point, so the self-wrap's NIP-44 ECDH throws
         // before reaching the publish call. These tests pair the signer
         // with a sender pubkey actually derived from its private key, so
-        // the self-wrap path runs end-to-end and the publish-side
+        // the self-wrap path runs end-to-end and the publish/build-side
         // branches are exercised.
         late NIP17MessageService realKeyService;
 
@@ -437,10 +458,6 @@ void main() {
 
         test('returns selfWrapPublished=false when self-wrap event '
             'creation returns null (defensive null-event branch)', () async {
-          // The recipient wrap is built by the real GiftWrapUtil so a
-          // valid kind-1059 event flows into the publish path; the
-          // self-wrap call returns null without throwing, exercising
-          // the previously-untested defensive branch in the service.
           var builderCalls = 0;
           final service = NIP17MessageService(
             signer: LocalNostrSigner(_testPrivateKey),
@@ -460,7 +477,9 @@ void main() {
           );
 
           when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-            (invocation) async => invocation.positionalArguments[0] as Event,
+            (invocation) async => PublishSuccess(
+              event: invocation.positionalArguments[0] as Event,
+            ),
           );
 
           final result = await service.sendPrivateMessage(
@@ -478,10 +497,48 @@ void main() {
                 'the injected builder; the second call returning null '
                 'is what we are exercising here.',
           );
-          // Only the recipient publish runs because the self-wrap event is
-          // never built.
           verify(() => mockNostrClient.publishEvent(any())).called(1);
         });
+
+        test(
+          'returns selfWrapPublished=false when self-wrap builder '
+          'throws (decoupled from SDK internals via injection seam)',
+          () async {
+            var builderCalls = 0;
+            final service = NIP17MessageService(
+              signer: LocalNostrSigner(_testPrivateKey),
+              senderPublicKey: getPublicKey(_testPrivateKey),
+              nostrService: mockNostrClient,
+              giftWrapBuilder: (nostr, rumor, recipientPubkey) async {
+                builderCalls++;
+                if (builderCalls == 1) {
+                  return GiftWrapUtil.getGiftWrapEvent(
+                    nostr,
+                    rumor,
+                    recipientPubkey,
+                  );
+                }
+                throw Exception('builder boom');
+              },
+            );
+
+            when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+              (invocation) async => PublishSuccess(
+                event: invocation.positionalArguments[0] as Event,
+              ),
+            );
+
+            final result = await service.sendPrivateMessage(
+              recipientPubkey: _recipientPubkey,
+              content: 'Test message',
+            );
+
+            expect(result.success, isTrue);
+            expect(result.selfWrapPublished, isFalse);
+            expect(builderCalls, equals(2));
+            verify(() => mockNostrClient.publishEvent(any())).called(1);
+          },
+        );
       });
 
       test(

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -12,6 +12,7 @@ import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
@@ -264,6 +265,47 @@ void main() {
         );
       });
 
+      test('emits info log "Successfully published NIP-17 message '
+          '(selfWrapPublished=false)" when self-wrap publish throws', () async {
+        // Closes the gap from PR #3910's manual-verification checklist:
+        // the reviewer asked for a real-device confirmation that this
+        // exact log line fires on partial delivery (Keycast RPC slow ->
+        // self-wrap second sign throws). Captured deterministically here
+        // so CI guards against future drift in the log copy.
+        await LogCaptureService().clearAllLogs();
+
+        var callCount = 0;
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+          invocation,
+        ) async {
+          callCount++;
+          if (callCount == 1) {
+            return invocation.positionalArguments[0] as Event;
+          }
+          throw Exception('keycast rpc timeout');
+        });
+
+        await service.sendPrivateMessage(
+          recipientPubkey: _recipientPubkey,
+          content: 'Test message',
+        );
+
+        final logs = LogCaptureService().getRecentLogs();
+        expect(
+          logs.any(
+            (e) =>
+                e.level == LogLevel.info &&
+                e.message ==
+                    'Successfully published NIP-17 message '
+                        '(selfWrapPublished=false)',
+          ),
+          isTrue,
+          reason:
+              'Partial-delivery log line is the contract the outgoing '
+              'queue (#3909) will key off; pin the exact text.',
+        );
+      });
+
       test(
         'returns success with selfWrapPublished=false '
         'when self-wrap publish returns PublishFailed',
@@ -430,6 +472,32 @@ void main() {
             verify(() => mockNostrClient.publishEvent(any())).called(2);
           },
         );
+
+        test('emits info log "Successfully published NIP-17 message '
+            '(selfWrapPublished=true)" when both publishes succeed', () async {
+          await LogCaptureService().clearAllLogs();
+
+          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+            (invocation) async => invocation.positionalArguments[0] as Event,
+          );
+
+          await realKeyService.sendPrivateMessage(
+            recipientPubkey: _recipientPubkey,
+            content: 'Test message',
+          );
+
+          final logs = LogCaptureService().getRecentLogs();
+          expect(
+            logs.any(
+              (e) =>
+                  e.level == LogLevel.info &&
+                  e.message ==
+                      'Successfully published NIP-17 message '
+                          '(selfWrapPublished=true)',
+            ),
+            isTrue,
+          );
+        });
 
         test('returns selfWrapPublished=false when self-wrap publish '
             'returns PublishFailed without throwing', () async {

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -380,30 +380,32 @@ void main() {
         },
       );
 
-      test('returns success with selfWrapPublished=false when self-wrap '
-          'publish returns PublishFailed (relay rejected with no exception)',
-          () async {
-        var callCount = 0;
-        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-          (invocation) async {
-            callCount++;
-            if (callCount == 1) {
-              return PublishSuccess(
-                event: invocation.positionalArguments[0] as Event,
-              );
-            }
-            return const PublishFailed();
-          },
-        );
+      test(
+        'returns success with selfWrapPublished=false when self-wrap '
+        'publish returns PublishFailed (relay rejected with no exception)',
+        () async {
+          var callCount = 0;
+          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+            (invocation) async {
+              callCount++;
+              if (callCount == 1) {
+                return PublishSuccess(
+                  event: invocation.positionalArguments[0] as Event,
+                );
+              }
+              return const PublishFailed();
+            },
+          );
 
-        final result = await service.sendPrivateMessage(
-          recipientPubkey: _recipientPubkey,
-          content: 'Test message',
-        );
+          final result = await service.sendPrivateMessage(
+            recipientPubkey: _recipientPubkey,
+            content: 'Test message',
+          );
 
-        expect(result.success, isTrue);
-        expect(result.selfWrapPublished, isFalse);
-      });
+          expect(result.success, isTrue);
+          expect(result.selfWrapPublished, isFalse);
+        },
+      );
 
       test(
         'publishes a self-wrap with selfWrapPublished=true '

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -9,6 +9,7 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
 
@@ -432,6 +433,54 @@ void main() {
           expect(result.success, isTrue);
           expect(result.selfWrapPublished, isFalse);
           verify(() => mockNostrClient.publishEvent(any())).called(2);
+        });
+
+        test('returns selfWrapPublished=false when self-wrap event '
+            'creation returns null (defensive null-event branch)', () async {
+          // The recipient wrap is built by the real GiftWrapUtil so a
+          // valid kind-1059 event flows into the publish path; the
+          // self-wrap call returns null without throwing, exercising
+          // the previously-untested defensive branch in the service.
+          var builderCalls = 0;
+          final service = NIP17MessageService(
+            signer: LocalNostrSigner(_testPrivateKey),
+            senderPublicKey: getPublicKey(_testPrivateKey),
+            nostrService: mockNostrClient,
+            giftWrapBuilder: (nostr, rumor, recipientPubkey) async {
+              builderCalls++;
+              if (builderCalls == 1) {
+                return GiftWrapUtil.getGiftWrapEvent(
+                  nostr,
+                  rumor,
+                  recipientPubkey,
+                );
+              }
+              return null;
+            },
+          );
+
+          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+            (invocation) async => invocation.positionalArguments[0] as Event,
+          );
+
+          final result = await service.sendPrivateMessage(
+            recipientPubkey: _recipientPubkey,
+            content: 'Test message',
+          );
+
+          expect(result.success, isTrue);
+          expect(result.selfWrapPublished, isFalse);
+          expect(
+            builderCalls,
+            equals(2),
+            reason:
+                'Both the recipient wrap and the self-wrap go through '
+                'the injected builder; the second call returning null '
+                'is what we are exercising here.',
+          );
+          // Only the recipient publish runs because the self-wrap event is
+          // never built.
+          verify(() => mockNostrClient.publishEvent(any())).called(1);
         });
       });
 

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -301,8 +301,10 @@ void main() {
           ),
           isTrue,
           reason:
-              'Partial-delivery log line is the contract the outgoing '
-              'queue (#3909) will key off; pin the exact text.',
+              'Diagnostic log copy for production triage of partial '
+              'delivery. Not a load-bearing contract — the durable '
+              'outgoing-DM queue (#3909) keys off '
+              'NIP17SendResult.selfWrapPublished, not this string.',
         );
       });
 
@@ -496,6 +498,11 @@ void main() {
                           '(selfWrapPublished=true)',
             ),
             isTrue,
+            reason:
+                'Diagnostic log copy for production triage. Symmetric '
+                'with the partial-delivery log assertion above; neither '
+                'is a contract the outgoing queue (#3909) keys off — '
+                'the queue keys off NIP17SendResult.selfWrapPublished.',
           );
         });
 

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -6,6 +6,7 @@ import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
@@ -261,7 +262,7 @@ void main() {
 
       test(
         'returns success with selfWrapPublished=false '
-        'when self-wrap publish returns PublishFailed',
+        'when self-wrap publish returns null',
         () async {
           // Mirrors the silent-failure shape the reviewer flagged on
           // PR #3908: publishEvent returns null with no exception, so
@@ -370,6 +371,69 @@ void main() {
           expect(capturedEvents[1].kind, EventKind.giftWrap);
         },
       );
+
+      group('with sender pubkey derived from signer key', () {
+        // Existing tests use a synthetic _testPublicKey that is not a
+        // valid secp256k1 point, so the self-wrap's NIP-44 ECDH throws
+        // before reaching the publish call. These tests pair the signer
+        // with a sender pubkey actually derived from its private key, so
+        // the self-wrap path runs end-to-end and the publish-side
+        // branches are exercised.
+        late NIP17MessageService realKeyService;
+
+        setUp(() {
+          realKeyService = NIP17MessageService(
+            signer: LocalNostrSigner(_testPrivateKey),
+            senderPublicKey: getPublicKey(_testPrivateKey),
+            nostrService: mockNostrClient,
+          );
+        });
+
+        test(
+          'returns selfWrapPublished=true when both publishes succeed',
+          () async {
+            when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+              (invocation) async => PublishSuccess(
+                event: invocation.positionalArguments[0] as Event,
+              ),
+            );
+
+            final result = await realKeyService.sendPrivateMessage(
+              recipientPubkey: _recipientPubkey,
+              content: 'Test message',
+            );
+
+            expect(result.success, isTrue);
+            expect(result.selfWrapPublished, isTrue);
+            verify(() => mockNostrClient.publishEvent(any())).called(2);
+          },
+        );
+
+        test('returns selfWrapPublished=false when self-wrap publish '
+            'returns PublishFailed without throwing', () async {
+          var callCount = 0;
+          when(() => mockNostrClient.publishEvent(any())).thenAnswer((
+            invocation,
+          ) async {
+            callCount++;
+            if (callCount == 1) {
+              return PublishSuccess(
+                event: invocation.positionalArguments[0] as Event,
+              );
+            }
+            return const PublishFailed();
+          });
+
+          final result = await realKeyService.sendPrivateMessage(
+            recipientPubkey: _recipientPubkey,
+            content: 'Test message',
+          );
+
+          expect(result.success, isTrue);
+          expect(result.selfWrapPublished, isFalse);
+          verify(() => mockNostrClient.publishEvent(any())).called(2);
+        });
+      });
 
       test(
         'returns failure when signer throws during key refresh',

--- a/mobile/packages/models/lib/src/nip17_send_result.dart
+++ b/mobile/packages/models/lib/src/nip17_send_result.dart
@@ -1,7 +1,25 @@
 // ABOUTME: Result model for NIP-17 encrypted message sending operations
 // ABOUTME: Indicates success/failure with message event ID and recipient info
 
-/// Result of NIP-17 encrypted message sending
+/// Result of NIP-17 encrypted message sending.
+///
+/// NIP-17 send is two independent publishes to relays:
+///
+/// 1. The **recipient** gift wrap (kind 1059), encrypted to the
+///    recipient's pubkey. Without this, the recipient never sees the
+///    message — its publish status is the headline `success` field.
+/// 2. The **self-addressed** gift wrap (kind 1059), encrypted to the
+///    sender's own pubkey. Without this, the sender's other devices
+///    never see the message they just sent: the recipient gets it but
+///    the sender's own conversation history won't have it after a
+///    reinstall, account swap, or fresh login on a second device.
+///
+/// Pre-existing callers only checked [success]. [selfWrapPublished]
+/// surfaces partial delivery so a half-delivered send can be visibly
+/// distinguished from a fully-delivered one. Acting on it (e.g.
+/// retrying only the missing self-wrap publish without re-publishing
+/// to the recipient) is left to future callers — the durable
+/// outgoing-message queue tracked in #3909 is not yet on `main`.
 class NIP17SendResult {
   const NIP17SendResult({
     required this.success,
@@ -10,16 +28,14 @@ class NIP17SendResult {
     this.recipientPubkey,
     this.error,
     this.timestamp,
-    this.selfWrapPublished = true,
+    this.selfWrapPublished,
   });
 
-  /// Create success result.
-  ///
-  /// [selfWrapPublished] indicates whether the sender's self-addressed gift
-  /// wrap (NIP-17) was also delivered to relays. When `false`, the recipient
-  /// got the message but the sender's other devices won't see it on a
-  /// relay-only restore. The send is still considered a success because the
-  /// recipient was reached.
+  /// Create success result. [selfWrapPublished] defaults to `true` so
+  /// existing call sites that don't yet care about per-wrap status are
+  /// not affected. Pass `false` from the service layer when the
+  /// self-addressed wrap could not be created or did not land on any
+  /// relay.
   factory NIP17SendResult.success({
     required String rumorEventId,
     required String messageEventId,
@@ -34,10 +50,14 @@ class NIP17SendResult {
     selfWrapPublished: selfWrapPublished,
   );
 
-  /// Create failure result
+  /// Create failure result. [selfWrapPublished] is left `null` because
+  /// the self-wrap is never attempted when the recipient publish
+  /// fails — the type encodes "not applicable on this branch."
   factory NIP17SendResult.failure(String error) =>
       NIP17SendResult(success: false, error: error);
 
+  /// Whether the recipient gift wrap (kind 1059, encrypted to the
+  /// recipient) reached at least one relay. The headline send status.
   final bool success;
 
   /// The rumor event ID (kind 14/15) — the canonical message identifier.
@@ -51,21 +71,35 @@ class NIP17SendResult {
   final String? error;
   final DateTime? timestamp;
 
-  /// Whether the sender's self-addressed gift wrap reached relays.
+  /// Whether the **self-addressed** gift wrap (kind 1059, encrypted to
+  /// the sender's own pubkey) reached at least one relay.
   ///
-  /// When `success` is `true` and this is `false`, the message was delivered
-  /// to the recipient but cross-device sync for the sender is degraded. UI
-  /// can surface this as a partial-delivery state distinct from a full
-  /// failure. Defaults to `true` for failure results and for callers that
-  /// do not yet track this signal.
-  final bool selfWrapPublished;
+  /// Meaningful only when [success] is `true`. The three observable
+  /// states:
+  ///
+  /// - `success: true, selfWrapPublished: true` — fully delivered. The
+  ///   recipient sees the message, and the sender's other devices /
+  ///   future installs will see it after relay re-fetch.
+  /// - `success: true, selfWrapPublished: false` — partially delivered.
+  ///   The recipient saw the message but the self-addressed wrap did
+  ///   not land on any relay, so the sender will not see this message
+  ///   after a reinstall or on a second device. Surfaced so callers
+  ///   can persist enough state to act on it once retry handling
+  ///   lands (see #3909). Re-publishing the recipient wrap on retry
+  ///   would double-deliver, so any future retry must target only the
+  ///   self-wrap.
+  /// - `success: false` — recipient never received the message;
+  ///   [selfWrapPublished] is `null` because the self-wrap is not
+  ///   attempted when the recipient publish fails.
+  final bool? selfWrapPublished;
 
   @override
   String toString() {
     if (success) {
       return 'NIP17SendResult(success: true, '
           'rumorEventId: $rumorEventId, '
-          'messageEventId: $messageEventId, recipient: $recipientPubkey, '
+          'messageEventId: $messageEventId, '
+          'recipient: $recipientPubkey, '
           'selfWrapPublished: $selfWrapPublished)';
     } else {
       return 'NIP17SendResult(success: false, error: $error)';

--- a/mobile/packages/models/lib/src/nip17_send_result.dart
+++ b/mobile/packages/models/lib/src/nip17_send_result.dart
@@ -1,5 +1,8 @@
-// ABOUTME: Result model for NIP-17 encrypted message sending operations
-// ABOUTME: Indicates success/failure with message event ID and recipient info
+// ABOUTME: Result type for NIP-17 encrypted message sending operations
+// ABOUTME: Sealed class — Success carries per-wrap delivery state,
+// ABOUTME: Failure carries the error and never carries selfWrapPublished
+
+import 'package:meta/meta.dart';
 
 /// Result of NIP-17 encrypted message sending.
 ///
@@ -7,107 +10,190 @@
 ///
 /// 1. The **recipient** gift wrap (kind 1059), encrypted to the
 ///    recipient's pubkey. Without this, the recipient never sees the
-///    message — its publish status is the headline `success` field.
+///    message — its publish status is the headline success/failure
+///    branch of this result.
 /// 2. The **self-addressed** gift wrap (kind 1059), encrypted to the
 ///    sender's own pubkey. Without this, the sender's other devices
 ///    never see the message they just sent: the recipient gets it but
 ///    the sender's own conversation history won't have it after a
 ///    reinstall, account swap, or fresh login on a second device.
 ///
-/// Pre-existing callers only checked [success]. [selfWrapPublished]
-/// surfaces partial delivery so a half-delivered send can be visibly
+/// Use pattern matching (or the [success] / [selfWrapPublished]
+/// getters) to handle each variant:
+///
+/// ```dart
+/// switch (result) {
+///   case NIP17SendSuccess(:final selfWrapPublished):
+///     // recipient delivered; selfWrapPublished tells you whether
+///     // the sender will see this message on other devices.
+///   case NIP17SendFailure(:final error):
+///     // recipient never received the message.
+/// }
+/// ```
+///
+/// Pre-existing callers that only check [success] continue to work
+/// unchanged via the base-class getter. [selfWrapPublished] surfaces
+/// partial delivery so a half-delivered send can be visibly
 /// distinguished from a fully-delivered one. Acting on it (e.g.
 /// retrying only the missing self-wrap publish without re-publishing
 /// to the recipient) is left to future callers — the durable
 /// outgoing-message queue tracked in #3909 is not yet on `main`.
-class NIP17SendResult {
-  const NIP17SendResult({
-    required this.success,
-    this.rumorEventId,
-    this.messageEventId,
-    this.recipientPubkey,
-    this.error,
-    this.timestamp,
-    this.selfWrapPublished,
-  }) : assert(
-         !success || selfWrapPublished != null,
-         'selfWrapPublished must be set when success is true. Use '
-         'NIP17SendResult.success(selfWrapPublished: ...) so the '
-         'three-state invariant in the dartdoc is preserved.',
-       );
+sealed class NIP17SendResult {
+  const NIP17SendResult();
 
-  /// Create success result. [selfWrapPublished] defaults to `true` so
-  /// existing call sites that don't yet care about per-wrap status are
-  /// not affected. Pass `false` from the service layer when the
-  /// self-addressed wrap could not be created or did not land on any
-  /// relay.
+  /// Build a success result. [selfWrapPublished] defaults to `true`
+  /// so existing call sites that don't yet care about per-wrap status
+  /// remain in the fully-delivered state. Pass `false` from the
+  /// service layer when the self-addressed wrap could not be created
+  /// or did not land on any relay.
   factory NIP17SendResult.success({
     required String rumorEventId,
     required String messageEventId,
     required String recipientPubkey,
     bool selfWrapPublished = true,
-  }) => NIP17SendResult(
-    success: true,
+  }) => NIP17SendSuccess(
     rumorEventId: rumorEventId,
     messageEventId: messageEventId,
     recipientPubkey: recipientPubkey,
-    timestamp: DateTime.now(),
     selfWrapPublished: selfWrapPublished,
+    timestamp: DateTime.now(),
   );
 
-  /// Create failure result. [selfWrapPublished] is left `null` because
-  /// the self-wrap is never attempted when the recipient publish
-  /// fails — the type encodes "not applicable on this branch."
-  factory NIP17SendResult.failure(String error) =>
-      NIP17SendResult(success: false, error: error);
+  /// Build a failure result. [NIP17SendFailure] has no
+  /// `selfWrapPublished` field — the self-wrap is never attempted
+  /// when the recipient publish fails.
+  const factory NIP17SendResult.failure(String error) = NIP17SendFailure;
 
   /// Whether the recipient gift wrap (kind 1059, encrypted to the
   /// recipient) reached at least one relay. The headline send status.
-  final bool success;
+  bool get success => this is NIP17SendSuccess;
 
-  /// The rumor event ID (kind 14/15) — the canonical message identifier.
-  /// Use this as the primary key when persisting sent messages.
-  final String? rumorEventId;
+  /// The rumor event ID (kind 14/15) — the canonical message
+  /// identifier. Use this as the primary key when persisting sent
+  /// messages. `null` on the failure branch.
+  String? get rumorEventId;
 
-  /// The recipient's gift wrap event ID (kind 1059).
-  final String? messageEventId;
+  /// The recipient's gift wrap event ID (kind 1059). `null` on the
+  /// failure branch.
+  String? get messageEventId;
 
-  final String? recipientPubkey;
-  final String? error;
-  final DateTime? timestamp;
+  /// Recipient's public key (hex). `null` on the failure branch.
+  String? get recipientPubkey;
 
-  /// Whether the **self-addressed** gift wrap (kind 1059, encrypted to
-  /// the sender's own pubkey) reached at least one relay.
+  /// Failure reason. `null` on the success branch.
+  String? get error;
+
+  /// When the result was constructed. `null` on the failure branch.
+  DateTime? get timestamp;
+
+  /// Whether the **self-addressed** gift wrap (kind 1059, encrypted
+  /// to the sender's own pubkey) reached at least one relay.
   ///
-  /// Meaningful only when [success] is `true`. The three observable
-  /// states:
-  ///
-  /// - `success: true, selfWrapPublished: true` — fully delivered. The
-  ///   recipient sees the message, and the sender's other devices /
-  ///   future installs will see it after relay re-fetch.
-  /// - `success: true, selfWrapPublished: false` — partially delivered.
-  ///   The recipient saw the message but the self-addressed wrap did
-  ///   not land on any relay, so the sender will not see this message
-  ///   after a reinstall or on a second device. Surfaced so callers
-  ///   can persist enough state to act on it once retry handling
-  ///   lands (see #3909). Re-publishing the recipient wrap on retry
-  ///   would double-deliver, so any future retry must target only the
-  ///   self-wrap.
-  /// - `success: false` — recipient never received the message;
-  ///   [selfWrapPublished] is `null` because the self-wrap is not
-  ///   attempted when the recipient publish fails.
-  final bool? selfWrapPublished;
+  /// - `true` on [NIP17SendSuccess] when the self-wrap was published.
+  ///   The recipient sees the message, and the sender's other devices
+  ///   / future installs will see it after relay re-fetch.
+  /// - `false` on [NIP17SendSuccess] when the self-wrap was not
+  ///   published. The recipient saw the message but the sender will
+  ///   not see this message after a reinstall or on a second device.
+  ///   Surfaced so callers can persist enough state to act on it once
+  ///   retry handling lands (see #3909). Re-publishing the recipient
+  ///   wrap on retry would double-deliver, so any future retry must
+  ///   target only the self-wrap.
+  /// - `null` on [NIP17SendFailure] — the self-wrap is not attempted
+  ///   when the recipient publish fails.
+  bool? get selfWrapPublished;
+}
+
+/// Recipient gift wrap was published to at least one relay.
+@immutable
+final class NIP17SendSuccess extends NIP17SendResult {
+  const NIP17SendSuccess({
+    required this.rumorEventId,
+    required this.messageEventId,
+    required this.recipientPubkey,
+    required this.selfWrapPublished,
+    this.timestamp,
+  });
 
   @override
-  String toString() {
-    if (success) {
-      return 'NIP17SendResult(success: true, '
-          'rumorEventId: $rumorEventId, '
-          'messageEventId: $messageEventId, '
-          'recipient: $recipientPubkey, '
-          'selfWrapPublished: $selfWrapPublished)';
-    } else {
-      return 'NIP17SendResult(success: false, error: $error)';
-    }
+  final String rumorEventId;
+
+  @override
+  final String messageEventId;
+
+  @override
+  final String recipientPubkey;
+
+  @override
+  final bool selfWrapPublished;
+
+  @override
+  final DateTime? timestamp;
+
+  @override
+  String? get error => null;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is NIP17SendSuccess &&
+        other.rumorEventId == rumorEventId &&
+        other.messageEventId == messageEventId &&
+        other.recipientPubkey == recipientPubkey &&
+        other.selfWrapPublished == selfWrapPublished &&
+        other.timestamp == timestamp;
   }
+
+  @override
+  int get hashCode => Object.hash(
+    rumorEventId,
+    messageEventId,
+    recipientPubkey,
+    selfWrapPublished,
+    timestamp,
+  );
+
+  @override
+  String toString() =>
+      'NIP17SendSuccess(rumorEventId: $rumorEventId, '
+      'messageEventId: $messageEventId, '
+      'recipient: $recipientPubkey, '
+      'selfWrapPublished: $selfWrapPublished)';
+}
+
+/// Recipient gift wrap was not published — the message did not reach
+/// the recipient at all. Self-wrap is not attempted on this branch.
+@immutable
+final class NIP17SendFailure extends NIP17SendResult {
+  const NIP17SendFailure(this.error);
+
+  @override
+  final String error;
+
+  @override
+  String? get rumorEventId => null;
+
+  @override
+  String? get messageEventId => null;
+
+  @override
+  String? get recipientPubkey => null;
+
+  @override
+  DateTime? get timestamp => null;
+
+  @override
+  bool? get selfWrapPublished => null;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is NIP17SendFailure && other.error == error;
+  }
+
+  @override
+  int get hashCode => error.hashCode;
+
+  @override
+  String toString() => 'NIP17SendFailure(error: $error)';
 }

--- a/mobile/packages/models/lib/src/nip17_send_result.dart
+++ b/mobile/packages/models/lib/src/nip17_send_result.dart
@@ -29,7 +29,12 @@ class NIP17SendResult {
     this.error,
     this.timestamp,
     this.selfWrapPublished,
-  });
+  }) : assert(
+         !success || selfWrapPublished != null,
+         'selfWrapPublished must be set when success is true. Use '
+         'NIP17SendResult.success(selfWrapPublished: ...) so the '
+         'three-state invariant in the dartdoc is preserved.',
+       );
 
   /// Create success result. [selfWrapPublished] defaults to `true` so
   /// existing call sites that don't yet care about per-wrap status are

--- a/mobile/packages/models/test/src/nip17_send_result_test.dart
+++ b/mobile/packages/models/test/src/nip17_send_result_test.dart
@@ -1,5 +1,6 @@
 // ABOUTME: Tests for NIP17SendResult including the per-wrap status
-// ABOUTME: surfaced for the DM outgoing-message queue (#3909).
+// ABOUTME: that surfaces partial delivery (recipient delivered but
+// ABOUTME: self-wrap dropped); future retry handling tracked in #3909.
 
 import 'package:models/models.dart';
 import 'package:test/test.dart';
@@ -38,21 +39,18 @@ void main() {
         );
       });
 
-      test(
-        'preserves selfWrapPublished=false when explicitly passed '
-        '(NIP17MessageService partial-delivery path)',
-        () {
-          final result = NIP17SendResult.success(
-            rumorEventId: rumorEventId,
-            messageEventId: messageEventId,
-            recipientPubkey: recipientPubkey,
-            selfWrapPublished: false,
-          );
+      test('preserves selfWrapPublished=false when explicitly passed '
+          '(NIP17MessageService partial-delivery path)', () {
+        final result = NIP17SendResult.success(
+          rumorEventId: rumorEventId,
+          messageEventId: messageEventId,
+          recipientPubkey: recipientPubkey,
+          selfWrapPublished: false,
+        );
 
-          expect(result.success, isTrue);
-          expect(result.selfWrapPublished, isFalse);
-        },
-      );
+        expect(result.success, isTrue);
+        expect(result.selfWrapPublished, isFalse);
+      });
     });
 
     group('failure factory', () {
@@ -67,20 +65,17 @@ void main() {
         expect(result.timestamp, isNull);
       });
 
-      test(
-        'leaves selfWrapPublished as null on the failure branch — the '
-        'field is meaningful only when success is true (self-wrap is '
-        'never attempted when the recipient publish fails)',
-        () {
-          final result = NIP17SendResult.failure('publish to relays failed');
+      test('leaves selfWrapPublished as null on the failure branch — the '
+          'field is meaningful only when success is true (self-wrap is '
+          'never attempted when the recipient publish fails)', () {
+        final result = NIP17SendResult.failure('publish to relays failed');
 
-          expect(result.success, isFalse);
-          // Type-level guarantee: a failure cannot carry a misleading
-          // success-like `true`. The bool? shape encodes "not
-          // applicable on this branch."
-          expect(result.selfWrapPublished, isNull);
-        },
-      );
+        expect(result.success, isFalse);
+        // Type-level guarantee: a failure cannot carry a misleading
+        // success-like `true`. The bool? shape encodes "not
+        // applicable on this branch."
+        expect(result.selfWrapPublished, isNull);
+      });
     });
 
     group('toString', () {

--- a/mobile/packages/models/test/src/nip17_send_result_test.dart
+++ b/mobile/packages/models/test/src/nip17_send_result_test.dart
@@ -1,0 +1,108 @@
+// ABOUTME: Tests for NIP17SendResult including the per-wrap status
+// ABOUTME: surfaced for the DM outgoing-message queue (#3909).
+
+import 'package:models/models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const rumorEventId =
+      '1111111111111111111111111111111111111111111111111111111111111111';
+  const messageEventId =
+      '2222222222222222222222222222222222222222222222222222222222222222';
+  const recipientPubkey =
+      '3333333333333333333333333333333333333333333333333333333333333333';
+
+  group(NIP17SendResult, () {
+    group('success factory', () {
+      test('defaults selfWrapPublished to true for backward compatibility', () {
+        final result = NIP17SendResult.success(
+          rumorEventId: rumorEventId,
+          messageEventId: messageEventId,
+          recipientPubkey: recipientPubkey,
+        );
+
+        expect(result.success, isTrue);
+        expect(result.rumorEventId, equals(rumorEventId));
+        expect(result.messageEventId, equals(messageEventId));
+        expect(result.recipientPubkey, equals(recipientPubkey));
+        expect(result.error, isNull);
+        expect(result.timestamp, isNotNull);
+        expect(
+          result.selfWrapPublished,
+          isTrue,
+          reason:
+              'Pre-existing call sites do not pass selfWrapPublished. '
+              'The default must keep them in the fully-delivered state '
+              'to avoid spurious "partial delivery" UX after the field '
+              'was added.',
+        );
+      });
+
+      test(
+        'preserves selfWrapPublished=false when explicitly passed '
+        '(NIP17MessageService partial-delivery path)',
+        () {
+          final result = NIP17SendResult.success(
+            rumorEventId: rumorEventId,
+            messageEventId: messageEventId,
+            recipientPubkey: recipientPubkey,
+            selfWrapPublished: false,
+          );
+
+          expect(result.success, isTrue);
+          expect(result.selfWrapPublished, isFalse);
+        },
+      );
+    });
+
+    group('failure factory', () {
+      test('builds a failure result with error and no message ids', () {
+        final result = NIP17SendResult.failure('publish to relays failed');
+
+        expect(result.success, isFalse);
+        expect(result.error, equals('publish to relays failed'));
+        expect(result.rumorEventId, isNull);
+        expect(result.messageEventId, isNull);
+        expect(result.recipientPubkey, isNull);
+        expect(result.timestamp, isNull);
+      });
+
+      test(
+        'leaves selfWrapPublished at the const-default true; the field is '
+        'unused on the failure branch (recipient publish never landed, '
+        'self-wrap is never attempted)',
+        () {
+          final result = NIP17SendResult.failure('publish to relays failed');
+
+          expect(result.success, isFalse);
+          // Documented as "unused when success=false"; the test pins
+          // the default so unrelated changes to the constructor do not
+          // accidentally flip its meaning.
+          expect(result.selfWrapPublished, isTrue);
+        },
+      );
+    });
+
+    group('toString', () {
+      test('success path includes selfWrapPublished status', () {
+        final result = NIP17SendResult.success(
+          rumorEventId: rumorEventId,
+          messageEventId: messageEventId,
+          recipientPubkey: recipientPubkey,
+          selfWrapPublished: false,
+        );
+
+        expect(result.toString(), contains('selfWrapPublished: false'));
+        expect(result.toString(), contains('success: true'));
+      });
+
+      test('failure path omits selfWrapPublished and shows error', () {
+        final result = NIP17SendResult.failure('relay timeout');
+
+        expect(result.toString(), contains('success: false'));
+        expect(result.toString(), contains('error: relay timeout'));
+        expect(result.toString(), isNot(contains('selfWrapPublished')));
+      });
+    });
+  });
+}

--- a/mobile/packages/models/test/src/nip17_send_result_test.dart
+++ b/mobile/packages/models/test/src/nip17_send_result_test.dart
@@ -55,7 +55,7 @@ void main() {
 
     group('failure factory', () {
       test('builds a failure result with error and no message ids', () {
-        final result = NIP17SendResult.failure('publish to relays failed');
+        const result = NIP17SendResult.failure('publish to relays failed');
 
         expect(result.success, isFalse);
         expect(result.error, equals('publish to relays failed'));
@@ -68,12 +68,13 @@ void main() {
       test('leaves selfWrapPublished as null on the failure branch — the '
           'field is meaningful only when success is true (self-wrap is '
           'never attempted when the recipient publish fails)', () {
-        final result = NIP17SendResult.failure('publish to relays failed');
+        const result = NIP17SendResult.failure('publish to relays failed');
 
         expect(result.success, isFalse);
-        // Type-level guarantee: a failure cannot carry a misleading
-        // success-like `true`. The bool? shape encodes "not
-        // applicable on this branch."
+        // Sealed shape: NIP17SendFailure has no `selfWrapPublished`
+        // field; the base getter returns `null`. A failure cannot
+        // carry a misleading success-like `true` because the field
+        // does not exist on this branch.
         expect(result.selfWrapPublished, isNull);
       });
     });
@@ -88,15 +89,131 @@ void main() {
         );
 
         expect(result.toString(), contains('selfWrapPublished: false'));
-        expect(result.toString(), contains('success: true'));
+        expect(result.toString(), startsWith('NIP17SendSuccess('));
       });
 
       test('failure path omits selfWrapPublished and shows error', () {
-        final result = NIP17SendResult.failure('relay timeout');
+        const result = NIP17SendResult.failure('relay timeout');
 
-        expect(result.toString(), contains('success: false'));
+        expect(result.toString(), startsWith('NIP17SendFailure('));
         expect(result.toString(), contains('error: relay timeout'));
         expect(result.toString(), isNot(contains('selfWrapPublished')));
+      });
+    });
+
+    group('sealed shape', () {
+      test('NIP17SendSuccess requires non-null selfWrapPublished at '
+          'compile time — pin a runtime example so the test breaks '
+          'loudly if someone changes the parameter to a default later', () {
+        const result = NIP17SendSuccess(
+          rumorEventId: rumorEventId,
+          messageEventId: messageEventId,
+          recipientPubkey: recipientPubkey,
+          selfWrapPublished: true,
+        );
+
+        expect(result.selfWrapPublished, isTrue);
+        expect(result.success, isTrue);
+        expect(result, isA<NIP17SendResult>());
+      });
+
+      test('NIP17SendFailure does not expose selfWrapPublished', () {
+        const result = NIP17SendFailure('boom');
+
+        expect(result.selfWrapPublished, isNull);
+        expect(result.success, isFalse);
+        expect(result.error, equals('boom'));
+        expect(result, isA<NIP17SendResult>());
+      });
+
+      test('factories produce the matching subclass', () {
+        final success = NIP17SendResult.success(
+          rumorEventId: rumorEventId,
+          messageEventId: messageEventId,
+          recipientPubkey: recipientPubkey,
+        );
+        expect(success, isA<NIP17SendSuccess>());
+        expect(success, isNot(isA<NIP17SendFailure>()));
+
+        const failure = NIP17SendResult.failure('boom');
+        expect(failure, isA<NIP17SendFailure>());
+        expect(failure, isNot(isA<NIP17SendSuccess>()));
+      });
+
+      test('exhaustive switch at the use site compiles and discriminates '
+          'the variant', () {
+        const result = NIP17SendResult.failure('x');
+        final label = switch (result) {
+          NIP17SendSuccess() => 'ok',
+          NIP17SendFailure() => 'err',
+        };
+        expect(label, equals('err'));
+      });
+
+      test('value equality: identical successes are equal', () {
+        final timestamp = DateTime(2026, 5, 7);
+        final a = NIP17SendSuccess(
+          rumorEventId: rumorEventId,
+          messageEventId: messageEventId,
+          recipientPubkey: recipientPubkey,
+          selfWrapPublished: true,
+          timestamp: timestamp,
+        );
+        final b = NIP17SendSuccess(
+          rumorEventId: rumorEventId,
+          messageEventId: messageEventId,
+          recipientPubkey: recipientPubkey,
+          selfWrapPublished: true,
+          timestamp: timestamp,
+        );
+
+        expect(a, equals(b));
+        expect(a.hashCode, equals(b.hashCode));
+      });
+
+      test('value equality: differing selfWrapPublished breaks equality', () {
+        final timestamp = DateTime(2026, 5, 7);
+        final fully = NIP17SendSuccess(
+          rumorEventId: rumorEventId,
+          messageEventId: messageEventId,
+          recipientPubkey: recipientPubkey,
+          selfWrapPublished: true,
+          timestamp: timestamp,
+        );
+        final partially = NIP17SendSuccess(
+          rumorEventId: rumorEventId,
+          messageEventId: messageEventId,
+          recipientPubkey: recipientPubkey,
+          selfWrapPublished: false,
+          timestamp: timestamp,
+        );
+
+        expect(fully, isNot(equals(partially)));
+      });
+
+      test('value equality: failures with same error are equal', () {
+        expect(
+          const NIP17SendFailure('boom'),
+          equals(const NIP17SendFailure('boom')),
+        );
+        expect(
+          const NIP17SendFailure('boom').hashCode,
+          equals(const NIP17SendFailure('boom').hashCode),
+        );
+      });
+
+      test('value equality: success and failure are never equal', () {
+        final success = NIP17SendSuccess(
+          rumorEventId: rumorEventId,
+          messageEventId: messageEventId,
+          recipientPubkey: recipientPubkey,
+          selfWrapPublished: true,
+          timestamp: DateTime(2026, 5, 7),
+        );
+        const failure = NIP17SendFailure('boom');
+
+        expect(success, isNot(equals(failure)));
+        expect(failure, isNot(equals(success)));
       });
     });
   });

--- a/mobile/packages/models/test/src/nip17_send_result_test.dart
+++ b/mobile/packages/models/test/src/nip17_send_result_test.dart
@@ -68,17 +68,17 @@ void main() {
       });
 
       test(
-        'leaves selfWrapPublished at the const-default true; the field is '
-        'unused on the failure branch (recipient publish never landed, '
-        'self-wrap is never attempted)',
+        'leaves selfWrapPublished as null on the failure branch — the '
+        'field is meaningful only when success is true (self-wrap is '
+        'never attempted when the recipient publish fails)',
         () {
           final result = NIP17SendResult.failure('publish to relays failed');
 
           expect(result.success, isFalse);
-          // Documented as "unused when success=false"; the test pins
-          // the default so unrelated changes to the constructor do not
-          // accidentally flip its meaning.
-          expect(result.selfWrapPublished, isTrue);
+          // Type-level guarantee: a failure cannot carry a misleading
+          // success-like `true`. The bool? shape encodes "not
+          // applicable on this branch."
+          expect(result.selfWrapPublished, isNull);
         },
       );
     });

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -243,7 +243,8 @@ void main() {
                 content: 'Hello',
               ),
             ).thenAnswer(
-              (_) async => NIP17SendResult.failure('Failed to publish message'),
+              (_) async =>
+                  const NIP17SendResult.failure('Failed to publish message'),
             );
           },
           build: buildBloc,
@@ -409,7 +410,7 @@ void main() {
                   messageEventId: sentEventId,
                   recipientPubkey: recipientPubkey,
                 ),
-                NIP17SendResult.failure('Failed for second recipient'),
+                const NIP17SendResult.failure('Failed for second recipient'),
               ],
             );
           },
@@ -447,8 +448,8 @@ void main() {
               ),
             ).thenAnswer(
               (_) async => [
-                NIP17SendResult.failure('Relay timeout'),
-                NIP17SendResult.failure('Connection refused'),
+                const NIP17SendResult.failure('Relay timeout'),
+                const NIP17SendResult.failure('Connection refused'),
               ],
             );
           },

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -690,7 +690,7 @@ void main() {
                   recipientPubkey: recipientPubkey,
                 );
               }
-              return NIP17SendResult.failure('Relay timeout');
+              return const NIP17SendResult.failure('Relay timeout');
             });
           },
           build: () {

--- a/mobile/test/services/bug_report_worker_api_test.dart
+++ b/mobile/test/services/bug_report_worker_api_test.dart
@@ -144,10 +144,7 @@ void main() {
             additionalTags: any(named: 'additionalTags'),
           ),
         ).thenAnswer(
-          (_) async => const NIP17SendResult(
-            success: false,
-            error: 'No relays available',
-          ),
+          (_) async => const NIP17SendResult.failure('No relays available'),
         );
 
         final result = await service.sendBugReportToRecipient(

--- a/mobile/test/services/collaborator_invite_service_test.dart
+++ b/mobile/test/services/collaborator_invite_service_test.dart
@@ -418,7 +418,9 @@ void main() {
         additionalTags: any(named: 'additionalTags'),
         skipNip04Fallback: any(named: 'skipNip04Fallback'),
       ),
-    ).thenAnswer((_) async => NIP17SendResult.failure('relay unavailable'));
+    ).thenAnswer(
+      (_) async => const NIP17SendResult.failure('relay unavailable'),
+    );
 
     final result = await service.sendInvite(
       collaboratorPubkey: collaboratorPubkey,

--- a/mobile/test/services/video_sharing_service_test.dart
+++ b/mobile/test/services/video_sharing_service_test.dart
@@ -420,7 +420,9 @@ void main() {
           recipientPubkey: any(named: 'recipientPubkey'),
           content: any(named: 'content'),
         ),
-      ).thenAnswer((_) async => NIP17SendResult.failure('Relay rejected'));
+      ).thenAnswer(
+        (_) async => const NIP17SendResult.failure('Relay rejected'),
+      );
 
       final now = DateTime.now();
       final result = await nip17Service.shareVideoWithUser(


### PR DESCRIPTION
## Description

First step of the durable-outgoing-DM stack tracked in #3909. Surfaces
the NIP-17 self-addressed gift-wrap publish failure to callers via the
`NIP17SendResult`. Pre-fix, that failure was swallowed silently — the
recipient got the message, but the sender's own conversation history
silently dropped it on the next reinstall / second-device login.

**Related Issue:** Relates to #3909 (follow-up to #3902 / #3908)

### What this changes

NIP-17 sends are **two** independent kind-1059 publishes:

1. The **recipient** gift wrap. Without this, the recipient never sees
   the message — its publish status is the headline `success` flag.
2. The **self-addressed** gift wrap. Without this, the sender does not
   see their own messages on a second device or after a reinstall —
   the recipient's copy is encrypted to the recipient and unreadable
   by the sender.

Pre-fix `NIP17MessageService.sendPrivateMessage` published the
recipient wrap, then ran the self-wrap inside a swallow-all catch:

```dart
try {
  final selfWrapEvent = await GiftWrapUtil.getGiftWrapEvent(...);
  if (selfWrapEvent != null) {
    await _nostrService.publishEvent(selfWrapEvent);  // result discarded
  }
} on Object catch (e) {
  Log.error('Self-wrap failed (non-fatal): $e', ...);
}
```

Three independent failure paths — `getGiftWrapEvent` returned null,
`publishEvent` returned null, or the call threw — collapsed to the
same `NIP17SendResult.success(...)`. The downstream queue (#3909)
needs to distinguish "fully delivered" from "recipient-only delivered"
to retry only the missing publish without double-delivering.

### What this PR does

- `NIP17SendResult` gains a `selfWrapPublished` field, defaulting
  to `true` so existing call sites that don't yet act on per-wrap
  status are unaffected. Documented as only meaningful when
  `success: true`.
- `NIP17MessageService.sendPrivateMessage` now tracks the self-wrap
  outcome across **all three** failure paths and propagates it.
  Swallow-still-swallows because the recipient was delivered, but
  with category-appropriate logging.
- New tests pin the partial-delivery path:
  - recipient ✓ + self-wrap throws → `selfWrapPublished: false`
    (this was the silently-swallowed bug)
  - recipient ✓ + self-wrap publish returns null without throwing →
    `selfWrapPublished: false` (previously indistinguishable from
    success)
  - the prior test that pinned the swallow-all behavior is **updated**
    — that test was pinning the bug; new contract is "result reflects
    partial delivery."
- New `nip17_send_result_test.dart` covering the success-default,
  explicit-false, and failure-branch field behavior.

### What this PR deliberately does NOT do

- No behavior change for `DmRepository.sendMessage` callers. The
  `success: true` path is still treated as "send succeeded" by the
  bloc — the new field is plumbed through, ready for #3909 to act on,
  but no new UI surface yet.
- No retry. The queue + retry service land in the next PR in the
  stack.
- No schema change. The next PR adds the `outgoing_dms` Drift
  table.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

## Test plan

Automated:
- [x] `flutter analyze packages/models packages/dm_repository` — clean.
- [x] `flutter analyze lib test` — clean.
- [x] `dart format` — no changes.
- [x] `flutter test` — `packages/dm_repository` 182/182 passing,
  `packages/models` new test 6/6 passing, `packages/dm_repository/
  test/src/nip17_message_service_test.dart` 12/12 passing.

The `selfWrapPublished=true` success path is **structurally** covered
by the `nip17_send_result_test.dart` model test. It is **not**
exercised end-to-end in the service-level test because the synthetic
`_testPublicKey` constant is not a valid secp256k1 point, so NIP-44
ECDH throws inside `GiftWrapUtil.getGiftWrapEvent`. The existing
service tests already work around this with
`greaterThanOrEqualTo(1)` assertions on publish-call counts (see
"uses random ephemeral key for each gift wrap"); the same constraint
applies here. Documented in an inline comment where the missing
assertion would otherwise live.

Manual verification (please confirm during review):
- [ ] Send a DM on a real device where Keycast RPC is intermittently
  slow → log line should appear:
  `Successfully published NIP-17 message (selfWrapPublished=false)`
  on a partial delivery.

## Stacking

Part of the #3909 stack:

1. **This PR** — surface per-wrap publish status (no behavior change for users)
2. Next: `outgoing_dms` Drift table + DAO
3. Then: `DmRepository.sendMessage` rewires through the queue
4. Then: `OutgoingDmRetryService` (connectivity-driven retry)
5. Then: BLoC + UI (per-bubble delivery indicator + retry/cancel actions)

Each independently reviewable; this one is the foundation.