### PR TITLE
feat(video-editor): enhance timeline controls with duplicate and split functionalities

### DIFF
--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_scope.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_scope.dart
@@ -29,12 +29,19 @@ class VideoEditorScope extends InheritedWidget {
     required this.originalClipAspectRatio,
     required this.bodySizeNotifier,
     required this.fromLibrary,
+    this.editorOverride,
     super.child = const SizedBox.shrink(),
     super.key,
   });
 
   /// Global key to access the [ProImageEditorState].
   final GlobalKey<ProImageEditorState> editorKey;
+
+  /// Direct editor reference, used in tests to inject a mock.
+  ///
+  /// When non-null this takes precedence over [editorKey.currentState].
+  @visibleForTesting
+  final ProImageEditorState? editorOverride;
 
   /// Global key to access the remove area widget.
   final GlobalKey removeAreaKey;
@@ -82,7 +89,7 @@ class VideoEditorScope extends InheritedWidget {
   }
 
   /// Returns the [ProImageEditorState] if available.
-  ProImageEditorState? get editor => editorKey.currentState;
+  ProImageEditorState? get editor => editorOverride ?? editorKey.currentState;
 
   /// Returns the [ProImageEditorState], throwing a descriptive error if null.
   ///

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
@@ -33,58 +33,64 @@ class VideoEditorTimelineControls extends StatelessWidget {
       ),
       child: Container(
         width: double.infinity,
-        padding: const .fromLTRB(16, 16, 16, 8),
+        padding: const .fromLTRB(0, 16, 0, 8),
         child: SafeArea(
           top: false,
-          child: Wrap(
-            spacing: 32,
-            runSpacing: 24,
-            alignment: .center,
-            runAlignment: .center,
-            crossAxisAlignment: .center,
-            children: [
-              if (onDelete != null)
-                _ControlButton(
-                  icon: .trash,
-                  label: context.l10n.videoEditorDeleteLabel,
-                  semanticLabel:
-                      context.l10n.videoEditorDeleteSelectedItemSemanticLabel,
-                  onPressed: onDelete,
-                  type: .error,
-                ),
-              if (onEdit != null)
-                _ControlButton(
-                  icon: .pencilSimple,
-                  label: context.l10n.videoEditorEditLabel,
-                  semanticLabel:
-                      context.l10n.videoEditorEditSelectedItemSemanticLabel,
-                  onPressed: onEdit,
-                ),
-              if (onDuplicated != null)
-                _ControlButton(
-                  icon: .copy,
-                  label: context.l10n.videoEditorDuplicateLabel,
-                  semanticLabel: context
-                      .l10n
-                      .videoEditorDuplicateSelectedItemSemanticLabel,
-                  onPressed: onDuplicated,
-                ),
-              if (onSplit != null)
-                _ControlButton(
-                  icon: .scissors,
-                  label: context.l10n.videoEditorSplitLabel,
-                  semanticLabel:
-                      context.l10n.videoEditorSplitSelectedClipSemanticLabel,
-                  onPressed: onSplit,
-                ),
-              _ControlButton(
-                icon: .check,
-                label: context.l10n.videoEditorDoneLabel,
-                semanticLabel:
-                    context.l10n.videoEditorFinishTimelineEditingSemanticLabel,
-                onPressed: onDone,
+          child: Center(
+            child: SingleChildScrollView(
+              scrollDirection: .horizontal,
+              padding: const .symmetric(horizontal: 16),
+              child: Row(
+                spacing: 16,
+                mainAxisAlignment: .center,
+                children: [
+                  if (onDelete != null)
+                    _ControlButton(
+                      icon: .trash,
+                      label: context.l10n.videoEditorDeleteLabel,
+                      semanticLabel: context
+                          .l10n
+                          .videoEditorDeleteSelectedItemSemanticLabel,
+                      onPressed: onDelete,
+                      type: .error,
+                    ),
+                  if (onEdit != null)
+                    _ControlButton(
+                      icon: .pencilSimple,
+                      label: context.l10n.videoEditorEditLabel,
+                      semanticLabel:
+                          context.l10n.videoEditorEditSelectedItemSemanticLabel,
+                      onPressed: onEdit,
+                    ),
+                  if (onDuplicated != null)
+                    _ControlButton(
+                      icon: .copy,
+                      label: context.l10n.videoEditorDuplicateLabel,
+                      semanticLabel: context
+                          .l10n
+                          .videoEditorDuplicateSelectedItemSemanticLabel,
+                      onPressed: onDuplicated,
+                    ),
+                  if (onSplit != null)
+                    _ControlButton(
+                      icon: .scissors,
+                      label: context.l10n.videoEditorSplitLabel,
+                      semanticLabel: context
+                          .l10n
+                          .videoEditorSplitSelectedClipSemanticLabel,
+                      onPressed: onSplit,
+                    ),
+                  _ControlButton(
+                    icon: .check,
+                    label: context.l10n.videoEditorDoneLabel,
+                    semanticLabel: context
+                        .l10n
+                        .videoEditorFinishTimelineEditingSemanticLabel,
+                    onPressed: onDone,
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
         ),
       ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls.dart
@@ -1,14 +1,17 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/timeline_overlay_item.dart';
 import 'package:openvine/screens/video_editor/video_audio_editor_timing_screen.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart';
 import 'package:pro_image_editor/core/models/layers/layer.dart';
+import 'package:pro_image_editor/features/filter_editor/types/filter_state.dart';
 
 /// Controls shown when an overlay item is selected.
 /// Adapts buttons based on the overlay type (layer vs filter).
@@ -34,7 +37,8 @@ class TimelineOverlayControls extends StatelessWidget {
 }
 
 /// Controls for layer overlays (text, drawing, emoji, sticker).
-/// Text layers get an Edit button; others get Delete + Done.
+/// Text layers get an Edit button; all layers support delete, duplicate,
+/// split, and done.
 class _LayerOverlayControls extends StatelessWidget {
   const _LayerOverlayControls({required this.item});
 
@@ -54,6 +58,8 @@ class _LayerOverlayControls extends StatelessWidget {
       onEdit: isTextLayer
           ? () => _editTextLayer(context: context, layer: layer)
           : null,
+      onDuplicated: () => _duplicateLayer(context: context, layer: layer),
+      onSplit: () => _splitLayer(context: context, layer: layer),
       onDone: () => TimelineOverlayControls._deselect(context),
     );
   }
@@ -81,9 +87,54 @@ class _LayerOverlayControls extends StatelessWidget {
 
     editor.applyTextLayerChanges(layer, updatedLayer);
   }
+
+  void _duplicateLayer({required BuildContext context, Layer? layer}) {
+    final editor = VideoEditorScope.of(context).editor;
+    if (editor == null || layer == null) return;
+
+    final layers = List<Layer>.from(editor.activeLayers);
+    final layerIdx = layers.indexWhere((l) => l.id == item.id);
+    if (layerIdx < 0) return;
+
+    final copy = layer.copyWith(
+      id: _copyId(layer.id),
+      offset: layer.offset + const Offset(24, 24),
+    );
+
+    layers.insert(layerIdx + 1, copy);
+    editor.addHistory(layers: layers);
+    context.read<TimelineOverlayBloc>().add(
+      TimelineOverlayItemSelected(copy.id),
+    );
+  }
+
+  void _splitLayer({required BuildContext context, Layer? layer}) {
+    final editor = VideoEditorScope.of(context).editor;
+    if (editor == null || layer == null) return;
+
+    final splitAt = _validSplitPosition(context, item);
+    if (splitAt == null) return;
+
+    final layers = List<Layer>.from(editor.activeLayers);
+    final layerIdx = layers.indexWhere((l) => l.id == item.id);
+    if (layerIdx < 0) return;
+
+    final second = layer.copyWith(
+      id: _copyId(layer.id),
+      startTime: splitAt,
+      endTime: item.endTime,
+    );
+
+    layers[layerIdx] = layer.copyWith(endTime: splitAt);
+    layers.insert(layerIdx + 1, second);
+    editor.addHistory(layers: layers);
+    context.read<TimelineOverlayBloc>().add(
+      TimelineOverlayItemSelected(second.id),
+    );
+  }
 }
 
-/// Controls for filter overlays: Delete + Done.
+/// Controls for filter overlays: delete, duplicate, split, and done.
 class _FilterOverlayControls extends StatelessWidget {
   const _FilterOverlayControls({required this.item});
 
@@ -93,6 +144,8 @@ class _FilterOverlayControls extends StatelessWidget {
   Widget build(BuildContext context) {
     return VideoEditorTimelineControls(
       onDelete: () => _removeFilter(context: context),
+      onDuplicated: () => _duplicateFilter(context: context),
+      onSplit: () => _splitFilter(context: context),
       onDone: () => TimelineOverlayControls._deselect(context),
     );
   }
@@ -113,9 +166,51 @@ class _FilterOverlayControls extends StatelessWidget {
       const TimelineOverlayItemSelected(null),
     );
   }
+
+  void _duplicateFilter({required BuildContext context}) {
+    final editor = VideoEditorScope.of(context).editor;
+    if (editor == null) return;
+
+    final filters = List<FilterState>.from(editor.stateManager.activeFilters);
+    final filterIdx = filters.indexWhere((t) => t.id == item.id);
+    if (filterIdx < 0) return;
+
+    final copy = filters[filterIdx].copyWith(id: _copyId(item.id));
+    filters.insert(filterIdx + 1, copy);
+    editor.addHistory(filters: filters);
+    context.read<TimelineOverlayBloc>().add(
+      TimelineOverlayItemSelected(copy.id),
+    );
+  }
+
+  void _splitFilter({required BuildContext context}) {
+    final editor = VideoEditorScope.of(context).editor;
+    if (editor == null) return;
+
+    final splitAt = _validSplitPosition(context, item);
+    if (splitAt == null) return;
+
+    final filters = List<FilterState>.from(editor.stateManager.activeFilters);
+    final filterIdx = filters.indexWhere((t) => t.id == item.id);
+    if (filterIdx < 0) return;
+
+    final filter = filters[filterIdx];
+    final second = filter.copyWith(
+      id: _copyId(item.id),
+      startTime: splitAt,
+      endTime: item.endTime,
+    );
+
+    filters[filterIdx] = filter.copyWith(endTime: splitAt);
+    filters.insert(filterIdx + 1, second);
+    editor.addHistory(filters: filters);
+    context.read<TimelineOverlayBloc>().add(
+      TimelineOverlayItemSelected(second.id),
+    );
+  }
 }
 
-/// Controls for sound overlays: Delete + Done.
+/// Controls for sound overlays: delete, edit, duplicate, split, and done.
 class _SoundOverlayControls extends StatelessWidget {
   const _SoundOverlayControls({required this.item});
 
@@ -126,6 +221,8 @@ class _SoundOverlayControls extends StatelessWidget {
     return VideoEditorTimelineControls(
       onDelete: () => _removeSound(context: context),
       onEdit: () => _editSound(context: context),
+      onDuplicated: () => _duplicateSound(context: context),
+      onSplit: () => _splitSound(context: context),
       onDone: () => TimelineOverlayControls._deselect(context),
     );
   }
@@ -187,4 +284,82 @@ class _SoundOverlayControls extends StatelessWidget {
       const TimelineOverlayItemSelected(null),
     );
   }
+
+  void _duplicateSound({required BuildContext context}) {
+    final editor = VideoEditorScope.of(context).editor;
+    if (editor == null) return;
+
+    final tracks = editor.stateManager.audioTracks;
+    final trackIdx = tracks.indexWhere((t) => t.id == item.id);
+    if (trackIdx < 0) return;
+
+    final copy = tracks[trackIdx].copyWith(id: _copyId(item.id));
+    final updatedTracks = List.of(tracks)..insert(trackIdx + 1, copy);
+
+    editor.addHistory(
+      meta: {
+        ...editor.stateManager.activeMeta,
+        VideoEditorConstants.audioStateHistoryKey: updatedTracks
+            .map((e) => e.toJson())
+            .toList(),
+      },
+    );
+    context.read<TimelineOverlayBloc>().add(
+      TimelineOverlayItemSelected(copy.id),
+    );
+  }
+
+  void _splitSound({required BuildContext context}) {
+    final editor = VideoEditorScope.of(context).editor;
+    if (editor == null) return;
+
+    final splitAt = _validSplitPosition(context, item);
+    if (splitAt == null) return;
+
+    final tracks = editor.stateManager.audioTracks;
+    final trackIdx = tracks.indexWhere((t) => t.id == item.id);
+    if (trackIdx < 0) return;
+
+    final track = tracks[trackIdx];
+    final offsetShift = splitAt - item.startTime;
+    final second = track.copyWith(
+      id: _copyId(item.id),
+      startOffset: track.startOffset + offsetShift,
+      startTime: splitAt,
+      endTime: item.endTime,
+    );
+
+    final updatedTracks = List.of(tracks)
+      ..[trackIdx] = track.copyWith(endTime: splitAt)
+      ..insert(trackIdx + 1, second);
+
+    editor.addHistory(
+      meta: {
+        ...editor.stateManager.activeMeta,
+        VideoEditorConstants.audioStateHistoryKey: updatedTracks
+            .map((e) => e.toJson())
+            .toList(),
+      },
+    );
+    context.read<TimelineOverlayBloc>().add(
+      TimelineOverlayItemSelected(second.id),
+    );
+  }
+}
+
+String _copyId(String id) =>
+    '${id}_copy_${DateTime.now().microsecondsSinceEpoch}';
+
+Duration? _validSplitPosition(BuildContext context, TimelineOverlayItem item) {
+  final splitAt = context.read<VideoEditorMainBloc>().state.currentPosition;
+  if (splitAt <= item.startTime || splitAt >= item.endTime) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      DivineSnackbarContainer.snackBar(
+        context.l10n.videoEditorSplitPlayheadOutsideClip,
+      ),
+    );
+    return null;
+  }
+
+  return splitAt;
 }

--- a/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_icon_button.dart
@@ -129,6 +129,8 @@ class _DivineIconButtonContent extends StatelessWidget {
   final String? semanticLabel;
   final String? semanticValue;
 
+  static const _borderWidth = 2.0;
+
   bool get _isEnabled => onPressed != null;
 
   /// Inner padding around the icon.
@@ -205,31 +207,33 @@ class _DivineIconButtonContent extends StatelessWidget {
       color: _backgroundColor,
       borderRadius: BorderRadius.circular(_borderRadius),
       border: _borderColor != null
-          ? Border.all(color: _borderColor!, width: 2)
+          ? Border.all(color: _borderColor!, width: _borderWidth)
           : null,
       boxShadow: _isEnabled ? _boxShadow : null,
     );
-
     Widget button = Semantics(
       label: semanticLabel,
       value: semanticValue,
       button: true,
       enabled: _isEnabled,
-      child: AnimatedOpacity(
-        duration: const Duration(milliseconds: 150),
-        opacity: _isEnabled ? 1.0 : _disabledOpacity,
-        child: Material(
-          color: VineTheme.transparent,
-          child: InkWell(
-            onTap: onPressed,
-            borderRadius: BorderRadius.circular(_borderRadius),
-            splashColor: _iconColor.withValues(alpha: 0.1),
-            highlightColor: _iconColor.withValues(alpha: 0.05),
-            child: Ink(
-              decoration: decoration,
-              child: Padding(
-                padding: EdgeInsets.all(_padding),
-                child: iconWidget,
+      child: Padding(
+        padding: .all(_borderColor == null ? _borderWidth : 0),
+        child: AnimatedOpacity(
+          duration: const Duration(milliseconds: 150),
+          opacity: _isEnabled ? 1.0 : _disabledOpacity,
+          child: Material(
+            type: .transparency,
+            child: InkWell(
+              onTap: onPressed,
+              borderRadius: BorderRadius.circular(_borderRadius),
+              splashColor: _iconColor.withValues(alpha: 0.1),
+              highlightColor: _iconColor.withValues(alpha: 0.05),
+              child: Ink(
+                decoration: decoration,
+                child: Padding(
+                  padding: EdgeInsets.all(_padding),
+                  child: iconWidget,
+                ),
               ),
             ),
           ),

--- a/mobile/packages/divine_ui/test/src/button/divine_icon_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_icon_button_test.dart
@@ -289,6 +289,62 @@ void main() {
       });
     });
 
+    group('border-compensating outer padding', () {
+      // No-border variants wrap their content in a 2px Padding to match the
+      // visual footprint of the secondary type's 2px border.  Removing or
+      // changing that compensation would silently reintroduce the size
+      // mismatch this fix addressed.
+
+      testWidgets(
+        'no-border type (primary) applies 2px outer padding to compensate for '
+        'missing border',
+        (tester) async {
+          await tester.pumpWidget(
+            buildTestWidget(
+              onPressed: () {},
+            ),
+          );
+
+          // Walk up from AnimatedOpacity: the nearest Padding ancestor is the
+          // border-compensation wrapper, not the inner icon padding.
+          final compensatingPadding = tester.widget<Padding>(
+            find
+                .ancestor(
+                  of: find.byType(AnimatedOpacity),
+                  matching: find.byType(Padding),
+                )
+                .first,
+          );
+          expect(
+            compensatingPadding.padding,
+            equals(const EdgeInsets.all(2)),
+          );
+        },
+      );
+
+      testWidgets(
+        'bordered type (secondary) applies no outer compensating padding',
+        (tester) async {
+          await tester.pumpWidget(
+            buildTestWidget(
+              type: DivineIconButtonType.secondary,
+              onPressed: () {},
+            ),
+          );
+
+          final compensatingPadding = tester.widget<Padding>(
+            find
+                .ancestor(
+                  of: find.byType(AnimatedOpacity),
+                  matching: find.byType(Padding),
+                )
+                .first,
+          );
+          expect(compensatingPadding.padding, equals(EdgeInsets.zero));
+        },
+      );
+    });
+
     group('all types render in both sizes', () {
       for (final type in DivineIconButtonType.values) {
         for (final size in DivineIconButtonSize.values) {

--- a/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
+++ b/mobile/test/blocs/video_interactions/video_interactions_bloc_test.dart
@@ -344,23 +344,28 @@ void main() {
         },
       );
 
+      late Completer<void> commentsCountStarted;
+      late Completer<int> commentsCountCompleter;
+
       blocTest<VideoInteractionsBloc, VideoInteractionsState>(
         'preserves optimistic toggle when tap lands mid-fetch',
         setUp: () {
+          commentsCountStarted = Completer<void>();
+          commentsCountCompleter = Completer<int>();
           // Pre-fetch repository state: not liked, count from initial seed.
           when(
             () => mockLikesRepository.isLiked(testEventId),
           ).thenAnswer((_) async => false);
-          // Hold the fetch open via a slow comment count so the tap can
-          // land between the loading emit and the success emit. Without
-          // the pre-fetch snapshot guard in [_onFetchRequested], the
-          // success emit overwrites isLiked + likeCount with stale relay
-          // values and the heart bounces back off.
+          // Hold the fetch open until the test explicitly releases it so
+          // the tap deterministically lands between the loading emit and
+          // the success emit. Fixed delays were flaky on CI.
           when(
             () => mockCommentsRepository.getCommentsCount(testEventId),
           ).thenAnswer((_) async {
-            await Future<void>.delayed(const Duration(milliseconds: 30));
-            return 0;
+            if (!commentsCountStarted.isCompleted) {
+              commentsCountStarted.complete();
+            }
+            return commentsCountCompleter.future;
           });
           when(
             () => mockRepostsRepository.getRepostCountByEventId(testEventId),
@@ -375,12 +380,10 @@ void main() {
         build: () => createBloc(initialLikeCount: 10),
         act: (bloc) async {
           bloc.add(const VideoInteractionsFetchRequested());
-          // Let the fetch handler reach its first await on isLiked +
-          // schedule the slow comments query, but not finish.
-          await Future<void>.delayed(const Duration(milliseconds: 5));
+          await commentsCountStarted.future;
           bloc.add(const VideoInteractionsLikeToggled());
+          commentsCountCompleter.complete(0);
         },
-        wait: const Duration(milliseconds: 100),
         expect: () => [
           // Fetch enters loading. Seeded likeCount=10 carries through.
           const VideoInteractionsState(

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls_test.dart
@@ -22,6 +22,7 @@ class _MockTimelineOverlayBloc
 void main() {
   group(TimelineOverlayControls, () {
     late _MockTimelineOverlayBloc overlayBloc;
+    final l10n = lookupAppLocalizations(const Locale('en'));
 
     setUp(() {
       overlayBloc = _MockTimelineOverlayBloc();
@@ -72,6 +73,11 @@ void main() {
       await tester.pumpWidget(build(item));
 
       expect(find.byType(VideoEditorTimelineControls), findsOneWidget);
+      expect(find.text(l10n.videoEditorDeleteLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorDuplicateLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorSplitLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorDoneLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorEditLabel), findsNothing);
     });
 
     testWidgets('renders $VideoEditorTimelineControls for filter', (
@@ -87,6 +93,11 @@ void main() {
       await tester.pumpWidget(build(item));
 
       expect(find.byType(VideoEditorTimelineControls), findsOneWidget);
+      expect(find.text(l10n.videoEditorDeleteLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorDuplicateLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorSplitLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorDoneLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorEditLabel), findsNothing);
     });
 
     testWidgets('renders $VideoEditorTimelineControls for sound', (
@@ -102,6 +113,11 @@ void main() {
       await tester.pumpWidget(build(item));
 
       expect(find.byType(VideoEditorTimelineControls), findsOneWidget);
+      expect(find.text(l10n.videoEditorDeleteLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorEditLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorDuplicateLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorSplitLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorDoneLabel), findsOneWidget);
     });
   });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls_test.dart
@@ -8,21 +8,41 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/timeline_overlay_item.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
 
 class _MockTimelineOverlayBloc
     extends MockBloc<TimelineOverlayEvent, TimelineOverlayState>
     implements TimelineOverlayBloc {}
 
+class _MockVideoEditorMainBloc
+    extends MockBloc<VideoEditorMainEvent, VideoEditorMainState>
+    implements VideoEditorMainBloc {}
+
+class _MockProImageEditorState extends Mock implements ProImageEditorState {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      '_MockProImageEditorState';
+}
+
+class _MockStateManager extends Mock implements StateManager {}
+
 void main() {
   group(TimelineOverlayControls, () {
     late _MockTimelineOverlayBloc overlayBloc;
     final l10n = lookupAppLocalizations(const Locale('en'));
+
+    setUpAll(() {
+      registerFallbackValue(const TimelineOverlayItemSelected(null));
+    });
 
     setUp(() {
       overlayBloc = _MockTimelineOverlayBloc();
@@ -31,6 +51,42 @@ void main() {
       ).thenAnswer((_) => const Stream<TimelineOverlayState>.empty());
       when(() => overlayBloc.state).thenReturn(const TimelineOverlayState());
     });
+
+    Widget buildWithEditor(
+      TimelineOverlayItem item,
+      _MockProImageEditorState mockEditor,
+      _MockVideoEditorMainBloc mainBloc,
+    ) {
+      return ProviderScope(
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: MultiBlocProvider(
+              providers: [
+                BlocProvider<VideoEditorMainBloc>.value(value: mainBloc),
+                BlocProvider<TimelineOverlayBloc>.value(value: overlayBloc),
+              ],
+              child: VideoEditorScope(
+                editorKey: GlobalKey(),
+                removeAreaKey: GlobalKey(),
+                originalClipAspectRatio: 9 / 16,
+                bodySizeNotifier: ValueNotifier(const Size(400, 600)),
+                fromLibrary: false,
+                onOpenCamera: () {},
+                onOpenClipsEditor: () {},
+                onAddStickers: () {},
+                onAdjustVolume: () {},
+                onAddEditTextLayer: ([layer]) async => null,
+                onOpenMusicLibrary: () {},
+                editorOverride: mockEditor,
+                child: TimelineOverlayControls(item: item),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
 
     Widget build(TimelineOverlayItem item) {
       return ProviderScope(
@@ -118,6 +174,237 @@ void main() {
       expect(find.text(l10n.videoEditorDuplicateLabel), findsOneWidget);
       expect(find.text(l10n.videoEditorSplitLabel), findsOneWidget);
       expect(find.text(l10n.videoEditorDoneLabel), findsOneWidget);
+    });
+
+    group('behavior', () {
+      late _MockProImageEditorState mockEditor;
+      late _MockStateManager mockStateManager;
+      late _MockVideoEditorMainBloc mainBloc;
+
+      setUp(() {
+        mockEditor = _MockProImageEditorState();
+        mockStateManager = _MockStateManager();
+        mainBloc = _MockVideoEditorMainBloc();
+        when(() => mainBloc.stream).thenAnswer(
+          (_) => const Stream<VideoEditorMainState>.empty(),
+        );
+        when(() => mockEditor.stateManager).thenReturn(mockStateManager);
+        when(
+          () => mockEditor.addHistory(
+            layers: any(named: 'layers'),
+            filters: any(named: 'filters'),
+            meta: any(named: 'meta'),
+          ),
+        ).thenAnswer((_) {});
+      });
+
+      testWidgets(
+        'duplicate inserts a copy after the selected filter item and selects it',
+        (tester) async {
+          final filterA = FilterState(
+            id: 'filter-a',
+            name: 'test-filter',
+            matrices: const [
+              [1.0],
+            ],
+            startTime: const Duration(seconds: 1),
+            endTime: const Duration(seconds: 5),
+          );
+          when(() => mockStateManager.activeFilters).thenReturn([filterA]);
+          when(() => mainBloc.state).thenReturn(
+            const VideoEditorMainState(),
+          );
+
+          const item = TimelineOverlayItem(
+            id: 'filter-a',
+            type: TimelineOverlayType.filter,
+            startTime: Duration(seconds: 1),
+            endTime: Duration(seconds: 5),
+          );
+          await tester.pumpWidget(
+            buildWithEditor(item, mockEditor, mainBloc),
+          );
+
+          await tester.tap(
+            find.bySemanticsLabel(
+              l10n.videoEditorDuplicateSelectedItemSemanticLabel,
+            ),
+          );
+          await tester.pump();
+
+          final result = verify(
+            () => mockEditor.addHistory(
+              filters: captureAny(named: 'filters'),
+            ),
+          )..called(1);
+          final filters = result.captured.single as List<FilterState>;
+          expect(filters, hasLength(2));
+          expect(filters[1].id, startsWith('filter-a_copy_'));
+
+          final addEvent = verify(
+            () => overlayBloc.add(captureAny()),
+          ).captured.whereType<TimelineOverlayItemSelected>().last;
+          expect(addEvent.itemId, startsWith('filter-a_copy_'));
+        },
+      );
+
+      testWidgets(
+        'split at valid position creates two segments and selects the second',
+        (tester) async {
+          final filterA = FilterState(
+            id: 'filter-a',
+            name: 'test-filter',
+            matrices: const [
+              [1.0],
+            ],
+            startTime: const Duration(seconds: 1),
+            endTime: const Duration(seconds: 5),
+          );
+          when(() => mockStateManager.activeFilters).thenReturn([filterA]);
+          when(() => mainBloc.state).thenReturn(
+            const VideoEditorMainState(
+              currentPosition: Duration(seconds: 3),
+            ),
+          );
+
+          const item = TimelineOverlayItem(
+            id: 'filter-a',
+            type: TimelineOverlayType.filter,
+            startTime: Duration(seconds: 1),
+            endTime: Duration(seconds: 5),
+          );
+          await tester.pumpWidget(
+            buildWithEditor(item, mockEditor, mainBloc),
+          );
+
+          await tester.tap(
+            find.bySemanticsLabel(
+              l10n.videoEditorSplitSelectedClipSemanticLabel,
+            ),
+          );
+          await tester.pump();
+
+          final result = verify(
+            () => mockEditor.addHistory(
+              filters: captureAny(named: 'filters'),
+            ),
+          )..called(1);
+          final filters = result.captured.single as List<FilterState>;
+          expect(filters, hasLength(2));
+          expect(filters[0].endTime, equals(const Duration(seconds: 3)));
+          expect(filters[1].startTime, equals(const Duration(seconds: 3)));
+          expect(filters[1].endTime, equals(const Duration(seconds: 5)));
+
+          final addEvent = verify(
+            () => overlayBloc.add(captureAny()),
+          ).captured.whereType<TimelineOverlayItemSelected>().last;
+          expect(addEvent.itemId, isNotNull);
+        },
+      );
+
+      testWidgets(
+        'split at invalid position shows snackbar and does not commit history',
+        (tester) async {
+          final filterA = FilterState(
+            id: 'filter-a',
+            name: 'test-filter',
+            matrices: const [
+              [1.0],
+            ],
+            startTime: const Duration(seconds: 1),
+            endTime: const Duration(seconds: 5),
+          );
+          when(() => mockStateManager.activeFilters).thenReturn([filterA]);
+          // currentPosition = 0, which is <= startTime(1s) → invalid
+          when(() => mainBloc.state).thenReturn(
+            const VideoEditorMainState(),
+          );
+
+          const item = TimelineOverlayItem(
+            id: 'filter-a',
+            type: TimelineOverlayType.filter,
+            startTime: Duration(seconds: 1),
+            endTime: Duration(seconds: 5),
+          );
+          await tester.pumpWidget(
+            buildWithEditor(item, mockEditor, mainBloc),
+          );
+
+          await tester.tap(
+            find.bySemanticsLabel(
+              l10n.videoEditorSplitSelectedClipSemanticLabel,
+            ),
+          );
+          await tester.pump();
+
+          expect(
+            find.text(l10n.videoEditorSplitPlayheadOutsideClip),
+            findsOneWidget,
+          );
+          verifyNever(
+            () => mockEditor.addHistory(
+              layers: any(named: 'layers'),
+              filters: any(named: 'filters'),
+              meta: any(named: 'meta'),
+            ),
+          );
+        },
+      );
+
+      testWidgets(
+        'sound split sets startOffset of second segment to '
+        'originalOffset + (splitAt - startTime)',
+        (tester) async {
+          const track = AudioEvent(
+            id: 'sound-1',
+            pubkey: 'pub',
+            createdAt: 0,
+            startOffset: Duration(seconds: 2),
+            startTime: Duration(seconds: 3),
+            endTime: Duration(seconds: 8),
+          );
+          when(() => mockStateManager.activeMeta).thenReturn({
+            VideoEditorConstants.audioStateHistoryKey: [track.toJson()],
+          });
+          // splitAt = 5s, which is within [3s, 8s)
+          when(() => mainBloc.state).thenReturn(
+            const VideoEditorMainState(
+              currentPosition: Duration(seconds: 5),
+            ),
+          );
+
+          const item = TimelineOverlayItem(
+            id: 'sound-1',
+            type: TimelineOverlayType.sound,
+            startTime: Duration(seconds: 3),
+            endTime: Duration(seconds: 8),
+          );
+          await tester.pumpWidget(
+            buildWithEditor(item, mockEditor, mainBloc),
+          );
+
+          await tester.tap(
+            find.bySemanticsLabel(
+              l10n.videoEditorSplitSelectedClipSemanticLabel,
+            ),
+          );
+          await tester.pump();
+
+          final result = verify(
+            () => mockEditor.addHistory(meta: captureAny(named: 'meta')),
+          )..called(1);
+          final meta = result.captured.single as Map<String, dynamic>;
+          final tracksJson =
+              meta[VideoEditorConstants.audioStateHistoryKey] as List<dynamic>;
+          final second = AudioEvent.fromJson(
+            tracksJson[1] as Map<String, dynamic>,
+          );
+
+          // second.startOffset = originalStartOffset + (splitAt - item.startTime)
+          //                     = 2s + (5s - 3s) = 4s
+          expect(second.startOffset, equals(const Duration(seconds: 4)));
+        },
+      );
     });
   });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls_test.dart
@@ -199,6 +199,66 @@ void main() {
       });
 
       testWidgets(
+        'duplicate inserts a copied layer after the selected item, offsets it, '
+        'and selects it',
+        (tester) async {
+          final layerA = TextLayer(
+            text: 'Layer A',
+            id: 'layer-a',
+            offset: const Offset(10, 20),
+            startTime: const Duration(seconds: 1),
+            endTime: const Duration(seconds: 5),
+          );
+          final layerB = TextLayer(
+            text: 'Layer B',
+            id: 'layer-b',
+            offset: const Offset(50, 60),
+            startTime: const Duration(seconds: 5),
+            endTime: const Duration(seconds: 9),
+          );
+          when(() => mockEditor.activeLayers).thenReturn([layerA, layerB]);
+          when(() => mainBloc.state).thenReturn(
+            const VideoEditorMainState(),
+          );
+
+          const item = TimelineOverlayItem(
+            id: 'layer-a',
+            type: TimelineOverlayType.layer,
+            startTime: Duration(seconds: 1),
+            endTime: Duration(seconds: 5),
+          );
+          await tester.pumpWidget(
+            buildWithEditor(item, mockEditor, mainBloc),
+          );
+
+          await tester.tap(
+            find.bySemanticsLabel(
+              l10n.videoEditorDuplicateSelectedItemSemanticLabel,
+            ),
+          );
+          await tester.pump();
+
+          final result = verify(
+            () => mockEditor.addHistory(
+              layers: captureAny(named: 'layers'),
+            ),
+          )..called(1);
+          final layers = result.captured.single as List<Layer>;
+          final inserted = layers[1] as TextLayer;
+
+          expect(layers, hasLength(3));
+          expect(inserted.id, startsWith('layer-a_copy_'));
+          expect(inserted.offset, equals(const Offset(34, 44)));
+          expect(layers[2].id, equals('layer-b'));
+
+          final addEvent = verify(
+            () => overlayBloc.add(captureAny()),
+          ).captured.whereType<TimelineOverlayItemSelected>().last;
+          expect(addEvent.itemId, startsWith('layer-a_copy_'));
+        },
+      );
+
+      testWidgets(
         'duplicate inserts a copy after the selected filter item and selects it',
         (tester) async {
           final filterA = FilterState(
@@ -245,6 +305,71 @@ void main() {
             () => overlayBloc.add(captureAny()),
           ).captured.whereType<TimelineOverlayItemSelected>().last;
           expect(addEvent.itemId, startsWith('filter-a_copy_'));
+        },
+      );
+
+      testWidgets(
+        'split layer inserts the second segment after the original and selects '
+        'it',
+        (tester) async {
+          final layerA = TextLayer(
+            text: 'Layer A',
+            id: 'layer-a',
+            offset: const Offset(10, 20),
+            startTime: const Duration(seconds: 1),
+            endTime: const Duration(seconds: 5),
+          );
+          final layerB = TextLayer(
+            text: 'Layer B',
+            id: 'layer-b',
+            offset: const Offset(50, 60),
+            startTime: const Duration(seconds: 5),
+            endTime: const Duration(seconds: 9),
+          );
+          when(() => mockEditor.activeLayers).thenReturn([layerA, layerB]);
+          when(() => mainBloc.state).thenReturn(
+            const VideoEditorMainState(
+              currentPosition: Duration(seconds: 3),
+            ),
+          );
+
+          const item = TimelineOverlayItem(
+            id: 'layer-a',
+            type: TimelineOverlayType.layer,
+            startTime: Duration(seconds: 1),
+            endTime: Duration(seconds: 5),
+          );
+          await tester.pumpWidget(
+            buildWithEditor(item, mockEditor, mainBloc),
+          );
+
+          await tester.tap(
+            find.bySemanticsLabel(
+              l10n.videoEditorSplitSelectedClipSemanticLabel,
+            ),
+          );
+          await tester.pump();
+
+          final result = verify(
+            () => mockEditor.addHistory(
+              layers: captureAny(named: 'layers'),
+            ),
+          )..called(1);
+          final layers = result.captured.single as List<Layer>;
+          final first = layers[0] as TextLayer;
+          final second = layers[1] as TextLayer;
+
+          expect(layers, hasLength(3));
+          expect(first.endTime, equals(const Duration(seconds: 3)));
+          expect(second.id, startsWith('layer-a_copy_'));
+          expect(second.startTime, equals(const Duration(seconds: 3)));
+          expect(second.endTime, equals(const Duration(seconds: 5)));
+          expect(layers[2].id, equals('layer-b'));
+
+          final addEvent = verify(
+            () => overlayBloc.add(captureAny()),
+          ).captured.whereType<TimelineOverlayItemSelected>().last;
+          expect(addEvent.itemId, startsWith('layer-a_copy_'));
         },
       );
 
@@ -348,6 +473,77 @@ void main() {
               meta: any(named: 'meta'),
             ),
           );
+        },
+      );
+
+      testWidgets(
+        'sound duplicate serializes updated tracks under the audio history key '
+        'and selects the copy',
+        (tester) async {
+          const trackA = AudioEvent(
+            id: 'sound-1',
+            pubkey: 'pub',
+            createdAt: 0,
+            startOffset: Duration(seconds: 2),
+            startTime: Duration(seconds: 3),
+            endTime: Duration(seconds: 8),
+          );
+          const trackB = AudioEvent(
+            id: 'sound-2',
+            pubkey: 'pub',
+            createdAt: 1,
+            startOffset: Duration(seconds: 1),
+            startTime: Duration(seconds: 8),
+            endTime: Duration(seconds: 12),
+          );
+          when(() => mockStateManager.activeMeta).thenReturn({
+            VideoEditorConstants.audioStateHistoryKey: [
+              trackA.toJson(),
+              trackB.toJson(),
+            ],
+          });
+          when(() => mainBloc.state).thenReturn(
+            const VideoEditorMainState(),
+          );
+
+          const item = TimelineOverlayItem(
+            id: 'sound-1',
+            type: TimelineOverlayType.sound,
+            startTime: Duration(seconds: 3),
+            endTime: Duration(seconds: 8),
+          );
+          await tester.pumpWidget(
+            buildWithEditor(item, mockEditor, mainBloc),
+          );
+
+          await tester.tap(
+            find.bySemanticsLabel(
+              l10n.videoEditorDuplicateSelectedItemSemanticLabel,
+            ),
+          );
+          await tester.pump();
+
+          final result = verify(
+            () => mockEditor.addHistory(meta: captureAny(named: 'meta')),
+          )..called(1);
+          final meta = result.captured.single as Map<String, dynamic>;
+          final tracksJson =
+              meta[VideoEditorConstants.audioStateHistoryKey] as List<dynamic>;
+          final copied = AudioEvent.fromJson(
+            tracksJson[1] as Map<String, dynamic>,
+          );
+          final trailing = AudioEvent.fromJson(
+            tracksJson[2] as Map<String, dynamic>,
+          );
+
+          expect(tracksJson, hasLength(3));
+          expect(copied.id, startsWith('sound-1_copy_'));
+          expect(trailing.id, equals('sound-2'));
+
+          final addEvent = verify(
+            () => overlayBloc.add(captureAny()),
+          ).captured.whereType<TimelineOverlayItemSelected>().last;
+          expect(addEvent.itemId, startsWith('sound-1_copy_'));
         },
       );
 


### PR DESCRIPTION
Closes #3926

## Description

Users on Discord asked [here](https://discord.com/channels/1470168817589158040/1470256031434149953/1499922830584840242) for a feature to split or duplicate audio tracks. This PR implements that feature and also extends it to filters and layers. 
In addition, it fixes two minor issues: one where DivineIconButton had the wrong size when no border color was set, and another where the action buttons are now consistently aligned on the same row.


**Related Issue:** 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore