### PR TITLE
feat(profile): verified-account chips read path (PR2 of #3933)

### DIFF
--- a/mobile/lib/blocs/my_profile/my_profile_bloc.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_bloc.dart
@@ -17,7 +17,9 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
   MyProfileBloc({
     required ProfileRepository profileRepository,
     required this.pubkey,
+    IdentityClaimsRepository? identityClaimsRepository,
   }) : _profileRepository = profileRepository,
+       _identityClaimsRepository = identityClaimsRepository,
        super(const MyProfileInitial()) {
     on<MyProfileLoadRequested>(_onLoadRequested);
     on<MyProfileSubscriptionRequested>(
@@ -25,9 +27,11 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       transformer: restartable(),
     );
     on<MyProfileFetchRequested>(_onFetchRequested);
+    on<VerifiedClaimsRequested>(_onVerifiedClaimsRequested);
   }
 
   final ProfileRepository _profileRepository;
+  final IdentityClaimsRepository? _identityClaimsRepository;
 
   /// The pubkey of the current user.
   final String pubkey;
@@ -63,6 +67,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
             externalNip05: freshProfile.externalNip05,
           ),
         );
+        add(const VerifiedClaimsRequested());
       } else if (cachedProfile != null) {
         emit(
           MyProfileLoaded(
@@ -72,6 +77,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
             externalNip05: cachedProfile.externalNip05,
           ),
         );
+        add(const VerifiedClaimsRequested());
       } else {
         emit(const MyProfileError(errorType: MyProfileErrorType.notFound));
       }
@@ -85,6 +91,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
             externalNip05: cachedProfile.externalNip05,
           ),
         );
+        add(const VerifiedClaimsRequested());
       } else {
         emit(const MyProfileError(errorType: MyProfileErrorType.networkError));
       }
@@ -101,6 +108,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       _profileRepository.watchProfile(pubkey: pubkey),
       onData: (profile) {
         if (profile != null) {
+          add(const VerifiedClaimsRequested());
           return MyProfileUpdated(
             profile: profile,
             extractedUsername: profile.divineUsername,
@@ -124,6 +132,53 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       await _profileRepository.fetchFreshProfile(pubkey: pubkey);
     } on Exception catch (e, stackTrace) {
       addError(e, stackTrace);
+    }
+  }
+
+  Future<void> _onVerifiedClaimsRequested(
+    VerifiedClaimsRequested event,
+    Emitter<MyProfileState> emit,
+  ) async {
+    final repo = _identityClaimsRepository;
+    if (repo == null) return;
+
+    final current = state;
+    final UserProfile profile;
+    if (current is MyProfileLoaded) {
+      profile = current.profile;
+    } else if (current is MyProfileUpdated) {
+      profile = current.profile;
+    } else {
+      return;
+    }
+
+    try {
+      final claims = await repo.verifiedClaims(
+        pubkey: profile.pubkey,
+        tags: profile.rawTags,
+      );
+      // State may have changed mid-await; re-check before emitting.
+      final latest = state;
+      if (latest is MyProfileLoaded &&
+          latest.profile.pubkey == profile.pubkey) {
+        emit(latest.copyWith(verifiedClaims: claims));
+      } else if (latest is MyProfileUpdated &&
+          latest.profile.pubkey == profile.pubkey) {
+        emit(latest.copyWith(verifiedClaims: claims));
+      }
+    } on Exception catch (e, stackTrace) {
+      // Verifier failures are expected (network/4xx/5xx/timeout). Per
+      // .claude/rules/error_handling.md they are NOT Reportable. Surface as
+      // empty list rather than blocking the UI.
+      addError(e, stackTrace);
+      final latest = state;
+      if (latest is MyProfileLoaded &&
+          latest.profile.pubkey == profile.pubkey) {
+        emit(latest.copyWith(verifiedClaims: const []));
+      } else if (latest is MyProfileUpdated &&
+          latest.profile.pubkey == profile.pubkey) {
+        emit(latest.copyWith(verifiedClaims: const []));
+      }
     }
   }
 }

--- a/mobile/lib/blocs/my_profile/my_profile_event.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_event.dart
@@ -38,3 +38,12 @@ final class MyProfileSubscriptionRequested extends MyProfileEvent {
 final class MyProfileFetchRequested extends MyProfileEvent {
   const MyProfileFetchRequested();
 }
+
+/// Event triggered to fetch verifier-confirmed NIP-39 identity claims for
+/// the currently loaded profile.
+///
+/// Auto-dispatched after a successful profile load. Falls back to an empty
+/// claim list if the verifier is unreachable or returns an error.
+final class VerifiedClaimsRequested extends MyProfileEvent {
+  const VerifiedClaimsRequested();
+}

--- a/mobile/lib/blocs/my_profile/my_profile_state.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_state.dart
@@ -55,6 +55,7 @@ final class MyProfileLoaded extends MyProfileState {
     required this.isFresh,
     this.extractedUsername,
     this.externalNip05,
+    this.verifiedClaims = const [],
   });
 
   /// The loaded user profile.
@@ -75,12 +76,27 @@ final class MyProfileLoaded extends MyProfileState {
   /// Null if the NIP-05 is a divine.video/openvine.co domain or not set.
   final String? externalNip05;
 
+  /// Verifier-confirmed NIP-39 identity claims for this profile. Empty until
+  /// [VerifiedClaimsRequested] resolves; stays empty if the verifier fails.
+  final List<IdentityClaim> verifiedClaims;
+
+  /// Returns a copy of this state with the given fields replaced.
+  MyProfileLoaded copyWith({List<IdentityClaim>? verifiedClaims}) =>
+      MyProfileLoaded(
+        profile: profile,
+        isFresh: isFresh,
+        extractedUsername: extractedUsername,
+        externalNip05: externalNip05,
+        verifiedClaims: verifiedClaims ?? this.verifiedClaims,
+      );
+
   @override
   List<Object?> get props => [
     profile,
     isFresh,
     extractedUsername,
     externalNip05,
+    verifiedClaims,
   ];
 }
 
@@ -94,6 +110,7 @@ final class MyProfileUpdated extends MyProfileState {
     required this.profile,
     this.extractedUsername,
     this.externalNip05,
+    this.verifiedClaims = const [],
   });
 
   /// The current user profile from the local database.
@@ -105,8 +122,25 @@ final class MyProfileUpdated extends MyProfileState {
   /// External NIP-05 identifier (e.g., `alice@example.com`).
   final String? externalNip05;
 
+  /// Verifier-confirmed NIP-39 identity claims for this profile.
+  final List<IdentityClaim> verifiedClaims;
+
+  /// Returns a copy of this state with the given fields replaced.
+  MyProfileUpdated copyWith({List<IdentityClaim>? verifiedClaims}) =>
+      MyProfileUpdated(
+        profile: profile,
+        extractedUsername: extractedUsername,
+        externalNip05: externalNip05,
+        verifiedClaims: verifiedClaims ?? this.verifiedClaims,
+      );
+
   @override
-  List<Object?> get props => [profile, extractedUsername, externalNip05];
+  List<Object?> get props => [
+    profile,
+    extractedUsername,
+    externalNip05,
+    verifiedClaims,
+  ];
 }
 
 /// Error state when profile loading fails.

--- a/mobile/lib/blocs/other_profile/other_profile_bloc.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_bloc.dart
@@ -31,21 +31,25 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
     required ContentBlocklistRepository contentBlocklistRepository,
     required String currentUserPubkey,
     required FollowRepository followRepository,
+    IdentityClaimsRepository? identityClaimsRepository,
   }) : _profileRepository = profileRepository,
        _blocklistRepository = contentBlocklistRepository,
        _currentUserPubkey = currentUserPubkey,
        _followRepository = followRepository,
+       _identityClaimsRepository = identityClaimsRepository,
        super(const OtherProfileInitial()) {
     on<OtherProfileLoadRequested>(_onLoadRequested);
     on<OtherProfileRefreshRequested>(_onRefreshRequested);
     on<OtherProfileBlockRequested>(_onBlockRequested);
     on<OtherProfileUnblockRequested>(_onUnblockRequested);
+    on<VerifiedClaimsRequested>(_onVerifiedClaimsRequested);
   }
 
   final ProfileRepository _profileRepository;
   final ContentBlocklistRepository _blocklistRepository;
   final String _currentUserPubkey;
   final FollowRepository _followRepository;
+  final IdentityClaimsRepository? _identityClaimsRepository;
 
   /// The pubkey of the profile being viewed.
   final String pubkey;
@@ -72,8 +76,10 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
       );
       if (freshProfile != null) {
         emit(OtherProfileLoaded(profile: freshProfile, isFresh: true));
+        add(const VerifiedClaimsRequested());
       } else if (cachedProfile != null) {
         emit(OtherProfileLoaded(profile: cachedProfile, isFresh: false));
+        add(const VerifiedClaimsRequested());
       } else {
         emit(
           const OtherProfileError(errorType: OtherProfileErrorType.notFound),
@@ -82,6 +88,7 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
     } catch (e) {
       if (cachedProfile != null) {
         emit(OtherProfileLoaded(profile: cachedProfile, isFresh: false));
+        add(const VerifiedClaimsRequested());
       } else {
         emit(
           const OtherProfileError(
@@ -110,6 +117,7 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
       );
       if (freshProfile != null) {
         emit(OtherProfileLoaded(profile: freshProfile, isFresh: true));
+        add(const VerifiedClaimsRequested());
       } else {
         emit(
           OtherProfileError(
@@ -121,12 +129,46 @@ class OtherProfileBloc extends Bloc<OtherProfileEvent, OtherProfileState> {
     } catch (e) {
       if (currentProfile != null) {
         emit(OtherProfileLoaded(profile: currentProfile, isFresh: false));
+        add(const VerifiedClaimsRequested());
       } else {
         emit(
           const OtherProfileError(
             errorType: OtherProfileErrorType.networkError,
           ),
         );
+      }
+    }
+  }
+
+  Future<void> _onVerifiedClaimsRequested(
+    VerifiedClaimsRequested event,
+    Emitter<OtherProfileState> emit,
+  ) async {
+    final repo = _identityClaimsRepository;
+    if (repo == null) return;
+
+    final current = state;
+    if (current is! OtherProfileLoaded) return;
+    final profile = current.profile;
+
+    try {
+      final claims = await repo.verifiedClaims(
+        pubkey: profile.pubkey,
+        tags: profile.rawTags,
+      );
+      final latest = state;
+      if (latest is OtherProfileLoaded &&
+          latest.profile.pubkey == profile.pubkey) {
+        emit(latest.copyWith(verifiedClaims: claims));
+      }
+    } on Exception catch (e, stackTrace) {
+      // Verifier failures are expected (network/4xx/5xx/timeout). Per
+      // .claude/rules/error_handling.md they are NOT Reportable.
+      addError(e, stackTrace);
+      final latest = state;
+      if (latest is OtherProfileLoaded &&
+          latest.profile.pubkey == profile.pubkey) {
+        emit(latest.copyWith(verifiedClaims: const []));
       }
     }
   }

--- a/mobile/lib/blocs/other_profile/other_profile_event.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_event.dart
@@ -46,3 +46,12 @@ final class OtherProfileBlockRequested extends OtherProfileEvent {
 final class OtherProfileUnblockRequested extends OtherProfileEvent {
   const OtherProfileUnblockRequested();
 }
+
+/// Event triggered to fetch verifier-confirmed NIP-39 identity claims for
+/// the currently loaded profile.
+///
+/// Auto-dispatched after a successful profile load. Falls back to an empty
+/// claim list if the verifier is unreachable or returns an error.
+final class VerifiedClaimsRequested extends OtherProfileEvent {
+  const VerifiedClaimsRequested();
+}

--- a/mobile/lib/blocs/other_profile/other_profile_state.dart
+++ b/mobile/lib/blocs/other_profile/other_profile_state.dart
@@ -39,7 +39,11 @@ final class OtherProfileLoading extends OtherProfileState {
 
 /// Successfully loaded profile state.
 final class OtherProfileLoaded extends OtherProfileState {
-  const OtherProfileLoaded({required this.profile, required this.isFresh});
+  const OtherProfileLoaded({
+    required this.profile,
+    required this.isFresh,
+    this.verifiedClaims = const [],
+  });
 
   /// The loaded user profile.
   final UserProfile profile;
@@ -48,8 +52,20 @@ final class OtherProfileLoaded extends OtherProfileState {
   /// or loaded from cache (false).
   final bool isFresh;
 
+  /// Verifier-confirmed NIP-39 identity claims for this profile. Empty until
+  /// [VerifiedClaimsRequested] resolves; stays empty if the verifier fails.
+  final List<IdentityClaim> verifiedClaims;
+
+  /// Returns a copy of this state with the given fields replaced.
+  OtherProfileLoaded copyWith({List<IdentityClaim>? verifiedClaims}) =>
+      OtherProfileLoaded(
+        profile: profile,
+        isFresh: isFresh,
+        verifiedClaims: verifiedClaims ?? this.verifiedClaims,
+      );
+
   @override
-  List<Object?> get props => [profile, isFresh];
+  List<Object?> get props => [profile, isFresh, verifiedClaims];
 }
 
 /// Error state - may still contain cached profile to display.

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3616,5 +3616,13 @@
   "badgesIssuedEmptySubtitle": "Badges you issue will show acceptance status here.",
   "badgesIssuedNoRecipients": "No recipients found for this award.",
   "badgesRecipientAcceptedStatus": "Accepted by recipient",
-  "badgesRecipientWaitingStatus": "Waiting for recipient"
+  "badgesRecipientWaitingStatus": "Waiting for recipient",
+  "verifiedAccountChipSemanticLabel": "Verified {platform} account: {identity}",
+  "@verifiedAccountChipSemanticLabel": {
+    "description": "Screen reader label for a verified-account chip on a user's profile.",
+    "placeholders": {
+      "platform": { "type": "String" },
+      "identity": { "type": "String" }
+    }
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -11943,6 +11943,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Waiting for recipient'**
   String get badgesRecipientWaitingStatus;
+
+  /// Screen reader label for a verified-account chip on a user's profile.
+  ///
+  /// In en, this message translates to:
+  /// **'Verified {platform} account: {identity}'**
+  String verifiedAccountChipSemanticLabel(String platform, String identity);
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6627,4 +6627,9 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6708,4 +6708,9 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6847,4 +6847,9 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6846,4 +6846,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6763,4 +6763,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6837,4 +6837,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6860,4 +6860,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6742,4 +6742,9 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6831,4 +6831,9 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -6516,4 +6516,9 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -6540,4 +6540,9 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6799,4 +6799,9 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6913,4 +6913,9 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6807,4 +6807,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6924,4 +6924,9 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6766,4 +6766,9 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6747,4 +6747,9 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get badgesRecipientWaitingStatus => 'Waiting for recipient';
+
+  @override
+  String verifiedAccountChipSemanticLabel(String platform, String identity) {
+    return 'Verified $platform account: $identity';
+  }
 }

--- a/mobile/lib/models/environment_config.dart
+++ b/mobile/lib/models/environment_config.dart
@@ -97,6 +97,11 @@ class EnvironmentConfig {
     return url;
   }
 
+  /// Base URL for the Divine identity verification service
+  /// (verifier.divine.video). Single host across all environments — the
+  /// service is not part of local_stack.
+  String get verifierBaseUrl => 'https://verifier.divine.video';
+
   /// Get blossom media server URL
   String get blossomUrl {
     if (environment == AppEnvironment.local) {

--- a/mobile/lib/providers/app_providers.dart
+++ b/mobile/lib/providers/app_providers.dart
@@ -1748,6 +1748,23 @@ ProfileRepository? profileRepository(Ref ref) {
   return repo;
 }
 
+/// Provider for [VerifierClient] pointed at the current environment's
+/// verifier base URL. Stateless — every call hits the network.
+@Riverpod(keepAlive: true)
+VerifierClient verifierClient(Ref ref) {
+  final env = ref.watch(currentEnvironmentProvider);
+  return VerifierClient(baseUrl: env.verifierBaseUrl);
+}
+
+/// Provider for [IdentityClaimsRepository] composing the verifier client
+/// with NIP-39 i tag parsing.
+@Riverpod(keepAlive: true)
+IdentityClaimsRepository identityClaimsRepository(Ref ref) {
+  return IdentityClaimsRepository(
+    verifierClient: ref.watch(verifierClientProvider),
+  );
+}
+
 /// Enhanced notification service with Nostr integration (lazy loaded)
 @riverpod
 NotificationServiceEnhanced notificationServiceEnhanced(Ref ref) {

--- a/mobile/lib/providers/app_providers.g.dart
+++ b/mobile/lib/providers/app_providers.g.dart
@@ -3320,6 +3320,111 @@ final class ProfileRepositoryProvider
 
 String _$profileRepositoryHash() => r'150346c88eeee57501b7dfac4c5e5904d99f0e56';
 
+/// Provider for [VerifierClient] pointed at the current environment's
+/// verifier base URL. Stateless — every call hits the network.
+
+@ProviderFor(verifierClient)
+const verifierClientProvider = VerifierClientProvider._();
+
+/// Provider for [VerifierClient] pointed at the current environment's
+/// verifier base URL. Stateless — every call hits the network.
+
+final class VerifierClientProvider
+    extends $FunctionalProvider<VerifierClient, VerifierClient, VerifierClient>
+    with $Provider<VerifierClient> {
+  /// Provider for [VerifierClient] pointed at the current environment's
+  /// verifier base URL. Stateless — every call hits the network.
+  const VerifierClientProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'verifierClientProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$verifierClientHash();
+
+  @$internal
+  @override
+  $ProviderElement<VerifierClient> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  VerifierClient create(Ref ref) {
+    return verifierClient(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(VerifierClient value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<VerifierClient>(value),
+    );
+  }
+}
+
+String _$verifierClientHash() => r'1d6966c5483814cd7fa203e7e9e198dc5c9c232d';
+
+/// Provider for [IdentityClaimsRepository] composing the verifier client
+/// with NIP-39 i tag parsing.
+
+@ProviderFor(identityClaimsRepository)
+const identityClaimsRepositoryProvider = IdentityClaimsRepositoryProvider._();
+
+/// Provider for [IdentityClaimsRepository] composing the verifier client
+/// with NIP-39 i tag parsing.
+
+final class IdentityClaimsRepositoryProvider
+    extends
+        $FunctionalProvider<
+          IdentityClaimsRepository,
+          IdentityClaimsRepository,
+          IdentityClaimsRepository
+        >
+    with $Provider<IdentityClaimsRepository> {
+  /// Provider for [IdentityClaimsRepository] composing the verifier client
+  /// with NIP-39 i tag parsing.
+  const IdentityClaimsRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'identityClaimsRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$identityClaimsRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<IdentityClaimsRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  IdentityClaimsRepository create(Ref ref) {
+    return identityClaimsRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(IdentityClaimsRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<IdentityClaimsRepository>(value),
+    );
+  }
+}
+
+String _$identityClaimsRepositoryHash() =>
+    r'451c65b551cddcf8cf2ef3d23ac862ab0ae1441d';
+
 /// Enhanced notification service with Nostr integration (lazy loaded)
 
 @ProviderFor(notificationServiceEnhanced)

--- a/mobile/lib/screens/other_profile_screen.dart
+++ b/mobile/lib/screens/other_profile_screen.dart
@@ -84,6 +84,9 @@ class OtherProfileScreen extends ConsumerWidget {
     final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
     final nostrClient = ref.watch(nostrServiceProvider);
     final followRepository = ref.watch(followRepositoryProvider);
+    final identityClaimsRepository = ref.watch(
+      identityClaimsRepositoryProvider,
+    );
 
     return BlocProvider(
       create: (context) => OtherProfileBloc(
@@ -92,6 +95,7 @@ class OtherProfileScreen extends ConsumerWidget {
         contentBlocklistRepository: blocklistRepository,
         currentUserPubkey: nostrClient.publicKey,
         followRepository: followRepository,
+        identityClaimsRepository: identityClaimsRepository,
       )..add(const OtherProfileLoadRequested()),
       child: OtherProfileView(
         pubkey: pubkey,

--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -116,6 +116,9 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
     if (isOwnProfileGrid) {
       final userIdHex = ref.read(authServiceProvider).currentPublicKeyHex;
       final profileRepository = ref.watch(profileRepositoryProvider);
+      final identityClaimsRepository = ref.watch(
+        identityClaimsRepositoryProvider,
+      );
 
       if (userIdHex == null || profileRepository == null) {
         return const _ProfileScaffold(body: ProfileLoadingView());
@@ -126,6 +129,7 @@ class _ProfileScreenRouterState extends ConsumerState<ProfileScreenRouter>
             MyProfileBloc(
                 profileRepository: profileRepository,
                 pubkey: userIdHex,
+                identityClaimsRepository: identityClaimsRepository,
               )
               ..add(const MyProfileSubscriptionRequested())
               ..add(const MyProfileFetchRequested()),

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -72,6 +72,9 @@ class ProfileSetupScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final profileRepository = ref.watch(profileRepositoryProvider);
     final authService = ref.watch(authServiceProvider);
+    final identityClaimsRepository = ref.watch(
+      identityClaimsRepositoryProvider,
+    );
 
     final pubkey = authService.currentPublicKeyHex;
 
@@ -94,6 +97,7 @@ class ProfileSetupScreen extends ConsumerWidget {
             final bloc = MyProfileBloc(
               profileRepository: profileRepository,
               pubkey: pubkey,
+              identityClaimsRepository: identityClaimsRepository,
             );
             if (!isNewUser) bloc.add(const MyProfileLoadRequested());
             return bloc;

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -27,7 +27,9 @@ import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:openvine/utils/user_profile_utils.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
 import 'package:openvine/widgets/profile/nostr_info_sheet_content.dart';
+import 'package:openvine/widgets/profile/verified_accounts_row.dart';
 import 'package:openvine/widgets/user_avatar.dart';
+import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -766,6 +768,8 @@ class _ProfileSetupScreenViewState
                                 onChanged: (_) => setState(() {}),
                               ),
                               const SizedBox(height: 16),
+
+                              const _VerifiedAccountsSection(),
 
                               const _PublicKeyLink(),
                               const SizedBox(height: 16),
@@ -2241,6 +2245,25 @@ class _PublicKeyLink extends StatelessWidget {
           style: VineTheme.labelMediumFont(color: VineTheme.primary),
         ),
       ),
+    );
+  }
+}
+
+class _VerifiedAccountsSection extends StatelessWidget {
+  const _VerifiedAccountsSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final claims = context.select<MyProfileBloc, List<IdentityClaim>>((bloc) {
+      final state = bloc.state;
+      if (state is MyProfileLoaded) return state.verifiedClaims;
+      if (state is MyProfileUpdated) return state.verifiedClaims;
+      return const [];
+    });
+    if (claims.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: VerifiedAccountsRow(claims: claims),
     );
   }
 }

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -11,6 +11,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
+import 'package:openvine/blocs/other_profile/other_profile_bloc.dart';
 import 'package:openvine/features/people_lists/view/people_list_membership_indicator.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -29,9 +30,11 @@ import 'package:openvine/utils/user_profile_utils.dart';
 import 'package:openvine/widgets/profile/profile_action_buttons_widget.dart';
 import 'package:openvine/widgets/profile/profile_actions_sheet/profile_actions_sheet.dart';
 import 'package:openvine/widgets/profile/profile_stats_row_widget.dart';
+import 'package:openvine/widgets/profile/verified_accounts_row.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
+import 'package:profile_repository/profile_repository.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 /// Profile header widget displaying avatar, stats, name, and bio.
@@ -393,8 +396,52 @@ class _ProfileNameAndBio extends StatelessWidget {
           const SizedBox(height: 16),
           _AboutText(about: about!),
         ],
+        _VerifiedAccountsBlock(isOwnProfile: isOwnProfile),
       ],
     );
+  }
+}
+
+class _VerifiedAccountsBlock extends StatelessWidget {
+  const _VerifiedAccountsBlock({required this.isOwnProfile});
+
+  final bool isOwnProfile;
+
+  @override
+  Widget build(BuildContext context) {
+    final claims = isOwnProfile
+        ? _readMyClaims(context)
+        : _readOtherClaims(context);
+    if (claims.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(top: 12),
+      child: VerifiedAccountsRow(claims: claims),
+    );
+  }
+
+  static List<IdentityClaim> _readMyClaims(BuildContext context) {
+    try {
+      return context.select<MyProfileBloc, List<IdentityClaim>>((bloc) {
+        final state = bloc.state;
+        if (state is MyProfileLoaded) return state.verifiedClaims;
+        if (state is MyProfileUpdated) return state.verifiedClaims;
+        return const [];
+      });
+    } on ProviderNotFoundException {
+      return const [];
+    }
+  }
+
+  static List<IdentityClaim> _readOtherClaims(BuildContext context) {
+    try {
+      return context.select<OtherProfileBloc, List<IdentityClaim>>((bloc) {
+        final state = bloc.state;
+        if (state is OtherProfileLoaded) return state.verifiedClaims;
+        return const [];
+      });
+    } on ProviderNotFoundException {
+      return const [];
+    }
   }
 }
 

--- a/mobile/lib/widgets/profile/verified_account_chip.dart
+++ b/mobile/lib/widgets/profile/verified_account_chip.dart
@@ -1,0 +1,100 @@
+// ABOUTME: VerifiedAccountChip — single chip for one verified identity claim.
+// ABOUTME: Tapping opens the platform profile in the system browser.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:profile_repository/profile_repository.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Pluggable URL launcher for tests.
+typedef ChipUrlLauncher = Future<bool> Function(Uri uri);
+
+Future<bool> _defaultLauncher(Uri uri) =>
+    launchUrl(uri, mode: LaunchMode.externalApplication);
+
+/// Chip rendering a single verified [IdentityClaim].
+///
+/// Tapping opens the platform profile via [launchUrl] (override [launcher] in
+/// tests). Platforms without a clean public URL fall through to the verifier
+/// lookup page.
+class VerifiedAccountChip extends StatelessWidget {
+  /// Creates a chip for [claim]. [launcher] defaults to the system browser.
+  const VerifiedAccountChip({
+    required this.claim,
+    super.key,
+    this.launcher = _defaultLauncher,
+  });
+
+  /// The verified claim this chip represents.
+  final IdentityClaim claim;
+
+  /// URL launcher hook for tests.
+  final ChipUrlLauncher launcher;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final url = _platformUrl(claim);
+    return Semantics(
+      button: true,
+      label: l10n.verifiedAccountChipSemanticLabel(
+        claim.platform,
+        claim.identity,
+      ),
+      child: Material(
+        color: VineTheme.surfaceBackground,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+          side: const BorderSide(color: VineTheme.neutral10),
+        ),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(16),
+          onTap: () => launcher(Uri.parse(url)),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.public, size: 14, color: VineTheme.lightText),
+                const SizedBox(width: 6),
+                Text(
+                  '${claim.platform}/${claim.identity}',
+                  style: VineTheme.labelMediumFont(),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Builds an external URL for [claim].
+///
+/// Platforms with a stable public profile URL (`github`, `twitter`, `bluesky`,
+/// `youtube`, `tiktok`) get a direct link. Everything else (mastodon, discord,
+/// telegram, unknown) routes through the verifier lookup page so the
+/// verifier itself can resolve the canonical URL.
+String _platformUrl(IdentityClaim claim) {
+  switch (claim.platform.toLowerCase()) {
+    case 'github':
+      return 'https://github.com/${claim.identity}';
+    case 'twitter':
+      return 'https://twitter.com/${claim.identity}';
+    case 'bluesky':
+      return 'https://bsky.app/profile/${claim.identity}';
+    case 'youtube':
+      return 'https://youtube.com/@${claim.identity}';
+    case 'tiktok':
+      return 'https://tiktok.com/@${claim.identity}';
+    case 'mastodon':
+    case 'discord':
+    case 'telegram':
+    default:
+      return 'https://verifier.divine.video/u'
+          '?platform=${claim.platform}'
+          '&identity=${Uri.encodeComponent(claim.identity)}';
+  }
+}

--- a/mobile/lib/widgets/profile/verified_account_chip.dart
+++ b/mobile/lib/widgets/profile/verified_account_chip.dart
@@ -1,5 +1,5 @@
 // ABOUTME: VerifiedAccountChip — single chip for one verified identity claim.
-// ABOUTME: Tapping opens the platform profile in the system browser.
+// ABOUTME: Tapping opens the linked platform profile in the system browser.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';

--- a/mobile/lib/widgets/profile/verified_accounts_row.dart
+++ b/mobile/lib/widgets/profile/verified_accounts_row.dart
@@ -1,0 +1,28 @@
+// ABOUTME: VerifiedAccountsRow — wraps verified-account chips under a profile.
+
+import 'package:flutter/material.dart';
+import 'package:openvine/widgets/profile/verified_account_chip.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+/// Wrap of [VerifiedAccountChip]s for a profile's verified identity claims.
+///
+/// Renders nothing when [claims] is empty.
+class VerifiedAccountsRow extends StatelessWidget {
+  /// Creates a [VerifiedAccountsRow] for [claims].
+  const VerifiedAccountsRow({required this.claims, super.key});
+
+  /// The verified claims to render. Each becomes one [VerifiedAccountChip].
+  final List<IdentityClaim> claims;
+
+  @override
+  Widget build(BuildContext context) {
+    if (claims.isEmpty) return const SizedBox.shrink();
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        for (final c in claims) VerifiedAccountChip(claim: c),
+      ],
+    );
+  }
+}

--- a/mobile/packages/models/lib/src/user_profile.dart
+++ b/mobile/packages/models/lib/src/user_profile.dart
@@ -32,6 +32,7 @@ class UserProfile {
     this.nip05,
     this.lud16,
     this.lud06,
+    this.rawTags = const [],
   });
 
   /// Create UserProfile from a Nostr kind 0 event
@@ -58,6 +59,9 @@ class UserProfile {
         lud16: content['lud16']?.toString(),
         lud06: content['lud06']?.toString(),
         rawData: content,
+        rawTags: List<List<String>>.unmodifiable(
+          event.tags.map(List<String>.unmodifiable),
+        ),
         createdAt: event.createdAtDateTime,
         eventId: event.id,
       );
@@ -73,24 +77,35 @@ class UserProfile {
   }
 
   /// Create profile from JSON
-  factory UserProfile.fromJson(Map<String, dynamic> json) => UserProfile(
-    pubkey: json['pubkey'] as String,
-    name: json['name'] as String?,
-    displayName: json['display_name'] as String?,
-    about: json['about'] as String?,
-    picture: json['picture'] as String?,
-    banner: json['banner'] as String?,
-    website: json['website'] as String?,
-    nip05: json['nip05'] as String?,
-    lud16: json['lud16'] as String?,
-    lud06: json['lud06'] as String?,
-    rawData: json['raw_data'] as Map<String, dynamic>? ?? {},
-    createdAt: DateTime.fromMillisecondsSinceEpoch(
-      json['created_at'] as int,
-      isUtc: true,
-    ),
-    eventId: json['event_id'] as String,
-  );
+  factory UserProfile.fromJson(Map<String, dynamic> json) {
+    final rawTagsJson = json['raw_tags'] as List<dynamic>?;
+    final parsedRawTags = rawTagsJson == null
+        ? const <List<String>>[]
+        : List<List<String>>.unmodifiable(
+            rawTagsJson.cast<List<dynamic>>().map(
+              (tag) => List<String>.unmodifiable(tag.cast<String>()),
+            ),
+          );
+    return UserProfile(
+      pubkey: json['pubkey'] as String,
+      name: json['name'] as String?,
+      displayName: json['display_name'] as String?,
+      about: json['about'] as String?,
+      picture: json['picture'] as String?,
+      banner: json['banner'] as String?,
+      website: json['website'] as String?,
+      nip05: json['nip05'] as String?,
+      lud16: json['lud16'] as String?,
+      lud06: json['lud06'] as String?,
+      rawData: json['raw_data'] as Map<String, dynamic>? ?? {},
+      rawTags: parsedRawTags,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(
+        json['created_at'] as int,
+        isUtc: true,
+      ),
+      eventId: json['event_id'] as String,
+    );
+  }
 
   /// Creates a [UserProfile] from a typed [UserProfileFound] result.
   ///
@@ -160,6 +175,13 @@ class UserProfile {
   final Map<String, dynamic> rawData;
   final DateTime createdAt;
   final String eventId;
+
+  /// Raw tags from the source kind 0 event, preserved for callers that need
+  /// to inspect them (e.g. NIP-39 `i` identity claim parsing).
+  ///
+  /// Defaults to an empty list when the profile was constructed from a source
+  /// that doesn't carry tags (REST API, Drift cache row, malformed event).
+  final List<List<String>> rawTags;
 
   /// Get shortened pubkey for display
   String get shortPubkey {
@@ -379,6 +401,7 @@ class UserProfile {
     'created_at': createdAt.millisecondsSinceEpoch,
     'event_id': eventId,
     'raw_data': rawData,
+    'raw_tags': rawTags,
   };
 
   /// Create copy with updated fields
@@ -393,6 +416,7 @@ class UserProfile {
     String? lud16,
     String? lud06,
     Map<String, dynamic>? rawData,
+    List<List<String>>? rawTags,
   }) => UserProfile(
     pubkey: pubkey,
     name: name ?? this.name,
@@ -405,6 +429,7 @@ class UserProfile {
     lud16: lud16 ?? this.lud16,
     lud06: lud06 ?? this.lud06,
     rawData: rawData ?? this.rawData,
+    rawTags: rawTags ?? this.rawTags,
     createdAt: createdAt,
     eventId: eventId,
   );

--- a/mobile/packages/models/test/src/user_profile_test.dart
+++ b/mobile/packages/models/test/src/user_profile_test.dart
@@ -175,6 +175,65 @@ void main() {
         expect(profile.rawData['custom_field'], equals('custom_value'));
         expect(profile.rawData['nested'], equals({'key': 'value'}));
       });
+
+      test('preserves event tags as rawTags', () {
+        final event = Event(
+          testPubkey,
+          EventKind.metadata,
+          [
+            ['i', 'github:octocat', 'abc123'],
+            ['i', 'twitter:elonmusk', 'def456'],
+            ['p', 'somepubkey'],
+          ],
+          jsonEncode({'name': 'alice'}),
+          createdAt: 1704067200,
+        )..id = testEventId;
+
+        final profile = UserProfile.fromNostrEvent(event);
+
+        expect(profile.rawTags, hasLength(3));
+        expect(
+          profile.rawTags.first,
+          equals(['i', 'github:octocat', 'abc123']),
+        );
+        expect(
+          profile.rawTags[1],
+          equals(['i', 'twitter:elonmusk', 'def456']),
+        );
+      });
+
+      test('rawTags defaults to empty when JSON content is malformed', () {
+        final event = Event(
+          testPubkey,
+          EventKind.metadata,
+          [
+            ['i', 'github:octocat', 'abc'],
+          ],
+          'not-json',
+          createdAt: 1704067200,
+        )..id = testEventId;
+
+        final profile = UserProfile.fromNostrEvent(event);
+
+        // Malformed JSON falls through to the recovery branch which does not
+        // re-emit tags; callers needing tags should source them from a
+        // well-formed kind 0 event.
+        expect(profile.rawTags, isEmpty);
+      });
+
+      test('rawTags is empty when the event has no tags', () {
+        final event = Event(
+          testPubkey,
+          EventKind.metadata,
+          const [],
+          jsonEncode({'name': 'alice'}),
+          createdAt: 1704067200,
+        )..id = testEventId;
+
+        final profile = UserProfile.fromNostrEvent(event);
+
+        expect(profile.rawTags, isEmpty);
+      });
     });
 
     group('fromJson', () {

--- a/mobile/packages/profile_repository/lib/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/profile_repository.dart
@@ -3,6 +3,8 @@ library;
 
 export 'src/blocked_profile_filter.dart';
 export 'src/exceptions.dart';
+export 'src/identity_claim.dart';
+export 'src/identity_claims_repository.dart';
 export 'src/profile_repository.dart';
 export 'src/username_availability_result.dart';
 export 'src/username_claim_result.dart';

--- a/mobile/packages/profile_repository/lib/src/identity_claim.dart
+++ b/mobile/packages/profile_repository/lib/src/identity_claim.dart
@@ -1,0 +1,12 @@
+// ABOUTME: Re-exports verifier_client identity types so profile_repository
+// ABOUTME: callers have one cohesive surface for NIP-39 claims.
+
+export 'package:verifier_client/verifier_client.dart'
+    show
+        IdentityClaim,
+        VerificationResult,
+        VerifierApiException,
+        VerifierClient,
+        VerifierClientException,
+        VerifierNetworkException,
+        VerifierTimeoutException;

--- a/mobile/packages/profile_repository/lib/src/identity_claims_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/identity_claims_repository.dart
@@ -1,0 +1,75 @@
+// ABOUTME: IdentityClaimsRepository — composes VerifierClient with NIP-39
+// ABOUTME: i tag parsing off kind 0 events.
+
+import 'package:verifier_client/verifier_client.dart';
+
+/// Composes [VerifierClient] with NIP-39 `i` tag parsing off kind 0 events.
+class IdentityClaimsRepository {
+  /// Creates an [IdentityClaimsRepository] backed by [verifierClient].
+  IdentityClaimsRepository({required VerifierClient verifierClient})
+    : _verifierClient = verifierClient;
+
+  final VerifierClient _verifierClient;
+
+  /// Parses NIP-39 identity claims out of the given kind-0 event tag list.
+  ///
+  /// Filters to `['i', '<platform>:<identity>', '<proof>']` shape, skips
+  /// malformed entries, dedupes case-insensitively on `<platform>:<identity>`
+  /// (preferring the first occurrence — matches verifier UI behaviour at
+  /// `divine-identify-verification-service/src/index.ts:1784`), caps at
+  /// [VerifierClient.maxBatchSize] (10) so a single batch suffices.
+  static List<IdentityClaim> parseClaims(
+    String pubkey,
+    List<List<String>> tags,
+  ) {
+    final seen = <String>{};
+    final claims = <IdentityClaim>[];
+    for (final tag in tags) {
+      if (tag.isEmpty || tag[0] != 'i') continue;
+      if (tag.length < 3) continue;
+      final claimKey = tag[1];
+      final colon = claimKey.indexOf(':');
+      if (colon <= 0 || colon == claimKey.length - 1) continue;
+      final platform = claimKey.substring(0, colon);
+      final identity = claimKey.substring(colon + 1);
+      final dedupeKey = '$platform:$identity'.toLowerCase();
+      if (!seen.add(dedupeKey)) continue;
+      claims.add(
+        IdentityClaim(
+          pubkey: pubkey,
+          platform: platform,
+          identity: identity,
+          proof: tag[2],
+        ),
+      );
+      if (claims.length >= VerifierClient.maxBatchSize) break;
+    }
+    return claims;
+  }
+
+  /// Parses claims from [tags] and asks the verifier to re-check them. Returns
+  /// only the verified ones, preserving input order.
+  ///
+  /// Throws [VerifierClientException] subtypes — callers should catch and emit
+  /// empty / failure state without surfacing the message.
+  Future<List<IdentityClaim>> verifiedClaims({
+    required String pubkey,
+    required List<List<String>> tags,
+  }) async {
+    final claims = parseClaims(pubkey, tags);
+    if (claims.isEmpty) return const [];
+    final results = await _verifierClient.verifyBatch(claims);
+    final verifiedKeys = <String>{
+      for (final r in results)
+        if (r.verified)
+          '${r.platform.toLowerCase()}:${r.identity.toLowerCase()}',
+    };
+    return claims
+        .where(
+          (c) => verifiedKeys.contains(
+            '${c.platform.toLowerCase()}:${c.identity.toLowerCase()}',
+          ),
+        )
+        .toList();
+  }
+}

--- a/mobile/packages/profile_repository/pubspec.yaml
+++ b/mobile/packages/profile_repository/pubspec.yaml
@@ -27,3 +27,4 @@ dependencies:
   nostr_sdk:
   unified_logger:
     path: ../unified_logger
+  verifier_client:

--- a/mobile/packages/profile_repository/test/src/identity_claims_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/identity_claims_repository_test.dart
@@ -1,0 +1,189 @@
+// ABOUTME: Tests for IdentityClaimsRepository — parseClaims + verifiedClaims.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart' hide VerificationResult;
+import 'package:profile_repository/profile_repository.dart';
+
+class _MockVerifierClient extends Mock implements VerifierClient {}
+
+const _pubkey =
+    '1111111111111111111111111111111111111111111111111111111111111111';
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<IdentityClaim>[]);
+  });
+
+  group('IdentityClaimsRepository.parseClaims', () {
+    test('extracts well-formed i tags', () {
+      final tags = [
+        ['i', 'github:octocat', 'abc'],
+        ['i', 'twitter:elon', 'def'],
+      ];
+      final claims = IdentityClaimsRepository.parseClaims(_pubkey, tags);
+      expect(claims, hasLength(2));
+      expect(claims.first.platform, equals('github'));
+      expect(claims.first.identity, equals('octocat'));
+      expect(claims.first.proof, equals('abc'));
+    });
+
+    test('skips tags whose name is not "i"', () {
+      final tags = [
+        ['p', 'somepubkey'],
+        ['i', 'github:octocat', 'abc'],
+      ];
+      expect(
+        IdentityClaimsRepository.parseClaims(_pubkey, tags),
+        hasLength(1),
+      );
+    });
+
+    test('skips i tags without a platform:identity prefix', () {
+      final tags = [
+        ['i', 'no_colon_here', 'abc'],
+        ['i', '', 'abc'],
+        ['i', ':no_platform', 'abc'],
+        ['i', 'no_identity:', 'abc'],
+      ];
+      expect(IdentityClaimsRepository.parseClaims(_pubkey, tags), isEmpty);
+    });
+
+    test('skips i tags missing a proof', () {
+      final tags = [
+        ['i', 'github:octocat'],
+      ];
+      expect(IdentityClaimsRepository.parseClaims(_pubkey, tags), isEmpty);
+    });
+
+    test('skips empty tag entries', () {
+      final tags = [
+        <String>[],
+        ['i', 'github:octocat', 'abc'],
+      ];
+      expect(
+        IdentityClaimsRepository.parseClaims(_pubkey, tags),
+        hasLength(1),
+      );
+    });
+
+    test('dedupes by case-insensitive platform:identity, keeping first', () {
+      final tags = [
+        ['i', 'GitHub:Octocat', 'first'],
+        ['i', 'github:octocat', 'second'],
+      ];
+      final claims = IdentityClaimsRepository.parseClaims(_pubkey, tags);
+      expect(claims, hasLength(1));
+      expect(claims.single.proof, equals('first'));
+    });
+
+    test('caps the result at 10 to match server MAX_BATCH_SIZE', () {
+      final tags = List<List<String>>.generate(
+        15,
+        (i) => ['i', 'github:user$i', 'p$i'],
+      );
+      final claims = IdentityClaimsRepository.parseClaims(_pubkey, tags);
+      expect(claims, hasLength(10));
+    });
+
+    test('attaches the pubkey to each claim', () {
+      final tags = [
+        ['i', 'github:octocat', 'abc'],
+      ];
+      expect(
+        IdentityClaimsRepository.parseClaims(_pubkey, tags).single.pubkey,
+        equals(_pubkey),
+      );
+    });
+  });
+
+  group('IdentityClaimsRepository.verifiedClaims', () {
+    late _MockVerifierClient client;
+    late IdentityClaimsRepository repo;
+
+    setUp(() {
+      client = _MockVerifierClient();
+      repo = IdentityClaimsRepository(verifierClient: client);
+    });
+
+    test('returns only claims the verifier confirmed', () async {
+      when(() => client.verifyBatch(any())).thenAnswer(
+        (_) async => const [
+          VerificationResult(
+            platform: 'github',
+            identity: 'octocat',
+            verified: true,
+            checkedAt: 1,
+            cached: true,
+          ),
+          VerificationResult(
+            platform: 'twitter',
+            identity: 'fake',
+            verified: false,
+            checkedAt: 1,
+            cached: false,
+          ),
+        ],
+      );
+      final result = await repo.verifiedClaims(
+        pubkey: _pubkey,
+        tags: [
+          ['i', 'github:octocat', 'a'],
+          ['i', 'twitter:fake', 'b'],
+        ],
+      );
+      expect(result, hasLength(1));
+      expect(result.single.platform, equals('github'));
+    });
+
+    test('returns empty when there are no i tags', () async {
+      final result = await repo.verifiedClaims(
+        pubkey: _pubkey,
+        tags: const [
+          ['p', 'someone'],
+        ],
+      );
+      expect(result, isEmpty);
+      verifyNever(() => client.verifyBatch(any()));
+    });
+
+    test('case-insensitively matches verifier results to claims', () async {
+      // Verifier returns lowercase platform/identity even if claim used
+      // mixed case.
+      when(() => client.verifyBatch(any())).thenAnswer(
+        (_) async => const [
+          VerificationResult(
+            platform: 'github',
+            identity: 'octocat',
+            verified: true,
+            checkedAt: 1,
+            cached: true,
+          ),
+        ],
+      );
+      final result = await repo.verifiedClaims(
+        pubkey: _pubkey,
+        tags: [
+          ['i', 'GitHub:Octocat', 'a'],
+        ],
+      );
+      expect(result, hasLength(1));
+      expect(result.single.platform, equals('GitHub'));
+      expect(result.single.identity, equals('Octocat'));
+    });
+
+    test('propagates VerifierApiException', () async {
+      when(() => client.verifyBatch(any())).thenThrow(
+        const VerifierApiException(500, 'boom'),
+      );
+      await expectLater(
+        () => repo.verifiedClaims(
+          pubkey: _pubkey,
+          tags: [
+            ['i', 'github:octocat', 'abc'],
+          ],
+        ),
+        throwsA(isA<VerifierApiException>()),
+      );
+    });
+  });
+}

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -19,6 +19,9 @@ class MockEvent extends Mock implements Event {
   @override
   DateTime get createdAtDateTime =>
       DateTime.fromMillisecondsSinceEpoch(createdAt * 1000, isUtc: true);
+
+  @override
+  List<List<String>> get tags => const [];
 }
 
 class MockUserProfilesDao extends Mock implements UserProfilesDao {}

--- a/mobile/packages/verifier_client/README.md
+++ b/mobile/packages/verifier_client/README.md
@@ -1,0 +1,22 @@
+# verifier_client
+
+HTTP client for the Divine identity verification service at
+`https://verifier.divine.video`.
+
+This is a thin Dart client. It has no Nostr knowledge and no BLoC knowledge —
+upper layers (`profile_repository`'s `IdentityClaimsRepository`, the profile
+BLoCs, and the UI) compose it with their own logic.
+
+## Usage
+
+```dart
+final client = VerifierClient();
+final results = await client.verifyBatch([
+  IdentityClaim(
+    pubkey: pubkey,
+    platform: 'github',
+    identity: 'octocat',
+    proof: 'https://gist.github.com/octocat/...',
+  ),
+]);
+```

--- a/mobile/packages/verifier_client/analysis_options.yaml
+++ b/mobile/packages/verifier_client/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:very_good_analysis/analysis_options.yaml

--- a/mobile/packages/verifier_client/lib/src/exceptions.dart
+++ b/mobile/packages/verifier_client/lib/src/exceptions.dart
@@ -1,0 +1,40 @@
+// ABOUTME: Typed exceptions thrown by VerifierClient.
+
+/// Base class for all errors thrown by the verifier client.
+sealed class VerifierClientException implements Exception {
+  /// Creates a verifier exception with a human-readable [message].
+  const VerifierClientException(this.message, this.kind);
+
+  /// Free-form message describing the failure.
+  final String message;
+
+  /// Stable identifier for the exception subtype, safe for production logs.
+  final String kind;
+
+  @override
+  String toString() => '$kind: $message';
+}
+
+/// HTTP non-2xx response from the verifier.
+final class VerifierApiException extends VerifierClientException {
+  /// Creates a [VerifierApiException] with the response [statusCode].
+  const VerifierApiException(this.statusCode, String message)
+    : super(message, 'VerifierApiException');
+
+  /// The HTTP status code returned by the verifier.
+  final int statusCode;
+}
+
+/// Request did not complete within the configured timeout.
+final class VerifierTimeoutException extends VerifierClientException {
+  /// Creates a [VerifierTimeoutException] with [message].
+  const VerifierTimeoutException(String message)
+    : super(message, 'VerifierTimeoutException');
+}
+
+/// Network or transport error before a response could be read.
+final class VerifierNetworkException extends VerifierClientException {
+  /// Creates a [VerifierNetworkException] with [message].
+  const VerifierNetworkException(String message)
+    : super(message, 'VerifierNetworkException');
+}

--- a/mobile/packages/verifier_client/lib/src/models/identity_claim.dart
+++ b/mobile/packages/verifier_client/lib/src/models/identity_claim.dart
@@ -1,0 +1,48 @@
+// ABOUTME: IdentityClaim model — a single platform attestation request.
+// ABOUTME: Mirrors the verifier service's VerifyClaim payload shape.
+
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+/// A single claim that a Nostr pubkey owns an external identity on a
+/// supported platform.
+///
+/// Mirrors the verifier service's `VerifyClaim` shape in
+/// `divine-identify-verification-service/src/types.ts`.
+@immutable
+class IdentityClaim extends Equatable {
+  /// Creates an [IdentityClaim] for [pubkey] on [platform] with [identity]
+  /// and [proof].
+  const IdentityClaim({
+    required this.pubkey,
+    required this.platform,
+    required this.identity,
+    required this.proof,
+  });
+
+  /// 64-character lowercase hex pubkey.
+  final String pubkey;
+
+  /// Platform identifier — one of `github | twitter | mastodon |
+  /// telegram | bluesky | discord | youtube | tiktok` at the time of
+  /// writing. Forward-compatible: the verifier may add platforms.
+  final String platform;
+
+  /// Platform-specific user identifier (handle, account ID).
+  final String identity;
+
+  /// Proof material (URL, post ID, OAuth token reference, …) — opaque
+  /// to mobile.
+  final String proof;
+
+  /// Serializes this claim to the verifier API JSON shape.
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    'pubkey': pubkey,
+    'platform': platform,
+    'identity': identity,
+    'proof': proof,
+  };
+
+  @override
+  List<Object?> get props => [pubkey, platform, identity, proof];
+}

--- a/mobile/packages/verifier_client/lib/src/models/verification_result.dart
+++ b/mobile/packages/verifier_client/lib/src/models/verification_result.dart
@@ -1,0 +1,58 @@
+// ABOUTME: VerificationResult model — verifier API response per claim.
+
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+/// Result of asking the verifier to re-check a single identity claim.
+@immutable
+class VerificationResult extends Equatable {
+  /// Creates a [VerificationResult] from explicit fields.
+  const VerificationResult({
+    required this.platform,
+    required this.identity,
+    required this.verified,
+    required this.checkedAt,
+    required this.cached,
+    this.error,
+  });
+
+  /// Parses a [VerificationResult] from the verifier API JSON shape.
+  factory VerificationResult.fromJson(Map<String, dynamic> json) {
+    return VerificationResult(
+      platform: json['platform'] as String,
+      identity: json['identity'] as String,
+      verified: json['verified'] as bool,
+      checkedAt: json['checked_at'] as int,
+      cached: json['cached'] as bool? ?? false,
+      error: json['error'] as String?,
+    );
+  }
+
+  /// Platform identifier the result is for (e.g. `github`).
+  final String platform;
+
+  /// Platform-specific identity (handle, account ID).
+  final String identity;
+
+  /// Whether the verifier confirmed the claim.
+  final bool verified;
+
+  /// Unix epoch seconds when the verifier last checked the claim.
+  final int checkedAt;
+
+  /// True when the result was served from the verifier's KV cache.
+  final bool cached;
+
+  /// Free-form error string when [verified] is false. Not a stable key.
+  final String? error;
+
+  @override
+  List<Object?> get props => [
+    platform,
+    identity,
+    verified,
+    checkedAt,
+    cached,
+    error,
+  ];
+}

--- a/mobile/packages/verifier_client/lib/src/verifier_client.dart
+++ b/mobile/packages/verifier_client/lib/src/verifier_client.dart
@@ -1,0 +1,113 @@
+// ABOUTME: VerifierClient — HTTP client over verifier.divine.video.
+// ABOUTME: Stateless: every call hits the network; server owns freshness.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
+import 'package:verifier_client/src/exceptions.dart';
+import 'package:verifier_client/src/models/identity_claim.dart';
+import 'package:verifier_client/src/models/verification_result.dart';
+
+/// HTTP client for `https://verifier.divine.video`.
+///
+/// Stateless: every call hits the network. The verifier owns freshness via
+/// Cloudflare KV; intentionally no client-side cache, no retry, no rechecking.
+class VerifierClient {
+  /// Creates a [VerifierClient] pointed at [baseUrl].
+  ///
+  /// Pass an [httpClient] to inject a [http.Client] for testing. Pass
+  /// [timeout] to override the per-request timeout (default 10 seconds).
+  VerifierClient({
+    required String baseUrl,
+    http.Client? httpClient,
+    Duration timeout = const Duration(seconds: 10),
+  }) : _baseUrl = baseUrl.endsWith('/')
+           ? baseUrl.substring(0, baseUrl.length - 1)
+           : baseUrl,
+       _httpClient = httpClient ?? http.Client(),
+       _timeout = timeout;
+
+  /// Server-side cap from
+  /// `divine-identify-verification-service/src/routes/verify.ts:12`.
+  /// Keep this in sync if the service raises it.
+  static const int maxBatchSize = 10;
+
+  final String _baseUrl;
+  final http.Client _httpClient;
+  final Duration _timeout;
+
+  /// Re-verifies a batch of claims. Returns one result per input claim in the
+  /// order the verifier responds (typically input order).
+  ///
+  /// Returns an empty list when [claims] is empty without hitting the network.
+  ///
+  /// Throws:
+  /// * [ArgumentError] if [claims] has more than [maxBatchSize] items.
+  /// * [VerifierApiException] for any non-2xx response.
+  /// * [VerifierTimeoutException] if the request does not complete within the
+  ///   configured timeout.
+  /// * [VerifierNetworkException] for transport-level failures.
+  Future<List<VerificationResult>> verifyBatch(
+    List<IdentityClaim> claims,
+  ) async {
+    if (claims.isEmpty) return const [];
+    if (claims.length > maxBatchSize) {
+      throw ArgumentError.value(
+        claims.length,
+        'claims',
+        'must contain at most $maxBatchSize items',
+      );
+    }
+    final body = jsonEncode(<String, dynamic>{
+      'claims': claims.map((c) => c.toJson()).toList(),
+    });
+    final json = await _post('/verify', body);
+    final results = (json['results'] as List).cast<Map<String, dynamic>>();
+    return results.map(VerificationResult.fromJson).toList();
+  }
+
+  /// Re-verifies a single claim via `/verify/single`.
+  ///
+  /// Throws the same exceptions as [verifyBatch].
+  Future<VerificationResult> verifySingle(IdentityClaim claim) async {
+    final body = jsonEncode(claim.toJson());
+    final json = await _post('/verify/single', body);
+    return VerificationResult.fromJson(json);
+  }
+
+  Future<Map<String, dynamic>> _post(String path, String body) async {
+    final uri = Uri.parse('$_baseUrl$path');
+    try {
+      final res = await _httpClient
+          .post(
+            uri,
+            headers: const {'content-type': 'application/json'},
+            body: body,
+          )
+          .timeout(_timeout);
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        throw VerifierApiException(
+          res.statusCode,
+          'verifier returned ${res.statusCode}: ${res.body}',
+        );
+      }
+      return jsonDecode(res.body) as Map<String, dynamic>;
+    } on VerifierClientException {
+      rethrow;
+    } on TimeoutException catch (e) {
+      throw VerifierTimeoutException(e.toString());
+    } on SocketException catch (e) {
+      throw VerifierNetworkException(e.toString());
+    } on http.ClientException catch (e) {
+      throw VerifierNetworkException(e.toString());
+    }
+  }
+
+  /// Test hook returning the underlying [http.Client]. Do not use in
+  /// production code.
+  @visibleForTesting
+  http.Client get debugHttpClient => _httpClient;
+}

--- a/mobile/packages/verifier_client/lib/verifier_client.dart
+++ b/mobile/packages/verifier_client/lib/verifier_client.dart
@@ -1,0 +1,7 @@
+// ABOUTME: Public surface for the verifier_client package.
+// ABOUTME: HTTP client over https://verifier.divine.video.
+
+export 'src/exceptions.dart';
+export 'src/models/identity_claim.dart';
+export 'src/models/verification_result.dart';
+export 'src/verifier_client.dart';

--- a/mobile/packages/verifier_client/pubspec.yaml
+++ b/mobile/packages/verifier_client/pubspec.yaml
@@ -1,0 +1,19 @@
+name: verifier_client
+description: HTTP client for the Divine identity verification service (verifier.divine.video).
+version: 0.1.0+1
+publish_to: none
+
+environment:
+  sdk: ^3.11.0
+
+resolution: workspace
+
+dependencies:
+  equatable: ^2.0.8
+  http: ^1.4.0
+  meta: ^1.17.0
+
+dev_dependencies:
+  mocktail: ^1.0.4
+  test: ^1.26.3
+  very_good_analysis: ^10.0.0

--- a/mobile/packages/verifier_client/test/src/models/identity_claim_test.dart
+++ b/mobile/packages/verifier_client/test/src/models/identity_claim_test.dart
@@ -1,0 +1,58 @@
+// ABOUTME: Tests for the IdentityClaim model — JSON shape and equality.
+
+import 'package:test/test.dart';
+import 'package:verifier_client/verifier_client.dart';
+
+const _hex64 =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+void main() {
+  group(IdentityClaim, () {
+    test('encodes to verifier API JSON shape', () {
+      const claim = IdentityClaim(
+        pubkey: _hex64,
+        platform: 'github',
+        identity: 'octocat',
+        proof: 'abc123',
+      );
+      expect(claim.toJson(), {
+        'pubkey': _hex64,
+        'platform': 'github',
+        'identity': 'octocat',
+        'proof': 'abc123',
+      });
+    });
+
+    test('two claims with the same fields are equal', () {
+      const a = IdentityClaim(
+        pubkey: _hex64,
+        platform: 'github',
+        identity: 'octocat',
+        proof: 'abc123',
+      );
+      const b = IdentityClaim(
+        pubkey: _hex64,
+        platform: 'github',
+        identity: 'octocat',
+        proof: 'abc123',
+      );
+      expect(a, equals(b));
+    });
+
+    test('claims with different fields are not equal', () {
+      const a = IdentityClaim(
+        pubkey: _hex64,
+        platform: 'github',
+        identity: 'octocat',
+        proof: 'abc123',
+      );
+      const b = IdentityClaim(
+        pubkey: _hex64,
+        platform: 'twitter',
+        identity: 'octocat',
+        proof: 'abc123',
+      );
+      expect(a, isNot(equals(b)));
+    });
+  });
+}

--- a/mobile/packages/verifier_client/test/src/models/verification_result_test.dart
+++ b/mobile/packages/verifier_client/test/src/models/verification_result_test.dart
@@ -1,0 +1,50 @@
+// ABOUTME: Tests for the VerificationResult model — JSON parsing.
+
+import 'package:test/test.dart';
+import 'package:verifier_client/verifier_client.dart';
+
+void main() {
+  group(VerificationResult, () {
+    test('parses a verified result from JSON', () {
+      final json = <String, dynamic>{
+        'platform': 'github',
+        'identity': 'octocat',
+        'verified': true,
+        'checked_at': 1700000000,
+        'cached': true,
+      };
+      final result = VerificationResult.fromJson(json);
+      expect(result.verified, isTrue);
+      expect(result.platform, equals('github'));
+      expect(result.identity, equals('octocat'));
+      expect(result.cached, isTrue);
+      expect(result.checkedAt, equals(1700000000));
+      expect(result.error, isNull);
+    });
+
+    test('parses a failed result from JSON', () {
+      final json = <String, dynamic>{
+        'platform': 'twitter',
+        'identity': 'fake',
+        'verified': false,
+        'error': 'proof not found',
+        'checked_at': 1700000000,
+        'cached': false,
+      };
+      final result = VerificationResult.fromJson(json);
+      expect(result.verified, isFalse);
+      expect(result.error, equals('proof not found'));
+    });
+
+    test('defaults cached to false when missing', () {
+      final json = <String, dynamic>{
+        'platform': 'github',
+        'identity': 'octocat',
+        'verified': true,
+        'checked_at': 1700000000,
+      };
+      final result = VerificationResult.fromJson(json);
+      expect(result.cached, isFalse);
+    });
+  });
+}

--- a/mobile/packages/verifier_client/test/src/verifier_client_test.dart
+++ b/mobile/packages/verifier_client/test/src/verifier_client_test.dart
@@ -1,0 +1,203 @@
+// ABOUTME: VerifierClient tests — batch + single + error mapping + caps.
+
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+import 'package:verifier_client/verifier_client.dart';
+
+const _hex = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+IdentityClaim _claim({String platform = 'github'}) => IdentityClaim(
+  pubkey: _hex,
+  platform: platform,
+  identity: 'octocat',
+  proof: 'abc',
+);
+
+void main() {
+  group(VerifierClient, () {
+    group('verifyBatch', () {
+      test('returns parsed results on 200', () async {
+        final mock = MockClient((req) async {
+          expect(req.method, equals('POST'));
+          expect(
+            req.url.toString(),
+            equals('https://verifier.example/verify'),
+          );
+          final body = jsonDecode(req.body) as Map<String, dynamic>;
+          expect(body['claims'] as List, hasLength(1));
+          return http.Response(
+            jsonEncode({
+              'results': [
+                {
+                  'platform': 'github',
+                  'identity': 'octocat',
+                  'verified': true,
+                  'checked_at': 1,
+                  'cached': true,
+                },
+              ],
+            }),
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+
+        final client = VerifierClient(
+          baseUrl: 'https://verifier.example',
+          httpClient: mock,
+        );
+
+        final results = await client.verifyBatch([_claim()]);
+        expect(results, hasLength(1));
+        expect(results.single.verified, isTrue);
+      });
+
+      test('returns empty list when given empty input', () async {
+        final mock = MockClient((req) async {
+          fail('client should not hit the network for an empty batch');
+        });
+        final client = VerifierClient(
+          baseUrl: 'https://verifier.example',
+          httpClient: mock,
+        );
+        expect(await client.verifyBatch(const []), isEmpty);
+      });
+
+      test('throws VerifierApiException on 4xx', () async {
+        final mock = MockClient((_) async => http.Response('bad', 400));
+        final client = VerifierClient(
+          baseUrl: 'https://verifier.example',
+          httpClient: mock,
+        );
+        await expectLater(
+          () => client.verifyBatch([_claim()]),
+          throwsA(isA<VerifierApiException>()),
+        );
+      });
+
+      test('throws VerifierApiException on 429', () async {
+        final mock = MockClient((_) async => http.Response('rl', 429));
+        final client = VerifierClient(
+          baseUrl: 'https://verifier.example',
+          httpClient: mock,
+        );
+        await expectLater(
+          () => client.verifyBatch([_claim()]),
+          throwsA(
+            isA<VerifierApiException>().having(
+              (e) => e.statusCode,
+              'statusCode',
+              429,
+            ),
+          ),
+        );
+      });
+
+      test('throws VerifierApiException on 5xx', () async {
+        final mock = MockClient((_) async => http.Response('boom', 500));
+        final client = VerifierClient(
+          baseUrl: 'https://verifier.example',
+          httpClient: mock,
+        );
+        await expectLater(
+          () => client.verifyBatch([_claim()]),
+          throwsA(isA<VerifierApiException>()),
+        );
+      });
+
+      test('rejects batches over the server cap', () async {
+        final mock = MockClient((_) async {
+          fail('client should reject before hitting the network');
+        });
+        final client = VerifierClient(
+          baseUrl: 'https://verifier.example',
+          httpClient: mock,
+        );
+        final tooMany = List<IdentityClaim>.generate(11, (_) => _claim());
+        await expectLater(
+          () => client.verifyBatch(tooMany),
+          throwsArgumentError,
+        );
+      });
+
+      test('strips trailing slash from baseUrl', () async {
+        final mock = MockClient((req) async {
+          expect(
+            req.url.toString(),
+            equals('https://verifier.example/verify'),
+          );
+          return http.Response(
+            jsonEncode(<String, dynamic>{'results': <Object?>[]}),
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+        final client = VerifierClient(
+          baseUrl: 'https://verifier.example/',
+          httpClient: mock,
+        );
+        await client.verifyBatch([_claim()]);
+      });
+    });
+
+    group('verifySingle', () {
+      test('posts a flat object to /verify/single', () async {
+        final mock = MockClient((req) async {
+          expect(
+            req.url.toString(),
+            equals('https://verifier.example/verify/single'),
+          );
+          final body = jsonDecode(req.body) as Map<String, dynamic>;
+          expect(body['platform'], equals('github'));
+          expect(body['pubkey'], equals(_hex));
+          return http.Response(
+            jsonEncode({
+              'platform': 'github',
+              'identity': 'octocat',
+              'verified': true,
+              'checked_at': 1,
+              'cached': true,
+            }),
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+        final client = VerifierClient(
+          baseUrl: 'https://verifier.example',
+          httpClient: mock,
+        );
+        final result = await client.verifySingle(_claim());
+        expect(result.verified, isTrue);
+      });
+
+      test('throws VerifierApiException on non-2xx', () async {
+        final mock = MockClient((_) async => http.Response('boom', 503));
+        final client = VerifierClient(
+          baseUrl: 'https://verifier.example',
+          httpClient: mock,
+        );
+        await expectLater(
+          () => client.verifySingle(_claim()),
+          throwsA(isA<VerifierApiException>()),
+        );
+      });
+
+      test('maps ClientException to VerifierNetworkException', () async {
+        final mock = MockClient((_) async {
+          throw http.ClientException('boom');
+        });
+        final client = VerifierClient(
+          baseUrl: 'https://verifier.example',
+          httpClient: mock,
+        );
+        await expectLater(
+          () => client.verifySingle(_claim()),
+          throwsA(isA<VerifierNetworkException>()),
+        );
+      });
+    });
+  });
+}

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -66,6 +66,7 @@ workspace:
   - packages/time_formatter
   - packages/tv_static_effect
   - packages/unified_logger
+  - packages/verifier_client
   - packages/video_event_cache
   - packages/videos_repository
 
@@ -234,6 +235,9 @@ dependencies:
   # Logging
   logging: ^1.2.0
   unified_logger:
+
+  # Verifier Client - HTTP client for verifier.divine.video identity attestations
+  verifier_client:
 
   # Date formatting
   intl: ">=0.19.0 <1.0.0"

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -357,6 +357,7 @@ const _knownUntranslatedDebt = {
   'keyManagementYourPublicKeyLabel',
   'keyManagementCopyPublicKeyTooltip',
   'keyManagementPublicKeyCopied',
+  'verifiedAccountChipSemanticLabel',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/models/environment_config_test.dart
+++ b/mobile/test/models/environment_config_test.dart
@@ -207,6 +207,25 @@ void main() {
       );
     });
 
+    group('verifierBaseUrl', () {
+      test('production returns the verifier host', () {
+        const config = EnvironmentConfig(
+          environment: AppEnvironment.production,
+        );
+        expect(config.verifierBaseUrl, equals('https://verifier.divine.video'));
+      });
+
+      test('is the same across environments (no local stub)', () {
+        for (final env in AppEnvironment.values) {
+          final config = EnvironmentConfig(environment: env);
+          expect(
+            config.verifierBaseUrl,
+            equals('https://verifier.divine.video'),
+          );
+        }
+      });
+    });
+
     group('equality', () {
       test('same environment are equal', () {
         const config1 = EnvironmentConfig(environment: AppEnvironment.staging);

--- a/mobile/test/widgets/profile/verified_account_chip_test.dart
+++ b/mobile/test/widgets/profile/verified_account_chip_test.dart
@@ -1,0 +1,95 @@
+// ABOUTME: Widget tests for VerifiedAccountChip — render + tap launches URL.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/profile/verified_account_chip.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+const _hex64 =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+Widget _wrap(Widget child) => MaterialApp(
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: Scaffold(body: Center(child: child)),
+);
+
+void main() {
+  group(VerifiedAccountChip, () {
+    testWidgets('renders platform and identity text', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          VerifiedAccountChip(
+            claim: const IdentityClaim(
+              pubkey: _hex64,
+              platform: 'github',
+              identity: 'octocat',
+              proof: 'abc',
+            ),
+            launcher: (_) async => true,
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(find.textContaining('github'), findsOneWidget);
+      expect(find.textContaining('octocat'), findsOneWidget);
+    });
+
+    testWidgets('taps launch a github URL for github claims', (tester) async {
+      Uri? launched;
+      await tester.pumpWidget(
+        _wrap(
+          VerifiedAccountChip(
+            claim: const IdentityClaim(
+              pubkey: _hex64,
+              platform: 'github',
+              identity: 'octocat',
+              proof: 'abc',
+            ),
+            launcher: (uri) async {
+              launched = uri;
+              return true;
+            },
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.tap(find.byType(InkWell));
+      await tester.pumpAndSettle();
+      expect(launched.toString(), equals('https://github.com/octocat'));
+    });
+
+    testWidgets('mastodon claims route through verifier lookup', (
+      tester,
+    ) async {
+      Uri? launched;
+      await tester.pumpWidget(
+        _wrap(
+          VerifiedAccountChip(
+            claim: const IdentityClaim(
+              pubkey: _hex64,
+              platform: 'mastodon',
+              identity: 'fosstodon.org/@alice',
+              proof: 'abc',
+            ),
+            launcher: (uri) async {
+              launched = uri;
+              return true;
+            },
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.tap(find.byType(InkWell));
+      await tester.pumpAndSettle();
+      expect(launched, isNotNull);
+      expect(launched!.host, equals('verifier.divine.video'));
+      expect(launched!.queryParameters['platform'], equals('mastodon'));
+      expect(
+        launched!.queryParameters['identity'],
+        equals('fosstodon.org/@alice'),
+      );
+    });
+  });
+}

--- a/mobile/test/widgets/profile/verified_accounts_row_test.dart
+++ b/mobile/test/widgets/profile/verified_accounts_row_test.dart
@@ -1,0 +1,54 @@
+// ABOUTME: Widget tests for VerifiedAccountsRow — empty + multi-chip rendering.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/profile/verified_account_chip.dart';
+import 'package:openvine/widgets/profile/verified_accounts_row.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+const _hex64 =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+Widget _wrap(Widget child) => MaterialApp(
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: Scaffold(body: Center(child: child)),
+);
+
+void main() {
+  group(VerifiedAccountsRow, () {
+    testWidgets('renders no chips when claims is empty', (tester) async {
+      await tester.pumpWidget(
+        _wrap(const VerifiedAccountsRow(claims: [])),
+      );
+      await tester.pump();
+      expect(find.byType(VerifiedAccountChip), findsNothing);
+    });
+
+    testWidgets('renders one chip per claim', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          const VerifiedAccountsRow(
+            claims: [
+              IdentityClaim(
+                pubkey: _hex64,
+                platform: 'github',
+                identity: 'octocat',
+                proof: 'abc',
+              ),
+              IdentityClaim(
+                pubkey: _hex64,
+                platform: 'twitter',
+                identity: 'elon',
+                proof: 'def',
+              ),
+            ],
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(find.byType(VerifiedAccountChip), findsNWidgets(2));
+    });
+  });
+}


### PR DESCRIPTION
Closes #3933

## Summary
- Adds `verifier_client` package (HTTP client + models + exceptions) wrapping `https://verifier.divine.video`.
- Preserves raw event tags on `UserProfile` so `IdentityClaimsRepository` can parse NIP-39 `i` tags into `IdentityClaim` records and verify them via the verifier batch API.
- Wires the repository into `MyProfileBloc` and `OtherProfileBloc` so each `*Loaded`/`*Updated` state carries `verifiedClaims`; renders a `VerifiedAccountsRow` of tap-to-launch chips on the view-profile header and the edit-profile screen.

Stacks on PR1 (#3941). No write path yet — that lands as PR3.

## Test Plan
- [x] `flutter test` passes for `verifier_client`, `profile_repository`, `models` packages
- [x] `flutter test` passes for `my_profile_bloc`, `other_profile_bloc`, `profile_setup_screen`, `profile_header_widget`, `verified_account_chip`, `verified_accounts_row`, `arb_consistency_test`
- [x] `flutter analyze lib test integration_test` clean
- [ ] Manual: open own profile with NIP-39 `i` tags → chips render after verifier responds; tapping a chip opens the platform profile in the system browser
- [ ] Manual: open another user's profile → same behaviour
- [ ] Manual: open edit-profile screen → chips render below the bio block, above the public-key link

🤖 Generated with [Claude Code](https://claude.com/claude-code)