### PR TITLE
feat(db): add outgoing_dms Drift table + DAO for durable DM queue

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -1415,6 +1415,10 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
             'pendingActions',
             () => db.pendingActionsDao.clearAll(userPubkey),
           );
+          await safeDelete(
+            'outgoingDms',
+            () => db.outgoingDmsDao.clearAllForUser(userPubkey),
+          );
         }
       };
 

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -2269,6 +2269,7 @@ DmRepository dmRepository(Ref ref) {
     nostrClient: nostrService,
     directMessagesDao: db.directMessagesDao,
     conversationsDao: db.conversationsDao,
+    outgoingDmsDao: db.outgoingDmsDao,
     syncState: DmSyncState(prefs),
   );
 

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -2723,7 +2723,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'fb6ba794267634f54696092a5888224fa3364dd7';
+    r'6a327dc21d05b9ec426424250176bfe8c1e42a41';
 
 /// Subscription manager for centralized subscription management
 
@@ -4643,7 +4643,7 @@ final class DmRepositoryProvider
   }
 }
 
-String _$dmRepositoryHash() => r'a2fa1b080fa8ff0db62cc19074de841115603487';
+String _$dmRepositoryHash() => r'e1f90979df308591183e6bc05b1aabd5ffdb4649';
 
 /// Provider for CommentsRepository instance
 ///

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -441,29 +441,42 @@ class AppDatabase extends _$AppDatabase {
           recipient_wrap_event_id TEXT,
           self_wrap_event_id TEXT,
           retry_count INTEGER NOT NULL DEFAULT 0,
-          last_error TEXT,
+          recipient_wrap_last_error TEXT,
+          self_wrap_last_error TEXT,
           last_attempt_at INTEGER,
           queued_at INTEGER NOT NULL,
           owner_pubkey TEXT NOT NULL
         )
       ''');
-      await customStatement('''
-        CREATE INDEX IF NOT EXISTS idx_outgoing_dms_owner_conversation
-        ON outgoing_dms (owner_pubkey, conversation_id, created_at DESC)
-      ''');
-      await customStatement('''
-        CREATE INDEX IF NOT EXISTS idx_outgoing_dms_owner_recipient_status
-        ON outgoing_dms (owner_pubkey, recipient_wrap_status)
-      ''');
-      await customStatement('''
-        CREATE INDEX IF NOT EXISTS idx_outgoing_dms_owner_self_status
-        ON outgoing_dms (owner_pubkey, self_wrap_status)
-      ''');
-      await customStatement('''
-        CREATE INDEX IF NOT EXISTS idx_outgoing_dms_queued_at
-        ON outgoing_dms (queued_at)
-      ''');
     }
+    // Create indexes unconditionally (for new and existing databases).
+    // Drift's `m.createAll()` doesn't register the `List<Index> get
+    // indexes` getter on `OutgoingDms` (the project doesn't wire them
+    // through `@DriftDatabase(indexes: ...)`), so a Drift-created fresh
+    // install would otherwise have the table but none of its indexes,
+    // and `getRetryableForOwner` / `getStillPendingForOwner` would fall
+    // back to a full table scan. Hoisting the CREATE INDEX statements
+    // outside the "if table missing" block makes the runtime path the
+    // single source of truth for the index set on both new and existing
+    // databases — and makes the fresh-install vs runtime-create paths
+    // emit identical schemas, which the schema-parity test in
+    // `app_database_test.dart` pins.
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_outgoing_dms_owner_conversation
+      ON outgoing_dms (owner_pubkey, conversation_id, created_at DESC)
+    ''');
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_outgoing_dms_owner_recipient_status
+      ON outgoing_dms (owner_pubkey, recipient_wrap_status)
+    ''');
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_outgoing_dms_owner_self_status
+      ON outgoing_dms (owner_pubkey, self_wrap_status)
+    ''');
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_outgoing_dms_queued_at
+      ON outgoing_dms (queued_at)
+    ''');
 
     // Populate new columns from existing JSON data blobs
     await _backfillFilePathColumns();

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -32,6 +32,7 @@ const _notificationRetentionDays = 7;
     Clips,
     DirectMessages,
     Conversations,
+    OutgoingDms,
   ],
   daos: [
     UserProfilesDao,
@@ -49,6 +50,7 @@ const _notificationRetentionDays = 7;
     ClipsDao,
     DirectMessagesDao,
     ConversationsDao,
+    OutgoingDmsDao,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -413,6 +415,55 @@ class AppDatabase extends _$AppDatabase {
       CREATE INDEX IF NOT EXISTS idx_conversation_owner_pubkey
       ON conversations (owner_pubkey)
     ''');
+
+    // Check if outgoing_dms table exists, create if missing.
+    // Added for #3909 (durable outgoing-DM queue + self-wrap retry).
+    // Schema version stays at 1 — same runtime CREATE-IF-NOT-EXISTS
+    // pattern as personal_reposts and nip05_verifications above.
+    final outgoingDmsResult = await customSelect(
+      "SELECT name FROM sqlite_master WHERE type='table' "
+      "AND name='outgoing_dms'",
+    ).get();
+
+    if (outgoingDmsResult.isEmpty) {
+      await customStatement('''
+        CREATE TABLE outgoing_dms (
+          id TEXT NOT NULL PRIMARY KEY,
+          conversation_id TEXT NOT NULL,
+          recipient_pubkey TEXT NOT NULL,
+          content TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          rumor_event_json TEXT NOT NULL,
+          message_kind INTEGER NOT NULL DEFAULT 14,
+          reply_to_id TEXT,
+          recipient_wrap_status TEXT NOT NULL,
+          self_wrap_status TEXT NOT NULL,
+          recipient_wrap_event_id TEXT,
+          self_wrap_event_id TEXT,
+          retry_count INTEGER NOT NULL DEFAULT 0,
+          last_error TEXT,
+          last_attempt_at INTEGER,
+          queued_at INTEGER NOT NULL,
+          owner_pubkey TEXT NOT NULL
+        )
+      ''');
+      await customStatement('''
+        CREATE INDEX IF NOT EXISTS idx_outgoing_dms_owner_conversation
+        ON outgoing_dms (owner_pubkey, conversation_id, created_at DESC)
+      ''');
+      await customStatement('''
+        CREATE INDEX IF NOT EXISTS idx_outgoing_dms_owner_recipient_status
+        ON outgoing_dms (owner_pubkey, recipient_wrap_status)
+      ''');
+      await customStatement('''
+        CREATE INDEX IF NOT EXISTS idx_outgoing_dms_owner_self_status
+        ON outgoing_dms (owner_pubkey, self_wrap_status)
+      ''');
+      await customStatement('''
+        CREATE INDEX IF NOT EXISTS idx_outgoing_dms_queued_at
+        ON outgoing_dms (queued_at)
+      ''');
+    }
 
     // Populate new columns from existing JSON data blobs
     await _backfillFilePathColumns();

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -10194,6 +10194,1079 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
   }
 }
 
+class $OutgoingDmsTable extends OutgoingDms
+    with TableInfo<$OutgoingDmsTable, OutgoingDmRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $OutgoingDmsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+    'id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _conversationIdMeta = const VerificationMeta(
+    'conversationId',
+  );
+  @override
+  late final GeneratedColumn<String> conversationId = GeneratedColumn<String>(
+    'conversation_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _recipientPubkeyMeta = const VerificationMeta(
+    'recipientPubkey',
+  );
+  @override
+  late final GeneratedColumn<String> recipientPubkey = GeneratedColumn<String>(
+    'recipient_pubkey',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _contentMeta = const VerificationMeta(
+    'content',
+  );
+  @override
+  late final GeneratedColumn<String> content = GeneratedColumn<String>(
+    'content',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<int> createdAt = GeneratedColumn<int>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _rumorEventJsonMeta = const VerificationMeta(
+    'rumorEventJson',
+  );
+  @override
+  late final GeneratedColumn<String> rumorEventJson = GeneratedColumn<String>(
+    'rumor_event_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _messageKindMeta = const VerificationMeta(
+    'messageKind',
+  );
+  @override
+  late final GeneratedColumn<int> messageKind = GeneratedColumn<int>(
+    'message_kind',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(14),
+  );
+  static const VerificationMeta _replyToIdMeta = const VerificationMeta(
+    'replyToId',
+  );
+  @override
+  late final GeneratedColumn<String> replyToId = GeneratedColumn<String>(
+    'reply_to_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _recipientWrapStatusMeta =
+      const VerificationMeta('recipientWrapStatus');
+  @override
+  late final GeneratedColumn<String> recipientWrapStatus =
+      GeneratedColumn<String>(
+        'recipient_wrap_status',
+        aliasedName,
+        false,
+        type: DriftSqlType.string,
+        requiredDuringInsert: true,
+      );
+  static const VerificationMeta _selfWrapStatusMeta = const VerificationMeta(
+    'selfWrapStatus',
+  );
+  @override
+  late final GeneratedColumn<String> selfWrapStatus = GeneratedColumn<String>(
+    'self_wrap_status',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _recipientWrapEventIdMeta =
+      const VerificationMeta('recipientWrapEventId');
+  @override
+  late final GeneratedColumn<String> recipientWrapEventId =
+      GeneratedColumn<String>(
+        'recipient_wrap_event_id',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _selfWrapEventIdMeta = const VerificationMeta(
+    'selfWrapEventId',
+  );
+  @override
+  late final GeneratedColumn<String> selfWrapEventId = GeneratedColumn<String>(
+    'self_wrap_event_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _retryCountMeta = const VerificationMeta(
+    'retryCount',
+  );
+  @override
+  late final GeneratedColumn<int> retryCount = GeneratedColumn<int>(
+    'retry_count',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _lastErrorMeta = const VerificationMeta(
+    'lastError',
+  );
+  @override
+  late final GeneratedColumn<String> lastError = GeneratedColumn<String>(
+    'last_error',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _lastAttemptAtMeta = const VerificationMeta(
+    'lastAttemptAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> lastAttemptAt =
+      GeneratedColumn<DateTime>(
+        'last_attempt_at',
+        aliasedName,
+        true,
+        type: DriftSqlType.dateTime,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _queuedAtMeta = const VerificationMeta(
+    'queuedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> queuedAt = GeneratedColumn<DateTime>(
+    'queued_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _ownerPubkeyMeta = const VerificationMeta(
+    'ownerPubkey',
+  );
+  @override
+  late final GeneratedColumn<String> ownerPubkey = GeneratedColumn<String>(
+    'owner_pubkey',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    conversationId,
+    recipientPubkey,
+    content,
+    createdAt,
+    rumorEventJson,
+    messageKind,
+    replyToId,
+    recipientWrapStatus,
+    selfWrapStatus,
+    recipientWrapEventId,
+    selfWrapEventId,
+    retryCount,
+    lastError,
+    lastAttemptAt,
+    queuedAt,
+    ownerPubkey,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'outgoing_dms';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<OutgoingDmRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('conversation_id')) {
+      context.handle(
+        _conversationIdMeta,
+        conversationId.isAcceptableOrUnknown(
+          data['conversation_id']!,
+          _conversationIdMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_conversationIdMeta);
+    }
+    if (data.containsKey('recipient_pubkey')) {
+      context.handle(
+        _recipientPubkeyMeta,
+        recipientPubkey.isAcceptableOrUnknown(
+          data['recipient_pubkey']!,
+          _recipientPubkeyMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_recipientPubkeyMeta);
+    }
+    if (data.containsKey('content')) {
+      context.handle(
+        _contentMeta,
+        content.isAcceptableOrUnknown(data['content']!, _contentMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_contentMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    if (data.containsKey('rumor_event_json')) {
+      context.handle(
+        _rumorEventJsonMeta,
+        rumorEventJson.isAcceptableOrUnknown(
+          data['rumor_event_json']!,
+          _rumorEventJsonMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_rumorEventJsonMeta);
+    }
+    if (data.containsKey('message_kind')) {
+      context.handle(
+        _messageKindMeta,
+        messageKind.isAcceptableOrUnknown(
+          data['message_kind']!,
+          _messageKindMeta,
+        ),
+      );
+    }
+    if (data.containsKey('reply_to_id')) {
+      context.handle(
+        _replyToIdMeta,
+        replyToId.isAcceptableOrUnknown(data['reply_to_id']!, _replyToIdMeta),
+      );
+    }
+    if (data.containsKey('recipient_wrap_status')) {
+      context.handle(
+        _recipientWrapStatusMeta,
+        recipientWrapStatus.isAcceptableOrUnknown(
+          data['recipient_wrap_status']!,
+          _recipientWrapStatusMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_recipientWrapStatusMeta);
+    }
+    if (data.containsKey('self_wrap_status')) {
+      context.handle(
+        _selfWrapStatusMeta,
+        selfWrapStatus.isAcceptableOrUnknown(
+          data['self_wrap_status']!,
+          _selfWrapStatusMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_selfWrapStatusMeta);
+    }
+    if (data.containsKey('recipient_wrap_event_id')) {
+      context.handle(
+        _recipientWrapEventIdMeta,
+        recipientWrapEventId.isAcceptableOrUnknown(
+          data['recipient_wrap_event_id']!,
+          _recipientWrapEventIdMeta,
+        ),
+      );
+    }
+    if (data.containsKey('self_wrap_event_id')) {
+      context.handle(
+        _selfWrapEventIdMeta,
+        selfWrapEventId.isAcceptableOrUnknown(
+          data['self_wrap_event_id']!,
+          _selfWrapEventIdMeta,
+        ),
+      );
+    }
+    if (data.containsKey('retry_count')) {
+      context.handle(
+        _retryCountMeta,
+        retryCount.isAcceptableOrUnknown(data['retry_count']!, _retryCountMeta),
+      );
+    }
+    if (data.containsKey('last_error')) {
+      context.handle(
+        _lastErrorMeta,
+        lastError.isAcceptableOrUnknown(data['last_error']!, _lastErrorMeta),
+      );
+    }
+    if (data.containsKey('last_attempt_at')) {
+      context.handle(
+        _lastAttemptAtMeta,
+        lastAttemptAt.isAcceptableOrUnknown(
+          data['last_attempt_at']!,
+          _lastAttemptAtMeta,
+        ),
+      );
+    }
+    if (data.containsKey('queued_at')) {
+      context.handle(
+        _queuedAtMeta,
+        queuedAt.isAcceptableOrUnknown(data['queued_at']!, _queuedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_queuedAtMeta);
+    }
+    if (data.containsKey('owner_pubkey')) {
+      context.handle(
+        _ownerPubkeyMeta,
+        ownerPubkey.isAcceptableOrUnknown(
+          data['owner_pubkey']!,
+          _ownerPubkeyMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_ownerPubkeyMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  OutgoingDmRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return OutgoingDmRow(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}id'],
+      )!,
+      conversationId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}conversation_id'],
+      )!,
+      recipientPubkey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}recipient_pubkey'],
+      )!,
+      content: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}content'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}created_at'],
+      )!,
+      rumorEventJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}rumor_event_json'],
+      )!,
+      messageKind: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}message_kind'],
+      )!,
+      replyToId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}reply_to_id'],
+      ),
+      recipientWrapStatus: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}recipient_wrap_status'],
+      )!,
+      selfWrapStatus: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}self_wrap_status'],
+      )!,
+      recipientWrapEventId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}recipient_wrap_event_id'],
+      ),
+      selfWrapEventId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}self_wrap_event_id'],
+      ),
+      retryCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}retry_count'],
+      )!,
+      lastError: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}last_error'],
+      ),
+      lastAttemptAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}last_attempt_at'],
+      ),
+      queuedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}queued_at'],
+      )!,
+      ownerPubkey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}owner_pubkey'],
+      )!,
+    );
+  }
+
+  @override
+  $OutgoingDmsTable createAlias(String alias) {
+    return $OutgoingDmsTable(attachedDatabase, alias);
+  }
+}
+
+class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
+  /// Primary key. Equal to the rumor's event id (`rumor_event_json` →
+  /// `id`), so a single logical message has exactly one queue row even
+  /// across retries.
+  final String id;
+
+  /// Deterministic conversation identifier (SHA-256 of sorted
+  /// participant pubkeys). Same shape as `direct_messages.conversation_id`
+  /// so the BLoC can `Rx.combineLatest2(watchMessages, watchOutgoing)`
+  /// for a conversation view.
+  final String conversationId;
+
+  /// Recipient's hex pubkey for the 1:1 path. (Group sends file one row
+  /// per participant — `conversation_id` is the group conversation, but
+  /// each row is targeted at one recipient.)
+  final String recipientPubkey;
+
+  /// Plaintext message content. Stored alongside `rumor_event_json` so
+  /// the UI can render the bubble without re-parsing the rumor on every
+  /// rebuild. Authoritative source for retries is `rumor_event_json`.
+  final String content;
+
+  /// Unix timestamp from the rumor event's `created_at`. Stable across
+  /// retries because the rumor itself is reused.
+  final int createdAt;
+
+  /// Serialized JSON of the unsigned NIP-17 rumor (kind 14 or 15). Used
+  /// on retry so we re-wrap the same rumor — preserving `rumor.id`,
+  /// which is what the receiver's gift-wrap dedup keys on.
+  final String rumorEventJson;
+
+  /// The rumor event kind (14 = text, 15 = file). Defaults to 14.
+  final int messageKind;
+
+  /// Optional reply target rumor id.
+  final String? replyToId;
+
+  /// Status of the recipient gift-wrap publish: `pending` | `sent` |
+  /// `failed`. Stored as a string so adding new states (e.g. `cancelled`)
+  /// is a non-migration change.
+  final String recipientWrapStatus;
+
+  /// Status of the self-addressed gift-wrap publish: same enum as
+  /// `recipient_wrap_status`. The `false` value of
+  /// `NIP17SendResult.selfWrapPublished` flips this to `failed`; a row
+  /// with `recipient: sent, self: failed` is the partial-delivery state
+  /// from #3909 / #3902.
+  final String selfWrapStatus;
+
+  /// Recipient gift-wrap event id (kind 1059) once published. Null while
+  /// `recipient_wrap_status` is `pending` or `failed`.
+  final String? recipientWrapEventId;
+
+  /// Self gift-wrap event id (kind 1059) once published. Null while
+  /// `self_wrap_status` is `pending` or `failed`.
+  final String? selfWrapEventId;
+
+  /// How many publish attempts this row has survived. Caps growth at the
+  /// retry policy's max; once exhausted the UI surfaces a manual retry
+  /// affordance.
+  final int retryCount;
+
+  /// Last error message from a failed publish attempt. `null` when the
+  /// most recent transition was a success.
+  final String? lastError;
+
+  /// Wall-clock timestamp of the most recent publish attempt. Drives
+  /// the retry service's backoff scheduling.
+  final DateTime? lastAttemptAt;
+
+  /// Wall-clock timestamp of the row's creation. Used to order the queue
+  /// when retrying.
+  final DateTime queuedAt;
+
+  /// Hex pubkey of the account that queued this send. Mirrors
+  /// `direct_messages.owner_pubkey` for multi-account isolation.
+  final String ownerPubkey;
+  const OutgoingDmRow({
+    required this.id,
+    required this.conversationId,
+    required this.recipientPubkey,
+    required this.content,
+    required this.createdAt,
+    required this.rumorEventJson,
+    required this.messageKind,
+    this.replyToId,
+    required this.recipientWrapStatus,
+    required this.selfWrapStatus,
+    this.recipientWrapEventId,
+    this.selfWrapEventId,
+    required this.retryCount,
+    this.lastError,
+    this.lastAttemptAt,
+    required this.queuedAt,
+    required this.ownerPubkey,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['conversation_id'] = Variable<String>(conversationId);
+    map['recipient_pubkey'] = Variable<String>(recipientPubkey);
+    map['content'] = Variable<String>(content);
+    map['created_at'] = Variable<int>(createdAt);
+    map['rumor_event_json'] = Variable<String>(rumorEventJson);
+    map['message_kind'] = Variable<int>(messageKind);
+    if (!nullToAbsent || replyToId != null) {
+      map['reply_to_id'] = Variable<String>(replyToId);
+    }
+    map['recipient_wrap_status'] = Variable<String>(recipientWrapStatus);
+    map['self_wrap_status'] = Variable<String>(selfWrapStatus);
+    if (!nullToAbsent || recipientWrapEventId != null) {
+      map['recipient_wrap_event_id'] = Variable<String>(recipientWrapEventId);
+    }
+    if (!nullToAbsent || selfWrapEventId != null) {
+      map['self_wrap_event_id'] = Variable<String>(selfWrapEventId);
+    }
+    map['retry_count'] = Variable<int>(retryCount);
+    if (!nullToAbsent || lastError != null) {
+      map['last_error'] = Variable<String>(lastError);
+    }
+    if (!nullToAbsent || lastAttemptAt != null) {
+      map['last_attempt_at'] = Variable<DateTime>(lastAttemptAt);
+    }
+    map['queued_at'] = Variable<DateTime>(queuedAt);
+    map['owner_pubkey'] = Variable<String>(ownerPubkey);
+    return map;
+  }
+
+  OutgoingDmsCompanion toCompanion(bool nullToAbsent) {
+    return OutgoingDmsCompanion(
+      id: Value(id),
+      conversationId: Value(conversationId),
+      recipientPubkey: Value(recipientPubkey),
+      content: Value(content),
+      createdAt: Value(createdAt),
+      rumorEventJson: Value(rumorEventJson),
+      messageKind: Value(messageKind),
+      replyToId: replyToId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(replyToId),
+      recipientWrapStatus: Value(recipientWrapStatus),
+      selfWrapStatus: Value(selfWrapStatus),
+      recipientWrapEventId: recipientWrapEventId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(recipientWrapEventId),
+      selfWrapEventId: selfWrapEventId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(selfWrapEventId),
+      retryCount: Value(retryCount),
+      lastError: lastError == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastError),
+      lastAttemptAt: lastAttemptAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastAttemptAt),
+      queuedAt: Value(queuedAt),
+      ownerPubkey: Value(ownerPubkey),
+    );
+  }
+
+  factory OutgoingDmRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return OutgoingDmRow(
+      id: serializer.fromJson<String>(json['id']),
+      conversationId: serializer.fromJson<String>(json['conversationId']),
+      recipientPubkey: serializer.fromJson<String>(json['recipientPubkey']),
+      content: serializer.fromJson<String>(json['content']),
+      createdAt: serializer.fromJson<int>(json['createdAt']),
+      rumorEventJson: serializer.fromJson<String>(json['rumorEventJson']),
+      messageKind: serializer.fromJson<int>(json['messageKind']),
+      replyToId: serializer.fromJson<String?>(json['replyToId']),
+      recipientWrapStatus: serializer.fromJson<String>(
+        json['recipientWrapStatus'],
+      ),
+      selfWrapStatus: serializer.fromJson<String>(json['selfWrapStatus']),
+      recipientWrapEventId: serializer.fromJson<String?>(
+        json['recipientWrapEventId'],
+      ),
+      selfWrapEventId: serializer.fromJson<String?>(json['selfWrapEventId']),
+      retryCount: serializer.fromJson<int>(json['retryCount']),
+      lastError: serializer.fromJson<String?>(json['lastError']),
+      lastAttemptAt: serializer.fromJson<DateTime?>(json['lastAttemptAt']),
+      queuedAt: serializer.fromJson<DateTime>(json['queuedAt']),
+      ownerPubkey: serializer.fromJson<String>(json['ownerPubkey']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'conversationId': serializer.toJson<String>(conversationId),
+      'recipientPubkey': serializer.toJson<String>(recipientPubkey),
+      'content': serializer.toJson<String>(content),
+      'createdAt': serializer.toJson<int>(createdAt),
+      'rumorEventJson': serializer.toJson<String>(rumorEventJson),
+      'messageKind': serializer.toJson<int>(messageKind),
+      'replyToId': serializer.toJson<String?>(replyToId),
+      'recipientWrapStatus': serializer.toJson<String>(recipientWrapStatus),
+      'selfWrapStatus': serializer.toJson<String>(selfWrapStatus),
+      'recipientWrapEventId': serializer.toJson<String?>(recipientWrapEventId),
+      'selfWrapEventId': serializer.toJson<String?>(selfWrapEventId),
+      'retryCount': serializer.toJson<int>(retryCount),
+      'lastError': serializer.toJson<String?>(lastError),
+      'lastAttemptAt': serializer.toJson<DateTime?>(lastAttemptAt),
+      'queuedAt': serializer.toJson<DateTime>(queuedAt),
+      'ownerPubkey': serializer.toJson<String>(ownerPubkey),
+    };
+  }
+
+  OutgoingDmRow copyWith({
+    String? id,
+    String? conversationId,
+    String? recipientPubkey,
+    String? content,
+    int? createdAt,
+    String? rumorEventJson,
+    int? messageKind,
+    Value<String?> replyToId = const Value.absent(),
+    String? recipientWrapStatus,
+    String? selfWrapStatus,
+    Value<String?> recipientWrapEventId = const Value.absent(),
+    Value<String?> selfWrapEventId = const Value.absent(),
+    int? retryCount,
+    Value<String?> lastError = const Value.absent(),
+    Value<DateTime?> lastAttemptAt = const Value.absent(),
+    DateTime? queuedAt,
+    String? ownerPubkey,
+  }) => OutgoingDmRow(
+    id: id ?? this.id,
+    conversationId: conversationId ?? this.conversationId,
+    recipientPubkey: recipientPubkey ?? this.recipientPubkey,
+    content: content ?? this.content,
+    createdAt: createdAt ?? this.createdAt,
+    rumorEventJson: rumorEventJson ?? this.rumorEventJson,
+    messageKind: messageKind ?? this.messageKind,
+    replyToId: replyToId.present ? replyToId.value : this.replyToId,
+    recipientWrapStatus: recipientWrapStatus ?? this.recipientWrapStatus,
+    selfWrapStatus: selfWrapStatus ?? this.selfWrapStatus,
+    recipientWrapEventId: recipientWrapEventId.present
+        ? recipientWrapEventId.value
+        : this.recipientWrapEventId,
+    selfWrapEventId: selfWrapEventId.present
+        ? selfWrapEventId.value
+        : this.selfWrapEventId,
+    retryCount: retryCount ?? this.retryCount,
+    lastError: lastError.present ? lastError.value : this.lastError,
+    lastAttemptAt: lastAttemptAt.present
+        ? lastAttemptAt.value
+        : this.lastAttemptAt,
+    queuedAt: queuedAt ?? this.queuedAt,
+    ownerPubkey: ownerPubkey ?? this.ownerPubkey,
+  );
+  OutgoingDmRow copyWithCompanion(OutgoingDmsCompanion data) {
+    return OutgoingDmRow(
+      id: data.id.present ? data.id.value : this.id,
+      conversationId: data.conversationId.present
+          ? data.conversationId.value
+          : this.conversationId,
+      recipientPubkey: data.recipientPubkey.present
+          ? data.recipientPubkey.value
+          : this.recipientPubkey,
+      content: data.content.present ? data.content.value : this.content,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      rumorEventJson: data.rumorEventJson.present
+          ? data.rumorEventJson.value
+          : this.rumorEventJson,
+      messageKind: data.messageKind.present
+          ? data.messageKind.value
+          : this.messageKind,
+      replyToId: data.replyToId.present ? data.replyToId.value : this.replyToId,
+      recipientWrapStatus: data.recipientWrapStatus.present
+          ? data.recipientWrapStatus.value
+          : this.recipientWrapStatus,
+      selfWrapStatus: data.selfWrapStatus.present
+          ? data.selfWrapStatus.value
+          : this.selfWrapStatus,
+      recipientWrapEventId: data.recipientWrapEventId.present
+          ? data.recipientWrapEventId.value
+          : this.recipientWrapEventId,
+      selfWrapEventId: data.selfWrapEventId.present
+          ? data.selfWrapEventId.value
+          : this.selfWrapEventId,
+      retryCount: data.retryCount.present
+          ? data.retryCount.value
+          : this.retryCount,
+      lastError: data.lastError.present ? data.lastError.value : this.lastError,
+      lastAttemptAt: data.lastAttemptAt.present
+          ? data.lastAttemptAt.value
+          : this.lastAttemptAt,
+      queuedAt: data.queuedAt.present ? data.queuedAt.value : this.queuedAt,
+      ownerPubkey: data.ownerPubkey.present
+          ? data.ownerPubkey.value
+          : this.ownerPubkey,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('OutgoingDmRow(')
+          ..write('id: $id, ')
+          ..write('conversationId: $conversationId, ')
+          ..write('recipientPubkey: $recipientPubkey, ')
+          ..write('content: $content, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('rumorEventJson: $rumorEventJson, ')
+          ..write('messageKind: $messageKind, ')
+          ..write('replyToId: $replyToId, ')
+          ..write('recipientWrapStatus: $recipientWrapStatus, ')
+          ..write('selfWrapStatus: $selfWrapStatus, ')
+          ..write('recipientWrapEventId: $recipientWrapEventId, ')
+          ..write('selfWrapEventId: $selfWrapEventId, ')
+          ..write('retryCount: $retryCount, ')
+          ..write('lastError: $lastError, ')
+          ..write('lastAttemptAt: $lastAttemptAt, ')
+          ..write('queuedAt: $queuedAt, ')
+          ..write('ownerPubkey: $ownerPubkey')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    conversationId,
+    recipientPubkey,
+    content,
+    createdAt,
+    rumorEventJson,
+    messageKind,
+    replyToId,
+    recipientWrapStatus,
+    selfWrapStatus,
+    recipientWrapEventId,
+    selfWrapEventId,
+    retryCount,
+    lastError,
+    lastAttemptAt,
+    queuedAt,
+    ownerPubkey,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is OutgoingDmRow &&
+          other.id == this.id &&
+          other.conversationId == this.conversationId &&
+          other.recipientPubkey == this.recipientPubkey &&
+          other.content == this.content &&
+          other.createdAt == this.createdAt &&
+          other.rumorEventJson == this.rumorEventJson &&
+          other.messageKind == this.messageKind &&
+          other.replyToId == this.replyToId &&
+          other.recipientWrapStatus == this.recipientWrapStatus &&
+          other.selfWrapStatus == this.selfWrapStatus &&
+          other.recipientWrapEventId == this.recipientWrapEventId &&
+          other.selfWrapEventId == this.selfWrapEventId &&
+          other.retryCount == this.retryCount &&
+          other.lastError == this.lastError &&
+          other.lastAttemptAt == this.lastAttemptAt &&
+          other.queuedAt == this.queuedAt &&
+          other.ownerPubkey == this.ownerPubkey);
+}
+
+class OutgoingDmsCompanion extends UpdateCompanion<OutgoingDmRow> {
+  final Value<String> id;
+  final Value<String> conversationId;
+  final Value<String> recipientPubkey;
+  final Value<String> content;
+  final Value<int> createdAt;
+  final Value<String> rumorEventJson;
+  final Value<int> messageKind;
+  final Value<String?> replyToId;
+  final Value<String> recipientWrapStatus;
+  final Value<String> selfWrapStatus;
+  final Value<String?> recipientWrapEventId;
+  final Value<String?> selfWrapEventId;
+  final Value<int> retryCount;
+  final Value<String?> lastError;
+  final Value<DateTime?> lastAttemptAt;
+  final Value<DateTime> queuedAt;
+  final Value<String> ownerPubkey;
+  final Value<int> rowid;
+  const OutgoingDmsCompanion({
+    this.id = const Value.absent(),
+    this.conversationId = const Value.absent(),
+    this.recipientPubkey = const Value.absent(),
+    this.content = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.rumorEventJson = const Value.absent(),
+    this.messageKind = const Value.absent(),
+    this.replyToId = const Value.absent(),
+    this.recipientWrapStatus = const Value.absent(),
+    this.selfWrapStatus = const Value.absent(),
+    this.recipientWrapEventId = const Value.absent(),
+    this.selfWrapEventId = const Value.absent(),
+    this.retryCount = const Value.absent(),
+    this.lastError = const Value.absent(),
+    this.lastAttemptAt = const Value.absent(),
+    this.queuedAt = const Value.absent(),
+    this.ownerPubkey = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  OutgoingDmsCompanion.insert({
+    required String id,
+    required String conversationId,
+    required String recipientPubkey,
+    required String content,
+    required int createdAt,
+    required String rumorEventJson,
+    this.messageKind = const Value.absent(),
+    this.replyToId = const Value.absent(),
+    required String recipientWrapStatus,
+    required String selfWrapStatus,
+    this.recipientWrapEventId = const Value.absent(),
+    this.selfWrapEventId = const Value.absent(),
+    this.retryCount = const Value.absent(),
+    this.lastError = const Value.absent(),
+    this.lastAttemptAt = const Value.absent(),
+    required DateTime queuedAt,
+    required String ownerPubkey,
+    this.rowid = const Value.absent(),
+  }) : id = Value(id),
+       conversationId = Value(conversationId),
+       recipientPubkey = Value(recipientPubkey),
+       content = Value(content),
+       createdAt = Value(createdAt),
+       rumorEventJson = Value(rumorEventJson),
+       recipientWrapStatus = Value(recipientWrapStatus),
+       selfWrapStatus = Value(selfWrapStatus),
+       queuedAt = Value(queuedAt),
+       ownerPubkey = Value(ownerPubkey);
+  static Insertable<OutgoingDmRow> custom({
+    Expression<String>? id,
+    Expression<String>? conversationId,
+    Expression<String>? recipientPubkey,
+    Expression<String>? content,
+    Expression<int>? createdAt,
+    Expression<String>? rumorEventJson,
+    Expression<int>? messageKind,
+    Expression<String>? replyToId,
+    Expression<String>? recipientWrapStatus,
+    Expression<String>? selfWrapStatus,
+    Expression<String>? recipientWrapEventId,
+    Expression<String>? selfWrapEventId,
+    Expression<int>? retryCount,
+    Expression<String>? lastError,
+    Expression<DateTime>? lastAttemptAt,
+    Expression<DateTime>? queuedAt,
+    Expression<String>? ownerPubkey,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (conversationId != null) 'conversation_id': conversationId,
+      if (recipientPubkey != null) 'recipient_pubkey': recipientPubkey,
+      if (content != null) 'content': content,
+      if (createdAt != null) 'created_at': createdAt,
+      if (rumorEventJson != null) 'rumor_event_json': rumorEventJson,
+      if (messageKind != null) 'message_kind': messageKind,
+      if (replyToId != null) 'reply_to_id': replyToId,
+      if (recipientWrapStatus != null)
+        'recipient_wrap_status': recipientWrapStatus,
+      if (selfWrapStatus != null) 'self_wrap_status': selfWrapStatus,
+      if (recipientWrapEventId != null)
+        'recipient_wrap_event_id': recipientWrapEventId,
+      if (selfWrapEventId != null) 'self_wrap_event_id': selfWrapEventId,
+      if (retryCount != null) 'retry_count': retryCount,
+      if (lastError != null) 'last_error': lastError,
+      if (lastAttemptAt != null) 'last_attempt_at': lastAttemptAt,
+      if (queuedAt != null) 'queued_at': queuedAt,
+      if (ownerPubkey != null) 'owner_pubkey': ownerPubkey,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  OutgoingDmsCompanion copyWith({
+    Value<String>? id,
+    Value<String>? conversationId,
+    Value<String>? recipientPubkey,
+    Value<String>? content,
+    Value<int>? createdAt,
+    Value<String>? rumorEventJson,
+    Value<int>? messageKind,
+    Value<String?>? replyToId,
+    Value<String>? recipientWrapStatus,
+    Value<String>? selfWrapStatus,
+    Value<String?>? recipientWrapEventId,
+    Value<String?>? selfWrapEventId,
+    Value<int>? retryCount,
+    Value<String?>? lastError,
+    Value<DateTime?>? lastAttemptAt,
+    Value<DateTime>? queuedAt,
+    Value<String>? ownerPubkey,
+    Value<int>? rowid,
+  }) {
+    return OutgoingDmsCompanion(
+      id: id ?? this.id,
+      conversationId: conversationId ?? this.conversationId,
+      recipientPubkey: recipientPubkey ?? this.recipientPubkey,
+      content: content ?? this.content,
+      createdAt: createdAt ?? this.createdAt,
+      rumorEventJson: rumorEventJson ?? this.rumorEventJson,
+      messageKind: messageKind ?? this.messageKind,
+      replyToId: replyToId ?? this.replyToId,
+      recipientWrapStatus: recipientWrapStatus ?? this.recipientWrapStatus,
+      selfWrapStatus: selfWrapStatus ?? this.selfWrapStatus,
+      recipientWrapEventId: recipientWrapEventId ?? this.recipientWrapEventId,
+      selfWrapEventId: selfWrapEventId ?? this.selfWrapEventId,
+      retryCount: retryCount ?? this.retryCount,
+      lastError: lastError ?? this.lastError,
+      lastAttemptAt: lastAttemptAt ?? this.lastAttemptAt,
+      queuedAt: queuedAt ?? this.queuedAt,
+      ownerPubkey: ownerPubkey ?? this.ownerPubkey,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (conversationId.present) {
+      map['conversation_id'] = Variable<String>(conversationId.value);
+    }
+    if (recipientPubkey.present) {
+      map['recipient_pubkey'] = Variable<String>(recipientPubkey.value);
+    }
+    if (content.present) {
+      map['content'] = Variable<String>(content.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<int>(createdAt.value);
+    }
+    if (rumorEventJson.present) {
+      map['rumor_event_json'] = Variable<String>(rumorEventJson.value);
+    }
+    if (messageKind.present) {
+      map['message_kind'] = Variable<int>(messageKind.value);
+    }
+    if (replyToId.present) {
+      map['reply_to_id'] = Variable<String>(replyToId.value);
+    }
+    if (recipientWrapStatus.present) {
+      map['recipient_wrap_status'] = Variable<String>(
+        recipientWrapStatus.value,
+      );
+    }
+    if (selfWrapStatus.present) {
+      map['self_wrap_status'] = Variable<String>(selfWrapStatus.value);
+    }
+    if (recipientWrapEventId.present) {
+      map['recipient_wrap_event_id'] = Variable<String>(
+        recipientWrapEventId.value,
+      );
+    }
+    if (selfWrapEventId.present) {
+      map['self_wrap_event_id'] = Variable<String>(selfWrapEventId.value);
+    }
+    if (retryCount.present) {
+      map['retry_count'] = Variable<int>(retryCount.value);
+    }
+    if (lastError.present) {
+      map['last_error'] = Variable<String>(lastError.value);
+    }
+    if (lastAttemptAt.present) {
+      map['last_attempt_at'] = Variable<DateTime>(lastAttemptAt.value);
+    }
+    if (queuedAt.present) {
+      map['queued_at'] = Variable<DateTime>(queuedAt.value);
+    }
+    if (ownerPubkey.present) {
+      map['owner_pubkey'] = Variable<String>(ownerPubkey.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('OutgoingDmsCompanion(')
+          ..write('id: $id, ')
+          ..write('conversationId: $conversationId, ')
+          ..write('recipientPubkey: $recipientPubkey, ')
+          ..write('content: $content, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('rumorEventJson: $rumorEventJson, ')
+          ..write('messageKind: $messageKind, ')
+          ..write('replyToId: $replyToId, ')
+          ..write('recipientWrapStatus: $recipientWrapStatus, ')
+          ..write('selfWrapStatus: $selfWrapStatus, ')
+          ..write('recipientWrapEventId: $recipientWrapEventId, ')
+          ..write('selfWrapEventId: $selfWrapEventId, ')
+          ..write('retryCount: $retryCount, ')
+          ..write('lastError: $lastError, ')
+          ..write('lastAttemptAt: $lastAttemptAt, ')
+          ..write('queuedAt: $queuedAt, ')
+          ..write('ownerPubkey: $ownerPubkey, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -10216,6 +11289,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $ClipsTable clips = $ClipsTable(this);
   late final $DirectMessagesTable directMessages = $DirectMessagesTable(this);
   late final $ConversationsTable conversations = $ConversationsTable(this);
+  late final $OutgoingDmsTable outgoingDms = $OutgoingDmsTable(this);
   late final UserProfilesDao userProfilesDao = UserProfilesDao(
     this as AppDatabase,
   );
@@ -10256,6 +11330,9 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final ConversationsDao conversationsDao = ConversationsDao(
     this as AppDatabase,
   );
+  late final OutgoingDmsDao outgoingDmsDao = OutgoingDmsDao(
+    this as AppDatabase,
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -10276,6 +11353,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     clips,
     directMessages,
     conversations,
+    outgoingDms,
   ];
 }
 
@@ -15070,6 +16148,456 @@ typedef $$ConversationsTableProcessedTableManager =
       ConversationRow,
       PrefetchHooks Function()
     >;
+typedef $$OutgoingDmsTableCreateCompanionBuilder =
+    OutgoingDmsCompanion Function({
+      required String id,
+      required String conversationId,
+      required String recipientPubkey,
+      required String content,
+      required int createdAt,
+      required String rumorEventJson,
+      Value<int> messageKind,
+      Value<String?> replyToId,
+      required String recipientWrapStatus,
+      required String selfWrapStatus,
+      Value<String?> recipientWrapEventId,
+      Value<String?> selfWrapEventId,
+      Value<int> retryCount,
+      Value<String?> lastError,
+      Value<DateTime?> lastAttemptAt,
+      required DateTime queuedAt,
+      required String ownerPubkey,
+      Value<int> rowid,
+    });
+typedef $$OutgoingDmsTableUpdateCompanionBuilder =
+    OutgoingDmsCompanion Function({
+      Value<String> id,
+      Value<String> conversationId,
+      Value<String> recipientPubkey,
+      Value<String> content,
+      Value<int> createdAt,
+      Value<String> rumorEventJson,
+      Value<int> messageKind,
+      Value<String?> replyToId,
+      Value<String> recipientWrapStatus,
+      Value<String> selfWrapStatus,
+      Value<String?> recipientWrapEventId,
+      Value<String?> selfWrapEventId,
+      Value<int> retryCount,
+      Value<String?> lastError,
+      Value<DateTime?> lastAttemptAt,
+      Value<DateTime> queuedAt,
+      Value<String> ownerPubkey,
+      Value<int> rowid,
+    });
+
+class $$OutgoingDmsTableFilterComposer
+    extends Composer<_$AppDatabase, $OutgoingDmsTable> {
+  $$OutgoingDmsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get recipientPubkey => $composableBuilder(
+    column: $table.recipientPubkey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get content => $composableBuilder(
+    column: $table.content,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get rumorEventJson => $composableBuilder(
+    column: $table.rumorEventJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get messageKind => $composableBuilder(
+    column: $table.messageKind,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get replyToId => $composableBuilder(
+    column: $table.replyToId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get recipientWrapStatus => $composableBuilder(
+    column: $table.recipientWrapStatus,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get selfWrapStatus => $composableBuilder(
+    column: $table.selfWrapStatus,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get recipientWrapEventId => $composableBuilder(
+    column: $table.recipientWrapEventId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get selfWrapEventId => $composableBuilder(
+    column: $table.selfWrapEventId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get lastError => $composableBuilder(
+    column: $table.lastError,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get lastAttemptAt => $composableBuilder(
+    column: $table.lastAttemptAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get queuedAt => $composableBuilder(
+    column: $table.queuedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$OutgoingDmsTableOrderingComposer
+    extends Composer<_$AppDatabase, $OutgoingDmsTable> {
+  $$OutgoingDmsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get recipientPubkey => $composableBuilder(
+    column: $table.recipientPubkey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get content => $composableBuilder(
+    column: $table.content,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get rumorEventJson => $composableBuilder(
+    column: $table.rumorEventJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get messageKind => $composableBuilder(
+    column: $table.messageKind,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get replyToId => $composableBuilder(
+    column: $table.replyToId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get recipientWrapStatus => $composableBuilder(
+    column: $table.recipientWrapStatus,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get selfWrapStatus => $composableBuilder(
+    column: $table.selfWrapStatus,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get recipientWrapEventId => $composableBuilder(
+    column: $table.recipientWrapEventId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get selfWrapEventId => $composableBuilder(
+    column: $table.selfWrapEventId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get lastError => $composableBuilder(
+    column: $table.lastError,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get lastAttemptAt => $composableBuilder(
+    column: $table.lastAttemptAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get queuedAt => $composableBuilder(
+    column: $table.queuedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$OutgoingDmsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $OutgoingDmsTable> {
+  $$OutgoingDmsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get conversationId => $composableBuilder(
+    column: $table.conversationId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get recipientPubkey => $composableBuilder(
+    column: $table.recipientPubkey,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get content =>
+      $composableBuilder(column: $table.content, builder: (column) => column);
+
+  GeneratedColumn<int> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<String> get rumorEventJson => $composableBuilder(
+    column: $table.rumorEventJson,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get messageKind => $composableBuilder(
+    column: $table.messageKind,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get replyToId =>
+      $composableBuilder(column: $table.replyToId, builder: (column) => column);
+
+  GeneratedColumn<String> get recipientWrapStatus => $composableBuilder(
+    column: $table.recipientWrapStatus,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get selfWrapStatus => $composableBuilder(
+    column: $table.selfWrapStatus,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get recipientWrapEventId => $composableBuilder(
+    column: $table.recipientWrapEventId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get selfWrapEventId => $composableBuilder(
+    column: $table.selfWrapEventId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get retryCount => $composableBuilder(
+    column: $table.retryCount,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get lastError =>
+      $composableBuilder(column: $table.lastError, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get lastAttemptAt => $composableBuilder(
+    column: $table.lastAttemptAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get queuedAt =>
+      $composableBuilder(column: $table.queuedAt, builder: (column) => column);
+
+  GeneratedColumn<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
+    builder: (column) => column,
+  );
+}
+
+class $$OutgoingDmsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $OutgoingDmsTable,
+          OutgoingDmRow,
+          $$OutgoingDmsTableFilterComposer,
+          $$OutgoingDmsTableOrderingComposer,
+          $$OutgoingDmsTableAnnotationComposer,
+          $$OutgoingDmsTableCreateCompanionBuilder,
+          $$OutgoingDmsTableUpdateCompanionBuilder,
+          (
+            OutgoingDmRow,
+            BaseReferences<_$AppDatabase, $OutgoingDmsTable, OutgoingDmRow>,
+          ),
+          OutgoingDmRow,
+          PrefetchHooks Function()
+        > {
+  $$OutgoingDmsTableTableManager(_$AppDatabase db, $OutgoingDmsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$OutgoingDmsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$OutgoingDmsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$OutgoingDmsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> id = const Value.absent(),
+                Value<String> conversationId = const Value.absent(),
+                Value<String> recipientPubkey = const Value.absent(),
+                Value<String> content = const Value.absent(),
+                Value<int> createdAt = const Value.absent(),
+                Value<String> rumorEventJson = const Value.absent(),
+                Value<int> messageKind = const Value.absent(),
+                Value<String?> replyToId = const Value.absent(),
+                Value<String> recipientWrapStatus = const Value.absent(),
+                Value<String> selfWrapStatus = const Value.absent(),
+                Value<String?> recipientWrapEventId = const Value.absent(),
+                Value<String?> selfWrapEventId = const Value.absent(),
+                Value<int> retryCount = const Value.absent(),
+                Value<String?> lastError = const Value.absent(),
+                Value<DateTime?> lastAttemptAt = const Value.absent(),
+                Value<DateTime> queuedAt = const Value.absent(),
+                Value<String> ownerPubkey = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => OutgoingDmsCompanion(
+                id: id,
+                conversationId: conversationId,
+                recipientPubkey: recipientPubkey,
+                content: content,
+                createdAt: createdAt,
+                rumorEventJson: rumorEventJson,
+                messageKind: messageKind,
+                replyToId: replyToId,
+                recipientWrapStatus: recipientWrapStatus,
+                selfWrapStatus: selfWrapStatus,
+                recipientWrapEventId: recipientWrapEventId,
+                selfWrapEventId: selfWrapEventId,
+                retryCount: retryCount,
+                lastError: lastError,
+                lastAttemptAt: lastAttemptAt,
+                queuedAt: queuedAt,
+                ownerPubkey: ownerPubkey,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String id,
+                required String conversationId,
+                required String recipientPubkey,
+                required String content,
+                required int createdAt,
+                required String rumorEventJson,
+                Value<int> messageKind = const Value.absent(),
+                Value<String?> replyToId = const Value.absent(),
+                required String recipientWrapStatus,
+                required String selfWrapStatus,
+                Value<String?> recipientWrapEventId = const Value.absent(),
+                Value<String?> selfWrapEventId = const Value.absent(),
+                Value<int> retryCount = const Value.absent(),
+                Value<String?> lastError = const Value.absent(),
+                Value<DateTime?> lastAttemptAt = const Value.absent(),
+                required DateTime queuedAt,
+                required String ownerPubkey,
+                Value<int> rowid = const Value.absent(),
+              }) => OutgoingDmsCompanion.insert(
+                id: id,
+                conversationId: conversationId,
+                recipientPubkey: recipientPubkey,
+                content: content,
+                createdAt: createdAt,
+                rumorEventJson: rumorEventJson,
+                messageKind: messageKind,
+                replyToId: replyToId,
+                recipientWrapStatus: recipientWrapStatus,
+                selfWrapStatus: selfWrapStatus,
+                recipientWrapEventId: recipientWrapEventId,
+                selfWrapEventId: selfWrapEventId,
+                retryCount: retryCount,
+                lastError: lastError,
+                lastAttemptAt: lastAttemptAt,
+                queuedAt: queuedAt,
+                ownerPubkey: ownerPubkey,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$OutgoingDmsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $OutgoingDmsTable,
+      OutgoingDmRow,
+      $$OutgoingDmsTableFilterComposer,
+      $$OutgoingDmsTableOrderingComposer,
+      $$OutgoingDmsTableAnnotationComposer,
+      $$OutgoingDmsTableCreateCompanionBuilder,
+      $$OutgoingDmsTableUpdateCompanionBuilder,
+      (
+        OutgoingDmRow,
+        BaseReferences<_$AppDatabase, $OutgoingDmsTable, OutgoingDmRow>,
+      ),
+      OutgoingDmRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -15104,4 +16632,6 @@ class $AppDatabaseManager {
       $$DirectMessagesTableTableManager(_db, _db.directMessages);
   $$ConversationsTableTableManager get conversations =>
       $$ConversationsTableTableManager(_db, _db.conversations);
+  $$OutgoingDmsTableTableManager get outgoingDms =>
+      $$OutgoingDmsTableTableManager(_db, _db.outgoingDms);
 }

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -10343,17 +10343,29 @@ class $OutgoingDmsTable extends OutgoingDms
     requiredDuringInsert: false,
     defaultValue: const Constant(0),
   );
-  static const VerificationMeta _lastErrorMeta = const VerificationMeta(
-    'lastError',
+  static const VerificationMeta _recipientWrapLastErrorMeta =
+      const VerificationMeta('recipientWrapLastError');
+  @override
+  late final GeneratedColumn<String> recipientWrapLastError =
+      GeneratedColumn<String>(
+        'recipient_wrap_last_error',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _selfWrapLastErrorMeta = const VerificationMeta(
+    'selfWrapLastError',
   );
   @override
-  late final GeneratedColumn<String> lastError = GeneratedColumn<String>(
-    'last_error',
-    aliasedName,
-    true,
-    type: DriftSqlType.string,
-    requiredDuringInsert: false,
-  );
+  late final GeneratedColumn<String> selfWrapLastError =
+      GeneratedColumn<String>(
+        'self_wrap_last_error',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
   static const VerificationMeta _lastAttemptAtMeta = const VerificationMeta(
     'lastAttemptAt',
   );
@@ -10403,7 +10415,8 @@ class $OutgoingDmsTable extends OutgoingDms
     recipientWrapEventId,
     selfWrapEventId,
     retryCount,
-    lastError,
+    recipientWrapLastError,
+    selfWrapLastError,
     lastAttemptAt,
     queuedAt,
     ownerPubkey,
@@ -10535,10 +10548,22 @@ class $OutgoingDmsTable extends OutgoingDms
         retryCount.isAcceptableOrUnknown(data['retry_count']!, _retryCountMeta),
       );
     }
-    if (data.containsKey('last_error')) {
+    if (data.containsKey('recipient_wrap_last_error')) {
       context.handle(
-        _lastErrorMeta,
-        lastError.isAcceptableOrUnknown(data['last_error']!, _lastErrorMeta),
+        _recipientWrapLastErrorMeta,
+        recipientWrapLastError.isAcceptableOrUnknown(
+          data['recipient_wrap_last_error']!,
+          _recipientWrapLastErrorMeta,
+        ),
+      );
+    }
+    if (data.containsKey('self_wrap_last_error')) {
+      context.handle(
+        _selfWrapLastErrorMeta,
+        selfWrapLastError.isAcceptableOrUnknown(
+          data['self_wrap_last_error']!,
+          _selfWrapLastErrorMeta,
+        ),
       );
     }
     if (data.containsKey('last_attempt_at')) {
@@ -10630,9 +10655,13 @@ class $OutgoingDmsTable extends OutgoingDms
         DriftSqlType.int,
         data['${effectivePrefix}retry_count'],
       )!,
-      lastError: attachedDatabase.typeMapping.read(
+      recipientWrapLastError: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
-        data['${effectivePrefix}last_error'],
+        data['${effectivePrefix}recipient_wrap_last_error'],
+      ),
+      selfWrapLastError: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}self_wrap_last_error'],
       ),
       lastAttemptAt: attachedDatabase.typeMapping.read(
         DriftSqlType.dateTime,
@@ -10693,8 +10722,12 @@ class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
   final String? replyToId;
 
   /// Status of the recipient gift-wrap publish: `pending` | `sent` |
-  /// `failed`. Stored as a string so adding new states (e.g. `cancelled`)
-  /// is a non-migration change.
+  /// `failed`. Stored as a string (rather than an int-coded enum) so a
+  /// dump of the table is human-readable. Adding a new state requires a
+  /// matching update to `OutgoingWrapStatus` in the DAO — the read
+  /// path throws on unknown values rather than silently coercing them
+  /// back to `pending` (which would put corrupt or future-schema rows
+  /// back into the retry service's active set and risk double-delivery).
   final String recipientWrapStatus;
 
   /// Status of the self-addressed gift-wrap publish: same enum as
@@ -10717,9 +10750,22 @@ class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
   /// affordance.
   final int retryCount;
 
-  /// Last error message from a failed publish attempt. `null` when the
-  /// most recent transition was a success.
-  final String? lastError;
+  /// Last error message from the most recent failed **recipient** wrap
+  /// publish. `null` when the recipient wrap has never failed or when the
+  /// most recent recipient transition was a success.
+  ///
+  /// Stored independently of [selfWrapLastError] because the two wraps
+  /// fail for different reasons (e.g. recipient relay rejected the
+  /// kind-1059 vs ephemeral self-relay timeout) — collapsing both into a
+  /// single column would silently overwrite one cause with the other on
+  /// the second failure and starve the retry service of useful diagnostics.
+  final String? recipientWrapLastError;
+
+  /// Last error message from the most recent failed **self** wrap
+  /// publish. Same lifecycle and rationale as [recipientWrapLastError];
+  /// kept in its own column so a recipient failure followed by a self
+  /// failure preserves both reasons.
+  final String? selfWrapLastError;
 
   /// Wall-clock timestamp of the most recent publish attempt. Drives
   /// the retry service's backoff scheduling.
@@ -10746,7 +10792,8 @@ class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
     this.recipientWrapEventId,
     this.selfWrapEventId,
     required this.retryCount,
-    this.lastError,
+    this.recipientWrapLastError,
+    this.selfWrapLastError,
     this.lastAttemptAt,
     required this.queuedAt,
     required this.ownerPubkey,
@@ -10773,8 +10820,13 @@ class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
       map['self_wrap_event_id'] = Variable<String>(selfWrapEventId);
     }
     map['retry_count'] = Variable<int>(retryCount);
-    if (!nullToAbsent || lastError != null) {
-      map['last_error'] = Variable<String>(lastError);
+    if (!nullToAbsent || recipientWrapLastError != null) {
+      map['recipient_wrap_last_error'] = Variable<String>(
+        recipientWrapLastError,
+      );
+    }
+    if (!nullToAbsent || selfWrapLastError != null) {
+      map['self_wrap_last_error'] = Variable<String>(selfWrapLastError);
     }
     if (!nullToAbsent || lastAttemptAt != null) {
       map['last_attempt_at'] = Variable<DateTime>(lastAttemptAt);
@@ -10805,9 +10857,12 @@ class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
           ? const Value.absent()
           : Value(selfWrapEventId),
       retryCount: Value(retryCount),
-      lastError: lastError == null && nullToAbsent
+      recipientWrapLastError: recipientWrapLastError == null && nullToAbsent
           ? const Value.absent()
-          : Value(lastError),
+          : Value(recipientWrapLastError),
+      selfWrapLastError: selfWrapLastError == null && nullToAbsent
+          ? const Value.absent()
+          : Value(selfWrapLastError),
       lastAttemptAt: lastAttemptAt == null && nullToAbsent
           ? const Value.absent()
           : Value(lastAttemptAt),
@@ -10839,7 +10894,12 @@ class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
       ),
       selfWrapEventId: serializer.fromJson<String?>(json['selfWrapEventId']),
       retryCount: serializer.fromJson<int>(json['retryCount']),
-      lastError: serializer.fromJson<String?>(json['lastError']),
+      recipientWrapLastError: serializer.fromJson<String?>(
+        json['recipientWrapLastError'],
+      ),
+      selfWrapLastError: serializer.fromJson<String?>(
+        json['selfWrapLastError'],
+      ),
       lastAttemptAt: serializer.fromJson<DateTime?>(json['lastAttemptAt']),
       queuedAt: serializer.fromJson<DateTime>(json['queuedAt']),
       ownerPubkey: serializer.fromJson<String>(json['ownerPubkey']),
@@ -10862,7 +10922,10 @@ class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
       'recipientWrapEventId': serializer.toJson<String?>(recipientWrapEventId),
       'selfWrapEventId': serializer.toJson<String?>(selfWrapEventId),
       'retryCount': serializer.toJson<int>(retryCount),
-      'lastError': serializer.toJson<String?>(lastError),
+      'recipientWrapLastError': serializer.toJson<String?>(
+        recipientWrapLastError,
+      ),
+      'selfWrapLastError': serializer.toJson<String?>(selfWrapLastError),
       'lastAttemptAt': serializer.toJson<DateTime?>(lastAttemptAt),
       'queuedAt': serializer.toJson<DateTime>(queuedAt),
       'ownerPubkey': serializer.toJson<String>(ownerPubkey),
@@ -10883,7 +10946,8 @@ class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
     Value<String?> recipientWrapEventId = const Value.absent(),
     Value<String?> selfWrapEventId = const Value.absent(),
     int? retryCount,
-    Value<String?> lastError = const Value.absent(),
+    Value<String?> recipientWrapLastError = const Value.absent(),
+    Value<String?> selfWrapLastError = const Value.absent(),
     Value<DateTime?> lastAttemptAt = const Value.absent(),
     DateTime? queuedAt,
     String? ownerPubkey,
@@ -10905,7 +10969,12 @@ class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
         ? selfWrapEventId.value
         : this.selfWrapEventId,
     retryCount: retryCount ?? this.retryCount,
-    lastError: lastError.present ? lastError.value : this.lastError,
+    recipientWrapLastError: recipientWrapLastError.present
+        ? recipientWrapLastError.value
+        : this.recipientWrapLastError,
+    selfWrapLastError: selfWrapLastError.present
+        ? selfWrapLastError.value
+        : this.selfWrapLastError,
     lastAttemptAt: lastAttemptAt.present
         ? lastAttemptAt.value
         : this.lastAttemptAt,
@@ -10945,7 +11014,12 @@ class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
       retryCount: data.retryCount.present
           ? data.retryCount.value
           : this.retryCount,
-      lastError: data.lastError.present ? data.lastError.value : this.lastError,
+      recipientWrapLastError: data.recipientWrapLastError.present
+          ? data.recipientWrapLastError.value
+          : this.recipientWrapLastError,
+      selfWrapLastError: data.selfWrapLastError.present
+          ? data.selfWrapLastError.value
+          : this.selfWrapLastError,
       lastAttemptAt: data.lastAttemptAt.present
           ? data.lastAttemptAt.value
           : this.lastAttemptAt,
@@ -10972,7 +11046,8 @@ class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
           ..write('recipientWrapEventId: $recipientWrapEventId, ')
           ..write('selfWrapEventId: $selfWrapEventId, ')
           ..write('retryCount: $retryCount, ')
-          ..write('lastError: $lastError, ')
+          ..write('recipientWrapLastError: $recipientWrapLastError, ')
+          ..write('selfWrapLastError: $selfWrapLastError, ')
           ..write('lastAttemptAt: $lastAttemptAt, ')
           ..write('queuedAt: $queuedAt, ')
           ..write('ownerPubkey: $ownerPubkey')
@@ -10995,7 +11070,8 @@ class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
     recipientWrapEventId,
     selfWrapEventId,
     retryCount,
-    lastError,
+    recipientWrapLastError,
+    selfWrapLastError,
     lastAttemptAt,
     queuedAt,
     ownerPubkey,
@@ -11017,7 +11093,8 @@ class OutgoingDmRow extends DataClass implements Insertable<OutgoingDmRow> {
           other.recipientWrapEventId == this.recipientWrapEventId &&
           other.selfWrapEventId == this.selfWrapEventId &&
           other.retryCount == this.retryCount &&
-          other.lastError == this.lastError &&
+          other.recipientWrapLastError == this.recipientWrapLastError &&
+          other.selfWrapLastError == this.selfWrapLastError &&
           other.lastAttemptAt == this.lastAttemptAt &&
           other.queuedAt == this.queuedAt &&
           other.ownerPubkey == this.ownerPubkey);
@@ -11037,7 +11114,8 @@ class OutgoingDmsCompanion extends UpdateCompanion<OutgoingDmRow> {
   final Value<String?> recipientWrapEventId;
   final Value<String?> selfWrapEventId;
   final Value<int> retryCount;
-  final Value<String?> lastError;
+  final Value<String?> recipientWrapLastError;
+  final Value<String?> selfWrapLastError;
   final Value<DateTime?> lastAttemptAt;
   final Value<DateTime> queuedAt;
   final Value<String> ownerPubkey;
@@ -11056,7 +11134,8 @@ class OutgoingDmsCompanion extends UpdateCompanion<OutgoingDmRow> {
     this.recipientWrapEventId = const Value.absent(),
     this.selfWrapEventId = const Value.absent(),
     this.retryCount = const Value.absent(),
-    this.lastError = const Value.absent(),
+    this.recipientWrapLastError = const Value.absent(),
+    this.selfWrapLastError = const Value.absent(),
     this.lastAttemptAt = const Value.absent(),
     this.queuedAt = const Value.absent(),
     this.ownerPubkey = const Value.absent(),
@@ -11076,7 +11155,8 @@ class OutgoingDmsCompanion extends UpdateCompanion<OutgoingDmRow> {
     this.recipientWrapEventId = const Value.absent(),
     this.selfWrapEventId = const Value.absent(),
     this.retryCount = const Value.absent(),
-    this.lastError = const Value.absent(),
+    this.recipientWrapLastError = const Value.absent(),
+    this.selfWrapLastError = const Value.absent(),
     this.lastAttemptAt = const Value.absent(),
     required DateTime queuedAt,
     required String ownerPubkey,
@@ -11105,7 +11185,8 @@ class OutgoingDmsCompanion extends UpdateCompanion<OutgoingDmRow> {
     Expression<String>? recipientWrapEventId,
     Expression<String>? selfWrapEventId,
     Expression<int>? retryCount,
-    Expression<String>? lastError,
+    Expression<String>? recipientWrapLastError,
+    Expression<String>? selfWrapLastError,
     Expression<DateTime>? lastAttemptAt,
     Expression<DateTime>? queuedAt,
     Expression<String>? ownerPubkey,
@@ -11127,7 +11208,9 @@ class OutgoingDmsCompanion extends UpdateCompanion<OutgoingDmRow> {
         'recipient_wrap_event_id': recipientWrapEventId,
       if (selfWrapEventId != null) 'self_wrap_event_id': selfWrapEventId,
       if (retryCount != null) 'retry_count': retryCount,
-      if (lastError != null) 'last_error': lastError,
+      if (recipientWrapLastError != null)
+        'recipient_wrap_last_error': recipientWrapLastError,
+      if (selfWrapLastError != null) 'self_wrap_last_error': selfWrapLastError,
       if (lastAttemptAt != null) 'last_attempt_at': lastAttemptAt,
       if (queuedAt != null) 'queued_at': queuedAt,
       if (ownerPubkey != null) 'owner_pubkey': ownerPubkey,
@@ -11149,7 +11232,8 @@ class OutgoingDmsCompanion extends UpdateCompanion<OutgoingDmRow> {
     Value<String?>? recipientWrapEventId,
     Value<String?>? selfWrapEventId,
     Value<int>? retryCount,
-    Value<String?>? lastError,
+    Value<String?>? recipientWrapLastError,
+    Value<String?>? selfWrapLastError,
     Value<DateTime?>? lastAttemptAt,
     Value<DateTime>? queuedAt,
     Value<String>? ownerPubkey,
@@ -11169,7 +11253,9 @@ class OutgoingDmsCompanion extends UpdateCompanion<OutgoingDmRow> {
       recipientWrapEventId: recipientWrapEventId ?? this.recipientWrapEventId,
       selfWrapEventId: selfWrapEventId ?? this.selfWrapEventId,
       retryCount: retryCount ?? this.retryCount,
-      lastError: lastError ?? this.lastError,
+      recipientWrapLastError:
+          recipientWrapLastError ?? this.recipientWrapLastError,
+      selfWrapLastError: selfWrapLastError ?? this.selfWrapLastError,
       lastAttemptAt: lastAttemptAt ?? this.lastAttemptAt,
       queuedAt: queuedAt ?? this.queuedAt,
       ownerPubkey: ownerPubkey ?? this.ownerPubkey,
@@ -11223,8 +11309,13 @@ class OutgoingDmsCompanion extends UpdateCompanion<OutgoingDmRow> {
     if (retryCount.present) {
       map['retry_count'] = Variable<int>(retryCount.value);
     }
-    if (lastError.present) {
-      map['last_error'] = Variable<String>(lastError.value);
+    if (recipientWrapLastError.present) {
+      map['recipient_wrap_last_error'] = Variable<String>(
+        recipientWrapLastError.value,
+      );
+    }
+    if (selfWrapLastError.present) {
+      map['self_wrap_last_error'] = Variable<String>(selfWrapLastError.value);
     }
     if (lastAttemptAt.present) {
       map['last_attempt_at'] = Variable<DateTime>(lastAttemptAt.value);
@@ -11257,7 +11348,8 @@ class OutgoingDmsCompanion extends UpdateCompanion<OutgoingDmRow> {
           ..write('recipientWrapEventId: $recipientWrapEventId, ')
           ..write('selfWrapEventId: $selfWrapEventId, ')
           ..write('retryCount: $retryCount, ')
-          ..write('lastError: $lastError, ')
+          ..write('recipientWrapLastError: $recipientWrapLastError, ')
+          ..write('selfWrapLastError: $selfWrapLastError, ')
           ..write('lastAttemptAt: $lastAttemptAt, ')
           ..write('queuedAt: $queuedAt, ')
           ..write('ownerPubkey: $ownerPubkey, ')
@@ -16163,7 +16255,8 @@ typedef $$OutgoingDmsTableCreateCompanionBuilder =
       Value<String?> recipientWrapEventId,
       Value<String?> selfWrapEventId,
       Value<int> retryCount,
-      Value<String?> lastError,
+      Value<String?> recipientWrapLastError,
+      Value<String?> selfWrapLastError,
       Value<DateTime?> lastAttemptAt,
       required DateTime queuedAt,
       required String ownerPubkey,
@@ -16184,7 +16277,8 @@ typedef $$OutgoingDmsTableUpdateCompanionBuilder =
       Value<String?> recipientWrapEventId,
       Value<String?> selfWrapEventId,
       Value<int> retryCount,
-      Value<String?> lastError,
+      Value<String?> recipientWrapLastError,
+      Value<String?> selfWrapLastError,
       Value<DateTime?> lastAttemptAt,
       Value<DateTime> queuedAt,
       Value<String> ownerPubkey,
@@ -16265,8 +16359,13 @@ class $$OutgoingDmsTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
-  ColumnFilters<String> get lastError => $composableBuilder(
-    column: $table.lastError,
+  ColumnFilters<String> get recipientWrapLastError => $composableBuilder(
+    column: $table.recipientWrapLastError,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get selfWrapLastError => $composableBuilder(
+    column: $table.selfWrapLastError,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -16360,8 +16459,13 @@ class $$OutgoingDmsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
-  ColumnOrderings<String> get lastError => $composableBuilder(
-    column: $table.lastError,
+  ColumnOrderings<String> get recipientWrapLastError => $composableBuilder(
+    column: $table.recipientWrapLastError,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get selfWrapLastError => $composableBuilder(
+    column: $table.selfWrapLastError,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -16447,8 +16551,15 @@ class $$OutgoingDmsTableAnnotationComposer
     builder: (column) => column,
   );
 
-  GeneratedColumn<String> get lastError =>
-      $composableBuilder(column: $table.lastError, builder: (column) => column);
+  GeneratedColumn<String> get recipientWrapLastError => $composableBuilder(
+    column: $table.recipientWrapLastError,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get selfWrapLastError => $composableBuilder(
+    column: $table.selfWrapLastError,
+    builder: (column) => column,
+  );
 
   GeneratedColumn<DateTime> get lastAttemptAt => $composableBuilder(
     column: $table.lastAttemptAt,
@@ -16508,7 +16619,8 @@ class $$OutgoingDmsTableTableManager
                 Value<String?> recipientWrapEventId = const Value.absent(),
                 Value<String?> selfWrapEventId = const Value.absent(),
                 Value<int> retryCount = const Value.absent(),
-                Value<String?> lastError = const Value.absent(),
+                Value<String?> recipientWrapLastError = const Value.absent(),
+                Value<String?> selfWrapLastError = const Value.absent(),
                 Value<DateTime?> lastAttemptAt = const Value.absent(),
                 Value<DateTime> queuedAt = const Value.absent(),
                 Value<String> ownerPubkey = const Value.absent(),
@@ -16527,7 +16639,8 @@ class $$OutgoingDmsTableTableManager
                 recipientWrapEventId: recipientWrapEventId,
                 selfWrapEventId: selfWrapEventId,
                 retryCount: retryCount,
-                lastError: lastError,
+                recipientWrapLastError: recipientWrapLastError,
+                selfWrapLastError: selfWrapLastError,
                 lastAttemptAt: lastAttemptAt,
                 queuedAt: queuedAt,
                 ownerPubkey: ownerPubkey,
@@ -16548,7 +16661,8 @@ class $$OutgoingDmsTableTableManager
                 Value<String?> recipientWrapEventId = const Value.absent(),
                 Value<String?> selfWrapEventId = const Value.absent(),
                 Value<int> retryCount = const Value.absent(),
-                Value<String?> lastError = const Value.absent(),
+                Value<String?> recipientWrapLastError = const Value.absent(),
+                Value<String?> selfWrapLastError = const Value.absent(),
                 Value<DateTime?> lastAttemptAt = const Value.absent(),
                 required DateTime queuedAt,
                 required String ownerPubkey,
@@ -16567,7 +16681,8 @@ class $$OutgoingDmsTableTableManager
                 recipientWrapEventId: recipientWrapEventId,
                 selfWrapEventId: selfWrapEventId,
                 retryCount: retryCount,
-                lastError: lastError,
+                recipientWrapLastError: recipientWrapLastError,
+                selfWrapLastError: selfWrapLastError,
                 lastAttemptAt: lastAttemptAt,
                 queuedAt: queuedAt,
                 ownerPubkey: ownerPubkey,

--- a/mobile/packages/db_client/lib/src/database/daos/daos.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/daos.dart
@@ -6,6 +6,7 @@ export 'hashtag_stats_dao.dart';
 export 'nip05_verifications_dao.dart';
 export 'nostr_events_dao.dart';
 export 'notifications_dao.dart';
+export 'outgoing_dms_dao.dart';
 export 'pending_actions_dao.dart';
 export 'pending_uploads_dao.dart';
 export 'personal_reactions_dao.dart';

--- a/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
@@ -77,7 +77,8 @@ class OutgoingDm {
     this.recipientWrapEventId,
     this.selfWrapEventId,
     this.retryCount = 0,
-    this.lastError,
+    this.recipientWrapLastError,
+    this.selfWrapLastError,
     this.lastAttemptAt,
   });
 
@@ -95,7 +96,16 @@ class OutgoingDm {
   final String? recipientWrapEventId;
   final String? selfWrapEventId;
   final int retryCount;
-  final String? lastError;
+
+  /// Last error from a failed recipient-wrap publish, independent of
+  /// [selfWrapLastError]. See the table doc on
+  /// `OutgoingDms.recipientWrapLastError` for why the two wraps carry
+  /// their own error channels.
+  final String? recipientWrapLastError;
+
+  /// Last error from a failed self-wrap publish.
+  final String? selfWrapLastError;
+
   final DateTime? lastAttemptAt;
   final DateTime queuedAt;
   final String ownerPubkey;
@@ -127,7 +137,8 @@ class OutgoingDm {
     String? recipientWrapEventId,
     String? selfWrapEventId,
     int? retryCount,
-    String? lastError,
+    String? recipientWrapLastError,
+    String? selfWrapLastError,
     DateTime? lastAttemptAt,
     DateTime? queuedAt,
     String? ownerPubkey,
@@ -145,7 +156,9 @@ class OutgoingDm {
     recipientWrapEventId: recipientWrapEventId ?? this.recipientWrapEventId,
     selfWrapEventId: selfWrapEventId ?? this.selfWrapEventId,
     retryCount: retryCount ?? this.retryCount,
-    lastError: lastError ?? this.lastError,
+    recipientWrapLastError:
+        recipientWrapLastError ?? this.recipientWrapLastError,
+    selfWrapLastError: selfWrapLastError ?? this.selfWrapLastError,
     lastAttemptAt: lastAttemptAt ?? this.lastAttemptAt,
     queuedAt: queuedAt ?? this.queuedAt,
     ownerPubkey: ownerPubkey ?? this.ownerPubkey,
@@ -190,7 +203,8 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
       recipientWrapEventId: Value(dm.recipientWrapEventId),
       selfWrapEventId: Value(dm.selfWrapEventId),
       retryCount: Value(dm.retryCount),
-      lastError: Value(dm.lastError),
+      recipientWrapLastError: Value(dm.recipientWrapLastError),
+      selfWrapLastError: Value(dm.selfWrapLastError),
       lastAttemptAt: Value(dm.lastAttemptAt),
       queuedAt: dm.queuedAt,
       ownerPubkey: dm.ownerPubkey,
@@ -212,7 +226,8 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
       recipientWrapEventId: row.recipientWrapEventId,
       selfWrapEventId: row.selfWrapEventId,
       retryCount: row.retryCount,
-      lastError: row.lastError,
+      recipientWrapLastError: row.recipientWrapLastError,
+      selfWrapLastError: row.selfWrapLastError,
       lastAttemptAt: row.lastAttemptAt,
       queuedAt: row.queuedAt,
       ownerPubkey: row.ownerPubkey,
@@ -254,7 +269,9 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
 
   /// Update the recipient gift-wrap status for [id]. Pass [eventId] when
   /// transitioning to [OutgoingWrapStatus.sent] so the published id is
-  /// recorded for downstream debugging.
+  /// recorded for downstream debugging. Pass [lastError] when transitioning
+  /// to [OutgoingWrapStatus.failed]; it lands in `recipient_wrap_last_error`
+  /// so the self-wrap's own error history is never overwritten.
   Future<bool> markRecipientWrapStatus({
     required String id,
     required OutgoingWrapStatus status,
@@ -268,7 +285,7 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
             recipientWrapEventId: eventId != null
                 ? Value(eventId)
                 : const Value.absent(),
-            lastError: lastError != null
+            recipientWrapLastError: lastError != null
                 ? Value(lastError)
                 : const Value.absent(),
             lastAttemptAt: Value(DateTime.now()),
@@ -277,7 +294,9 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
     return rows > 0;
   }
 
-  /// Update the self-addressed gift-wrap status for [id].
+  /// Update the self-addressed gift-wrap status for [id]. Same per-wrap
+  /// error semantics as [markRecipientWrapStatus] — [lastError] writes to
+  /// `self_wrap_last_error` only.
   Future<bool> markSelfWrapStatus({
     required String id,
     required OutgoingWrapStatus status,
@@ -291,7 +310,7 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
             selfWrapEventId: eventId != null
                 ? Value(eventId)
                 : const Value.absent(),
-            lastError: lastError != null
+            selfWrapLastError: lastError != null
                 ? Value(lastError)
                 : const Value.absent(),
             lastAttemptAt: Value(DateTime.now()),
@@ -303,17 +322,32 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
   /// Increment the retry count for [id]. The retry service calls this
   /// after scheduling a replay regardless of the eventual outcome —
   /// backoff caps growth at the policy max.
+  ///
+  /// Implemented as a typed Drift `update().write()` inside a transaction
+  /// so the [DateTime] write goes through the same codec
+  /// `markRecipientWrapStatus` / `markSelfWrapStatus` use. The earlier raw
+  /// `customUpdate` form wrote `Variable<int>(millisecondsSinceEpoch)`
+  /// while the codec is configured for seconds-since-epoch
+  /// (`store_date_time_values_as_text: false` in `drift_schema_v1.json`),
+  /// so reads decoded the value ~1000× in the future. Going through the
+  /// codec is the only durable fix — `incrementRetry` and the
+  /// `markXxxWrapStatus` writers must not disagree about the unit.
   Future<bool> incrementRetry(String id) async {
-    final rows = await customUpdate(
-      'UPDATE outgoing_dms SET retry_count = retry_count + 1, '
-      'last_attempt_at = ? WHERE id = ?',
-      variables: [
-        Variable<int>(DateTime.now().millisecondsSinceEpoch),
-        Variable<String>(id),
-      ],
-      updates: {outgoingDms},
-    );
-    return rows > 0;
+    return transaction(() async {
+      final row = await (select(
+        outgoingDms,
+      )..where((t) => t.id.equals(id))).getSingleOrNull();
+      if (row == null) return false;
+
+      final affected =
+          await (update(outgoingDms)..where((t) => t.id.equals(id))).write(
+            OutgoingDmsCompanion(
+              retryCount: Value(row.retryCount + 1),
+              lastAttemptAt: Value(DateTime.now()),
+            ),
+          );
+      return affected > 0;
+    });
   }
 
   /// Delete the row for [id]. Called by the repository in the same

--- a/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
@@ -325,6 +325,18 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
     return (delete(outgoingDms)..where((t) => t.id.equals(id))).go();
   }
 
+  /// Delete every queued outgoing DM owned by [ownerPubkey].
+  ///
+  /// Mirrors [DirectMessagesDao.clearAllForUser]: the repository calls
+  /// this from the signout / account-switch path so a different
+  /// account's retry service never picks up the previous user's
+  /// in-flight rows. Returns the number of rows removed.
+  Future<int> clearAllForUser(String ownerPubkey) {
+    return (delete(
+      outgoingDms,
+    )..where((t) => t.ownerPubkey.equals(ownerPubkey))).go();
+  }
+
   // ---------------------------------------------------------------------
   // Reads
   // ---------------------------------------------------------------------

--- a/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
@@ -27,6 +27,34 @@ enum OutgoingWrapStatus {
   failed,
 }
 
+/// Thrown when [OutgoingDmsDao] reads a row whose persisted wrap-status
+/// string does not match any known [OutgoingWrapStatus].
+///
+/// This signals either database corruption or a downgrade from a future
+/// schema that introduced new states. The DAO refuses to coerce the
+/// unknown value back to [OutgoingWrapStatus.pending] because that would
+/// silently re-activate a row the user (or a newer client) already moved
+/// to a terminal state — for a retry queue, that risks double-delivery.
+///
+/// Callers (the retry service, the conversation BLoC) should treat this
+/// as a non-recoverable read failure for the affected row: log it, skip
+/// the row, and surface a corruption alert. It is never safe to retry
+/// the publish based on an unrecognised status.
+class UnknownOutgoingWrapStatusException implements Exception {
+  const UnknownOutgoingWrapStatusException(this.rawValue);
+
+  /// The raw string read from the database that did not parse.
+  final String rawValue;
+
+  @override
+  String toString() {
+    final known = OutgoingWrapStatus.values.map((e) => e.name).join(', ');
+    return 'UnknownOutgoingWrapStatusException: '
+        'unrecognised outgoing_dms wrap status "$rawValue"; '
+        'expected one of $known';
+  }
+}
+
 /// Domain model for one queued outgoing DM.
 ///
 /// Independent of [OutgoingDmRow] (the Drift-generated row) so callers
@@ -191,11 +219,19 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
     );
   }
 
-  OutgoingWrapStatus _parseStatus(String raw) =>
-      OutgoingWrapStatus.values.firstWhere(
-        (e) => e.name == raw,
-        orElse: () => OutgoingWrapStatus.pending,
-      );
+  /// Parse a persisted wrap-status string back to [OutgoingWrapStatus].
+  ///
+  /// Throws [UnknownOutgoingWrapStatusException] when [raw] does not
+  /// match any known case. Coercing unknown values to
+  /// [OutgoingWrapStatus.pending] would put corrupt or future-schema
+  /// rows back into the retry service's active set — for a retry queue
+  /// that risks double-delivery, so we fail loudly instead.
+  OutgoingWrapStatus _parseStatus(String raw) {
+    for (final status in OutgoingWrapStatus.values) {
+      if (status.name == raw) return status;
+    }
+    throw UnknownOutgoingWrapStatusException(raw);
+  }
 
   // ---------------------------------------------------------------------
   // Writes
@@ -203,12 +239,17 @@ class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
 
   /// Enqueue a new outgoing DM with both wraps in [OutgoingWrapStatus.pending].
   ///
-  /// Uses `INSERT OR REPLACE` semantics via `insertOnConflictUpdate` so that
-  /// a retry which re-enqueues the same rumor id is a safe no-op (the row
-  /// already exists, and the PRIMARY KEY clash is resolved by replacing the
-  /// row with the same id — which is the same logical row).
-  Future<void> enqueue(OutgoingDm dm) {
-    return into(outgoingDms).insertOnConflictUpdate(_modelToCompanion(dm));
+  /// Uses `INSERT OR IGNORE` semantics: when a row with [OutgoingDm.id]
+  /// already exists, this call is a true no-op — the existing row's
+  /// mutable delivery state (`recipient_wrap_status`, `self_wrap_status`,
+  /// `retry_count`, `last_error`, `last_attempt_at`, the published wrap
+  /// event ids) is preserved. Use [markRecipientWrapStatus],
+  /// [markSelfWrapStatus], or [incrementRetry] to update a row in place.
+  Future<void> enqueue(OutgoingDm dm) async {
+    await into(outgoingDms).insert(
+      _modelToCompanion(dm),
+      mode: InsertMode.insertOrIgnore,
+    );
   }
 
   /// Update the recipient gift-wrap status for [id]. Pass [eventId] when

--- a/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.dart
@@ -1,0 +1,370 @@
+// ABOUTME: Data Access Object for the durable outgoing-DM queue.
+// ABOUTME: Tracks per-wrap publish status (recipient + self gift wrap)
+// ABOUTME: so partial deliveries can be retried without double-delivering.
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/drift.dart';
+import 'package:meta/meta.dart';
+
+part 'outgoing_dms_dao.g.dart';
+
+/// Status of one of the two NIP-17 gift-wrap publishes for an outgoing DM.
+///
+/// Each row in `outgoing_dms` carries two of these — one for the
+/// recipient gift wrap and one for the self-addressed gift wrap. They
+/// transition independently so a partial delivery (recipient sent, self
+/// failed) can be retried without re-publishing to the recipient.
+enum OutgoingWrapStatus {
+  /// Not yet attempted, or attempted and waiting for a relay reply.
+  pending,
+
+  /// Published and accepted by at least one relay.
+  sent,
+
+  /// Last attempt failed. `last_error` carries the reason; the retry
+  /// service will replay this wrap (only) until `retry_count` reaches
+  /// the policy cap.
+  failed,
+}
+
+/// Domain model for one queued outgoing DM.
+///
+/// Independent of [OutgoingDmRow] (the Drift-generated row) so callers
+/// at the repository / service / bloc layers don't import Drift types.
+@immutable
+class OutgoingDm {
+  const OutgoingDm({
+    required this.id,
+    required this.conversationId,
+    required this.recipientPubkey,
+    required this.content,
+    required this.createdAt,
+    required this.rumorEventJson,
+    required this.recipientWrapStatus,
+    required this.selfWrapStatus,
+    required this.queuedAt,
+    required this.ownerPubkey,
+    this.messageKind = 14,
+    this.replyToId,
+    this.recipientWrapEventId,
+    this.selfWrapEventId,
+    this.retryCount = 0,
+    this.lastError,
+    this.lastAttemptAt,
+  });
+
+  /// Rumor event id (kind 14/15). Stable across retries.
+  final String id;
+  final String conversationId;
+  final String recipientPubkey;
+  final String content;
+  final int createdAt;
+  final String rumorEventJson;
+  final int messageKind;
+  final String? replyToId;
+  final OutgoingWrapStatus recipientWrapStatus;
+  final OutgoingWrapStatus selfWrapStatus;
+  final String? recipientWrapEventId;
+  final String? selfWrapEventId;
+  final int retryCount;
+  final String? lastError;
+  final DateTime? lastAttemptAt;
+  final DateTime queuedAt;
+  final String ownerPubkey;
+
+  /// Whether **both** wraps have landed. The repository deletes the
+  /// queue row only when this is true (in the same transaction that
+  /// inserts the corresponding `direct_messages` row).
+  bool get isFullyDelivered =>
+      recipientWrapStatus == OutgoingWrapStatus.sent &&
+      selfWrapStatus == OutgoingWrapStatus.sent;
+
+  /// Whether either wrap is still in a retryable failed state. The
+  /// retry service uses this filter to enumerate work.
+  bool get hasRetryableFailure =>
+      recipientWrapStatus == OutgoingWrapStatus.failed ||
+      selfWrapStatus == OutgoingWrapStatus.failed;
+
+  OutgoingDm copyWith({
+    String? id,
+    String? conversationId,
+    String? recipientPubkey,
+    String? content,
+    int? createdAt,
+    String? rumorEventJson,
+    int? messageKind,
+    String? replyToId,
+    OutgoingWrapStatus? recipientWrapStatus,
+    OutgoingWrapStatus? selfWrapStatus,
+    String? recipientWrapEventId,
+    String? selfWrapEventId,
+    int? retryCount,
+    String? lastError,
+    DateTime? lastAttemptAt,
+    DateTime? queuedAt,
+    String? ownerPubkey,
+  }) => OutgoingDm(
+    id: id ?? this.id,
+    conversationId: conversationId ?? this.conversationId,
+    recipientPubkey: recipientPubkey ?? this.recipientPubkey,
+    content: content ?? this.content,
+    createdAt: createdAt ?? this.createdAt,
+    rumorEventJson: rumorEventJson ?? this.rumorEventJson,
+    messageKind: messageKind ?? this.messageKind,
+    replyToId: replyToId ?? this.replyToId,
+    recipientWrapStatus: recipientWrapStatus ?? this.recipientWrapStatus,
+    selfWrapStatus: selfWrapStatus ?? this.selfWrapStatus,
+    recipientWrapEventId: recipientWrapEventId ?? this.recipientWrapEventId,
+    selfWrapEventId: selfWrapEventId ?? this.selfWrapEventId,
+    retryCount: retryCount ?? this.retryCount,
+    lastError: lastError ?? this.lastError,
+    lastAttemptAt: lastAttemptAt ?? this.lastAttemptAt,
+    queuedAt: queuedAt ?? this.queuedAt,
+    ownerPubkey: ownerPubkey ?? this.ownerPubkey,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OutgoingDm && runtimeType == other.runtimeType && id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  String toString() =>
+      'OutgoingDm{id: $id, conversation: $conversationId, '
+      'recipient: $recipientWrapStatus, self: $selfWrapStatus, '
+      'retry: $retryCount}';
+}
+
+@DriftAccessor(tables: [OutgoingDms])
+class OutgoingDmsDao extends DatabaseAccessor<AppDatabase>
+    with _$OutgoingDmsDaoMixin {
+  OutgoingDmsDao(super.attachedDatabase);
+
+  // ---------------------------------------------------------------------
+  // Mapping
+  // ---------------------------------------------------------------------
+
+  OutgoingDmsCompanion _modelToCompanion(OutgoingDm dm) {
+    return OutgoingDmsCompanion.insert(
+      id: dm.id,
+      conversationId: dm.conversationId,
+      recipientPubkey: dm.recipientPubkey,
+      content: dm.content,
+      createdAt: dm.createdAt,
+      rumorEventJson: dm.rumorEventJson,
+      messageKind: Value(dm.messageKind),
+      replyToId: Value(dm.replyToId),
+      recipientWrapStatus: dm.recipientWrapStatus.name,
+      selfWrapStatus: dm.selfWrapStatus.name,
+      recipientWrapEventId: Value(dm.recipientWrapEventId),
+      selfWrapEventId: Value(dm.selfWrapEventId),
+      retryCount: Value(dm.retryCount),
+      lastError: Value(dm.lastError),
+      lastAttemptAt: Value(dm.lastAttemptAt),
+      queuedAt: dm.queuedAt,
+      ownerPubkey: dm.ownerPubkey,
+    );
+  }
+
+  OutgoingDm _rowToModel(OutgoingDmRow row) {
+    return OutgoingDm(
+      id: row.id,
+      conversationId: row.conversationId,
+      recipientPubkey: row.recipientPubkey,
+      content: row.content,
+      createdAt: row.createdAt,
+      rumorEventJson: row.rumorEventJson,
+      messageKind: row.messageKind,
+      replyToId: row.replyToId,
+      recipientWrapStatus: _parseStatus(row.recipientWrapStatus),
+      selfWrapStatus: _parseStatus(row.selfWrapStatus),
+      recipientWrapEventId: row.recipientWrapEventId,
+      selfWrapEventId: row.selfWrapEventId,
+      retryCount: row.retryCount,
+      lastError: row.lastError,
+      lastAttemptAt: row.lastAttemptAt,
+      queuedAt: row.queuedAt,
+      ownerPubkey: row.ownerPubkey,
+    );
+  }
+
+  OutgoingWrapStatus _parseStatus(String raw) =>
+      OutgoingWrapStatus.values.firstWhere(
+        (e) => e.name == raw,
+        orElse: () => OutgoingWrapStatus.pending,
+      );
+
+  // ---------------------------------------------------------------------
+  // Writes
+  // ---------------------------------------------------------------------
+
+  /// Enqueue a new outgoing DM with both wraps in [OutgoingWrapStatus.pending].
+  ///
+  /// Uses `INSERT OR REPLACE` semantics via `insertOnConflictUpdate` so that
+  /// a retry which re-enqueues the same rumor id is a safe no-op (the row
+  /// already exists, and the PRIMARY KEY clash is resolved by replacing the
+  /// row with the same id — which is the same logical row).
+  Future<void> enqueue(OutgoingDm dm) {
+    return into(outgoingDms).insertOnConflictUpdate(_modelToCompanion(dm));
+  }
+
+  /// Update the recipient gift-wrap status for [id]. Pass [eventId] when
+  /// transitioning to [OutgoingWrapStatus.sent] so the published id is
+  /// recorded for downstream debugging.
+  Future<bool> markRecipientWrapStatus({
+    required String id,
+    required OutgoingWrapStatus status,
+    String? eventId,
+    String? lastError,
+  }) async {
+    final rows = await (update(outgoingDms)..where((t) => t.id.equals(id)))
+        .write(
+          OutgoingDmsCompanion(
+            recipientWrapStatus: Value(status.name),
+            recipientWrapEventId: eventId != null
+                ? Value(eventId)
+                : const Value.absent(),
+            lastError: lastError != null
+                ? Value(lastError)
+                : const Value.absent(),
+            lastAttemptAt: Value(DateTime.now()),
+          ),
+        );
+    return rows > 0;
+  }
+
+  /// Update the self-addressed gift-wrap status for [id].
+  Future<bool> markSelfWrapStatus({
+    required String id,
+    required OutgoingWrapStatus status,
+    String? eventId,
+    String? lastError,
+  }) async {
+    final rows = await (update(outgoingDms)..where((t) => t.id.equals(id)))
+        .write(
+          OutgoingDmsCompanion(
+            selfWrapStatus: Value(status.name),
+            selfWrapEventId: eventId != null
+                ? Value(eventId)
+                : const Value.absent(),
+            lastError: lastError != null
+                ? Value(lastError)
+                : const Value.absent(),
+            lastAttemptAt: Value(DateTime.now()),
+          ),
+        );
+    return rows > 0;
+  }
+
+  /// Increment the retry count for [id]. The retry service calls this
+  /// after scheduling a replay regardless of the eventual outcome —
+  /// backoff caps growth at the policy max.
+  Future<bool> incrementRetry(String id) async {
+    final rows = await customUpdate(
+      'UPDATE outgoing_dms SET retry_count = retry_count + 1, '
+      'last_attempt_at = ? WHERE id = ?',
+      variables: [
+        Variable<int>(DateTime.now().millisecondsSinceEpoch),
+        Variable<String>(id),
+      ],
+      updates: {outgoingDms},
+    );
+    return rows > 0;
+  }
+
+  /// Delete the row for [id]. Called by the repository in the same
+  /// transaction that promotes the message to `direct_messages` once
+  /// both wraps are sent (atomicity prevents a watcher window where the
+  /// message is in neither table) — and called directly by the user's
+  /// "Cancel send" action while the message is still pending or failed.
+  Future<int> deleteById(String id) {
+    return (delete(outgoingDms)..where((t) => t.id.equals(id))).go();
+  }
+
+  // ---------------------------------------------------------------------
+  // Reads
+  // ---------------------------------------------------------------------
+
+  /// Fetch the queue row for [id], or `null` if not enqueued.
+  Future<OutgoingDm?> getById(String id) async {
+    final query = select(outgoingDms)..where((t) => t.id.equals(id));
+    final row = await query.getSingleOrNull();
+    return row == null ? null : _rowToModel(row);
+  }
+
+  /// Watch every row in [conversationId] for the given account, newest
+  /// first. Empty stream if no enqueued sends.
+  ///
+  /// The conversation BLoC merges this with `watchMessagesForConversation`
+  /// to render a unified timeline including pending / failed bubbles.
+  Stream<List<OutgoingDm>> watchForConversation({
+    required String conversationId,
+    required String ownerPubkey,
+  }) {
+    final query = select(outgoingDms)
+      ..where(
+        (t) =>
+            t.conversationId.equals(conversationId) &
+            t.ownerPubkey.equals(ownerPubkey),
+      )
+      ..orderBy([
+        (t) => OrderingTerm(
+          expression: t.createdAt,
+          mode: OrderingMode.desc,
+        ),
+      ]);
+    return query.watch().map((rows) => rows.map(_rowToModel).toList());
+  }
+
+  /// Watch every row for the given account, oldest first.
+  ///
+  /// Used by the retry service / a future "X messages failed" badge in
+  /// the inbox app bar.
+  Stream<List<OutgoingDm>> watchAllForOwner(String ownerPubkey) {
+    final query = select(outgoingDms)
+      ..where((t) => t.ownerPubkey.equals(ownerPubkey))
+      ..orderBy([(t) => OrderingTerm(expression: t.queuedAt)]);
+    return query.watch().map((rows) => rows.map(_rowToModel).toList());
+  }
+
+  /// Fetch all rows for [ownerPubkey] where at least one wrap is still
+  /// in [OutgoingWrapStatus.failed]. Excludes rows that have exhausted
+  /// the retry budget (caller decides what to do with those, typically
+  /// surface a manual retry affordance).
+  Future<List<OutgoingDm>> getRetryableForOwner({
+    required String ownerPubkey,
+    required int maxRetries,
+  }) async {
+    final query = select(outgoingDms)
+      ..where(
+        (t) =>
+            t.ownerPubkey.equals(ownerPubkey) &
+            t.retryCount.isSmallerThanValue(maxRetries) &
+            (t.recipientWrapStatus.equals(OutgoingWrapStatus.failed.name) |
+                t.selfWrapStatus.equals(OutgoingWrapStatus.failed.name)),
+      )
+      ..orderBy([(t) => OrderingTerm(expression: t.queuedAt)]);
+    final rows = await query.get();
+    return rows.map(_rowToModel).toList();
+  }
+
+  /// Fetch all rows for [ownerPubkey] still in
+  /// [OutgoingWrapStatus.pending] for either wrap. Used to recover
+  /// in-flight sends after an app kill that interrupted the publish
+  /// before the row could be marked sent or failed.
+  Future<List<OutgoingDm>> getStillPendingForOwner(String ownerPubkey) async {
+    final query = select(outgoingDms)
+      ..where(
+        (t) =>
+            t.ownerPubkey.equals(ownerPubkey) &
+            (t.recipientWrapStatus.equals(OutgoingWrapStatus.pending.name) |
+                t.selfWrapStatus.equals(OutgoingWrapStatus.pending.name)),
+      )
+      ..orderBy([(t) => OrderingTerm(expression: t.queuedAt)]);
+    final rows = await query.get();
+    return rows.map(_rowToModel).toList();
+  }
+}

--- a/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.g.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/outgoing_dms_dao.g.dart
@@ -1,0 +1,8 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'outgoing_dms_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$OutgoingDmsDaoMixin on DatabaseAccessor<AppDatabase> {
+  $OutgoingDmsTable get outgoingDms => attachedDatabase.outgoingDms;
+}

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -1007,9 +1007,24 @@ class OutgoingDms extends Table {
   IntColumn get retryCount =>
       integer().withDefault(const Constant(0)).named('retry_count')();
 
-  /// Last error message from a failed publish attempt. `null` when the
-  /// most recent transition was a success.
-  TextColumn get lastError => text().nullable().named('last_error')();
+  /// Last error message from the most recent failed **recipient** wrap
+  /// publish. `null` when the recipient wrap has never failed or when the
+  /// most recent recipient transition was a success.
+  ///
+  /// Stored independently of [selfWrapLastError] because the two wraps
+  /// fail for different reasons (e.g. recipient relay rejected the
+  /// kind-1059 vs ephemeral self-relay timeout) — collapsing both into a
+  /// single column would silently overwrite one cause with the other on
+  /// the second failure and starve the retry service of useful diagnostics.
+  TextColumn get recipientWrapLastError =>
+      text().nullable().named('recipient_wrap_last_error')();
+
+  /// Last error message from the most recent failed **self** wrap
+  /// publish. Same lifecycle and rationale as [recipientWrapLastError];
+  /// kept in its own column so a recipient failure followed by a self
+  /// failure preserves both reasons.
+  TextColumn get selfWrapLastError =>
+      text().nullable().named('self_wrap_last_error')();
 
   /// Wall-clock timestamp of the most recent publish attempt. Drives
   /// the retry service's backoff scheduling.

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -906,3 +906,143 @@ class PersonalReposts extends Table {
     ),
   ];
 }
+
+/// Durable queue of outgoing NIP-17 direct messages.
+///
+/// Holds rows for messages that the user has attempted to send but whose
+/// publish to relays is not yet fully confirmed. NIP-17 is **two**
+/// independent kind-1059 publishes (recipient gift wrap + self gift
+/// wrap), tracked separately so a partial-delivery state can be retried
+/// without re-publishing the recipient wrap and double-delivering.
+///
+/// Lifecycle:
+/// - Insert with both statuses = `pending` immediately before
+///   `NIP17MessageService.sendPrivateMessage`.
+/// - On result: update each status to `sent` or `failed` based on the
+///   per-wrap publish outcome (`NIP17SendResult.success` for recipient,
+///   `NIP17SendResult.selfWrapPublished` for self).
+/// - When **both** statuses are `sent`: delete the row in the same
+///   transaction that inserts the corresponding `direct_messages` row.
+///   Atomicity prevents the watcher from observing a window where the
+///   message is in neither table.
+/// - When **either** status is `failed`: keep the row, populate
+///   `last_error` and `last_attempt_at`, increment `retry_count`.
+///   Background retry service replays only the still-failed wrap.
+///
+/// `rumor_event_json` stores the serialized rumor (kind 14/15 unsigned
+/// event) so retries re-wrap the **same** rumor — preserves the
+/// rumor's `id` (a hash of its fields) so the receiver's gift-wrap
+/// dedup correctly drops the duplicate publish on retry.
+@DataClassName('OutgoingDmRow')
+class OutgoingDms extends Table {
+  @override
+  String get tableName => 'outgoing_dms';
+
+  /// Primary key. Equal to the rumor's event id (`rumor_event_json` →
+  /// `id`), so a single logical message has exactly one queue row even
+  /// across retries.
+  TextColumn get id => text()();
+
+  /// Deterministic conversation identifier (SHA-256 of sorted
+  /// participant pubkeys). Same shape as `direct_messages.conversation_id`
+  /// so the BLoC can `Rx.combineLatest2(watchMessages, watchOutgoing)`
+  /// for a conversation view.
+  TextColumn get conversationId => text().named('conversation_id')();
+
+  /// Recipient's hex pubkey for the 1:1 path. (Group sends file one row
+  /// per participant — `conversation_id` is the group conversation, but
+  /// each row is targeted at one recipient.)
+  TextColumn get recipientPubkey => text().named('recipient_pubkey')();
+
+  /// Plaintext message content. Stored alongside `rumor_event_json` so
+  /// the UI can render the bubble without re-parsing the rumor on every
+  /// rebuild. Authoritative source for retries is `rumor_event_json`.
+  TextColumn get content => text()();
+
+  /// Unix timestamp from the rumor event's `created_at`. Stable across
+  /// retries because the rumor itself is reused.
+  IntColumn get createdAt => integer().named('created_at')();
+
+  /// Serialized JSON of the unsigned NIP-17 rumor (kind 14 or 15). Used
+  /// on retry so we re-wrap the same rumor — preserving `rumor.id`,
+  /// which is what the receiver's gift-wrap dedup keys on.
+  TextColumn get rumorEventJson => text().named('rumor_event_json')();
+
+  /// The rumor event kind (14 = text, 15 = file). Defaults to 14.
+  IntColumn get messageKind =>
+      integer().withDefault(const Constant(14)).named('message_kind')();
+
+  /// Optional reply target rumor id.
+  TextColumn get replyToId => text().nullable().named('reply_to_id')();
+
+  /// Status of the recipient gift-wrap publish: `pending` | `sent` |
+  /// `failed`. Stored as a string so adding new states (e.g. `cancelled`)
+  /// is a non-migration change.
+  TextColumn get recipientWrapStatus => text().named('recipient_wrap_status')();
+
+  /// Status of the self-addressed gift-wrap publish: same enum as
+  /// `recipient_wrap_status`. The `false` value of
+  /// `NIP17SendResult.selfWrapPublished` flips this to `failed`; a row
+  /// with `recipient: sent, self: failed` is the partial-delivery state
+  /// from #3909 / #3902.
+  TextColumn get selfWrapStatus => text().named('self_wrap_status')();
+
+  /// Recipient gift-wrap event id (kind 1059) once published. Null while
+  /// `recipient_wrap_status` is `pending` or `failed`.
+  TextColumn get recipientWrapEventId =>
+      text().nullable().named('recipient_wrap_event_id')();
+
+  /// Self gift-wrap event id (kind 1059) once published. Null while
+  /// `self_wrap_status` is `pending` or `failed`.
+  TextColumn get selfWrapEventId =>
+      text().nullable().named('self_wrap_event_id')();
+
+  /// How many publish attempts this row has survived. Caps growth at the
+  /// retry policy's max; once exhausted the UI surfaces a manual retry
+  /// affordance.
+  IntColumn get retryCount =>
+      integer().withDefault(const Constant(0)).named('retry_count')();
+
+  /// Last error message from a failed publish attempt. `null` when the
+  /// most recent transition was a success.
+  TextColumn get lastError => text().nullable().named('last_error')();
+
+  /// Wall-clock timestamp of the most recent publish attempt. Drives
+  /// the retry service's backoff scheduling.
+  DateTimeColumn get lastAttemptAt =>
+      dateTime().nullable().named('last_attempt_at')();
+
+  /// Wall-clock timestamp of the row's creation. Used to order the queue
+  /// when retrying.
+  DateTimeColumn get queuedAt => dateTime().named('queued_at')();
+
+  /// Hex pubkey of the account that queued this send. Mirrors
+  /// `direct_messages.owner_pubkey` for multi-account isolation.
+  TextColumn get ownerPubkey => text().named('owner_pubkey')();
+
+  @override
+  Set<Column> get primaryKey => {id};
+
+  List<Index> get indexes => [
+    Index(
+      'idx_outgoing_dms_owner_conversation',
+      'CREATE INDEX IF NOT EXISTS idx_outgoing_dms_owner_conversation '
+          'ON outgoing_dms (owner_pubkey, conversation_id, created_at DESC)',
+    ),
+    Index(
+      'idx_outgoing_dms_owner_recipient_status',
+      'CREATE INDEX IF NOT EXISTS idx_outgoing_dms_owner_recipient_status '
+          'ON outgoing_dms (owner_pubkey, recipient_wrap_status)',
+    ),
+    Index(
+      'idx_outgoing_dms_owner_self_status',
+      'CREATE INDEX IF NOT EXISTS idx_outgoing_dms_owner_self_status '
+          'ON outgoing_dms (owner_pubkey, self_wrap_status)',
+    ),
+    Index(
+      'idx_outgoing_dms_queued_at',
+      'CREATE INDEX IF NOT EXISTS idx_outgoing_dms_queued_at '
+          'ON outgoing_dms (queued_at)',
+    ),
+  ];
+}

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -976,8 +976,12 @@ class OutgoingDms extends Table {
   TextColumn get replyToId => text().nullable().named('reply_to_id')();
 
   /// Status of the recipient gift-wrap publish: `pending` | `sent` |
-  /// `failed`. Stored as a string so adding new states (e.g. `cancelled`)
-  /// is a non-migration change.
+  /// `failed`. Stored as a string (rather than an int-coded enum) so a
+  /// dump of the table is human-readable. Adding a new state requires a
+  /// matching update to `OutgoingWrapStatus` in the DAO — the read
+  /// path throws on unknown values rather than silently coercing them
+  /// back to `pending` (which would put corrupt or future-schema rows
+  /// back into the retry service's active set and risk double-delivery).
   TextColumn get recipientWrapStatus => text().named('recipient_wrap_status')();
 
   /// Status of the self-addressed gift-wrap publish: same enum as

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -185,6 +185,98 @@ void main() {
         expect(result.oldNotificationsDeleted, equals(0));
       });
 
+      test('upgrade path — recreates outgoing_dms when missing', () async {
+        // Simulate an existing install that pre-dates the
+        // outgoing_dms table (added for #3909 / #3911 without a
+        // schema-version bump): drop the table from a fresh database,
+        // close, then reopen and assert the runtime
+        // CREATE-IF-NOT-EXISTS path in `_createMissingTables`
+        // recreated the table, indexes, and that the DAO works.
+        await database.customStatement('DROP TABLE outgoing_dms');
+
+        // Confirm the precondition — table really is gone before reopen.
+        final droppedCheck = await database
+            .customSelect(
+              "SELECT name FROM sqlite_master WHERE type='table' "
+              "AND name='outgoing_dms'",
+            )
+            .get();
+        expect(
+          droppedCheck,
+          isEmpty,
+          reason: 'precondition: outgoing_dms must be missing before reopen',
+        );
+
+        await database.close();
+
+        // Reopen the same on-disk file. `beforeOpen` runs
+        // `_createMissingTables`, which should detect the missing
+        // outgoing_dms table and recreate it without bumping
+        // schemaVersion.
+        database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+
+        // Trigger `beforeOpen` by issuing a query (Drift opens the
+        // database lazily on first use).
+        final tableCheck = await database
+            .customSelect(
+              "SELECT name FROM sqlite_master WHERE type='table' "
+              "AND name='outgoing_dms'",
+            )
+            .get();
+        expect(
+          tableCheck,
+          hasLength(1),
+          reason: 'outgoing_dms must be re-created on reopen',
+        );
+
+        // Assert the indexes are in place too — the runtime path also
+        // owns those, and a missing index would silently degrade
+        // retry-sweep performance without failing the table check.
+        final indexCheck = await database
+            .customSelect(
+              "SELECT name FROM sqlite_master WHERE type='index' "
+              "AND tbl_name='outgoing_dms'",
+            )
+            .get();
+        final indexNames = indexCheck
+            .map((row) => row.read<String>('name'))
+            .toSet();
+        expect(
+          indexNames,
+          containsAll(<String>[
+            'idx_outgoing_dms_owner_conversation',
+            'idx_outgoing_dms_owner_recipient_status',
+            'idx_outgoing_dms_owner_self_status',
+            'idx_outgoing_dms_queued_at',
+          ]),
+        );
+
+        // Finally, prove the DAO actually works against the upgraded
+        // schema — a re-created table with mismatched columns or a
+        // botched insert path would break this round-trip.
+        final dao = database.outgoingDmsDao;
+        final dm = OutgoingDm(
+          id: 'upgrade-test-id',
+          conversationId: 'conv-1',
+          recipientPubkey: testPubkey,
+          content: 'hello after upgrade',
+          createdAt: 1700000000,
+          rumorEventJson:
+              '{"id":"upgrade-test-id","kind":14,"content":"hello"}',
+          recipientWrapStatus: OutgoingWrapStatus.pending,
+          selfWrapStatus: OutgoingWrapStatus.pending,
+          queuedAt: DateTime.utc(2026, 5),
+          ownerPubkey: testPubkey,
+        );
+        await dao.enqueue(dm);
+
+        final fetched = await dao.getById('upgrade-test-id');
+        expect(fetched, isNotNull);
+        expect(fetched!.content, equals('hello after upgrade'));
+        expect(fetched.recipientWrapStatus, OutgoingWrapStatus.pending);
+        expect(fetched.selfWrapStatus, OutgoingWrapStatus.pending);
+      });
+
       test('does not delete non-expired data', () async {
         final eventsDao = database.nostrEventsDao;
         final profileStatsDao = database.profileStatsDao;

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -277,6 +277,94 @@ void main() {
         expect(fetched.selfWrapStatus, OutgoingWrapStatus.pending);
       });
 
+      test(
+        'schema parity — fresh-install matches runtime CREATE-IF-NOT-EXISTS '
+        'path column-for-column and index-for-index',
+        () async {
+          // The `outgoing_dms` table is defined in two places:
+          //   1. Drift `OutgoingDms` table in `tables.dart`, applied by
+          //      `m.createAll()` on first open of a brand-new database.
+          //   2. Handwritten SQL in `_createMissingTables`, applied to
+          //      existing installs that pre-date the table.
+          // Both paths must agree exactly. This test inspects the same
+          // database from both code paths and diffs the resulting
+          // `outgoing_dms` shape — a future Drift edit that misses the
+          // runtime SQL (or vice-versa) fails this test loudly.
+
+          // Path 1: capture the fresh-install shape from the database
+          // already opened by the outer `setUp` (Drift's `m.createAll()`
+          // path). This represents a brand-new install.
+          final freshColumns = await _collectTableInfo(
+            database,
+            'outgoing_dms',
+          );
+          final freshIndexes = await _collectIndexNames(
+            database,
+            'outgoing_dms',
+          );
+
+          expect(
+            freshColumns,
+            isNotEmpty,
+            reason: 'precondition: fresh install should have outgoing_dms',
+          );
+
+          // Path 2: drop the table and reopen the same on-disk file so
+          // `_createMissingTables` recreates it via the runtime SQL path.
+          await database.customStatement('DROP TABLE outgoing_dms');
+          // Drop the indexes too so `_createMissingTables` is responsible
+          // for recreating them — otherwise stale indexes could mask a
+          // missing CREATE INDEX statement.
+          for (final indexName in freshIndexes) {
+            await database.customStatement('DROP INDEX IF EXISTS $indexName');
+          }
+          await database.close();
+
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+          // Trigger `beforeOpen` lazily.
+          await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='outgoing_dms'",
+              )
+              .get();
+
+          final recreatedColumns = await _collectTableInfo(
+            database,
+            'outgoing_dms',
+          );
+          final recreatedIndexes = await _collectIndexNames(
+            database,
+            'outgoing_dms',
+          );
+
+          // Column-by-column equality: `pragma table_info` returns
+          // (name, type, notnull, dflt_value, pk) tuples. List equality
+          // also catches column ordering drift, which sqlite preserves
+          // across `CREATE TABLE` statements and would surface a
+          // mis-ordered hand-written runtime SQL.
+          expect(
+            recreatedColumns,
+            equals(freshColumns),
+            reason:
+                'runtime CREATE-IF-NOT-EXISTS path must produce the same '
+                'columns as Drift `m.createAll()` — drift between the two '
+                'is exactly the bug Liz flagged',
+          );
+
+          // Index name set equality. Drift and the runtime SQL may emit
+          // CREATE INDEX statements in different orders, so set
+          // semantics is the right comparison here.
+          expect(
+            recreatedIndexes,
+            equals(freshIndexes),
+            reason:
+                'runtime CREATE-IF-NOT-EXISTS path must declare the same '
+                'index set as Drift fresh-install',
+          );
+        },
+      );
+
       test('does not delete non-expired data', () async {
         final eventsDao = database.nostrEventsDao;
         final profileStatsDao = database.profileStatsDao;
@@ -325,4 +413,48 @@ void main() {
       });
     });
   });
+}
+
+/// Captures `pragma table_info(<table>)` as a list of comparable tuples.
+///
+/// Each entry is `(name, type, notnull, dflt_value)` — the four fields
+/// that define the column shape. `cid` is intentionally dropped because
+/// it is just the column ordinal and is already encoded by the list
+/// position, and `pk` is included because the primary-key flag is part
+/// of the shape contract. `dflt_value` is a string sqlite-renders for
+/// defaults (e.g. `'0'`, `'14'`) so the same Dart-level default lands
+/// at the same string from both the Drift and the runtime SQL paths.
+Future<List<List<Object?>>> _collectTableInfo(
+  AppDatabase db,
+  String table,
+) async {
+  final rows = await db.customSelect('PRAGMA table_info($table)').get();
+  return rows
+      .map(
+        (row) => <Object?>[
+          row.read<String>('name'),
+          row.read<String>('type'),
+          row.read<int>('notnull'),
+          row.readNullable<String>('dflt_value'),
+          row.read<int>('pk'),
+        ],
+      )
+      .toList();
+}
+
+/// Captures the set of index names attached to [table], excluding the
+/// auto-generated `sqlite_autoindex_*` entries that sqlite adds for
+/// primary keys. Returns a [Set] because Drift and the runtime SQL may
+/// declare indexes in different orders.
+Future<Set<String>> _collectIndexNames(
+  AppDatabase db,
+  String table,
+) async {
+  final rows = await db
+      .customSelect(
+        "SELECT name FROM sqlite_master WHERE type='index' "
+        "AND tbl_name='$table' AND name NOT LIKE 'sqlite_autoindex_%'",
+      )
+      .get();
+  return rows.map((row) => row.read<String>('name')).toSet();
 }

--- a/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
@@ -1,0 +1,487 @@
+// ABOUTME: Unit tests for OutgoingDmsDao — durable outgoing-DM queue
+// ABOUTME: with per-wrap publish status. Tests CRUD, reactive streams,
+// ABOUTME: retry filtering, and owner-pubkey isolation.
+
+import 'dart:io';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase database;
+  late OutgoingDmsDao dao;
+  late String tempDbPath;
+
+  // Valid 64-char hex pubkeys for testing.
+  const ownerA =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  const ownerB =
+      'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+  const recipient =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const recipient2 =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const conversationId =
+      'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+  const conversationId2 =
+      'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+  // Helper: build a fresh queued OutgoingDm with both wraps pending.
+  OutgoingDm makeDm({
+    required String id,
+    String owner = ownerA,
+    String recipientPubkey = recipient,
+    String conversationIdValue = conversationId,
+    OutgoingWrapStatus recipientStatus = OutgoingWrapStatus.pending,
+    OutgoingWrapStatus selfStatus = OutgoingWrapStatus.pending,
+    int retryCount = 0,
+    DateTime? queuedAt,
+    int createdAt = 1700000000,
+  }) {
+    return OutgoingDm(
+      id: id,
+      conversationId: conversationIdValue,
+      recipientPubkey: recipientPubkey,
+      content: 'hello',
+      createdAt: createdAt,
+      rumorEventJson: '{"id":"$id","kind":14,"content":"hello"}',
+      recipientWrapStatus: recipientStatus,
+      selfWrapStatus: selfStatus,
+      retryCount: retryCount,
+      queuedAt: queuedAt ?? DateTime.utc(2026, 5),
+      ownerPubkey: owner,
+    );
+  }
+
+  setUp(() async {
+    final tempDir = Directory.systemTemp.createTempSync('outgoing_dms_test_');
+    tempDbPath = '${tempDir.path}/test.db';
+
+    database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+    dao = database.outgoingDmsDao;
+  });
+
+  tearDown(() async {
+    await database.close();
+    final file = File(tempDbPath);
+    if (file.existsSync()) {
+      file.deleteSync();
+    }
+    final dir = Directory(tempDbPath).parent;
+    if (dir.existsSync()) {
+      dir.deleteSync(recursive: true);
+    }
+  });
+
+  group('OutgoingDmsDao', () {
+    group('enqueue', () {
+      test('inserts a new row in pending/pending state', () async {
+        final dm = makeDm(id: 'aaaa');
+        await dao.enqueue(dm);
+
+        final fetched = await dao.getById('aaaa');
+        expect(fetched, isNotNull);
+        expect(fetched!.recipientWrapStatus, OutgoingWrapStatus.pending);
+        expect(fetched.selfWrapStatus, OutgoingWrapStatus.pending);
+        expect(fetched.retryCount, equals(0));
+        expect(fetched.lastError, isNull);
+      });
+
+      test(
+        're-enqueueing the same id replaces the row (idempotent retry)',
+        () async {
+          await dao.enqueue(makeDm(id: 'aaaa'));
+          await dao.enqueue(
+            makeDm(id: 'aaaa', retryCount: 3),
+          );
+
+          final fetched = await dao.getById('aaaa');
+          expect(fetched!.retryCount, equals(3));
+        },
+      );
+    });
+
+    group('markRecipientWrapStatus / markSelfWrapStatus', () {
+      test('flips recipient status to sent and records eventId', () async {
+        await dao.enqueue(makeDm(id: 'aaaa'));
+
+        final ok = await dao.markRecipientWrapStatus(
+          id: 'aaaa',
+          status: OutgoingWrapStatus.sent,
+          eventId: 'rcpt-evt-id',
+        );
+
+        expect(ok, isTrue);
+        final fetched = await dao.getById('aaaa');
+        expect(fetched!.recipientWrapStatus, OutgoingWrapStatus.sent);
+        expect(fetched.recipientWrapEventId, equals('rcpt-evt-id'));
+        expect(fetched.lastAttemptAt, isNotNull);
+        expect(
+          fetched.selfWrapStatus,
+          OutgoingWrapStatus.pending,
+          reason: 'self status is independent of recipient status',
+        );
+      });
+
+      test(
+        'flips self status to failed and records lastError independent '
+        'of recipient status (the partial-delivery state)',
+        () async {
+          await dao.enqueue(makeDm(id: 'aaaa'));
+          await dao.markRecipientWrapStatus(
+            id: 'aaaa',
+            status: OutgoingWrapStatus.sent,
+            eventId: 'rcpt-evt-id',
+          );
+
+          final ok = await dao.markSelfWrapStatus(
+            id: 'aaaa',
+            status: OutgoingWrapStatus.failed,
+            lastError: 'self-wrap relay rejected',
+          );
+
+          expect(ok, isTrue);
+          final fetched = await dao.getById('aaaa');
+          expect(fetched!.recipientWrapStatus, OutgoingWrapStatus.sent);
+          expect(fetched.selfWrapStatus, OutgoingWrapStatus.failed);
+          expect(fetched.lastError, equals('self-wrap relay rejected'));
+          expect(fetched.isFullyDelivered, isFalse);
+          expect(fetched.hasRetryableFailure, isTrue);
+        },
+      );
+
+      test('returns false when the row does not exist', () async {
+        final ok = await dao.markRecipientWrapStatus(
+          id: 'missing',
+          status: OutgoingWrapStatus.sent,
+        );
+        expect(ok, isFalse);
+      });
+    });
+
+    group('incrementRetry', () {
+      test('increases retry_count by one and updates lastAttemptAt', () async {
+        await dao.enqueue(makeDm(id: 'aaaa'));
+
+        final before = await dao.getById('aaaa');
+        expect(before!.retryCount, equals(0));
+        expect(before.lastAttemptAt, isNull);
+
+        await dao.incrementRetry('aaaa');
+        await dao.incrementRetry('aaaa');
+
+        final after = await dao.getById('aaaa');
+        expect(after!.retryCount, equals(2));
+        expect(after.lastAttemptAt, isNotNull);
+      });
+    });
+
+    group('deleteById', () {
+      test('removes the row and returns the affected count', () async {
+        await dao.enqueue(makeDm(id: 'aaaa'));
+
+        final deleted = await dao.deleteById('aaaa');
+
+        expect(deleted, equals(1));
+        expect(await dao.getById('aaaa'), isNull);
+      });
+
+      test('returns 0 when the row does not exist', () async {
+        expect(await dao.deleteById('missing'), equals(0));
+      });
+    });
+
+    group('watchForConversation', () {
+      test('emits initial empty list for an empty conversation', () async {
+        final stream = dao.watchForConversation(
+          conversationId: conversationId,
+          ownerPubkey: ownerA,
+        );
+
+        await expectLater(
+          stream,
+          emits(isEmpty),
+        );
+      });
+
+      test('emits a new list after enqueue', () async {
+        await dao.enqueue(makeDm(id: 'aaaa'));
+
+        // After the row is committed, the stream's first emission to a
+        // fresh subscriber is the post-enqueue state.
+        await expectLater(
+          dao.watchForConversation(
+            conversationId: conversationId,
+            ownerPubkey: ownerA,
+          ),
+          emits(
+            allOf(
+              hasLength(1),
+              contains(
+                isA<OutgoingDm>()
+                    .having((e) => e.id, 'id', 'aaaa')
+                    .having(
+                      (e) => e.recipientWrapStatus,
+                      'recipientWrapStatus',
+                      OutgoingWrapStatus.pending,
+                    ),
+              ),
+            ),
+          ),
+        );
+      });
+
+      test('emits the new status after markRecipientWrapStatus', () async {
+        await dao.enqueue(makeDm(id: 'aaaa'));
+        await dao.markRecipientWrapStatus(
+          id: 'aaaa',
+          status: OutgoingWrapStatus.sent,
+          eventId: 'evt-1',
+        );
+
+        await expectLater(
+          dao.watchForConversation(
+            conversationId: conversationId,
+            ownerPubkey: ownerA,
+          ),
+          emits(
+            contains(
+              isA<OutgoingDm>().having(
+                (e) => e.recipientWrapStatus,
+                'recipientWrapStatus',
+                OutgoingWrapStatus.sent,
+              ),
+            ),
+          ),
+        );
+      });
+
+      test('emits empty after deleteById', () async {
+        await dao.enqueue(makeDm(id: 'aaaa'));
+        await dao.deleteById('aaaa');
+
+        await expectLater(
+          dao.watchForConversation(
+            conversationId: conversationId,
+            ownerPubkey: ownerA,
+          ),
+          emits(isEmpty),
+        );
+      });
+
+      test('owner-pubkey isolation — does not include other owners', () async {
+        await dao.enqueue(makeDm(id: 'aaaa'));
+        await dao.enqueue(makeDm(id: 'bbbb', owner: ownerB));
+
+        final stream = dao.watchForConversation(
+          conversationId: conversationId,
+          ownerPubkey: ownerA,
+        );
+
+        await expectLater(
+          stream,
+          emits(
+            allOf(
+              hasLength(1),
+              contains(isA<OutgoingDm>().having((e) => e.id, 'id', 'aaaa')),
+            ),
+          ),
+        );
+      });
+
+      test('does not include rows from a different conversation', () async {
+        await dao.enqueue(makeDm(id: 'aaaa'));
+        await dao.enqueue(
+          makeDm(id: 'bbbb', conversationIdValue: conversationId2),
+        );
+
+        final stream = dao.watchForConversation(
+          conversationId: conversationId,
+          ownerPubkey: ownerA,
+        );
+
+        await expectLater(
+          stream,
+          emits(
+            allOf(
+              hasLength(1),
+              contains(isA<OutgoingDm>().having((e) => e.id, 'id', 'aaaa')),
+            ),
+          ),
+        );
+      });
+    });
+
+    group('getRetryableForOwner', () {
+      test(
+        'returns rows where either wrap is failed and retry_count is '
+        'under the cap',
+        () async {
+          // Both pending: not retryable yet (no failure recorded).
+          await dao.enqueue(makeDm(id: 'pending'));
+          // Recipient failed: retryable.
+          await dao.enqueue(
+            makeDm(
+              id: 'rcpt-failed',
+              recipientStatus: OutgoingWrapStatus.failed,
+            ),
+          );
+          // Self failed (the F3 partial-delivery): retryable.
+          await dao.enqueue(
+            makeDm(
+              id: 'self-failed',
+              recipientStatus: OutgoingWrapStatus.sent,
+              selfStatus: OutgoingWrapStatus.failed,
+            ),
+          );
+          // Both sent: not retryable.
+          await dao.enqueue(
+            makeDm(
+              id: 'both-sent',
+              recipientStatus: OutgoingWrapStatus.sent,
+              selfStatus: OutgoingWrapStatus.sent,
+            ),
+          );
+          // Failed but past the retry cap: excluded.
+          await dao.enqueue(
+            makeDm(
+              id: 'exhausted',
+              recipientStatus: OutgoingWrapStatus.failed,
+              retryCount: 5,
+            ),
+          );
+
+          final retryable = await dao.getRetryableForOwner(
+            ownerPubkey: ownerA,
+            maxRetries: 5,
+          );
+
+          expect(
+            retryable.map((e) => e.id),
+            unorderedEquals(['rcpt-failed', 'self-failed']),
+          );
+        },
+      );
+
+      test('owner-pubkey isolation', () async {
+        await dao.enqueue(
+          makeDm(
+            id: 'aaaa',
+            recipientStatus: OutgoingWrapStatus.failed,
+          ),
+        );
+        await dao.enqueue(
+          makeDm(
+            id: 'bbbb',
+            owner: ownerB,
+            recipientStatus: OutgoingWrapStatus.failed,
+          ),
+        );
+
+        final retryable = await dao.getRetryableForOwner(
+          ownerPubkey: ownerA,
+          maxRetries: 5,
+        );
+
+        expect(retryable.map((e) => e.id), equals(['aaaa']));
+      });
+    });
+
+    group('getStillPendingForOwner', () {
+      test('returns rows with at least one wrap still pending', () async {
+        await dao.enqueue(makeDm(id: 'pending'));
+        await dao.enqueue(
+          makeDm(
+            id: 'half-pending',
+            recipientStatus: OutgoingWrapStatus.sent,
+          ),
+        );
+        await dao.enqueue(
+          makeDm(
+            id: 'both-sent',
+            recipientStatus: OutgoingWrapStatus.sent,
+            selfStatus: OutgoingWrapStatus.sent,
+          ),
+        );
+        await dao.enqueue(
+          makeDm(
+            id: 'failed',
+            recipientStatus: OutgoingWrapStatus.failed,
+            selfStatus: OutgoingWrapStatus.failed,
+          ),
+        );
+
+        final pending = await dao.getStillPendingForOwner(ownerA);
+
+        expect(
+          pending.map((e) => e.id),
+          unorderedEquals(['pending', 'half-pending']),
+        );
+      });
+    });
+
+    group('isFullyDelivered + hasRetryableFailure (model getters)', () {
+      test('isFullyDelivered is true only when both wraps are sent', () async {
+        final dm = makeDm(id: 'aaaa');
+        expect(dm.isFullyDelivered, isFalse);
+        expect(
+          dm
+              .copyWith(
+                recipientWrapStatus: OutgoingWrapStatus.sent,
+                selfWrapStatus: OutgoingWrapStatus.sent,
+              )
+              .isFullyDelivered,
+          isTrue,
+        );
+        expect(
+          dm
+              .copyWith(
+                recipientWrapStatus: OutgoingWrapStatus.sent,
+                selfWrapStatus: OutgoingWrapStatus.failed,
+              )
+              .isFullyDelivered,
+          isFalse,
+        );
+      });
+
+      test('hasRetryableFailure is true if either wrap is failed', () async {
+        final dm = makeDm(id: 'aaaa');
+        expect(dm.hasRetryableFailure, isFalse);
+        expect(
+          dm
+              .copyWith(recipientWrapStatus: OutgoingWrapStatus.failed)
+              .hasRetryableFailure,
+          isTrue,
+        );
+        expect(
+          dm
+              .copyWith(selfWrapStatus: OutgoingWrapStatus.failed)
+              .hasRetryableFailure,
+          isTrue,
+        );
+      });
+    });
+
+    test(
+      'multiple owners + recipients + conversations stay isolated end-to-end',
+      () async {
+        await dao.enqueue(makeDm(id: 'a-1'));
+        await dao.enqueue(makeDm(id: 'a-2', recipientPubkey: recipient2));
+        await dao.enqueue(makeDm(id: 'b-1', owner: ownerB));
+
+        final ownerAStream = dao.watchAllForOwner(ownerA);
+        await expectLater(
+          ownerAStream,
+          emits(hasLength(2)),
+        );
+
+        final ownerBStream = dao.watchAllForOwner(ownerB);
+        await expectLater(
+          ownerBStream,
+          emits(hasLength(1)),
+        );
+      },
+    );
+  });
+}

--- a/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
@@ -212,6 +212,30 @@ void main() {
       });
     });
 
+    group('clearAllForUser', () {
+      test('removes only rows owned by the given pubkey', () async {
+        await dao.enqueue(makeDm(id: 'a1', owner: ownerA));
+        await dao.enqueue(makeDm(id: 'a2', owner: ownerA));
+        await dao.enqueue(makeDm(id: 'b1', owner: ownerB));
+
+        final cleared = await dao.clearAllForUser(ownerA);
+
+        expect(cleared, equals(2));
+        expect(await dao.getById('a1'), isNull);
+        expect(await dao.getById('a2'), isNull);
+        expect(await dao.getById('b1'), isNotNull);
+      });
+
+      test('returns 0 when the user has no queued rows', () async {
+        await dao.enqueue(makeDm(id: 'b1', owner: ownerB));
+
+        final cleared = await dao.clearAllForUser(ownerA);
+
+        expect(cleared, equals(0));
+        expect(await dao.getById('b1'), isNotNull);
+      });
+    });
+
     group('watchForConversation', () {
       test('emits initial empty list for an empty conversation', () async {
         final stream = dao.watchForConversation(

--- a/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
@@ -89,15 +89,35 @@ void main() {
       });
 
       test(
-        're-enqueueing the same id replaces the row (idempotent retry)',
+        're-enqueueing the same id is a no-op — leaves mutable delivery '
+        'state on the existing row untouched',
         () async {
           await dao.enqueue(makeDm(id: 'aaaa'));
-          await dao.enqueue(
-            makeDm(id: 'aaaa', retryCount: 3),
+
+          // Move the row out of the initial pending/pending state.
+          await dao.markRecipientWrapStatus(
+            id: 'aaaa',
+            status: OutgoingWrapStatus.sent,
+            eventId: 'rcpt-evt-id',
           );
+          await dao.markSelfWrapStatus(
+            id: 'aaaa',
+            status: OutgoingWrapStatus.failed,
+            lastError: 'self-wrap relay rejected',
+          );
+          await dao.incrementRetry('aaaa');
+
+          // A second enqueue with a fresh OutgoingDm (retry_count = 0,
+          // both wraps pending, no eventId, no lastError) must NOT
+          // overwrite the in-flight delivery state.
+          await dao.enqueue(makeDm(id: 'aaaa'));
 
           final fetched = await dao.getById('aaaa');
-          expect(fetched!.retryCount, equals(3));
+          expect(fetched!.recipientWrapStatus, OutgoingWrapStatus.sent);
+          expect(fetched.recipientWrapEventId, equals('rcpt-evt-id'));
+          expect(fetched.selfWrapStatus, OutgoingWrapStatus.failed);
+          expect(fetched.lastError, equals('self-wrap relay rejected'));
+          expect(fetched.retryCount, equals(1));
         },
       );
     });
@@ -419,6 +439,79 @@ void main() {
           unorderedEquals(['pending', 'half-pending']),
         );
       });
+    });
+
+    group('unknown wrap status', () {
+      // The DAO refuses to coerce unrecognised persisted statuses back
+      // to `pending` because that would silently re-activate a row a
+      // newer client (or a corrupt write) already moved to a terminal
+      // state — for a retry queue, that risks double-delivery. See the
+      // doc on `_parseStatus` and the table-column doc on
+      // `recipient_wrap_status`.
+      test(
+        'getById throws UnknownOutgoingWrapStatusException when a row '
+        'carries an unrecognised recipient_wrap_status',
+        () async {
+          await dao.enqueue(makeDm(id: 'aaaa'));
+          // Simulate a newer client persisting `cancelled`, or a corrupt
+          // write — bypass the DAO and write a raw value directly.
+          await database.customStatement(
+            "UPDATE outgoing_dms SET recipient_wrap_status = 'cancelled' "
+            "WHERE id = 'aaaa'",
+          );
+
+          await expectLater(
+            dao.getById('aaaa'),
+            throwsA(
+              isA<UnknownOutgoingWrapStatusException>().having(
+                (e) => e.rawValue,
+                'rawValue',
+                'cancelled',
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'getById throws when a row carries an unrecognised '
+        'self_wrap_status',
+        () async {
+          await dao.enqueue(makeDm(id: 'aaaa'));
+          await database.customStatement(
+            "UPDATE outgoing_dms SET self_wrap_status = 'archived' "
+            "WHERE id = 'aaaa'",
+          );
+
+          await expectLater(
+            dao.getById('aaaa'),
+            throwsA(
+              isA<UnknownOutgoingWrapStatusException>().having(
+                (e) => e.rawValue,
+                'rawValue',
+                'archived',
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'getStillPendingForOwner does not silently include rows with an '
+        'unknown status — it throws so the caller can surface corruption',
+        () async {
+          await dao.enqueue(makeDm(id: 'aaaa'));
+          await database.customStatement(
+            "UPDATE outgoing_dms SET recipient_wrap_status = 'cancelled' "
+            "WHERE id = 'aaaa'",
+          );
+
+          await expectLater(
+            dao.getStillPendingForOwner(ownerA),
+            throwsA(isA<UnknownOutgoingWrapStatusException>()),
+          );
+        },
+      );
     });
 
     group('isFullyDelivered + hasRetryableFailure (model getters)', () {

--- a/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
@@ -85,7 +85,8 @@ void main() {
         expect(fetched!.recipientWrapStatus, OutgoingWrapStatus.pending);
         expect(fetched.selfWrapStatus, OutgoingWrapStatus.pending);
         expect(fetched.retryCount, equals(0));
-        expect(fetched.lastError, isNull);
+        expect(fetched.recipientWrapLastError, isNull);
+        expect(fetched.selfWrapLastError, isNull);
       });
 
       test(
@@ -116,7 +117,15 @@ void main() {
           expect(fetched!.recipientWrapStatus, OutgoingWrapStatus.sent);
           expect(fetched.recipientWrapEventId, equals('rcpt-evt-id'));
           expect(fetched.selfWrapStatus, OutgoingWrapStatus.failed);
-          expect(fetched.lastError, equals('self-wrap relay rejected'));
+          expect(
+            fetched.selfWrapLastError,
+            equals('self-wrap relay rejected'),
+          );
+          expect(
+            fetched.recipientWrapLastError,
+            isNull,
+            reason: 'recipient wrap never failed; its error column stays null',
+          );
           expect(fetched.retryCount, equals(1));
         },
       );
@@ -165,9 +174,51 @@ void main() {
           final fetched = await dao.getById('aaaa');
           expect(fetched!.recipientWrapStatus, OutgoingWrapStatus.sent);
           expect(fetched.selfWrapStatus, OutgoingWrapStatus.failed);
-          expect(fetched.lastError, equals('self-wrap relay rejected'));
+          expect(
+            fetched.selfWrapLastError,
+            equals('self-wrap relay rejected'),
+          );
+          expect(
+            fetched.recipientWrapLastError,
+            isNull,
+            reason: 'recipient wrap succeeded; its error column must stay null',
+          );
           expect(fetched.isFullyDelivered, isFalse);
           expect(fetched.hasRetryableFailure, isTrue);
+        },
+      );
+
+      test(
+        'recipient failure followed by self failure preserves both '
+        'errors independently — neither overwrites the other',
+        () async {
+          await dao.enqueue(makeDm(id: 'aaaa'));
+
+          await dao.markRecipientWrapStatus(
+            id: 'aaaa',
+            status: OutgoingWrapStatus.failed,
+            lastError: 'recipient relay rejected: rate-limited',
+          );
+          await dao.markSelfWrapStatus(
+            id: 'aaaa',
+            status: OutgoingWrapStatus.failed,
+            lastError: 'self-relay timeout',
+          );
+
+          final fetched = await dao.getById('aaaa');
+          expect(
+            fetched!.recipientWrapLastError,
+            equals('recipient relay rejected: rate-limited'),
+            reason:
+                'B2 contract: per-wrap error columns mean a later self '
+                'failure must not overwrite the earlier recipient reason',
+          );
+          expect(
+            fetched.selfWrapLastError,
+            equals('self-relay timeout'),
+          );
+          expect(fetched.recipientWrapStatus, OutgoingWrapStatus.failed);
+          expect(fetched.selfWrapStatus, OutgoingWrapStatus.failed);
         },
       );
 
@@ -188,12 +239,43 @@ void main() {
         expect(before!.retryCount, equals(0));
         expect(before.lastAttemptAt, isNull);
 
+        // Capture wall-clock before/after the increment. The decoded
+        // lastAttemptAt must land inside this window — locks the codec
+        // contract so a future regression to a raw-SQL writer that
+        // disagreed about ms-vs-seconds (the bug rabble flagged on
+        // `outgoing_dms_dao.dart:306`) fails the test loudly instead of
+        // returning a year-57000 timestamp.
+        final beforeNow = DateTime.now();
         await dao.incrementRetry('aaaa');
         await dao.incrementRetry('aaaa');
+        final afterNow = DateTime.now();
 
         final after = await dao.getById('aaaa');
         expect(after!.retryCount, equals(2));
         expect(after.lastAttemptAt, isNotNull);
+        // Drift's int DateTime codec stores seconds, so the truncation
+        // may push lastAttemptAt up to one second behind beforeNow.
+        // Allow a 2-second slack on each side to absorb that and any
+        // CI scheduling noise; the bug we're guarding against would
+        // produce a value ~50,000 years off, not 2 seconds.
+        final lower = beforeNow.subtract(const Duration(seconds: 2));
+        final upper = afterNow.add(const Duration(seconds: 2));
+        expect(
+          after.lastAttemptAt!.isAfter(lower),
+          isTrue,
+          reason:
+              'lastAttemptAt ${after.lastAttemptAt} should be after $lower; '
+              'a value far in the past would suggest a codec mismatch in the '
+              'opposite direction',
+        );
+        expect(
+          after.lastAttemptAt!.isBefore(upper),
+          isTrue,
+          reason:
+              'lastAttemptAt ${after.lastAttemptAt} should be before $upper; '
+              'a value far in the future suggests incrementRetry is writing '
+              'milliseconds into a seconds-typed column',
+        );
       });
     });
 
@@ -360,23 +442,38 @@ void main() {
     group('getRetryableForOwner', () {
       test(
         'returns rows where either wrap is failed and retry_count is '
-        'under the cap',
+        'under the cap, ordered oldest queuedAt first (FIFO)',
         () async {
+          // Distinct queuedAt timestamps so the ordering assertion is
+          // meaningful — the retry service depends on FIFO so older
+          // failures are replayed before newer ones.
+          // 'self-failed' is queued FIRST and 'rcpt-failed' SECOND, so
+          // ordering by queuedAt asc must surface 'self-failed' before
+          // 'rcpt-failed' regardless of the row insertion order or
+          // alphabetical id ordering.
+
           // Both pending: not retryable yet (no failure recorded).
-          await dao.enqueue(makeDm(id: 'pending'));
-          // Recipient failed: retryable.
           await dao.enqueue(
             makeDm(
-              id: 'rcpt-failed',
-              recipientStatus: OutgoingWrapStatus.failed,
+              id: 'pending',
+              queuedAt: DateTime.utc(2026, 5),
             ),
           );
-          // Self failed (the F3 partial-delivery): retryable.
+          // Self failed (the F3 partial-delivery): retryable, queued earliest.
           await dao.enqueue(
             makeDm(
               id: 'self-failed',
               recipientStatus: OutgoingWrapStatus.sent,
               selfStatus: OutgoingWrapStatus.failed,
+              queuedAt: DateTime.utc(2026, 5, 2),
+            ),
+          );
+          // Recipient failed: retryable, queued LATER than self-failed.
+          await dao.enqueue(
+            makeDm(
+              id: 'rcpt-failed',
+              recipientStatus: OutgoingWrapStatus.failed,
+              queuedAt: DateTime.utc(2026, 5, 3),
             ),
           );
           // Both sent: not retryable.
@@ -385,6 +482,7 @@ void main() {
               id: 'both-sent',
               recipientStatus: OutgoingWrapStatus.sent,
               selfStatus: OutgoingWrapStatus.sent,
+              queuedAt: DateTime.utc(2026, 5, 4),
             ),
           );
           // Failed but past the retry cap: excluded.
@@ -393,6 +491,7 @@ void main() {
               id: 'exhausted',
               recipientStatus: OutgoingWrapStatus.failed,
               retryCount: 5,
+              queuedAt: DateTime.utc(2026, 5, 5),
             ),
           );
 
@@ -403,7 +502,11 @@ void main() {
 
           expect(
             retryable.map((e) => e.id),
-            unorderedEquals(['rcpt-failed', 'self-failed']),
+            equals(['self-failed', 'rcpt-failed']),
+            reason:
+                'FIFO contract: getRetryableForOwner orders by queuedAt asc, '
+                'so self-failed (2026-05-02) must precede rcpt-failed '
+                '(2026-05-03)',
           );
         },
       );
@@ -433,36 +536,56 @@ void main() {
     });
 
     group('getStillPendingForOwner', () {
-      test('returns rows with at least one wrap still pending', () async {
-        await dao.enqueue(makeDm(id: 'pending'));
-        await dao.enqueue(
-          makeDm(
-            id: 'half-pending',
-            recipientStatus: OutgoingWrapStatus.sent,
-          ),
-        );
-        await dao.enqueue(
-          makeDm(
-            id: 'both-sent',
-            recipientStatus: OutgoingWrapStatus.sent,
-            selfStatus: OutgoingWrapStatus.sent,
-          ),
-        );
-        await dao.enqueue(
-          makeDm(
-            id: 'failed',
-            recipientStatus: OutgoingWrapStatus.failed,
-            selfStatus: OutgoingWrapStatus.failed,
-          ),
-        );
+      test(
+        'returns rows with at least one wrap still pending, ordered '
+        'oldest queuedAt first (FIFO)',
+        () async {
+          // 'half-pending' is queued FIRST (oldest), 'pending' SECOND.
+          // Insertion order is reversed from chronological order to
+          // prove the query orders by queuedAt, not by row id or
+          // primary-key default order.
+          await dao.enqueue(
+            makeDm(
+              id: 'half-pending',
+              recipientStatus: OutgoingWrapStatus.sent,
+              queuedAt: DateTime.utc(2026, 5),
+            ),
+          );
+          await dao.enqueue(
+            makeDm(
+              id: 'pending',
+              queuedAt: DateTime.utc(2026, 5, 2),
+            ),
+          );
+          await dao.enqueue(
+            makeDm(
+              id: 'both-sent',
+              recipientStatus: OutgoingWrapStatus.sent,
+              selfStatus: OutgoingWrapStatus.sent,
+              queuedAt: DateTime.utc(2026, 5, 3),
+            ),
+          );
+          await dao.enqueue(
+            makeDm(
+              id: 'failed',
+              recipientStatus: OutgoingWrapStatus.failed,
+              selfStatus: OutgoingWrapStatus.failed,
+              queuedAt: DateTime.utc(2026, 5, 4),
+            ),
+          );
 
-        final pending = await dao.getStillPendingForOwner(ownerA);
+          final pending = await dao.getStillPendingForOwner(ownerA);
 
-        expect(
-          pending.map((e) => e.id),
-          unorderedEquals(['pending', 'half-pending']),
-        );
-      });
+          expect(
+            pending.map((e) => e.id),
+            equals(['half-pending', 'pending']),
+            reason:
+                'FIFO contract: getStillPendingForOwner orders by queuedAt '
+                'asc, so half-pending (2026-05-01) must precede pending '
+                '(2026-05-02) even though pending was inserted second',
+          );
+        },
+      );
     });
 
     group('unknown wrap status', () {

--- a/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/outgoing_dms_dao_test.dart
@@ -296,8 +296,8 @@ void main() {
 
     group('clearAllForUser', () {
       test('removes only rows owned by the given pubkey', () async {
-        await dao.enqueue(makeDm(id: 'a1', owner: ownerA));
-        await dao.enqueue(makeDm(id: 'a2', owner: ownerA));
+        await dao.enqueue(makeDm(id: 'a1'));
+        await dao.enqueue(makeDm(id: 'a2'));
         await dao.enqueue(makeDm(id: 'b1', owner: ownerB));
 
         final cleared = await dao.clearAllForUser(ownerA);

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -775,14 +775,18 @@ class DmRepository {
   /// Throws [ArgumentError] if [recipientPubkey] is not a 64-character
   /// hex string or if [content] is empty.
   ///
-  /// When an [OutgoingDmsDao] was injected, the send goes through the
+  /// When an [OutgoingDmsDao] is injected, the send goes through the
   /// durable queue: build the rumor, enqueue a `pending`/`pending` row
-  /// keyed by the rumor's id, publish, then either delete the row in
-  /// the same transaction that inserts the `direct_messages` row (full
-  /// success) or mark both wraps `failed` with the error (publish
-  /// failure). Per-wrap precision lands once #3910 surfaces
-  /// `selfWrapPublished` on `NIP17SendResult` — until then both wrap
-  /// statuses follow `result.success`.
+  /// keyed by the rumor's id, publish, then transition the queue row
+  /// by wrap outcome:
+  ///
+  /// - Full NIP-17 delivery (`selfWrapPublished == true`): delete the
+  ///   queue row in the same transaction that inserts `direct_messages`.
+  /// - Partial delivery (`selfWrapPublished == false`): keep the row,
+  ///   mark the recipient wrap `sent`, and mark the self-wrap `failed`
+  ///   so only the missing self-wrap is retried later.
+  /// - Recipient publish failure: mark both wraps `failed` and leave
+  ///   the row queued for replay.
   Future<NIP17SendResult> sendMessage({
     required String recipientPubkey,
     required String content,
@@ -847,9 +851,9 @@ class DmRepository {
         final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
         // Persist message + conversation atomically. When the queue is
-        // wired in, the queue-row delete also lives in this transaction
+        // wired in, the queue transition also lives in this transaction
         // so a watcher never observes a window where the message is in
-        // neither table.
+        // neither table and so partial delivery preserves the retry row.
         String? protocol;
         await _conversationsDao.runInTransaction(() async {
           await _directMessagesDao.insertMessage(
@@ -889,7 +893,20 @@ class DmRepository {
           );
 
           if (outgoingDao != null) {
-            await outgoingDao.deleteById(rumor.id);
+            if (result.selfWrapPublished == true) {
+              await outgoingDao.deleteById(rumor.id);
+            } else {
+              await outgoingDao.markRecipientWrapStatus(
+                id: rumor.id,
+                status: OutgoingWrapStatus.sent,
+                eventId: result.messageEventId,
+              );
+              await outgoingDao.markSelfWrapStatus(
+                id: rumor.id,
+                status: OutgoingWrapStatus.failed,
+                lastError: 'Recipient delivered, but self-wrap publish failed',
+              );
+            }
           }
         });
 
@@ -930,10 +947,8 @@ class DmRepository {
         // Local persistence failure is a degraded state, not a send failure.
       }
     } else if (outgoingDao != null) {
-      // Mark both wraps failed with the error so the retry service can
-      // pick this row up. Tying both statuses to result.success is the
-      // pre-#3910 behaviour — once selfWrapPublished is exposed on the
-      // result, the recipient and self transitions split here.
+      // Recipient publish failed before the self-wrap could land, so
+      // both wrap statuses remain retryable on the queue row.
       final errorMessage = result.error ?? 'Unknown publish failure';
       try {
         await outgoingDao.markRecipientWrapStatus(

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -68,6 +68,7 @@ class DmRepository {
     required NostrClient nostrClient,
     required DirectMessagesDao directMessagesDao,
     required ConversationsDao conversationsDao,
+    OutgoingDmsDao? outgoingDmsDao,
     DmSyncState? syncState,
     NIP17MessageService? messageService,
     String? userPubkey,
@@ -77,6 +78,7 @@ class DmRepository {
   }) : _nostrClient = nostrClient,
        _directMessagesDao = directMessagesDao,
        _conversationsDao = conversationsDao,
+       _outgoingDmsDao = outgoingDmsDao,
        _syncState = syncState,
        _messageService = messageService,
        _userPubkey = userPubkey ?? '',
@@ -87,6 +89,15 @@ class DmRepository {
   final NostrClient _nostrClient;
   final DirectMessagesDao _directMessagesDao;
   final ConversationsDao _conversationsDao;
+
+  /// Optional DAO for the durable outgoing-DM queue. When provided,
+  /// [sendMessage] enqueues a row before publishing so a crash mid-send
+  /// leaves a recoverable trace; the retry service introduced later in
+  /// the #3909 stack uses this same queue. Nullable to keep older test
+  /// fixtures working without rewiring — when `null`, [sendMessage]
+  /// keeps its previous direct-write behaviour.
+  final OutgoingDmsDao? _outgoingDmsDao;
+
   final DmSyncState? _syncState;
   NIP17MessageService? _messageService;
   String _userPubkey;
@@ -763,6 +774,15 @@ class DmRepository {
   /// Throws [StateError] if the repository has not been initialized.
   /// Throws [ArgumentError] if [recipientPubkey] is not a 64-character
   /// hex string or if [content] is empty.
+  ///
+  /// When an [OutgoingDmsDao] was injected, the send goes through the
+  /// durable queue: build the rumor, enqueue a `pending`/`pending` row
+  /// keyed by the rumor's id, publish, then either delete the row in
+  /// the same transaction that inserts the `direct_messages` row (full
+  /// success) or mark both wraps `failed` with the error (publish
+  /// failure). Per-wrap precision lands once #3910 surfaces
+  /// `selfWrapPublished` on `NIP17SendResult` — until then both wrap
+  /// statuses follow `result.success`.
   Future<NIP17SendResult> sendMessage({
     required String recipientPubkey,
     required String content,
@@ -780,22 +800,56 @@ class DmRepository {
       ...additionalTags,
       if (replyToId != null) ['e', replyToId],
     ];
+    final participants = [_userPubkey, recipientPubkey]..sort();
+    final conversationId = computeConversationId(participants);
 
-    final result = await _messageService!.sendPrivateMessage(
+    // Build the rumor up front so the queue row PK matches the rumor id
+    // the relay will see — receiver-side gift-wrap dedup keys on this id
+    // and a re-mint between enqueue and publish would defeat it.
+    final rumor = _messageService!.buildRumor(
       recipientPubkey: recipientPubkey,
       content: content,
       additionalTags: rumorTags,
+    );
+
+    // Enqueue before publish so an app crash mid-send leaves a
+    // recoverable trace. No-op when the queue dao isn't wired in
+    // (older test fixtures, NIP-04-only callers).
+    final outgoingDao = _outgoingDmsDao;
+    if (outgoingDao != null) {
+      await outgoingDao.enqueue(
+        OutgoingDm(
+          id: rumor.id,
+          conversationId: conversationId,
+          recipientPubkey: recipientPubkey,
+          content: content,
+          createdAt: rumor.createdAt,
+          rumorEventJson: jsonEncode(rumor.toJson()),
+          messageKind: rumor.kind,
+          replyToId: replyToId,
+          recipientWrapStatus: OutgoingWrapStatus.pending,
+          selfWrapStatus: OutgoingWrapStatus.pending,
+          queuedAt: DateTime.now(),
+          ownerPubkey: _userPubkey,
+        ),
+      );
+    }
+
+    final result = await _messageService!.sendRumor(
+      rumorEvent: rumor,
+      recipientPubkey: recipientPubkey,
     );
 
     if (result.success) {
       // Persist our own sent message locally so it appears immediately
       // without waiting for a relay round-trip.
       try {
-        final participants = [_userPubkey, recipientPubkey]..sort();
-        final conversationId = computeConversationId(participants);
         final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
-        // Persist message + conversation atomically.
+        // Persist message + conversation atomically. When the queue is
+        // wired in, the queue-row delete also lives in this transaction
+        // so a watcher never observes a window where the message is in
+        // neither table.
         String? protocol;
         await _conversationsDao.runInTransaction(() async {
           await _directMessagesDao.insertMessage(
@@ -833,6 +887,10 @@ class DmRepository {
             ownerPubkey: _userPubkey,
             dmProtocol: nextProtocol,
           );
+
+          if (outgoingDao != null) {
+            await outgoingDao.deleteById(rumor.id);
+          }
         });
 
         Log.debug(
@@ -870,6 +928,34 @@ class DmRepository {
         );
         // Don't rethrow — the message was published successfully.
         // Local persistence failure is a degraded state, not a send failure.
+      }
+    } else if (outgoingDao != null) {
+      // Mark both wraps failed with the error so the retry service can
+      // pick this row up. Tying both statuses to result.success is the
+      // pre-#3910 behaviour — once selfWrapPublished is exposed on the
+      // result, the recipient and self transitions split here.
+      final errorMessage = result.error ?? 'Unknown publish failure';
+      try {
+        await outgoingDao.markRecipientWrapStatus(
+          id: rumor.id,
+          status: OutgoingWrapStatus.failed,
+          lastError: errorMessage,
+        );
+        await outgoingDao.markSelfWrapStatus(
+          id: rumor.id,
+          status: OutgoingWrapStatus.failed,
+          lastError: errorMessage,
+        );
+      } on Object catch (e, stackTrace) {
+        Log.error(
+          'Failed to mark outgoing_dms row failed for ${rumor.id}: $e',
+          category: LogCategory.system,
+          error: e,
+          stackTrace: stackTrace,
+        );
+        // Don't rethrow — caller already gets the failure result. The
+        // queue row stays in pending/pending; getStillPendingForOwner
+        // will surface it on the next retry sweep.
       }
     }
 

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -54,23 +54,48 @@ class NIP17MessageService {
   /// Access to the underlying NostrService for relay management
   NostrClient get nostrService => _nostrService;
 
-  /// Send a private encrypted message to a recipient.
+  /// Build the unsigned NIP-17 rumor event for a 1:1 send.
   ///
-  /// Uses NIP-17 three-layer encryption:
-  /// 1. Rumor (unsigned) — the actual message content
-  /// 2. Kind 13 (seal) — signed and encrypted by sender
-  /// 3. Kind 1059 (gift wrap) — wrapped with random ephemeral key
+  /// Pure construction — does not touch relays or the signer. Exposed
+  /// separately from [sendRumor] so the repository can persist the
+  /// rumor (or its serialized JSON) into the durable outgoing-DM queue
+  /// **before** publishing, keyed by the rumor's id. Without this split
+  /// a publish that succeeds with the recipient relay but the app
+  /// crashes before [sendPrivateMessage] returns leaves no local
+  /// trace of the in-flight send.
   ///
   /// Parameters:
   /// - [recipientPubkey]: Recipient's public key (hex format)
   /// - [content]: Message content (text for kind 14, file URL for kind 15)
   /// - [eventKind]: The rumor event kind (14 = text, 15 = file)
   /// - [additionalTags]: Optional tags to include in the rumor event
-  Future<NIP17SendResult> sendPrivateMessage({
+  Event buildRumor({
     required String recipientPubkey,
     required String content,
     int eventKind = EventKind.privateDirectMessage,
     List<List<String>> additionalTags = const [],
+  }) {
+    final rumorTags = <List<String>>[
+      ['p', recipientPubkey],
+      ...additionalTags,
+    ];
+
+    return Event(_senderPublicKey, eventKind, rumorTags, content);
+  }
+
+  /// Wrap and publish a pre-built [rumorEvent] to the recipient and to
+  /// ourselves (self-addressed gift wrap for cross-device recovery).
+  ///
+  /// Self-wrap failure is intentionally non-fatal — the message has
+  /// already been delivered to the recipient at that point, and
+  /// blocking the success result on the self-wrap would cause the
+  /// repository to mark a successfully-delivered message as failed and
+  /// retry the recipient publish, double-delivering. A future revision
+  /// (PR #3910) will surface the self-wrap outcome separately so the
+  /// repository can mark each wrap status independently.
+  Future<NIP17SendResult> sendRumor({
+    required Event rumorEvent,
+    required String recipientPubkey,
   }) async {
     try {
       Log.info(
@@ -87,16 +112,8 @@ class NIP17MessageService {
       );
       await nostr.refreshPublicKey();
 
-      // Create kind 14 rumor event (unsigned, will be encrypted)
-      final rumorTags = <List<String>>[
-        ['p', recipientPubkey],
-        ...additionalTags,
-      ];
-
-      final rumorEvent = Event(_senderPublicKey, eventKind, rumorTags, content);
-
       Log.debug(
-        'Created kind $eventKind rumor event',
+        'Wrapping kind ${rumorEvent.kind} rumor event',
         category: LogCategory.system,
       );
 
@@ -191,6 +208,30 @@ class NIP17MessageService {
       );
       return NIP17SendResult.failure('Failed to send message: $e');
     }
+  }
+
+  /// Convenience wrapper that builds a rumor and sends it in one call.
+  ///
+  /// Existing callers (group sends, file sends, NIP-04 fallback wiring)
+  /// keep working unchanged. New callers that need to enqueue a durable
+  /// queue row keyed by the rumor's id should call [buildRumor] +
+  /// [sendRumor] directly so the queue insert happens between the two.
+  Future<NIP17SendResult> sendPrivateMessage({
+    required String recipientPubkey,
+    required String content,
+    int eventKind = EventKind.privateDirectMessage,
+    List<List<String>> additionalTags = const [],
+  }) async {
+    final rumor = buildRumor(
+      recipientPubkey: recipientPubkey,
+      content: content,
+      eventKind: eventKind,
+      additionalTags: additionalTags,
+    );
+    return sendRumor(
+      rumorEvent: rumor,
+      recipientPubkey: recipientPubkey,
+    );
   }
 
   /// Dummy relay generator - we don't use relays in this Nostr instance

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -7400,7 +7400,7 @@ void main() {
         ).thenAnswer((_) async => null);
         when(
           () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => null);
+        ).thenAnswer((_) async => const PublishFailed());
       });
 
       test(
@@ -7482,7 +7482,7 @@ void main() {
               additionalTags: any(named: 'additionalTags'),
             ),
           ).thenAnswer(
-            (_) async => NIP17SendResult.failure('relay unavailable'),
+            (_) async => const NIP17SendResult.failure('relay unavailable'),
           );
 
           final repository = createRepository(
@@ -7501,11 +7501,8 @@ void main() {
           ).captured;
           final enqueued = captured.single as OutgoingDm;
 
-          // Both wraps must be marked failed with the error so the
-          // retry service can pick them up. Pre-#3910 both transitions
-          // are tied to overall result.success; once #3910 surfaces
-          // selfWrapPublished, the recipient and self transitions
-          // diverge here.
+          // Recipient publish failed before the self-wrap could land,
+          // so both wrap states stay retryable.
           verify(
             () => mockOutgoingDmsDao.markRecipientWrapStatus(
               id: enqueued.id,
@@ -7552,6 +7549,86 @@ void main() {
               tagsJson: any(named: 'tagsJson'),
             ),
           );
+        },
+      );
+
+      test(
+        'on partial delivery: persists locally, keeps the queue row, '
+        'marks recipient sent, and marks self failed',
+        () async {
+          when(
+            () => mockMessageService.sendPrivateMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              eventKind: any(named: 'eventKind'),
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId,
+              recipientPubkey: _validPubkeyB,
+              selfWrapPublished: false,
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'recipient got it, self-wrap failed',
+          );
+
+          expect(result.success, isTrue);
+          expect(result.selfWrapPublished, isFalse);
+
+          final captured = verify(
+            () => mockOutgoingDmsDao.enqueue(captureAny()),
+          ).captured;
+          final enqueued = captured.single as OutgoingDm;
+
+          verify(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: enqueued.id,
+              status: OutgoingWrapStatus.sent,
+              eventId: _giftWrapEventId,
+            ),
+          ).called(1);
+          verify(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: enqueued.id,
+              status: OutgoingWrapStatus.failed,
+              lastError: 'Recipient delivered, but self-wrap publish failed',
+            ),
+          ).called(1);
+          verifyNever(() => mockOutgoingDmsDao.deleteById(any()));
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: _rumorEventId,
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: _validPubkeyA,
+              content: 'recipient got it, self-wrap failed',
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: _giftWrapEventId,
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: _validPubkeyA,
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).called(1);
         },
       );
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -18,6 +18,10 @@ import 'package:nostr_sdk/filter.dart' as nostr_filter;
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
 
+class _MockOutgoingDmsDao extends Mock implements OutgoingDmsDao {}
+
+class _FakeOutgoingDm extends Fake implements OutgoingDm {}
+
 class _MockNostrClient extends Mock implements NostrClient {}
 
 class _MockNIP17MessageService extends Mock implements NIP17MessageService {}
@@ -97,6 +101,8 @@ void main() {
 
     setUpAll(() {
       registerFallbackValue(_FakeEvent());
+      registerFallbackValue(_FakeOutgoingDm());
+      registerFallbackValue(OutgoingWrapStatus.pending);
     });
 
     setUp(() {
@@ -143,6 +149,73 @@ void main() {
         final callback = inv.positionalArguments[0] as Future<Null> Function();
         await callback();
       });
+
+      // Default stub for buildRumor — production sendMessage now calls
+      // buildRumor first to enqueue a queue row keyed by the rumor's id
+      // before publishing. Returning a real Event so .id is computed
+      // deterministically from the rumor fields, matching what the
+      // production message service does.
+      when(
+        () => mockMessageService.buildRumor(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          eventKind: any(named: 'eventKind'),
+          additionalTags: any(named: 'additionalTags'),
+        ),
+      ).thenAnswer((inv) {
+        final recipient = inv.namedArguments[#recipientPubkey] as String;
+        final content = inv.namedArguments[#content] as String;
+        final eventKind =
+            (inv.namedArguments[#eventKind] as int?) ??
+            EventKind.privateDirectMessage;
+        final additionalTags =
+            (inv.namedArguments[#additionalTags] as List<List<String>>?) ??
+            const <List<String>>[];
+        return Event(
+          _validPubkeyA,
+          eventKind,
+          [
+            ['p', recipient],
+            ...additionalTags,
+          ],
+          content,
+        );
+      });
+
+      // Forward sendRumor invocations to sendPrivateMessage so the many
+      // existing `when(() => mockMessageService.sendPrivateMessage(...))`
+      // stubs and `verify(() => mockMessageService.sendPrivateMessage(...))`
+      // assertions in this file keep working unchanged after the
+      // refactor that split sendPrivateMessage into buildRumor +
+      // sendRumor. The forwarded call records both invocations on the
+      // mock — sendRumor for new tests that target the split, and
+      // sendPrivateMessage for the legacy assertions.
+      when(
+        () => mockMessageService.sendRumor(
+          rumorEvent: any(named: 'rumorEvent'),
+          recipientPubkey: any(named: 'recipientPubkey'),
+        ),
+      ).thenAnswer((inv) async {
+        final rumorEvent = inv.namedArguments[#rumorEvent] as Event;
+        final recipientPubkey = inv.namedArguments[#recipientPubkey] as String;
+        // additionalTags excludes the leading p-tag that buildRumor
+        // injected, so the legacy verify assertions match the original
+        // caller-supplied tags exactly.
+        final passthroughTags = rumorEvent.tags
+            .where(
+              (tag) =>
+                  !(tag.length >= 2 &&
+                      tag[0] == 'p' &&
+                      tag[1] == recipientPubkey),
+            )
+            .toList();
+        return mockMessageService.sendPrivateMessage(
+          recipientPubkey: recipientPubkey,
+          content: rumorEvent.content,
+          eventKind: rumorEvent.kind,
+          additionalTags: passthroughTags,
+        );
+      });
     });
 
     DmRepository createRepository({
@@ -150,12 +223,14 @@ void main() {
       RumorDecryptor? rumorDecryptor,
       Nip04Decryptor? nip04Decryptor,
       DmSyncState? syncState,
+      OutgoingDmsDao? outgoingDmsDao,
     }) {
       return DmRepository(
         nostrClient: mockNostrClient,
         messageService: mockMessageService,
         directMessagesDao: mockDirectMessagesDao,
         conversationsDao: mockConversationsDao,
+        outgoingDmsDao: outgoingDmsDao,
         userPubkey: userPubkey ?? _validPubkeyA,
         signer: LocalNostrSigner(_validPrivateKey),
         rumorDecryptor: rumorDecryptor,
@@ -7239,6 +7314,279 @@ void main() {
               dmProtocol: 'nip17',
             ),
           ).called(1);
+        },
+      );
+    });
+
+    group('sendMessage with outgoing_dms queue wired in', () {
+      late _MockOutgoingDmsDao mockOutgoingDmsDao;
+
+      setUp(() {
+        mockOutgoingDmsDao = _MockOutgoingDmsDao();
+        // Default stubs covering the queue lifecycle a successful or
+        // failed send touches.
+        when(
+          () => mockOutgoingDmsDao.enqueue(any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockOutgoingDmsDao.deleteById(any()),
+        ).thenAnswer((_) async => 1);
+        when(
+          () => mockOutgoingDmsDao.markRecipientWrapStatus(
+            id: any(named: 'id'),
+            status: any(named: 'status'),
+            eventId: any(named: 'eventId'),
+            lastError: any(named: 'lastError'),
+          ),
+        ).thenAnswer((_) async => true);
+        when(
+          () => mockOutgoingDmsDao.markSelfWrapStatus(
+            id: any(named: 'id'),
+            status: any(named: 'status'),
+            eventId: any(named: 'eventId'),
+            lastError: any(named: 'lastError'),
+          ),
+        ).thenAnswer((_) async => true);
+
+        // Surrounding stubs the success path needs (insertMessage,
+        // upsertConversation, getConversation, publishEvent for the
+        // NIP-04 fallback).
+        when(
+          () => mockDirectMessagesDao.insertMessage(
+            id: any(named: 'id'),
+            conversationId: any(named: 'conversationId'),
+            senderPubkey: any(named: 'senderPubkey'),
+            content: any(named: 'content'),
+            createdAt: any(named: 'createdAt'),
+            giftWrapId: any(named: 'giftWrapId'),
+            messageKind: any(named: 'messageKind'),
+            replyToId: any(named: 'replyToId'),
+            subject: any(named: 'subject'),
+            fileType: any(named: 'fileType'),
+            encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+            decryptionKey: any(named: 'decryptionKey'),
+            decryptionNonce: any(named: 'decryptionNonce'),
+            fileHash: any(named: 'fileHash'),
+            originalFileHash: any(named: 'originalFileHash'),
+            fileSize: any(named: 'fileSize'),
+            dimensions: any(named: 'dimensions'),
+            blurhash: any(named: 'blurhash'),
+            thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            tagsJson: any(named: 'tagsJson'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockConversationsDao.upsertConversation(
+            id: any(named: 'id'),
+            participantPubkeys: any(named: 'participantPubkeys'),
+            isGroup: any(named: 'isGroup'),
+            createdAt: any(named: 'createdAt'),
+            lastMessageContent: any(named: 'lastMessageContent'),
+            lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+            lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+            subject: any(named: 'subject'),
+            isRead: any(named: 'isRead'),
+            currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            dmProtocol: any(named: 'dmProtocol'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockNostrClient.publishEvent(any()),
+        ).thenAnswer((_) async => null);
+      });
+
+      test(
+        'enqueues a pending row with the rumor id, then deletes it on '
+        'full delivery',
+        () async {
+          when(
+            () => mockMessageService.sendPrivateMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              eventKind: any(named: 'eventKind'),
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId,
+              recipientPubkey: _validPubkeyB,
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'queue-wired message',
+          );
+
+          expect(result.success, isTrue);
+
+          // Capture the enqueue call so we can assert the row shape and
+          // re-use the rumor id for the deleteById verify.
+          final captured = verify(
+            () => mockOutgoingDmsDao.enqueue(captureAny()),
+          ).captured;
+          expect(captured, hasLength(1));
+          final enqueued = captured.single as OutgoingDm;
+          expect(enqueued.recipientPubkey, equals(_validPubkeyB));
+          expect(enqueued.ownerPubkey, equals(_validPubkeyA));
+          expect(enqueued.content, equals('queue-wired message'));
+          expect(enqueued.recipientWrapStatus, OutgoingWrapStatus.pending);
+          expect(enqueued.selfWrapStatus, OutgoingWrapStatus.pending);
+          expect(
+            enqueued.id,
+            isNotEmpty,
+            reason:
+                'queue PK is the rumor id; the buildRumor stub computes '
+                'a deterministic id from rumor fields',
+          );
+
+          verify(
+            () => mockOutgoingDmsDao.deleteById(enqueued.id),
+          ).called(1);
+          // The failure-path mark methods must NOT fire on a successful
+          // send — that would leave the row in a phantom failed state
+          // even though delivery succeeded.
+          verifyNever(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: any(named: 'id'),
+              status: any(named: 'status'),
+              eventId: any(named: 'eventId'),
+              lastError: any(named: 'lastError'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'on publish failure: marks both wraps failed with the error '
+        'and leaves the row for the retry service',
+        () async {
+          when(
+            () => mockMessageService.sendPrivateMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              eventKind: any(named: 'eventKind'),
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.failure('relay unavailable'),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'this will fail',
+          );
+
+          expect(result.success, isFalse);
+
+          final captured = verify(
+            () => mockOutgoingDmsDao.enqueue(captureAny()),
+          ).captured;
+          final enqueued = captured.single as OutgoingDm;
+
+          // Both wraps must be marked failed with the error so the
+          // retry service can pick them up. Pre-#3910 both transitions
+          // are tied to overall result.success; once #3910 surfaces
+          // selfWrapPublished, the recipient and self transitions
+          // diverge here.
+          verify(
+            () => mockOutgoingDmsDao.markRecipientWrapStatus(
+              id: enqueued.id,
+              status: OutgoingWrapStatus.failed,
+              lastError: 'relay unavailable',
+            ),
+          ).called(1);
+          verify(
+            () => mockOutgoingDmsDao.markSelfWrapStatus(
+              id: enqueued.id,
+              status: OutgoingWrapStatus.failed,
+              lastError: 'relay unavailable',
+            ),
+          ).called(1);
+          // On failure the row stays put — deleteById must not fire,
+          // otherwise the user loses the failed bubble + retry option.
+          verifyNever(
+            () => mockOutgoingDmsDao.deleteById(any()),
+          );
+          // direct_messages must not be inserted — that's reserved for
+          // confirmed deliveries.
+          verifyNever(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'queue is opt-in: when no OutgoingDmsDao is injected, '
+        'sendMessage falls back to the direct-write behaviour and '
+        'never touches the queue',
+        () async {
+          when(
+            () => mockMessageService.sendPrivateMessage(
+              recipientPubkey: any(named: 'recipientPubkey'),
+              content: any(named: 'content'),
+              eventKind: any(named: 'eventKind'),
+              additionalTags: any(named: 'additionalTags'),
+            ),
+          ).thenAnswer(
+            (_) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId,
+              recipientPubkey: _validPubkeyB,
+            ),
+          );
+
+          // No outgoingDmsDao argument — older test fixtures and
+          // (until provider is updated) production paths.
+          final repository = createRepository();
+
+          final result = await repository.sendMessage(
+            recipientPubkey: _validPubkeyB,
+            content: 'no queue here',
+          );
+
+          expect(result.success, isTrue);
+          verifyNever(() => mockOutgoingDmsDao.enqueue(any()));
+          verifyNever(() => mockOutgoingDmsDao.deleteById(any()));
         },
       );
     });

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -646,5 +646,117 @@ void main() {
         },
       );
     });
+
+    group('buildRumor + sendRumor split', () {
+      test(
+        'buildRumor returns the unsigned rumor event without touching '
+        'the relay or signer',
+        () async {
+          final rumor = service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'queue this before publishing',
+          );
+
+          expect(rumor.kind, equals(EventKind.privateDirectMessage));
+          expect(rumor.content, equals('queue this before publishing'));
+          expect(rumor.pubkey, equals(_testPublicKey));
+          expect(
+            rumor.tags.first,
+            equals(['p', _recipientPubkey]),
+            reason: 'p-tag must be the first tag for NIP-17 compliance',
+          );
+          expect(
+            rumor.id,
+            isNotEmpty,
+            reason:
+                'Event constructor computes the rumor id deterministically '
+                'from its fields — DmRepository keys the queue row by it',
+          );
+          // No publish should fire from a pure build call.
+          verifyNever(() => mockNostrClient.publishEvent(any()));
+        },
+      );
+
+      test(
+        'sendRumor wraps and publishes a pre-built rumor with the same '
+        'rumor id as buildRumor returned',
+        () async {
+          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+            (invocation) async => invocation.positionalArguments[0] as Event,
+          );
+
+          final rumor = service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'split-flow message',
+          );
+          final rumorIdBeforeSend = rumor.id;
+
+          final result = await service.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+          );
+
+          expect(result.success, isTrue);
+          expect(
+            result.rumorEventId,
+            equals(rumorIdBeforeSend),
+            reason:
+                'sendRumor must surface the same rumor id the caller saw '
+                'from buildRumor — the queue row PK depends on this',
+          );
+          expect(result.recipientPubkey, equals(_recipientPubkey));
+        },
+      );
+
+      test(
+        'buildRumor includes additional tags after the recipient p-tag',
+        () {
+          final rumor = service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'reply test',
+            additionalTags: [
+              ['e', 'parent-message-id'],
+            ],
+          );
+
+          expect(rumor.tags, [
+            ['p', _recipientPubkey],
+            ['e', 'parent-message-id'],
+          ]);
+        },
+      );
+
+      test(
+        'buildRumor honors a non-default eventKind so kind 15 file '
+        'messages can be enqueued before publishing',
+        () {
+          final rumor = service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'https://example.com/file.enc',
+            eventKind: EventKind.fileMessage,
+          );
+
+          expect(rumor.kind, equals(EventKind.fileMessage));
+        },
+      );
+
+      test(
+        'sendPrivateMessage convenience wrapper still works (delegates '
+        'to buildRumor + sendRumor)',
+        () async {
+          when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+            (invocation) async => invocation.positionalArguments[0] as Event,
+          );
+
+          final result = await service.sendPrivateMessage(
+            recipientPubkey: _recipientPubkey,
+            content: 'convenience-wrapper smoke test',
+          );
+
+          expect(result.success, isTrue);
+          expect(result.rumorEventId, isNotNull);
+        },
+      );
+    });
   });
 }

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -682,7 +682,9 @@ void main() {
         'rumor id as buildRumor returned',
         () async {
           when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-            (invocation) async => invocation.positionalArguments[0] as Event,
+            (invocation) async => PublishSuccess(
+              event: invocation.positionalArguments[0] as Event,
+            ),
           );
 
           final rumor = service.buildRumor(
@@ -745,7 +747,9 @@ void main() {
         'to buildRumor + sendRumor)',
         () async {
           when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-            (invocation) async => invocation.positionalArguments[0] as Event,
+            (invocation) async => PublishSuccess(
+              event: invocation.positionalArguments[0] as Event,
+            ),
           );
 
           final result = await service.sendPrivateMessage(


### PR DESCRIPTION
## Description

Step 2 of the #3909 stack. Adds the persistence layer for the durable
outgoing-DM queue. Pure data layer — no behavior change for users yet,
no new wiring outside the `db_client` package.

**Related Issue:** Relates to #3909 (follow-up to #3902 / #3908)

### What's in here

`outgoing_dms` Drift table with **two independent** wrap-status
columns. NIP-17 sends are two relay publishes (recipient gift wrap +
self-addressed gift wrap), so the queue must track them separately —
otherwise a partial delivery either gets re-published to the recipient
(double-deliver) or the row is dropped and the sender silently loses
their own message.

| column | purpose |
|---|---|
| `id` (PK) | The rumor event id — stable across retries because `rumor_event_json` stores the serialized rumor (rumor.id is a hash of its fields, so re-mint would break receiver-side dedup) |
| `conversation_id` | Same shape as `direct_messages.conversation_id` so the BLoC can `Rx.combineLatest2(watchMessages, watchOutgoing)` for a unified timeline |
| `rumor_event_json` | The unsigned rumor JSON; retries re-wrap **this** instead of minting a new rumor |
| `recipient_wrap_status` | `pending` / `sent` / `failed`. String-encoded enum so new states (e.g. `cancelled`) don't need a schema bump |
| `self_wrap_status` | Same enum, independent transitions. The `false` value of `NIP17SendResult.selfWrapPublished` (from #3910) flips this to `failed` |
| `recipient_wrap_event_id` / `self_wrap_event_id` | Published kind-1059 ids for downstream debugging |
| `retry_count`, `last_error`, `last_attempt_at` | Mirror `PendingActions` for the retry service's backoff |
| `queued_at` | Ordering for retry sweeps |
| `owner_pubkey` | Multi-account isolation, mirroring `direct_messages.owner_pubkey` |

Indexes for the access patterns the queue + retry service need:
per-conversation watch, per-wrap-status retry sweeps, queued-at
ordering.

### Schema management

Schema version stays at **1**. The table is registered via the existing
`_createMissingTables` runtime CREATE-IF-NOT-EXISTS pattern, mirroring
`personal_reposts` (`app_database.dart:85-100`) and
`nip05_verifications`. Fresh installs get it via Drift's `m.createAll()`
on first open; existing installs get it on next launch via the
runtime check. No formal Drift migration to write.

### DAO

`OutgoingDmsDao` mirrors `PendingActionsDao`:

- `enqueue` (idempotent via `insertOnConflictUpdate` — retry-enqueue
  is a no-op)
- `markRecipientWrapStatus` / `markSelfWrapStatus` — independent
  transitions
- `incrementRetry`, `deleteById`
- `getById`, `watchForConversation`, `watchAllForOwner`
- `getRetryableForOwner` (max-retry-cap filter)
- `getStillPendingForOwner` (recovers in-flight sends after an app
  kill that interrupted the publish before mark-sent / mark-failed)

Domain model `OutgoingDm` exposes derived getters so callers don't
reason about the two enums by hand:
- `isFullyDelivered` — both wraps sent (the queue row is deleted in
  the same transaction that inserts the `direct_messages` row)
- `hasRetryableFailure` — either wrap failed (drives the retry
  service's enumeration)

### What this PR deliberately does NOT do

- No `DmRepository.sendMessage` rewire — that's PR 3 in the stack.
- No retry service — PR 4.
- No BLoC / UI changes — PR 5.
- No formal Drift migration — schema version 1 stays put per the
  existing pattern.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Test plan

Automated:
- [x] `dart analyze` — clean.
- [x] `dart format` — no changes.
- [x] `flutter test` — `packages/db_client` 586/586 passing.
- [x] `flutter analyze lib test` — clean (mobile app builds against the
  new exports).

New tests in `outgoing_dms_dao_test.dart` (20 / 20 passing):
- enqueue: inserts pending row, idempotent re-enqueue
- markRecipientWrapStatus: flips status, records eventId, leaves
  self status untouched
- markSelfWrapStatus: flips status independently of recipient (the
  partial-delivery state)
- markXxxWrapStatus on missing id: returns false
- incrementRetry: bumps count and lastAttemptAt
- deleteById: removes row, returns affected count
- watchForConversation: emits initial empty, after enqueue, after
  delete (split into separate tests to avoid Drift coalescing
  multiple writes into one emission)
- watchForConversation: owner-pubkey isolation, conversation-id
  isolation
- getRetryableForOwner: returns rows with either wrap failed and
  under retry cap; excludes both-pending, both-sent, and exhausted
- getStillPendingForOwner: returns half-pending or both-pending
- isFullyDelivered + hasRetryableFailure model getters across the
  full status matrix
- multi-owner / multi-recipient / multi-conversation end-to-end
  isolation

Manual verification (please confirm during review):
- [ ] No-op verification: existing installs that upgrade should NOT
  see any data loss; the new table is additive.
- [ ] Fresh-install verification: `outgoing_dms` table appears in the
  DB schema on first launch.

## Stacking

Part of the #3909 stack:

1. ✅ #3910 — surface per-wrap publish status (foundation)
2. **This PR** — `outgoing_dms` table + DAO (data layer)
3. Next: `DmRepository.sendMessage` rewires through the queue (uses
   #3910's `selfWrapPublished` to write the per-wrap status here)
4. Then: `OutgoingDmRetryService` (connectivity-driven retry)
5. Then: BLoC + UI (per-bubble delivery indicator + retry/cancel)

Independent of #3910 in code (different files); both can be reviewed
in parallel.