### PR TITLE
feat(profile): move custom NIP-05 to a Nostr Settings sub-screen

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3592,5 +3592,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3454,5 +3454,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3598,5 +3598,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3454,5 +3454,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -433,6 +433,42 @@
   "profileSetupNip05AddressLabel": "NIP-05 Address",
   "profileSetupExternalNip05InvalidFormat": "Invalid NIP-05 format (e.g., name@domain.com)",
   "profileSetupExternalNip05DivineDomain": "Use the username field above for divine.video",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "@nostrSettingsNip05Address": {
+    "description": "Title of the Nostr Settings → Account tile that opens the NIP-05 address sub-screen, and the title of that sub-screen."
+  },
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "@nostrSettingsNip05AddressSubtitle": {
+    "description": "Subtitle on the Nostr Settings tile and intro text on the NIP-05 sub-screen."
+  },
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "@nostrSettingsNip05SaveAction": {
+    "description": "Label of the Save button on the NIP-05 settings sub-screen."
+  },
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "@nostrSettingsNip05Saved": {
+    "description": "Snackbar shown after the NIP-05 sub-screen successfully publishes the updated profile."
+  },
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "@nostrSettingsNip05SaveFailed": {
+    "description": "Snackbar shown when saving NIP-05 from the sub-screen fails."
+  },
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "@profileSetupNip05ConfirmTitle": {
+    "description": "Title of the confirm dialog shown when a user toggles on the 'Use your own NIP-05 address' option in the NIP-05 settings sub-screen."
+  },
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "@profileSetupNip05ConfirmBody": {
+    "description": "Body text explaining the risk before turning on a custom NIP-05 address. Aimed at non-technical users; explains what NIP-05 is and what breaks if misconfigured."
+  },
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "@profileSetupNip05ConfirmContinue": {
+    "description": "Primary button on the custom NIP-05 confirm dialog that proceeds with enabling the option."
+  },
+  "profileSetupNip05ConfirmCancel": "Cancel",
+  "@profileSetupNip05ConfirmCancel": {
+    "description": "Cancel button on the custom NIP-05 confirm dialog that closes the dialog without enabling the option."
+  },
   "profileSetupProfilePicturePreview": "Profile picture preview",
   "nostrInfoIntroBuiltOn": "DiVine is built on Nostr,",
   "nostrInfoIntroDescription": " a censorship-resistant open protocol that lets people communicate online without relying on a single company or platform. ",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3454,5 +3454,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3454,5 +3454,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3454,5 +3454,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3454,5 +3454,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3454,5 +3454,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2750,5 +2750,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3454,5 +3454,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3454,5 +3454,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3454,5 +3454,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3454,5 +3454,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3454,5 +3454,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3454,5 +3454,14 @@
   "videoEditorAudioFeaturedEmptySubtitle": "We’ll drop featured sounds here once they’re ready.",
   "videoEditorAudioFeaturedEmptyTitle": "Featured sounds coming soon",
   "videoMetadataAudioReuseSubtitle": "Let others save and reuse this video's audio.",
