### PR TITLE
fix(auth): recover duplicate sign-up to sign in

### DIFF
--- a/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_cubit.dart
@@ -53,11 +53,16 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
   final bool _requirePasswordConfirmation;
 
   /// Initialize form with default state (sign up mode)
-  void initialize({bool isSignIn = false, String? initialEmail}) {
+  void initialize({
+    bool isSignIn = false,
+    String? initialEmail,
+    String? initialGeneralError,
+  }) {
     emit(
       DivineAuthFormState(
         isSignIn: isSignIn,
         email: initialEmail ?? '',
+        generalError: initialGeneralError,
         requiresPasswordConfirmation: _requirePasswordConfirmation && !isSignIn,
       ),
     );
@@ -254,7 +259,13 @@ class DivineAuthCubit extends Cubit<DivineAuthState> {
 
       final current = state;
       if (current is DivineAuthFormState) {
-        emit(current.copyWith(isSubmitting: false, generalError: errorMsg));
+        emit(
+          current.copyWith(
+            isSubmitting: false,
+            generalError: errorMsg,
+            showLoginOptionsRecovery: result.errorCode == 'CONFLICT',
+          ),
+        );
       }
       return;
     }

--- a/mobile/lib/blocs/divine_auth/divine_auth_state.dart
+++ b/mobile/lib/blocs/divine_auth/divine_auth_state.dart
@@ -31,6 +31,7 @@ class DivineAuthFormState extends DivineAuthState {
     this.showInviteGateRecovery = false,
     this.inviteRecoveryCode,
     this.inviteRecoverySourceSlug,
+    this.showLoginOptionsRecovery = false,
     this.obscurePassword = true,
     this.isSubmitting = false,
     this.isSkipping = false,
@@ -72,6 +73,9 @@ class DivineAuthFormState extends DivineAuthState {
   /// Creator source slug to preserve when recovery falls back to waitlist.
   final String? inviteRecoverySourceSlug;
 
+  /// Whether the UI should route the user to sign in instead.
+  final bool showLoginOptionsRecovery;
+
   /// Whether password is obscured in the UI
   final bool obscurePassword;
 
@@ -105,6 +109,7 @@ class DivineAuthFormState extends DivineAuthState {
     bool? showInviteGateRecovery,
     String? inviteRecoveryCode,
     String? inviteRecoverySourceSlug,
+    bool? showLoginOptionsRecovery,
     bool? obscurePassword,
     bool? isSubmitting,
     bool? isSkipping,
@@ -140,6 +145,8 @@ class DivineAuthFormState extends DivineAuthState {
       inviteRecoverySourceSlug: clearInviteGateRecovery
           ? null
           : (inviteRecoverySourceSlug ?? this.inviteRecoverySourceSlug),
+      showLoginOptionsRecovery:
+          showLoginOptionsRecovery ?? this.showLoginOptionsRecovery,
       obscurePassword: obscurePassword ?? this.obscurePassword,
       isSubmitting: isSubmitting ?? this.isSubmitting,
       isSkipping: isSkipping ?? this.isSkipping,
@@ -160,6 +167,7 @@ class DivineAuthFormState extends DivineAuthState {
     showInviteGateRecovery,
     inviteRecoveryCode,
     inviteRecoverySourceSlug,
+    showLoginOptionsRecovery,
     obscurePassword,
     isSubmitting,
     isSkipping,

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -972,9 +972,6 @@ AuthService authService(Ref ref) {
   final oauthClient = ref.watch(oauthClientProvider);
   final flutterSecureStorage = ref.watch(flutterSecureStorageProvider);
   final oauthConfig = ref.watch(oauthConfigProvider);
-  final pendingVerificationService = ref.watch(
-    pendingVerificationServiceProvider,
-  );
   // NOTE: We construct FunnelcakeApiClient directly here instead of using
   // funnelcakeApiClientProvider to avoid a circular dependency:
   //   authService → funnelcakeApiClient → nostrService → authService
@@ -987,7 +984,6 @@ AuthService authService(Ref ref) {
     oauthClient: oauthClient,
     flutterSecureStorage: flutterSecureStorage,
     oauthConfig: oauthConfig,
-    pendingVerificationService: pendingVerificationService,
     profileCheckIndexerUrl: authEnv.indexerRelays.first,
     indexerRelays: authEnv.indexerRelays,
     primaryRelayUrl: authEnv.relayUrl,

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -2320,7 +2320,7 @@ final class AuthServiceProvider
   }
 }
 
-String _$authServiceHash() => r'0186da78bd76297e5f2a4ad6f558b4108cbd8015';
+String _$authServiceHash() => r'5ed8b2e4f69b956cef94207839973aa1f676df4c';
 
 /// Provider that returns current auth state and rebuilds when it changes.
 /// Widgets should watch this instead of authService.authState directly

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -644,7 +644,10 @@ final goRouterProvider = Provider<GoRouter>((ref) {
           GoRoute(
             path: 'login-options',
             name: LoginOptionsScreen.routeName,
-            builder: (_, _) => const LoginOptionsScreen(),
+            builder: (_, state) => LoginOptionsScreen(
+              initialEmail: state.uri.queryParameters['email'],
+              initialError: state.uri.queryParameters['error'],
+            ),
             routes: [
               // Route for deep link when resetting password
               GoRoute(

--- a/mobile/lib/screens/auth/create_account_screen.dart
+++ b/mobile/lib/screens/auth/create_account_screen.dart
@@ -69,8 +69,19 @@ class _CreateAccountView extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocListener<DivineAuthCubit, DivineAuthState>(
       listenWhen: (prev, next) =>
-          next is DivineAuthEmailVerification || next is DivineAuthSuccess,
+          next is DivineAuthEmailVerification ||
+          next is DivineAuthSuccess ||
+          next is DivineAuthFormState && next.showLoginOptionsRecovery,
       listener: (context, state) {
+        if (state is DivineAuthFormState && state.showLoginOptionsRecovery) {
+          context.go(
+            WelcomeScreen.loginOptionsPathWithRecovery(
+              email: state.email,
+              error: state.generalError,
+            ),
+          );
+          return;
+        }
         if (state is DivineAuthEmailVerification) {
           TextInput.finishAutofillContext();
           final encodedEmail = Uri.encodeComponent(state.email);

--- a/mobile/lib/screens/auth/login_options_screen.dart
+++ b/mobile/lib/screens/auth/login_options_screen.dart
@@ -30,7 +30,13 @@ class LoginOptionsScreen extends ConsumerWidget {
   /// Route path for this screen.
   static const String path = '/login-options';
 
-  const LoginOptionsScreen({super.key});
+  const LoginOptionsScreen({this.initialEmail, this.initialError, super.key});
+
+  /// Optional email to prefill from create-account recovery.
+  final String? initialEmail;
+
+  /// Optional error to display when arriving from create-account recovery.
+  final String? initialError;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -42,12 +48,17 @@ class LoginOptionsScreen extends ConsumerWidget {
     );
 
     return BlocProvider(
-      create: (_) => DivineAuthCubit(
-        oauthClient: oauthClient,
-        authService: authService,
-        pendingVerificationService: pendingVerificationService,
-        validationMessages: AuthValidationMessages.fromL10n(l10n),
-      )..initialize(isSignIn: true),
+      create: (_) =>
+          DivineAuthCubit(
+            oauthClient: oauthClient,
+            authService: authService,
+            pendingVerificationService: pendingVerificationService,
+            validationMessages: AuthValidationMessages.fromL10n(l10n),
+          )..initialize(
+            isSignIn: true,
+            initialEmail: initialEmail,
+            initialGeneralError: initialError,
+          ),
       child: const _LoginOptionsView(),
     );
   }

--- a/mobile/lib/screens/auth/welcome_screen.dart
+++ b/mobile/lib/screens/auth/welcome_screen.dart
@@ -50,6 +50,26 @@ class WelcomeScreen extends ConsumerWidget {
     queryParameters: {selectedPubkeyParam: pubkeyHex},
   ).toString();
 
+  /// Build a login-options path with optional recovery context prefilled.
+  static String loginOptionsPathWithRecovery({
+    String? email,
+    String? error,
+  }) {
+    final queryParameters = <String, String>{};
+
+    if (email != null && email.isNotEmpty) {
+      queryParameters['email'] = email;
+    }
+    if (error != null && error.isNotEmpty) {
+      queryParameters['error'] = error;
+    }
+
+    return Uri(
+      path: loginOptionsPath,
+      queryParameters: queryParameters.isEmpty ? null : queryParameters,
+    ).toString();
+  }
+
   /// Build invite gate path with optional recovery context prefilled.
   static String inviteGatePathWithCode(
     String code, {

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -26,7 +26,6 @@ import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/local_key_signer.dart';
 import 'package:openvine/services/nostr_identity.dart';
-import 'package:openvine/services/pending_verification_service.dart';
 import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:openvine/utils/divine_login_banner_dismissal.dart';
@@ -165,7 +164,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     KeycastOAuth? oauthClient,
     FlutterSecureStorage? flutterSecureStorage,
     OAuthConfig? oauthConfig,
-    PendingVerificationService? pendingVerificationService,
     PreFetchFollowingCallback? preFetchFollowing,
     String? profileCheckIndexerUrl,
     List<String>? indexerRelays,
@@ -176,7 +174,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
        _userDataCleanupService = userDataCleanupService,
        _oauthClient = oauthClient,
        _flutterSecureStorage = flutterSecureStorage,
-       _pendingVerificationService = pendingVerificationService,
        _preFetchFollowing = preFetchFollowing,
        _profileCheckIndexerUrl = profileCheckIndexerUrl,
        _primaryRelayUrl = primaryRelayUrl ?? AppConstants.defaultRelayUrl,
@@ -191,7 +188,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   final UserDataCleanupService _userDataCleanupService;
   final KeycastOAuth? _oauthClient;
   final FlutterSecureStorage? _flutterSecureStorage;
-  final PendingVerificationService? _pendingVerificationService;
   final PreFetchFollowingCallback? _preFetchFollowing;
   final String? _profileCheckIndexerUrl;
 
@@ -3121,10 +3117,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           await KeycastSession.clear(_flutterSecureStorage);
         }
       } catch (_) {}
-
-      // Clear any pending verification data
-      // (fire-and-forget since it's best-effort)
-      unawaited(_pendingVerificationService?.clear());
 
       // Redirect recovery prefs AFTER all signer cleanup so that
       // _restoreSignerInfo can re-stage the remaining account's archived

--- a/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
+++ b/mobile/test/blocs/divine_auth/divine_auth_cubit_test.dart
@@ -856,11 +856,17 @@ void main() {
                 password: testPassword,
                 isSubmitting: true,
               ),
-              isA<DivineAuthFormState>().having(
-                (s) => s.generalError,
-                'generalError',
-                contains('already registered'),
-              ),
+              isA<DivineAuthFormState>()
+                  .having(
+                    (s) => s.generalError,
+                    'generalError',
+                    contains('already registered'),
+                  )
+                  .having(
+                    (s) => s.showLoginOptionsRecovery,
+                    'showLoginOptionsRecovery',
+                    isTrue,
+                  ),
             ],
           );
 
@@ -1577,7 +1583,7 @@ void main() {
           obscurePassword: false,
           isSubmitting: true,
         );
-        expect(state.props, hasLength(15));
+        expect(state.props, hasLength(16));
       });
     });
 

--- a/mobile/test/screens/auth/create_account_screen_test.dart
+++ b/mobile/test/screens/auth/create_account_screen_test.dart
@@ -19,6 +19,7 @@ import 'package:openvine/blocs/invite_gate/invite_gate_state.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/auth/create_account_screen.dart';
+import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/pending_verification_service.dart';
 import 'package:openvine/widgets/auth_back_button.dart';
@@ -384,6 +385,110 @@ void main() {
           await tester.pump(const Duration(milliseconds: 100));
 
           expect(recorder.didFinishAutofillContext, isTrue);
+        },
+      );
+
+      testWidgets(
+        'navigates to sign in when registration reports duplicate email',
+        (tester) async {
+          when(
+            () => mockOAuth.headlessRegister(
+              email: any(named: 'email'),
+              password: any(named: 'password'),
+              scope: any(named: 'scope'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              HeadlessRegisterResult.error(
+                'This email is already registered.',
+                code: 'CONFLICT',
+              ),
+              'test-verifier',
+            ),
+          );
+
+          final router = GoRouter(
+            initialLocation: '/',
+            routes: [
+              GoRoute(
+                path: '/',
+                builder: (_, _) => ProviderScope(
+                  overrides: [
+                    ...getStandardTestOverrides(
+                      mockAuthService: mockAuthService,
+                    ),
+                    oauthClientProvider.overrideWithValue(mockOAuth),
+                    pendingVerificationServiceProvider.overrideWithValue(
+                      mockPendingVerification,
+                    ),
+                  ],
+                  child: RepositoryProvider<InviteApiClient>.value(
+                    value: mockInviteApiClient,
+                    child: BlocProvider(
+                      create: (_) =>
+                          InviteGateBloc(inviteApiClient: mockInviteApiClient),
+                      child: const CreateAccountScreen(),
+                    ),
+                  ),
+                ),
+              ),
+              GoRoute(
+                path: WelcomeScreen.loginOptionsPath,
+                builder: (_, state) => Scaffold(
+                  body: Text(
+                    'login:${state.uri.queryParameters['email'] ?? ''}|'
+                    'error:${state.uri.queryParameters['error'] ?? ''}',
+                  ),
+                ),
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(
+            MaterialApp.router(
+              theme: VineTheme.theme,
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              routerConfig: router,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.enterText(
+            find.descendant(
+              of: find.widgetWithText(DivineAuthTextField, 'Email'),
+              matching: find.byType(TextField),
+            ),
+            'person@example.com',
+          );
+          await tester.enterText(
+            find.descendant(
+              of: find.widgetWithText(DivineAuthTextField, 'Password'),
+              matching: find.byType(TextField),
+            ),
+            'SecurePass123!',
+          );
+          await tester.enterText(
+            find.descendant(
+              of: find.widgetWithText(
+                DivineAuthTextField,
+                'Confirm password',
+              ),
+              matching: find.byType(TextField),
+            ),
+            'SecurePass123!',
+          );
+
+          await tester.tap(find.widgetWithText(DivineButton, 'Create account'));
+          await tester.pumpAndSettle();
+
+          expect(
+            find.text(
+              'login:person@example.com|error:'
+              'This email is already registered. Please sign in instead.',
+            ),
+            findsOneWidget,
+          );
         },
       );
 

--- a/mobile/test/screens/auth/login_options_screen_test.dart
+++ b/mobile/test/screens/auth/login_options_screen_test.dart
@@ -36,7 +36,7 @@ void main() {
     mockPendingVerification = _MockPendingVerificationService();
   });
 
-  Widget createTestWidget() {
+  Widget createTestWidget({String initialLocation = LoginOptionsScreen.path}) {
     return ProviderScope(
       overrides: [
         ...getStandardTestOverrides(mockAuthService: mockAuthService),
@@ -50,12 +50,15 @@ void main() {
         supportedLocales: AppLocalizations.supportedLocales,
         theme: VineTheme.theme,
         routerConfig: GoRouter(
-          initialLocation: LoginOptionsScreen.path,
+          initialLocation: initialLocation,
           routes: [
             GoRoute(path: '/', builder: (_, _) => const Scaffold()),
             GoRoute(
               path: LoginOptionsScreen.path,
-              builder: (_, _) => const LoginOptionsScreen(),
+              builder: (_, state) => LoginOptionsScreen(
+                initialEmail: state.uri.queryParameters['email'],
+                initialError: state.uri.queryParameters['error'],
+              ),
             ),
             GoRoute(
               path: '/import-key',
@@ -88,6 +91,32 @@ void main() {
                 widget is Text &&
                 widget.data == 'Sign in' &&
                 widget.style?.fontSize == 28,
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('prefills email and shows recovery error from query params', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          createTestWidget(
+            initialLocation:
+                '${LoginOptionsScreen.path}?email=person%40example.com&error=This%20email%20is%20already%20registered.%20Please%20sign%20in%20instead.',
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final emailField = find.descendant(
+          of: find.widgetWithText(DivineAuthTextField, 'Email'),
+          matching: find.byType(TextField),
+        );
+        final emailTextField = tester.widget<TextField>(emailField);
+        expect(emailTextField.controller?.text, 'person@example.com');
+
+        expect(
+          find.text(
+            'This email is already registered. Please sign in instead.',
           ),
           findsOneWidget,
         );


### PR DESCRIPTION
## Summary\n- When create-account returns CONFLICT for an already-registered email, route the user to sign in instead of leaving them stuck on the create-account form.\n- Carry the email and server error into login-options so the user can continue without retyping.\n- Add screen and cubit coverage for the recovery path.\n\n## Verification\n- flutter test test/blocs/divine_auth/divine_auth_cubit_test.dart test/screens/auth/create_account_screen_test.dart test/screens/auth/login_options_screen_test.dart\n- pre-commit analyzer and generated-file checks passed on commit