### PR TITLE
docs: update mobile welcome copy

### DIFF
--- a/brand-guidelines/AGENT_QUICK_REFERENCE.md
+++ b/brand-guidelines/AGENT_QUICK_REFERENCE.md
@@ -51,6 +51,7 @@ Divine is a decentralized short-form video app reviving Vine's 6-second format, 
 
 ## Key Messages
 
+- **Welcome Home**: our arrival greeting for people coming to Divine or returning to it. It signals inclusion, belonging, and a human place to land on the internet.
 - **No AI slop**: Human-made content only. We detect and remove machine-generated content.
 - **User ownership**: Your content, your data, your feed. Built on Nostr where you own everything.
 - **Joy scrolling**: Trade doom scrolling for delight. Quick bursts of real human creativity.
@@ -92,6 +93,7 @@ Secondary accent colors: Yellow `#FFF140`, Lime `#D2FF40`, Pink `#FF7FAF`, Orang
 
 ## Taglines / Phrases to Use
 
+- "Welcome Home"
 - "Life in Loops"
 - "Live, Love, Loop"
 - "Your playground for human creativity"

--- a/brand-guidelines/BRAND_DNA.md
+++ b/brand-guidelines/BRAND_DNA.md
@@ -23,6 +23,7 @@ Then social media grew darker. It got hateful and heavier. It learned how to div
 At Divine, we say: fuck that.
 
 We want you to own what you make. Choose what you see. Trade doom scrolling for joy scrolling. Trade keyboard wars for a playground of human creativity. Crack the algorithm open and make it work for you. Bring your weird unfiltered self. Chances are you'll find someone just like you. Together, we'll put the power of creativity back in human hands.
+When people arrive, we want the feeling to be simple: Welcome Home.
 
 ---
 
@@ -44,6 +45,7 @@ We want you to own what you make. Choose what you see. Trade doom scrolling for 
 - Your content and data stay yours
 - Space to play and experiment
 - Access to 100,000+ archived Vine videos from the original era
+- A place that feels like arrival, not conversion
 
 ---
 

--- a/brand-guidelines/TONE_OF_VOICE.md
+++ b/brand-guidelines/TONE_OF_VOICE.md
@@ -81,6 +81,10 @@ We have three tone of voice principles that shape how we sound. They ensure cons
 - Calling AI-generated content "creative" -- this is a human creativity space
 - Sounding polished or sterile -- a little rough around the edges is on brand
 
+### Arrival Language
+
+When someone is arriving for the first time or coming back, use "Welcome Home" as the default greeting if the copy needs to feel warm, direct, and inclusive.
+
 ### Tone Dial by Context
 
 | Context | Rebel | Playful |

--- a/mobile/e2e/maestro/asserts/assertLogin.yaml
+++ b/mobile/e2e/maestro/asserts/assertLogin.yaml
@@ -1,7 +1,7 @@
 appId: co.openvine.app
 ---
 - waitForAnimationToEnd # Divine logo may take some time to load
-- assertVisible: Authentic moments.
+- assertVisible: Welcome Home.
 - assertVisible: Human creativity.
 - assertVisible: Create a new Divine account
 - assertVisible: Sign in with a different account

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1355,7 +1355,7 @@
   "authPleaseWaitVerifying": "Please wait while we verify your email...",
   "authWaitingForVerification": "Waiting for verification",
   "authOpenEmailApp": "Open email app",
-  "authWelcomeToDivine": "Welcome to Divine!",
+  "authWelcomeToDivine": "Welcome Home!",
   "authEmailVerified": "Your email has been verified.",
   "authSigningYouIn": "Signing you in",
   "authErrorTitle": "Uh oh.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -4611,7 +4611,7 @@ abstract class AppLocalizations {
   /// No description provided for @authWelcomeToDivine.
   ///
   /// In en, this message translates to:
-  /// **'Welcome to Divine!'**
+  /// **'Welcome Home!'**
   String get authWelcomeToDivine;
 
   /// No description provided for @authEmailVerified.

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2608,7 +2608,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authOpenEmailApp => 'Open email app';
 
   @override
-  String get authWelcomeToDivine => 'Welcome to Divine!';
+  String get authWelcomeToDivine => 'Welcome Home!';
 
   @override
   String get authEmailVerified => 'Your email has been verified.';

