### PR TITLE
fix(og-viner): teach badge cache from every feed, not just classics

### DIFF
--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -41,6 +41,7 @@ import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/og_viner_cache_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/account_deletion_service.dart';
 import 'package:openvine/services/account_label_service.dart';
@@ -1462,6 +1463,17 @@ VideoEventService videoEventService(Ref ref) {
   service.setContentFilterService(ref.watch(contentFilterServiceProvider));
   service.setModerationLabelService(moderationLabelService);
   service.setDivineHostFilterService(divineHostFilterService);
+
+  // Teach the OG Viner badge cache from every video that flows through the
+  // service. The cache filters internally (only `isOriginalVine` videos
+  // contribute pubkeys), so it's safe to feed it every batch — popular,
+  // new, classics, profile, hashtag, search, anything.
+  final ogVinerCache = ref.read(ogVinerCacheServiceProvider);
+  final disposeObserver = service.addVideoObserver(
+    (videos) => unawaited(ogVinerCache.learnFromVideos(videos)),
+  );
+  ref.onDispose(disposeObserver);
+
   return service;
 }
 

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -2828,7 +2828,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'92b71b57fc8b77723a40b99cc1ac9e902bace647';
+String _$videoEventServiceHash() => r'fe3844e03b9ba6ecc42983a02175926dfbc40793';
 
 /// Hashtag service depends on Video event service and cache service
 

--- a/mobile/lib/providers/classic_vines_provider.dart
+++ b/mobile/lib/providers/classic_vines_provider.dart
@@ -9,7 +9,6 @@ import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/feed_refresh_helpers.dart';
-import 'package:openvine/providers/og_viner_cache_provider.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
 import 'package:openvine/state/video_feed_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -82,14 +81,6 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
     return _random.nextInt(pageCount) * _pageSize;
   }
 
-  void _learnOgVinersFromArchiveVideos(List<VideoEvent> videos) {
-    if (videos.isEmpty) return;
-
-    unawaited(
-      ref.read(ogVinerCacheServiceProvider).markFromArchiveVideos(videos),
-    );
-  }
-
   Future<VideoFeedState> _loadFirstPage({
     required bool funnelcakeAvailable,
     bool preserveCurrentOnEmptyFallback = false,
@@ -119,7 +110,6 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
                 )
                 .toList(),
           );
-          _learnOgVinersFromArchiveVideos(filteredVideos);
 
           return filteredVideos..shuffle(_random);
         } catch (e) {
@@ -234,8 +224,6 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
       throw restError ?? StateError('Classics API unavailable');
     }
 
-    _learnOgVinersFromArchiveVideos(topClassics);
-
     return VideoFeedState(
       videos: topClassics,
       hasMoreContent: classicVideos.length > _pageSize,
@@ -298,7 +286,6 @@ class ClassicVinesFeed extends _$ClassicVinesFeed {
             .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
             .toList(),
       );
-      _learnOgVinersFromArchiveVideos(filteredVideos);
 
       final allVideos = [...currentState.videos, ...filteredVideos];
       final followingOffset = nextOffset + _pageSize;

--- a/mobile/lib/providers/classic_vines_provider.g.dart
+++ b/mobile/lib/providers/classic_vines_provider.g.dart
@@ -54,7 +54,7 @@ final class ClassicVinesFeedProvider
   ClassicVinesFeed create() => ClassicVinesFeed();
 }
 
-String _$classicVinesFeedHash() => r'edcd8aefeb057aaf1af8ceeb2566a736eac90454';
+String _$classicVinesFeedHash() => r'ea3cbaa8514eda258c00dada696d256c279d91e4';
 
 /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
 ///

--- a/mobile/lib/services/og_viner_cache_service.dart
+++ b/mobile/lib/services/og_viner_cache_service.dart
@@ -24,7 +24,14 @@ class OgVinerCacheService extends ChangeNotifier {
     return normalized != null && _pubkeys.contains(normalized);
   }
 
-  Future<int> markFromArchiveVideos(Iterable<VideoEvent> videos) async {
+  /// Observe a batch of [videos] and learn the pubkeys of any that are
+  /// archive Vine reposts. Non-archive videos are silently ignored, so this
+  /// method is safe to call from any feed surface — only `isOriginalVine`
+  /// videos contribute new pubkeys to the cache.
+  ///
+  /// Returns the number of newly-added pubkeys (0 if everything was already
+  /// known or no archive videos were present).
+  Future<int> learnFromVideos(Iterable<VideoEvent> videos) async {
     var added = 0;
 
     for (final video in videos) {

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -227,6 +227,14 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   DivineHostFilterService? _divineHostFilterService;
   final SubscriptionManager _subscriptionManager;
 
+  // Side-channel observers that fire for every video that flows through the
+  // service after filtering — both REST-loaded batches via [filterVideoList]
+  // and WebSocket-driven additions via [_addVideoToSubscription], including
+  // historical (paginated) ones that [_notifyNewVideo] intentionally skips.
+  // Composition-root concerns (e.g. badge caches) wire themselves here
+  // without coupling this service to any specific consumer.
+  final List<void Function(Iterable<VideoEvent> videos)> _videoObservers = [];
+
   // Like count batching - accumulates video IDs and fetches counts in batches
   // to prevent ANR issues from too many concurrent relay requests
   final Map<String, SubscriptionType> _pendingLikeCountVideoIds = {};
@@ -296,6 +304,38 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       } catch (e) {
         Log.error(
           'Error in new video callback: $e',
+          name: 'VideoEventService',
+          category: LogCategory.video,
+        );
+      }
+    }
+  }
+
+  /// Register an observer that receives every batch of videos flowing
+  /// through the service after filtering — both REST-loaded results from
+  /// [filterVideoList] and individual WebSocket-driven additions from
+  /// [_addVideoToSubscription], regardless of historical/live status.
+  ///
+  /// Designed for cross-cutting concerns that must learn from any video
+  /// surface (e.g. the OG Viner badge cache) without coupling this service
+  /// to a specific consumer.
+  ///
+  /// Returns a disposer that unregisters the observer.
+  VoidCallback addVideoObserver(
+    void Function(Iterable<VideoEvent> videos) observer,
+  ) {
+    _videoObservers.add(observer);
+    return () => _videoObservers.remove(observer);
+  }
+
+  void _notifyVideoObservers(Iterable<VideoEvent> videos) {
+    if (_videoObservers.isEmpty) return;
+    for (final observer in _videoObservers) {
+      try {
+        observer(videos);
+      } catch (e) {
+        Log.error(
+          'Error in video observer: $e',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
@@ -593,9 +633,12 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     final baseVideos = videos
         .where((video) => !shouldHideVideo(video))
         .toList();
-    if (service == null) return baseVideos;
+    if (service == null) {
+      _notifyVideoObservers(baseVideos);
+      return baseVideos;
+    }
 
-    return baseVideos
+    final result = baseVideos
         .map((video) {
           final labels = resolveEffectiveContentLabels(
             video,
@@ -646,6 +689,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           return true;
         })
         .toList();
+
+    _notifyVideoObservers(result);
+    return result;
   }
 
   /// Check if a VideoEvent contains adult content based on hashtags and tags
@@ -4473,6 +4519,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     //     '✅ Added $subscriptionType video: ${videoEvent.title ?? videoEvent.id} (total: ${eventList.length})',
     //     name: 'VideoEventService',
     //     category: LogCategory.video);
+
+    _notifyVideoObservers([videoEvent]);
 
     // Schedule frame-based UI update for progressive loading
     _scheduleFrameUpdate();

--- a/mobile/test/providers/classic_vines_refresh_test.dart
+++ b/mobile/test/providers/classic_vines_refresh_test.dart
@@ -11,7 +11,6 @@ import 'package:models/models.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/classic_vines_provider.dart';
 import 'package:openvine/providers/curation_providers.dart';
-import 'package:openvine/providers/og_viner_cache_provider.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/video_event_service.dart';
@@ -114,37 +113,6 @@ void main() {
         expect(limits, everyElement(lessThanOrEqualTo(50)));
       },
     );
-
-    test('caches OG Viner pubkeys from loaded archive videos', () async {
-      when(
-        () =>
-            mockFunnelcakeClient.getClassicVines(offset: any(named: 'offset')),
-      ).thenAnswer((_) async {
-        return [
-          _videoStats(
-            'classic-og',
-            pubkey:
-                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            isOriginalVine: true,
-          ),
-        ];
-      });
-
-      final container = createContainer();
-      addTearDown(container.dispose);
-
-      await container.read(funnelcakeAvailableProvider.future);
-      await container.read(classicVinesFeedProvider.future);
-      await Future<void>.delayed(Duration.zero);
-
-      final cache = container.read(ogVinerCacheServiceProvider);
-      expect(
-        cache.isOgViner(
-          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        ),
-        isTrue,
-      );
-    });
 
     test('refresh selects a fresh random classics page', () async {
       final offsets = <int>[];

--- a/mobile/test/providers/og_viner_cache_provider_test.dart
+++ b/mobile/test/providers/og_viner_cache_provider_test.dart
@@ -4,6 +4,7 @@
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
 import 'package:openvine/providers/og_viner_cache_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/og_viner_cache_service.dart';
@@ -11,12 +12,14 @@ import 'package:riverpod/riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  const pubkey =
+  const ogPubkey =
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const newcomerPubkey =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
   test('reads cached OG Viner pubkeys from SharedPreferences', () async {
     SharedPreferences.setMockInitialValues({
-      ogVinerPubkeysCacheKey: jsonEncode([pubkey]),
+      ogVinerPubkeysCacheKey: jsonEncode([ogPubkey]),
     });
     final prefs = await SharedPreferences.getInstance();
     final container = ProviderContainer(
@@ -26,7 +29,7 @@ void main() {
 
     final service = container.read(ogVinerCacheServiceProvider);
 
-    expect(service.isOgViner(pubkey), isTrue);
+    expect(service.isOgViner(ogPubkey), isTrue);
   });
 
   test('falls back to an empty in-memory cache when prefs are not wired', () {
@@ -37,4 +40,47 @@ void main() {
 
     expect(service.knownPubkeys, isEmpty);
   });
+
+  group('learnFromVideos', () {
+    test(
+      'mixed batches teach only the archive-vine pubkeys, so any feed '
+      'surface (popular / new / for-you / profile / classics) can safely '
+      'pump the same observer wired in app_providers.dart',
+      () async {
+        SharedPreferences.setMockInitialValues({});
+        final prefs = await SharedPreferences.getInstance();
+        final service = OgVinerCacheService(prefs: prefs);
+
+        await service.learnFromVideos([
+          _archiveVine(id: 'archive-1', pubkey: ogPubkey),
+          _freshUpload(id: 'fresh-1', pubkey: newcomerPubkey),
+        ]);
+
+        expect(service.isOgViner(ogPubkey), isTrue);
+        expect(service.isOgViner(newcomerPubkey), isFalse);
+      },
+    );
+  });
+}
+
+VideoEvent _archiveVine({required String id, required String pubkey}) {
+  return VideoEvent(
+    id: id,
+    pubkey: pubkey,
+    createdAt: 1700000000,
+    content: 'archive vine',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+    rawTags: const {'platform': 'vine'},
+    originalLoops: 1234,
+  );
+}
+
+VideoEvent _freshUpload({required String id, required String pubkey}) {
+  return VideoEvent(
+    id: id,
+    pubkey: pubkey,
+    createdAt: 1750000000,
+    content: 'fresh',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1750000000000),
+  );
 }

--- a/mobile/test/services/og_viner_cache_service_test.dart
+++ b/mobile/test/services/og_viner_cache_service_test.dart
@@ -46,12 +46,12 @@ void main() {
     });
 
     test(
-      'markFromArchiveVideos stores only original Vine video authors',
+      'learnFromVideos stores only original Vine video authors',
       () async {
         final prefs = await SharedPreferences.getInstance();
         final service = OgVinerCacheService(prefs: prefs);
 
-        final added = await service.markFromArchiveVideos([
+        final added = await service.learnFromVideos([
           _video(pubkey: ogPubkey, isOriginalVine: true),
           _video(pubkey: nonOgPubkey),
         ]);
@@ -67,14 +67,14 @@ void main() {
       },
     );
 
-    test('markFromArchiveVideos does not duplicate existing pubkeys', () async {
+    test('learnFromVideos does not duplicate existing pubkeys', () async {
       SharedPreferences.setMockInitialValues({
         ogVinerPubkeysCacheKey: jsonEncode([ogPubkey]),
       });
       final prefs = await SharedPreferences.getInstance();
       final service = OgVinerCacheService(prefs: prefs);
 
-      final added = await service.markFromArchiveVideos([
+      final added = await service.learnFromVideos([
         _video(pubkey: ogPubkey, isOriginalVine: true),
         _video(pubkey: secondOgPubkey, isOriginalVine: true),
       ]);
@@ -88,7 +88,7 @@ void main() {
     });
 
     test(
-      'markFromArchiveVideos returns zero and skips writes when unchanged',
+      'learnFromVideos returns zero and skips writes when unchanged',
       () async {
         SharedPreferences.setMockInitialValues({
           ogVinerPubkeysCacheKey: jsonEncode([ogPubkey]),
@@ -99,7 +99,7 @@ void main() {
         var notifications = 0;
         service.addListener(() => notifications++);
 
-        final added = await service.markFromArchiveVideos([
+        final added = await service.learnFromVideos([
           _video(pubkey: ogPubkey, isOriginalVine: true),
           _video(pubkey: nonOgPubkey),
         ]);

--- a/mobile/test/services/video_event_service_observer_test.dart
+++ b/mobile/test/services/video_event_service_observer_test.dart
@@ -1,0 +1,123 @@
+// ABOUTME: Tests the addVideoObserver side-channel hook on VideoEventService.
+// ABOUTME: Cross-cutting consumers (badge caches) rely on it firing universally.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+class _FakeFilter extends Fake implements Filter {}
+
+VideoEvent _video(String id, {String? pubkey}) {
+  return VideoEvent(
+    id: id,
+    pubkey: pubkey ?? 'pubkey-$id',
+    createdAt: DateTime(2025).millisecondsSinceEpoch,
+    content: 'test',
+    timestamp: DateTime(2025),
+    videoUrl: 'https://example.com/$id.mp4',
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<Filter>[_FakeFilter()]);
+  });
+
+  late _MockNostrClient mockNostrClient;
+  late _MockSubscriptionManager mockSubscriptionManager;
+  late VideoEventService service;
+
+  setUp(() {
+    mockNostrClient = _MockNostrClient();
+    mockSubscriptionManager = _MockSubscriptionManager();
+    when(() => mockNostrClient.publicKey).thenReturn('');
+    service = VideoEventService(
+      mockNostrClient,
+      subscriptionManager: mockSubscriptionManager,
+    );
+  });
+
+  group('addVideoObserver', () {
+    test('fires for every batch returned by filterVideoList', () {
+      final received = <List<String>>[];
+      service.addVideoObserver(
+        (videos) => received.add(videos.map((v) => v.id).toList()),
+      );
+
+      service.filterVideoList([_video('a'), _video('b')]);
+      service.filterVideoList([_video('c')]);
+
+      expect(received, [
+        ['a', 'b'],
+        ['c'],
+      ]);
+    });
+
+    test(
+      'fires per video added via addVideoEvent (covers WebSocket path '
+      'including historical pagination that _notifyNewVideo skips)',
+      () {
+        final received = <String>[];
+        service.addVideoObserver(
+          (videos) => received.addAll(videos.map((v) => v.id)),
+        );
+
+        service.addVideoEvent(_video('socket-1'));
+        service.addVideoEvent(_video('socket-2'));
+
+        expect(received, ['socket-1', 'socket-2']);
+      },
+    );
+
+    test('disposer removes the observer', () {
+      final received = <String>[];
+      final dispose = service.addVideoObserver(
+        (videos) => received.addAll(videos.map((v) => v.id)),
+      );
+
+      service.filterVideoList([_video('before')]);
+      dispose();
+      service.filterVideoList([_video('after')]);
+
+      expect(received, ['before']);
+    });
+
+    test('multiple observers each receive every batch', () {
+      final receivedA = <String>[];
+      final receivedB = <String>[];
+      service
+        ..addVideoObserver(
+          (videos) => receivedA.addAll(videos.map((v) => v.id)),
+        )
+        ..addVideoObserver(
+          (videos) => receivedB.addAll(videos.map((v) => v.id)),
+        );
+
+      service.filterVideoList([_video('x'), _video('y')]);
+
+      expect(receivedA, ['x', 'y']);
+      expect(receivedB, ['x', 'y']);
+    });
+
+    test('one observer throwing does not block the others', () {
+      final received = <String>[];
+      service
+        ..addVideoObserver((_) => throw StateError('boom'))
+        ..addVideoObserver(
+          (videos) => received.addAll(videos.map((v) => v.id)),
+        );
+
+      service.filterVideoList([_video('z')]);
+
+      expect(received, ['z']);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Follow-up to **#3885 (`feat(mobile): add OG Viner badges`)**. The OG Viner positive cache only learned pubkeys from `ClassicVinesFeedProvider`, so anyone whose archive vines hadn't surfaced in the user's classics session was missing a badge everywhere — Popular, New, For You, Profile, Search — even though the badge widget was wired correctly in all of those grids.

### Repro
1. Don't visit the Classics tab.
2. Open Popular. OG Viners like Lele Pons / KingBach show no badge.
3. Visit Classics, then return to Popular. Badges appear for the OGs whose archive vines happened to be in the random page Classics loaded — but not for OGs whose archive content didn't surface (e.g. JustJed, JimmyHere, vincentmarcus, kurtisconner in the screenshots that motivated this PR).

### Fix

A single, domain-agnostic observer hook on `VideoEventService`:

- New `addVideoObserver(...)` registration with a disposer.
- Fires from end of `filterVideoList(...)` — covers every REST-loaded feed (popular, new, classics, for-you, profile, popularNow, route, list, video_events: 18+ call sites across 9 providers).
- Fires from end of `_addVideoToSubscription(...)` — covers WebSocket-driven adds, **including historical (paginated) ones that `_notifyNewVideo` intentionally skips**.
- Wired in `app_providers.dart` composition root to call `ogVinerCacheService.learnFromVideos(videos)`, with `ref.onDispose` cleanup. The cache filters internally (only `isOriginalVine` videos contribute), so it's safe to feed every batch.

The now-redundant per-provider learning hook in `classic_vines_provider.dart` is removed — the central observer handles it. Renamed `markFromArchiveVideos` → `learnFromVideos` for clarity (the method already filtered archive vines internally; the new name reflects that callers don't need to pre-filter).

### Sustainability

Zero per-feed plumbing. Any current or future feed provider that follows the architecture (`UI → BLoC → Repository → Client` via `VideoEventService`) gets badge learning for free. No rule to document, no review checklist to maintain. Adding new cross-cutting observers (e.g. analytics, content-warning learning) follows the same one-line pattern in `app_providers.dart`.

**Related Issue:** Relates to #3885

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor

## Test plan

- [x] New unit test: `test/services/video_event_service_observer_test.dart` (5 tests covering observer fires on `filterVideoList`, on `addVideoEvent`, disposer, multiple observers, throwing-observer isolation)
- [x] Updated `test/providers/og_viner_cache_provider_test.dart` to exercise the mixed-batch case (archive + non-archive) proving any feed surface can safely pump the same observer
- [x] Updated `test/services/og_viner_cache_service_test.dart` for the rename
- [x] Removed obsolete `caches OG Viner pubkeys from loaded archive videos` test from `classic_vines_refresh_test.dart` (responsibility moved out of classics)
- [x] Format ✓ Analyze ✓ 22 scoped tests pass locally
- [x] Broader test sweep (160 tests across `video_event_service_*`, `classic_vines_*`, `popular_*`, `explore_*`, `feed_*`, `profile_feed_*`, `video_events_provider_*`) all pass
- [ ] Manual verify: OG badges appear on Popular grid for OG creators whose archive vines have flowed through any feed in the session

## Follow-up (separate PR)

Pre-warm the cache at app startup from a server-provided OG Viner pubkey list so the badge is consistent for every OG creator immediately, without depending on archive vines having flowed through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)