### PR TITLE
fix(video_player): resolve black video preview issue

### DIFF
--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -177,6 +177,8 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
   String? _lastTrimClipId;
   Duration? _lastTrimPositionInClip;
 
+  bool get _isPlayerInitialized => _videoPlayer?.isInitialized == true;
+
   @override
   void initState() {
     super.initState();
@@ -217,7 +219,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
 
   /// Handles playback restart requests from BLoC.
   void _onPlaybackRestartRequested() {
-    if (!_isPlayerReadyNotifier.value) return;
+    if (!_isPlayerReadyNotifier.value || !_isPlayerInitialized) return;
 
     _videoPlayer?.seekTo(Duration.zero);
     _videoPlayer?.play();
@@ -225,7 +227,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
 
   /// Handles playback toggle requests from BLoC.
   void _onPlaybackToggleRequested() {
-    if (!_isPlayerReadyNotifier.value) return;
+    if (!_isPlayerReadyNotifier.value || !_isPlayerInitialized) return;
 
     final isPlaying = _videoPlayer?.state.isPlaying ?? false;
     if (isPlaying) {
@@ -237,7 +239,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
 
   /// Handles external pause requests from BLoC.
   void _onExternalPauseChanged({required bool isPaused}) {
-    if (!_isPlayerReadyNotifier.value) return;
+    if (!_isPlayerReadyNotifier.value || !_isPlayerInitialized) return;
 
     if (isPaused) {
       _videoPlayer?.pause();
@@ -287,7 +289,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
   }
 
   Future<void> _onSeekRequested(Duration position) async {
-    if (!_isPlayerReadyNotifier.value) return;
+    if (!_isPlayerReadyNotifier.value || !_isPlayerInitialized) return;
 
     _proVideoController.setPlayTime(position);
 
@@ -356,6 +358,8 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
   /// Called when clip paths change. Updates the player with the new clips
   /// or pauses when no clips are available.
   void _onClipPathsChanged(List<String> clipPaths) {
+    if (!_isPlayerInitialized) return;
+
     if (clipPaths.isEmpty) {
       _videoPlayer?.pause();
       _isPlayerReadyNotifier.value = false;
@@ -491,7 +495,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
   /// state and combines them with the source [AudioEvent] from the
   /// Riverpod provider (URL, asset path, start offset).
   Future<void> _syncAudioTracks() async {
-    if (_videoPlayer == null) return;
+    if (_videoPlayer == null || !_videoPlayer!.isInitialized) return;
 
     final overlayState = context.read<TimelineOverlayBloc>().state;
     final audioEvents = overlayState.audioTracks;
@@ -746,11 +750,15 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
     // Live volume preview: sync player volumes when state changes
     ref.listen<double>(
       videoEditorProvider.select((s) => s.originalAudioVolume),
-      (_, volume) => _videoPlayer?.setVolume(volume),
+      (_, volume) {
+        if (_isPlayerInitialized) _videoPlayer?.setVolume(volume);
+      },
     );
     ref.listen<double>(
       videoEditorProvider.select((s) => s.customAudioVolume),
-      (_, volume) => _videoPlayer?.setAudioTrackVolume(0, volume),
+      (_, volume) {
+        if (_isPlayerInitialized) _videoPlayer?.setAudioTrackVolume(0, volume);
+      },
     );
 
     // Reinitialize the player when clip paths change.
@@ -790,7 +798,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
         // teardown). Sending `setClips([])` to the native player
         // builds a composition with `renderSize == .zero` on iOS,
         // which crashes `AVPlayerItem.setVideoComposition:`.
-        if (clips.isEmpty) return;
+        if (clips.isEmpty || !_isPlayerInitialized) return;
         final currentPosition = context
             .read<VideoEditorMainBloc>()
             .state
@@ -876,7 +884,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
               previous.trimmingClipId != current.trimmingClipId,
           listener: (context, state) {
             _isTrimmingClip = state.trimmingClipId != null;
-            if (state.trimmingClipId == null) return;
+            if (state.trimmingClipId == null || !_isPlayerInitialized) return;
             final clip = state.clips.firstWhere(
               (c) => c.id == state.trimmingClipId,
             );
@@ -961,7 +969,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
           listener: (context, state) async {
             // See note on the trim-times listener above: skip empty
             // clip lists to avoid crashing the iOS native player.
-            if (state.clips.isEmpty) return;
+            if (state.clips.isEmpty || !_isPlayerInitialized) return;
 
             // Seek to the trim handle's release point when restoring the composite.
             final trimEndPosition = _consumeTrimEndStartPosition(state.clips);
@@ -1045,7 +1053,8 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
           listenWhen: (previous, current) =>
               previous.isMuted != current.isMuted,
           listener: (context, state) {
-            _videoPlayer?.setVolume(state.isMuted ? 0 : 1);
+            if (_isPlayerInitialized)
+              _videoPlayer?.setVolume(state.isMuted ? 0 : 1);
             ref
                 .read(videoEditorProvider.notifier)
                 .setOriginalAudioVolume(state.isMuted ? 0 : 1);

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1053,8 +1053,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
           listenWhen: (previous, current) =>
               previous.isMuted != current.isMuted,
           listener: (context, state) {
-            if (_isPlayerInitialized)
+            if (_isPlayerInitialized) {
               _videoPlayer?.setVolume(state.isMuted ? 0 : 1);
+            }
             ref
                 .read(videoEditorProvider.notifier)
                 .setOriginalAudioVolume(state.isMuted ? 0 : 1);

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -495,7 +495,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
   /// state and combines them with the source [AudioEvent] from the
   /// Riverpod provider (URL, asset path, start offset).
   Future<void> _syncAudioTracks() async {
-    if (_videoPlayer == null || !_videoPlayer!.isInitialized) return;
+    if (!_isPlayerInitialized) return;
 
     final overlayState = context.read<TimelineOverlayBloc>().state;
     final audioEvents = overlayState.audioTracks;

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -106,6 +106,22 @@ internal class DivineVideoPlayerInstance(
         seekCompletionResult = null
     }
 
+    /**
+     * Pending result for an async setClips call.
+     * Held until ExoPlayer transitions to STATE_READY (or reports an error),
+     * so `await setClips()` on the Dart side only resolves once the decoder
+     * is truly ready. This replaces the `Future.delayed` workarounds in the
+     * Dart canvas and ensures correctness on OEM decoders (e.g. Mediatek)
+     * that take variable time to reach STATE_READY after prepare().
+     */
+    private var pendingSetClipsResult: MethodChannel.Result? = null
+
+    /** Safety timeout so Dart is never left hanging if STATE_READY is lost. */
+    private val setClipsTimeoutRunnable = Runnable {
+        pendingSetClipsResult?.success(null)
+        pendingSetClipsResult = null
+    }
+
     private val positionUpdater = object : Runnable {
         override fun run() {
             syncAudioOverlays()
@@ -279,7 +295,15 @@ internal class DivineVideoPlayerInstance(
         // position so the timeline doesn't show intermediate values.
         pendingGlobalStartMs = globalStartMs
 
-        result.success(null)
+        // Hold the Dart result until STATE_READY so `await setClips()` only
+        // resolves once the decoder is truly ready. Cancel any previous
+        // in-flight setClips (shouldn't happen, but defensive).
+        mainHandler.removeCallbacks(setClipsTimeoutRunnable)
+        pendingSetClipsResult?.success(null)
+        pendingSetClipsResult = result
+        // 10 s safety net — if STATE_READY never fires (e.g. corrupt file),
+        // Dart is unblocked rather than hanging forever.
+        mainHandler.postDelayed(setClipsTimeoutRunnable, 10_000L)
     }
 
     private fun handleSeekTo(call: MethodCall, result: MethodChannel.Result) {
@@ -572,6 +596,10 @@ internal class DivineVideoPlayerInstance(
                 // Seek complete — switch from reporting target to actual position.
                 pendingGlobalStartMs = 0L
                 completeSeekIfPending()
+                // setClips complete — unblock the Dart await.
+                mainHandler.removeCallbacks(setClipsTimeoutRunnable)
+                pendingSetClipsResult?.success(null)
+                pendingSetClipsResult = null
             }
             sendStateUpdate()
         }
@@ -603,6 +631,15 @@ internal class DivineVideoPlayerInstance(
         }
 
         override fun onPlayerError(error: PlaybackException) {
+            // Unblock a pending setClips with an error so Dart can react
+            // rather than waiting for the 10 s safety timeout.
+            mainHandler.removeCallbacks(setClipsTimeoutRunnable)
+            pendingSetClipsResult?.error(
+                "PLAYER_ERROR",
+                error.message ?: "Unknown playback error",
+                null,
+            )
+            pendingSetClipsResult = null
             sendStateUpdate()
         }
 
@@ -692,8 +729,11 @@ internal class DivineVideoPlayerInstance(
     fun dispose() {
         mainHandler.removeCallbacks(positionUpdater)
         mainHandler.removeCallbacks(seekTimeoutRunnable)
+        mainHandler.removeCallbacks(setClipsTimeoutRunnable)
         seekCompletionResult?.success(null)
         seekCompletionResult = null
+        pendingSetClipsResult?.success(null)
+        pendingSetClipsResult = null
         methodChannel.setMethodCallHandler(null)
         eventChannel.setStreamHandler(null)
         // Release the player before the surface producer. Releasing the

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -110,9 +110,8 @@ internal class DivineVideoPlayerInstance(
      * Pending result for an async setClips call.
      * Held until ExoPlayer transitions to STATE_READY (or reports an error),
      * so `await setClips()` on the Dart side only resolves once the decoder
-     * is truly ready. This replaces the `Future.delayed` workarounds in the
-     * Dart canvas and ensures correctness on OEM decoders (e.g. Mediatek)
-     * that take variable time to reach STATE_READY after prepare().
+     * is truly ready. Required for OEM decoders (e.g. Mediatek) that take
+     * variable time to reach STATE_READY after prepare().
      */
     private var pendingSetClipsResult: MethodChannel.Result? = null
 
@@ -297,9 +296,15 @@ internal class DivineVideoPlayerInstance(
 
         // Hold the Dart result until STATE_READY so `await setClips()` only
         // resolves once the decoder is truly ready. Cancel any previous
-        // in-flight setClips (shouldn't happen, but defensive).
+        // in-flight setClips (shouldn't happen, but defensive) — surface as
+        // an error so the superseded caller doesn't believe the player is
+        // ready for its clips.
         mainHandler.removeCallbacks(setClipsTimeoutRunnable)
-        pendingSetClipsResult?.success(null)
+        pendingSetClipsResult?.error(
+            "CANCELLED",
+            "Superseded by newer setClips call",
+            null,
+        )
         pendingSetClipsResult = result
         // 10 s safety net — if STATE_READY never fires (e.g. corrupt file),
         // Dart is unblocked rather than hanging forever.

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -3,10 +3,12 @@ package com.divinevideo.divine_video_player
 import android.content.Context
 import android.os.Handler
 import android.view.Surface
+import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
 import io.flutter.view.TextureRegistry
 import io.mockk.clearMocks
 import io.mockk.every
@@ -257,5 +259,74 @@ class DivineVideoPlayerInstanceTest {
         listener.onMediaItemTransition(null, Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED)
 
         verify(exactly = 0) { mockPlayer.setVideoSurface(any()) }
+    }
+
+    // -- setClips async completion contract --
+
+    private fun setClipsCall(uri: String = "file:///tmp/a.mp4"): MethodCall =
+        MethodCall(
+            "setClips",
+            mapOf(
+                "clips" to listOf(
+                    mapOf("uri" to uri, "startMs" to 0, "endMs" to 1000),
+                ),
+            ),
+        )
+
+    @Test
+    fun `setClips holds Dart result until STATE_READY then completes with success`() {
+        val listener = capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+
+        instance.onMethodCall(setClipsCall(), result)
+
+        // Result must NOT have completed yet — STATE_READY hasn't fired.
+        verify(exactly = 0) { result.success(any()) }
+        verify(exactly = 0) { result.error(any(), any(), any()) }
+
+        listener.onPlaybackStateChanged(Player.STATE_READY)
+
+        verify(exactly = 1) { result.success(null) }
+    }
+
+    @Test
+    fun `onPlayerError completes pending setClips result with error`() {
+        val listener = capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        instance.onMethodCall(setClipsCall(), result)
+
+        val error = mockk<PlaybackException>(relaxed = true)
+        every { error.message } returns "boom"
+        listener.onPlayerError(error)
+
+        verify(exactly = 1) { result.error("PLAYER_ERROR", "boom", null) }
+        verify(exactly = 0) { result.success(any()) }
+    }
+
+    @Test
+    fun `superseding setClips completes the previous result with CANCELLED`() {
+        capturePlayerListener()
+        val first = mockk<MethodChannel.Result>(relaxed = true)
+        val second = mockk<MethodChannel.Result>(relaxed = true)
+
+        instance.onMethodCall(setClipsCall("file:///tmp/a.mp4"), first)
+        instance.onMethodCall(setClipsCall("file:///tmp/b.mp4"), second)
+
+        verify(exactly = 1) {
+            first.error("CANCELLED", "Superseded by newer setClips call", null)
+        }
+        verify(exactly = 0) { first.success(any()) }
+        verify(exactly = 0) { second.success(any()) }
+    }
+
+    @Test
+    fun `dispose completes pending setClips result so Dart is not left hanging`() {
+        capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        instance.onMethodCall(setClipsCall(), result)
+
+        instance.dispose()
+
+        verify(exactly = 1) { result.success(null) }
     }
 }


### PR DESCRIPTION
Closes #3953

## Description

Some users reported that in the video editor, the preview turns black after a few seconds of playback. This PR resolves that issue.


**Related Issue:** Closes # or Relates to #

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore