### PR TITLE
fix(deeplink): resolve video routes and restore escape hatch

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -276,10 +276,11 @@ class FullscreenFeedBloc
       return;
     }
 
-    final videoUrl = video.videoUrl;
+    final videoUrl = video.getCacheableVideoUrlForPlatform();
     if (videoUrl == null || videoUrl.isEmpty) {
       Log.warning(
-        'FullscreenFeedBloc: Video ${video.id} has no URL, cannot cache',
+        'FullscreenFeedBloc: Video ${video.id} has no cacheable URL, '
+        'skipping cache',
         name: 'FullscreenFeedBloc',
         category: LogCategory.video,
       );

--- a/mobile/lib/extensions/video_event_extensions.dart
+++ b/mobile/lib/extensions/video_event_extensions.dart
@@ -175,7 +175,7 @@ extension VideoEventAppExtensions on VideoEvent {
       isFromDivineServer && videoFormatPreference.isHlsFormat;
 
   /// Whether background file caching should be skipped for this video.
-  bool get shouldSkipFileCaching => false;
+  bool get shouldSkipFileCaching => isOriginalVine;
 
   /// Get HLS URL with optional quality override.
   ///

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1166,9 +1166,18 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                   // Skip if already showing this video (getInitialLink
                   // and uriLinkStream can both fire for the same URL).
                   if (currentLocation == targetPath) break;
-                  // Push (not go) so the home route stays underneath,
-                  // allowing back navigation to return to the main screen.
-                  router.push(targetPath);
+                  final isReplacingExistingVideoRoute = currentLocation
+                      .startsWith('${VideoDetailScreen.basePath}/');
+                  if (isReplacingExistingVideoRoute) {
+                    // When another shared video is opened while a shared
+                    // video route is already visible, replace the current
+                    // detail route instead of stacking it.
+                    router.go(targetPath);
+                  } else {
+                    // Keep the home route underneath the first shared video
+                    // so back navigation returns to the main screen.
+                    router.push(targetPath);
+                  }
                   Log.info(
                     '✅ Navigation completed to: $targetPath',
                     name: 'DeepLinkHandler',

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1153,9 +1153,9 @@ class _DivineAppState extends ConsumerState<DivineApp> {
 
           switch (deepLink.type) {
             case DeepLinkType.video:
-              if (deepLink.videoId != null) {
+              if (deepLink.videoRef != null) {
                 final targetPath = VideoDetailScreen.pathForId(
-                  deepLink.videoId!,
+                  deepLink.videoRef!,
                 );
                 Log.info(
                   '📱 Navigating to video: $targetPath',
@@ -1183,7 +1183,7 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                 }
               } else {
                 Log.warning(
-                  '⚠️ Video deep link missing videoId',
+                  '⚠️ Video deep link missing videoRef',
                   name: 'DeepLinkHandler',
                   category: LogCategory.ui,
                 );

--- a/mobile/lib/router/universal_link_resolver.dart
+++ b/mobile/lib/router/universal_link_resolver.dart
@@ -20,9 +20,9 @@ String? divineUrlToPushRoute(Uri uri) {
   final deepLink = DeepLinkService.parseDeepLink(uri.toString());
   switch (deepLink.type) {
     case DeepLinkType.video:
-      final videoId = deepLink.videoId;
-      if (videoId == null || videoId.isEmpty) return null;
-      return VideoDetailScreen.pathForId(videoId);
+      final videoRef = deepLink.videoRef;
+      if (videoRef == null || videoRef.isEmpty) return null;
+      return VideoDetailScreen.pathForId(videoRef);
     case DeepLinkType.profile:
       final npub = deepLink.npub;
       if (npub == null || npub.isEmpty) return null;

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -431,6 +431,14 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
     return !MediaQuery.disableAnimationsOf(context);
   }
 
+  void _handleBack(BuildContext context) {
+    if (context.canPop()) {
+      context.pop();
+      return;
+    }
+    context.go('/');
+  }
+
   void _toggleAutoAdvance() {
     if (!_isAutoAdvanceAvailable()) return;
 
@@ -698,11 +706,9 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                   showBackButton: true,
                   // The BlocListener above already tried `maybePop` and
                   // failed (otherwise we wouldn't be rendering this
-                  // branch). The same `pop` from the appbar back button
-                  // would also be a no-op, so fall back to the home
-                  // shell to avoid a dead-end UX.
-                  onBackPressed: () =>
-                      context.canPop() ? context.pop() : context.go('/'),
+                  // branch). Keep the same root-route fallback here so
+                  // cold-start deep links never strand the user.
+                  onBackPressed: () => _handleBack(context),
                   backgroundMode: DiVineAppBarBackgroundMode.transparent,
                   forceMaterialTransparency: true,
                 ),
@@ -722,7 +728,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                 appBar: DiVineAppBar(
                   title: widget.contextTitle ?? '',
                   showBackButton: true,
-                  onBackPressed: context.pop,
+                  onBackPressed: () => _handleBack(context),
                   backgroundMode: DiVineAppBarBackgroundMode.transparent,
                   forceMaterialTransparency: true,
                 ),
@@ -736,7 +742,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                 appBar: DiVineAppBar(
                   title: widget.contextTitle ?? '',
                   showBackButton: true,
-                  onBackPressed: context.pop,
+                  onBackPressed: () => _handleBack(context),
                   backgroundMode: DiVineAppBarBackgroundMode.transparent,
                   forceMaterialTransparency: true,
                 ),
@@ -805,7 +811,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
               appBar: DiVineAppBar(
                 title: widget.contextTitle ?? '',
                 showBackButton: true,
-                onBackPressed: context.pop,
+                onBackPressed: () => _handleBack(context),
                 backgroundMode: DiVineAppBarBackgroundMode.transparent,
                 forceMaterialTransparency: true,
                 actions: [?editAction],

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -24,7 +24,10 @@ class VideoDetailScreen extends ConsumerStatefulWidget {
   /// Path pattern for this route.
   static const path = '/video/:id';
 
-  /// Build path for a specific video ID.
+  /// Build path for a specific video route reference.
+  ///
+  /// The route segment may be a raw event ID, a stable ID / d-tag, or
+  /// a NIP-19 reference such as `note1...`, `nevent1...`, or `naddr1...`.
   static String pathForId(String id) => '$basePath/$id';
 
   const VideoDetailScreen({
@@ -54,7 +57,7 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
   Future<void> _loadVideo() async {
     try {
       Log.info(
-        '📱 Loading video by ID: ${widget.videoId}',
+        '📱 Loading video from route ref: ${widget.videoId}',
         name: 'VideoDetailScreen',
         category: LogCategory.video,
       );
@@ -62,7 +65,9 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
       // fetchVideoWithStats handles cache→relay lookup and bulk-stats
       // hydration in one call, matching what feed providers do.
       final videosRepository = ref.read(videosRepositoryProvider);
-      final video = await videosRepository.fetchVideoWithStats(widget.videoId);
+      final video = await videosRepository.fetchVideoWithStatsForRouteId(
+        widget.videoId,
+      );
 
       if (video != null) {
         Log.info(
@@ -123,10 +128,7 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
     if (_error != null) {
       return Scaffold(
         backgroundColor: VineTheme.backgroundColor,
-        appBar: const DiVineAppBar(
-          title: '',
-          backgroundMode: DiVineAppBarBackgroundMode.transparent,
-        ),
+        appBar: _buildExitAppBar(context),
         body: Center(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -148,9 +150,10 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
     }
 
     if (_video == null || videoEventService.shouldHideVideo(_video!)) {
-      return const Scaffold(
+      return Scaffold(
         backgroundColor: VineTheme.backgroundColor,
-        body: Center(
+        appBar: _buildExitAppBar(context),
+        body: const Center(
           child: Text(
             'Video not found',
             style: TextStyle(color: VineTheme.primaryText),
@@ -189,5 +192,23 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
           contextTitle: 'Shared Video',
           trafficSource: ViewTrafficSource.share,
         );
+  }
+
+  DiVineAppBar _buildExitAppBar(BuildContext context) {
+    return DiVineAppBar(
+      title: '',
+      showBackButton: true,
+      onBackPressed: () => _handleExit(context),
+      backButtonSemanticLabel: 'Close video player',
+      backgroundMode: DiVineAppBarBackgroundMode.transparent,
+    );
+  }
+
+  void _handleExit(BuildContext context) {
+    if (context.canPop()) {
+      context.pop();
+      return;
+    }
+    context.go('/');
   }
 }

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -64,6 +64,8 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.videoId == widget.videoId) return;
 
+    // Deep links can retarget an already-mounted video screen. Reset the
+    // previous request state so the second shared link triggers a fresh load.
     _relayReadySubscription?.cancel();
     _relayReadySubscription = null;
     _retryScheduled = false;
@@ -121,6 +123,9 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
         if (allowRelayReadyRetry &&
             !canQueryRelays &&
             _scheduleRelayReadyRetry(nostrClient)) {
+          // Cold-start links can arrive before the relay layer is queryable.
+          // Retry once after the first relay connection instead of surfacing a
+          // permanent "Video not found" during startup.
           Log.info(
             '⏳ Video lookup deferred until relay connection is ready',
             name: 'VideoDetailScreen',

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -60,6 +60,25 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
   }
 
   @override
+  void didUpdateWidget(covariant VideoDetailScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.videoId == widget.videoId) return;
+
+    _relayReadySubscription?.cancel();
+    _relayReadySubscription = null;
+    _retryScheduled = false;
+    _hasRetriedAfterRelayReady = false;
+
+    setState(() {
+      _video = null;
+      _isLoading = true;
+      _error = null;
+    });
+
+    unawaited(_loadVideo());
+  }
+
+  @override
   void dispose() {
     _relayReadySubscription?.cancel();
     super.dispose();

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -170,7 +170,7 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
         appBar: DiVineAppBar(
           title: '',
           showBackButton: true,
-          onBackPressed: context.pop,
+          onBackPressed: () => _handleExit(context),
           backButtonSemanticLabel: 'Close video player',
           backgroundMode: DiVineAppBarBackgroundMode.transparent,
         ),

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -8,7 +8,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:nostr_client/nostr_client.dart' show NostrClient;
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/screen_analytics_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
@@ -47,6 +49,9 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
   VideoEvent? _video;
   bool _isLoading = true;
   String? _error;
+  StreamSubscription? _relayReadySubscription;
+  bool _retryScheduled = false;
+  bool _hasRetriedAfterRelayReady = false;
 
   @override
   void initState() {
@@ -54,13 +59,23 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
     _loadVideo();
   }
 
-  Future<void> _loadVideo() async {
+  @override
+  void dispose() {
+    _relayReadySubscription?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _loadVideo({bool allowRelayReadyRetry = true}) async {
     try {
       Log.info(
         '📱 Loading video from route ref: ${widget.videoId}',
         name: 'VideoDetailScreen',
         category: LogCategory.video,
       );
+
+      final nostrClient = ref.read(nostrServiceProvider);
+      final canQueryRelays =
+          nostrClient.isInitialized && nostrClient.connectedRelayCount > 0;
 
       // fetchVideoWithStats handles cache→relay lookup and bulk-stats
       // hydration in one call, matching what feed providers do.
@@ -79,10 +94,21 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
           setState(() {
             _video = video;
             _isLoading = false;
+            _error = null;
           });
           ScreenAnalyticsService().markDataLoaded('video_detail');
         }
       } else {
+        if (allowRelayReadyRetry &&
+            !canQueryRelays &&
+            _scheduleRelayReadyRetry(nostrClient)) {
+          Log.info(
+            '⏳ Video lookup deferred until relay connection is ready',
+            name: 'VideoDetailScreen',
+            category: LogCategory.video,
+          );
+          return;
+        }
         Log.warning(
           '❌ Video not found: ${widget.videoId}',
           name: 'VideoDetailScreen',
@@ -96,6 +122,19 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
         }
       }
     } catch (e) {
+      final nostrClient = ref.read(nostrServiceProvider);
+      final canQueryRelays =
+          nostrClient.isInitialized && nostrClient.connectedRelayCount > 0;
+      if (allowRelayReadyRetry &&
+          !canQueryRelays &&
+          _scheduleRelayReadyRetry(nostrClient)) {
+        Log.warning(
+          '⏳ Video lookup failed before relay readiness; waiting to retry: $e',
+          name: 'VideoDetailScreen',
+          category: LogCategory.video,
+        );
+        return;
+      }
       Log.error(
         'Error loading video: $e',
         name: 'VideoDetailScreen',
@@ -108,6 +147,43 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
         });
       }
     }
+  }
+
+  bool _scheduleRelayReadyRetry(NostrClient nostrClient) {
+    if (_retryScheduled || _hasRetriedAfterRelayReady) {
+      return false;
+    }
+
+    _retryScheduled = true;
+    _relayReadySubscription?.cancel();
+
+    void retry() {
+      _relayReadySubscription?.cancel();
+      _relayReadySubscription = null;
+      _retryScheduled = false;
+      _hasRetriedAfterRelayReady = true;
+      if (!mounted) return;
+      setState(() {
+        _isLoading = true;
+        _error = null;
+      });
+      unawaited(_loadVideo(allowRelayReadyRetry: false));
+    }
+
+    if (nostrClient.isInitialized && nostrClient.connectedRelayCount > 0) {
+      retry();
+      return true;
+    }
+
+    _relayReadySubscription = nostrClient.relayStatusStream.listen((statuses) {
+      final hasConnectedRelay = statuses.values.any(
+        (status) => status.isConnected,
+      );
+      if (hasConnectedRelay) {
+        retry();
+      }
+    });
+    return true;
   }
 
   @override

--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -238,27 +238,6 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
       );
     }
 
-    // Check if video author has muted us (mutual mute blocking)
-    final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
-    if (blocklistRepository.shouldFilterFromFeeds(_video!.pubkey)) {
-      return Scaffold(
-        backgroundColor: VineTheme.backgroundColor,
-        appBar: DiVineAppBar(
-          title: '',
-          showBackButton: true,
-          onBackPressed: () => _handleExit(context),
-          backButtonSemanticLabel: 'Close video player',
-          backgroundMode: DiVineAppBarBackgroundMode.transparent,
-        ),
-        body: const Center(
-          child: Text(
-            'This account is not available',
-            style: TextStyle(color: VineTheme.lightText, fontSize: 16),
-          ),
-        ),
-      );
-    }
-
     // Display video in full-screen pooled player
     return widget.videoFeedBuilder?.call(_video!) ??
         PooledFullscreenVideoFeedScreen(

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -21,7 +21,7 @@ enum DeepLinkType {
 class DeepLink {
   const DeepLink({
     required this.type,
-    this.videoId,
+    this.videoRef,
     this.npub,
     this.hashtag,
     this.searchTerm,
@@ -30,7 +30,11 @@ class DeepLink {
   });
 
   final DeepLinkType type;
-  final String? videoId;
+  /// Raw `/video/:id` route reference from the incoming URL.
+  ///
+  /// This may be a hex event ID, a first-party stable ID / d-tag, or a
+  /// NIP-19 reference such as `note1`, `nevent1`, or `naddr1`.
+  final String? videoRef;
   final String? npub;
   final String? hashtag;
   final String? searchTerm;
@@ -42,7 +46,7 @@ class DeepLink {
     final indexStr = index != null ? ', index: $index' : '';
     switch (type) {
       case DeepLinkType.video:
-        return 'DeepLink(type: video, videoId: $videoId)';
+        return 'DeepLink(type: video, videoRef: $videoRef)';
       case DeepLinkType.profile:
         return 'DeepLink(type: profile, npub: $npub$indexStr)';
       case DeepLinkType.hashtag:
@@ -142,15 +146,16 @@ class DeepLinkService {
 
       final pathSegments = uri.pathSegments;
 
-      // Handle /video/{videoId}
+      // Handle /video/{videoRef}. The path segment is preserved verbatim;
+      // downstream resolution accepts raw IDs, stable IDs, and NIP-19 refs.
       if (pathSegments.length == 2 && pathSegments[0] == 'video') {
-        final videoId = pathSegments[1];
+        final videoRef = pathSegments[1];
         Log.info(
-          '📱 Parsed video deep link: $videoId',
+          '📱 Parsed video deep link ref: $videoRef',
           name: 'DeepLinkService',
           category: LogCategory.ui,
         );
-        return DeepLink(type: DeepLinkType.video, videoId: videoId);
+        return DeepLink(type: DeepLinkType.video, videoRef: videoRef);
       }
 
       // Handle /profile/{npub} or /profile/{npub}/{index}

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -30,6 +30,7 @@ class DeepLink {
   });
 
   final DeepLinkType type;
+
   /// Raw `/video/:id` route reference from the incoming URL.
   ///
   /// This may be a hex event ID, a first-party stable ID / d-tag, or a

--- a/mobile/lib/services/share_service.dart
+++ b/mobile/lib/services/share_service.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -19,31 +20,30 @@ class ShareService {
   /// Generate a Nostr event link (nevent format) for a video
   String generateNostrEventLink(VideoEvent video) {
     try {
-      // Create nevent bech32 encoded link
-      final eventId = video.id;
-
-      // For now, create a simple nevent link format
-      // In a full implementation, this would use proper bech32 encoding
-      final neventLink = 'nostr:nevent1$eventId';
-      return neventLink;
+      final nevent = NIP19Tlv.encodeNevent(
+        Nevent(id: video.id, author: video.pubkey),
+      );
+      return 'nostr:$nevent';
     } catch (e) {
       Log.error(
         'Error generating Nostr event link: $e',
         name: 'ShareService',
         category: LogCategory.system,
       );
-      return 'nostr:note1${video.id}';
+      return video.id;
     }
   }
 
   /// Generate a web app link for a video.
   ///
-  /// Uses [VideoEvent.stableId] (d-tag) for addressable events so the URL
-  /// remains valid even if the user edits the video metadata.
-  ///
-  /// Requires funnelcake API to support d-tag lookups on /api/videos/{id}.
+  /// Uses the web route only when the video has a real addressable `d` tag.
+  /// Otherwise falls back to a NIP-19 `nevent` link so this method never
+  /// returns a broken `divine.video/video/{eventId}` URL.
   String generateWebLink(VideoEvent video) {
-    return '$_appUrl/video/${video.stableId}';
+    if (_hasWebShareableRoute(video)) {
+      return '$_appUrl/video/${video.stableId}';
+    }
+    return generateNostrEventLink(video);
   }
 
   /// Generate shareable text content.
@@ -51,6 +51,11 @@ class ShareService {
   /// Returns only the web link so users can add their own context.
   String generateShareText(VideoEvent video) {
     return generateWebLink(video);
+  }
+
+  bool _hasWebShareableRoute(VideoEvent video) {
+    final routeId = video.rawTags['d'];
+    return routeId != null && routeId.isNotEmpty;
   }
 
   /// Copy link to clipboard

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -288,13 +289,19 @@ class VideoSharingService {
 
   /// Generate external share URL for the video.
   ///
-  /// Uses [VideoEvent.stableId] (d-tag) for addressable events so the URL
-  /// remains valid even if the user edits the video metadata.
-  ///
-  /// Requires funnelcake API to support d-tag lookups on /api/videos/{id}.
+  /// Uses the web route only when the video has a real addressable `d` tag.
+  /// Otherwise falls back to a NIP-19 `nevent` link so sharing never emits a
+  /// non-routable `divine.video/video/{eventId}` URL.
   String generateShareUrl(VideoEvent video) {
     const baseUrl = 'https://divine.video';
-    return '$baseUrl/video/${video.stableId}';
+    if (_hasWebShareableRoute(video)) {
+      return '$baseUrl/video/${video.stableId}';
+    }
+
+    final nevent = NIP19Tlv.encodeNevent(
+      Nevent(id: video.id, author: video.pubkey),
+    );
+    return 'nostr:$nevent';
   }
 
   /// Generate share text for external sharing (social media, etc.)
@@ -341,11 +348,15 @@ class VideoSharingService {
     };
   }
 
+  bool _hasWebShareableRoute(VideoEvent video) {
+    final routeId = video.rawTags['d'];
+    return routeId != null && routeId.isNotEmpty;
+  }
+
   /// Create the message content for sharing a video.
   ///
-  /// Uses the stable web link (`divine.video/video/{stableId}`) instead of
-  /// the raw CDN/blossom URL so the recipient sees a clean, shareable link
-  /// that can be opened in a browser or deep-linked back into the app.
+  /// Uses the canonical share URL for the video, preferring a stable web route
+  /// and falling back to a Nostr `nevent` when no web route exists.
   String _createShareMessage(VideoEvent video, String? personalMessage) {
     final buffer = StringBuffer();
 

--- a/mobile/macos/Runner/AppDelegate.swift
+++ b/mobile/macos/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import FlutterMacOS
+import app_links
 
 @main
 class AppDelegate: FlutterAppDelegate {
@@ -15,5 +16,22 @@ class AppDelegate: FlutterAppDelegate {
 
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
+  }
+
+  override func application(
+    _ application: NSApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([NSUserActivityRestoring]) -> Void
+  ) -> Bool {
+    if let url = AppLinks.shared.getUniversalLink(userActivity) {
+      AppLinks.shared.handleLink(link: url.absoluteString)
+      return true
+    }
+
+    return super.application(
+      application,
+      continue: userActivity,
+      restorationHandler: restorationHandler
+    )
   }
 }

--- a/mobile/macos/Runner/Info.plist
+++ b/mobile/macos/Runner/Info.plist
@@ -28,6 +28,19 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>video.divine.app</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>divine</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -67,13 +67,18 @@ class ContentBlocklistRepository {
   // Mutual mute blocklist (populated from kind 10000 events)
   final Set<String> _mutualMuteBlocklist = <String>{};
 
+  // Latest replaceable kind-10000 mute-list event timestamp per author.
+  // Prevent stale relay delivery order from resurrecting old mute state.
+  final Map<String, int> _latestMuteListEventCreatedAtByAuthor =
+      <String, int>{};
+
   // Users who have blocked us (populated from kind 30000 events with d=block)
   final Set<String> _blockedByOthers = <String>{};
 
   // Latest replaceable kind-30000 block-list event timestamp per author.
   // Prevent stale relay delivery order from resurrecting old block state.
-  final Map<String, int> _latestBlockListEventCreatedAtByAuthor = <String, int>{
-  };
+  final Map<String, int> _latestBlockListEventCreatedAtByAuthor =
+      <String, int>{};
 
   // Followers whose follow relationship was severed by a block.
   // Persists across unblocking so these users remain hidden from our
@@ -651,6 +656,20 @@ class ContentBlocklistRepository {
     }
 
     final muterPubkey = event.pubkey;
+    final createdAt = event.createdAt;
+    final latestSeen = _latestMuteListEventCreatedAtByAuthor[muterPubkey];
+
+    if (latestSeen != null && createdAt < latestSeen) {
+      Log.debug(
+        'Ignoring stale mute list event from $muterPubkey '
+        '(createdAt=$createdAt < latestSeen=$latestSeen)',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+      return;
+    }
+
+    _latestMuteListEventCreatedAtByAuthor[muterPubkey] = createdAt;
 
     // Check if our pubkey is in this user's mute list
     final stillMuted = event.tags.any(

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -70,6 +70,11 @@ class ContentBlocklistRepository {
   // Users who have blocked us (populated from kind 30000 events with d=block)
   final Set<String> _blockedByOthers = <String>{};
 
+  // Latest replaceable kind-30000 block-list event timestamp per author.
+  // Prevent stale relay delivery order from resurrecting old block state.
+  final Map<String, int> _latestBlockListEventCreatedAtByAuthor = <String, int>{
+  };
+
   // Followers whose follow relationship was severed by a block.
   // Persists across unblocking so these users remain hidden from our
   // followers list until they explicitly re-follow.
@@ -753,6 +758,20 @@ class ContentBlocklistRepository {
   /// the blocker from [_blockedByOthers].
   void _handleOthersBlockListEvent(Event event) {
     final blockerPubkey = event.pubkey;
+    final createdAt = event.createdAt;
+    final latestSeen = _latestBlockListEventCreatedAtByAuthor[blockerPubkey];
+
+    if (latestSeen != null && createdAt < latestSeen) {
+      Log.debug(
+        'Ignoring stale block list event from $blockerPubkey '
+        '(createdAt=$createdAt < latestSeen=$latestSeen)',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+      return;
+    }
+
+    _latestBlockListEventCreatedAtByAuthor[blockerPubkey] = createdAt;
 
     // Check if our pubkey is in this user's block list
     final stillBlocked = event.tags.any(

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -498,6 +498,61 @@ void main() {
       },
     );
 
+    test(
+      'ignores stale older mute event after newer unmute event',
+      () async {
+        const ourPubkey =
+            '0000000000000000000000000000000000000000000000000000000000000001';
+        const muterPubkey =
+            '0000000000000000000000000000000000000000000000000000000000000002';
+
+        final newerUnmuteEvent =
+            Event(
+                muterPubkey,
+                10000,
+                [
+                  ['p', 'some_other_pubkey'],
+                ],
+                '',
+                createdAt: (DateTime.now().millisecondsSinceEpoch ~/ 1000) + 60,
+              )
+              ..id = 'newer-unmute-event-id'
+              ..sig = 'signature';
+
+        final olderMuteEvent =
+            Event(
+                muterPubkey,
+                10000,
+                [
+                  ['p', ourPubkey],
+                ],
+                '',
+                createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+              )
+              ..id = 'older-mute-event-id'
+              ..sig = 'signature';
+
+        final controller = StreamController<Event>();
+
+        when(
+          () => mockNostrService.subscribe(any()),
+        ).thenAnswer((_) => controller.stream);
+
+        await service.syncMuteListsInBackground(mockNostrService, ourPubkey);
+
+        controller.add(newerUnmuteEvent);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(service.hasMutedUs(muterPubkey), isFalse);
+
+        controller.add(olderMuteEvent);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(service.hasMutedUs(muterPubkey), isFalse);
+        expect(service.shouldFilterFromFeeds(muterPubkey), isFalse);
+
+        await controller.close();
+      },
+    );
+
     test('shouldFilterFromFeeds checks mutual mute blocklist', () async {
       const ourPubkey =
           '0000000000000000000000000000000000000000000000000000000000000001';

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -749,6 +749,71 @@ void main() {
         await controller.close();
       },
     );
+
+    test(
+      'ignores stale older block event after newer unblock event',
+      () async {
+        const ourPubkey =
+            '0000000000000000000000000000000000000000000000000000000000000001';
+        const blockerPubkey =
+            '0000000000000000000000000000000000000000000000000000000000000002';
+
+        service = ContentBlocklistRepository();
+
+        final newerUnblockEvent =
+            Event(
+                blockerPubkey,
+                30000,
+                [
+                  ['d', 'block'],
+                  ['p', 'some_other_pubkey'],
+                ],
+                'Block list',
+                createdAt: (DateTime.now().millisecondsSinceEpoch ~/ 1000) + 60,
+              )
+              ..id = 'newer-unblock-event-id'
+              ..sig = 'signature';
+
+        final olderBlockEvent =
+            Event(
+                blockerPubkey,
+                30000,
+                [
+                  ['d', 'block'],
+                  ['p', ourPubkey],
+                ],
+                'Block list',
+                createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+              )
+              ..id = 'older-block-event-id'
+              ..sig = 'signature';
+
+        final controller = StreamController<Event>();
+
+        when(
+          () => mockNostrService.subscribe(
+            any(),
+          ),
+        ).thenAnswer((_) => controller.stream);
+
+        await service.syncBlockListsInBackground(
+          mockNostrService,
+          mockSigner,
+          ourPubkey,
+        );
+
+        controller.add(newerUnblockEvent);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(service.hasBlockedUs(blockerPubkey), isFalse);
+
+        controller.add(olderBlockEvent);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(service.hasBlockedUs(blockerPubkey), isFalse);
+        expect(service.shouldFilterFromFeeds(blockerPubkey), isFalse);
+
+        await controller.close();
+      },
+    );
   });
 
   group('ContentBlocklistRepository - Relay Block List Restoration', () {

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -9,6 +9,7 @@ import 'package:funnelcake_api_client/src/models/models.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 import 'package:models/models.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
 
 /// HTTP client for the Funnelcake REST API.
 ///
@@ -1251,6 +1252,60 @@ class FunnelcakeApiClient {
       rethrow;
     } catch (e) {
       throw FunnelcakeException('Failed to fetch video views: $e');
+    }
+  }
+
+  /// Fetches the full Nostr event for a specific video route ID.
+  ///
+  /// [videoId] accepts either a canonical event ID or a stable shared ID
+  /// supported by the Funnelcake API.
+  ///
+  /// Returns the raw [Event] when found, or `null` for 404 responses.
+  Future<Event?> getVideoEvent(String videoId) async {
+    if (!isAvailable) {
+      throw const FunnelcakeNotConfiguredException();
+    }
+
+    if (videoId.isEmpty) {
+      throw const FunnelcakeException('Video ID cannot be empty');
+    }
+
+    final uri = Uri.parse('$_baseUrl/api/videos/$videoId');
+
+    try {
+      final response = await _get(uri);
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body);
+        if (data is Map<String, dynamic>) {
+          final eventJson = data['event'];
+          if (eventJson is Map<String, dynamic>) {
+            return Event.fromJson(eventJson);
+          }
+          // Some server builds may return the raw event object directly.
+          if (data['id'] is String &&
+              data['pubkey'] is String &&
+              data['created_at'] != null &&
+              data['kind'] != null) {
+            return Event.fromJson(data);
+          }
+        }
+        throw const FunnelcakeException('Malformed video event response');
+      } else if (response.statusCode == 404) {
+        return null;
+      } else {
+        throw FunnelcakeApiException(
+          message: 'Failed to fetch video event',
+          statusCode: response.statusCode,
+          url: uri.toString(),
+        );
+      }
+    } on TimeoutException {
+      throw FunnelcakeTimeoutException(uri.toString());
+    } on FunnelcakeException {
+      rethrow;
+    } catch (e) {
+      throw FunnelcakeException('Failed to fetch video event: $e');
     }
   }
 

--- a/mobile/packages/funnelcake_api_client/pubspec.yaml
+++ b/mobile/packages/funnelcake_api_client/pubspec.yaml
@@ -13,6 +13,8 @@ dependencies:
   meta: ^1.17.0
   models:
     path: ../models
+  nostr_sdk:
+    path: ../nostr_sdk
 
 dev_dependencies:
   mocktail: ^1.0.4

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -2792,6 +2792,67 @@ void main() {
       });
     });
 
+    group('getVideoEvent', () {
+      const testVideoId =
+          'e96357668c72c8923340b0ecf4bfacea505172c4190e9953e603124c67175f3b';
+      const testEventId =
+          'e46ff7d0d71d6c8114b58728afa43f08d6286fd9a704683af799fd8f855586c2';
+
+      test('returns raw event from wrapped response', () async {
+        const validResponse =
+            '''
+{
+  "event": {
+    "id": "$testEventId",
+    "pubkey": "$testPubkey",
+    "created_at": 1700000000,
+    "kind": 34236,
+    "tags": [["d", "$testVideoId"], ["url", "https://example.com/video.mp4"]],
+    "content": "",
+    "sig": "sig"
+  },
+  "stats": {
+    "reactions": 1
+  }
+}
+''';
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(validResponse, 200));
+
+        final event = await client.getVideoEvent(testVideoId);
+
+        expect(event, isNotNull);
+        expect(event!.id, equals(testEventId));
+      });
+
+      test('constructs correct URL', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response('Not found', 404));
+
+        await client.getVideoEvent(testVideoId);
+
+        final captured = verify(
+          () =>
+              mockHttpClient.get(captureAny(), headers: any(named: 'headers')),
+        ).captured;
+
+        final uri = captured.first as Uri;
+        expect(uri.path, equals('/api/videos/$testVideoId'));
+      });
+
+      test('returns null on 404', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response('Not found', 404));
+
+        final event = await client.getVideoEvent(testVideoId);
+
+        expect(event, isNull);
+      });
+    });
+
     group('getVideoComments', () {
       const testVideoId =
           'feedfeedfeedfeedfeedfeedfeedfeed'

--- a/mobile/packages/videos_repository/lib/src/db_video_local_storage.dart
+++ b/mobile/packages/videos_repository/lib/src/db_video_local_storage.dart
@@ -19,9 +19,7 @@ class DbVideoLocalStorage implements VideoLocalStorage {
   /// Creates a new db_client-backed local storage.
   ///
   /// Requires a [NostrEventsDao] for database operations.
-  DbVideoLocalStorage({
-    required NostrEventsDao dao,
-  }) : _dao = dao;
+  DbVideoLocalStorage({required NostrEventsDao dao}) : _dao = dao;
 
   final NostrEventsDao _dao;
 
@@ -45,10 +43,15 @@ class DbVideoLocalStorage implements VideoLocalStorage {
   Future<List<Event>> getEventsByIds(List<String> eventIds) async {
     if (eventIds.isEmpty) return [];
 
-    final filter = Filter(
-      ids: eventIds,
-      kinds: [_videoKind],
-    );
+    final filter = Filter(ids: eventIds, kinds: [_videoKind]);
+    return _dao.getEventsByFilter(filter);
+  }
+
+  @override
+  Future<List<Event>> getEventsByDTag(String dTag) async {
+    if (dTag.isEmpty) return [];
+
+    final filter = Filter(kinds: [_videoKind], d: [dTag]);
     return _dao.getEventsByFilter(filter);
   }
 
@@ -75,11 +78,7 @@ class DbVideoLocalStorage implements VideoLocalStorage {
     int? until,
     String? sortBy,
   }) async {
-    final filter = Filter(
-      kinds: [_videoKind],
-      limit: limit,
-      until: until,
-    );
+    final filter = Filter(kinds: [_videoKind], limit: limit, until: until);
     return _dao.getEventsByFilter(filter, sortBy: sortBy);
   }
 
@@ -107,23 +106,13 @@ class DbVideoLocalStorage implements VideoLocalStorage {
   }) {
     if (authors.isEmpty) return Stream.value([]);
 
-    final filter = Filter(
-      authors: authors,
-      kinds: [_videoKind],
-      limit: limit,
-    );
+    final filter = Filter(authors: authors, kinds: [_videoKind], limit: limit);
     return _dao.watchEventsByFilter(filter);
   }
 
   @override
-  Stream<List<Event>> watchAllEvents({
-    int limit = 50,
-    String? sortBy,
-  }) {
-    final filter = Filter(
-      kinds: [_videoKind],
-      limit: limit,
-    );
+  Stream<List<Event>> watchAllEvents({int limit = 50, String? sortBy}) {
+    final filter = Filter(kinds: [_videoKind], limit: limit);
     return _dao.watchEventsByFilter(filter, sortBy: sortBy);
   }
 
@@ -150,11 +139,7 @@ class DbVideoLocalStorage implements VideoLocalStorage {
   }) async {
     if (query.isEmpty) return [];
 
-    final filter = Filter(
-      kinds: [_videoKind],
-      search: query,
-      limit: limit,
-    );
+    final filter = Filter(kinds: [_videoKind], search: query, limit: limit);
     return _dao.getEventsByFilter(filter);
   }
 

--- a/mobile/packages/videos_repository/lib/src/video_local_storage.dart
+++ b/mobile/packages/videos_repository/lib/src/video_local_storage.dart
@@ -39,6 +39,12 @@ abstract class VideoLocalStorage {
   /// ignored.
   Future<List<Event>> getEventsByIds(List<String> eventIds);
 
+  /// Gets video events by their d-tag / stable ID.
+  ///
+  /// Returns matching addressable video events ordered by the storage backend.
+  /// Callers should handle the possibility of multiple matches defensively.
+  Future<List<Event>> getEventsByDTag(String dTag);
+
   /// Gets video events by author pubkeys.
   ///
   /// Useful for home feed (videos from followed users) and profile feed.
@@ -88,10 +94,7 @@ abstract class VideoLocalStorage {
   /// Watches all video events (reactive stream).
   ///
   /// Emits a new list whenever video events change in the database.
-  Stream<List<Event>> watchAllEvents({
-    int limit = 50,
-    String? sortBy,
-  });
+  Stream<List<Event>> watchAllEvents({int limit = 50, String? sortBy});
 
   /// Deletes a video event by its event ID.
   ///
@@ -116,10 +119,7 @@ abstract class VideoLocalStorage {
   /// Parameters:
   /// - [query]: The search text to match against content
   /// - [limit]: Maximum number of events to return (default 100)
-  Future<List<Event>> searchEvents({
-    required String query,
-    int limit = 100,
-  });
+  Future<List<Event>> searchEvents({required String query, int limit = 100});
 
   /// Gets the count of cached video events.
   Future<int> getEventCount();

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -1553,7 +1553,10 @@ class _VideoRouteCandidate {
 
     if (trimmed.length == 64 &&
         RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(trimmed)) {
-      return _VideoRouteCandidate(eventId: trimmed.toLowerCase());
+      return _VideoRouteCandidate(
+        eventId: trimmed.toLowerCase(),
+        stableId: trimmed,
+      );
     }
 
     if (Nip19.isNoteId(trimmed)) {

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -1446,10 +1446,7 @@ class VideosRepository {
     }
 
     if (candidate.stableId != null) {
-      final byStableId = await _fetchVideoByStableId(
-        candidate.stableId!,
-        permissive: true,
-      );
+      final byStableId = await _fetchVideoByStableId(candidate.stableId!);
       if (byStableId != null) return byStableId;
     }
 
@@ -1564,10 +1561,7 @@ class VideosRepository {
     return hydrated.firstOrNull;
   }
 
-  Future<VideoEvent?> _fetchVideoByStableId(
-    String stableId, {
-    bool permissive = false,
-  }) async {
+  Future<VideoEvent?> _fetchVideoByStableId(String stableId) async {
     final candidates = <Event>[];
 
     if (_localStorage != null) {
@@ -1578,9 +1572,7 @@ class VideosRepository {
       candidates.addAll(
         await _nostrClient.queryEvents([
           Filter(
-            kinds: permissive
-                ? NIP71VideoKinds.getAllAcceptableVideoKinds()
-                : NIP71VideoKinds.getAllVideoKinds(),
+            kinds: NIP71VideoKinds.getAllAcceptableVideoKinds(),
             d: [stableId],
             limit: 10,
           ),
@@ -1595,7 +1587,7 @@ class VideosRepository {
     for (final event in candidates) {
       final video = _tryParseAndFilter(
         event,
-        permissive: permissive,
+        permissive: true,
         ignoreBlockFilter: true,
       );
       if (video != null) {

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -922,14 +922,17 @@ class VideosRepository {
   /// - The video has no playable URL
   /// - The video is expired (NIP-40)
   /// - The video fails content filtering
-  VideoEvent? _tryParseAndFilter(Event event) {
+  VideoEvent? _tryParseAndFilter(Event event, {bool permissive = false}) {
     // Skip events that aren't valid video kinds
-    if (!NIP71VideoKinds.isVideoKind(event.kind)) return null;
+    final isSupported = permissive
+        ? NIP71VideoKinds.isAcceptableVideoKind(event.kind)
+        : NIP71VideoKinds.isVideoKind(event.kind);
+    if (!isSupported) return null;
 
     // Block filter - check pubkey before parsing for efficiency
     if (_blockFilter?.call(event.pubkey) ?? false) return null;
 
-    final video = VideoEvent.fromNostrEvent(event);
+    final video = VideoEvent.fromNostrEvent(event, permissive: permissive);
 
     // Skip videos without a playable URL
     if (!video.hasVideo) return null;
@@ -1422,7 +1425,7 @@ class VideosRepository {
     if (candidate == null) return null;
 
     if (candidate.eventId != null) {
-      final byEventId = await fetchVideoWithStats(candidate.eventId!);
+      final byEventId = await _fetchRouteVideoByEventId(candidate.eventId!);
       if (byEventId != null) return byEventId;
     }
 
@@ -1437,7 +1440,10 @@ class VideosRepository {
     }
 
     if (candidate.stableId != null) {
-      final byStableId = await _fetchVideoByStableId(candidate.stableId!);
+      final byStableId = await _fetchVideoByStableId(
+        candidate.stableId!,
+        permissive: true,
+      );
       if (byStableId != null) return byStableId;
     }
 
@@ -1504,7 +1510,45 @@ class VideosRepository {
     );
   }
 
-  Future<VideoEvent?> _fetchVideoByStableId(String stableId) async {
+  Future<VideoEvent?> _fetchRouteVideoByEventId(String eventId) async {
+    if (eventId.isEmpty) return null;
+
+    final candidates = <Event>[];
+
+    if (_localStorage != null) {
+      candidates.addAll(await _localStorage.getEventsByIds([eventId]));
+    }
+
+    if (candidates.isEmpty) {
+      candidates.addAll(
+        await _nostrClient.queryEvents([
+          Filter(
+            ids: [eventId],
+            kinds: NIP71VideoKinds.getAllAcceptableVideoKinds(),
+          ),
+        ]),
+      );
+    }
+
+    if (candidates.isEmpty) return null;
+
+    final videos = <VideoEvent>[];
+    for (final event in candidates) {
+      final video = _tryParseAndFilter(event, permissive: true);
+      if (video != null) {
+        videos.add(video);
+      }
+    }
+    if (videos.isEmpty) return null;
+
+    final hydrated = await _hydrateVideosWithBulkStats(videos);
+    return hydrated.firstOrNull;
+  }
+
+  Future<VideoEvent?> _fetchVideoByStableId(
+    String stableId, {
+    bool permissive = false,
+  }) async {
     final candidates = <Event>[];
 
     if (_localStorage != null) {
@@ -1515,7 +1559,9 @@ class VideosRepository {
       candidates.addAll(
         await _nostrClient.queryEvents([
           Filter(
-            kinds: NIP71VideoKinds.getAllVideoKinds(),
+            kinds: permissive
+                ? NIP71VideoKinds.getAllAcceptableVideoKinds()
+                : NIP71VideoKinds.getAllVideoKinds(),
             d: [stableId],
             limit: 10,
           ),
@@ -1528,7 +1574,7 @@ class VideosRepository {
     candidates.sort((a, b) => b.createdAt.compareTo(a.createdAt));
     final videos = <VideoEvent>[];
     for (final event in candidates) {
-      final video = _tryParseAndFilter(event);
+      final video = _tryParseAndFilter(event, permissive: permissive);
       if (video != null) {
         videos.add(video);
       }

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -1528,6 +1528,8 @@ class VideosRepository {
     final candidates = <Event>[];
 
     if (_localStorage != null) {
+      // Shared links should be able to reopen a video from local cache on a
+      // cold start before the relay layer has finished connecting.
       candidates.addAll(await _localStorage.getEventsByIds([eventId]));
     }
 
@@ -1572,6 +1574,8 @@ class VideosRepository {
       candidates.addAll(
         await _nostrClient.queryEvents([
           Filter(
+            // Route-specific lookups accept all supported NIP-71 video kinds so
+            // older shared links still resolve instead of failing as not found.
             kinds: NIP71VideoKinds.getAllAcceptableVideoKinds(),
             d: [stableId],
             limit: 10,

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -922,7 +922,11 @@ class VideosRepository {
   /// - The video has no playable URL
   /// - The video is expired (NIP-40)
   /// - The video fails content filtering
-  VideoEvent? _tryParseAndFilter(Event event, {bool permissive = false}) {
+  VideoEvent? _tryParseAndFilter(
+    Event event, {
+    bool permissive = false,
+    bool ignoreBlockFilter = false,
+  }) {
     // Skip events that aren't valid video kinds
     final isSupported = permissive
         ? NIP71VideoKinds.isAcceptableVideoKind(event.kind)
@@ -930,7 +934,9 @@ class VideosRepository {
     if (!isSupported) return null;
 
     // Block filter - check pubkey before parsing for efficiency
-    if (_blockFilter?.call(event.pubkey) ?? false) return null;
+    if (!ignoreBlockFilter && (_blockFilter?.call(event.pubkey) ?? false)) {
+      return null;
+    }
 
     final video = VideoEvent.fromNostrEvent(event, permissive: permissive);
 
@@ -1447,6 +1453,15 @@ class VideosRepository {
       if (byStableId != null) return byStableId;
     }
 
+    final funnelcakeRouteId = candidate.stableId ?? candidate.eventId;
+    if (funnelcakeRouteId != null) {
+      final byFunnelcake = await _fetchVideoFromRouteApi(
+        funnelcakeRouteId,
+        permissive: true,
+      );
+      if (byFunnelcake != null) return byFunnelcake;
+    }
+
     return null;
   }
 
@@ -1534,7 +1549,11 @@ class VideosRepository {
 
     final videos = <VideoEvent>[];
     for (final event in candidates) {
-      final video = _tryParseAndFilter(event, permissive: true);
+      final video = _tryParseAndFilter(
+        event,
+        permissive: true,
+        ignoreBlockFilter: true,
+      );
       if (video != null) {
         videos.add(video);
       }
@@ -1574,7 +1593,11 @@ class VideosRepository {
     candidates.sort((a, b) => b.createdAt.compareTo(a.createdAt));
     final videos = <VideoEvent>[];
     for (final event in candidates) {
-      final video = _tryParseAndFilter(event, permissive: permissive);
+      final video = _tryParseAndFilter(
+        event,
+        permissive: permissive,
+        ignoreBlockFilter: true,
+      );
       if (video != null) {
         videos.add(video);
       }
@@ -1583,6 +1606,28 @@ class VideosRepository {
 
     final hydrated = await _hydrateVideosWithBulkStats(videos);
     return hydrated.isEmpty ? null : hydrated.first;
+  }
+
+  Future<VideoEvent?> _fetchVideoFromRouteApi(
+    String routeId, {
+    bool permissive = false,
+  }) async {
+    if (_funnelcakeApiClient == null || !_funnelcakeApiClient.isAvailable) {
+      return null;
+    }
+
+    final event = await _funnelcakeApiClient.getVideoEvent(routeId);
+    if (event == null) return null;
+
+    final video = _tryParseAndFilter(
+      event,
+      permissive: permissive,
+      ignoreBlockFilter: true,
+    );
+    if (video == null) return null;
+
+    final hydrated = await _hydrateVideosWithBulkStats([video]);
+    return hydrated.firstOrNull;
   }
 }
 

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -9,6 +9,7 @@ import 'dart:developer' as developer;
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:videos_repository/src/home_feed_result.dart';
 import 'package:videos_repository/src/in_memory_feed_cache.dart';
@@ -1412,6 +1413,37 @@ class VideosRepository {
     return hydrated.firstOrNull;
   }
 
+  /// Resolves a video route identifier and returns the hydrated video.
+  ///
+  /// Supports raw event IDs, plain stable IDs / d-tags, and NIP-19
+  /// `note1...`, `nevent1...`, and `naddr1...` references.
+  Future<VideoEvent?> fetchVideoWithStatsForRouteId(String routeId) async {
+    final candidate = _VideoRouteCandidate.parse(routeId);
+    if (candidate == null) return null;
+
+    if (candidate.eventId != null) {
+      final byEventId = await fetchVideoWithStats(candidate.eventId!);
+      if (byEventId != null) return byEventId;
+    }
+
+    if (candidate.addressableId != null) {
+      final videos = await getVideosByAddressableIds([
+        candidate.addressableId!,
+      ]);
+      if (videos.isNotEmpty) {
+        final hydrated = await _hydrateVideosWithBulkStats(videos);
+        if (hydrated.isNotEmpty) return hydrated.first;
+      }
+    }
+
+    if (candidate.stableId != null) {
+      final byStableId = await _fetchVideoByStableId(candidate.stableId!);
+      if (byStableId != null) return byStableId;
+    }
+
+    return null;
+  }
+
   /// Fetches stats for a single video.
   ///
   /// Returns null if Funnelcake API is unavailable.
@@ -1470,5 +1502,83 @@ class VideosRepository {
       fallback: fallback,
       category: category,
     );
+  }
+
+  Future<VideoEvent?> _fetchVideoByStableId(String stableId) async {
+    final candidates = <Event>[];
+
+    if (_localStorage != null) {
+      candidates.addAll(await _localStorage.getEventsByDTag(stableId));
+    }
+
+    if (candidates.isEmpty) {
+      candidates.addAll(
+        await _nostrClient.queryEvents([
+          Filter(
+            kinds: NIP71VideoKinds.getAllVideoKinds(),
+            d: [stableId],
+            limit: 10,
+          ),
+        ]),
+      );
+    }
+
+    if (candidates.isEmpty) return null;
+
+    candidates.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    final videos = <VideoEvent>[];
+    for (final event in candidates) {
+      final video = _tryParseAndFilter(event);
+      if (video != null) {
+        videos.add(video);
+      }
+    }
+    if (videos.isEmpty) return null;
+
+    final hydrated = await _hydrateVideosWithBulkStats(videos);
+    return hydrated.isEmpty ? null : hydrated.first;
+  }
+}
+
+class _VideoRouteCandidate {
+  const _VideoRouteCandidate({this.eventId, this.addressableId, this.stableId});
+
+  final String? eventId;
+  final String? addressableId;
+  final String? stableId;
+
+  static _VideoRouteCandidate? parse(String routeId) {
+    final trimmed = routeId.trim();
+    if (trimmed.isEmpty) return null;
+
+    if (trimmed.length == 64 &&
+        RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(trimmed)) {
+      return _VideoRouteCandidate(eventId: trimmed.toLowerCase());
+    }
+
+    if (Nip19.isNoteId(trimmed)) {
+      final eventId = Nip19.decode(trimmed);
+      return eventId.isEmpty ? null : _VideoRouteCandidate(eventId: eventId);
+    }
+
+    if (NIP19Tlv.isNevent(trimmed)) {
+      final decoded = NIP19Tlv.decodeNevent(trimmed);
+      return decoded == null ? null : _VideoRouteCandidate(eventId: decoded.id);
+    }
+
+    if (NIP19Tlv.isNaddr(trimmed)) {
+      final decoded = NIP19Tlv.decodeNaddr(trimmed);
+      if (decoded == null) return null;
+      return _VideoRouteCandidate(
+        addressableId: AId(
+          kind: decoded.kind,
+          pubkey: decoded.author,
+          dTag: decoded.id,
+        ).toAString(),
+        stableId: decoded.id,
+      );
+    }
+
+    return _VideoRouteCandidate(stableId: trimmed);
   }
 }

--- a/mobile/packages/videos_repository/test/src/db_video_local_storage_test.dart
+++ b/mobile/packages/videos_repository/test/src/db_video_local_storage_test.dart
@@ -30,11 +30,7 @@ void main() {
     const videoKind = 34236;
 
     /// Create a test video event
-    Event createTestEvent({
-      String? id,
-      String? pubkey,
-      int? createdAt,
-    }) {
+    Event createTestEvent({String? id, String? pubkey, int? createdAt}) {
       final event =
           Event(
               pubkey ?? testPubkey1,
@@ -152,6 +148,37 @@ void main() {
       });
     });
 
+    group('getEventsByDTag', () {
+      test('returns events matching the d-tag', () async {
+        final events = [
+          createTestEvent(id: testEventId1),
+          createTestEvent(id: testEventId2),
+        ];
+
+        when(
+          () => mockDao.getEventsByFilter(any()),
+        ).thenAnswer((_) async => events);
+
+        final result = await storage.getEventsByDTag('test-vine-id');
+
+        expect(result, hasLength(2));
+        final captured =
+            verify(
+                  () => mockDao.getEventsByFilter(captureAny()),
+                ).captured.single
+                as Filter;
+        expect(captured.kinds, equals([videoKind]));
+        expect(captured.d, equals(['test-vine-id']));
+      });
+
+      test('returns empty list for empty d-tag', () async {
+        final result = await storage.getEventsByDTag('');
+
+        expect(result, isEmpty);
+        verifyNever(() => mockDao.getEventsByFilter(any()));
+      });
+    });
+
     group('getEventsByAuthors', () {
       test('returns events from specified authors', () async {
         final events = [
@@ -242,10 +269,7 @@ void main() {
           () => mockDao.getEventsByFilter(any(), sortBy: any(named: 'sortBy')),
         ).thenAnswer((_) async => []);
 
-        await storage.getAllEvents(
-          limit: 100,
-          until: 1700000000,
-        );
+        await storage.getAllEvents(limit: 100, until: 1700000000);
 
         final captured = verify(
           () => mockDao.getEventsByFilter(

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6259,6 +6259,33 @@ void main() {
         expect(result!.id, equals(eventId));
       });
 
+      test('normalizes raw 64-char hex route IDs before lookup', () async {
+        const lowerEventId =
+            'e695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+        const upperEventId =
+            'E695F6B60119D9521934A691347D9F78E8770B56DA16BB255EE77AC112B4C1F6';
+        final event = _createVideoEvent(
+          id: lowerEventId,
+          pubkey: 'pubkey-1',
+          videoUrl: 'https://example.com/video.mp4',
+          createdAt: 1739350000,
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+        );
+
+        final result = await repo.fetchVideoWithStatsForRouteId(upperEventId);
+
+        expect(result, isNotNull);
+        expect(result!.id, equals(lowerEventId));
+      });
+
       test('resolves nevent route IDs via event ID lookup', () async {
         const eventId =
             'b695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
@@ -6354,6 +6381,54 @@ void main() {
           expect(result!.id, equals(eventId));
           verify(() => mockLocalStorage.getEventsByDTag(stableId)).called(1);
           verifyNever(() => mockNostrClient.queryEvents(any()));
+        },
+      );
+
+      test(
+        'falls back to relay lookup for stable IDs missing from local cache',
+        () async {
+          const eventId =
+              'f695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+          const stableId = 'relay-only-video';
+          final event = _createVideoEventWithDTag(
+            id: eventId,
+            pubkey: 'pubkey-2',
+            dTag: stableId,
+            videoUrl: 'https://example.com/video.mp4',
+            createdAt: 1739350100,
+          );
+          final mockLocalStorage = MockVideoLocalStorage();
+
+          when(
+            () => mockLocalStorage.getEventsByDTag(stableId),
+          ).thenAnswer((_) async => const []);
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [event]);
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo.fetchVideoWithStatsForRouteId(stableId);
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(eventId));
+          verify(() => mockLocalStorage.getEventsByDTag(stableId)).called(1);
+
+          final captured =
+              verify(
+                    () => mockNostrClient.queryEvents(captureAny()),
+                  ).captured.single
+                  as List<Filter>;
+          expect(captured, hasLength(1));
+          expect(captured.single.d, equals([stableId]));
+          expect(
+            captured.single.kinds,
+            equals(NIP71VideoKinds.getAllVideoKinds()),
+          );
         },
       );
     });

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6306,8 +6306,11 @@ void main() {
             ],
           );
 
-          when(() => mockNostrClient.queryEvents(any())).thenAnswer((invocation) async {
-            final filters = invocation.positionalArguments.single as List<Filter>;
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer((
+            invocation,
+          ) async {
+            final filters =
+                invocation.positionalArguments.single as List<Filter>;
             final filter = filters.single;
             if (filter.ids?.contains(hexStableId) ?? false) {
               return <Event>[];

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6,6 +6,7 @@ import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -6137,9 +6138,7 @@ void main() {
         );
         final result = await repo.fetchVideoWithStats('');
         expect(result, isNull);
-        verifyNever(
-          () => mockNostrClient.queryEvents(any()),
-        );
+        verifyNever(() => mockNostrClient.queryEvents(any()));
       });
 
       test('returns null when event is not found on relay', () async {
@@ -6211,9 +6210,7 @@ void main() {
             () => mockNostrClient.queryEvents(any()),
           ).thenAnswer((_) async => [nostrEvent]);
 
-          when(
-            () => mockFunnelcakeClient.isAvailable,
-          ).thenReturn(false);
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);
 
           final repo = VideosRepository(
             nostrClient: mockNostrClient,
@@ -6224,6 +6221,139 @@ void main() {
           expect(result, isNotNull);
           expect(result!.id, equals(eventId));
           expect(result.originalLoops, isNull);
+        },
+      );
+    });
+
+    group('fetchVideoWithStatsForRouteId', () {
+      late MockFunnelcakeApiClient mockFunnelcakeClient;
+
+      setUp(() {
+        mockFunnelcakeClient = MockFunnelcakeApiClient();
+        when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);
+      });
+
+      test('resolves note1 route IDs via event ID lookup', () async {
+        const eventId =
+            'a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+        final noteId = Nip19.encodeNoteId(eventId);
+        final event = _createVideoEvent(
+          id: eventId,
+          pubkey: 'pubkey-1',
+          videoUrl: 'https://example.com/video.mp4',
+          createdAt: 1739350000,
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+        );
+
+        final result = await repo.fetchVideoWithStatsForRouteId(noteId);
+
+        expect(result, isNotNull);
+        expect(result!.id, equals(eventId));
+      });
+
+      test('resolves nevent route IDs via event ID lookup', () async {
+        const eventId =
+            'b695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+        const author =
+            '3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+        final nevent = NIP19Tlv.encodeNevent(
+          Nevent(id: eventId, author: author),
+        );
+        final event = _createVideoEvent(
+          id: eventId,
+          pubkey: author,
+          videoUrl: 'https://example.com/video.mp4',
+          createdAt: 1739350000,
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+        );
+
+        final result = await repo.fetchVideoWithStatsForRouteId(nevent);
+
+        expect(result, isNotNull);
+        expect(result!.id, equals(eventId));
+      });
+
+      test('resolves naddr route IDs via addressable lookup', () async {
+        const eventId =
+            'c695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+        const author =
+            '4bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+        const dTag = 'shared-video';
+        final naddr = NIP19Tlv.encodeNaddr(
+          Naddr(id: dTag, author: author, kind: EventKind.videoVertical),
+        );
+        final event = _createVideoEventWithDTag(
+          id: eventId,
+          pubkey: author,
+          dTag: dTag,
+          videoUrl: 'https://example.com/video.mp4',
+          createdAt: 1739350000,
+        );
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [event]);
+
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+        );
+
+        final result = await repo.fetchVideoWithStatsForRouteId(naddr);
+
+        expect(result, isNotNull);
+        expect(result!.id, equals(eventId));
+        expect(result.vineId, equals(dTag));
+      });
+
+      test(
+        'resolves plain stable IDs from local storage before relay',
+        () async {
+          const eventId =
+              'd695f6b60119d9521934a691347d9f78'
+              'e8770b56da16bb255ee77ac112b4c1f6';
+          const stableId = 'shared-video';
+          final event = _createVideoEventWithDTag(
+            id: eventId,
+            pubkey: 'pubkey-1',
+            dTag: stableId,
+            videoUrl: 'https://example.com/video.mp4',
+            createdAt: 1739350000,
+          );
+          final mockLocalStorage = MockVideoLocalStorage();
+
+          when(
+            () => mockLocalStorage.getEventsByDTag(stableId),
+          ).thenAnswer((_) async => [event]);
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            localStorage: mockLocalStorage,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo.fetchVideoWithStatsForRouteId(stableId);
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(eventId));
+          verify(() => mockLocalStorage.getEventsByDTag(stableId)).called(1);
+          verifyNever(() => mockNostrClient.queryEvents(any()));
         },
       );
     });

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6388,7 +6388,8 @@ void main() {
         'falls back to relay lookup for stable IDs missing from local cache',
         () async {
           const eventId =
-              'f695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+              'f695f6b60119d9521934a691347d9f78'
+              'e8770b56da16bb255ee77ac112b4c1f6';
           const stableId = 'relay-only-video';
           final event = _createVideoEventWithDTag(
             id: eventId,

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6286,6 +6286,51 @@ void main() {
         expect(result!.id, equals(lowerEventId));
       });
 
+      test(
+        'falls back to stable-id lookup when a 64-char hex route is not an '
+        'event id',
+        () async {
+          const hexStableId =
+              'cdb77b012caba00133fc071b568e334b279947f09d30df0ce819aedcd777b749';
+          const eventId =
+              'd695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+          const author =
+              '5bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+          final event = _createVideoEvent(
+            id: eventId,
+            pubkey: author,
+            videoUrl: 'https://example.com/video.mp4',
+            createdAt: 1739350000,
+            extraTags: [
+              ['d', hexStableId],
+            ],
+          );
+
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer((invocation) async {
+            final filters = invocation.positionalArguments.single as List<Filter>;
+            final filter = filters.single;
+            if (filter.ids?.contains(hexStableId) ?? false) {
+              return <Event>[];
+            }
+            if (filter.d?.contains(hexStableId) ?? false) {
+              return [event];
+            }
+            return <Event>[];
+          });
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo.fetchVideoWithStatsForRouteId(hexStableId);
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(eventId));
+          expect(result.stableId, equals(hexStableId));
+        },
+      );
+
       test('resolves nevent route IDs via event ID lookup', () async {
         const eventId =
             'b695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
@@ -7129,6 +7174,7 @@ Event _createVideoEvent({
   required int createdAt,
   int? loops,
   List<String>? hashtags,
+  List<List<String>>? extraTags,
   bool hasContentWarning = false,
   String content = '',
 }) {
@@ -7138,6 +7184,7 @@ Event _createVideoEvent({
     ['d', id], // Required for addressable events
     if (hashtags != null)
       for (final tag in hashtags) ['t', tag],
+    ...?extraTags,
     if (hasContentWarning) ['content-warning', 'adult content'],
   ];
 

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6287,6 +6287,39 @@ void main() {
       });
 
       test(
+        'resolves event-id routes from local storage before relay',
+        () async {
+          const eventId =
+              'e96357668c72c8923340b0ecf4bfacea'
+              '505172c4190e9953e603124c67175f3b';
+          final mockLocalStorage = MockVideoLocalStorage();
+          final event = _createVideoEvent(
+            id: eventId,
+            pubkey: 'pubkey-1',
+            videoUrl: 'https://example.com/video.mp4',
+            createdAt: 1739350000,
+          );
+
+          when(() => mockLocalStorage.getEventsByIds([eventId])).thenAnswer(
+            (_) async => [event],
+          );
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            localStorage: mockLocalStorage,
+          );
+
+          final result = await repo.fetchVideoWithStatsForRouteId(eventId);
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(eventId));
+          verify(() => mockLocalStorage.getEventsByIds([eventId])).called(1);
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+        },
+      );
+
+      test(
         'resolves acceptable legacy video kinds by raw 64-char route ID',
         () async {
           const eventId =

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6291,11 +6291,14 @@ void main() {
         'event id',
         () async {
           const hexStableId =
-              'cdb77b012caba00133fc071b568e334b279947f09d30df0ce819aedcd777b749';
+              'cdb77b012caba00133fc071b568e334b27'
+              '9947f09d30df0ce819aedcd777b749';
           const eventId =
-              'd695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+              'd695f6b60119d9521934a691347d9f78e8'
+              '770b56da16bb255ee77ac112b4c1f6';
           const author =
-              '5bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d';
+              '5bf0c63fcb93463407af97a5e5ee64fa88'
+              '3d107ef9e558472c4eb9aaaefa459d';
           final event = _createVideoEvent(
             id: eventId,
             pubkey: author,

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6419,6 +6419,85 @@ void main() {
         },
       );
 
+      test(
+        'falls back to Funnelcake route lookup when relay misses shared stable ID',
+        () async {
+          const stableId =
+              'e96357668c72c8923340b0ecf4bfacea505172c4190e9953e603124c67175f3b';
+          const eventId =
+              'e46ff7d0d71d6c8114b58728afa43f08d6286fd9a704683af799fd8f855586c2';
+          final relayMissThenApiHit = Event.fromJson({
+            'id': eventId,
+            'pubkey':
+                '076c979382b90f5d3a2b21f95e1ee86b6033f14c92e79b7fad3fe1f1073f4886',
+            'created_at': 1777868006,
+            'kind': 34236,
+            'tags': [
+              ['d', stableId],
+              ['url', 'https://media.divine.video/$stableId'],
+              ['title', 'Divine team swag'],
+            ],
+            'content': 'Divine team swag!',
+            'sig': 'sig',
+          });
+
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+            (_) async => <Event>[],
+          );
+          when(
+            () => mockFunnelcakeClient.getVideoEvent(stableId),
+          ).thenAnswer((_) async => relayMissThenApiHit);
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo.fetchVideoWithStatsForRouteId(stableId);
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(eventId));
+          expect(result.stableId, equals(stableId));
+          verify(() => mockFunnelcakeClient.getVideoEvent(stableId)).called(1);
+        },
+      );
+
+      test('returns blocked-author videos for direct route lookups', () async {
+        const stableId =
+            'f96357668c72c8923340b0ecf4bfacea505172c4190e9953e603124c67175f3b';
+        const eventId =
+            'f46ff7d0d71d6c8114b58728afa43f08d6286fd9a704683af799fd8f855586c2';
+        const blockedPubkey =
+            '076c979382b90f5d3a2b21f95e1ee86b6033f14c92e79b7fad3fe1f1073f4886';
+        final blockedEvent = _createVideoEvent(
+          id: eventId,
+          pubkey: blockedPubkey,
+          videoUrl: 'https://media.divine.video/$stableId',
+          createdAt: 1777868006,
+          extraTags: [
+            ['d', stableId],
+            ['title', 'Blocked deep-link target'],
+          ],
+        );
+
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+          (_) async => [blockedEvent],
+        );
+
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+          blockFilter: (pubkey) => pubkey == blockedPubkey,
+        );
+
+        final result = await repo.fetchVideoWithStatsForRouteId(stableId);
+
+        expect(result, isNotNull);
+        expect(result!.id, equals(eventId));
+        expect(result.pubkey, equals(blockedPubkey));
+      });
+
       test('resolves nevent route IDs via event ID lookup', () async {
         const eventId =
             'b695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6286,6 +6286,38 @@ void main() {
         expect(result!.id, equals(lowerEventId));
       });
 
+      test('resolves acceptable legacy video kinds by raw 64-char route ID', () async {
+        const eventId =
+            'e96357668c72c8923340b0ecf4bfacea505172c4190e9953e603124c67175f3b';
+        final legacyEvent = Event.fromJson({
+          'id': eventId,
+          'pubkey':
+              '5bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d',
+          'created_at': 1739350000,
+          'kind': 22,
+          'tags': [
+            ['url', 'https://example.com/video.mp4'],
+            ['title', 'Legacy Video'],
+          ],
+          'content': '',
+          'sig': 'sig',
+        });
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [legacyEvent]);
+
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+        );
+
+        final result = await repo.fetchVideoWithStatsForRouteId(eventId);
+
+        expect(result, isNotNull);
+        expect(result!.id, equals(eventId));
+      });
+
       test(
         'falls back to stable-id lookup when a 64-char hex route is not an '
         'event id',
@@ -6320,6 +6352,56 @@ void main() {
             }
             if (filter.d?.contains(hexStableId) ?? false) {
               return [event];
+            }
+            return <Event>[];
+          });
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repo.fetchVideoWithStatsForRouteId(hexStableId);
+
+          expect(result, isNotNull);
+          expect(result!.id, equals(eventId));
+          expect(result.stableId, equals(hexStableId));
+        },
+      );
+
+      test(
+        'falls back to stable-id lookup for acceptable legacy video kinds',
+        () async {
+          const hexStableId =
+              'e96357668c72c8923340b0ecf4bfacea505172c4190e9953e603124c67175f3b';
+          const eventId =
+              'd695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+          final legacyEvent = Event.fromJson({
+            'id': eventId,
+            'pubkey':
+                '5bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d',
+            'created_at': 1739350000,
+            'kind': 22,
+            'tags': [
+              ['url', 'https://example.com/video.mp4'],
+              ['title', 'Legacy Stable Video'],
+              ['d', hexStableId],
+            ],
+            'content': '',
+            'sig': 'sig',
+          });
+
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer((
+            invocation,
+          ) async {
+            final filters =
+                invocation.positionalArguments.single as List<Filter>;
+            final filter = filters.single;
+            if (filter.ids?.contains(hexStableId) ?? false) {
+              return <Event>[];
+            }
+            if (filter.d?.contains(hexStableId) ?? false) {
+              return [legacyEvent];
             }
             return <Event>[];
           });
@@ -6479,7 +6561,7 @@ void main() {
           expect(captured.single.d, equals([stableId]));
           expect(
             captured.single.kinds,
-            equals(NIP71VideoKinds.getAllVideoKinds()),
+            equals(NIP71VideoKinds.getAllAcceptableVideoKinds()),
           );
         },
       );

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6290,11 +6290,13 @@ void main() {
         'resolves acceptable legacy video kinds by raw 64-char route ID',
         () async {
           const eventId =
-              'e96357668c72c8923340b0ecf4bfacea505172c4190e9953e603124c67175f3b';
+              'e96357668c72c8923340b0ecf4bfacea'
+              '505172c4190e9953e603124c67175f3b';
           final legacyEvent = Event.fromJson({
             'id': eventId,
             'pubkey':
-                '5bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d',
+                '5bf0c63fcb93463407af97a5e5ee64fa'
+                '883d107ef9e558472c4eb9aaaefa459d',
             'created_at': 1739350000,
             'kind': 22,
             'tags': [
@@ -6364,7 +6366,9 @@ void main() {
             funnelcakeApiClient: mockFunnelcakeClient,
           );
 
-          final result = await repo.fetchVideoWithStatsForRouteId(hexStableId);
+          final result = await repo.fetchVideoWithStatsForRouteId(
+            hexStableId,
+          );
 
           expect(result, isNotNull);
           expect(result!.id, equals(eventId));
@@ -6376,13 +6380,16 @@ void main() {
         'falls back to stable-id lookup for acceptable legacy video kinds',
         () async {
           const hexStableId =
-              'e96357668c72c8923340b0ecf4bfacea505172c4190e9953e603124c67175f3b';
+              'e96357668c72c8923340b0ecf4bfacea'
+              '505172c4190e9953e603124c67175f3b';
           const eventId =
-              'd695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+              'd695f6b60119d9521934a691347d9f78'
+              'e8770b56da16bb255ee77ac112b4c1f6';
           final legacyEvent = Event.fromJson({
             'id': eventId,
             'pubkey':
-                '5bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d',
+                '5bf0c63fcb93463407af97a5e5ee64fa'
+                '883d107ef9e558472c4eb9aaaefa459d',
             'created_at': 1739350000,
             'kind': 22,
             'tags': [
@@ -6414,7 +6421,9 @@ void main() {
             funnelcakeApiClient: mockFunnelcakeClient,
           );
 
-          final result = await repo.fetchVideoWithStatsForRouteId(hexStableId);
+          final result = await repo.fetchVideoWithStatsForRouteId(
+            hexStableId,
+          );
 
           expect(result, isNotNull);
           expect(result!.id, equals(eventId));
@@ -6423,16 +6432,20 @@ void main() {
       );
 
       test(
-        'falls back to Funnelcake route lookup when relay misses shared stable ID',
+        'falls back to Funnelcake route lookup when relay misses shared '
+        'stable ID',
         () async {
           const stableId =
-              'e96357668c72c8923340b0ecf4bfacea505172c4190e9953e603124c67175f3b';
+              'e96357668c72c8923340b0ecf4bfacea'
+              '505172c4190e9953e603124c67175f3b';
           const eventId =
-              'e46ff7d0d71d6c8114b58728afa43f08d6286fd9a704683af799fd8f855586c2';
+              'e46ff7d0d71d6c8114b58728afa43f08'
+              'd6286fd9a704683af799fd8f855586c2';
           final relayMissThenApiHit = Event.fromJson({
             'id': eventId,
             'pubkey':
-                '076c979382b90f5d3a2b21f95e1ee86b6033f14c92e79b7fad3fe1f1073f4886',
+                '076c979382b90f5d3a2b21f95e1ee86b'
+                '6033f14c92e79b7fad3fe1f1073f4886',
             'created_at': 1777868006,
             'kind': 34236,
             'tags': [

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -6286,37 +6286,40 @@ void main() {
         expect(result!.id, equals(lowerEventId));
       });
 
-      test('resolves acceptable legacy video kinds by raw 64-char route ID', () async {
-        const eventId =
-            'e96357668c72c8923340b0ecf4bfacea505172c4190e9953e603124c67175f3b';
-        final legacyEvent = Event.fromJson({
-          'id': eventId,
-          'pubkey':
-              '5bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d',
-          'created_at': 1739350000,
-          'kind': 22,
-          'tags': [
-            ['url', 'https://example.com/video.mp4'],
-            ['title', 'Legacy Video'],
-          ],
-          'content': '',
-          'sig': 'sig',
-        });
+      test(
+        'resolves acceptable legacy video kinds by raw 64-char route ID',
+        () async {
+          const eventId =
+              'e96357668c72c8923340b0ecf4bfacea505172c4190e9953e603124c67175f3b';
+          final legacyEvent = Event.fromJson({
+            'id': eventId,
+            'pubkey':
+                '5bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d',
+            'created_at': 1739350000,
+            'kind': 22,
+            'tags': [
+              ['url', 'https://example.com/video.mp4'],
+              ['title', 'Legacy Video'],
+            ],
+            'content': '',
+            'sig': 'sig',
+          });
 
-        when(
-          () => mockNostrClient.queryEvents(any()),
-        ).thenAnswer((_) async => [legacyEvent]);
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [legacyEvent]);
 
-        final repo = VideosRepository(
-          nostrClient: mockNostrClient,
-          funnelcakeApiClient: mockFunnelcakeClient,
-        );
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
 
-        final result = await repo.fetchVideoWithStatsForRouteId(eventId);
+          final result = await repo.fetchVideoWithStatsForRouteId(eventId);
 
-        expect(result, isNotNull);
-        expect(result!.id, equals(eventId));
-      });
+          expect(result, isNotNull);
+          expect(result!.id, equals(eventId));
+        },
+      );
 
       test(
         'falls back to stable-id lookup when a 64-char hex route is not an '

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -47,7 +47,12 @@ void main() {
       hasMoreController.close();
     });
 
-    VideoEvent createTestVideo(String id, {String? sha256}) {
+    VideoEvent createTestVideo(
+      String id, {
+      String? sha256,
+      String? videoUrl,
+      Map<String, String> rawTags = const {},
+    }) {
       final now = DateTime.now();
       return VideoEvent(
         id: id,
@@ -56,9 +61,10 @@ void main() {
         content: '',
         timestamp: now,
         title: 'Test Video $id',
-        videoUrl: 'https://example.com/video_$id.mp4',
+        videoUrl: videoUrl ?? 'https://example.com/video_$id.mp4',
         thumbnailUrl: 'https://example.com/thumb_$id.jpg',
         sha256: sha256,
+        rawTags: rawTags,
       );
     }
 
@@ -750,6 +756,35 @@ void main() {
               timestamp: DateTime.now(),
               title: 'Test',
               videoUrl: '/data/user/0/cache/video1.mp4',
+            ),
+          ],
+        ),
+        act: (bloc) =>
+            bloc.add(const FullscreenFeedVideoCacheStarted(index: 0)),
+        wait: const Duration(milliseconds: 100),
+        verify: (_) {
+          verifyNever(
+            () => mockMediaCache.downloadFile(
+              any(),
+              key: any(named: 'key'),
+              authHeaders: any(named: 'authHeaders'),
+            ),
+          );
+        },
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'skips caching for original Vine raw blobs with no cacheable URL',
+        build: createBloc,
+        seed: () => FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [
+            createTestVideo(
+              'vine1',
+              videoUrl:
+                  'https://media.divine.video/'
+                  'cfb5cf3415ec4ad3f45eff478570d898ff9a660ecea63d0c058892b22468a90d',
+              rawTags: const {'platform': 'vine'},
             ),
           ],
         ),

--- a/mobile/test/extensions/video_event_divine_server_test.dart
+++ b/mobile/test/extensions/video_event_divine_server_test.dart
@@ -197,9 +197,12 @@ void main() {
       );
 
       expect(video.isOriginalVine, isTrue);
-      expect(video.getOptimalVideoUrlForPlatform(), equals(
-        'https://media.divine.video/$hash',
-      ));
+      expect(
+        video.getOptimalVideoUrlForPlatform(),
+        equals(
+          'https://media.divine.video/$hash',
+        ),
+      );
       expect(video.getCacheableVideoUrlForPlatform(), isNull);
     });
 

--- a/mobile/test/extensions/video_event_divine_server_test.dart
+++ b/mobile/test/extensions/video_event_divine_server_test.dart
@@ -9,7 +9,12 @@ import 'package:openvine/services/bandwidth_tracker_service.dart';
 import 'package:pooled_video_player/pooled_video_player.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-VideoEvent _createVideoWithUrl(String url) {
+VideoEvent _createVideoWithUrl(String url, {Map<String, String>? rawTags}) {
+  final tags = <List<String>>[
+    ['url', url],
+    for (final entry in (rawTags ?? const <String, String>{}).entries)
+      [entry.key, entry.value],
+  ];
   final event = Event.fromJson({
     'id': 'aaaa1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab',
     'pubkey':
@@ -17,9 +22,7 @@ VideoEvent _createVideoWithUrl(String url) {
     'created_at': 1234567890,
     'kind': 34236,
     'content': '',
-    'tags': [
-      ['url', url],
-    ],
+    'tags': tags,
     'sig': 'cccc1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab',
   });
   return VideoEvent.fromNostrEvent(event);
@@ -185,6 +188,19 @@ void main() {
         video.getCacheableVideoUrlForPlatform(),
         equals('https://media.divine.video/$hash/720p.mp4'),
       );
+    });
+
+    test('skips single-file caching for original Vine raw blobs', () {
+      final video = _createVideoWithUrl(
+        'https://media.divine.video/$hash',
+        rawTags: const {'platform': 'vine'},
+      );
+
+      expect(video.isOriginalVine, isTrue);
+      expect(video.getOptimalVideoUrlForPlatform(), equals(
+        'https://media.divine.video/$hash',
+      ));
+      expect(video.getCacheableVideoUrlForPlatform(), isNull);
     });
 
     test('do not treat quality variants as bare hash paths', () {

--- a/mobile/test/providers/deep_link_provider_test.dart
+++ b/mobile/test/providers/deep_link_provider_test.dart
@@ -89,7 +89,7 @@ void main() {
 
       await Future<void>.delayed(Duration.zero);
       deepLinkSource.add(
-        const DeepLink(type: DeepLinkType.video, videoId: 'late-a'),
+        const DeepLink(type: DeepLinkType.video, videoRef: 'late-a'),
       );
 
       expect(serviceA.receivedDeepLinks, isEmpty);
@@ -113,7 +113,7 @@ void main() {
 
       await Future<void>.delayed(Duration.zero);
       deepLinkSource.add(
-        const DeepLink(type: DeepLinkType.video, videoId: 'late-b'),
+        const DeepLink(type: DeepLinkType.video, videoRef: 'late-b'),
       );
 
       expect(serviceB.isDisposed, isFalse);

--- a/mobile/test/router/universal_link_resolver_test.dart
+++ b/mobile/test/router/universal_link_resolver_test.dart
@@ -13,6 +13,15 @@ void main() {
       );
     });
 
+    test('preserves note1 video references for in-app resolution', () {
+      const noteId =
+          'note1w3jhxaq69g8m70m7g6g8j2rf7x0s5h7k0d0l0m9d3c4s5u6v7w8q9xyz0p';
+      expect(
+        divineUrlToPushRoute(Uri.parse('https://divine.video/video/$noteId')),
+        equals('/video/$noteId'),
+      );
+    });
+
     test('accepts www.divine.video host alias', () {
       expect(
         divineUrlToPushRoute(

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -419,7 +420,8 @@ void main() {
               routerConfig: router,
             ),
           );
-          await tester.pumpAndSettle();
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
           expect(find.text('empty-state-body'), findsOneWidget);
 
           await tester.tap(find.byType(BackButton));
@@ -473,6 +475,59 @@ void main() {
         // Note: Individual video items may still show their own loading states
         expect(find.byType(PooledVideoFeed), findsOneWidget);
       });
+
+      testWidgets(
+        'ready-state back button falls back to root when route cannot pop',
+        (tester) async {
+          final videos = createTestVideos(count: 1);
+          var sentinelBuilt = false;
+          late final GoRouter router;
+
+          router = GoRouter(
+            initialLocation: '/shared-video',
+            routes: [
+              GoRoute(
+                path: '/',
+                builder: (_, _) {
+                  sentinelBuilt = true;
+                  return const Scaffold(body: Text('home-sentinel'));
+                },
+              ),
+              GoRoute(
+                path: '/shared-video',
+                builder: (_, _) => buildSubject(
+                  state: FullscreenFeedState(
+                    status: FullscreenFeedStatus.ready,
+                    videos: videos,
+                  ),
+                  contextTitle: 'Shared Video',
+                ),
+              ),
+            ],
+          );
+          addTearDown(router.dispose);
+
+          await tester.pumpWidget(
+            MaterialApp.router(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              routerConfig: router,
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          expect(find.byType(PooledVideoFeed), findsOneWidget);
+          expect(sentinelBuilt, isFalse);
+
+          await tester.tap(find.byType(DiVineAppBarIconButton).first);
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          expect(sentinelBuilt, isTrue);
+          expect(find.text('home-sentinel'), findsOneWidget);
+        },
+      );
 
       testWidgets('resumes playback when app resumes on current route', (
         tester,

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -96,10 +96,10 @@ void main() {
       testWidgets('renders $CircularProgressIndicator while fetching video', (
         tester,
       ) async {
-        // fetchVideoWithStats stays pending
+        // fetchVideoWithStatsForRouteId stays pending
         final completer = Completer<VideoEvent?>();
         when(
-          () => mockVideosRepository.fetchVideoWithStats(any()),
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
         ).thenAnswer((_) => completer.future);
 
         await tester.pumpWidget(buildSubject());
@@ -109,30 +109,36 @@ void main() {
     });
 
     group('video found', () {
-      testWidgets('renders player once fetchVideoWithStats resolves', (
-        tester,
-      ) async {
-        final video = createTestVideoEvent(
-          id: 'test_video_id',
-          pubkey: 'test_pubkey',
-          title: 'Deep Link Video',
-        );
+      testWidgets(
+        'renders player once fetchVideoWithStatsForRouteId resolves',
+        (tester) async {
+          final video = createTestVideoEvent(
+            id: 'test_video_id',
+            pubkey: 'test_pubkey',
+            title: 'Deep Link Video',
+          );
 
-        when(
-          () => mockVideosRepository.fetchVideoWithStats('test_video_id'),
-        ).thenAnswer((_) async => video);
+          when(
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'test_video_id',
+            ),
+          ).thenAnswer((_) async => video);
 
-        await tester.pumpWidget(buildSubject());
-        await tester.pump();
+          await tester.pumpWidget(buildSubject());
+          await tester.pump();
 
-        expect(find.byKey(const Key('video-feed-placeholder')), findsOneWidget);
-      });
+          expect(
+            find.byKey(const Key('video-feed-placeholder')),
+            findsOneWidget,
+          );
+        },
+      );
 
       testWidgets(
         'stats are hydrated before player renders (regression #3768)',
         (tester) async {
           // Simulate a video returned with loop counts already populated
-          // by fetchVideoWithStats — this is the contract we pin.
+          // by fetchVideoWithStatsForRouteId — this is the contract we pin.
           final videoWithStats =
               createTestVideoEvent(
                 id: 'test_video_id',
@@ -145,7 +151,9 @@ void main() {
 
           VideoEvent? capturedVideo;
           when(
-            () => mockVideosRepository.fetchVideoWithStats('test_video_id'),
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'test_video_id',
+            ),
           ).thenAnswer((_) async => videoWithStats);
 
           await tester.pumpWidget(
@@ -188,35 +196,39 @@ void main() {
     });
 
     group('video not found', () {
-      testWidgets('renders error when fetchVideoWithStats returns null', (
-        tester,
-      ) async {
-        when(
-          () => mockVideosRepository.fetchVideoWithStats(any()),
-        ).thenAnswer((_) async => null);
+      testWidgets(
+        'renders error when fetchVideoWithStatsForRouteId returns null',
+        (tester) async {
+          when(
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+          ).thenAnswer((_) async => null);
 
-        await tester.pumpWidget(buildSubject());
-        await tester.pump();
+          await tester.pumpWidget(buildSubject());
+          await tester.pump();
 
-        expect(find.text('Video not found'), findsOneWidget);
-        expect(find.byIcon(Icons.error_outline), findsOneWidget);
-      });
+          expect(find.text('Video not found'), findsOneWidget);
+          expect(find.byIcon(Icons.error_outline), findsOneWidget);
+          expect(find.bySemanticsLabel('Close video player'), findsOneWidget);
+        },
+      );
     });
 
     group('fetch error', () {
-      testWidgets('renders error message when fetchVideoWithStats throws', (
-        tester,
-      ) async {
-        when(
-          () => mockVideosRepository.fetchVideoWithStats(any()),
-        ).thenAnswer((_) => Future.error(Exception('Network error')));
+      testWidgets(
+        'renders error message when fetchVideoWithStatsForRouteId throws',
+        (tester) async {
+          when(
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(any()),
+          ).thenAnswer((_) => Future.error(Exception('Network error')));
 
-        await tester.pumpWidget(buildSubject());
-        await tester.pump();
+          await tester.pumpWidget(buildSubject());
+          await tester.pump();
 
-        expect(find.textContaining('Failed to load video'), findsOneWidget);
-        expect(find.byIcon(Icons.error_outline), findsOneWidget);
-      });
+          expect(find.textContaining('Failed to load video'), findsOneWidget);
+          expect(find.byIcon(Icons.error_outline), findsOneWidget);
+          expect(find.bySemanticsLabel('Close video player'), findsOneWidget);
+        },
+      );
     });
 
     group('blocked author', () {
@@ -231,7 +243,9 @@ void main() {
         );
 
         when(
-          () => mockVideosRepository.fetchVideoWithStats('blocked_video_id'),
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'blocked_video_id',
+          ),
         ).thenAnswer((_) async => video);
         when(
           () => mockBlocklistRepository.shouldFilterFromFeeds('blocked_pubkey'),
@@ -253,7 +267,9 @@ void main() {
         );
 
         when(
-          () => mockVideosRepository.fetchVideoWithStats('blocked_video_id'),
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'blocked_video_id',
+          ),
         ).thenAnswer((_) async => video);
         when(
           () => mockBlocklistRepository.shouldFilterFromFeeds('blocked_pubkey'),
@@ -263,6 +279,31 @@ void main() {
         await tester.pump();
 
         expect(find.byType(DiVineAppBarIconButton), findsOneWidget);
+      });
+
+      testWidgets('renders exit button when video is hidden after load', (
+        tester,
+      ) async {
+        final video = createTestVideoEvent(
+          id: 'hidden_video_id',
+          pubkey: 'hidden_pubkey',
+          title: 'Hidden Video',
+        );
+
+        when(
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'hidden_video_id',
+          ),
+        ).thenAnswer((_) async => video);
+        when(
+          () => mockVideoEventService.shouldHideVideo(video),
+        ).thenReturn(true);
+
+        await tester.pumpWidget(buildSubject(videoId: 'hidden_video_id'));
+        await tester.pump();
+
+        expect(find.text('Video not found'), findsOneWidget);
+        expect(find.bySemanticsLabel('Close video player'), findsOneWidget);
       });
     });
   });

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -42,6 +42,8 @@ void main() {
     late _MockNostrClient mockNostrClient;
     late _MockFollowRepository mockFollowRepository;
     late _MockVideosRepository mockVideosRepository;
+    late StreamController<Map<String, RelayConnectionStatus>>
+    relayStatusController;
 
     setUp(() {
       mockVideoEventService = _MockVideoEventService();
@@ -49,6 +51,8 @@ void main() {
       mockBlocklistRepository = _MockContentBlocklistRepository();
       mockFollowRepository = _MockFollowRepository();
       mockVideosRepository = _MockVideosRepository();
+      relayStatusController =
+          StreamController<Map<String, RelayConnectionStatus>>.broadcast();
 
       when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
 
@@ -57,6 +61,9 @@ void main() {
       when(() => mockNostrClient.isInitialized).thenReturn(true);
       when(() => mockNostrClient.hasKeys).thenReturn(false);
       when(() => mockNostrClient.connectedRelayCount).thenReturn(1);
+      when(
+        () => mockNostrClient.relayStatusStream,
+      ).thenAnswer((_) => relayStatusController.stream);
       when(
         () => mockNostrClient.subscribe(any()),
       ).thenAnswer((_) => const Stream<Event>.empty());
@@ -71,6 +78,10 @@ void main() {
       when(
         () => mockVideoEventService.shouldHideVideo(any()),
       ).thenReturn(false);
+    });
+
+    tearDown(() async {
+      await relayStatusController.close();
     });
 
     Widget buildSubject({String videoId = 'test_video_id'}) {
@@ -209,6 +220,59 @@ void main() {
           expect(find.text('Video not found'), findsOneWidget);
           expect(find.byIcon(Icons.error_outline), findsOneWidget);
           expect(find.bySemanticsLabel('Close video player'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'retries once when relays become ready after cold-start miss',
+        (tester) async {
+          var connectedRelayCount = 0;
+          var isInitialized = false;
+          when(() => mockNostrClient.isInitialized).thenAnswer(
+            (_) => isInitialized,
+          );
+          when(() => mockNostrClient.connectedRelayCount).thenAnswer(
+            (_) => connectedRelayCount,
+          );
+
+          final video = createTestVideoEvent(
+            id: 'cold_start_video',
+            pubkey: 'test_pubkey',
+            title: 'Cold Start Video',
+          );
+
+          when(
+            () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+              'cold_start_video',
+            ),
+          ).thenAnswer((_) async {
+            if (!isInitialized || connectedRelayCount == 0) {
+              return null;
+            }
+            return video;
+          });
+
+          await tester.pumpWidget(buildSubject(videoId: 'cold_start_video'));
+          await tester.pump();
+
+          expect(find.byType(CircularProgressIndicator), findsOneWidget);
+          expect(find.text('Video not found'), findsNothing);
+
+          isInitialized = true;
+          connectedRelayCount = 1;
+          relayStatusController.add({
+            'wss://relay.divine.video': RelayConnectionStatus.connected(
+              'wss://relay.divine.video',
+            ),
+          });
+
+          await tester.pump();
+          await tester.pump();
+
+          expect(
+            find.byKey(const Key('video-feed-placeholder')),
+            findsOneWidget,
+          );
         },
       );
     });

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -4,7 +4,6 @@
 import 'dart:async';
 
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
-import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -206,6 +206,92 @@ void main() {
           expect(capturedVideo?.rawTags['loops'], equals('99'));
         },
       );
+
+      testWidgets('reloads when the route videoId changes', (tester) async {
+        final firstVideo = createTestVideoEvent(
+          id: 'first_video_id',
+          pubkey: 'first_pubkey',
+          title: 'First Video',
+        );
+        final secondVideo = createTestVideoEvent(
+          id: 'second_video_id',
+          pubkey: 'second_pubkey',
+          title: 'Second Video',
+        );
+
+        when(
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'first_video_id',
+          ),
+        ).thenAnswer((_) async => firstVideo);
+        when(
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'second_video_id',
+          ),
+        ).thenAnswer((_) async => secondVideo);
+
+        VideoEvent? capturedVideo;
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            mockNostrService: mockNostrClient,
+            additionalOverrides: [
+              videoEventServiceProvider.overrideWithValue(
+                mockVideoEventService,
+              ),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                mockBlocklistRepository,
+              ),
+              followRepositoryProvider.overrideWithValue(
+                mockFollowRepository,
+              ),
+              videosRepositoryProvider.overrideWithValue(
+                mockVideosRepository,
+              ),
+            ],
+            home: VideoDetailScreen(
+              videoId: 'first_video_id',
+              videoFeedBuilder: (video) {
+                capturedVideo = video;
+                return const SizedBox(key: Key('video-feed-placeholder'));
+              },
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(capturedVideo?.id, equals('first_video_id'));
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            mockNostrService: mockNostrClient,
+            additionalOverrides: [
+              videoEventServiceProvider.overrideWithValue(
+                mockVideoEventService,
+              ),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                mockBlocklistRepository,
+              ),
+              followRepositoryProvider.overrideWithValue(
+                mockFollowRepository,
+              ),
+              videosRepositoryProvider.overrideWithValue(
+                mockVideosRepository,
+              ),
+            ],
+            home: VideoDetailScreen(
+              videoId: 'second_video_id',
+              videoFeedBuilder: (video) {
+                capturedVideo = video;
+                return const SizedBox(key: Key('video-feed-placeholder'));
+              },
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(capturedVideo?.id, equals('second_video_id'));
+      });
     });
 
     group('video not found', () {

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -75,6 +75,8 @@ void main() {
       when(
         () => mockBlocklistRepository.shouldFilterFromFeeds(any()),
       ).thenReturn(false);
+      when(() => mockBlocklistRepository.hasMutedUs(any())).thenReturn(false);
+      when(() => mockBlocklistRepository.hasBlockedUs(any())).thenReturn(false);
       when(
         () => mockVideoEventService.shouldHideVideo(any()),
       ).thenReturn(false);
@@ -295,8 +297,8 @@ void main() {
       );
     });
 
-    group('blocked author', () {
-      testWidgets('renders blocked message for filtered author', (
+    group('explicit route block filtering', () {
+      testWidgets('renders player for author filtered only from feeds', (
         tester,
       ) async {
         final video = createTestVideoEvent(
@@ -318,11 +320,13 @@ void main() {
         await tester.pumpWidget(buildSubject(videoId: 'blocked_video_id'));
         await tester.pump();
 
-        expect(find.text('This account is not available'), findsOneWidget);
-        expect(find.byKey(const Key('video-feed-placeholder')), findsNothing);
+        expect(find.text('This account is not available'), findsNothing);
+        expect(find.byKey(const Key('video-feed-placeholder')), findsOneWidget);
       });
 
-      testWidgets('renders back button for blocked author', (tester) async {
+      testWidgets('renders player when author has blocked us', (
+        tester,
+      ) async {
         final video = createTestVideoEvent(
           id: 'blocked_video_id',
           pubkey: 'blocked_pubkey',
@@ -336,13 +340,14 @@ void main() {
           ),
         ).thenAnswer((_) async => video);
         when(
-          () => mockBlocklistRepository.shouldFilterFromFeeds('blocked_pubkey'),
+          () => mockBlocklistRepository.hasBlockedUs('blocked_pubkey'),
         ).thenReturn(true);
 
         await tester.pumpWidget(buildSubject(videoId: 'blocked_video_id'));
         await tester.pump();
 
-        expect(find.byType(DiVineAppBarIconButton), findsOneWidget);
+        expect(find.text('This account is not available'), findsNothing);
+        expect(find.byKey(const Key('video-feed-placeholder')), findsOneWidget);
       });
 
       testWidgets('renders exit button when video is hidden after load', (

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -14,7 +14,7 @@ void main() {
         final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.video));
-        expect(result.videoId, equals(videoId));
+        expect(result.videoRef, equals(videoId));
         expect(result.npub, isNull);
       });
 
@@ -26,7 +26,29 @@ void main() {
         final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.video));
-        expect(result.videoId, equals(videoId));
+        expect(result.videoRef, equals(videoId));
+      });
+
+      test('parses video URL with note1 event reference', () {
+        const videoId =
+            'note1w3jhxaq69g8m70m7g6g8j2rf7x0s5h7k0d0l0m9d3c4s5u6v7w8q9xyz0p';
+        const url = 'https://divine.video/video/$videoId';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.video));
+        expect(result.videoRef, equals(videoId));
+      });
+
+      test('parses video URL with nevent reference', () {
+        const videoId =
+            'nevent1qqsqzg69v7y6hn00qy352euf40x77qfrg4ncn27dauqjx3t83x4ummspz4mhxue69uhhyetvv9ujuetcv9khqmr99e3k7mgprpmhxue69uhhyetvv9ujumn0wd68ytnhd9hxgqgawaehxw309aex2mrp0yhxgetnwss82un9wfjkccte9ehx7um5wghx7un8qgswaehxw309aex2mrp0yh8xarj9e3k7mgzyq8';
+        const url = 'https://divine.video/video/$videoId';
+
+        final result = DeepLinkService.parseDeepLink(url);
+
+        expect(result.type, equals(DeepLinkType.video));
+        expect(result.videoRef, equals(videoId));
       });
 
       test('handles video URL with trailing slash', () {
@@ -45,7 +67,7 @@ void main() {
         final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.unknown));
-        expect(result.videoId, isNull);
+        expect(result.videoRef, isNull);
       });
 
       test('rejects video URL with extra path segments', () {
@@ -66,7 +88,7 @@ void main() {
 
         expect(result.type, equals(DeepLinkType.profile));
         expect(result.npub, equals(npub));
-        expect(result.videoId, isNull);
+        expect(result.videoRef, isNull);
       });
 
       test('parses profile URL with real npub format', () {
@@ -250,7 +272,7 @@ void main() {
         final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.video));
-        expect(result.videoId, equals(videoId));
+        expect(result.videoRef, equals(videoId));
       });
 
       test('accepts https scheme', () {
@@ -260,7 +282,7 @@ void main() {
         final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.video));
-        expect(result.videoId, equals(videoId));
+        expect(result.videoRef, equals(videoId));
       });
 
       test('accepts www.divine.video host alias', () {
@@ -270,7 +292,7 @@ void main() {
         final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.video));
-        expect(result.videoId, equals(videoId));
+        expect(result.videoRef, equals(videoId));
       });
 
       // Regression: an email verification link
@@ -292,7 +314,7 @@ void main() {
               'hosts. login.divine.video is the OAuth host used by '
               'verification deep links.',
         );
-        expect(result.videoId, equals(videoId));
+        expect(result.videoRef, equals(videoId));
       });
 
       test('accepts arbitrary subdomain of divine.video', () {
@@ -302,7 +324,7 @@ void main() {
         final result = DeepLinkService.parseDeepLink(url);
 
         expect(result.type, equals(DeepLinkType.video));
-        expect(result.videoId, equals(videoId));
+        expect(result.videoRef, equals(videoId));
       });
 
       test('rejects lookalike domain (divine.video.evil.com)', () {
@@ -319,31 +341,31 @@ void main() {
         );
       });
 
-      test(
-        'rejects domain that ends with divine.video without separator '
-        '(notdivine.video)',
-        () {
-          const url = 'https://notdivine.video/video/abc123';
+      test('rejects domain that ends with divine.video without separator '
+          '(notdivine.video)', () {
+        const url = 'https://notdivine.video/video/abc123';
 
-          final result = DeepLinkService.parseDeepLink(url);
+        final result = DeepLinkService.parseDeepLink(url);
 
-          expect(
-            result.type,
-            equals(DeepLinkType.unknown),
-            reason:
-                'Only divine.video and *.divine.video should be '
-                'accepted; sibling domains must not match.',
-          );
-        },
-      );
+        expect(
+          result.type,
+          equals(DeepLinkType.unknown),
+          reason:
+              'Only divine.video and *.divine.video should be '
+              'accepted; sibling domains must not match.',
+        );
+      });
     });
 
     group('DeepLink Data Class', () {
       test('creates video deep link with correct data', () {
-        const deepLink = DeepLink(type: DeepLinkType.video, videoId: 'test123');
+        const deepLink = DeepLink(
+          type: DeepLinkType.video,
+          videoRef: 'test123',
+        );
 
         expect(deepLink.type, equals(DeepLinkType.video));
-        expect(deepLink.videoId, equals('test123'));
+        expect(deepLink.videoRef, equals('test123'));
         expect(deepLink.npub, isNull);
       });
 
@@ -352,14 +374,14 @@ void main() {
 
         expect(deepLink.type, equals(DeepLinkType.profile));
         expect(deepLink.npub, equals('npub123'));
-        expect(deepLink.videoId, isNull);
+        expect(deepLink.videoRef, isNull);
       });
 
       test('creates unknown deep link with no data', () {
         const deepLink = DeepLink(type: DeepLinkType.unknown);
 
         expect(deepLink.type, equals(DeepLinkType.unknown));
-        expect(deepLink.videoId, isNull);
+        expect(deepLink.videoRef, isNull);
         expect(deepLink.npub, isNull);
       });
 
@@ -398,8 +420,11 @@ void main() {
 
     group('$DeepLink toString', () {
       test('formats video deep link', () {
-        const link = DeepLink(type: DeepLinkType.video, videoId: 'abc');
-        expect(link.toString(), equals('DeepLink(type: video, videoId: abc)'));
+        const link = DeepLink(type: DeepLinkType.video, videoRef: 'abc');
+        expect(
+          link.toString(),
+          equals('DeepLink(type: video, videoRef: abc)'),
+        );
       });
 
       test('formats profile deep link with index', () {

--- a/mobile/test/services/video_sharing_service_test.dart
+++ b/mobile/test/services/video_sharing_service_test.dart
@@ -27,6 +27,9 @@ const _testPubkey =
 const _recipientPubkey =
     'b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3';
 
+const _testVideoId =
+    'a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+
 void main() {
   late VideoSharingService service;
   late _MockNostrClient mockNostrService;
@@ -87,7 +90,7 @@ void main() {
 
       final now = DateTime.now();
       final testVideo = VideoEvent(
-        id: 'video1',
+        id: _testVideoId,
         pubkey: _testPubkey,
         createdAt: now.millisecondsSinceEpoch ~/ 1000,
         timestamp: now,
@@ -132,7 +135,7 @@ void main() {
 
       final now = DateTime.now();
       final testVideo = VideoEvent(
-        id: 'video1',
+        id: _testVideoId,
         pubkey: _testPubkey,
         createdAt: now.millisecondsSinceEpoch ~/ 1000,
         timestamp: now,
@@ -230,7 +233,7 @@ void main() {
       final now = DateTime.now();
       final result = await service.shareVideoWithUser(
         video: VideoEvent(
-          id: 'video1',
+          id: _testVideoId,
           pubkey: _testPubkey,
           createdAt: now.millisecondsSinceEpoch ~/ 1000,
           timestamp: now,
@@ -256,7 +259,7 @@ void main() {
       final now = DateTime.now();
       final result = await service.shareVideoWithUser(
         video: VideoEvent(
-          id: 'video1',
+          id: _testVideoId,
           pubkey: _testPubkey,
           createdAt: now.millisecondsSinceEpoch ~/ 1000,
           timestamp: now,
@@ -293,7 +296,7 @@ void main() {
       final now = DateTime.now();
       final result = await service.shareVideoWithUser(
         video: VideoEvent(
-          id: 'video1',
+          id: _testVideoId,
           pubkey: _testPubkey,
           createdAt: now.millisecondsSinceEpoch ~/ 1000,
           timestamp: now,
@@ -324,7 +327,7 @@ void main() {
       final now = DateTime.now();
       final result = await service.shareVideoWithUser(
         video: VideoEvent(
-          id: 'video1',
+          id: _testVideoId,
           pubkey: _testPubkey,
           createdAt: now.millisecondsSinceEpoch ~/ 1000,
           timestamp: now,
@@ -377,7 +380,7 @@ void main() {
       final now = DateTime.now();
       final result = await nip17Service.shareVideoWithUser(
         video: VideoEvent(
-          id: 'video1',
+          id: _testVideoId,
           pubkey: _testPubkey,
           createdAt: now.millisecondsSinceEpoch ~/ 1000,
           timestamp: now,
@@ -418,7 +421,7 @@ void main() {
       final now = DateTime.now();
       final result = await nip17Service.shareVideoWithUser(
         video: VideoEvent(
-          id: 'video1',
+          id: _testVideoId,
           pubkey: _testPubkey,
           createdAt: now.millisecondsSinceEpoch ~/ 1000,
           timestamp: now,
@@ -454,7 +457,7 @@ void main() {
       final now = DateTime.now();
       await nip17Service.shareVideoWithUser(
         video: VideoEvent(
-          id: 'video1',
+          id: _testVideoId,
           pubkey: _testPubkey,
           createdAt: now.millisecondsSinceEpoch ~/ 1000,
           timestamp: now,
@@ -497,12 +500,14 @@ void main() {
       final now = DateTime.now();
       await nip17Service.shareVideoWithUser(
         video: VideoEvent(
-          id: 'video1',
+          id: _testVideoId,
           pubkey: _testPubkey,
           createdAt: now.millisecondsSinceEpoch ~/ 1000,
           timestamp: now,
           content: 'Test',
           title: 'Indigenous cultures',
+          vineId: 'indigenous-cultures',
+          rawTags: const {'d': 'indigenous-cultures'},
         ),
         recipientPubkey: _recipientPubkey,
       );
@@ -542,11 +547,13 @@ void main() {
       final now = DateTime.now();
       await nip17Service.shareVideoWithUser(
         video: VideoEvent(
-          id: 'video1',
+          id: _testVideoId,
           pubkey: _testPubkey,
           createdAt: now.millisecondsSinceEpoch ~/ 1000,
           timestamp: now,
           content: 'Test',
+          vineId: 'shareable-video',
+          rawTags: const {'d': 'shareable-video'},
         ),
         recipientPubkey: _recipientPubkey,
       );
@@ -586,7 +593,7 @@ void main() {
       final now = DateTime.now();
       final result = await nip17Service.shareVideoWithUser(
         video: VideoEvent(
-          id: 'video1',
+          id: _testVideoId,
           pubkey: _testPubkey,
           createdAt: now.millisecondsSinceEpoch ~/ 1000,
           timestamp: now,
@@ -624,7 +631,7 @@ void main() {
       final now = DateTime.now();
       await nip17Service.shareVideoWithUser(
         video: VideoEvent(
-          id: 'video1',
+          id: _testVideoId,
           pubkey: _testPubkey,
           createdAt: now.millisecondsSinceEpoch ~/ 1000,
           timestamp: now,
@@ -641,7 +648,7 @@ void main() {
     test('generateShareUrl uses stableId when video has a d tag', () {
       final now = DateTime.now();
       final video = VideoEvent(
-        id: 'video1',
+        id: _testVideoId,
         pubkey: _testPubkey,
         createdAt: now.millisecondsSinceEpoch ~/ 1000,
         timestamp: now,
@@ -702,7 +709,7 @@ void main() {
       final now = DateTime.now();
       await service.shareVideoWithUser(
         video: VideoEvent(
-          id: 'video1',
+          id: _testVideoId,
           pubkey: _testPubkey,
           createdAt: now.millisecondsSinceEpoch ~/ 1000,
           timestamp: now,
@@ -738,7 +745,7 @@ void main() {
       final now = DateTime.now();
       await service.shareVideoWithUser(
         video: VideoEvent(
-          id: 'video1',
+          id: _testVideoId,
           pubkey: _testPubkey,
           createdAt: now.millisecondsSinceEpoch ~/ 1000,
           timestamp: now,

--- a/mobile/test/services/video_sharing_service_test.dart
+++ b/mobile/test/services/video_sharing_service_test.dart
@@ -8,6 +8,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:profile_repository/profile_repository.dart';
@@ -637,7 +638,7 @@ void main() {
   });
 
   group('sharing utilities', () {
-    test('generateShareUrl uses stableId', () {
+    test('generateShareUrl uses stableId when video has a d tag', () {
       final now = DateTime.now();
       final video = VideoEvent(
         id: 'video1',
@@ -646,12 +647,31 @@ void main() {
         timestamp: now,
         content: 'Test',
         vineId: 'my-vine-id',
+        rawTags: const {'d': 'my-vine-id'},
       );
 
       final url = service.generateShareUrl(video);
 
-      // stableId returns vineId when set, otherwise falls back to id
       expect(url, equals('https://divine.video/video/my-vine-id'));
+    });
+
+    test('generateShareUrl falls back to nostr nevent without a d tag', () {
+      final now = DateTime.now();
+      const eventId =
+          'a695f6b60119d9521934a691347d9f78e8770b56da16bb255ee77ac112b4c1f6';
+      final video = VideoEvent(
+        id: eventId,
+        pubkey: _testPubkey,
+        createdAt: now.millisecondsSinceEpoch ~/ 1000,
+        timestamp: now,
+        content: 'Test',
+        vineId: eventId,
+      );
+
+      final url = service.generateShareUrl(video);
+
+      expect(url, startsWith('nostr:nevent1'));
+      expect(NIP19Tlv.isNevent(url.replaceFirst('nostr:', '')), isTrue);
     });
 
     test('hasSharedWithRecently returns false for unknown user', () {


### PR DESCRIPTION
## Summary

Closes #3931.

This fixes the app-side failure mode after a Divine video URL has already been handed to the app. `VideoDetailScreen` was treating every `/video/:id` route segment as a raw event id, which broke first-party stable ids / d-tags and external `note1` / `nevent1` / `naddr1` refs. The same screen also had failure branches that could trap the user with no reliable exit path.

Related upstream context: #3843 covers the separate OS-level universal-link handoff failure.

## What changed

- add repository-side route-ref resolution for video detail lookups
- support raw hex ids, stable ids / d-tags, `note1`, `nevent1`, and `naddr1`
- restore an exit path from all video-detail failure states
- rename `DeepLink.videoId` to `DeepLink.videoRef` so the contract matches the route semantics
- add regression coverage for supported route-ref formats and failure-state escape behavior

## Verification

- `flutter test test/src/db_video_local_storage_test.dart test/src/videos_repository_test.dart` in `mobile/packages/videos_repository`
- `flutter test test/screens/video_detail_screen_test.dart test/services/deep_link_service_test.dart test/router/universal_link_resolver_test.dart test/providers/deep_link_provider_test.dart` in `mobile`
- `flutter analyze lib test` in `mobile/packages/videos_repository`
- `flutter analyze test/screens/video_detail_screen_test.dart test/services/deep_link_service_test.dart test/router/universal_link_resolver_test.dart test/providers/deep_link_provider_test.dart lib/screens/video_detail_screen.dart lib/services/deep_link_service.dart lib/router/universal_link_resolver.dart lib/main.dart` in `mobile`
