### PR TITLE
fix(notifications): show "liked your comment" for likes on comments

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3124,6 +3124,14 @@
       }
     }
   },
+  "notificationLikedYourComment": "{actorName} አስተያየትህን ወደውታል።",
+  "@notificationLikedYourComment": {
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      }
+    }
+  },
   "notificationCommentedOnYourVideo": "{actorName} በቪዲዮዎ ላይ አስተያየት ሰጥቷል",
   "@notificationCommentedOnYourVideo": {
     "placeholders": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2494,6 +2494,14 @@
             }
         }
     },
+    "notificationLikedYourComment": "{actorName} أعجب بتعليقك",
+    "@notificationLikedYourComment": {
+        "placeholders": {
+            "actorName": {
+                "type": "String"
+            }
+        }
+    },
     "notificationMentionedYou": "{actorName} أشار إليك",
     "@notificationMentionedYou": {
         "placeholders": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2828,6 +2828,14 @@
       }
     }
   },
+  "notificationLikedYourComment": "{actorName} хареса коментара ти",
+  "@notificationLikedYourComment": {
+    "placeholders": {
+      "actorName": {
+        "type": "String"
+      }
+    }
+  },
   "notificationCommentedOnYourVideo": "{actorName} коментира видеото ти",
   "@notificationCommentedOnYourVideo": {
     "placeholders": {

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2502,6 +2502,14 @@
             }
         }
     },
+    "notificationLikedYourComment": "{actorName} hat deinen Kommentar geliked",
+    "@notificationLikedYourComment": {
+        "placeholders": {
+            "actorName": {
+                "type": "String"
+            }
+        }
+    },
     "notificationMentionedYou": "{actorName} hat dich erwähnt",
     "@notificationMentionedYou": {
         "placeholders": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3165,6 +3165,13 @@
       "actorName": { "type": "String" }
     }
   },
+  "notificationLikedYourComment": "{actorName} liked your comment",
+  "@notificationLikedYourComment": {
+    "description": "Notification text when someone reacts to a comment the user posted (typically under another user's video).",
+    "placeholders": {
+      "actorName": { "type": "String" }
+    }
+  },
   "notificationCommentedOnYourVideo": "{actorName} commented on your video",
   "@notificationCommentedOnYourVideo": {
     "placeholders": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2510,6 +2510,14 @@
             }
         }
     },
+    "notificationLikedYourComment": "{actorName} le dio like a tu comentario",
+    "@notificationLikedYourComment": {
+        "placeholders": {
+            "actorName": {
+                "type": "String"
+            }
+        }
+    },
     "notificationMentionedYou": "{actorName} te mencionó",
     "@notificationMentionedYou": {
         "placeholders": {

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2502,6 +2502,14 @@
             }
         }
     },
+    "notificationLikedYourComment": "{actorName} a aimé ton commentaire",
+    "@notificationLikedYourComment": {
+        "placeholders": {
+            "actorName": {
+                "type": "String"
+            }
+        }
+    },
     "notificationMentionedYou": "{actorName} t'a mentionné",
     "@notificationMentionedYou": {
         "placeholders": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2501,6 +2501,14 @@
             }
         }
     },
+    "notificationLikedYourComment": "{actorName} menyukai komentarmu",
+    "@notificationLikedYourComment": {
+        "placeholders": {
+            "actorName": {
+                "type": "String"
+            }
+        }
+    },
     "notificationMentionedYou": "{actorName} menyebutmu",
     "@notificationMentionedYou": {
         "placeholders": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2502,6 +2502,14 @@
             }
         }
     },
+    "notificationLikedYourComment": "{actorName} ha messo like al tuo commento",
+    "@notificationLikedYourComment": {
+        "placeholders": {
+            "actorName": {
+                "type": "String"
+            }
+        }
+    },
     "notificationMentionedYou": "{actorName} ti ha menzionato",
     "@notificationMentionedYou": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2494,6 +2494,14 @@
             }
         }
     },
+    "notificationLikedYourComment": "{actorName}さんがあなたのコメントにいいねしました",
+    "@notificationLikedYourComment": {
+        "placeholders": {
+            "actorName": {
+                "type": "String"
+            }
+        }
+    },
     "notificationMentionedYou": "{actorName}さんがあなたをメンションしました",
     "@notificationMentionedYou": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1790,6 +1790,14 @@
             }
         }
     },
+    "notificationLikedYourComment": "{actorName}님이 회원님의 댓글을 좋아해요",
+    "@notificationLikedYourComment": {
+        "placeholders": {
+            "actorName": {
+                "type": "String"
+            }
+        }
+    },
     "notificationMentionedYou": "{actorName}님이 회원님을 언급했어요",
     "@notificationMentionedYou": {
         "placeholders": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2502,6 +2502,14 @@
             }
         }
     },
+    "notificationLikedYourComment": "{actorName} vond je reactie leuk",
+    "@notificationLikedYourComment": {
+        "placeholders": {
+            "actorName": {
+                "type": "String"
+            }
+        }
+    },
     "notificationMentionedYou": "{actorName} heeft je genoemd",
     "@notificationMentionedYou": {
         "placeholders": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2502,6 +2502,14 @@
             }
         }
     },
+    "notificationLikedYourComment": "{actorName} polubił(a) Twój komentarz",
+    "@notificationLikedYourComment": {
+        "placeholders": {
+            "actorName": {
+                "type": "String"
+            }
+        }
+    },
     "notificationMentionedYou": "{actorName} wspomniał(a) o Tobie",
     "@notificationMentionedYou": {
         "placeholders": {

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2502,6 +2502,14 @@
             }
         }
     },
+    "notificationLikedYourComment": "{actorName} curtiu seu comentário",
+    "@notificationLikedYourComment": {
+        "placeholders": {
+            "actorName": {
+                "type": "String"
+            }
+        }
+    },
     "notificationMentionedYou": "{actorName} mencionou você",
     "@notificationMentionedYou": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2502,6 +2502,14 @@
             }
         }
     },
+    "notificationLikedYourComment": "{actorName} a apreciat comentariul tău",
+    "@notificationLikedYourComment": {
+        "placeholders": {
+            "actorName": {
+                "type": "String"
+            }
+        }
+    },
     "notificationMentionedYou": "{actorName} te-a menționat",
     "@notificationMentionedYou": {
         "placeholders": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2502,6 +2502,14 @@
             }
         }
     },
+    "notificationLikedYourComment": "{actorName} gillade din kommentar",
+    "@notificationLikedYourComment": {
+        "placeholders": {
+            "actorName": {
+                "type": "String"
+            }
+        }
+    },
     "notificationMentionedYou": "{actorName} nämnde dig",
     "@notificationMentionedYou": {
         "placeholders": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2501,6 +2501,14 @@
             }
         }
     },
+    "notificationLikedYourComment": "{actorName} yorumunu beğendi",
+    "@notificationLikedYourComment": {
+        "placeholders": {
+            "actorName": {
+                "type": "String"
+            }
+        }
+    },
     "notificationMentionedYou": "{actorName} senden bahsetti",
     "@notificationMentionedYou": {
         "placeholders": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10428,6 +10428,12 @@ abstract class AppLocalizations {
   /// **'{actorName} liked your video'**
   String notificationLikedYourVideo(String actorName);
 
+  /// Notification text when someone reacts to a comment the user posted (typically under another user's video).
+  ///
+  /// In en, this message translates to:
+  /// **'{actorName} liked your comment'**
+  String notificationLikedYourComment(String actorName);
+
   /// No description provided for @notificationCommentedOnYourVideo.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5794,6 +5794,11 @@ class AppLocalizationsAm extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName በቪዲዮዎ ላይ አስተያየት ሰጥቷል';
   }

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5795,7 +5795,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName አስተያየትህን ወደውታል።';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5866,7 +5866,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName أعجب بتعليقك';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5865,6 +5865,11 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName علّق على فيديوك';
   }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5973,7 +5973,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName хареса коментара ти';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5972,6 +5972,11 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName коментира видеото ти';
   }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5977,7 +5977,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName hat deinen Kommentar geliked';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5976,6 +5976,11 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName hat dein Video kommentiert';
   }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5915,6 +5915,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName commented on your video';
   }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5964,7 +5964,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName le dio like a tu comentario';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5963,6 +5963,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName comentó tu video';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5985,6 +5985,11 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName a commenté ta vidéo';
   }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5986,7 +5986,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName a aimé ton commentaire';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5884,6 +5884,11 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName mengomentari videomu';
   }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5885,7 +5885,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName menyukai komentarmu';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5959,6 +5959,11 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName ha commentato il tuo video';
   }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5960,7 +5960,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName ha messo like al tuo commento';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5693,6 +5693,11 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorNameさんがあなたの動画にコメントしました';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5694,7 +5694,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorNameさんがあなたのコメントにいいねしました';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5717,7 +5717,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName님이 회원님의 댓글을 좋아해요';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5716,6 +5716,11 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName님이 회원님의 동영상에 댓글을 남겼어요';
   }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5935,7 +5935,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName vond je reactie leuk';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5934,6 +5934,11 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName heeft op je video gereageerd';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6050,6 +6050,11 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName skomentował(a) Twoje wideo';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6051,7 +6051,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName polubił(a) Twój komentarz';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5944,6 +5944,11 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName comentou no seu vídeo';
   }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5945,7 +5945,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName curtiu seu comentário';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6049,6 +6049,11 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName a comentat la videoclipul tău';
   }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6050,7 +6050,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName a apreciat comentariul tău';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5906,6 +5906,11 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName kommenterade din video';
   }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5907,7 +5907,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName gillade din kommentar';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5892,7 +5892,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String notificationLikedYourComment(String actorName) {