--- a/mobile/lib/widgets/auth/auth_hero_section.dart
+++ b/mobile/lib/widgets/auth/auth_hero_section.dart
@@ -7,7 +7,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 
 /// Hero section with large tagline text and decorative 3D emoji stickers.
 ///
-/// Displays "Authentic moments." in green and "Human creativity." in white,
+/// Displays "Welcome Home." in green and "Human creativity." in white,
 /// with positioned sticker images and the Divine wordmark logo.
 class AuthHeroSection extends StatelessWidget {
   const AuthHeroSection({super.key});
@@ -28,9 +28,9 @@ class AuthHeroSection extends StatelessWidget {
                 padding: EdgeInsets.symmetric(vertical: 20),
                 child: Column(
                   children: [
-                    // "Authentic moments." - green, BricolageGrotesque font
+                    // "Welcome Home." - green, BricolageGrotesque font
                     Text(
-                      'Authentic moments.',
+                      'Welcome Home.',
                       textAlign: TextAlign.center,
                       style: TextStyle(
                         fontFamily: VineTheme.fontFamilyBricolage,

--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -236,7 +236,7 @@ void main() {
         );
         await tester.pump();
 
-        expect(find.text('Welcome to Divine!'), findsOneWidget);
+        expect(find.text('Welcome Home!'), findsOneWidget);
         expect(find.text('Your email has been verified.'), findsOneWidget);
       });
 

--- a/mobile/test/screens/notifications_screen_test.dart
+++ b/mobile/test/screens/notifications_screen_test.dart
@@ -488,7 +488,7 @@ void main() {
             id: 'notif-to-read',
             type: NotificationType.system,
             actorPubkey: pubkeyAlice,
-            message: 'Welcome to Divine!',
+            message: 'Welcome Home!',
             timestamp: now.subtract(const Duration(minutes: 1)),
           ),
         ];

--- a/mobile/test/widgets/auth/auth_hero_section_test.dart
+++ b/mobile/test/widgets/auth/auth_hero_section_test.dart
@@ -22,10 +22,10 @@ void main() {
     }
 
     group('renders', () {
-      testWidgets('displays "Authentic moments." text', (tester) async {
+      testWidgets('displays "Welcome Home." text', (tester) async {
         await tester.pumpWidget(createTestWidget());
 
-        expect(find.text('Authentic moments.'), findsOneWidget);
+        expect(find.text('Welcome Home.'), findsOneWidget);
       });
 
       testWidgets('displays "Human creativity." text', (tester) async {
@@ -34,12 +34,12 @@ void main() {
         expect(find.text('Human creativity.'), findsOneWidget);
       });
 
-      testWidgets('uses vineGreen color for "Authentic moments."', (
+      testWidgets('uses vineGreen color for "Welcome Home."', (
         tester,
       ) async {
         await tester.pumpWidget(createTestWidget());
 
-        final text = tester.widget<Text>(find.text('Authentic moments.'));
+        final text = tester.widget<Text>(find.text('Welcome Home.'));
         expect(text.style?.color, equals(VineTheme.vineGreen));
       });
 

--- a/mobile/test/widgets/welcome_screen_font_test.dart
+++ b/mobile/test/widgets/welcome_screen_font_test.dart
@@ -21,7 +21,7 @@ void main() {
       );
 
       // Verify hero tagline text
-      expect(find.text('Authentic moments.'), findsOneWidget);
+      expect(find.text('Welcome Home.'), findsOneWidget);
       expect(find.text('Human creativity.'), findsOneWidget);
     });
 
@@ -37,7 +37,7 @@ void main() {
         ),
       );
 
-      final greenText = tester.widget<Text>(find.text('Authentic moments.'));
+      final greenText = tester.widget<Text>(find.text('Welcome Home.'));
       expect(greenText.style?.fontFamily, equals('BricolageGrotesque'));
       expect(greenText.style?.fontWeight, equals(FontWeight.w800));
 


### PR DESCRIPTION
## Summary
- Update mobile auth welcome copy, hero text, and localization source to use "Welcome Home".
- Sync the matching widget tests, Maestro assert, and notification fixture with the new wording.

## Test Plan
- [x] Ran focused Flutter tests for the updated auth/notifications screens and hero widget.
- [x] Verified the mobile worktree passed its format/analyzer hooks before push.
- [x] Pushed branch `feat/welcome-home-mobile-copy` to origin.
