### PR TITLE
fix(blossom): retry image upload on transient 5xx (#3862)

### DIFF
--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -2504,10 +2504,17 @@ Upload Timeout Failure:
 
       _updateUploadProgress(upload.id, 0.85);
 
-      // Upload thumbnail to Blossom server
+      // Upload thumbnail to Blossom server.
+      //
+      // `maxAttempts: 1` opts out of `BlossomUploadService.uploadImage`'s
+      // service-level retry (added for #3862). UploadManager already wraps
+      // the entire video+thumbnail pipeline in `AsyncUtils.retryWithBackoff`
+      // (see `_uploadHandler` retry config), so retrying again at the
+      // service layer would compound delays without benefit.
       final uploadResult = await _blossomService.uploadImage(
         imageFile: thumbnailFile,
         nostrPubkey: nostrPubkey,
+        maxAttempts: 1,
         onProgress: (progress) {
           // Map thumbnail progress to 85%-100% of total upload
           _updateUploadProgress(upload.id, 0.85 + (progress * 0.15));

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -170,6 +170,32 @@ class BlossomUploadService {
   static const int _maxChunkRetries = 2;
   static const Duration _chunkRetryDelay = Duration(seconds: 1);
 
+  /// Default total attempts for a whole-image upload to a single server.
+  /// 1 initial + 2 retries; covers transient 5xx and connection blips on
+  /// `media.divine.video` without compounding when a caller (e.g. the
+  /// app-level UploadManager) already wraps the call in its own retry
+  /// loop — those callers pass `maxAttempts: 1`.
+  static const int _defaultUploadImageMaxAttempts = 3;
+
+  /// Base delay between retried image upload attempts. Doubled on each retry
+  /// up to [_uploadImageRetryMaxDelay].
+  static const Duration _uploadImageRetryBaseDelay = Duration(seconds: 1);
+
+  /// Hard ceiling on the per-attempt backoff for image uploads.
+  static const Duration _uploadImageRetryMaxDelay = Duration(seconds: 30);
+
+  /// HTTP status codes that justify retrying an image upload. Mirrors
+  /// `UploadManager.isRetriableError` so service-level and orchestrator-level
+  /// classification stay in sync.
+  static const Set<int> _retriableUploadStatusCodes = {
+    408, // Request timeout
+    429, // Rate limited
+    500, // Generic server error
+    502, // Bad gateway
+    503, // Service unavailable (the symptom in #3862)
+    504, // Gateway timeout
+  };
+
   /// How long a cached capability discovery result stays valid.
   static const Duration _capabilityCacheTtl = Duration(minutes: 5);
 
@@ -387,6 +413,106 @@ class BlossomUploadService {
       DioExceptionType.connectionError => true, // coverage:ignore-line
       _ => false,
     };
+  }
+
+  /// Whether an image-upload attempt threw a transient, retriable error.
+  ///
+  /// Transient = the same request stands a real chance of succeeding on a
+  /// subsequent attempt (5xx server, rate limit, connection / timeout).
+  bool _isTransientUploadError(Object error) {
+    if (error is DioException) {
+      final statusCode = error.response?.statusCode;
+      if (statusCode != null &&
+          _retriableUploadStatusCodes.contains(statusCode)) {
+        return true;
+      }
+      return switch (error.type) {
+        DioExceptionType.connectionTimeout ||
+        DioExceptionType.sendTimeout ||
+        DioExceptionType.receiveTimeout ||
+        DioExceptionType.connectionError => true,
+        _ => false,
+      };
+    }
+    return false;
+  }
+
+  /// Whether a [BlossomUploadResult] failure is transient and worth retrying.
+  ///
+  /// Some failure modes are caught inside the upload internals and surface as
+  /// `success: false` with a `statusCode`, rather than re-throwing — this
+  /// predicate covers that case symmetrically with [_isTransientUploadError].
+  bool _isTransientUploadResult(BlossomUploadResult result) {
+    if (result.success) return false;
+    final statusCode = result.statusCode;
+    return statusCode != null &&
+        _retriableUploadStatusCodes.contains(statusCode);
+  }
+
+  /// Run [attempt] up to [maxAttempts] times with exponential backoff,
+  /// stopping early on success or on a non-transient failure.
+  ///
+  /// `maxAttempts == 1` disables retry — useful for callers (UploadManager)
+  /// that already wrap the call in their own retry loop and want to avoid
+  /// compounded delays.
+  Future<BlossomUploadResult> _uploadWithRetry({
+    required Future<BlossomUploadResult> Function() attempt,
+    required int maxAttempts,
+    required String debugContext,
+  }) async {
+    var attemptNumber = 0;
+    while (true) {
+      attemptNumber++;
+      BlossomUploadResult? result;
+      Object? thrown;
+      try {
+        result = await attempt();
+      } on Object catch (e) {
+        thrown = e;
+      }
+
+      // Success path — return immediately.
+      if (result != null && result.success) {
+        return result;
+      }
+
+      // Decide whether the failure is retriable.
+      final retriable = thrown != null
+          ? _isTransientUploadError(thrown)
+          : _isTransientUploadResult(result!);
+
+      // Out of budget, or the failure mode is permanent — surface it.
+      if (attemptNumber >= maxAttempts || !retriable) {
+        if (thrown != null) {
+          // The original throwable is preserved so callers see the same
+          // exception type (DioException, BlossomResumableUploadException,
+          // etc.) they would have seen without the retry wrapper.
+          // ignore: only_throw_errors
+          throw thrown;
+        }
+        return result!;
+      }
+
+      // Compute the next backoff. Exponential: base, base*2, base*4 ...
+      // capped at the configured ceiling. attemptNumber is 1-indexed and
+      // we've just *finished* attempt N, so the multiplier is 2^(N-1).
+      final multiplier = 1 << (attemptNumber - 1);
+      final backoffMs = _uploadImageRetryBaseDelay.inMilliseconds * multiplier;
+      final cappedMs = math.min(
+        backoffMs,
+        _uploadImageRetryMaxDelay.inMilliseconds,
+      );
+      final delay = Duration(milliseconds: cappedMs);
+
+      Log.warning(
+        'Image upload attempt $attemptNumber/$maxAttempts failed '
+        '($debugContext); retrying in ${delay.inMilliseconds}ms',
+        name: 'BlossomUploadService',
+        category: LogCategory.video,
+      );
+
+      await Future<void>.delayed(delay);
+    }
   }
 
   bool _isDivineOwnedUploadHost(String serverUrl) {
@@ -1482,6 +1608,7 @@ class BlossomUploadService {
     required String nostrPubkey,
     String mimeType = 'image/jpeg',
     void Function(double)? onProgress,
+    int maxAttempts = _defaultUploadImageMaxAttempts,
   }) async {
     try {
       // Check authentication
@@ -1491,6 +1618,7 @@ class BlossomUploadService {
           errorMessage: 'Not authenticated',
         );
       }
+      assert(maxAttempts >= 1, 'maxAttempts must be at least 1');
 
       // Report initial progress
       onProgress?.call(0.1);
@@ -1539,39 +1667,51 @@ class BlossomUploadService {
 
           final capability = await _fetchDivineUploadCapability(serverUrl);
 
-          late BlossomUploadResult result;
-          if (capability.supportsResumable) {
-            result = await _uploadWithSingleLegacyFallback(
-              serverUrl: serverUrl,
-              uploadResumable: () => _uploadToServerResumable(
+          // Retry the actual upload work on transient 5xx / network blips
+          // before falling through to the next configured server. Capability
+          // discovery is not retried here — it has its own fail-soft path
+          // (`_isTransientCapabilityDiscoveryError`).
+          //
+          // #3862: previously a single 503 from the only server in the list
+          // (default config has just `media.divine.video`) surfaced to the
+          // user as a hard failure with no automatic recovery.
+          final result = await _uploadWithRetry(
+            attempt: () {
+              if (capability.supportsResumable) {
+                return _uploadWithSingleLegacyFallback(
+                  serverUrl: serverUrl,
+                  uploadResumable: () => _uploadToServerResumable(
+                    serverUrl: serverUrl,
+                    file: strippedFile,
+                    fileHash: fileHash,
+                    fileSize: fileSize,
+                    contentType: mimeType,
+                    onProgress: onProgress,
+                  ),
+                  uploadLegacyFallback: (fallbackReason) =>
+                      _uploadToServerLegacyFallback(
+                        serverUrl: serverUrl,
+                        file: strippedFile,
+                        fileHash: fileHash,
+                        fileSize: fileSize,
+                        contentType: mimeType,
+                        fallbackReason: fallbackReason,
+                        onProgress: onProgress,
+                      ),
+                );
+              }
+              return _uploadToServer(
                 serverUrl: serverUrl,
                 file: strippedFile,
                 fileHash: fileHash,
                 fileSize: fileSize,
                 contentType: mimeType,
                 onProgress: onProgress,
-              ),
-              uploadLegacyFallback: (fallbackReason) =>
-                  _uploadToServerLegacyFallback(
-                    serverUrl: serverUrl,
-                    file: strippedFile,
-                    fileHash: fileHash,
-                    fileSize: fileSize,
-                    contentType: mimeType,
-                    fallbackReason: fallbackReason,
-                    onProgress: onProgress,
-                  ),
-            );
-          } else {
-            result = await _uploadToServer(
-              serverUrl: serverUrl,
-              file: strippedFile,
-              fileHash: fileHash,
-              fileSize: fileSize,
-              contentType: mimeType,
-              onProgress: onProgress,
-            );
-          }
+              );
+            },
+            maxAttempts: maxAttempts,
+            debugContext: 'uploadImage($serverUrl)',
+          );
 
           if (result.success) {
             // Construct canonical Blossom URL from server + hash

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -435,6 +435,16 @@ class BlossomUploadService {
   ///
   /// Transient = the same request stands a real chance of succeeding on a
   /// subsequent attempt (5xx server, rate limit, connection / timeout).
+  ///
+  /// Covers two thrown shapes symmetrically:
+  ///   * [DioException] with a retriable status code (5xx, 429, 408) or a
+  ///     transient connection / timeout type.
+  ///   * [BlossomResumableUploadException] with a retriable status code —
+  ///     thrown when chunk PUT exhausts its internal retry budget on a 5xx
+  ///     and the resumable session bubbles up. An outer retry rebuilds the
+  ///     session via `_initResumableUpload`. 404/410 (session expired) and
+  ///     null statusCode (auth or malformed-response) are intentionally not
+  ///     transient.
   bool _isTransientUploadError(Object error) {
     if (error is DioException) {
       final statusCode = error.response?.statusCode;
@@ -449,6 +459,11 @@ class BlossomUploadService {
         DioExceptionType.connectionError => true,
         _ => false,
       };
+    }
+    if (error is BlossomResumableUploadException) {
+      final statusCode = error.statusCode;
+      return statusCode != null &&
+          _retriableUploadStatusCodes.contains(statusCode);
     }
     return false;
   }

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -1653,6 +1653,7 @@ class BlossomUploadService {
     void Function(double)? onProgress,
     int maxAttempts = _defaultUploadImageMaxAttempts,
   }) async {
+    assert(maxAttempts >= 1, 'maxAttempts must be at least 1');
     try {
       // Check authentication
       if (!authProvider.isAuthenticated) {
@@ -1661,7 +1662,6 @@ class BlossomUploadService {
           errorMessage: 'Not authenticated',
         );
       }
-      assert(maxAttempts >= 1, 'maxAttempts must be at least 1');
 
       // Report initial progress
       onProgress?.call(0.1);

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -33,6 +33,7 @@ class BlossomUploadResult {
     this.blurhash,
     this.errorMessage,
     this.statusCode,
+    this.isTransientNetworkFailure = false,
   });
 
   /// Whether the upload succeeded.
@@ -70,6 +71,13 @@ class BlossomUploadResult {
 
   /// HTTP status code on failure.
   final int? statusCode;
+
+  /// Whether this failure was caused by a transient network condition
+  /// (connection / send / receive timeout, or connection error) that the
+  /// upload internals caught and converted to a result instead of
+  /// rethrowing. Surfaced as a retry signal symmetric with [statusCode]
+  /// for the cases where there is no HTTP status to classify on.
+  final bool isTransientNetworkFailure;
 
   /// Convenience getter for backwards compatibility.
   String? get cdnUrl => fallbackUrl ?? url;
@@ -439,11 +447,19 @@ class BlossomUploadService {
 
   /// Whether a [BlossomUploadResult] failure is transient and worth retrying.
   ///
-  /// Some failure modes are caught inside the upload internals and surface as
-  /// `success: false` with a `statusCode`, rather than re-throwing — this
-  /// predicate covers that case symmetrically with [_isTransientUploadError].
+  /// Some failure modes are caught inside the upload internals (notably the
+  /// legacy PUT path through [_uploadToServer]) and surface as
+  /// `success: false` rather than re-throwing. Two signals classify a
+  /// caught failure as transient, symmetric with [_isTransientUploadError]:
+  ///
+  ///   * `statusCode` is in the retriable set (5xx, 429, 408), or
+  ///   * `isTransientNetworkFailure` is `true` — set by [_uploadToServer]
+  ///     when it caught a [DioException] of type connection / send /
+  ///     receive timeout or connection error and converted it to a result
+  ///     (these have no HTTP status to classify on).
   bool _isTransientUploadResult(BlossomUploadResult result) {
     if (result.success) return false;
+    if (result.isTransientNetworkFailure) return true;
     final statusCode = result.statusCode;
     return statusCode != null &&
         _retriableUploadStatusCodes.contains(statusCode);
@@ -1299,24 +1315,28 @@ class BlossomUploadService {
           success: false,
           statusCode: statusCode,
           errorMessage: 'Connection timeout - check server URL',
+          isTransientNetworkFailure: true,
         );
       } else if (e.type == DioExceptionType.sendTimeout) {
         return BlossomUploadResult(
           success: false,
           statusCode: statusCode,
           errorMessage: 'Send timeout - upload too slow or connection dropped',
+          isTransientNetworkFailure: true,
         );
       } else if (e.type == DioExceptionType.receiveTimeout) {
         return BlossomUploadResult(
           success: false,
           statusCode: statusCode,
           errorMessage: 'Receive timeout - server not responding',
+          isTransientNetworkFailure: true,
         );
       } else if (e.type == DioExceptionType.connectionError) {
         return BlossomUploadResult(
           success: false,
           statusCode: statusCode,
           errorMessage: 'Cannot connect to Blossom server: $errorDetail',
+          isTransientNetworkFailure: true,
         );
       } else if (e.type == DioExceptionType.cancel) {
         return BlossomUploadResult(

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -504,10 +504,12 @@ class BlossomUploadService {
       attemptNumber++;
       BlossomUploadResult? result;
       Object? thrown;
+      StackTrace? thrownStackTrace;
       try {
         result = await attempt();
-      } on Object catch (e) {
+      } on Object catch (e, stackTrace) {
         thrown = e;
+        thrownStackTrace = stackTrace;
       }
 
       // Success path — return immediately.
@@ -524,10 +526,10 @@ class BlossomUploadService {
       if (attemptNumber >= maxAttempts || !retriable) {
         if (thrown != null) {
           // The original throwable is preserved so callers see the same
-          // exception type (DioException, BlossomResumableUploadException,
-          // etc.) they would have seen without the retry wrapper.
-          // ignore: only_throw_errors
-          throw thrown;
+          // exception type and stack trace (DioException,
+          // BlossomResumableUploadException, etc.) they would have seen
+          // without the retry wrapper.
+          Error.throwWithStackTrace(thrown, thrownStackTrace!);
         }
         return result!;
       }

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -156,17 +156,24 @@ class _CachedCapability {
 /// Blossom BUD-01 media upload service with resumable upload support.
 class BlossomUploadService {
   /// Creates a [BlossomUploadService].
+  ///
+  /// [sleep] is the awaitable used to space out retries in
+  /// [_uploadWithRetry]. Defaults to `Future<void>.delayed`. Tests pass a
+  /// no-op so the retry-behavior group doesn't pay real wall time on each
+  /// backoff; production code should leave it at the default.
   BlossomUploadService({
     required this.authProvider,
     BlossomPerformanceMonitor? performanceMonitor,
     Dio? dio,
     String? defaultServerUrl,
     DateTime Function()? clock,
+    Future<void> Function(Duration)? sleep,
   }) : _performanceMonitor =
            performanceMonitor ?? const NoOpPerformanceMonitor(),
        dio = dio ?? Dio(),
        _defaultServerUrl = defaultServerUrl ?? defaultBlossomServer,
-       _clock = clock ?? DateTime.now;
+       _clock = clock ?? DateTime.now,
+       _sleep = sleep ?? Future<void>.delayed;
 
   static const String _blossomServerKey = 'blossom_server_url';
   static const String _useBlossomKey = 'use_blossom_upload';
@@ -215,6 +222,7 @@ class BlossomUploadService {
   final Dio dio;
   final String _defaultServerUrl;
   final DateTime Function() _clock;
+  final Future<void> Function(Duration) _sleep;
 
   /// In-memory cache of capability discovery results keyed by server URL.
   final Map<String, _CachedCapability> _capabilityCache = {};
@@ -527,7 +535,7 @@ class BlossomUploadService {
         category: LogCategory.video,
       );
 
-      await Future<void>.delayed(delay);
+      await _sleep(delay);
     }
   }
 

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -4821,9 +4821,13 @@ void main() {
 
       setUp(() {
         mockDio = _MockDio();
+        // No-op sleep: assertions in this group are about attempt counts and
+        // final state, not backoff timing. Skipping the real 1s/2s waits cuts
+        // the group's wall time from ~16s to ~1s without changing semantics.
         service = BlossomUploadService(
           authProvider: mockAuthProvider,
           dio: mockDio,
+          sleep: (_) async {},
         );
       });
 

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -5444,6 +5444,213 @@ void main() {
         },
       );
 
+      // Liz flagged that the retry helper's contract has to cover both
+      // signals: retriable HTTP statuses and the transient network
+      // failures that _uploadToServer catches and converts to result-typed
+      // failures with statusCode: null. The four tests below pin the
+      // default-host legacy PUT path for each transient DioExceptionType
+      // (connection / send / receive timeout, connection error). Without
+      // the isTransientNetworkFailure signal these would each short-circuit
+      // after one attempt — exactly the user-facing failure mode #3862
+      // describes when media.divine.video has a transient network blip.
+      test(
+        'retries on connectionTimeout from default-host legacy PUT',
+        () async {
+          stubAuth();
+          stubLegacyHead();
+
+          final imageFile = await tempImage('legacy_conn_timeout');
+          var attempt = 0;
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer((_) async {
+            attempt++;
+            if (attempt == 1) {
+              throw DioException(
+                requestOptions: RequestOptions(path: '/upload'),
+                type: DioExceptionType.connectionTimeout,
+              );
+            }
+            return uploadOkResponse();
+          });
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(result.success, isTrue);
+          expect(
+            attempt,
+            equals(2),
+            reason:
+                'connectionTimeout caught inside _uploadToServer is converted '
+                'to a result with statusCode: null, so the retry helper has '
+                'to look at isTransientNetworkFailure to retry.',
+          );
+
+          await imageFile.parent.delete(recursive: true);
+        },
+      );
+
+      test(
+        'retries on connectionError from default-host legacy PUT',
+        () async {
+          stubAuth();
+          stubLegacyHead();
+
+          final imageFile = await tempImage('legacy_conn_error');
+          var attempt = 0;
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer((_) async {
+            attempt++;
+            if (attempt == 1) {
+              throw DioException(
+                requestOptions: RequestOptions(path: '/upload'),
+                type: DioExceptionType.connectionError,
+              );
+            }
+            return uploadOkResponse();
+          });
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(result.success, isTrue);
+          expect(attempt, equals(2));
+
+          await imageFile.parent.delete(recursive: true);
+        },
+      );
+
+      test(
+        'retries on sendTimeout from default-host legacy PUT',
+        () async {
+          stubAuth();
+          stubLegacyHead();
+
+          final imageFile = await tempImage('legacy_send_timeout');
+          var attempt = 0;
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer((_) async {
+            attempt++;
+            if (attempt == 1) {
+              throw DioException(
+                requestOptions: RequestOptions(path: '/upload'),
+                type: DioExceptionType.sendTimeout,
+              );
+            }
+            return uploadOkResponse();
+          });
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(result.success, isTrue);
+          expect(attempt, equals(2));
+
+          await imageFile.parent.delete(recursive: true);
+        },
+      );
+
+      test(
+        'retries on receiveTimeout from default-host legacy PUT',
+        () async {
+          stubAuth();
+          stubLegacyHead();
+
+          final imageFile = await tempImage('legacy_recv_timeout');
+          var attempt = 0;
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer((_) async {
+            attempt++;
+            if (attempt == 1) {
+              throw DioException(
+                requestOptions: RequestOptions(path: '/upload'),
+                type: DioExceptionType.receiveTimeout,
+              );
+            }
+            return uploadOkResponse();
+          });
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(result.success, isTrue);
+          expect(attempt, equals(2));
+
+          await imageFile.parent.delete(recursive: true);
+        },
+      );
+
+      test(
+        'does NOT retry on cancel from default-host legacy PUT',
+        () async {
+          // Opposing-symmetry guard: cancel is a user action, not a
+          // transient network condition. _uploadToServer catches it but
+          // must NOT mark the result transient — otherwise we'd loop on a
+          // cancelled upload.
+          stubAuth();
+          stubLegacyHead();
+
+          final imageFile = await tempImage('legacy_cancel');
+          var attempt = 0;
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer((_) async {
+            attempt++;
+            throw DioException(
+              requestOptions: RequestOptions(path: '/upload'),
+              type: DioExceptionType.cancel,
+            );
+          });
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(result.success, isFalse);
+          expect(attempt, equals(1));
+
+          await imageFile.parent.delete(recursive: true);
+        },
+      );
+
       test(
         'falls through to next server after exhausting retries on the first',
         () async {

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -4622,9 +4622,14 @@ void main() {
             );
           });
 
+          // maxAttempts: 1 isolates this test to a single per-server attempt,
+          // which is the property under test (no duplicate legacy fallback
+          // *within* one attempt). The retry behavior across attempts is
+          // covered separately under "uploadImage - retry behavior".
           final result = await service.uploadImage(
             imageFile: imageFile,
             nostrPubkey: _testPublicKey,
+            maxAttempts: 1,
           );
 
           expect(result.success, isFalse);
@@ -4805,6 +4810,700 @@ void main() {
 
         await tempDir.delete(recursive: true);
       });
+    });
+
+    // Regression coverage for #3862: a single transient 5xx from the only
+    // configured server used to surface as a hard failure. The service now
+    // retries the per-server attempt with exponential backoff before falling
+    // through to the next server.
+    group('uploadImage - retry behavior', () {
+      late _MockDio mockDio;
+
+      setUp(() {
+        mockDio = _MockDio();
+        service = BlossomUploadService(
+          authProvider: mockAuthProvider,
+          dio: mockDio,
+        );
+      });
+
+      // Stock head() mock — capability discovery returns 200 with no
+      // resumable extension, so the legacy PUT path is taken.
+      void stubLegacyHead() {
+        when(
+          () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+        ).thenAnswer(
+          (_) async => Response(
+            requestOptions: RequestOptions(path: '/upload'),
+            statusCode: 200,
+            headers: Headers(),
+          ),
+        );
+      }
+
+      void stubAuth() {
+        when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+        when(
+          () => mockAuthProvider.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (_) async => _signedEvent(_testPublicKey, 24242, const [], 'upload'),
+        );
+      }
+
+      Future<File> tempImage(String tag) async {
+        final tempDir = await Directory.systemTemp.createTemp(
+          'image_retry_test_${tag}_',
+        );
+        return File('${tempDir.path}/image.jpg')
+          ..writeAsBytesSync([0xFF, 0xD8, 0xFF]);
+      }
+
+      DioException dioBadResponse(int statusCode) => DioException(
+        requestOptions: RequestOptions(path: '/upload'),
+        type: DioExceptionType.badResponse,
+        response: Response(
+          requestOptions: RequestOptions(path: '/upload'),
+          statusCode: statusCode,
+        ),
+      );
+
+      Response<dynamic> uploadOkResponse() => Response(
+        requestOptions: RequestOptions(path: '/upload'),
+        statusCode: 200,
+        data: {
+          'url': 'https://media.divine.video/hash',
+          'fallbackUrl': 'https://media.divine.video/hash',
+        },
+      );
+
+      test('retries on 503 and succeeds on second attempt', () async {
+        stubAuth();
+        stubLegacyHead();
+
+        final imageFile = await tempImage('503');
+        var attempt = 0;
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((_) async {
+          attempt++;
+          if (attempt == 1) throw dioBadResponse(503);
+          return uploadOkResponse();
+        });
+
+        final result = await service.uploadImage(
+          imageFile: imageFile,
+          nostrPubkey: _testPublicKey,
+        );
+
+        expect(result.success, isTrue);
+        expect(attempt, equals(2));
+
+        await imageFile.parent.delete(recursive: true);
+      });
+
+      test('retries on 504 and succeeds', () async {
+        stubAuth();
+        stubLegacyHead();
+
+        final imageFile = await tempImage('504');
+        var attempt = 0;
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((_) async {
+          attempt++;
+          if (attempt == 1) throw dioBadResponse(504);
+          return uploadOkResponse();
+        });
+
+        final result = await service.uploadImage(
+          imageFile: imageFile,
+          nostrPubkey: _testPublicKey,
+        );
+
+        expect(result.success, isTrue);
+        expect(attempt, equals(2));
+
+        await imageFile.parent.delete(recursive: true);
+      });
+
+      test('retries on 429 and succeeds', () async {
+        stubAuth();
+        stubLegacyHead();
+
+        final imageFile = await tempImage('429');
+        var attempt = 0;
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((_) async {
+          attempt++;
+          if (attempt == 1) throw dioBadResponse(429);
+          return uploadOkResponse();
+        });
+
+        final result = await service.uploadImage(
+          imageFile: imageFile,
+          nostrPubkey: _testPublicKey,
+        );
+
+        expect(result.success, isTrue);
+        expect(attempt, equals(2));
+
+        await imageFile.parent.delete(recursive: true);
+      });
+
+      test('retries on 408 and succeeds', () async {
+        stubAuth();
+        stubLegacyHead();
+
+        final imageFile = await tempImage('408');
+        var attempt = 0;
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((_) async {
+          attempt++;
+          if (attempt == 1) throw dioBadResponse(408);
+          return uploadOkResponse();
+        });
+
+        final result = await service.uploadImage(
+          imageFile: imageFile,
+          nostrPubkey: _testPublicKey,
+        );
+
+        expect(result.success, isTrue);
+        expect(attempt, equals(2));
+
+        await imageFile.parent.delete(recursive: true);
+      });
+
+      test(
+        'exhausts retries on persistent 503 and returns last error',
+        () async {
+          stubAuth();
+          stubLegacyHead();
+
+          final imageFile = await tempImage('exhaust');
+          var attempt = 0;
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer((_) async {
+            attempt++;
+            throw dioBadResponse(503);
+          });
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(result.success, isFalse);
+          expect(result.statusCode, equals(503));
+          expect(attempt, equals(3));
+
+          await imageFile.parent.delete(recursive: true);
+        },
+      );
+
+      test('does NOT retry on 401', () async {
+        stubAuth();
+        stubLegacyHead();
+
+        final imageFile = await tempImage('401');
+        var attempt = 0;
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((_) async {
+          attempt++;
+          throw dioBadResponse(401);
+        });
+
+        final result = await service.uploadImage(
+          imageFile: imageFile,
+          nostrPubkey: _testPublicKey,
+        );
+
+        expect(result.success, isFalse);
+        expect(result.statusCode, equals(401));
+        expect(attempt, equals(1));
+
+        await imageFile.parent.delete(recursive: true);
+      });
+
+      test('does NOT retry on 413 (file too large)', () async {
+        stubAuth();
+        stubLegacyHead();
+
+        final imageFile = await tempImage('413');
+        var attempt = 0;
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((_) async {
+          attempt++;
+          throw dioBadResponse(413);
+        });
+
+        final result = await service.uploadImage(
+          imageFile: imageFile,
+          nostrPubkey: _testPublicKey,
+        );
+
+        expect(result.success, isFalse);
+        expect(result.statusCode, equals(413));
+        expect(attempt, equals(1));
+
+        await imageFile.parent.delete(recursive: true);
+      });
+
+      test('does NOT retry on success', () async {
+        stubAuth();
+        stubLegacyHead();
+
+        final imageFile = await tempImage('happy');
+        var attempt = 0;
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((_) async {
+          attempt++;
+          return uploadOkResponse();
+        });
+
+        final result = await service.uploadImage(
+          imageFile: imageFile,
+          nostrPubkey: _testPublicKey,
+        );
+
+        expect(result.success, isTrue);
+        expect(attempt, equals(1));
+
+        await imageFile.parent.delete(recursive: true);
+      });
+
+      test('maxAttempts: 1 disables retry', () async {
+        stubAuth();
+        stubLegacyHead();
+
+        final imageFile = await tempImage('opt_out');
+        var attempt = 0;
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((_) async {
+          attempt++;
+          throw dioBadResponse(503);
+        });
+
+        final result = await service.uploadImage(
+          imageFile: imageFile,
+          nostrPubkey: _testPublicKey,
+          maxAttempts: 1,
+        );
+
+        expect(result.success, isFalse);
+        expect(result.statusCode, equals(503));
+        expect(
+          attempt,
+          equals(1),
+          reason:
+              'maxAttempts: 1 must short-circuit retry so callers with their '
+              'own outer retry loop (UploadManager) do not double-retry.',
+        );
+
+        await imageFile.parent.delete(recursive: true);
+      });
+
+      test(
+        'retries on DioException thrown from non-Divine host resumable init',
+        () async {
+          // Non-Divine hosts re-throw resumable failures (no Divine-only
+          // legacy fallback). The retry helper must classify a DioException
+          // with a 5xx status as transient and retry, exercising the
+          // exception-typed `_isTransientUploadError` branch.
+          await service.setBlossomEnabled(true);
+          await service.setBlossomServer('https://third-party.example');
+
+          stubAuth();
+
+          final imageFile = await tempImage('non_divine_dio');
+
+          when(
+            () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.extensions: [
+                  DivineUploadExtensions.resumableSessions,
+                ],
+              }),
+            ),
+          );
+
+          // Track init attempts per host so we can distinguish per-server
+          // retry from the multi-server fallback that runs after retries are
+          // exhausted.
+          final initAttemptsByHost = <String, int>{};
+          when(
+            () => mockDio.post<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer((invocation) async {
+            final url = invocation.positionalArguments.first as String;
+            if (!url.endsWith('/upload/init')) {
+              // Complete endpoint or anything else — return a generic OK so
+              // we only count init attempts in the assertion below.
+              return Response(
+                requestOptions: RequestOptions(path: url),
+                statusCode: 200,
+                data: {
+                  'url': 'https://media.divine.video/hash',
+                  'fallbackUrl': 'https://media.divine.video/hash',
+                },
+              );
+            }
+            final host = Uri.parse(url).host;
+            final n = (initAttemptsByHost[host] ?? 0) + 1;
+            initAttemptsByHost[host] = n;
+            if (host == 'third-party.example' && n == 1) {
+              throw DioException(
+                requestOptions: RequestOptions(path: '/upload/init'),
+                type: DioExceptionType.badResponse,
+                response: Response(
+                  requestOptions: RequestOptions(path: '/upload/init'),
+                  statusCode: 503,
+                ),
+              );
+            }
+            return Response(
+              requestOptions: RequestOptions(path: '/upload/init'),
+              statusCode: 201,
+              data: {
+                'uploadId': 'up_retry_dio',
+                'uploadUrl':
+                    'https://third-party.example/sessions/up_retry_dio',
+                'chunkSize': 1024,
+                'nextOffset': 0,
+                'expiresAt': 9999999999,
+              },
+            );
+          });
+
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(
+                path: '/sessions/up_retry_dio',
+              ),
+              statusCode: 204,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.uploadOffset: ['3'],
+              }),
+            ),
+          );
+
+          await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(
+            initAttemptsByHost['third-party.example'],
+            equals(2),
+            reason:
+                'A 503 DioException from non-Divine host resumable init must '
+                'be classified as transient by _isTransientUploadError so the '
+                'retry helper schedules another attempt on the same host.',
+          );
+
+          await imageFile.parent.delete(recursive: true);
+        },
+      );
+
+      test(
+        'does NOT retry on DioException with non-retriable status from '
+        'non-Divine host',
+        () async {
+          await service.setBlossomEnabled(true);
+          await service.setBlossomServer('https://third-party.example');
+
+          stubAuth();
+
+          final imageFile = await tempImage('non_divine_dio_401');
+
+          when(
+            () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.extensions: [
+                  DivineUploadExtensions.resumableSessions,
+                ],
+              }),
+            ),
+          );
+
+          final initAttemptsByHost = <String, int>{};
+          when(
+            () => mockDio.post<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer((invocation) async {
+            final url = invocation.positionalArguments.first as String;
+            final host = Uri.parse(url).host;
+            initAttemptsByHost[host] = (initAttemptsByHost[host] ?? 0) + 1;
+            throw DioException(
+              requestOptions: RequestOptions(path: '/upload/init'),
+              type: DioExceptionType.badResponse,
+              response: Response(
+                requestOptions: RequestOptions(path: '/upload/init'),
+                statusCode: 401,
+              ),
+            );
+          });
+
+          await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(
+            initAttemptsByHost['third-party.example'],
+            equals(1),
+            reason:
+                '401 is non-retriable, so a single DioException with that '
+                'status must short-circuit the retry helper for the failing '
+                'host.',
+          );
+
+          await imageFile.parent.delete(recursive: true);
+        },
+      );
+
+      test(
+        'retries on DioException of connectionTimeout type from non-Divine '
+        'host',
+        () async {
+          // Connection timeout has no statusCode; classification falls to
+          // the DioExceptionType switch in _isTransientUploadError.
+          await service.setBlossomEnabled(true);
+          await service.setBlossomServer('https://third-party.example');
+
+          stubAuth();
+
+          final imageFile = await tempImage('non_divine_dio_timeout');
+
+          when(
+            () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.extensions: [
+                  DivineUploadExtensions.resumableSessions,
+                ],
+              }),
+            ),
+          );
+
+          final initAttemptsByHost = <String, int>{};
+          when(
+            () => mockDio.post<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer((invocation) async {
+            final url = invocation.positionalArguments.first as String;
+            if (!url.endsWith('/upload/init')) {
+              return Response(
+                requestOptions: RequestOptions(path: url),
+                statusCode: 200,
+                data: {
+                  'url': 'https://media.divine.video/hash',
+                  'fallbackUrl': 'https://media.divine.video/hash',
+                },
+              );
+            }
+            final host = Uri.parse(url).host;
+            final n = (initAttemptsByHost[host] ?? 0) + 1;
+            initAttemptsByHost[host] = n;
+            if (host == 'third-party.example' && n == 1) {
+              throw DioException(
+                requestOptions: RequestOptions(path: '/upload/init'),
+                type: DioExceptionType.connectionTimeout,
+              );
+            }
+            return Response(
+              requestOptions: RequestOptions(path: '/upload/init'),
+              statusCode: 201,
+              data: {
+                'uploadId': 'up_retry_timeout',
+                'uploadUrl':
+                    'https://third-party.example/sessions/up_retry_timeout',
+                'chunkSize': 1024,
+                'nextOffset': 0,
+                'expiresAt': 9999999999,
+              },
+            );
+          });
+
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(
+                path: '/sessions/up_retry_timeout',
+              ),
+              statusCode: 204,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.uploadOffset: ['3'],
+              }),
+            ),
+          );
+
+          await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(
+            initAttemptsByHost['third-party.example'],
+            equals(2),
+            reason:
+                'connectionTimeout is transient and must be retried on the '
+                'same host by _isTransientUploadError.',
+          );
+
+          await imageFile.parent.delete(recursive: true);
+        },
+      );
+
+      test(
+        'falls through to next server after exhausting retries on the first',
+        () async {
+          stubAuth();
+
+          await service.setBlossomEnabled(true);
+          await service.setBlossomServer('https://blossom.example.com');
+
+          final imageFile = await tempImage('multi_server');
+
+          when(
+            () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers(),
+            ),
+          );
+
+          final attemptsByHost = <String, int>{};
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer((invocation) async {
+            final url = invocation.positionalArguments.first as String;
+            final host = Uri.parse(url).host;
+            attemptsByHost[host] = (attemptsByHost[host] ?? 0) + 1;
+            if (host == 'blossom.example.com') {
+              throw dioBadResponse(503);
+            }
+            return uploadOkResponse();
+          });
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(result.success, isTrue);
+          expect(
+            attemptsByHost['blossom.example.com'],
+            equals(3),
+            reason: 'Custom server should be tried 3 times before fallback.',
+          );
+          expect(
+            attemptsByHost['media.divine.video'],
+            equals(1),
+            reason:
+                'Default Divine server should succeed on its first attempt '
+                'after the custom server exhausts its retries.',
+          );
+
+          await imageFile.parent.delete(recursive: true);
+        },
+      );
     });
 
     group('Bug report upload success path', () {

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -5715,6 +5715,187 @@ void main() {
           await imageFile.parent.delete(recursive: true);
         },
       );
+
+      // Symmetry guard for _isTransientUploadError: a
+      // BlossomResumableUploadException whose statusCode is in the retriable
+      // set must be retried by the outer helper, the same way a
+      // DioException(503) already is. The init endpoint throws
+      // BlossomResumableUploadException directly for any non-200/201
+      // response that still passes validateStatus (4xx + 408 + 429 land
+      // here; 5xx is thrown by Dio as DioException(badResponse) instead).
+      test(
+        'retries on BlossomResumableUploadException with retriable status '
+        'from non-Divine host resumable init',
+        () async {
+          await service.setBlossomEnabled(true);
+          await service.setBlossomServer('https://third-party.example');
+
+          stubAuth();
+
+          final imageFile = await tempImage('non_divine_resumable_408');
+
+          when(
+            () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.extensions: [
+                  DivineUploadExtensions.resumableSessions,
+                ],
+              }),
+            ),
+          );
+
+          final initAttemptsByHost = <String, int>{};
+          when(
+            () => mockDio.post<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer((invocation) async {
+            final url = invocation.positionalArguments.first as String;
+            if (!url.endsWith('/upload/init')) {
+              return Response(
+                requestOptions: RequestOptions(path: url),
+                statusCode: 200,
+                data: {
+                  'url': 'https://media.divine.video/hash',
+                  'fallbackUrl': 'https://media.divine.video/hash',
+                },
+              );
+            }
+            final host = Uri.parse(url).host;
+            final n = (initAttemptsByHost[host] ?? 0) + 1;
+            initAttemptsByHost[host] = n;
+            if (host == 'third-party.example' && n == 1) {
+              // 408 passes validateStatus (< 500) so init throws a
+              // BlossomResumableUploadException(statusCode: 408) rather
+              // than a DioException.
+              return Response(
+                requestOptions: RequestOptions(path: '/upload/init'),
+                statusCode: 408,
+                data: 'Request timeout',
+              );
+            }
+            return Response(
+              requestOptions: RequestOptions(path: '/upload/init'),
+              statusCode: 201,
+              data: {
+                'uploadId': 'up_resumable_408',
+                'uploadUrl':
+                    'https://third-party.example/sessions/up_resumable_408',
+                'chunkSize': 1024,
+                'nextOffset': 0,
+                'expiresAt': 9999999999,
+              },
+            );
+          });
+
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(
+                path: '/sessions/up_resumable_408',
+              ),
+              statusCode: 204,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.uploadOffset: ['3'],
+              }),
+            ),
+          );
+
+          await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(
+            initAttemptsByHost['third-party.example'],
+            equals(2),
+            reason:
+                'BlossomResumableUploadException with statusCode 408 must be '
+                'classified transient by _isTransientUploadError so the outer '
+                'retry rebuilds the resumable session.',
+          );
+
+          await imageFile.parent.delete(recursive: true);
+        },
+      );
+
+      test(
+        'does NOT retry on BlossomResumableUploadException with '
+        'non-retriable status (410) from non-Divine host resumable init',
+        () async {
+          // Opposing-symmetry guard: 410 (session expired / gone) is
+          // explicitly non-transient — re-creating the session via outer
+          // retry would only produce another 410. _isTransientUploadError
+          // must short-circuit it to a single attempt.
+          await service.setBlossomEnabled(true);
+          await service.setBlossomServer('https://third-party.example');
+
+          stubAuth();
+
+          final imageFile = await tempImage('non_divine_resumable_410');
+
+          when(
+            () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.extensions: [
+                  DivineUploadExtensions.resumableSessions,
+                ],
+              }),
+            ),
+          );
+
+          final initAttemptsByHost = <String, int>{};
+          when(
+            () => mockDio.post<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer((invocation) async {
+            final url = invocation.positionalArguments.first as String;
+            final host = Uri.parse(url).host;
+            initAttemptsByHost[host] = (initAttemptsByHost[host] ?? 0) + 1;
+            return Response(
+              requestOptions: RequestOptions(path: '/upload/init'),
+              statusCode: 410,
+              data: 'Gone',
+            );
+          });
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+          );
+
+          expect(result.success, isFalse);
+          expect(
+            initAttemptsByHost['third-party.example'],
+            equals(1),
+            reason:
+                'A BlossomResumableUploadException with statusCode 410 must '
+                'short-circuit the retry helper — re-initing the session '
+                'would just return another 410.',
+          );
+
+          await imageFile.parent.delete(recursive: true);
+        },
+      );
     });
 
     group('Bug report upload success path', () {


### PR DESCRIPTION
## Summary

- Adds service-layer retry-with-backoff to `BlossomUploadService.uploadImage` so a single transient 5xx from `media.divine.video` no longer surfaces as a hard failure on profile-picture uploads.
- 3 attempts (1 + 2 retries), exponential backoff (1s, 2s) capped at 30s. Retriable status codes match `UploadManager.isRetriableError`: 408, 429, 500, 502, 503, 504. Multi-server fallback is preserved — retries are scoped to one server, then the loop falls through to the next configured server.
- `UploadManager` thumbnail upload passes `maxAttempts: 1` to opt out of the inner retry, since UploadManager already wraps the whole video+thumbnail pipeline in `AsyncUtils.retryWithBackoff`.

### API note

`BlossomUploadResult` gains an additive, defaulted `isTransientNetworkFailure` flag — set internally by `_uploadToServer` when it catches a transient `DioException` and converts it to a result. Purely additive (defaults to `false`); the only in-repo callers (`mobile/lib/services/upload_manager.dart`, `mobile/lib/screens/profile_setup_screen.dart`) read `success` / `cdnUrl` / `errorMessage` only and need no migration.

`BlossomUploadService` constructor gains an optional `sleep: Future<void> Function(Duration)?` parameter (defaults to `Future<void>.delayed`). Used by tests to skip real-time backoff; production calls leave it at the default.

## Why

Default-config users have a one-entry server list (`media.divine.video`). When that origin returns a transient 503, the user used to see the localized `profileSetupUploadServerError` snackbar and had to manually re-pick the image and re-tap upload. The 503 in the linked issue was corroborated by @hm21 (~2h reproduction window) and @dcadenas (infrastructure-side notes) — i.e. the failure mode is real and recurs.

Per-chunk retry already exists in this file (`_maxChunkRetries=2`) but only protects mid-stream chunk PUTs. The init / complete / legacy-PUT phases had no retry; this PR closes that gap.

## Triage clarification

The triage comment on the issue clustered #3862 with #3743 (push notifications), #3858 (account deletion), #3161 (username), #3271 (video deletion) under a "NIP-44 encryption failure" hypothesis. After tracing the upload code path, that hypothesis is incorrect for #3862: profile-picture upload uses kind 24242 BUD-01 **signed** events, not NIP-44 encrypted events. NIP-44 only affects push notification token registration (kinds 3079/3080/3083). The push registration race is a separate, real bug; it should be tracked under #3743 only — out of scope for this PR.

## Review responses (commits 2–6)

- **Liz's correctness gap** (commit 2, `3232aba9b`): caught `DioException` timeouts on the legacy PUT path now mark the result as `isTransientNetworkFailure: true`, so the retry helper retries them symmetrically with retriable status codes.
- **Faster tests** (commit 3, `134396bcc`): retry backoff goes through an injectable `sleep` callback. Retry-behavior test group's wall time dropped from ~16s to under 1s.
- **Resumable-exception symmetry** (commit 4, `b0c1fcd3f`): `BlossomResumableUploadException` with a retriable `statusCode` (408 / 429 / 5xx) is now classified transient, mirroring `DioException(503)`. 404/410 (session expired) and null-status (auth or malformed-response) stay non-transient by design.
- **Argument validation** (commit 5, `9abf4382f`): `assert(maxAttempts >= 1)` moved to the very first statement of `uploadImage` for fail-fast semantics.

## Tests

20 new cases under `'uploadImage - retry behavior'`, covering:

- Retry success on 503 / 504 / 429 / 408
- Exhaustion: persistent 503 stops at `maxAttempts` and returns the last error
- No retry on 401 / 413 / success / cancel
- `maxAttempts: 1` opt-out (regression-guards the UploadManager contract)
- Multi-server fallback after retries are exhausted on the first server
- `DioException`-typed paths: 5xx + connectionTimeout from non-Divine host resumable init; 401 not retried
- Default-host legacy PUT: connection / send / receive timeout and connection error all retried; cancel not retried
- `BlossomResumableUploadException` paths: retriable status (408) retried, non-retriable status (410) not retried

Strict-coverage gate (`min_coverage: 100`): all six files in `lib/src/` at 100% line coverage after the change.

## Test plan

- [x] `flutter test --coverage` in `mobile/packages/blossom_upload_service/` — 150 pass / 0 fail, 702/702 lines covered
- [x] `flutter test test/services/upload_manager_thumbnail_test.dart` — 9 pass / 0 fail
- [x] `flutter analyze lib test integration_test` (parent app) — clean
- [x] `dart format` — clean
- [ ] Manual: device test by intercepting the upload PUT to return 503 once then 200 — confirm the user sees `profileSetupUploadSuccess` without re-picking the image

## Related

- Closes #3862
- Out of scope (separate follow-up): NIP-44 push-registration race seen in DollyAnna's logs — should be linked to #3743 only, not the broader cluster.

Fixes #3862