-    return '$actorName liked your comment';
+    return '$actorName yorumunu beğendi';
   }
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5891,6 +5891,11 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String notificationLikedYourComment(String actorName) {
+    return '$actorName liked your comment';
+  }
+
+  @override
   String notificationCommentedOnYourVideo(String actorName) {
     return '$actorName videona yorum yaptı';
   }

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -154,6 +154,7 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
       case NotificationKind.follow:
         _navigateToProfile(context, notification.actor.pubkey);
       case NotificationKind.like:
+      case NotificationKind.likeComment:
       case NotificationKind.comment:
       case NotificationKind.reply:
       case NotificationKind.repost:
@@ -255,7 +256,8 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     final shouldAutoOpenComments =
         notificationKind == NotificationKind.comment ||
         notificationKind == NotificationKind.reply ||
-        notificationKind == NotificationKind.mention;
+        notificationKind == NotificationKind.mention ||
+        notificationKind == NotificationKind.likeComment;
 
     context.push(
       PooledFullscreenVideoFeedScreen.path,

--- a/mobile/lib/notifications/widgets/notification_list_item.dart
+++ b/mobile/lib/notifications/widgets/notification_list_item.dart
@@ -120,7 +120,8 @@ class _TypeIconSpec {
 
 _TypeIconSpec _typeIconSpec(NotificationKind type) {
   return switch (type) {
-    NotificationKind.like => const _TypeIconSpec(
+    NotificationKind.like ||
+    NotificationKind.likeComment => const _TypeIconSpec(
       icon: DivineIconName.heart,
       background: VineTheme.accentPinkBackground,
       foreground: VineTheme.accentPink,
@@ -355,6 +356,9 @@ String _verbFor(AppLocalizations l10n, NotificationKind type) {
   return switch (type) {
     NotificationKind.like => _stripActorPlaceholder(
       l10n.notificationLikedYourVideo(''),
+    ),
+    NotificationKind.likeComment => _stripActorPlaceholder(
+      l10n.notificationLikedYourComment(''),
     ),
     NotificationKind.comment => _stripActorPlaceholder(
       l10n.notificationCommentedOnYourVideo(''),

--- a/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
@@ -14,10 +14,19 @@ class RelayNotification {
     required this.read,
     this.referencedEventId,
     this.content,
+    this.isReferencedVideo = false,
+    this.referencedVideoTitle,
   });
 
   /// Parses a notification payload from the FunnelCake API.
   factory RelayNotification.fromJson(Map<String, dynamic> json) {
+    final referencedVideo = json['referenced_video'];
+    final referencedVideoMap = referencedVideo is Map<String, dynamic>
+        ? referencedVideo
+        : null;
+    final videoTitle =
+        referencedVideoMap?['title'] as String? ??
+        json['referenced_event_title'] as String?;
     return RelayNotification(
       id: json['id'] as String? ?? '',
       sourcePubkey: json['source_pubkey'] as String? ?? '',
@@ -30,6 +39,10 @@ class RelayNotification {
       ),
       read: json['read'] as bool? ?? false,
       content: json['content'] as String?,
+      isReferencedVideo: referencedVideoMap != null,
+      referencedVideoTitle: (videoTitle != null && videoTitle.isNotEmpty)
+          ? videoTitle
+          : null,
     );
   }
 
@@ -59,6 +72,16 @@ class RelayNotification {
 
   /// Optional content from the source event (e.g. reaction emoji).
   final String? content;
+
+  /// Whether the referenced event is a video. Set when the API populates
+  /// `referenced_video` (only present for video kinds). Lets the client
+  /// distinguish a like on a video from a like on a comment.
+  final bool isReferencedVideo;
+
+  /// Title of the referenced video, when the referenced event is a video
+  /// with a non-empty title. `null` for non-video targets or untitled
+  /// videos.
+  final String? referencedVideoTitle;
 
   /// Stable dedup key -- falls back to sourceEventId if id is empty.
   String get dedupeKey => id.isNotEmpty ? id : sourceEventId;

--- a/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
@@ -47,6 +47,99 @@ void main() {
 
         expect(notification.referencedEventId, isNull);
         expect(notification.content, isNull);
+        expect(notification.isReferencedVideo, isFalse);
+        expect(notification.referencedVideoTitle, isNull);
+      });
+
+      test(
+        'flags video target when referenced_video is populated',
+        () {
+          final json = {
+            'id': 'notif_123',
+            'source_pubkey': 'aabbccdd' * 8,
+            'source_event_id': '11223344' * 8,
+            'source_kind': 7,
+            'referenced_event_id': '55667788' * 8,
+            'referenced_video': {
+              'title': 'My funny vine',
+              'thumbnail': 'https://example.com/thumb.jpg',
+            },
+            'notification_type': 'reaction',
+            'created_at': 1712345678,
+            'read': false,
+          };
+
+          final notification = RelayNotification.fromJson(json);
+
+          expect(notification.isReferencedVideo, isTrue);
+          expect(notification.referencedVideoTitle, equals('My funny vine'));
+        },
+      );
+
+      test(
+        'reports non-video target when referenced_video is absent (like '
+        'on a comment)',
+        () {
+          final json = {
+            'id': 'notif_123',
+            'source_pubkey': 'aabbccdd' * 8,
+            'source_event_id': '11223344' * 8,
+            'source_kind': 7,
+            'referenced_event_id': '55667788' * 8,
+            'notification_type': 'reaction',
+            'created_at': 1712345678,
+            'read': false,
+          };
+
+          final notification = RelayNotification.fromJson(json);
+
+          expect(notification.isReferencedVideo, isFalse);
+          expect(notification.referencedVideoTitle, isNull);
+        },
+      );
+
+      test(
+        'falls back to referenced_event_title when referenced_video is null',
+        () {
+          final json = {
+            'id': 'notif_123',
+            'source_pubkey': 'aabbccdd' * 8,
+            'source_event_id': '11223344' * 8,
+            'source_kind': 7,
+            'referenced_event_id': '55667788' * 8,
+            'referenced_event_title': 'Top-level title',
+            'notification_type': 'reaction',
+            'created_at': 1712345678,
+            'read': false,
+          };
+
+          final notification = RelayNotification.fromJson(json);
+
+          expect(notification.isReferencedVideo, isFalse);
+          expect(
+            notification.referencedVideoTitle,
+            equals('Top-level title'),
+          );
+        },
+      );
+
+      test('treats empty referenced_video.title as null title', () {
+        final json = {
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 7,
+          'referenced_event_id': '55667788' * 8,
+          'referenced_video': {'title': ''},
+          'notification_type': 'reaction',
+          'created_at': 1712345678,
+          'read': false,
+        };
+
+        final notification = RelayNotification.fromJson(json);
+
+        expect(notification.isReferencedVideo, isTrue);
+        expect(notification.referencedVideoTitle, isNull);
       });
 
       test('handles missing fields with defaults', () {

--- a/mobile/packages/models/lib/src/notification_item.dart
+++ b/mobile/packages/models/lib/src/notification_item.dart
@@ -11,6 +11,7 @@ import 'package:models/src/actor_info.dart';
 /// `NotificationType` enum in `notification_model.dart`.
 enum NotificationKind {
   like,
+  likeComment,
   comment,
   reply,
   follow,
@@ -88,6 +89,7 @@ class SingleNotification extends NotificationItem {
       NotificationKind.like when title != null =>
         '$name liked your video $title',
       NotificationKind.like => '$name liked your video',
+      NotificationKind.likeComment => '$name liked your comment',
       NotificationKind.comment when title != null =>
         '$name commented on your video $title',
       NotificationKind.comment => '$name commented on your video',
@@ -184,19 +186,21 @@ class GroupedNotification extends NotificationItem {
 
   @override
   String get message {
-    if (actors.isEmpty) return 'Someone liked your video';
+    final isComment = type == NotificationKind.likeComment;
+    final target = isComment ? 'comment' : 'video';
+    if (actors.isEmpty) return 'Someone liked your $target';
     final name = actors.first.displayName;
     final othersCount = totalCount - 1;
-    final title = videoTitle;
+    final title = isComment ? null : videoTitle;
     if (othersCount <= 0) {
       return title != null
-          ? '$name liked your video $title'
-          : '$name liked your video';
+          ? '$name liked your $target $title'
+          : '$name liked your $target';
     }
     final others = '$othersCount ${othersCount == 1 ? 'other' : 'others'}';
     return title != null
-        ? '$name and $others liked your video $title'
-        : '$name and $others liked your video';
+        ? '$name and $others liked your $target $title'
+        : '$name and $others liked your $target';
   }
 
   @override

--- a/mobile/packages/models/test/src/notification_item_test.dart
+++ b/mobile/packages/models/test/src/notification_item_test.dart
@@ -87,6 +87,21 @@ void main() {
       expect(notification.message, equals('alice_rebel liked your video'));
     });
 
+    test('message for likeComment ignores videoTitle', () {
+      final notification = SingleNotification(
+        id: 'notif_1',
+        type: NotificationKind.likeComment,
+        actor: _testActor,
+        timestamp: DateTime(2026, 4, 6),
+        videoTitle: 'Should be ignored',
+      );
+
+      expect(
+        notification.message,
+        equals('alice_rebel liked your comment'),
+      );
+    });
+
     test('message for comment with title', () {
       final notification = SingleNotification(
         id: 'notif_1',
@@ -361,6 +376,54 @@ void main() {
       );
 
       expect(notification.message, equals('Someone liked your video'));
+    });
+
+    test('grouped likeComment uses comment phrasing', () {
+      const actors = [
+        ActorInfo(pubkey: _pubkeyAlice, displayName: 'alice'),
+        ActorInfo(pubkey: _pubkeyBob, displayName: 'bob'),
+      ];
+
+      final notification = GroupedNotification(
+        id: 'group_lc',
+        type: NotificationKind.likeComment,
+        actors: actors,
+        totalCount: 2,
+        timestamp: DateTime(2026, 4, 6),
+      );
+
+      expect(
+        notification.message,
+        equals('alice and 1 other liked your comment'),
+      );
+    });
+
+    test('grouped likeComment with single actor uses comment phrasing', () {
+      const actors = [
+        ActorInfo(pubkey: _pubkeyAlice, displayName: 'alice'),
+      ];
+
+      final notification = GroupedNotification(
+        id: 'group_lc',
+        type: NotificationKind.likeComment,
+        actors: actors,
+        totalCount: 1,
+        timestamp: DateTime(2026, 4, 6),
+      );
+
+      expect(notification.message, equals('alice liked your comment'));
+    });
+
+    test('grouped likeComment with empty actors list', () {
+      final notification = GroupedNotification(
+        id: 'group_lc',
+        type: NotificationKind.likeComment,
+        actors: const [],
+        totalCount: 0,
+        timestamp: DateTime(2026, 4, 6),
+      );
+
+      expect(notification.message, equals('Someone liked your comment'));
     });
 
     test('message without title', () {

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -224,7 +224,8 @@ class NotificationRepository {
 
     for (final n in consolidated) {
       final kind = _mapNotificationKind(n);
-      if (kind == NotificationKind.like) {
+      if (kind == NotificationKind.like ||
+          kind == NotificationKind.likeComment) {
         likes.add(n);
       } else {
         others.add(n);
@@ -232,7 +233,7 @@ class NotificationRepository {
     }
 
     // 4. Group likes by referenced event ID.
-    final groupedLikes = _groupLikesByVideo(likes, profiles);
+    final groupedLikes = _groupLikesByTarget(likes, profiles);
 
     // 5. Map remaining notifications to SingleNotification.
     final singles = others.map((n) {
@@ -245,6 +246,7 @@ class NotificationRepository {
         timestamp: n.createdAt,
         isRead: n.read,
         targetEventId: _resolveTargetEventId(n, kind),
+        videoTitle: n.referencedVideoTitle,
         commentText: _truncateComment(n.content, kind),
       );
     }).toList();
@@ -279,23 +281,28 @@ class NotificationRepository {
 
   /// Groups likes by referenced event ID.
   ///
-  /// 2+ likes on the same video become a [GroupedNotification].
-  /// A single like stays as a [SingleNotification].
-  List<NotificationItem> _groupLikesByVideo(
+  /// 2+ likes on the same target become a [GroupedNotification].
+  /// A single like stays as a [SingleNotification]. The target may be a
+  /// video ([NotificationKind.like]) or a comment
+  /// ([NotificationKind.likeComment]).
+  List<NotificationItem> _groupLikesByTarget(
     List<RelayNotification> likes,
     Map<String, UserProfile> profiles,
   ) {
-    final byVideo = <String, List<RelayNotification>>{};
+    final byTarget = <String, List<RelayNotification>>{};
 
     for (final like in likes) {
       final key = like.referencedEventId ?? like.dedupeKey;
-      (byVideo[key] ??= []).add(like);
+      (byTarget[key] ??= []).add(like);
     }
 
     final items = <NotificationItem>[];
 
-    for (final entry in byVideo.entries) {
+    for (final entry in byTarget.entries) {
       final group = entry.value;
+      // All likes on the same event share the same target kind.
+      final kind = _mapNotificationKind(group.first);
+      final isVideoLike = kind == NotificationKind.like;
       if (group.length >= 2) {
         // Sort by timestamp descending so newest actors come first.
         group.sort((a, b) => b.createdAt.compareTo(a.createdAt));
@@ -307,14 +314,15 @@ class NotificationRepository {
 
         items.add(
           GroupedNotification(
-            // Stable ID based on the video, not the newest liker.
+            // Stable ID based on the target, not the newest liker.
             id: 'group_like_${entry.key}',
-            type: NotificationKind.like,
+            type: kind,
             actors: actors,
             totalCount: group.length,
             timestamp: group.first.createdAt,
             isRead: group.every((n) => n.read),
             targetEventId: entry.key,
+            videoTitle: isVideoLike ? group.first.referencedVideoTitle : null,
           ),
         );
       } else {
@@ -322,11 +330,12 @@ class NotificationRepository {
         items.add(
           SingleNotification(
             id: n.dedupeKey,
-            type: NotificationKind.like,
+            type: kind,
             actor: _buildActor(n.sourcePubkey, profiles),
             timestamp: n.createdAt,
             isRead: n.read,
             targetEventId: n.referencedEventId,
+            videoTitle: isVideoLike ? n.referencedVideoTitle : null,
           ),
         );
       }
@@ -368,16 +377,26 @@ class NotificationRepository {
 
   /// Maps a relay notification type string + source kind to
   /// [NotificationKind].
+  ///
+  /// Likes (and zaps) on a non-video target — typically a kind 1111
+  /// comment — map to [NotificationKind.likeComment] so the UI can
+  /// render "liked your comment" instead of "liked your video".
   static NotificationKind _mapNotificationKind(RelayNotification n) {
+    final reaction = switch (n.notificationType) {
+      'reaction' || 'zap' => true,
+      _ => n.sourceKind == 7,
+    };
+    if (reaction) {
+      return n.isReferencedVideo
+          ? NotificationKind.like
+          : NotificationKind.likeComment;
+    }
     return switch (n.notificationType) {
-      'reaction' => NotificationKind.like,
       'reply' => NotificationKind.reply,
       'comment' => NotificationKind.comment,
       'repost' => NotificationKind.repost,
       'mention' => NotificationKind.mention,
       'follow' || 'contact' => NotificationKind.follow,
-      'zap' => NotificationKind.like,
-      _ when n.sourceKind == 7 => NotificationKind.like,
       _ when n.sourceKind == 6 => NotificationKind.repost,
       _ when n.sourceKind == 3 => NotificationKind.follow,
       _ when n.sourceKind == 1 => NotificationKind.comment,

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -63,6 +63,10 @@ void main() {
   });
 
   /// Helper to create a [RelayNotification] with sensible defaults.
+  ///
+  /// Defaults to a like on a video (`isReferencedVideo: true`); pass
+  /// `isReferencedVideo: false` to model a like on a non-video target
+  /// such as a comment.
   RelayNotification makeNotification({
     String id = 'n1',
     String sourcePubkey = 'pubkey_alice',
@@ -73,6 +77,8 @@ void main() {
     bool read = false,
     String? referencedEventId,
     String? content,
+    bool isReferencedVideo = true,
+    String? referencedVideoTitle,
   }) {
     return RelayNotification(
       id: id,
@@ -84,6 +90,8 @@ void main() {
       read: read,
       referencedEventId: referencedEventId,
       content: content,
+      isReferencedVideo: isReferencedVideo,
+      referencedVideoTitle: referencedVideoTitle,
     );
   }
 
@@ -425,6 +433,136 @@ void main() {
         expect(page.items, hasLength(1));
         expect(page.items.first, isA<SingleNotification>());
       });
+
+      test(
+        'reaction without referenced_video maps to likeComment',
+        () async {
+          stubNotifications([
+            makeNotification(
+              id: 'lc1',
+              sourcePubkey: 'pub_a',
+              referencedEventId: 'comment_x',
+              isReferencedVideo: false,
+            ),
+          ]);
+          stubProfiles({
+            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+          });
+
+          final page = await repository.getNotifications();
+
+          expect(page.items, hasLength(1));
+          final item = page.items.first as SingleNotification;
+          expect(item.type, equals(NotificationKind.likeComment));
+          expect(item.targetEventId, equals('comment_x'));
+          expect(item.videoTitle, isNull);
+        },
+      );
+
+      test(
+        '3 likes on the same comment become 1 GroupedNotification of '
+        'likeComment',
+        () async {
+          stubNotifications([
+            makeNotification(
+              id: 'lc1',
+              sourcePubkey: 'pub_a',
+              referencedEventId: 'comment_x',
+              isReferencedVideo: false,
+              createdAt: DateTime(2025, 1, 3),
+            ),
+            makeNotification(
+              id: 'lc2',
+              sourcePubkey: 'pub_b',
+              referencedEventId: 'comment_x',
+              isReferencedVideo: false,
+              createdAt: DateTime(2025, 1, 2),
+            ),
+            makeNotification(
+              id: 'lc3',
+              sourcePubkey: 'pub_c',
+              referencedEventId: 'comment_x',
+              isReferencedVideo: false,
+              createdAt: DateTime(2025),
+            ),
+          ]);
+          stubProfiles({
+            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+            'pub_b': makeProfile('pub_b', displayName: 'Bob'),
+            'pub_c': makeProfile('pub_c', displayName: 'Charlie'),
+          });
+
+          final page = await repository.getNotifications();
+
+          expect(page.items, hasLength(1));
+          final item = page.items.first as GroupedNotification;
+          expect(item.type, equals(NotificationKind.likeComment));
+          expect(item.totalCount, equals(3));
+          expect(item.targetEventId, equals('comment_x'));
+          expect(item.videoTitle, isNull);
+        },
+      );
+
+      test(
+        'likes on a video and a comment with same target_id never collide '
+        'because event ids are unique',
+        () async {
+          stubNotifications([
+            makeNotification(
+              id: 'l1',
+              sourcePubkey: 'pub_a',
+              referencedEventId: 'video_z',
+              referencedVideoTitle: 'Trip recap',
+            ),
+            makeNotification(
+              id: 'lc1',
+              sourcePubkey: 'pub_b',
+              referencedEventId: 'comment_z',
+              isReferencedVideo: false,
+            ),
+          ]);
+          stubProfiles({
+            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+            'pub_b': makeProfile('pub_b', displayName: 'Bob'),
+          });
+
+          final page = await repository.getNotifications();
+
+          expect(page.items, hasLength(2));
+          final byKind = {
+            for (final item in page.items.cast<SingleNotification>())
+              item.type: item,
+          };
+          expect(
+            byKind[NotificationKind.like]?.videoTitle,
+            equals('Trip recap'),
+          );
+          expect(byKind[NotificationKind.likeComment]?.videoTitle, isNull);
+        },
+      );
+
+      test(
+        'video like populates videoTitle from referencedVideoTitle',
+        () async {
+          stubNotifications([
+            makeNotification(
+              id: 'l1',
+              sourcePubkey: 'pub_a',
+              referencedEventId: 'video_y',
+              referencedVideoTitle: 'My funny vine',
+            ),
+          ]);
+          stubProfiles({
+            'pub_a': makeProfile('pub_a', displayName: 'Alice'),
+          });
+
+          final page = await repository.getNotifications();
+
+          final item = page.items.first as SingleNotification;
+          expect(item.type, equals(NotificationKind.like));
+          expect(item.videoTitle, equals('My funny vine'));
+        },
+      );
 
       test('likes on different videos are not grouped together', () async {
         stubNotifications([

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -69,6 +69,10 @@ const _knownUntranslatedDebt = {
   'notificationRepliedToYourComment',
   'notificationAndConnector',
   'notificationOthersCount',
+  // Added by #3957 (distinguishing likes on comments vs videos).
+  // Translators will pick this up in a follow-up pass; until then the
+  // generated l10n APIs fall back to the English source.
+  'notificationLikedYourComment',
   // Added by #3837 (Blossom URL scheme validation under strict ATS).
   // English fallback ships until translators pick this up.
   'blossomServerUrlMustUseHttps',

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -69,10 +69,6 @@ const _knownUntranslatedDebt = {
   'notificationRepliedToYourComment',
   'notificationAndConnector',
   'notificationOthersCount',
-  // Added by #3957 (distinguishing likes on comments vs videos).
-  // Translators will pick this up in a follow-up pass; until then the
-  // generated l10n APIs fall back to the English source.
-  'notificationLikedYourComment',
   // Added by #3837 (Blossom URL scheme validation under strict ATS).
   // English fallback ships until translators pick this up.
   'blossomServerUrlMustUseHttps',

--- a/mobile/test/notifications/widgets/notification_list_item_test.dart
+++ b/mobile/test/notifications/widgets/notification_list_item_test.dart
@@ -152,6 +152,45 @@ void main() {
         expect(followedBack, isTrue);
       });
 
+      testWidgets(
+        'renders "liked your comment" verb for likeComment type',
+        (tester) async {
+          final notification = SingleNotification(
+            id: 'lc1',
+            type: NotificationKind.likeComment,
+            actor: actor,
+            timestamp: DateTime.now().subtract(const Duration(minutes: 5)),
+          );
+
+          await tester.pumpWidget(buildSubject(notification));
+          await tester.pump();
+
+          expect(_findRichTextContaining('liked your comment'), findsOneWidget);
+          expect(_findRichTextContaining('liked your video'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'does not render videoTitle for likeComment notification',
+        (tester) async {
+          final notification = SingleNotification(
+            id: 'lc2',
+            type: NotificationKind.likeComment,
+            actor: actor,
+            timestamp: DateTime.now().subtract(const Duration(minutes: 5)),
+            // videoTitle should never be set on a likeComment, but if it
+            // ever leaks through the data layer, the UI must not show it
+            // as if the comment had a video title.
+            videoTitle: 'Should not appear',
+          );
+
+          await tester.pumpWidget(buildSubject(notification));
+          await tester.pump();
+
+          expect(find.textContaining('Should not appear'), findsNothing);
+        },
+      );
+
       testWidgets('renders reply comment text for reply type', (tester) async {
         final notification = SingleNotification(
           id: '7',
@@ -221,6 +260,25 @@ void main() {
 
         expect(find.byType(NotificationAvatarStack), findsOneWidget);
       });
+
+      testWidgets(
+        'renders "liked your comment" for grouped likeComment',
+        (tester) async {
+          final notification = GroupedNotification(
+            id: 'group_lc',
+            type: NotificationKind.likeComment,
+            actors: const [actor, actor2],
+            totalCount: 2,
+            timestamp: DateTime.now(),
+          );
+
+          await tester.pumpWidget(buildSubject(notification));
+          await tester.pump();
+
+          expect(_findRichTextContaining('liked your comment'), findsOneWidget);
+          expect(_findRichTextContaining('liked your video'), findsNothing);
+        },
+      );
 
       testWidgets('calls onTap when grouped row is tapped', (tester) async {
         var tapped = false;


### PR DESCRIPTION
## Summary

Fixes #3957 — likes on comments were displayed as "Charlie liked your video".

The notifications backend already distinguishes whether a reaction targets a video (`referenced_video` non-null) or something else (typically a NIP-22 kind 1111 comment), but the mobile client wasn't reading that field, so every reaction was rendered as a video like.

## Changes

- `RelayNotification` parses `referenced_video` and `referenced_event_title`, exposing `isReferencedVideo` and `referencedVideoTitle`.
- New `NotificationKind.likeComment` variant for reactions on non-video events.
- `NotificationRepository._mapNotificationKind` returns `likeComment` when a reaction's target isn't a video; grouping handles both kinds and stores the video title for video likes.
- `_verbFor` / `_typeIconSpec` get exhaustive `likeComment` cases (heart icon, "liked your comment" verb).
- Tapping a `likeComment` notification auto-opens the comments sheet, like comment/reply/mention notifications already do.
- Added `notificationLikedYourComment` ARB key.

## Test plan

- [x] `flutter analyze lib test integration_test` passes
- [x] `flutter test test/notifications` (57 tests) passes
- [x] `flutter test` in `packages/funnelcake_api_client` (294 tests), `packages/notification_repository` (48 tests), `packages/models` (557 tests)
- [ ] Manual: post a comment under another user's video, have a second account react to that comment, verify the notification reads "X liked your comment" (not "X liked your video"), and tapping it opens the video with the comments sheet open.
- [ ] Manual: regression check that "X liked your video Title" still renders correctly when someone reacts to a video.