-  "videoMetadataAudioReuseTitle": "Publish this sound"
+  "videoMetadataAudioReuseTitle": "Publish this sound",
+  "nostrSettingsNip05Address": "NIP-05 address",
+  "nostrSettingsNip05AddressSubtitle": "Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.",
+  "nostrSettingsNip05SaveAction": "Save NIP-05",
+  "nostrSettingsNip05Saved": "NIP-05 saved",
+  "nostrSettingsNip05SaveFailed": "Couldn't save NIP-05. Please try again.",
+  "profileSetupNip05ConfirmTitle": "Use your own NIP-05?",
+  "profileSetupNip05ConfirmBody": "NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it's wrong, people can't find you and your verified handle disappears. Continue only if you've set this up.",
+  "profileSetupNip05ConfirmContinue": "Continue",
+  "profileSetupNip05ConfirmCancel": "Cancel"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -1628,6 +1628,60 @@ abstract class AppLocalizations {
   /// **'Use the username field above for divine.video'**
   String get profileSetupExternalNip05DivineDomain;
 
+  /// Title of the Nostr Settings → Account tile that opens the NIP-05 address sub-screen, and the title of that sub-screen.
+  ///
+  /// In en, this message translates to:
+  /// **'NIP-05 address'**
+  String get nostrSettingsNip05Address;
+
+  /// Subtitle on the Nostr Settings tile and intro text on the NIP-05 sub-screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.'**
+  String get nostrSettingsNip05AddressSubtitle;
+
+  /// Label of the Save button on the NIP-05 settings sub-screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Save NIP-05'**
+  String get nostrSettingsNip05SaveAction;
+
+  /// Snackbar shown after the NIP-05 sub-screen successfully publishes the updated profile.
+  ///
+  /// In en, this message translates to:
+  /// **'NIP-05 saved'**
+  String get nostrSettingsNip05Saved;
+
+  /// Snackbar shown when saving NIP-05 from the sub-screen fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t save NIP-05. Please try again.'**
+  String get nostrSettingsNip05SaveFailed;
+
+  /// Title of the confirm dialog shown when a user toggles on the 'Use your own NIP-05 address' option in the NIP-05 settings sub-screen.
+  ///
+  /// In en, this message translates to:
+  /// **'Use your own NIP-05?'**
+  String get profileSetupNip05ConfirmTitle;
+
+  /// Body text explaining the risk before turning on a custom NIP-05 address. Aimed at non-technical users; explains what NIP-05 is and what breaks if misconfigured.
+  ///
+  /// In en, this message translates to:
+  /// **'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.'**
+  String get profileSetupNip05ConfirmBody;
+
+  /// Primary button on the custom NIP-05 confirm dialog that proceeds with enabling the option.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue'**
+  String get profileSetupNip05ConfirmContinue;
+
+  /// Cancel button on the custom NIP-05 confirm dialog that closes the dialog without enabling the option.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get profileSetupNip05ConfirmCancel;
+
   /// No description provided for @profileSetupProfilePicturePreview.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -859,6 +859,36 @@ class AppLocalizationsAm extends AppLocalizations {
       'ለdivine.video ከላይ ያለውን የተጠቃሚ ስም መስክ ይጠቀሙ';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview => 'የመገለጫ ስዕል ቅድመ እይታ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -863,6 +863,36 @@ class AppLocalizationsAr extends AppLocalizations {
       'استخدم حقل اسم المستخدم أعلاه لـ divine.video';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview => 'معاينة صورة الملف الشخصي';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -901,6 +901,36 @@ class AppLocalizationsBg extends AppLocalizations {
       'За divine.video използвай полето за потребителско име по-горе';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview =>
       'Визуализация на профилна снимка';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -899,6 +899,36 @@ class AppLocalizationsDe extends AppLocalizations {
       'Nutz das Nutzernamen-Feld oben für divine.video';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview => 'Profilbild-Vorschau';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -888,6 +888,36 @@ class AppLocalizationsEn extends AppLocalizations {
       'Use the username field above for divine.video';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview => 'Profile picture preview';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -899,6 +899,36 @@ class AppLocalizationsEs extends AppLocalizations {
       'Usá el campo de nombre de usuario de arriba para divine.video';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview =>
       'Vista previa de la foto de perfil';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -908,6 +908,36 @@ class AppLocalizationsFr extends AppLocalizations {
       'Utilise le champ nom d\'utilisateur ci-dessus pour divine.video';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview =>
       'Aperçu de la photo de profil';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -871,6 +871,36 @@ class AppLocalizationsId extends AppLocalizations {
       'Pakai kolom username di atas untuk divine.video';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview => 'Pratinjau foto profil';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -900,6 +900,36 @@ class AppLocalizationsIt extends AppLocalizations {
       'Usa il campo nome utente qui sopra per divine.video';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview => 'Anteprima foto profilo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -822,6 +822,36 @@ class AppLocalizationsJa extends AppLocalizations {
       'divine.video の場合は上のユーザー名欄を使ってね';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview => 'プロフィール画像のプレビュー';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -825,6 +825,36 @@ class AppLocalizationsKo extends AppLocalizations {
       'divine.video는 위의 사용자명 필드를 사용해주세요';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview => '프로필 사진 미리보기';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -891,6 +891,36 @@ class AppLocalizationsNl extends AppLocalizations {
       'Gebruik het gebruikersnaamveld hierboven voor divine.video';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview => 'Voorbeeld profielfoto';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -903,6 +903,36 @@ class AppLocalizationsPl extends AppLocalizations {
       'Użyj pola nazwy użytkownika powyżej dla divine.video';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview => 'Podgląd zdjęcia profilowego';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -900,6 +900,36 @@ class AppLocalizationsPt extends AppLocalizations {
       'Use o campo de nome de usuário acima para divine.video';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview =>
       'Pré-visualização da foto de perfil';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -917,6 +917,36 @@ class AppLocalizationsRo extends AppLocalizations {
       'Folosește câmpul de nume de utilizator de mai sus pentru divine.video';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview =>
       'Previzualizare poză de profil';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -876,6 +876,36 @@ class AppLocalizationsSv extends AppLocalizations {
       'Använd användarnamnsfältet ovan för divine.video';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview =>
       'Förhandsvisning av profilbild';
 

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -871,6 +871,36 @@ class AppLocalizationsTr extends AppLocalizations {
       'divine.video için yukarıdaki kullanıcı adı alanını kullan';
 
   @override
+  String get nostrSettingsNip05Address => 'NIP-05 address';
+
+  @override
+  String get nostrSettingsNip05AddressSubtitle =>
+      'Use your divine.video username, or point your handle at a NIP-05 address on a domain you control.';
+
+  @override
+  String get nostrSettingsNip05SaveAction => 'Save NIP-05';
+
+  @override
+  String get nostrSettingsNip05Saved => 'NIP-05 saved';
+
+  @override
+  String get nostrSettingsNip05SaveFailed =>
+      'Couldn\'t save NIP-05. Please try again.';
+
+  @override
+  String get profileSetupNip05ConfirmTitle => 'Use your own NIP-05?';
+
+  @override
+  String get profileSetupNip05ConfirmBody =>
+      'NIP-05 maps a name like you@yourdomain.com to your Nostr identity. You need to control the domain and host a verification file at the right path. If it\'s wrong, people can\'t find you and your verified handle disappears. Continue only if you\'ve set this up.';
+
+  @override
+  String get profileSetupNip05ConfirmContinue => 'Continue';
+
+  @override
+  String get profileSetupNip05ConfirmCancel => 'Cancel';
+
+  @override
   String get profileSetupProfilePicturePreview => 'Profil resmi önizlemesi';
 
   @override

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -69,6 +69,7 @@ import 'package:openvine/screens/settings/content_preferences_screen.dart';
 import 'package:openvine/screens/settings/general_settings_screen.dart';
 import 'package:openvine/screens/settings/invites_screen.dart';
 import 'package:openvine/screens/settings/legal_screen.dart';
+import 'package:openvine/screens/settings/nip05_settings_screen.dart';
 import 'package:openvine/screens/settings/nostr_settings_screen.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
 import 'package:openvine/screens/settings/support_center_screen.dart';
@@ -787,6 +788,11 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         path: NostrSettingsScreen.path,
         name: NostrSettingsScreen.routeName,
         builder: (_, _) => const NostrSettingsScreen(),
+      ),
+      GoRoute(
+        path: Nip05SettingsScreen.path,
+        name: Nip05SettingsScreen.routeName,
+        builder: (_, _) => const Nip05SettingsScreen(),
       ),
       GoRoute(
         path: RelaySettingsScreen.path,

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -120,14 +120,12 @@ class _ProfileSetupScreenViewState
   final _bioController = TextEditingController();
   final _pictureController = TextEditingController();
   final _nip05Controller = TextEditingController();
-  final _externalNip05Controller = TextEditingController();
   final ImagePicker _picker = ImagePicker();
 
   // Focus nodes for tracking field focus state
   final _nameFocusNode = FocusNode();
   final _bioFocusNode = FocusNode();
   final _usernameFocusNode = FocusNode();
-  final _externalNip05FocusNode = FocusNode();
 
   bool _isUploadingImage = false;
   File? _selectedImage;
@@ -143,7 +141,6 @@ class _ProfileSetupScreenViewState
     _nameFocusNode.addListener(_onFocusChange);
     _bioFocusNode.addListener(_onFocusChange);
     _usernameFocusNode.addListener(_onFocusChange);
-    _externalNip05FocusNode.addListener(_onFocusChange);
   }
 
   void _onFocusChange() {
@@ -157,15 +154,12 @@ class _ProfileSetupScreenViewState
     _bioController.dispose();
     _pictureController.dispose();
     _nip05Controller.dispose();
-    _externalNip05Controller.dispose();
     _nameFocusNode.removeListener(_onFocusChange);
     _bioFocusNode.removeListener(_onFocusChange);
     _usernameFocusNode.removeListener(_onFocusChange);
-    _externalNip05FocusNode.removeListener(_onFocusChange);
     _nameFocusNode.dispose();
     _bioFocusNode.dispose();
     _usernameFocusNode.dispose();
-    _externalNip05FocusNode.dispose();
 
     super.dispose();
   }
@@ -194,15 +188,14 @@ class _ProfileSetupScreenViewState
               if (extractedUsername != null) {
                 _nip05Controller.text = extractedUsername;
               }
-              if (externalNip05 != null) {
-                _externalNip05Controller.text = externalNip05;
-              }
             });
 
             final editorBloc = context.read<ProfileEditorBloc>();
             if (extractedUsername != null) {
               editorBloc.add(InitialUsernameSet(extractedUsername));
             }
+            // External NIP-05 lives on the Nostr Settings → NIP-05 sub-screen
+            // now; we still seed editor state so save preserves the value.
             if (externalNip05 != null) {
               editorBloc
                 ..add(InitialExternalNip05Set(externalNip05))
@@ -917,12 +910,6 @@ class _ProfileSetupScreenViewState
                                 },
                               ),
 
-                              // External NIP-05 section
-                              _ExternalNip05Section(
-                                controller: _externalNip05Controller,
-                                focusNode: _externalNip05FocusNode,
-                              ),
-
                               const SizedBox(height: 24),
 
                               // Profile Color (optional)
@@ -1025,13 +1012,15 @@ class _ProfileSetupScreenViewState
                               );
                               return;
                             }
-                            context.read<ProfileEditorBloc>().add(
+                            final editorBloc = context
+                                .read<ProfileEditorBloc>();
+                            editorBloc.add(
                               ProfileSaved(
                                 pubkey: pubkey,
                                 displayName: _nameController.text,
                                 about: _bioController.text,
                                 username: _nip05Controller.text,
-                                externalNip05: _externalNip05Controller.text,
+                                externalNip05: editorBloc.state.externalNip05,
                                 picture: _pictureController.text,
                                 banner: _selectedProfileColor != null
                                     ? '0x${_selectedProfileColor!.toARGB32().toRadixString(16).substring(2)}'
@@ -1062,13 +1051,14 @@ class _ProfileSetupScreenViewState
   ) async {
     await ref.read(nostrServiceProvider).retryDisconnectedRelays();
     if (!context.mounted) return;
-    context.read<ProfileEditorBloc>().add(
+    final editorBloc = context.read<ProfileEditorBloc>();
+    editorBloc.add(
       ProfileSaved(
         pubkey: pubkey,
         displayName: _nameController.text,
         about: _bioController.text,
         username: _nip05Controller.text,
-        externalNip05: _externalNip05Controller.text,
+        externalNip05: editorBloc.state.externalNip05,
         picture: _pictureController.text,
         banner: _selectedProfileColor != null
             ? '0x${_selectedProfileColor!.toARGB32().toRadixString(16).substring(2)}'
@@ -2083,142 +2073,6 @@ class _CustomColorButton extends StatelessWidget {
     if (result != null) {
       onColorPicked(result);
     }
-  }
-}
-
-/// Collapsible section for entering an external NIP-05 identifier.
-///
-/// Shows a toggle to switch between divine.video username mode and external
-/// NIP-05 mode. When expanded, displays a text field for entering the
-/// external NIP-05 (e.g., `alice@example.com`).
-class _ExternalNip05Section extends StatelessWidget {
-  const _ExternalNip05Section({
-    required this.controller,
-    required this.focusNode,
-  });
-
-  final TextEditingController controller;
-  final FocusNode focusNode;
-
-  @override
-  Widget build(BuildContext context) {
-    return BlocBuilder<ProfileEditorBloc, ProfileEditorState>(
-      buildWhen: (prev, curr) =>
-          prev.nip05Mode != curr.nip05Mode ||
-          prev.externalNip05Error != curr.externalNip05Error,
-      builder: (context, state) {
-        final isExternal = state.nip05Mode == Nip05Mode.external_;
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const SizedBox(height: 8),
-            // Toggle button
-            GestureDetector(
-              onTap: () {
-                final newMode = isExternal
-                    ? Nip05Mode.divine
-                    : Nip05Mode.external_;
-                context.read<ProfileEditorBloc>()
-                  ..add(Nip05ModeChanged(newMode))
-                  ..add(
-                    ExternalNip05Changed(
-                      newMode == Nip05Mode.external_ ? controller.text : '',
-                    ),
-                  );
-              },
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 8,
-                ),
-                child: Row(
-                  children: [
-                    Icon(
-                      isExternal
-                          ? Icons.check_box
-                          : Icons.check_box_outline_blank,
-                      color: isExternal
-                          ? VineTheme.vineGreen
-                          : VineTheme.onSurfaceMuted,
-                      size: 20,
-                    ),
-                    const SizedBox(width: 8),
-                    Flexible(
-                      child: Text(
-                        context.l10n.profileSetupUseOwnNip05,
-                        style: VineTheme.bodyMediumFont(
-                          color: VineTheme.onSurfaceVariant,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            // External NIP-05 input field (visible when toggled)
-            if (isExternal) ...[
-              const SizedBox(height: 4),
-              Padding(
-                padding: const EdgeInsetsDirectional.only(start: 16),
-                child: Text(
-                  context.l10n.profileSetupNip05AddressLabel,
-                  style: VineTheme.labelMediumFont(
-                    color: focusNode.hasFocus
-                        ? VineTheme.primary
-                        : VineTheme.onSurfaceMuted,
-                  ),
-                ),
-              ),
-              TextFormField(
-                controller: controller,
-                focusNode: focusNode,
-                style: VineTheme.bodyLargeFont(color: VineTheme.onSurface),
-                decoration: InputDecoration(
-                  isCollapsed: true,
-                  hintText: 'you@example.com',
-                  hintStyle: const TextStyle(color: VineTheme.onSurfaceMuted),
-                  border: const UnderlineInputBorder(
-                    borderRadius: BorderRadius.zero,
-                    borderSide: BorderSide(color: VineTheme.neutral10),
-                  ),
-                  enabledBorder: const UnderlineInputBorder(
-                    borderRadius: BorderRadius.zero,
-                    borderSide: BorderSide(color: VineTheme.neutral10),
-                  ),
-                  focusedBorder: const UnderlineInputBorder(
-                    borderRadius: BorderRadius.zero,
-                    borderSide: BorderSide(color: VineTheme.neutral10),
-                  ),
-                  errorBorder: const UnderlineInputBorder(
-                    borderRadius: BorderRadius.zero,
-                    borderSide: BorderSide(color: VineTheme.neutral10),
-                  ),
-                  focusedErrorBorder: const UnderlineInputBorder(
-                    borderRadius: BorderRadius.zero,
-                    borderSide: BorderSide(color: VineTheme.neutral10),
-                  ),
-                  contentPadding: const EdgeInsets.all(16),
-                  errorMaxLines: 2,
-                  errorText: switch (state.externalNip05Error) {
-                    ExternalNip05ValidationError.invalidFormat =>
-                      context.l10n.profileSetupExternalNip05InvalidFormat,
-                    ExternalNip05ValidationError.divineDomain =>
-                      context.l10n.profileSetupExternalNip05DivineDomain,
-                    null => null,
-                  },
-                ),
-                keyboardType: TextInputType.emailAddress,
-                textInputAction: TextInputAction.next,
-                onFieldSubmitted: (_) => FocusScope.of(context).nextFocus(),
-                onChanged: (value) => context.read<ProfileEditorBloc>().add(
-                  ExternalNip05Changed(value),
-                ),
-              ),
-            ],
-          ],
-        );
-      },
-    );
   }
 }
 

--- a/mobile/lib/screens/settings/nip05_settings_screen.dart
+++ b/mobile/lib/screens/settings/nip05_settings_screen.dart
@@ -3,6 +3,7 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -10,6 +11,7 @@ import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/screens/profile_setup_screen.dart';
 import 'package:openvine/utils/user_profile_utils.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
 
@@ -63,19 +65,21 @@ class Nip05SettingsView extends StatefulWidget {
 }
 
 class _Nip05SettingsViewState extends State<Nip05SettingsView> {
+  final _usernameController = TextEditingController();
   final _externalController = TextEditingController();
+  final _usernameFocus = FocusNode();
   final _externalFocus = FocusNode();
 
   String _displayName = '';
   String? _about;
   String? _picture;
   String? _banner;
-  String? _username;
   bool _profileLoaded = false;
 
   @override
   void initState() {
     super.initState();
+    _usernameFocus.addListener(_onFocusChange);
     _externalFocus.addListener(_onFocusChange);
   }
 
@@ -83,9 +87,13 @@ class _Nip05SettingsViewState extends State<Nip05SettingsView> {
 
   @override
   void dispose() {
+    _usernameFocus
+      ..removeListener(_onFocusChange)
+      ..dispose();
     _externalFocus
       ..removeListener(_onFocusChange)
       ..dispose();
+    _usernameController.dispose();
     _externalController.dispose();
     super.dispose();
   }
@@ -119,6 +127,8 @@ class _Nip05SettingsViewState extends State<Nip05SettingsView> {
               children: const [
                 _Intro(),
                 SizedBox(height: 8),
+                _DivineUsernameField(),
+                SizedBox(height: 16),
                 _ToggleRow(),
                 _ExternalNip05Field(),
                 SizedBox(height: 24),
@@ -145,9 +155,11 @@ class _Nip05SettingsViewState extends State<Nip05SettingsView> {
       _banner = color != null
           ? '0x${color.toARGB32().toRadixString(16).substring(2)}'
           : null;
-      _username = extractedUsername;
       if (externalNip05 != null) {
         _externalController.text = externalNip05;
+      }
+      if (extractedUsername != null) {
+        _usernameController.text = extractedUsername;
       }
       _profileLoaded = true;
     });
@@ -245,7 +257,7 @@ class _Nip05SettingsViewState extends State<Nip05SettingsView> {
         pubkey: widget.pubkey,
         displayName: _displayName,
         about: _about,
-        username: isExternal ? null : _username,
+        username: isExternal ? null : _usernameController.text,
         externalNip05: isExternal ? _externalController.text : null,
         picture: _picture,
         banner: _banner,
@@ -265,6 +277,115 @@ class _Intro extends StatelessWidget {
         context.l10n.nostrSettingsNip05AddressSubtitle,
         style: VineTheme.bodyMediumFont(color: VineTheme.lightText),
       ),
+    );
+  }
+}
+
+class _DivineUsernameField extends StatelessWidget {
+  const _DivineUsernameField();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ProfileEditorBloc, ProfileEditorState>(
+      buildWhen: (prev, curr) =>
+          prev.nip05Mode != curr.nip05Mode ||
+          prev.usernameStatus != curr.usernameStatus ||
+          prev.usernameError != curr.usernameError ||
+          prev.usernameFormatMessage != curr.usernameFormatMessage,
+      builder: (context, state) {
+        final viewState = context
+            .findAncestorStateOfType<_Nip05SettingsViewState>();
+        if (viewState == null) return const SizedBox.shrink();
+        final isExternal = state.nip05Mode == Nip05Mode.external_;
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                context.l10n.profileSetupUsernameLabel,
+                style: VineTheme.labelMediumFont(
+                  color: viewState._usernameFocus.hasFocus && !isExternal
+                      ? VineTheme.primary
+                      : VineTheme.onSurfaceMuted,
+                ),
+              ),
+              const SizedBox(height: 4),
+              TextFormField(
+                controller: viewState._usernameController,
+                focusNode: viewState._usernameFocus,
+                enabled: !isExternal,
+                style: VineTheme.bodyLargeFont(
+                  color: isExternal
+                      ? VineTheme.onSurfaceMuted
+                      : VineTheme.onSurface,
+                ),
+                autovalidateMode: AutovalidateMode.onUserInteraction,
+                decoration: InputDecoration(
+                  isCollapsed: true,
+                  hintText: context.l10n.profileSetupUsernameHint,
+                  helperText: context.l10n.profileSetupUsernameHelper,
+                  helperStyle: const TextStyle(
+                    color: VineTheme.onSurfaceMuted,
+                    fontSize: 12,
+                  ),
+                  hintStyle: const TextStyle(color: VineTheme.onSurfaceMuted),
+                  border: const UnderlineInputBorder(
+                    borderRadius: BorderRadius.zero,
+                    borderSide: BorderSide(color: VineTheme.neutral10),
+                  ),
+                  enabledBorder: const UnderlineInputBorder(
+                    borderRadius: BorderRadius.zero,
+                    borderSide: BorderSide(color: VineTheme.neutral10),
+                  ),
+                  disabledBorder: const UnderlineInputBorder(
+                    borderRadius: BorderRadius.zero,
+                    borderSide: BorderSide(color: VineTheme.neutral10),
+                  ),
+                  focusedBorder: const UnderlineInputBorder(
+                    borderRadius: BorderRadius.zero,
+                    borderSide: BorderSide(color: VineTheme.neutral10),
+                  ),
+                  errorBorder: const UnderlineInputBorder(
+                    borderRadius: BorderRadius.zero,
+                    borderSide: BorderSide(color: VineTheme.neutral10),
+                  ),
+                  focusedErrorBorder: const UnderlineInputBorder(
+                    borderRadius: BorderRadius.zero,
+                    borderSide: BorderSide(color: VineTheme.neutral10),
+                  ),
+                  contentPadding: const EdgeInsets.all(16),
+                  prefixText: '@',
+                  prefixStyle: VineTheme.bodyLargeFont(
+                    color: VineTheme.onSurfaceMuted,
+                  ),
+                  suffixText: '.divine.video',
+                  suffixStyle: VineTheme.bodyLargeFont(
+                    color: VineTheme.onSurfaceMuted,
+                  ),
+                  errorMaxLines: 2,
+                ),
+                inputFormatters: [
+                  const LowercaseTextInputFormatter(),
+                  FilteringTextInputFormatter.allow(RegExp('[a-z0-9-]')),
+                ],
+                textInputAction: TextInputAction.next,
+                onFieldSubmitted: (_) => FocusScope.of(context).nextFocus(),
+                onChanged: (value) => context.read<ProfileEditorBloc>().add(
+                  UsernameChanged(value),
+                ),
+              ),
+              if (!isExternal)
+                UsernameStatusIndicator(
+                  status: state.usernameStatus,
+                  error: state.usernameError,
+                  formatMessage: state.usernameFormatMessage,
+                ),
+            ],
+          ),
+        );
+      },
     );
   }
 }
@@ -406,17 +527,18 @@ class _SaveButton extends StatelessWidget {
       buildWhen: (prev, curr) =>
           prev.status != curr.status ||
           prev.nip05Mode != curr.nip05Mode ||
+          prev.username != curr.username ||
+          prev.usernameStatus != curr.usernameStatus ||
           prev.externalNip05Error != curr.externalNip05Error ||
           prev.externalNip05 != curr.externalNip05,
       builder: (context, state) {
         final viewState = context
             .findAncestorStateOfType<_Nip05SettingsViewState>();
         final isLoading = state.status == ProfileEditorStatus.loading;
-        final isExternal = state.nip05Mode == Nip05Mode.external_;
         final canSave =
             !isLoading &&
             (viewState?._profileLoaded ?? false) &&
-            (!isExternal || state.isExternalNip05SaveReady);
+            state.isSaveReady;
         return Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: DivineButton(

--- a/mobile/lib/screens/settings/nip05_settings_screen.dart
+++ b/mobile/lib/screens/settings/nip05_settings_screen.dart
@@ -1,0 +1,432 @@
+// ABOUTME: Nostr Settings → NIP-05 sub-screen for editing the user's NIP-05 identifier.
+// ABOUTME: Lets the user toggle between the divine.video username and a custom external NIP-05.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
+import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/utils/user_profile_utils.dart';
+import 'package:openvine/widgets/branded_loading_scaffold.dart';
+
+class Nip05SettingsScreen extends ConsumerWidget {
+  static const routeName = 'nip05-settings';
+  static const path = '/nostr-settings/nip05';
+
+  const Nip05SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profileRepository = ref.watch(profileRepositoryProvider);
+    final authService = ref.watch(authServiceProvider);
+    final pubkey = authService.currentPublicKeyHex;
+
+    if (profileRepository == null || pubkey == null) {
+      return const BrandedLoadingScaffold();
+    }
+
+    return MultiBlocProvider(
+      key: ValueKey((profileRepository, pubkey)),
+      providers: [
+        BlocProvider<ProfileEditorBloc>(
+          create: (_) => ProfileEditorBloc(
+            profileRepository: profileRepository,
+            hasExistingProfile: authService.hasExistingProfile,
+            currentUserPubkey: pubkey,
+          ),
+        ),
+        BlocProvider<MyProfileBloc>(
+          create: (_) => MyProfileBloc(
+            profileRepository: profileRepository,
+            pubkey: pubkey,
+          )..add(const MyProfileLoadRequested()),
+        ),
+      ],
+      child: Nip05SettingsView(pubkey: pubkey),
+    );
+  }
+}
+
+@visibleForTesting
+class Nip05SettingsView extends StatefulWidget {
+  @visibleForTesting
+  const Nip05SettingsView({required this.pubkey, super.key});
+
+  final String pubkey;
+
+  @override
+  State<Nip05SettingsView> createState() => _Nip05SettingsViewState();
+}
+
+class _Nip05SettingsViewState extends State<Nip05SettingsView> {
+  final _externalController = TextEditingController();
+  final _externalFocus = FocusNode();
+
+  String _displayName = '';
+  String? _about;
+  String? _picture;
+  String? _banner;
+  String? _username;
+  bool _profileLoaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _externalFocus.addListener(_onFocusChange);
+  }
+
+  void _onFocusChange() => setState(() {});
+
+  @override
+  void dispose() {
+    _externalFocus
+      ..removeListener(_onFocusChange)
+      ..dispose();
+    _externalController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: DiVineAppBar(
+        title: context.l10n.nostrSettingsNip05Address,
+        showBackButton: true,
+        onBackPressed: context.pop,
+      ),
+      backgroundColor: VineTheme.backgroundColor,
+      body: MultiBlocListener(
+        listeners: [
+          BlocListener<MyProfileBloc, MyProfileState>(
+            listenWhen: (prev, curr) => curr is MyProfileLoaded,
+            listener: _onProfileLoaded,
+          ),
+          BlocListener<ProfileEditorBloc, ProfileEditorState>(
+            listenWhen: (prev, curr) => prev.status != curr.status,
+            listener: _onSaveStatusChanged,
+          ),
+        ],
+        child: Align(
+          alignment: Alignment.topCenter,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 600),
+            child: ListView(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              children: const [
+                _Intro(),
+                SizedBox(height: 8),
+                _ToggleRow(),
+                _ExternalNip05Field(),
+                SizedBox(height: 24),
+                _SaveButton(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _onProfileLoaded(BuildContext context, MyProfileState state) {
+    if (state is! MyProfileLoaded) return;
+    final profile = state.profile;
+    final externalNip05 = state.externalNip05;
+    final extractedUsername = state.extractedUsername;
+
+    setState(() {
+      _displayName = profile.displayName ?? profile.name ?? '';
+      _about = profile.about;
+      _picture = profile.picture;
+      final color = profile.profileBackgroundColor;
+      _banner = color != null
+          ? '0x${color.toARGB32().toRadixString(16).substring(2)}'
+          : null;
+      _username = extractedUsername;
+      if (externalNip05 != null) {
+        _externalController.text = externalNip05;
+      }
+      _profileLoaded = true;
+    });
+
+    final editorBloc = context.read<ProfileEditorBloc>();
+    if (extractedUsername != null) {
+      editorBloc.add(InitialUsernameSet(extractedUsername));
+    }
+    if (externalNip05 != null) {
+      editorBloc
+        ..add(InitialExternalNip05Set(externalNip05))
+        ..add(const Nip05ModeChanged(Nip05Mode.external_))
+        ..add(ExternalNip05Changed(externalNip05));
+    }
+  }
+
+  void _onSaveStatusChanged(BuildContext context, ProfileEditorState state) {
+    if (state.status == ProfileEditorStatus.success) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(context.l10n.nostrSettingsNip05Saved),
+          backgroundColor: VineTheme.vineGreen,
+        ),
+      );
+      context.pop();
+    } else if (state.status == ProfileEditorStatus.failure) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(context.l10n.nostrSettingsNip05SaveFailed),
+          backgroundColor: VineTheme.error,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onTogglePressed() async {
+    final bloc = context.read<ProfileEditorBloc>();
+    final isExternal = bloc.state.nip05Mode == Nip05Mode.external_;
+    if (isExternal) {
+      bloc
+        ..add(const Nip05ModeChanged(Nip05Mode.divine))
+        ..add(const ExternalNip05Changed(''));
+      return;
+    }
+    final confirmed = await _showConfirmDialog();
+    if (!confirmed || !mounted) return;
+    bloc
+      ..add(const Nip05ModeChanged(Nip05Mode.external_))
+      ..add(ExternalNip05Changed(_externalController.text));
+  }
+
+  Future<bool> _showConfirmDialog() async {
+    final l10n = context.l10n;
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: VineTheme.surfaceBackground,
+        title: Text(
+          l10n.profileSetupNip05ConfirmTitle,
+          style: VineTheme.titleMediumFont(color: VineTheme.onSurface),
+        ),
+        content: Text(
+          l10n.profileSetupNip05ConfirmBody,
+          style: VineTheme.bodyMediumFont(color: VineTheme.onSurfaceVariant),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(
+              l10n.profileSetupNip05ConfirmCancel,
+              style: VineTheme.labelLargeFont(
+                color: VineTheme.onSurfaceMuted,
+              ),
+            ),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(
+              l10n.profileSetupNip05ConfirmContinue,
+              style: VineTheme.labelLargeFont(color: VineTheme.primary),
+            ),
+          ),
+        ],
+      ),
+    );
+    return result ?? false;
+  }
+
+  void _onSavePressed() {
+    if (!_profileLoaded || _displayName.isEmpty) return;
+    final bloc = context.read<ProfileEditorBloc>();
+    final isExternal = bloc.state.nip05Mode == Nip05Mode.external_;
+    bloc.add(
+      ProfileSaved(
+        pubkey: widget.pubkey,
+        displayName: _displayName,
+        about: _about,
+        username: isExternal ? null : _username,
+        externalNip05: isExternal ? _externalController.text : null,
+        picture: _picture,
+        banner: _banner,
+      ),
+    );
+  }
+}
+
+class _Intro extends StatelessWidget {
+  const _Intro();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Text(
+        context.l10n.nostrSettingsNip05AddressSubtitle,
+        style: VineTheme.bodyMediumFont(color: VineTheme.lightText),
+      ),
+    );
+  }
+}
+
+class _ToggleRow extends StatelessWidget {
+  const _ToggleRow();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ProfileEditorBloc, ProfileEditorState>(
+      buildWhen: (prev, curr) => prev.nip05Mode != curr.nip05Mode,
+      builder: (context, editorState) {
+        final isExternal = editorState.nip05Mode == Nip05Mode.external_;
+        final viewState = context
+            .findAncestorStateOfType<_Nip05SettingsViewState>();
+        return GestureDetector(
+          onTap: viewState?._onTogglePressed,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 16,
+              vertical: 12,
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  isExternal ? Icons.check_box : Icons.check_box_outline_blank,
+                  color: isExternal
+                      ? VineTheme.vineGreen
+                      : VineTheme.onSurfaceMuted,
+                  size: 22,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    context.l10n.profileSetupUseOwnNip05,
+                    style: VineTheme.bodyLargeFont(
+                      color: VineTheme.onSurface,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ExternalNip05Field extends StatelessWidget {
+  const _ExternalNip05Field();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ProfileEditorBloc, ProfileEditorState>(
+      buildWhen: (prev, curr) =>
+          prev.nip05Mode != curr.nip05Mode ||
+          prev.externalNip05Error != curr.externalNip05Error,
+      builder: (context, state) {
+        if (state.nip05Mode != Nip05Mode.external_) {
+          return const SizedBox.shrink();
+        }
+        final viewState = context
+            .findAncestorStateOfType<_Nip05SettingsViewState>();
+        if (viewState == null) return const SizedBox.shrink();
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 8),
+              Text(
+                context.l10n.profileSetupNip05AddressLabel,
+                style: VineTheme.labelMediumFont(
+                  color: viewState._externalFocus.hasFocus
+                      ? VineTheme.primary
+                      : VineTheme.onSurfaceMuted,
+                ),
+              ),
+              const SizedBox(height: 4),
+              TextFormField(
+                controller: viewState._externalController,
+                focusNode: viewState._externalFocus,
+                style: VineTheme.bodyLargeFont(color: VineTheme.onSurface),
+                decoration: InputDecoration(
+                  isCollapsed: true,
+                  hintText: 'you@example.com',
+                  hintStyle: const TextStyle(color: VineTheme.onSurfaceMuted),
+                  border: const UnderlineInputBorder(
+                    borderRadius: BorderRadius.zero,
+                    borderSide: BorderSide(color: VineTheme.neutral10),
+                  ),
+                  enabledBorder: const UnderlineInputBorder(
+                    borderRadius: BorderRadius.zero,
+                    borderSide: BorderSide(color: VineTheme.neutral10),
+                  ),
+                  focusedBorder: const UnderlineInputBorder(
+                    borderRadius: BorderRadius.zero,
+                    borderSide: BorderSide(color: VineTheme.neutral10),
+                  ),
+                  errorBorder: const UnderlineInputBorder(
+                    borderRadius: BorderRadius.zero,
+                    borderSide: BorderSide(color: VineTheme.neutral10),
+                  ),
+                  focusedErrorBorder: const UnderlineInputBorder(
+                    borderRadius: BorderRadius.zero,
+                    borderSide: BorderSide(color: VineTheme.neutral10),
+                  ),
+                  contentPadding: const EdgeInsets.all(16),
+                  errorMaxLines: 2,
+                  errorText: switch (state.externalNip05Error) {
+                    ExternalNip05ValidationError.invalidFormat =>
+                      context.l10n.profileSetupExternalNip05InvalidFormat,
+                    ExternalNip05ValidationError.divineDomain =>
+                      context.l10n.profileSetupExternalNip05DivineDomain,
+                    null => null,
+                  },
+                ),
+                keyboardType: TextInputType.emailAddress,
+                textInputAction: TextInputAction.done,
+                onChanged: (value) => context.read<ProfileEditorBloc>().add(
+                  ExternalNip05Changed(value),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SaveButton extends StatelessWidget {
+  const _SaveButton();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ProfileEditorBloc, ProfileEditorState>(
+      buildWhen: (prev, curr) =>
+          prev.status != curr.status ||
+          prev.nip05Mode != curr.nip05Mode ||
+          prev.externalNip05Error != curr.externalNip05Error ||
+          prev.externalNip05 != curr.externalNip05,
+      builder: (context, state) {
+        final viewState = context
+            .findAncestorStateOfType<_Nip05SettingsViewState>();
+        final isLoading = state.status == ProfileEditorStatus.loading;
+        final isExternal = state.nip05Mode == Nip05Mode.external_;
+        final canSave =
+            !isLoading &&
+            (viewState?._profileLoaded ?? false) &&
+            (!isExternal || state.isExternalNip05SaveReady);
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: DivineButton(
+            label: context.l10n.nostrSettingsNip05SaveAction,
+            onPressed: canSave ? viewState?._onSavePressed : null,
+            expanded: true,
+            isLoading: isLoading,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/mobile/lib/screens/settings/nostr_settings_screen.dart
+++ b/mobile/lib/screens/settings/nostr_settings_screen.dart
@@ -117,7 +117,7 @@ class NostrSettingsScreen extends ConsumerWidget {
                   icon: Icons.alternate_email,
                   title: context.l10n.nostrSettingsNip05Address,
                   subtitle: context.l10n.nostrSettingsNip05AddressSubtitle,
-                  onTap: () => context.push(Nip05SettingsScreen.path),
+                  onTap: () => context.pushNamed(Nip05SettingsScreen.routeName),
                 ),
                 _RemoveKeysTile(ref: ref),
                 _SectionHeader(

--- a/mobile/lib/screens/settings/nostr_settings_screen.dart
+++ b/mobile/lib/screens/settings/nostr_settings_screen.dart
@@ -20,6 +20,7 @@ import 'package:openvine/screens/developer_options_screen.dart';
 import 'package:openvine/screens/key_management_screen.dart';
 import 'package:openvine/screens/relay_diagnostic_screen.dart';
 import 'package:openvine/screens/relay_settings_screen.dart';
+import 'package:openvine/screens/settings/nip05_settings_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/widgets/delete_account_dialog.dart';
 
@@ -111,6 +112,12 @@ class NostrSettingsScreen extends ConsumerWidget {
                   title: context.l10n.nostrSettingsKeyManagement,
                   subtitle: context.l10n.nostrSettingsKeyManagementSubtitle,
                   onTap: () => context.push(KeyManagementScreen.path),
+                ),
+                _SettingsTile(
+                  icon: Icons.alternate_email,
+                  title: context.l10n.nostrSettingsNip05Address,
+                  subtitle: context.l10n.nostrSettingsNip05AddressSubtitle,
+                  onTap: () => context.push(Nip05SettingsScreen.path),
                 ),
                 _RemoveKeysTile(ref: ref),
                 _SectionHeader(

--- a/mobile/lib/screens/settings/nostr_settings_screen.dart
+++ b/mobile/lib/screens/settings/nostr_settings_screen.dart
@@ -117,7 +117,7 @@ class NostrSettingsScreen extends ConsumerWidget {
                   icon: Icons.alternate_email,
                   title: context.l10n.nostrSettingsNip05Address,
                   subtitle: context.l10n.nostrSettingsNip05AddressSubtitle,
-                  onTap: () => context.pushNamed(Nip05SettingsScreen.routeName),
+                  onTap: () => context.push(Nip05SettingsScreen.path),
                 ),
                 _RemoveKeysTile(ref: ref),
                 _SectionHeader(

--- a/mobile/test/screens/settings/nip05_settings_screen_test.dart
+++ b/mobile/test/screens/settings/nip05_settings_screen_test.dart
@@ -1,0 +1,158 @@
+// ABOUTME: Widget tests for the Nostr Settings -> NIP-05 editor screen.
+// ABOUTME: Verifies the screen exposes the actual NIP-05 form controls.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
+import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/screens/settings/nip05_settings_screen.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+import '../../helpers/go_router.dart';
+
+class _MockProfileRepository extends Mock implements ProfileRepository {}
+
+void main() {
+  group(Nip05SettingsScreen, () {
+    const pubkey =
+        'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+
+    late _MockProfileRepository profileRepository;
+
+    setUpAll(() {
+      registerFallbackValue(makeFallbackProfile(pubkey: pubkey));
+    });
+
+    UserProfile makeProfile({String? nip05}) {
+      return makeFallbackProfile(pubkey: pubkey, nip05: nip05);
+    }
+
+    Widget buildSubject({String? nip05, MockGoRouter? goRouter}) {
+      final profile = makeProfile(nip05: nip05);
+      when(
+        () => profileRepository.getCachedProfile(pubkey: pubkey),
+      ).thenAnswer((_) async => profile);
+      when(
+        () => profileRepository.fetchFreshProfile(pubkey: pubkey),
+      ).thenAnswer((_) async => profile);
+      when(
+        () => profileRepository.checkUsernameAvailability(
+          username: any(named: 'username'),
+          currentUserPubkey: any(named: 'currentUserPubkey'),
+        ),
+      ).thenAnswer((_) async => const UsernameAvailable());
+
+      final app = MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider(
+              create: (_) => ProfileEditorBloc(
+                profileRepository: profileRepository,
+                hasExistingProfile: true,
+                currentUserPubkey: pubkey,
+              ),
+            ),
+            BlocProvider(
+              create: (_) => MyProfileBloc(
+                profileRepository: profileRepository,
+                pubkey: pubkey,
+              )..add(const MyProfileLoadRequested()),
+            ),
+          ],
+          child: const Nip05SettingsView(pubkey: pubkey),
+        ),
+      );
+
+      if (goRouter == null) return app;
+      return MockGoRouterProvider(goRouter: goRouter, child: app);
+    }
+
+    setUp(() {
+      profileRepository = _MockProfileRepository();
+    });
+
+    testWidgets('shows the divine.video username form by default', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(nip05: '_@existing.divine.video'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Username (Optional)'), findsOneWidget);
+      expect(find.text('Your unique identity on Divine'), findsOneWidget);
+      expect(find.text('existing'), findsOneWidget);
+
+      await tester.enterText(find.byType(TextFormField).first, 'newname');
+      await tester.pump(const Duration(milliseconds: 600));
+
+      expect(find.text('newname'), findsOneWidget);
+    });
+
+    testWidgets('saves the edited divine.video username', (tester) async {
+      final goRouter = MockGoRouter();
+      when(
+        () => profileRepository.claimUsername(username: 'newname'),
+      ).thenAnswer((_) async => const UsernameClaimSuccess());
+      when(
+        () => profileRepository.saveProfileEvent(
+          displayName: 'Test User',
+          about: 'Still making weird loops',
+          username: 'newname',
+          picture: 'https://example.com/avatar.png',
+          currentProfile: any(named: 'currentProfile'),
+        ),
+      ).thenAnswer((_) async => makeProfile(nip05: '_@newname.divine.video'));
+      when(
+        () => profileRepository.cacheProfile(any()),
+      ).thenAnswer((_) async {});
+
+      await tester.pumpWidget(
+        buildSubject(
+          nip05: '_@existing.divine.video',
+          goRouter: goRouter,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField).first, 'newname');
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Save NIP-05'));
+      await tester.tap(find.text('Save NIP-05'));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => profileRepository.claimUsername(username: 'newname'),
+      ).called(1);
+      verify(
+        () => profileRepository.saveProfileEvent(
+          displayName: 'Test User',
+          about: 'Still making weird loops',
+          username: 'newname',
+          picture: 'https://example.com/avatar.png',
+          currentProfile: any(named: 'currentProfile'),
+        ),
+      ).called(1);
+    });
+  });
+}
+
+UserProfile makeFallbackProfile({required String pubkey, String? nip05}) {
+  return UserProfile(
+    pubkey: pubkey,
+    displayName: 'Test User',
+    about: 'Still making weird loops',
+    picture: 'https://example.com/avatar.png',
+    nip05: nip05,
+    rawData: const {},
+    createdAt: DateTime(2024),
+    eventId:
+        'event123456789012345678901234567890123456789012345678901234567890',
+  );
+}

--- a/mobile/test/widgets/nostr_settings_screen_test.dart
+++ b/mobile/test/widgets/nostr_settings_screen_test.dart
@@ -9,9 +9,12 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/screens/settings/nip05_settings_screen.dart';
 import 'package:openvine/screens/settings/nostr_settings_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/go_router.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
 
@@ -29,8 +32,11 @@ void main() {
       ).thenAnswer((_) => Stream.value(AuthState.authenticated));
     });
 
-    Widget buildSubject({bool advancedRelaySettingsEnabled = false}) {
-      return ProviderScope(
+    Widget buildSubject({
+      bool advancedRelaySettingsEnabled = false,
+      MockGoRouter? goRouter,
+    }) {
+      final app = ProviderScope(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(sharedPreferences),
           authServiceProvider.overrideWithValue(mockAuthService),
@@ -48,6 +54,10 @@ void main() {
           home: NostrSettingsScreen(),
         ),
       );
+
+      if (goRouter == null) return app;
+
+      return MockGoRouterProvider(goRouter: goRouter, child: app);
     }
 
     testWidgets('shows Experimental Features tile and opens feature flags', (
@@ -94,6 +104,26 @@ void main() {
         find.text(l10n.nostrSettingsNip05AddressSubtitle),
         findsOneWidget,
       );
+    });
+
+    testWidgets('opens the NIP-05 settings route from the account tile', (
+      tester,
+    ) async {
+      final mockGoRouter = MockGoRouter();
+      when(
+        () => mockGoRouter.pushNamed<Object?>(Nip05SettingsScreen.routeName),
+      ).thenAnswer((_) async => null);
+
+      await tester.pumpWidget(buildSubject(goRouter: mockGoRouter));
+      await tester.pumpAndSettle();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.tap(find.text(l10n.nostrSettingsNip05Address));
+      await tester.pump();
+
+      verify(
+        () => mockGoRouter.pushNamed<Object?>(Nip05SettingsScreen.routeName),
+      ).called(1);
     });
   });
 }

--- a/mobile/test/widgets/nostr_settings_screen_test.dart
+++ b/mobile/test/widgets/nostr_settings_screen_test.dart
@@ -81,5 +81,19 @@ void main() {
       expect(find.text('Relays'), findsOneWidget);
       expect(find.text('Relay Diagnostics'), findsOneWidget);
     });
+
+    testWidgets('shows NIP-05 address tile in the Account section', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pumpAndSettle();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.nostrSettingsNip05Address), findsOneWidget);
+      expect(
+        find.text(l10n.nostrSettingsNip05AddressSubtitle),
+        findsOneWidget,
+      );
+    });
   });
 }

--- a/mobile/test/widgets/nostr_settings_screen_test.dart
+++ b/mobile/test/widgets/nostr_settings_screen_test.dart
@@ -110,9 +110,9 @@ void main() {
       tester,
     ) async {
       final mockGoRouter = MockGoRouter();
-      when(
-        () => mockGoRouter.pushNamed<Object?>(Nip05SettingsScreen.routeName),
-      ).thenAnswer((_) async => null);
+      when(() => mockGoRouter.push(Nip05SettingsScreen.path)).thenAnswer(
+        (_) async => null,
+      );
 
       await tester.pumpWidget(buildSubject(goRouter: mockGoRouter));
       await tester.pumpAndSettle();
@@ -121,9 +121,7 @@ void main() {
       await tester.tap(find.text(l10n.nostrSettingsNip05Address));
       await tester.pump();
 
-      verify(
-        () => mockGoRouter.pushNamed<Object?>(Nip05SettingsScreen.routeName),
-      ).called(1);
+      verify(() => mockGoRouter.push(Nip05SettingsScreen.path)).called(1);
     });
   });
 }


### PR DESCRIPTION
Closes #3997

## Summary

- **Moves** the custom NIP-05 control out of Edit Profile and into a new dedicated screen at **Settings → Nostr → Account → "NIP-05 address"**.
- Available by default — no feature flag, no settings gate. Discoverable from the Settings hub.
- Confirm dialog still appears the first time a user flips to "use your own NIP-05 address" so they see the misconfiguration warning before it applies.
- Edit Profile no longer surfaces this section at all.

## Why

The original placement on Edit Profile was both hard to find (users couldn't find where to set NIP-05 at all) and easy to misconfigure (a single tap of a checkbox under the username field flipped them off divine.video onto a domain they likely didn't control). The new sub-screen is purpose-built for this control and groups with the rest of the account-identity settings.

## Changes

- **New** `lib/screens/settings/nip05_settings_screen.dart` — toggle + input + Save, backed by `ProfileEditorBloc` and `MyProfileBloc` so the save path is the same kind 0 publish as Edit Profile.
- **New** route at `/nostr-settings/nip05`.
- **New** "NIP-05 address" tile in the Account section of `nostr_settings_screen.dart`.
- **Removed** `ExternalNip05Section` and the external NIP-05 controller / focus node from `profile_setup_screen.dart`. The save path still preserves the existing external NIP-05 from editor state.
- **Removed** `advanced_identity_options_provider` (and the gate built around it).
- **l10n**: removed `nostrSettingsAdvancedIdentityOptions*`; added `nostrSettingsNip05Address`, `nostrSettingsNip05AddressSubtitle`, `nostrSettingsNip05SaveAction`, `nostrSettingsNip05Saved`, `nostrSettingsNip05SaveFailed`. Confirm dialog keys (`profileSetupNip05Confirm*`) kept and reused. Propagated to all 16 non-English locales.

## Test plan

- [x] `flutter analyze lib test` clean
- [x] `flutter test test/screens/profile_setup_screen_test.dart test/widgets/nostr_settings_screen_test.dart test/l10n/arb_consistency_test.dart` (41 passing)
- [ ] Manual: Settings → Nostr Settings → "NIP-05 address" → toggle on → confirm dialog → enter `you@yourdomain.com` → Save → snackbar + return
- [ ] Manual: Edit Profile no longer shows the "Use your own NIP-05 address" checkbox
- [ ] Manual: existing external NIP-05 users see their value pre-filled in the new screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)