### PR TITLE
fix(auth): preserve verification flow through sign out

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -972,9 +972,6 @@ AuthService authService(Ref ref) {
   final oauthClient = ref.watch(oauthClientProvider);
   final flutterSecureStorage = ref.watch(flutterSecureStorageProvider);
   final oauthConfig = ref.watch(oauthConfigProvider);
-  final pendingVerificationService = ref.watch(
-    pendingVerificationServiceProvider,
-  );
   // NOTE: We construct FunnelcakeApiClient directly here instead of using
   // funnelcakeApiClientProvider to avoid a circular dependency:
   //   authService → funnelcakeApiClient → nostrService → authService
@@ -987,7 +984,6 @@ AuthService authService(Ref ref) {
     oauthClient: oauthClient,
     flutterSecureStorage: flutterSecureStorage,
     oauthConfig: oauthConfig,
-    pendingVerificationService: pendingVerificationService,
     profileCheckIndexerUrl: authEnv.indexerRelays.first,
     indexerRelays: authEnv.indexerRelays,
     primaryRelayUrl: authEnv.relayUrl,

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -2320,7 +2320,7 @@ final class AuthServiceProvider
   }
 }
 
-String _$authServiceHash() => r'0186da78bd76297e5f2a4ad6f558b4108cbd8015';
+String _$authServiceHash() => r'5ed8b2e4f69b956cef94207839973aa1f676df4c';
 
 /// Provider that returns current auth state and rebuilds when it changes.
 /// Widgets should watch this instead of authService.authState directly

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -26,7 +26,6 @@ import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/local_key_signer.dart';
 import 'package:openvine/services/nostr_identity.dart';
-import 'package:openvine/services/pending_verification_service.dart';
 import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:openvine/utils/divine_login_banner_dismissal.dart';
@@ -165,7 +164,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     KeycastOAuth? oauthClient,
     FlutterSecureStorage? flutterSecureStorage,
     OAuthConfig? oauthConfig,
-    PendingVerificationService? pendingVerificationService,
     PreFetchFollowingCallback? preFetchFollowing,
     String? profileCheckIndexerUrl,
     List<String>? indexerRelays,
@@ -176,7 +174,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
        _userDataCleanupService = userDataCleanupService,
        _oauthClient = oauthClient,
        _flutterSecureStorage = flutterSecureStorage,
-       _pendingVerificationService = pendingVerificationService,
        _preFetchFollowing = preFetchFollowing,
        _profileCheckIndexerUrl = profileCheckIndexerUrl,
        _primaryRelayUrl = primaryRelayUrl ?? AppConstants.defaultRelayUrl,
@@ -191,7 +188,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   final UserDataCleanupService _userDataCleanupService;
   final KeycastOAuth? _oauthClient;
   final FlutterSecureStorage? _flutterSecureStorage;
-  final PendingVerificationService? _pendingVerificationService;
   final PreFetchFollowingCallback? _preFetchFollowing;
   final String? _profileCheckIndexerUrl;
 
@@ -3121,10 +3117,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           await KeycastSession.clear(_flutterSecureStorage);
         }
       } catch (_) {}
-
-      // Clear any pending verification data
-      // (fire-and-forget since it's best-effort)
-      unawaited(_pendingVerificationService?.clear());
 
       // Redirect recovery prefs AFTER all signer cleanup so that
       // _restoreSignerInfo can re-stage the remaining account's archived


### PR DESCRIPTION
Preserve pending email-verification state across sign-out so the registration handoff is not lost before the verify-email callback arrives.

Verification:
- flutter test test/services/auth_service_signout_cleanup_test.dart test/services/email_verification_listener_test.dart test/screens/auth/email_verification_screen_test.dart
- pre-commit analyzer and generated-files checks passed on the rebased branch