### PR TITLE
feat(collabs): include video link in collaborator invite DMs (#3942)

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2602,6 +2602,8 @@
   "@inboxConversationCollabInvitePreview": {
     "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list. The plaintext copy ('Open diVine to review and accept') is misleading inside diVine."
   },
+  "collaboratorInviteDmBody": "በ{title} ላይ እንድትተባበር ተጋብዘሃል፦ {url}\n\nOpen diVine to review and accept.",
+  "collaboratorInviteDmBodyUntitled": "በቪዲዮ ላይ እንድትተባበር ተጋብዘሃል፦ {url}\n\nOpen diVine to review and accept.",
   "reportDialogCancel": "ሰርዝ",
   "reportDialogReport": "ሪፖርት አድርግ",
   "exploreVideoId": "ID: {id}",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2282,6 +2282,8 @@
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },
+    "collaboratorInviteDmBody": "تمت دعوتك للتعاون على {title}: {url}\n\nOpen diVine to review and accept.",
+    "collaboratorInviteDmBodyUntitled": "تمت دعوتك للتعاون على فيديو: {url}\n\nOpen diVine to review and accept.",
     "inboxCollabInviteSentStatus": "تم إرسال الدعوة",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2476,6 +2476,8 @@
   "@inboxConversationCollabInvitePreview": {
     "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list. The plaintext copy ('Open diVine to review and accept') is misleading inside diVine."
   },
+  "collaboratorInviteDmBody": "Поканени сте да си сътрудничите по {title}: {url}\n\nOpen diVine to review and accept.",
+  "collaboratorInviteDmBodyUntitled": "Поканени сте да си сътрудничите по видеоклип: {url}\n\nOpen diVine to review and accept.",
   "reportDialogCancel": "Отказ",
   "reportDialogReport": "Докладвай",
   "exploreVideoId": "ID: {id}",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2290,6 +2290,8 @@
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },
+    "collaboratorInviteDmBody": "Du wurdest eingeladen, an {title} mitzuarbeiten: {url}\n\nOpen diVine to review and accept.",
+    "collaboratorInviteDmBodyUntitled": "Du wurdest eingeladen, an einem Video mitzuarbeiten: {url}\n\nOpen diVine to review and accept.",
     "inboxCollabInviteSentStatus": "Einladung gesendet",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2613,6 +2613,31 @@
     "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list. The plaintext copy ('Open diVine to review and accept') is misleading inside diVine."
   },
 
+  "collaboratorInviteDmBody": "You were invited to collaborate on {title}: {url}\n\nOpen diVine to review and accept.",
+  "@collaboratorInviteDmBody": {
+    "description": "Plaintext body of the encrypted DM that invites someone to collaborate on a video. Includes a clickable web link so non-Divine Nostr clients can preview the video. The trailing 'Open diVine to review and accept.' sentence MUST stay verbatim — diVine uses it as a marker to suppress legacy plaintext invites in conversation views.",
+    "placeholders": {
+      "title": {
+        "type": "String",
+        "example": "Skate loop"
+      },
+      "url": {
+        "type": "String",
+        "example": "https://divine.video/video/abc123"
+      }
+    }
+  },
+  "collaboratorInviteDmBodyUntitled": "You were invited to collaborate on a video: {url}\n\nOpen diVine to review and accept.",
+  "@collaboratorInviteDmBodyUntitled": {
+    "description": "Plaintext body of the encrypted DM that invites someone to collaborate on a video where the video has no title. Includes a clickable web link so non-Divine Nostr clients can preview the video. The trailing 'Open diVine to review and accept.' sentence MUST stay verbatim — diVine uses it as a marker to suppress legacy plaintext invites in conversation views.",
+    "placeholders": {
+      "url": {
+        "type": "String",
+        "example": "https://divine.video/video/abc123"
+      }
+    }
+  },
+
   "reportDialogCancel": "Cancel",
   "reportDialogReport": "Report",
 

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2294,6 +2294,8 @@
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },
+    "collaboratorInviteDmBody": "Te invitaron a colaborar en {title}: {url}\n\nOpen diVine to review and accept.",
+    "collaboratorInviteDmBodyUntitled": "Te invitaron a colaborar en un video: {url}\n\nOpen diVine to review and accept.",
     "inboxCollabInviteSentStatus": "Invitación enviada",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2290,6 +2290,8 @@
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },
+    "collaboratorInviteDmBody": "Tu as été invité(e) à collaborer sur {title} : {url}\n\nOpen diVine to review and accept.",
+    "collaboratorInviteDmBodyUntitled": "Tu as été invité(e) à collaborer sur une vidéo : {url}\n\nOpen diVine to review and accept.",
     "inboxCollabInviteSentStatus": "Invitation envoyée",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2289,6 +2289,8 @@
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },
+    "collaboratorInviteDmBody": "Kamu diundang untuk berkolaborasi di {title}: {url}\n\nOpen diVine to review and accept.",
+    "collaboratorInviteDmBodyUntitled": "Kamu diundang untuk berkolaborasi pada sebuah video: {url}\n\nOpen diVine to review and accept.",
     "inboxCollabInviteSentStatus": "Undangan terkirim",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2290,6 +2290,8 @@
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },
+    "collaboratorInviteDmBody": "Sei stato invitato a collaborare a {title}: {url}\n\nOpen diVine to review and accept.",
+    "collaboratorInviteDmBodyUntitled": "Sei stato invitato a collaborare a un video: {url}\n\nOpen diVine to review and accept.",
     "inboxCollabInviteSentStatus": "Invito inviato",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2282,6 +2282,8 @@
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },
+    "collaboratorInviteDmBody": "{title}のコラボに招待されたよ：{url}\n\nOpen diVine to review and accept.",
+    "collaboratorInviteDmBodyUntitled": "動画のコラボに招待されたよ：{url}\n\nOpen diVine to review and accept.",
     "inboxCollabInviteSentStatus": "招待を送ったよ",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1578,6 +1578,8 @@
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },
+    "collaboratorInviteDmBody": "{title} 콜라보에 초대받았어요: {url}\n\nOpen diVine to review and accept.",
+    "collaboratorInviteDmBodyUntitled": "동영상 콜라보에 초대받았어요: {url}\n\nOpen diVine to review and accept.",
     "inboxCollabInviteSentStatus": "초대를 보냈어요",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2290,6 +2290,8 @@
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },
+    "collaboratorInviteDmBody": "Je bent uitgenodigd om samen te werken aan {title}: {url}\n\nOpen diVine to review and accept.",
+    "collaboratorInviteDmBodyUntitled": "Je bent uitgenodigd om samen te werken aan een video: {url}\n\nOpen diVine to review and accept.",
     "inboxCollabInviteSentStatus": "Uitnodiging verzonden",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2290,6 +2290,8 @@
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },
+    "collaboratorInviteDmBody": "Zaproszono Cię do współpracy nad {title}: {url}\n\nOpen diVine to review and accept.",
+    "collaboratorInviteDmBodyUntitled": "Zaproszono Cię do współpracy nad filmem: {url}\n\nOpen diVine to review and accept.",
     "inboxCollabInviteSentStatus": "Zaproszenie wysłane",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2290,6 +2290,8 @@
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },
+    "collaboratorInviteDmBody": "Você foi convidado(a) para colaborar em {title}: {url}\n\nOpen diVine to review and accept.",
+    "collaboratorInviteDmBodyUntitled": "Você foi convidado(a) para colaborar em um vídeo: {url}\n\nOpen diVine to review and accept.",
     "inboxCollabInviteSentStatus": "Convite enviado",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2290,6 +2290,8 @@
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },
+    "collaboratorInviteDmBody": "Ai fost invitat(ă) să colaborezi la {title}: {url}\n\nOpen diVine to review and accept.",
+    "collaboratorInviteDmBodyUntitled": "Ai fost invitat(ă) să colaborezi la un videoclip: {url}\n\nOpen diVine to review and accept.",
     "inboxCollabInviteSentStatus": "Invitație trimisă",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2290,6 +2290,8 @@
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },
+    "collaboratorInviteDmBody": "Du har bjudits in att samarbeta på {title}: {url}\n\nOpen diVine to review and accept.",
+    "collaboratorInviteDmBodyUntitled": "Du har bjudits in att samarbeta på en video: {url}\n\nOpen diVine to review and accept.",
     "inboxCollabInviteSentStatus": "Inbjudan skickad",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2289,6 +2289,8 @@
     "@inboxConversationCollabInvitePreview": {
         "description": "Substituted for the legacy NIP-04 plaintext invite copy when shown as the most-recent-message preview in the DM conversation list."
     },
+    "collaboratorInviteDmBody": "{title} üzerinde işbirliği yapmaya davet edildin: {url}\n\nOpen diVine to review and accept.",
+    "collaboratorInviteDmBodyUntitled": "Bir videoda işbirliği yapmaya davet edildin: {url}\n\nOpen diVine to review and accept.",
     "inboxCollabInviteSentStatus": "Davet gönderildi",
     "@inboxCollabInviteSentStatus": {
         "description": "Shown on the inviter's own outgoing collaborator invite card in their DM with the collaborator. Replaces Accept/Ignore which are recipient-only actions."

--- a/mobile/lib/l10n/current_app_l10n.dart
+++ b/mobile/lib/l10n/current_app_l10n.dart
@@ -1,0 +1,31 @@
+// ABOUTME: Resolves AppLocalizations outside of a BuildContext.
+// ABOUTME: Used by services constructed via Riverpod providers / factories.
+
+import 'dart:ui';
+
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/l10n/resolve_app_ui_locale.dart';
+import 'package:openvine/services/locale_preference_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Returns [AppLocalizations] for the user's current preferred locale,
+/// or for the device default falling back through [resolveAppUiLocale].
+///
+/// Mirrors the locale that `MaterialApp.router` ends up using at runtime
+/// (via `LocaleCubit` + `localeListResolutionCallback: resolveAppUiLocale`)
+/// without requiring a [BuildContext]. Use this from services that are
+/// constructed inside Riverpod factories or other context-less call sites
+/// — e.g. `CollaboratorInviteService` built by `VideoPublishService`.
+AppLocalizations currentAppL10n(SharedPreferences prefs) {
+  final saved = prefs.getString(LocalePreferenceService.prefsKey);
+  const supported = AppLocalizations.supportedLocales;
+  final isSupported =
+      saved != null && supported.any((locale) => locale.languageCode == saved);
+  final locale = isSupported
+      ? Locale(saved)
+      : resolveAppUiLocale(
+          PlatformDispatcher.instance.locales,
+          supported,
+        );
+  return lookupAppLocalizations(locale);
+}

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -8964,6 +8964,18 @@ abstract class AppLocalizations {
   /// **'Collaborator invite'**
   String get inboxConversationCollabInvitePreview;
 
+  /// Plaintext body of the encrypted DM that invites someone to collaborate on a video. Includes a clickable web link so non-Divine Nostr clients can preview the video. The trailing 'Open diVine to review and accept.' sentence MUST stay verbatim — diVine uses it as a marker to suppress legacy plaintext invites in conversation views.
+  ///
+  /// In en, this message translates to:
+  /// **'You were invited to collaborate on {title}: {url}\n\nOpen diVine to review and accept.'**
+  String collaboratorInviteDmBody(String title, String url);
+
+  /// Plaintext body of the encrypted DM that invites someone to collaborate on a video where the video has no title. Includes a clickable web link so non-Divine Nostr clients can preview the video. The trailing 'Open diVine to review and accept.' sentence MUST stay verbatim — diVine uses it as a marker to suppress legacy plaintext invites in conversation views.
+  ///
+  /// In en, this message translates to:
+  /// **'You were invited to collaborate on a video: {url}\n\nOpen diVine to review and accept.'**
+  String collaboratorInviteDmBodyUntitled(String url);
+
   /// No description provided for @reportDialogCancel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4953,6 +4953,16 @@ class AppLocalizationsAm extends AppLocalizations {
   String get inboxConversationCollabInvitePreview => 'የተባባሪ ግብዣ';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return 'በ$title ላይ እንድትተባበር ተጋብዘሃል፦ $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'በቪዲዮ ላይ እንድትተባበር ተጋብዘሃል፦ $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'ሰርዝ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5009,6 +5009,16 @@ class AppLocalizationsAr extends AppLocalizations {
   String get inboxConversationCollabInvitePreview => 'دعوة للتعاون';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return 'تمت دعوتك للتعاون على $title: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'تمت دعوتك للتعاون على فيديو: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'إلغاء';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5103,6 +5103,16 @@ class AppLocalizationsBg extends AppLocalizations {
   String get inboxConversationCollabInvitePreview => 'Покана за сътрудник';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return 'Поканени сте да си сътрудничите по $title: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'Поканени сте да си сътрудничите по видеоклип: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'Отказ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5113,6 +5113,16 @@ class AppLocalizationsDe extends AppLocalizations {
       'Einladung zur Zusammenarbeit';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return 'Du wurdest eingeladen, an $title mitzuarbeiten: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'Du wurdest eingeladen, an einem Video mitzuarbeiten: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'Abbrechen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5057,6 +5057,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get inboxConversationCollabInvitePreview => 'Collaborator invite';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return 'You were invited to collaborate on $title: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'You were invited to collaborate on a video: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'Cancel';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5099,6 +5099,16 @@ class AppLocalizationsEs extends AppLocalizations {
   String get inboxConversationCollabInvitePreview => 'Invitación a colaborar';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return 'Te invitaron a colaborar en $title: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'Te invitaron a colaborar en un video: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5120,6 +5120,16 @@ class AppLocalizationsFr extends AppLocalizations {
   String get inboxConversationCollabInvitePreview => 'Invitation à collaborer';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return 'Tu as été invité(e) à collaborer sur $title : $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'Tu as été invité(e) à collaborer sur une vidéo : $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'Annuler';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5027,6 +5027,16 @@ class AppLocalizationsId extends AppLocalizations {
   String get inboxConversationCollabInvitePreview => 'Undangan kolaborasi';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return 'Kamu diundang untuk berkolaborasi di $title: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'Kamu diundang untuk berkolaborasi pada sebuah video: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'Batal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5099,6 +5099,16 @@ class AppLocalizationsIt extends AppLocalizations {
   String get inboxConversationCollabInvitePreview => 'Invito a collaborare';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return 'Sei stato invitato a collaborare a $title: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'Sei stato invitato a collaborare a un video: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'Annulla';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4851,6 +4851,16 @@ class AppLocalizationsJa extends AppLocalizations {
   String get inboxConversationCollabInvitePreview => 'コラボ招待';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return '$titleのコラボに招待されたよ：$url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return '動画のコラボに招待されたよ：$url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'キャンセル';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4867,6 +4867,16 @@ class AppLocalizationsKo extends AppLocalizations {
   String get inboxConversationCollabInvitePreview => '콜라보 초대';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return '$title 콜라보에 초대받았어요: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return '동영상 콜라보에 초대받았어요: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => '취소';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5073,6 +5073,16 @@ class AppLocalizationsNl extends AppLocalizations {
       'Uitnodiging om samen te werken';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return 'Je bent uitgenodigd om samen te werken aan $title: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'Je bent uitgenodigd om samen te werken aan een video: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'Annuleren';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5181,6 +5181,16 @@ class AppLocalizationsPl extends AppLocalizations {
       'Zaproszenie do współpracy';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return 'Zaproszono Cię do współpracy nad $title: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'Zaproszono Cię do współpracy nad filmem: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'Anuluj';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5084,6 +5084,16 @@ class AppLocalizationsPt extends AppLocalizations {
   String get inboxConversationCollabInvitePreview => 'Convite para colaborar';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return 'Você foi convidado(a) para colaborar em $title: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'Você foi convidado(a) para colaborar em um vídeo: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'Cancelar';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5189,6 +5189,16 @@ class AppLocalizationsRo extends AppLocalizations {
   String get inboxConversationCollabInvitePreview => 'Invitație de colaborare';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return 'Ai fost invitat(ă) să colaborezi la $title: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'Ai fost invitat(ă) să colaborezi la un videoclip: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'Anulează';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5051,6 +5051,16 @@ class AppLocalizationsSv extends AppLocalizations {
   String get inboxConversationCollabInvitePreview => 'Inbjudan att samarbeta';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return 'Du har bjudits in att samarbeta på $title: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'Du har bjudits in att samarbeta på en video: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'Avbryt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5036,6 +5036,16 @@ class AppLocalizationsTr extends AppLocalizations {
   String get inboxConversationCollabInvitePreview => 'İşbirliği daveti';
 
   @override
+  String collaboratorInviteDmBody(String title, String url) {
+    return '$title üzerinde işbirliği yapmaya davet edildin: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
+  String collaboratorInviteDmBodyUntitled(String url) {
+    return 'Bir videoda işbirliği yapmaya davet edildin: $url\n\nOpen diVine to review and accept.';
+  }
+
+  @override
   String get reportDialogCancel => 'İptal';
 
   @override

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -40,6 +40,7 @@ import 'package:openvine/features/app/startup/startup_phase.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/features/people_lists/people_lists.dart';
+import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/l10n/email_verification_error_l10n.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/resolve_app_ui_locale.dart';
@@ -1567,6 +1568,7 @@ class _DivineAppState extends ConsumerState<DivineApp> {
         draftService: ref.read(draftStorageServiceProvider),
         collaboratorInviteService: CollaboratorInviteService(
           dmRepository: ref.read(dmRepositoryProvider),
+          l10n: currentAppL10n(ref.read(sharedPreferencesProvider)),
         ),
         onProgressChanged:
             ({required String draftId, required double progress}) {

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -13,11 +13,13 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' show NativeProofData;
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/video_publish/video_publish_provider_state.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_recorder_provider.dart';
 import 'package:openvine/router/navigator_keys.dart';
@@ -115,6 +117,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
       draftService: _draftService,
       collaboratorInviteService: CollaboratorInviteService(
         dmRepository: ref.read(dmRepositoryProvider),
+        l10n: currentAppL10n(ref.read(sharedPreferencesProvider)),
       ),
       languagePreferenceService: ref.read(languagePreferenceServiceProvider),
       onProgressChanged: ({required String draftId, required double progress}) {

--- a/mobile/lib/services/collaborator_invite_service.dart
+++ b/mobile/lib/services/collaborator_invite_service.dart
@@ -1,8 +1,11 @@
 // ABOUTME: Sends encrypted collaborator invites via NIP-17 direct messages.
 // ABOUTME: Builds readable fallback content plus structured collab tags.
 
+import 'dart:ui' show Locale;
+
 import 'package:dm_repository/dm_repository.dart';
 import 'package:equatable/equatable.dart';
+import 'package:openvine/l10n/l10n.dart';
 
 class CollaboratorInviteResult extends Equatable {
   const CollaboratorInviteResult({
@@ -33,18 +36,40 @@ class CollaboratorInviteBatchResult extends Equatable {
 }
 
 class CollaboratorInviteService {
-  const CollaboratorInviteService({
+  CollaboratorInviteService({
     required DmRepository dmRepository,
+    AppLocalizations? l10n,
+    this.videoLinkBase = defaultVideoLinkBase,
     this.defaultRelayHint = 'wss://relay.divine.video',
-  }) : _dmRepository = dmRepository;
+  }) : _dmRepository = dmRepository,
+       _l10n = l10n ?? lookupAppLocalizations(const Locale('en'));
 
   final DmRepository _dmRepository;
+  final AppLocalizations _l10n;
+  final String videoLinkBase;
   final String defaultRelayHint;
 
-  /// Suffix that uniquely identifies the plaintext fallback body of a
-  /// collaborator invite DM — kept in sync with [_buildContent]. The
-  /// conversation view uses this to suppress legacy NIP-04 invite
-  /// duplicates that cannot be turned into actionable cards (#3559).
+  /// Base URL the plaintext fallback uses to link back to the invited
+  /// video. The full URL is `<videoLinkBase>/<stableId>`, where
+  /// `stableId` is the video's d-tag (parameterized addressable per
+  /// NIP-71). Matches the format `ShareService.generateWebLink`
+  /// produces — the divine.video web frontend serves d-tag lookups
+  /// today, so non-Divine clients always see a tappable preview.
+  /// In-app deep-link routing from this d-tag URL on cold start
+  /// depends on the route-ref resolver landing in #3932; until that
+  /// merges, the path inside diVine for recipients is the structured
+  /// `CollaboratorInviteCard` produced from the invite tags by
+  /// `CollaboratorInviteParser`, not URL deep-linking.
+  static const String defaultVideoLinkBase = 'https://divine.video/video';
+
+  /// Suffix that uniquely identifies the plaintext fallback body of an
+  /// **English-locale** collaborator invite DM — kept in sync with the
+  /// English ARB value of `collaboratorInviteDmBody` /
+  /// `collaboratorInviteDmBodyUntitled`. The conversation view uses
+  /// this to suppress legacy NIP-04 invite duplicates that cannot be
+  /// turned into actionable cards (#3559); newer locale-translated
+  /// invites surface inside diVine via the structured-tag parser path
+  /// (`CollaboratorInviteParser`) and don't depend on this suffix.
   static const String invitePlaintextSuffix =
       'Open diVine to review and accept.';
 
@@ -56,7 +81,7 @@ class CollaboratorInviteService {
     String? thumbnailUrl,
     String? relayHint,
   }) async {
-    final content = _buildContent(title);
+    final content = _buildContent(title: title, videoAddress: videoAddress);
     final tags = _buildTags(
       creatorPubkey: creatorPubkey,
       videoAddress: videoAddress,
@@ -104,12 +129,25 @@ class CollaboratorInviteService {
     return CollaboratorInviteBatchResult(results: results);
   }
 
-  String _buildContent(String? title) {
-    final videoLabel = title == null || title.trim().isEmpty
-        ? 'a diVine video'
-        : title.trim();
-    return 'You were invited to collaborate on $videoLabel. '
-        '$invitePlaintextSuffix';
+  String _buildContent({
+    required String videoAddress,
+    String? title,
+  }) {
+    final url = _videoUrlFor(videoAddress);
+    final cleanTitle = title?.trim();
+    if (cleanTitle == null || cleanTitle.isEmpty) {
+      return _l10n.collaboratorInviteDmBodyUntitled(url);
+    }
+    return _l10n.collaboratorInviteDmBody(cleanTitle, url);
+  }
+
+  String _videoUrlFor(String videoAddress) {
+    // Parameterized addressable format: `<kind>:<pubkey>:<dTag>`. The
+    // d-tag is the video's [VideoEvent.stableId], which divine.video
+    // routes via `/video/:id`.
+    final parts = videoAddress.split(':');
+    final stableId = parts.length == 3 ? parts[2] : '';
+    return '$videoLinkBase/$stableId';
   }
 
   List<List<String>> _buildTags({

--- a/mobile/lib/services/collaborator_invite_service.dart
+++ b/mobile/lib/services/collaborator_invite_service.dart
@@ -144,9 +144,11 @@ class CollaboratorInviteService {
   String _videoUrlFor(String videoAddress) {
     // Parameterized addressable format: `<kind>:<pubkey>:<dTag>`. The
     // d-tag is the video's [VideoEvent.stableId], which divine.video
-    // routes via `/video/:id`.
+    // routes via `/video/:id`. NIP-01 doesn't forbid `:` inside a d-tag,
+    // so re-join everything past the kind/pubkey prefix to keep colons
+    // in the stableId intact.
     final parts = videoAddress.split(':');
-    final stableId = parts.length == 3 ? parts[2] : '';
+    final stableId = parts.length >= 3 ? parts.sublist(2).join(':') : '';
     return '$videoLinkBase/$stableId';
   }
 

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -1396,6 +1396,11 @@ class _EditVideoDialogState extends ConsumerState<_EditVideoDialog> {
   Future<void> _updateVideo() async {
     setState(() => _isUpdating = true);
 
+    // Capture l10n eagerly — _updateVideo awaits a publish round-trip
+    // before constructing the invite service, and AppLocalizations.of
+    // can fail if the surrounding widget unmounts mid-flight.
+    final inviteL10n = context.l10n;
+
     try {
       // Parse hashtags from comma-separated string
       final hashtagsText = _hashtagsController.text.trim();
@@ -1586,6 +1591,7 @@ class _EditVideoDialogState extends ConsumerState<_EditVideoDialog> {
       final inviteResults = await sendPostPublishCollaboratorInvites(
         inviteService: CollaboratorInviteService(
           dmRepository: ref.read(dmRepositoryProvider),
+          l10n: inviteL10n,
         ),
         video: updatedVideoEvent,
         previousCollaboratorPubkeys: _initialCollaboratorPubkeys,

--- a/mobile/test/services/collaborator_invite_service_test.dart
+++ b/mobile/test/services/collaborator_invite_service_test.dart
@@ -75,6 +75,14 @@ void main() {
 
     expect(content, contains('Skate loop'));
     expect(content, contains('collaborate'));
+    expect(
+      content,
+      contains('https://divine.video/video/video-id'),
+      reason:
+          'Plaintext fallback must include a divine.video URL so non-Divine '
+          'Nostr clients can preview the video and verify the invite '
+          'matches a real video before accepting (#3942).',
+    );
     expect(_containsTag(tags, const ['divine', 'collab-invite']), isTrue);
     expect(
       _containsTag(tags, const [
@@ -147,6 +155,101 @@ void main() {
       );
     },
   );
+
+  test('includes divine.video URL when title is missing', () async {
+    when(
+      () => dmRepository.sendMessage(
+        recipientPubkey: any(named: 'recipientPubkey'),
+        content: any(named: 'content'),
+        replyToId: any(named: 'replyToId'),
+        additionalTags: any(named: 'additionalTags'),
+        skipNip04Fallback: any(named: 'skipNip04Fallback'),
+      ),
+    ).thenAnswer(
+      (_) async => NIP17SendResult.success(
+        rumorEventId: 'rumor-id',
+        messageEventId: 'message-id',
+        recipientPubkey: collaboratorPubkey,
+      ),
+    );
+
+    await service.sendInvite(
+      collaboratorPubkey: collaboratorPubkey,
+      creatorPubkey: creatorPubkey,
+      videoAddress: videoAddress,
+    );
+
+    final captured =
+        verify(
+              () => dmRepository.sendMessage(
+                recipientPubkey: collaboratorPubkey,
+                content: captureAny(named: 'content'),
+                replyToId: any(named: 'replyToId'),
+                additionalTags: any(named: 'additionalTags'),
+                skipNip04Fallback: any(named: 'skipNip04Fallback'),
+              ),
+            ).captured.single
+            as String;
+
+    expect(captured, contains('https://divine.video/video/video-id'));
+    expect(
+      captured.endsWith(CollaboratorInviteService.invitePlaintextSuffix),
+      isTrue,
+    );
+  });
+
+  test('URL stableId matches the d-tag of the videoAddress', () async {
+    when(
+      () => dmRepository.sendMessage(
+        recipientPubkey: any(named: 'recipientPubkey'),
+        content: any(named: 'content'),
+        replyToId: any(named: 'replyToId'),
+        additionalTags: any(named: 'additionalTags'),
+        skipNip04Fallback: any(named: 'skipNip04Fallback'),
+      ),
+    ).thenAnswer(
+      (_) async => NIP17SendResult.success(
+        rumorEventId: 'rumor-id',
+        messageEventId: 'message-id',
+        recipientPubkey: collaboratorPubkey,
+      ),
+    );
+
+    const otherVideoAddress =
+        '34236:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:custom-d-tag';
+
+    await service.sendInvite(
+      collaboratorPubkey: collaboratorPubkey,
+      creatorPubkey: creatorPubkey,
+      videoAddress: otherVideoAddress,
+      title: 'Highlight reel',
+    );
+
+    final captured =
+        verify(
+              () => dmRepository.sendMessage(
+                recipientPubkey: collaboratorPubkey,
+                content: captureAny(named: 'content'),
+                replyToId: any(named: 'replyToId'),
+                additionalTags: any(named: 'additionalTags'),
+                skipNip04Fallback: any(named: 'skipNip04Fallback'),
+              ),
+            ).captured.single
+            as String;
+
+    expect(
+      captured,
+      contains('https://divine.video/video/custom-d-tag'),
+      reason:
+          'URL must use the d-tag (third segment of the parameterized '
+          'addressable) so it deep-links via the existing /video/:id route.',
+    );
+    expect(
+      captured,
+      isNot(contains('https://divine.video/video/video-id')),
+      reason: 'URL must reflect the videoAddress passed in, not a default.',
+    );
+  });
 
   test('returns failure when encrypted DM send fails', () async {
     when(

--- a/mobile/test/services/collaborator_invite_service_test.dart
+++ b/mobile/test/services/collaborator_invite_service_test.dart
@@ -1,11 +1,14 @@
 // ABOUTME: Tests encrypted collaborator invite payload construction.
 // ABOUTME: Verifies collab invites are NIP-17 DMs with structured tags.
 
+import 'dart:ui' show Locale;
+
 import 'package:collection/collection.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 
 class _MockDmRepository extends Mock implements DmRepository {}
@@ -250,6 +253,161 @@ void main() {
       reason: 'URL must reflect the videoAddress passed in, not a default.',
     );
   });
+
+  test('preserves colons inside d-tag stableId in URL', () async {
+    when(
+      () => dmRepository.sendMessage(
+        recipientPubkey: any(named: 'recipientPubkey'),
+        content: any(named: 'content'),
+        replyToId: any(named: 'replyToId'),
+        additionalTags: any(named: 'additionalTags'),
+        skipNip04Fallback: any(named: 'skipNip04Fallback'),
+      ),
+    ).thenAnswer(
+      (_) async => NIP17SendResult.success(
+        rumorEventId: 'rumor-id',
+        messageEventId: 'message-id',
+        recipientPubkey: collaboratorPubkey,
+      ),
+    );
+
+    // NIP-01 doesn't reserve `:` in d-tags. A naive split-on-colon parser
+    // truncates everything past the third segment, producing
+    // `https://divine.video/video/foo` for a stableId of `foo:bar`.
+    const colonyVideoAddress =
+        '34236:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc:foo:bar';
+
+    await service.sendInvite(
+      collaboratorPubkey: collaboratorPubkey,
+      creatorPubkey: creatorPubkey,
+      videoAddress: colonyVideoAddress,
+      title: 'Edge case',
+    );
+
+    final captured =
+        verify(
+              () => dmRepository.sendMessage(
+                recipientPubkey: collaboratorPubkey,
+                content: captureAny(named: 'content'),
+                replyToId: any(named: 'replyToId'),
+                additionalTags: any(named: 'additionalTags'),
+                skipNip04Fallback: any(named: 'skipNip04Fallback'),
+              ),
+            ).captured.single
+            as String;
+
+    expect(
+      captured,
+      contains('https://divine.video/video/foo:bar'),
+      reason:
+          'd-tag is everything after kind:pubkey: — colons within it must '
+          'survive into the URL so divine.video can resolve the stableId.',
+    );
+  });
+
+  test(
+    'localized DM body for non-English locale still contains the video URL',
+    () async {
+      // Translators must preserve the {url} placeholder. Without an
+      // assertion on the resolved body, a translator could silently drop
+      // the URL and the only signal would be a missing tappable preview
+      // in non-English clients (the bug this PR fixes).
+      final esService = CollaboratorInviteService(
+        dmRepository: dmRepository,
+        l10n: lookupAppLocalizations(const Locale('es')),
+      );
+      when(
+        () => dmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          replyToId: any(named: 'replyToId'),
+          additionalTags: any(named: 'additionalTags'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
+        ),
+      ).thenAnswer(
+        (_) async => NIP17SendResult.success(
+          rumorEventId: 'rumor-id',
+          messageEventId: 'message-id',
+          recipientPubkey: collaboratorPubkey,
+        ),
+      );
+
+      await esService.sendInvite(
+        collaboratorPubkey: collaboratorPubkey,
+        creatorPubkey: creatorPubkey,
+        videoAddress: videoAddress,
+        title: 'Skate loop',
+      );
+
+      final captured =
+          verify(
+                () => dmRepository.sendMessage(
+                  recipientPubkey: collaboratorPubkey,
+                  content: captureAny(named: 'content'),
+                  replyToId: any(named: 'replyToId'),
+                  additionalTags: any(named: 'additionalTags'),
+                  skipNip04Fallback: any(named: 'skipNip04Fallback'),
+                ),
+              ).captured.single
+              as String;
+
+      expect(captured, contains('https://divine.video/video/video-id'));
+      expect(captured, contains('Skate loop'));
+      // Sanity-check that we actually produced the Spanish body — not
+      // the English fallback that lookupAppLocalizations could silently
+      // return if the locale failed to resolve.
+      expect(
+        captured,
+        contains('colaborar'),
+        reason: 'Spanish body should contain the translated verb.',
+      );
+    },
+  );
+
+  test(
+    'localized untitled DM body for non-English locale still contains URL',
+    () async {
+      final esService = CollaboratorInviteService(
+        dmRepository: dmRepository,
+        l10n: lookupAppLocalizations(const Locale('es')),
+      );
+      when(
+        () => dmRepository.sendMessage(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          content: any(named: 'content'),
+          replyToId: any(named: 'replyToId'),
+          additionalTags: any(named: 'additionalTags'),
+          skipNip04Fallback: any(named: 'skipNip04Fallback'),
+        ),
+      ).thenAnswer(
+        (_) async => NIP17SendResult.success(
+          rumorEventId: 'rumor-id',
+          messageEventId: 'message-id',
+          recipientPubkey: collaboratorPubkey,
+        ),
+      );
+
+      await esService.sendInvite(
+        collaboratorPubkey: collaboratorPubkey,
+        creatorPubkey: creatorPubkey,
+        videoAddress: videoAddress,
+      );
+
+      final captured =
+          verify(
+                () => dmRepository.sendMessage(
+                  recipientPubkey: collaboratorPubkey,
+                  content: captureAny(named: 'content'),
+                  replyToId: any(named: 'replyToId'),
+                  additionalTags: any(named: 'additionalTags'),
+                  skipNip04Fallback: any(named: 'skipNip04Fallback'),
+                ),
+              ).captured.single
+              as String;
+
+      expect(captured, contains('https://divine.video/video/video-id'));
+    },
+  );
 
   test('returns failure when encrypted DM send fails', () async {
     when(


### PR DESCRIPTION
## Description

Encrypted collaborator invite DMs sent via `CollaboratorInviteService.sendInvite` now include a `https://divine.video/video/<stableId>` link in the plaintext fallback body. Recipients viewing the DM in **non-Divine Nostr clients** (Damus, Amethyst, Primal) finally see a tappable preview, and any recipient can verify the invite matches a real video before accepting it.

The body is also localized via `context.l10n` (or a context-less equivalent for service-level callers) and translated across all 17 supported locales — no `_knownUntranslatedDebt` shortcut.

**Related Issue:** Closes #3942

## What changed

- `_buildContent` in `collaborator_invite_service.dart` now derives the URL from the d-tag of the parameterized addressable (`kind:pubkey:dTag`) and renders the localized body via two new ARB keys: `collaboratorInviteDmBody` (with title) and `collaboratorInviteDmBodyUntitled` (no title).
- New `lib/l10n/current_app_l10n.dart` resolves `AppLocalizations` outside `BuildContext`, mirroring `MaterialApp`'s `localeListResolutionCallback: resolveAppUiLocale` for service-level construction sites.
- Construction sites updated:
  - `share_video_menu.dart` captures `context.l10n` early (before publish awaits) and threads it through `sendPostPublishCollaboratorInvites`.
  - `main.dart` and `video_publish_provider.dart` resolve l10n via `currentAppL10n(ref.read(sharedPreferencesProvider))`.
- New keys translated in: am, ar, bg, de, en, es, fr, id, it, ja, ko, nl, pl, pt, ro, sv, tr.
- Trailing `Open diVine to review and accept.` is kept verbatim in **every** locale so the existing suffix-based detection in `conversation_view.dart` and `conversation_tile.dart` (#3559) keeps suppressing legacy NIP-04 plaintext duplicates.

## Design choices

**URL form: d-tag / stableId** (matches `ShareService.generateWebLink`, divine.video web frontend serves d-tag lookups today). The issue listed three options (event-id hex, `naddr1...`, address-aware route); I shipped option 3 realized via the existing `/video/:id` route. Trade-offs vs. the issue's recommendation of option 1:

- ✅ Survives republish (event-id-hex form goes stale)
- ✅ Single canonical URL across share menu and invite DM
- ⚠️ In-app cold-start deep-link from this d-tag URL becomes fully wired once the route-ref resolver in #3932 lands. Until then, in-Divine recipients use the structured `CollaboratorInviteCard` (tag-based, URL-irrelevant) — which is what they always used.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Reproducing the bug (before this PR)

1. Sign in as **A**, mutual-follow **B**.
2. Publish a video on A; invite B as a collaborator.
3. Open the resulting DM in any non-Divine Nostr client (e.g. Damus, Primal web).
4. The message reads `You were invited to collaborate on <title>. Open diVine to review and accept.` — **no URL**, nothing tappable, no way for the recipient to preview the video before accepting.

## Verifying the fix (after this PR)

### Test 1 — Post-publish invite, video with title (English)
1. On A: record a video, set title `Test invite link`, invite B as collaborator, publish.
2. **In B's diVine inbox:** `CollaboratorInviteCard` appears with Accept / Ignore. Tapping the card opens the correct video.
3. **In B's non-Divine client:** plaintext message reading
   > You were invited to collaborate on Test invite link: https://divine.video/video/&lt;dTag&gt;
   >
   > Open diVine to review and accept.
   The URL is tappable and the `<dTag>` matches the video's d-tag.

### Test 2 — Post-edit invite (existing video, add collaborator)
1. On A: open an existing video → Share menu → Edit → add B as collaborator → save.
2. Same expectations as Test 1.

### Test 3 — Video without title
1. On A: publish a new video, leave title empty, invite B.
2. **In non-Divine client:** plaintext starts with `You were invited to collaborate on a video: https://divine.video/video/<id>` followed by the English suffix.

### Test 4 — Localization
1. On A: Settings → Language → Español (or Deutsch / Français / etc.) → publish a new video with B as collaborator.
2. **In non-Divine client:** prefix is in the picked language (e.g. _"Te invitaron a colaborar en …"_); URL identical; suffix stays English so suffix-detection still works.

### Test 5 — Deep-link from a fresh install (gated on #3932)
1. On B: uninstall diVine → from non-Divine client, copy the URL → reinstall diVine → sign in → tap the URL.
2. After #3932 merges: app cold-starts and lands on `VideoDetailScreen` for the invited video. Before #3932 merges this falls back to the existing legacy resolver behavior — same as any d-tag share link today.

### Test 6 — No regressions
- B's inbox list (English locale) preview row reads "Collaborator invite", not raw plaintext.
- B's conversation view: legacy NIP-04 fallback bubble is still suppressed; only the structured card renders.
- Existing English-locale `invitePlaintextSuffix` test contract holds (suffix preserved verbatim across all 17 locales).

## Test plan (automated)

- [x] `flutter test test/services/collaborator_invite_service_test.dart` — 5 tests, including new coverage that the URL appears in the body, the URL stableId matches the d-tag of the videoAddress, and the URL is present in the untitled variant.
- [x] `flutter test test/l10n/arb_consistency_test.dart` — all locales remain in sync; new keys present in all 17 ARB files (no `_knownUntranslatedDebt` entry).
- [x] `flutter test test/services/collaborator_invite_parser_test.dart test/services/collaborator_invite_state_store_test.dart test/blocs/dm/conversation/collaborator_invite_actions_cubit_test.dart test/widgets/share_video_menu_collaborators_test.dart test/services/video_publish/video_publish_service_test.dart test/screens/inbox/widgets/conversation_tile_test.dart test/screens/inbox/conversation/conversation_view_test.dart` — 82 tests pass; structured-tag rendering and suffix-detection paths are not regressed.
- [x] `flutter analyze lib test integration_test` — clean.
- [x] `dart format` — clean.